### PR TITLE
Issue #96: Fix cache labels in ldapRegistry-3.0 feature.

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/l10n/metatype.properties
@@ -293,11 +293,11 @@ size.desc=The size of the cache. The number of search results that are stored in
 searchResultsTimeOut=Timeout
 searchResultsTimeOut.desc=Defines the maximum time that the contents of the search results cache are available. When the specified time has elapsed, the search results cache is cleared.
 
-sizeLimit=Size limit
-sizeLimit.desc=The size limit for the cache.
+sizeLimit=Maximum entity attributes cached
+sizeLimit.desc=The maximum number of attributes per LDAP entity that will be cached.
 
-resultsSizeLimit=Results size limit
-resultsSizeLimit.desc=The maximum number of results that can be returned in the search.
+resultsSizeLimit=Maximum search results cached
+resultsSizeLimit.desc=The maximum number of results that can be cached for a single LDAP search.
 
 #==== LDAP Attribute configuration
 attribute=LDAP Attribute Properties


### PR DESCRIPTION
Updated descriptions to be more accurate. This requires including the word "attribute," which is restricted and will need to be allowed.