### PR TITLE
90 - Add Introspector for Policy Executor to ThreadingIntrospector

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutorProvider.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutorProvider.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.threading;
 
+import java.io.PrintWriter;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
@@ -62,5 +63,11 @@ public class PolicyExecutorProvider {
      */
     public PolicyExecutor create(String identifier) {
         return new PolicyExecutorImpl((ExecutorServiceImpl) globalExecutor, identifier, policyExecutors);
+    }
+
+    public void introspectPolicyExecutors(PrintWriter out) {
+        for (PolicyExecutorImpl executor : policyExecutors.values()) {
+            executor.introspect(out);
+        }
     }
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.threading.internal;
 
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -958,5 +959,47 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         PolicyTaskFuture<?> policyTaskFuture = new PolicyTaskFuture<Void>(task, null);
         enqueue(policyTaskFuture, maxWaitForEnqueueNS.get(), null);
         return policyTaskFuture;
+    }
+
+    public void introspect(PrintWriter out) {
+        final String INDENT = "  ";
+        final String DOUBLEINDENT = INDENT + INDENT;
+        out.println(identifier);
+        out.println(INDENT + "coreConcurrency = " + coreConcurrency);
+        out.println(INDENT + "maxConcurrency = " + maxConcurrency);
+        out.println(INDENT + "maxQueueSize = " + maxQueueSize);
+        out.println(INDENT + "maxWaitForEnqueue = " + TimeUnit.NANOSECONDS.toMillis(maxWaitForEnqueueNS.get()) + " ms");
+        out.println(INDENT + "queueFullAction = " + queueFullAction.toString());
+        int numRunningThreads, numRunningPrioritizedThreads;
+        synchronized (configLock) {
+            numRunningThreads = maxConcurrency - maxConcurrencyConstraint.availablePermits();
+            numRunningPrioritizedThreads = coreConcurrency - coreConcurrencyAvailable.get();
+        }
+        out.println(INDENT + "Total Enqueued to Global Executor = " + numRunningThreads + " (" + numRunningPrioritizedThreads + " expedited)");
+        out.println(INDENT + "withheldConcurrency = " + withheldConcurrency.get());
+        out.println(INDENT + "Remaining Queue Capacity = " + maxQueueSizeConstraint.availablePermits());
+        out.println(INDENT + "Created by PolicyExecutorProvider = " + (providerCreated != null));
+        out.println(INDENT + "state = " + state.toString());
+        out.println(INDENT + "Running Task Futures: ");
+        if (running.isEmpty()) {
+            out.println(DOUBLEINDENT + "None");
+        } else {
+            for (PolicyTaskFuture<?> task : running) {
+                out.println(DOUBLEINDENT + task.toString());
+            }
+        }
+        int counter = 50;
+        out.println(INDENT + "Queued Task Futures (up to first " + counter + "):");
+        if (queue.isEmpty()) {
+            out.println(DOUBLEINDENT + "None");
+        } else {
+            for (PolicyTaskFuture<?> task : queue) {
+                if (counter-- > 0)
+                    out.println(DOUBLEINDENT + task.toString());
+                else
+                    break;
+            }
+        }
+        out.println();
     }
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ThreadingIntrospector.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ThreadingIntrospector.java
@@ -17,6 +17,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
+import com.ibm.ws.threading.PolicyExecutorProvider;
 import com.ibm.wsspi.logging.Introspector;
 import com.ibm.wsspi.threading.WSExecutorService;
 
@@ -40,6 +41,9 @@ public class ThreadingIntrospector implements Introspector {
     protected void unsetWSExecutorService(WSExecutorService wses) {
         impl = null;
     }
+
+    @Reference
+    private PolicyExecutorProvider provider;
 
     /*
      * (non-Javadoc)
@@ -74,6 +78,8 @@ public class ThreadingIntrospector implements Introspector {
             ThreadPoolController tpc = impl.threadPoolController;
             tpc.introspect(out);
         }
+        out.println();
+        provider.introspectPolicyExecutors(out);
     }
 
 }


### PR DESCRIPTION
Example Policy Executor Introspector output:

PolicyExecutorProvider-testConcurrentCancelQueuedTasks
&nbsp;&nbsp;coreConcurrency = 0
&nbsp;&nbsp;maxConcurrency = 1
&nbsp;&nbsp;maxQueueSize = 4
&nbsp;&nbsp;maxWaitForEnqueue = 720000 ms
&nbsp;&nbsp;queueFullAction = null
&nbsp;&nbsp;Total Enqueued to Global Executor = 1 (0 expedited)
&nbsp;&nbsp;withheldConcurrency = 0
&nbsp;&nbsp;Remaining Queue Capacity = 4
&nbsp;&nbsp;Created by PolicyExecutorProvider = true
&nbsp;&nbsp;state = ACTIVE
&nbsp;&nbsp;Running Task Futures: 
&nbsp;&nbsp;&nbsp;&nbsp;PolicyTaskFuture@7178b821 for web.CountDownTask@7dd937c0 on PolicyExecutorProvider-testConcurrentCancelQueuedTasks
&nbsp;&nbsp;Queued Task Futures (up to first 50):
&nbsp;&nbsp;&nbsp;&nbsp;None