### PR TITLE
Make messages which reference a method less verbose

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/config/AsynchronousConfig.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/config/AsynchronousConfig.java
@@ -18,6 +18,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefiniti
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.microprofile.faulttolerance.utils.FTDebug;
 
 public class AsynchronousConfig extends AbstractAnnotationConfig<Asynchronous> implements Asynchronous {
 
@@ -44,7 +45,7 @@ public class AsynchronousConfig extends AbstractAnnotationConfig<Asynchronous> i
         if (method != null) {
             Class<?> originalMethodReturnType = getAnnotatedMethod().getReturnType();
             if (!(Future.class.isAssignableFrom(originalMethodReturnType))) {
-                throw new FaultToleranceDefinitionException(Tr.formatMessage(tc, "asynchronous.method.not.returning.future.CWMFT5001E", method));
+                throw new FaultToleranceDefinitionException(Tr.formatMessage(tc, "asynchronous.method.not.returning.future.CWMFT5001E", FTDebug.formatMethod(method)));
             }
         }
     }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/config/FallbackConfig.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/config/FallbackConfig.java
@@ -32,6 +32,7 @@ import com.ibm.ws.microprofile.faulttolerance.spi.FallbackHandlerFactory;
 import com.ibm.ws.microprofile.faulttolerance.spi.FallbackPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.FaultToleranceFunction;
 import com.ibm.ws.microprofile.faulttolerance.spi.FaultToleranceProvider;
