### PR TITLE
Capture all the thread context necessary when starting async tasks (17.0.0.3)

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
@@ -33,6 +33,7 @@ test.project: true
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.config.1.1;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.ws.security;version=latest,\
 	com.ibm.websphere.security;version=latest,\

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIAsyncTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIAsyncTest.java
@@ -72,6 +72,34 @@ public class CDIAsyncTest extends LoggingTest {
                                          "SUCCESS");
     }
 
+    @Test
+    public void testAsyncConfig() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/async?testMethod=testAsyncConfig",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testAsyncConfigInjected() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/async?testMethod=testAsyncConfigInjected",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testAsyncGetCdi() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/async?testMethod=testAsyncGetCdi",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testAsyncGetBeanManagerViaJndi() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/async?testMethod=testAsyncGetBeanManagerViaJndi",
+                                         "SUCCESS");
+    }
+
     /** {@inheritDoc} */
     @Override
     protected SharedServer getSharedServer() {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/resources/META-INF/microprofile-config.properties
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/resources/META-INF/microprofile-config.properties
@@ -11,3 +11,4 @@
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.FallbackBeanWithoutRetry/connectB/Fallback/value=com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.MyFallbackHandler2
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.FallbackBeanWithoutRetry/connectC/Fallback/fallbackMethod=connectFallback2
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanC/connectC2/Retry/abortOn=java.lang.IllegalArgumentException,com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException
+test/AsyncConfigValue=configuredAsyncValue

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/AsyncServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/AsyncServlet.java
@@ -24,6 +24,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -34,6 +36,8 @@ import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.AsyncBean;
 import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.AsyncBean2;
 import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.AsyncBean3;
 import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.AsyncCallableBean;
+import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.AsyncConfigBean;
+import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.AsyncThreadContextTestBean;
 import com.ibm.ws.microprofile.faulttolerance_fat.util.Connection;
 
 import componenttest.app.FATServlet;
@@ -53,6 +57,12 @@ public class AsyncServlet extends FATServlet {
 
     @Inject
     AsyncCallableBean callableBean;
+
+    @Inject
+    AsyncConfigBean configBean;
+
+    @Inject
+    AsyncThreadContextTestBean threadContextBean;
 
     public void testAsync(HttpServletRequest request,
                           HttpServletResponse response) throws ServletException, IOException, InterruptedException, ExecutionException, TimeoutException {
@@ -264,6 +274,26 @@ public class AsyncServlet extends FATServlet {
         assertThat("Call duration", duration, greaterThan(TestConstants.WORK_TIME - TestConstants.TEST_TWEAK_TIME_UNIT));
         assertThat("Call result", future.get(), is(notNullValue()));
         assertThat("Call result", future.get().getData(), equalTo(AsyncBean.CONNECT_A_DATA));
+    }
+
+    public void testAsyncConfig() throws Exception {
+        Future<String> value = configBean.getValue();
+        assertThat(value.get(), is("configuredAsyncValue"));
+    }
+
+    public void testAsyncConfigInjected() throws Exception {
+        Future<String> value = threadContextBean.getConfigValueFromInjectedBean();
+        assertThat(value.get(), is("configuredAsyncValue"));
+    }
+
+    public void testAsyncGetCdi() throws Exception {
+        Future<CDI<Object>> value = threadContextBean.getCdi();
+        assertThat(value.get(), notNullValue());
+    }
+
+    public void testAsyncGetBeanManagerViaJndi() throws Exception {
+        Future<BeanManager> value = threadContextBean.getBeanManagerViaJndi();
+        assertThat(value.get(), notNullValue());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/AsyncConfigBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/AsyncConfigBean.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+@ApplicationScoped
+@Asynchronous
+public class AsyncConfigBean {
+
+    @Inject
+    @ConfigProperty(name = "test/AsyncConfigValue")
+    String asyncConfigValue;
+
+    public Future<String> getValue() {
+        return CompletableFuture.completedFuture(asyncConfigValue);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/AsyncThreadContextTestBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/AsyncThreadContextTestBean.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+@ApplicationScoped
+@Asynchronous
+public class AsyncThreadContextTestBean {
+
+    @Inject
+    ConfigInjectedBean configBean;
+
+    public Future<String> getConfigValueFromInjectedBean() {
+        return CompletableFuture.completedFuture(configBean.getValue());
+    }
+
+    public Future<BeanManager> getBeanManagerViaJndi() throws NamingException {
+        BeanManager bm = (BeanManager) new InitialContext().lookup("java:comp/BeanManager");
+        return CompletableFuture.completedFuture(bm);
+    }
+
+    public Future<CDI<Object>> getCdi() {
+        return CompletableFuture.completedFuture(CDI.current());
+    }
+
+    @ApplicationScoped
+    public static class ConfigInjectedBean {
+        @Inject
+        @ConfigProperty(name = "test/AsyncConfigValue")
+        String asyncConfigValue;
+
+        public String getValue() {
+            return asyncConfigValue;
+        }
+    }
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance.impl.async;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Callable;
@@ -61,6 +63,20 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
     private final BulkheadPolicy bulkheadPolicy;
     private final WSContextService contextService;
     private final ExecutorService executorService;
+
+    /**
+     * The collection of contexts to capture under createThreadContext.
+     * Classloader, JeeMetadata, and security.
+     */
+    @SuppressWarnings("unchecked")
+    private static final Map<String, ?>[] THREAD_CONTEXT_PROVIDERS = new Map[] {
+                                                                                 Collections.singletonMap(WSContextService.THREAD_CONTEXT_PROVIDER,
+                                                                                                          "com.ibm.ws.classloader.context.provider"),
+                                                                                 Collections.singletonMap(WSContextService.THREAD_CONTEXT_PROVIDER,
+                                                                                                          "com.ibm.ws.javaee.metadata.context.provider"),
+                                                                                 Collections.singletonMap(WSContextService.THREAD_CONTEXT_PROVIDER,
+                                                                                                          "com.ibm.ws.security.context.provider"),
+    };
 
     public AsyncOuterExecutorImpl(RetryPolicy retryPolicy,
                                   CircuitBreakerPolicy circuitBreakerPolicy,
@@ -150,7 +166,7 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
             public Future<R> call() {
                 ThreadContextDescriptor threadContext = null;
                 if (contextService != null) {
-                    threadContext = contextService.captureThreadContext(new HashMap<String, String>());
+                    threadContext = contextService.captureThreadContext(new HashMap<String, String>(), THREAD_CONTEXT_PROVIDERS);
                 }
                 QueuedFuture<R> queuedFuture = new QueuedFuture<>(innerTask, executionContext, threadContext);
 


### PR DESCRIPTION
Also add tests to ensure that CDI bean initialization, config injection,
JNDI lookup and getting the CDI container all work inside an Async
method.