### PR TITLE
Update local JDK wiring

### DIFF
--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -71,7 +71,7 @@ def loadBuildProps() {
   
   def fetchRepoPublic = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemotePublic;releaseUrl=https://repo.maven.apache.org/maven2/;index=${build}/oss_dependencies.maven')
   def fetchRepoIBM = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemoteIBM;releaseUrl=http://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/wasliberty-open-liberty/;index=${build}/oss_ibm.maven')
-  def fetchRepoIBMJava = ('error') //Not yet supported to not have this set via gradle.startup.properties
+  def fetchRepoIBMJava = fetchRepoIBM //Not yet supported to not have this set via gradle.startup.properties
   def pushRepoIBM = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemotePublish')
 
   def javaHome = org.gradle.internal.jvm.Jvm.current().getJavaHome()


### PR DESCRIPTION
The dummy plugin that takes the place of the controlled JDK plugin location needs a valid name, for now it can be a copy of another valid one.