### PR TITLE
Remove linux badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # OpenLiberty
 
 [![Twitter](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/OpenLibertyIO)
-![Linux](https://img.shields.io/badge/os-linux-green.svg?style=flat)
 [![License](https://img.shields.io/badge/License-EPL%201.0-green.svg)](https://opensource.org/licenses/EPL-1.0)
 
 # Summary


### PR DESCRIPTION
Although we don't have an official statement of supported platform's - the linux badge was confusing, as OL does in fact run on a variety of platforms.  Removing.