### PR TITLE
Include jsf container integration jar when server is minified

### DIFF
--- a/dev/com.ibm.websphere.appserver.jsfContainer-2.2/com.ibm.websphere.appserver.jsfContainer-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.jsfContainer-2.2/com.ibm.websphere.appserver.jsfContainer-2.2.feature
@@ -17,5 +17,6 @@ IBM-API-Package: org.jboss.weld; type="internal", \
   com.ibm.websphere.appserver.jndi-1.0, \
   com.ibm.websphere.appserver.jsp-2.3, \
   com.ibm.websphere.appserver.javaeeCompatible-7.0
+-files=lib/com.ibm.ws.jsfContainer.2.2_1.0.${libertyBundleMicroVersion}.jar
 kind=noship
 edition=full


### PR DESCRIPTION
Currently for the jsfContainer-2.2 feature we use a custom mechanism of applying the integration jar to the applications classloader, as opposed to having it be a proper OSGi bundle.

Regardless, there needs to be some sort of linkage that declares the integration jar as a resource needed by the jsfContainer-2.2 feature, so that when a server is minified the integration jar remains.