### PR TITLE
Make jsonp-1.0 and jsonp-1.1 singleton features

### DIFF
--- a/dev/com.ibm.websphere.appserver.jsonp-1.0/com.ibm.websphere.appserver.jsonp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.jsonp-1.0/com.ibm.websphere.appserver.jsonp-1.0.feature
@@ -1,6 +1,7 @@
 -include= ~../cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.jsonp-1.0
 visibility=public
+singleton=true
 IBM-API-Package: javax.json; type="spec", \
  javax.json.stream; type="spec", \
  javax.json.spi; type="spec"

--- a/dev/com.ibm.websphere.appserver.jsonp-1.1/com.ibm.websphere.appserver.jsonp-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.jsonp-1.1/com.ibm.websphere.appserver.jsonp-1.1.feature
@@ -1,6 +1,7 @@
 -include= ~../cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.jsonp-1.1
 visibility=public
+singleton=true
 IBM-API-Package: javax.json; type="spec", \
  javax.json.stream; type="spec", \
  javax.json.spi; type="spec"


### PR DESCRIPTION
Signed-off-by: Andrew Guibert <andy.guibert@gmail.com>

Currently, both jsonp-1.0 and jsonp-1.1 can be configured at the same time, which should not be allowed.