### PR TITLE
Issue 68: Enable authentication of resource methods requiring auth

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/providers/security/SecurityAnnoProviderRegister.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/providers/security/SecurityAnnoProviderRegister.java
@@ -13,10 +13,10 @@ package com.ibm.ws.jaxrs20.providers.security;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.cxf.jaxrs.security.SimpleAuthorizingFilter;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.ws.jaxrs20.providers.api.JaxRsProviderRegister;
+import com.ibm.ws.jaxrs20.security.LibertyAuthFilter;
 import com.ibm.ws.jaxrs20.security.LibertySimpleAuthorizingInterceptor;
 
 @Component(immediate = true)
@@ -28,10 +28,10 @@ public class SecurityAnnoProviderRegister implements JaxRsProviderRegister {
         if (!clientSide) {
             if (features.contains("appSecurity-2.0") || features.contains("appSecurity-1.0")) {
                 //add one built-in ContainerRequestFilter to handle basic security
-                SimpleAuthorizingFilter sm = new SimpleAuthorizingFilter();
+                LibertyAuthFilter laf = new LibertyAuthFilter();
                 LibertySimpleAuthorizingInterceptor in = new LibertySimpleAuthorizingInterceptor();
-                sm.setInterceptor(in);
-                providers.add(sm);
+                laf.setInterceptor(in);
+                providers.add(laf);
             }
         }
     }

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/security/LibertyAuthFilter.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/security/LibertyAuthFilter.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.security;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+
+import org.apache.cxf.interceptor.security.AccessDeniedException;
+import org.apache.cxf.interceptor.security.AuthenticationException;
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+@Priority(Priorities.AUTHORIZATION)
+public class LibertyAuthFilter implements ContainerRequestFilter {
+    private LibertySimpleAuthorizingInterceptor interceptor;
+
+    @Override
+    @FFDCIgnore({ AuthenticationException.class, AccessDeniedException.class })
+    public void filter(ContainerRequestContext context) {
+        Message m = JAXRSUtils.getCurrentMessage();
+        try {
+            try {
+                interceptor.handleMessage(m);
+            } catch (AuthenticationException ex) {
+                if (authenticate(m)) {
+                    // try again with authenticated user
+                    interceptor.handleMessage(m);
+                } else {
+                    // could not authenticate - return 401
+                    // TODO: check response code on servlet response and use the same status?
+                    context.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
+                }
+            }
+        } catch (AccessDeniedException ex) {
+            context.abortWith(Response.status(Response.Status.FORBIDDEN).build());
+        }
+    }
+
+    private boolean authenticate(Message m) {
+        HttpServletRequest req = (HttpServletRequest) m.get(AbstractHTTPDestination.HTTP_REQUEST);
+        HttpServletResponse res = (HttpServletResponse) m.get(AbstractHTTPDestination.HTTP_RESPONSE);
+        try {
+            return req.authenticate(res);
+        } catch (IOException | ServletException e) {
+            // AutoFFDC
+        }
+        return false;
+    }
+
+    public void setInterceptor(LibertySimpleAuthorizingInterceptor in) {
+        interceptor = in;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/security/LibertySimpleAuthorizingInterceptor.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/security/LibertySimpleAuthorizingInterceptor.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.jaxrs20.security;
 
 import java.lang.reflect.Method;
+import java.security.Principal;
 import java.util.Arrays;
 import java.util.List;
 
@@ -21,6 +22,7 @@ import javax.annotation.security.RolesAllowed;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.interceptor.security.AbstractAuthorizingInInterceptor;
 import org.apache.cxf.interceptor.security.AccessDeniedException;
+import org.apache.cxf.interceptor.security.AuthenticationException;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.security.SecurityContext;
 
@@ -41,7 +43,16 @@ public class LibertySimpleAuthorizingInterceptor extends
                 return;
             }
         }
+
         throw new AccessDeniedException("Unauthorized");
+    }
+
+    private boolean ensureAuthentication(SecurityContext sc) {
+        Principal p = sc.getUserPrincipal();
+        if (p == null || "UNAUTHENTICATED".equals(p.getName())) {
+            throw new AuthenticationException();
+        }
+        return true;
     }
 
     private boolean parseMethodSecurity(Method method, SecurityContext sc) {
@@ -63,7 +74,11 @@ public class LibertySimpleAuthorizingInterceptor extends
                     Tr.debug(
                              tc,
                              "found RolesAllowed in method: {} "
-                                             + method.getName());
+                                 + method.getName(),
+                             new Object[] { rolesAllowed.value() });
+                }
+                if (!ensureAuthentication(sc)) {
+                    return false;
                 }
                 String[] theseroles = rolesAllowed.value();
 