+import com.ibm.ws.microprofile.faulttolerance.utils.FTDebug;
 
 public class FallbackConfig extends AbstractAnnotationConfig<Fallback> implements Fallback {
 
@@ -70,7 +71,8 @@ public class FallbackConfig extends AbstractAnnotationConfig<Fallback> implement
         String fallbackMethodName = fallbackMethod();
         //If both fallback method and fallback class are set, it is an illegal state.
         if ((fallbackClass != null && fallbackClass != Fallback.DEFAULT.class) && (fallbackMethodName != null && !"".equals(fallbackMethodName))) {
-            throw new FaultToleranceDefinitionException(Tr.formatMessage(tc, "fallback.policy.conflicts.CWMFT5009E", originalMethod, fallbackClass, fallbackMethodName));
+            throw new FaultToleranceDefinitionException(Tr.formatMessage(tc, "fallback.policy.conflicts.CWMFT5009E", FTDebug.formatMethod(originalMethod), fallbackClass,
+                                                                         fallbackMethodName));
         } else if (fallbackClass != null && fallbackClass != Fallback.DEFAULT.class) {
             //need to load the fallback class and then find out the method return type
             try {
@@ -91,8 +93,8 @@ public class FallbackConfig extends AbstractAnnotationConfig<Fallback> implement
                 }
 
                 if (!validFallbackHandler) {
-                    throw new FaultToleranceDefinitionException(Tr.formatMessage(tc, "fallback.policy.invalid.CWMFT5008E", originalMethod, fallbackClass, originalMethodReturnType,
-                                                                                 originalMethod));
+                    throw new FaultToleranceDefinitionException(Tr.formatMessage(tc, "fallback.policy.invalid.CWMFT5008E", FTDebug.formatMethod(originalMethod), fallbackClass,
+                                                                                 originalMethodReturnType, originalMethod.getName()));
                 }
             } catch (NoSuchMethodException e) {
                 //should not happen

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/.classpath
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/.classpath
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-        <classpathentry kind="src" path="resources"/>
-        <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-        <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-        <classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" path="resources"/>
+	<classpathentry kind="src" output="bin_test" path="test/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/.project
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=skip
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/bnd.bnd
@@ -20,7 +20,9 @@ Bundle-Description: MicroProfile Fault Tolerance SPI, version ${bVersion}
 
 Import-Package: *
 
-Export-Package: com.ibm.ws.microprofile.faulttolerance.spi
+Export-Package:\
+    com.ibm.ws.microprofile.faulttolerance.spi,\
+    com.ibm.ws.microprofile.faulttolerance.utils
 
 Private-Package: \
     com.ibm.ws.microprofile.faulttolerance.spi.resources
@@ -33,6 +35,8 @@ WS-TraceGroup: FAULTTOLERANCE
 -dsannotations-inherit: true
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+testsrc: test/src
 
 -buildpath: \
 	com.ibm.ws.logging;version=latest,\
@@ -47,4 +51,9 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 	com.ibm.ws.cdi.1.2.interfaces;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+
+-testpath: \
+	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
+	../build.sharedResources/lib/ws-junit/ws-junit.jar;version=file, \
+	org.hamcrest:hamcrest-all;version=1.3
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/utils/FTDebug.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/utils/FTDebug.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance.utils;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ *
+ */
+public class FTDebug {
+
+    @Trivial
+    public static void debugRelativeTime(TraceComponent tc, String id, String message, long relativePointA) {
+        debugRelativeTime(tc, id, message, relativePointA, System.nanoTime());
+    }
+
+    @Trivial
+    public static void debugRelativeTime(TraceComponent tc, String id, String message, long relativePointA, long relativePointB) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "{0}: {1}: {2}", id, message, relativeSeconds(relativePointA, relativePointB));
+        }
+    }
+
+    @Trivial
+    public static void debugTime(TraceComponent tc, String message, long time) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "{0}: {1}", message, toSeconds(time));
+        }
+    }
+
+    @Trivial
+    public static void debugTime(TraceComponent tc, String id, String message, long time) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "{0}: {1}: {2}", id, message, toSeconds(time));
+        }
+    }
+
+    /**
+     * Format a method for display in a log message
+     * <p>
+     * Uses the format:
+     * <p>
+     * {@code com.example.MyClass.InnerClass.myMethod(String, Map, MyBean)}
+     * <p>
+     * This is a compromise between including enough information to identify the method, while not being too verbose like {@code Method.toString()}
+     *
+     * @param m the method
+     * @return a string representation of the method
+     */
+    @Trivial
+    public static String formatMethod(Method m) {
+        if (m == null) {
+            return "null";
+        }
+    
+        StringBuilder sb = new StringBuilder();
+        sb.append(m.getDeclaringClass().getName());
+        sb.append(".");
+        sb.append(m.getName());
+    
+        sb.append("(");
+        sb.append(Arrays.stream(m.getParameterTypes()).map(Class::getSimpleName).collect(Collectors.joining(", ")));
+        sb.append(")");
+    
+        return sb.toString();
+    }
+
+    //in seconds, how long between two a relative points (nanoTime)
+    @Trivial
+    public static double relativeSeconds(long relativePointA, long relativePointB) {
+        long diff = relativePointB - relativePointA;
+        double seconds = toSeconds(diff);
+        return seconds;
+    }
+
+    //convert from nanos (long) to seconds (double)
+    @Trivial
+    public static double toSeconds(long nanos) {
+        return ((double) nanos / (double) 1000000000);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/utils/package-info.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/utils/package-info.java
@@ -6,19 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.microprofile.faulttolerance.impl;
-
-/**
- *
- */
-public class FTConstants {
-
-    public static final String SCHEDULED_EXECUTOR_SERVICE_JNDI = "java:comp/DefaultManagedScheduledExecutorService";
-
-    public static final String JSE_FLAG = "com.ibm.ws.microprofile.faulttolerance.jse";
-
-    public static final long MIN_TIMEOUT_NANO = 1000000; //1ms
-
-}
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.ws.microprofile.faulttolerance.utils;

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/test/src/com/ibm/ws/microprofile/faulttolerance/utils/test/MethodFormatSample.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/test/src/com/ibm/ws/microprofile/faulttolerance/utils/test/MethodFormatSample.java
@@ -8,17 +8,24 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.microprofile.faulttolerance.impl;
+package com.ibm.ws.microprofile.faulttolerance.utils.test;
+
+import java.util.concurrent.Future;
+
+import com.ibm.ws.microprofile.faulttolerance.utils.test.TestFormatMethod;
 
 /**
- *
+ * Sample class with methods to support {@link TestFormatMethod}
  */
-public class FTConstants {
+public class MethodFormatSample {
 
-    public static final String SCHEDULED_EXECUTOR_SERVICE_JNDI = "java:comp/DefaultManagedScheduledExecutorService";
+    public void simpleMethod() {}
 
-    public static final String JSE_FLAG = "com.ibm.ws.microprofile.faulttolerance.jse";
+    public void methodWithParameters(String a, int b) {}
 
-    public static final long MIN_TIMEOUT_NANO = 1000000; //1ms
+    public void genericParameter(Future<String> future) {}
 
+    public static class InnerClass {
+        public void innerClassMethod() {}
+    }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/test/src/com/ibm/ws/microprofile/faulttolerance/utils/test/TestFormatMethod.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/test/src/com/ibm/ws/microprofile/faulttolerance/utils/test/TestFormatMethod.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance.utils.test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.faulttolerance.utils.FTDebug;
+import com.ibm.ws.microprofile.faulttolerance.utils.test.MethodFormatSample.InnerClass;
+
+/**
+ * Test {@link FTConstants#formatMethod(Method)}
+ */
+public class TestFormatMethod {
+
+    @Test
+    public void testSimpleMethod() {
+        String methodString = FTDebug.formatMethod(getMethod(MethodFormatSample.class, "simpleMethod"));
+        assertThat(methodString, is("com.ibm.ws.microprofile.faulttolerance.utils.test.MethodFormatSample.simpleMethod()"));
+    }
+
+    @Test
+    public void testMethodWithParameters() {
+        String methodString = FTDebug.formatMethod(getMethod(MethodFormatSample.class, "methodWithParameters"));
+        assertThat(methodString, is("com.ibm.ws.microprofile.faulttolerance.utils.test.MethodFormatSample.methodWithParameters(String, int)"));
+    }
+
+    @Test
+    public void testInnerClassMethod() {
+        String methodString = FTDebug.formatMethod(getMethod(InnerClass.class, "innerClassMethod"));
+        assertThat(methodString, is("com.ibm.ws.microprofile.faulttolerance.utils.test.MethodFormatSample$InnerClass.innerClassMethod()"));
+    }
+
+    @Test
+    public void testGenericParameter() {
+        String methodString = FTDebug.formatMethod(getMethod(MethodFormatSample.class, "genericParameter"));
+        assertThat(methodString, is("com.ibm.ws.microprofile.faulttolerance.utils.test.MethodFormatSample.genericParameter(Future)"));
+    }
+
+    @Test
+    public void testInheritedMethod() {
+        String methodString = FTDebug.formatMethod(getMethod(MethodFormatSample.class, "toString"));
+        assertThat(methodString, is("java.lang.Object.toString()"));
+    }
+
+    @Test
+    public void testNull() {
+        assertThat(FTDebug.formatMethod(null), is("null"));
+    }
+
+    private Method getMethod(Class<?> clazz, String methodName) {
+        return Arrays.stream(clazz.getMethods()).filter((m) -> m.getName().equals(methodName)).findFirst().get();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/ExecutionContextImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/ExecutionContextImpl.java
@@ -19,6 +19,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.microprofile.faulttolerance.impl.async.QueuedFuture;
 import com.ibm.ws.microprofile.faulttolerance.spi.FTExecutionContext;
 import com.ibm.ws.microprofile.faulttolerance.spi.FallbackPolicy;
+import com.ibm.ws.microprofile.faulttolerance.utils.FTDebug;
 
 public class ExecutionContextImpl implements FTExecutionContext {
 
@@ -79,7 +80,7 @@ public class ExecutionContextImpl implements FTExecutionContext {
     }
 
     public void start(QueuedFuture<?> future) {
-        if(this.closed){
+        if (this.closed) {
             throw new IllegalStateException();
         }
         this.startTime = System.nanoTime();
@@ -195,7 +196,7 @@ public class ExecutionContextImpl implements FTExecutionContext {
     private void debugRelativeTime(String message) {
         //System.out.println(getDescriptor() + " (" + FTConstants.relativeSeconds(startTime, System.nanoTime()) + "): " + message);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            FTConstants.debugRelativeTime(tc, getDescriptor(), message, this.startTime);
+            FTDebug.debugRelativeTime(tc, getDescriptor(), message, this.startTime);
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/TimeoutImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/TimeoutImpl.java
@@ -22,6 +22,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.microprofile.faulttolerance.impl.async.QueuedFuture;
 import com.ibm.ws.microprofile.faulttolerance.spi.TimeoutPolicy;
+import com.ibm.ws.microprofile.faulttolerance.utils.FTDebug;
 
 /**
  *
@@ -289,7 +290,7 @@ public class TimeoutImpl {
     @Trivial
     private void debugRelativeTime(String message) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            FTConstants.debugRelativeTime(tc, getDescriptor(), message, this.start);
+            FTDebug.debugRelativeTime(tc, getDescriptor(), message, this.start);
         }
     }
 
@@ -302,7 +303,7 @@ public class TimeoutImpl {
     @Trivial
     private void debugTime(String message, long nanos) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            FTConstants.debugTime(tc, getDescriptor(), message, nanos);
+            FTDebug.debugTime(tc, getDescriptor(), message, nanos);
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
@@ -39,6 +39,7 @@ import com.ibm.ws.microprofile.faulttolerance.spi.ExecutionException;
 import com.ibm.ws.microprofile.faulttolerance.spi.FallbackPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.RetryPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.TimeoutPolicy;
+import com.ibm.ws.microprofile.faulttolerance.utils.FTDebug;
 import com.ibm.ws.threading.PolicyExecutor;
 import com.ibm.ws.threading.PolicyExecutor.QueueFullAction;
 import com.ibm.ws.threading.PolicyExecutorProvider;
@@ -163,7 +164,8 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
                     //be rejected otherwise!
                     executionContext.close();
 
-                    BulkheadException bulkheadException = new BulkheadException(Tr.formatMessage(tc, "bulkhead.no.threads.CWMFT0001E", executionContext.getMethod()), e);
+                    BulkheadException bulkheadException = new BulkheadException(Tr.formatMessage(tc, "bulkhead.no.threads.CWMFT0001E",
+                                                                                                 FTDebug.formatMethod(executionContext.getMethod())), e);
                     reportFailure(executionContext, bulkheadException);
                     throw bulkheadException;
                 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/sync/SemaphoreTaskRunner.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/sync/SemaphoreTaskRunner.java
@@ -19,6 +19,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.microprofile.faulttolerance.impl.ExecutionContextImpl;
 import com.ibm.ws.microprofile.faulttolerance.spi.BulkheadPolicy;
+import com.ibm.ws.microprofile.faulttolerance.utils.FTDebug;
 
 /**
  * SemaphoreTaskRunner will try to acquire a semaphore token before running. If it can not then an exception is thrown.
@@ -42,7 +43,7 @@ public class SemaphoreTaskRunner<R> extends SimpleTaskRunner<R> {
         }
         boolean acquired = this.semaphore.tryAcquire();
         if (!acquired) {
-            throw new BulkheadException(Tr.formatMessage(tc, "bulkhead.no.threads.CWMFT0001E", executionContext.getMethod()));
+            throw new BulkheadException(Tr.formatMessage(tc, "bulkhead.no.threads.CWMFT0001E", FTDebug.formatMethod(executionContext.getMethod())));
         }
         try {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/sync/SimpleTaskRunner.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/sync/SimpleTaskRunner.java
@@ -16,8 +16,8 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.microprofile.faulttolerance.impl.ExecutionContextImpl;
-import com.ibm.ws.microprofile.faulttolerance.impl.FTConstants;
 import com.ibm.ws.microprofile.faulttolerance.impl.TaskRunner;
+import com.ibm.ws.microprofile.faulttolerance.utils.FTDebug;
 
 /**
  * SimpleTaskRunner will call the task and end the execution afterwards
@@ -35,7 +35,7 @@ public class SimpleTaskRunner<R> implements TaskRunner<R> {
         } catch (InterruptedException e) {
             //if the interrupt was caused by a timeout then check and throw that instead (which is what check does)
             long remaining = executionContext.check();
-            FTConstants.debugTime(tc, "Task Interrupted", remaining);
+            FTDebug.debugTime(tc, "Task Interrupted", remaining);
             throw e;
         } finally {
             executionContext.end();


### PR DESCRIPTION
Previously these messages were putting in java.lang.Method.toString()
which is very verbose and includes all information about the method.

In an error message, this is not useful. We just want enough
information for the user to identify the problematic method.