### PR TITLE
Microprofile Fault Tolerance changes (integration branch)

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceCDIExtension.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceCDIExtension.java
@@ -54,6 +54,8 @@ public class FaultToleranceCDIExtension implements Extension, WebSphereCDIExtens
         beforeBeanDiscovery.addInterceptorBinding(bindingType);
         AnnotatedType<FaultToleranceInterceptor> interceptorType = beanManager.createAnnotatedType(FaultToleranceInterceptor.class);
         beforeBeanDiscovery.addAnnotatedType(interceptorType);
+        AnnotatedType<FaultToleranceInterceptor.ExecutorCleanup> executorCleanup = beanManager.createAnnotatedType(FaultToleranceInterceptor.ExecutorCleanup.class);
+        beforeBeanDiscovery.addAnnotatedType(executorCleanup);
     }
 
     public <T> void processAnnotatedType(@Observes @WithAnnotations({ Asynchronous.class, Fallback.class, Timeout.class, CircuitBreaker.class, Retry.class,

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
@@ -223,7 +223,12 @@ public class FaultToleranceInterceptor {
                 };
 
                 Executor<Future<Object>> async = (Executor<Future<Object>>) executor;
-                result = async.execute(callable, executionContext);
+                try {
+                    result = async.execute(callable, executionContext);
+                } catch (ExecutionException e) {
+                    throw e.getCause();
+                }
+
             } else {
 
                 Callable<Object> callable = () -> {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
@@ -12,12 +12,14 @@ package com.ibm.ws.microprofile.faulttolerance.cdi;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 
 import javax.annotation.PreDestroy;
 import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
@@ -32,6 +34,8 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.microprofile.faulttolerance.cdi.config.AsynchronousConfig;
 import com.ibm.ws.microprofile.faulttolerance.cdi.config.BulkheadConfig;
@@ -57,6 +61,11 @@ public class FaultToleranceInterceptor {
     BeanManager beanManager;
 
     private final ConcurrentHashMap<Method, AggregatedFTPolicy> policyCache = new ConcurrentHashMap<>();
+
+    @Inject
+    public FaultToleranceInterceptor(ExecutorCleanup executorCleanup) {
+        executorCleanup.setPolicies(policyCache.values());
+    }
 
     @AroundInvoke
     public Object executeFT(InvocationContext context) throws Throwable {
@@ -235,11 +244,25 @@ public class FaultToleranceInterceptor {
         return result;
     }
 
-    @PreDestroy
-    public void cleanUpExecutors(InvocationContext ctx) throws Exception {
-        ctx.proceed();
-        policyCache.forEach((k, v) -> {
-            v.close();
-        });
+    @Dependent
+    public static class ExecutorCleanup {
+        private static final TraceComponent tc = Tr.register(ExecutorCleanup.class);
+
+        private Collection<AggregatedFTPolicy> policies;
+
+        public void setPolicies(Collection<AggregatedFTPolicy> policies) {
+            this.policies = policies;
+        }
+
+        @PreDestroy
+        public void cleanUpExecutors() {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Cleaning up executors");
+            }
+
+            policies.forEach((e) -> {
+                e.close();
+            });
+        }
     }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDICircuitBreakerTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDICircuitBreakerTest.java
@@ -42,19 +42,33 @@ public class CDICircuitBreakerTest extends LoggingTest {
                                          "SUCCESS");
     }
 
+    @Test
+    public void testCBAsync() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBAsync",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testCBAsyncFallback() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBAsyncFallback",
+                                         "SUCCESS");
+    }
+
     /** {@inheritDoc} */
     @Override
     protected SharedServer getSharedServer() {
         return SHARED_SERVER;
     }
-	
-		@BeforeClass
-	public static void setUp() throws Exception {
-		if (!SHARED_SERVER.getLibertyServer().isStarted()) {
-			SHARED_SERVER.getLibertyServer().startServer();
-		}
-		
-	}
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        if (!SHARED_SERVER.getLibertyServer().isStarted()) {
+            SHARED_SERVER.getLibertyServer().startServer();
+        }
+
+    }
 
     @AfterClass
     public static void tearDown() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIRetryTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIRetryTest.java
@@ -15,6 +15,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;
@@ -70,6 +71,23 @@ public class CDIRetryTest extends LoggingTest {
     public void testRetryDurationZero() throws Exception {
         WebBrowser browser = createWebBrowserForTestCase();
         getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/retry?testMethod=testRetryDurationZero", "SUCCESS");
+    }
+
+    /**
+     * Not really related to retry but it's easiest to test it here
+     */
+    @Test
+    public void testExecutorsClose() throws Exception {
+
+        RemoteFile traceLog = SHARED_SERVER.getLibertyServer().getMostRecentTraceFile();
+        SHARED_SERVER.getLibertyServer().setMarkToEndOfLog(traceLog);
+
+        // This calls a RequestScoped bean which only has fault tolerance annotations on the method
+        // This should cause executors to get cleaned up
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/retry?testMethod=testRetryAbortOn", "SUCCESS");
+
+        SHARED_SERVER.getLibertyServer().waitForStringInLog("Cleaning up executors", traceLog);
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDITimeoutTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDITimeoutTest.java
@@ -60,6 +60,18 @@ public class CDITimeoutTest extends LoggingTest {
         getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/timeout?testMethod=testTimeoutZero", "SUCCESS");
     }
 
+    @Test
+    public void testNonInterruptableTimeout() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/timeout?testMethod=testNonInterruptableTimeout", "SUCCESS");
+    }
+
+    @Test
+    public void testNonInterruptableDoesntTimeout() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/timeout?testMethod=testNonInterruptableDoesntTimeout", "SUCCESS");
+    }
+
     /** {@inheritDoc} */
     @Override
     protected SharedServer getSharedServer() {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/AsyncServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/AsyncServlet.java
@@ -261,7 +261,7 @@ public class AsyncServlet extends FATServlet {
         long duration = end - start;
 
         // Ensure that this method was executed synchronously
-        assertThat("Call duration", duration, greaterThan(TestConstants.WORK_TIME));
+        assertThat("Call duration", duration, greaterThan(TestConstants.WORK_TIME - TestConstants.TEST_TWEAK_TIME_UNIT));
         assertThat("Call result", future.get(), is(notNullValue()));
         assertThat("Call result", future.get().getData(), equalTo(AsyncBean.CONNECT_A_DATA));
     }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/TimeoutServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/TimeoutServlet.java
@@ -118,4 +118,27 @@ public class TimeoutServlet extends FATServlet {
         // No TimeoutException expected
     }
 
+    public void testNonInterruptableTimeout() throws InterruptedException {
+        try {
+            bean.busyWait(1000); // Busy wait time is greater than timeout (=500)
+            fail("No exception thrown");
+        } catch (TimeoutException e) {
+            if (Thread.interrupted()) {
+                fail("Thread was in interrupted state upon return");
+            }
+            // This wait is to ensure our thread doesn't get interrupted later, after the method has finished
+            Thread.sleep(1000);
+        }
+    }
+
+    public void testNonInterruptableDoesntTimeout() throws Exception {
+        bean.busyWait(10); // Busy wait time is less than timeout (=500)
+
+        if (Thread.interrupted()) {
+            fail("Thread was in interrupted state upon return");
+        }
+
+        Thread.sleep(2000); // Wait to ensure that our thread isn't interrupted after the method has finished
+    }
+
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/TimeoutBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/TimeoutBean.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans;
 
+import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -90,5 +91,19 @@ public class TimeoutBean {
     @Timeout(0)
     public void connectE() throws InterruptedException {
         Thread.sleep(2000);
+    }
+
+    /**
+     * Used for testing timeout with workloads which are not interruptable
+     * 
+     * @param milliseconds number of milliseconds to busy wait for
+     */
+    @Timeout(500)
+    public void busyWait(int milliseconds) {
+        long duration = Duration.ofMillis(milliseconds).toNanos();
+        long start = System.nanoTime();
+        while (System.nanoTime() - start < duration) {
+            // Do nothing
+        }
     }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/CircuitBreakerImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/CircuitBreakerImpl.java
@@ -13,6 +13,8 @@ package com.ibm.ws.microprofile.faulttolerance.impl;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.microprofile.faulttolerance.spi.CircuitBreakerPolicy;
 
 import net.jodah.failsafe.CircuitBreaker;
@@ -22,11 +24,9 @@ import net.jodah.failsafe.CircuitBreaker;
  */
 public class CircuitBreakerImpl extends CircuitBreaker {
 
-    private final boolean async;
-    private volatile boolean nested = false;
+    private static final TraceComponent tc = Tr.register(CircuitBreakerImpl.class);
 
-    public CircuitBreakerImpl(CircuitBreakerPolicy policy, boolean async) {
-        this.async = async;
+    public CircuitBreakerImpl(CircuitBreakerPolicy policy) {
 
         Duration delay = policy.getDelay();
         Class<? extends Throwable>[] failOn = policy.getFailOn();
@@ -48,14 +48,4 @@ public class CircuitBreakerImpl extends CircuitBreaker {
         withSuccessThreshold(successThreshold);
     }
 
-    @Override
-    public void recordSuccess() {
-        if (!async || nested) {
-            super.recordSuccess();
-        }
-    }
-
-    public void setNested() {
-        this.nested = true;
-    }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/ExecutionContextImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/ExecutionContextImpl.java
@@ -132,10 +132,6 @@ public class ExecutionContextImpl implements FTExecutionContext {
             timeout.restartOnNewThread(Thread.currentThread());
         }
 
-        if (this.circuitBreaker != null) {
-            this.circuitBreaker.setNested();
-        }
-
         int retriesRemaining = this.retry.getMaxRetries() - this.retries;
         if (this.retry.getMaxDuration() != null) {
             long maxDuration = this.retry.getMaxDuration().toNanos();

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/TimeoutImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/TimeoutImpl.java
@@ -238,9 +238,18 @@ public class TimeoutImpl {
         lock.readLock().lock();
         try {
             if (this.timedout) {
+                // Note: this clears the interrupted flag if it was set
+                // Assumption is that the interruption was caused by the Timeout
+                boolean wasInterrupted = Thread.interrupted();
+
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "{0}: Throwing timeout exception", getDescriptor());
+                    if (wasInterrupted) {
+                        Tr.debug(tc, "{0}: Throwing timeout exception", getDescriptor());
+                    } else {
+                        Tr.debug(tc, "{0}: Throwing timeout exception and clearing interrupted flag", getDescriptor());
+                    }
                 }
+
                 throw new TimeoutException(Tr.formatMessage(tc, "timeout.occurred.CWMFT0000E"));
             }
             long now = System.nanoTime();

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
@@ -21,17 +21,21 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.microprofile.faulttolerance.impl.CircuitBreakerImpl;
 import com.ibm.ws.microprofile.faulttolerance.impl.ExecutionContextImpl;
 import com.ibm.ws.microprofile.faulttolerance.impl.FTConstants;
 import com.ibm.ws.microprofile.faulttolerance.impl.sync.SynchronousExecutorImpl;
 import com.ibm.ws.microprofile.faulttolerance.spi.BulkheadPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.CircuitBreakerPolicy;
+import com.ibm.ws.microprofile.faulttolerance.spi.ExecutionException;
 import com.ibm.ws.microprofile.faulttolerance.spi.FallbackPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.RetryPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.TimeoutPolicy;
@@ -40,6 +44,9 @@ import com.ibm.ws.threading.PolicyExecutor.QueueFullAction;
 import com.ibm.ws.threading.PolicyExecutorProvider;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.FailsafeException;
 
 /**
  * An AsyncExecutorImpl builds on SynchronousExecutorImpl but the task which is run actually submits another task to be run asynchronously.
@@ -110,6 +117,24 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
     }
 
     @Override
+    public Future<R> execute(Callable<Future<R>> callable, ExecutionContext executionContext) {
+        ExecutionContextImpl context = (ExecutionContextImpl) executionContext;
+
+        CircuitBreakerImpl breaker = context.getCircuitBreaker();
+
+        // Check whether the circuit is open
+        if (breaker != null && !breaker.allowsExecution()) {
+            if (context.getFallbackPolicy() != null) {
+                return callFallback(context);
+            } else {
+                throw new CircuitBreakerOpenException();
+            }
+        }
+
+        return super.execute(callable, executionContext);
+    }
+
+    @Override
     protected Callable<Future<R>> createTask(Callable<Future<R>> callable, ExecutionContextImpl executionContext) {
         //this is the inner nested task that will be run synchronously
         Callable<Future<R>> innerTask = () -> {
@@ -136,14 +161,72 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
                     //if the execution was rejected then end the execution and throw a BulkheadException
                     //TODO there might not really have been a bulkhead?? but it's pretty unlikely that the execution would
                     //be rejected otherwise!
-                    executionContext.end();
-                    throw new BulkheadException(Tr.formatMessage(tc, "bulkhead.no.threads.CWMFT0001E", executionContext.getMethod()), e);
+                    executionContext.close();
+
+                    BulkheadException bulkheadException = new BulkheadException(Tr.formatMessage(tc, "bulkhead.no.threads.CWMFT0001E", executionContext.getMethod()), e);
+                    reportFailure(executionContext, bulkheadException);
+                    throw bulkheadException;
                 }
 
                 return queuedFuture;
             }
         };
         return outerTask;
+    }
+
+    /**
+     * Call the fallback function.
+     * <p>
+     * This method may only be called if there is a fallback function defined.
+     *
+     * @param context the execution context
+     * @return the fallback result
+     * @throws ExecutionException if the fallback method throws an exception
+     */
+    @FFDCIgnore(Throwable.class)
+    private Future<R> callFallback(ExecutionContextImpl context) {
+        try {
+            return (Future<R>) context.getFallbackPolicy().getFallbackFunction().execute(context);
+        } catch (Throwable t) {
+            throw new ExecutionException(t);
+        }
+    }
+
+    /**
+     * Records an execution failure with the circuit breaker.
+     * <p>
+     * We do this by checking that the circuit breaker considers the exeception as a failure, and then running a function through failsafe which just throws that exception.
+     * <p>
+     * We need to do this because we want to register failures to start an async method, but not register successes, and there's no Failsafe API to manually register a failure
+     * without corrupting the internal state.
+     *
+     * @param context the execution context
+     * @param ex the exception which caused the failure
+     */
+    private void reportFailure(ExecutionContextImpl context, Exception ex) {
+        CircuitBreakerImpl breaker = context.getCircuitBreaker();
+        if (breaker != null && breaker.isFailure(null, ex)) {
+            try {
+                Failsafe.with(breaker).run(() -> {
+                    throw ex;
+                });
+            } catch (FailsafeException | CircuitBreakerOpenException failsafeException) {
+                // Do  nothing, all we wanted to do was register a failed execution with the circuit breaker
+            }
+        }
+    }
+
+    @Override
+    protected boolean enableCircuitBreaker() {
+        // Don't want full circuit breaker as we only want to record failures
+        return false;
+    }
+
+    @Override
+    protected boolean enableFallback() {
+        // Since we're doing our own circuit breaking, we don't want failsafe to fallback for us
+        // as that would prevent us seeing the failure. We'll do our own falling back.
+        return false;
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/QueuedFuture.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/QueuedFuture.java
@@ -160,6 +160,12 @@ public class QueuedFuture<R> implements Future<R>, Callable<Future<R>> {
             }
 
             throw e;
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof com.ibm.ws.microprofile.faulttolerance.spi.ExecutionException) {
+                throw new ExecutionException(e.getCause().getCause());
+            } else {
+                throw e;
+            }
         }
         return result;
     }
@@ -194,6 +200,12 @@ public class QueuedFuture<R> implements Future<R>, Callable<Future<R>> {
             }
 
             throw e;
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof com.ibm.ws.microprofile.faulttolerance.spi.ExecutionException) {
+                throw new ExecutionException(e.getCause().getCause());
+            } else {
+                throw e;
+            }
         }
         return result;
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/BulkheadTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/BulkheadTest.java
@@ -264,7 +264,7 @@ public class BulkheadTest {
             ExecutionContext context = executor.newExecutionContext(id, (Method) null, id);
             AsyncTestFunction callable = new AsyncTestFunction(Duration.ofMillis(2000), id);
             try {
-                futures[5] = executor.execute(callable, context);
+                futures[4] = executor.execute(callable, context);
                 System.out.println(System.currentTimeMillis() + " Test " + id + " - submitted");
                 fail("Exception not thrown");
             } catch (BulkheadException e) {


### PR DESCRIPTION
* Close all executors when the bean is destroyed
* Make Async CircuitBreakers work
* Ensure interrupted flag is is cleared after timeout