@@ -98,6 +113,9 @@ public class LibertySimpleAuthorizingInterceptor extends
         // try DenyAll
         DenyAll denyAll = cls.getAnnotation(DenyAll.class);
         if (denyAll != null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Found class level @DenyAll - authorization denied for " + cls.getName());
+            }
             return false;
         } else { // try RolesAllowed
 
@@ -109,7 +127,11 @@ public class LibertySimpleAuthorizingInterceptor extends
                     Tr.debug(
                              tc,
                              "found RolesAllowed in class level: {} "
-                                             + cls.getName());
+                                 + cls.getName(),
+                             new Object[] { theseroles });
+                }
+                if (!ensureAuthentication(sc)) {
+                    return false;
                 }
                 if (!isUserInRole(sc, Arrays.asList(theseroles), false)) {
                     return false;

--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/providers/security/SecurityAnnoProviderRegister.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/providers/security/SecurityAnnoProviderRegister.java
@@ -17,6 +17,7 @@ import org.apache.cxf.jaxrs.security.SimpleAuthorizingFilter;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.ws.jaxrs20.providers.api.JaxRsProviderRegister;
+import com.ibm.ws.jaxrs20.security.LibertyAuthFilter;
 import com.ibm.ws.jaxrs20.security.LibertySimpleAuthorizingInterceptor;
 
 @Component(immediate=true)
@@ -28,10 +29,10 @@ public class SecurityAnnoProviderRegister implements JaxRsProviderRegister {
         if (!clientSide) {
             if (features.contains("appSecurity-2.0") || features.contains("appSecurity-1.0")) {
                 //add one built-in ContainerRequestFilter to handle basic security
-                SimpleAuthorizingFilter sm = new SimpleAuthorizingFilter();
+                LibertyAuthFilter laf = new LibertyAuthFilter();
                 LibertySimpleAuthorizingInterceptor in = new LibertySimpleAuthorizingInterceptor();
-                sm.setInterceptor(in);
-                providers.add(sm);
+                laf.setInterceptor(in);
+                providers.add(laf);
             }
         }
     }

--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/security/LibertyAuthFilter.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/security/LibertyAuthFilter.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.security;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+
+import org.apache.cxf.interceptor.security.AccessDeniedException;
+import org.apache.cxf.interceptor.security.AuthenticationException;
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.jaxrs20.security.LibertySimpleAuthorizingInterceptor;
+
+@Priority(Priorities.AUTHORIZATION)
+public class LibertyAuthFilter implements ContainerRequestFilter {
+    private LibertySimpleAuthorizingInterceptor interceptor;
+
+    @Override
+    @FFDCIgnore({ AuthenticationException.class, AccessDeniedException.class })
+    public void filter(ContainerRequestContext context) {
+        Message m = JAXRSUtils.getCurrentMessage();
+        try {
+            try {
+                interceptor.handleMessage(m);
+            } catch (AuthenticationException ex) {
+                if (authenticate(m)) {
+                    // try again with authenticated user
+                    interceptor.handleMessage(m);
+                } else {
+                    // could not authenticate - return 401
+                    // TODO: check response code on servlet response and use the same status?
+                    context.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
+                }
+            }
+        } catch (AccessDeniedException ex) {
+            context.abortWith(Response.status(Response.Status.FORBIDDEN).build());
+        }
+    }
+
+    private boolean authenticate(Message m) {
+        HttpServletRequest req = (HttpServletRequest) m.get(AbstractHTTPDestination.HTTP_REQUEST);
+        HttpServletResponse res = (HttpServletResponse) m.get(AbstractHTTPDestination.HTTP_RESPONSE);
+        try {
+            return req.authenticate(res);
+        } catch (IOException | ServletException e) {
+            // AutoFFDC
+        }
+        return false;
+    }
+
+    public void setInterceptor(LibertySimpleAuthorizingInterceptor in) {
+        interceptor = in;
+    }
+}


### PR DESCRIPTION
If a resource method requires authorization (via the @RolesAllowed
annotation), then we need to ensure authentication has been performed
before checking whether the user is in the role.