### PR TITLE
Make jsf-2.2 and jsfContainer-2.2 features singletons

### DIFF
--- a/dev/com.ibm.websphere.appserver.jsf-2.2/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.jsf-2.2/bnd.bnd
@@ -21,6 +21,7 @@ publish.feature.resources: **
 	com.ibm.websphere.appserver.javax.jsf-2.2;version=latest, \
 	com.ibm.websphere.appserver.jsp-2.3;version=latest, \
 	com.ibm.websphere.appserver.javaeeCompatible-7.0;version=latest, \
+	com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces;version=latest,\
 	com.ibm.ws.org.apache.commons.beanutils;version=latest, \
 	com.ibm.ws.org.apache.commons.collections;version=latest, \
 	com.ibm.ws.jsf.2.2;version=latest, \

--- a/dev/com.ibm.websphere.appserver.jsf-2.2/com.ibm.websphere.appserver.jsf-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.jsf-2.2/com.ibm.websphere.appserver.jsf-2.2.feature
@@ -31,6 +31,7 @@ Subsystem-Name: JavaServer Faces 2.2
  com.ibm.websphere.appserver.javax.validation-1.1, \
  com.ibm.websphere.appserver.javax.jsf-2.2, \
  com.ibm.websphere.appserver.jsp-2.3, \
+ com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces, \
  com.ibm.websphere.appserver.javaeeCompatible-7.0
 -bundles=com.ibm.ws.org.apache.commons.beanutils.1.8.3, \
  com.ibm.ws.org.apache.commons.collections.3.2.1, \

--- a/dev/com.ibm.websphere.appserver.jsfContainer-2.2/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.jsfContainer-2.2/bnd.bnd
@@ -20,4 +20,5 @@ publish.feature.resources: **
 	com.ibm.websphere.appserver.javax.validation-1.1;version=latest, \
 	com.ibm.websphere.appserver.jsp-2.3;version=latest, \
 	com.ibm.websphere.appserver.jsfProvider-2.2.0.Container;version=latest, \
-	com.ibm.websphere.appserver.javaeeCompatible-7.0;version=latest
+	com.ibm.websphere.appserver.javaeeCompatible-7.0;version=latest, \
+	com.ibm.ws.jsfContainer.2.2;version=latest

--- a/dev/com.ibm.websphere.appserver.jsfContainer-2.2/com.ibm.websphere.appserver.jsfContainer-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.jsfContainer-2.2/com.ibm.websphere.appserver.jsfContainer-2.2.feature
@@ -18,5 +18,6 @@ IBM-API-Package: org.jboss.weld; type="internal", \
   com.ibm.websphere.appserver.jsp-2.3, \
   com.ibm.websphere.appserver.jsfProvider-2.2.0.Container, \
   com.ibm.websphere.appserver.javaeeCompatible-7.0
+-jars=com.ibm.ws.jsfContainer.2.2; location:=lib/
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.jsfContainer-2.2/com.ibm.websphere.appserver.jsfContainer-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.jsfContainer-2.2/com.ibm.websphere.appserver.jsfContainer-2.2.feature
@@ -16,6 +16,7 @@ IBM-API-Package: org.jboss.weld; type="internal", \
   com.ibm.websphere.appserver.javax.validation-1.1, \
   com.ibm.websphere.appserver.jndi-1.0, \
   com.ibm.websphere.appserver.jsp-2.3, \
+  com.ibm.websphere.appserver.jsfProvider-2.2.0.Container, \
   com.ibm.websphere.appserver.javaeeCompatible-7.0
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container/.classpath
+++ b/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container/.project
+++ b/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.websphere.appserver.jsfProvider-2.2.0.Container</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container/bnd.bnd
@@ -12,12 +12,4 @@
 
 -nobundles=true
 
-publish.feature.resources: **
-
--dependson: \
-	com.ibm.websphere.appserver.javax.cdi-1.2;version=latest, \
-	com.ibm.websphere.appserver.servlet-3.1;version=latest, \
-	com.ibm.websphere.appserver.javax.validation-1.1;version=latest, \
-	com.ibm.websphere.appserver.jsp-2.3;version=latest, \
-	com.ibm.websphere.appserver.jsfProvider-2.2.0.Container;version=latest, \
-	com.ibm.websphere.appserver.javaeeCompatible-7.0;version=latest
+publish.feature.resources: *.mf

--- a/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container/build.gradle
+++ b/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container/build.gradle
@@ -1,0 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/

--- a/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container.feature
+++ b/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container/com.ibm.websphere.appserver.jsfProvider-2.2.0.Container.feature
@@ -1,0 +1,8 @@
+# This private feature corresponds to using a JSF-providing feature
+# with just a container and no implementation (e.g. jsfContainer-2.2)
+-include= ~../cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.jsfProvider-2.2.0.Container
+singleton=true
+visibility=private
+kind=noship
+edition=full

--- a/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces/.classpath
+++ b/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces/.project
+++ b/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces/bnd.bnd
@@ -12,12 +12,4 @@
 
 -nobundles=true
 
-publish.feature.resources: **
-
--dependson: \
-	com.ibm.websphere.appserver.javax.cdi-1.2;version=latest, \
-	com.ibm.websphere.appserver.servlet-3.1;version=latest, \
-	com.ibm.websphere.appserver.javax.validation-1.1;version=latest, \
-	com.ibm.websphere.appserver.jsp-2.3;version=latest, \
-	com.ibm.websphere.appserver.jsfProvider-2.2.0.Container;version=latest, \
-	com.ibm.websphere.appserver.javaeeCompatible-7.0;version=latest
+publish.feature.resources: *.mf

--- a/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces/build.gradle
+++ b/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces/build.gradle
@@ -1,0 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/

--- a/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces.feature
+++ b/dev/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces/com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces.feature
@@ -1,0 +1,8 @@
+# This private feature corresponds to using a JSF-providing feature
+# with the Apache MyFaces implementation
+-include= ~../cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.jsfProvider-2.2.0.MyFaces
+singleton=true
+visibility=private
+kind=ga
+edition=core

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
@@ -23,7 +23,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 JSF22FlowsTests.class,
                 CDIFlowsTests.class,
                 JSF22StatelessViewTests.class,
-                JSF22BeanValidationTests.class
+                JSF22BeanValidationTests.class,
+                FeatureConflictTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/fat/src/com/ibm/ws/jsf/container/fat/FeatureConflictTest.java
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/fat/src/com/ibm/ws/jsf/container/fat/FeatureConflictTest.java
@@ -42,6 +42,6 @@ public class FeatureConflictTest extends FATServletClient {
         server.startServer();
         assertNotNull(server.waitForStringInLog(".* CWWKF0033E: " +
                                                 ".* com.ibm.websphere.appserver.jsfProvider-2.2.0.[MyFaces|Container]" +
-                                                ".* com.ibm.websphere.appserver.jsfProvider-2.2.0.[MyFaces|Container].*", 5000));
+                                                ".* com.ibm.websphere.appserver.jsfProvider-2.2.0.[MyFaces|Container].*"));
     }
 }

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/fat/src/com/ibm/ws/jsf/container/fat/FeatureConflictTest.java
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/fat/src/com/ibm/ws/jsf/container/fat/FeatureConflictTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jsf.container.fat;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class FeatureConflictTest extends FATServletClient {
+
+    @Server("jsf.container.2.2_fat.featureconflict")
+    public static LibertyServer server;
+
+    @AfterClass
+    public static void testCleanup() throws Exception {
+        server.stopServer();
+    }
+
+    /**
+     * Verify that the jsf-2.2 and jsfContainer-2.2 features cannot be loaded at the same time
+     */
+    @Test
+    @ExpectedFFDC("java.lang.IllegalArgumentException")
+    public void testFeatureConflict() throws Exception {
+        server.startServer();
+        assertNotNull(server.waitForStringInLog(".* CWWKF0033E: " +
+                                                ".* com.ibm.websphere.appserver.jsfProvider-2.2.0.[MyFaces|Container]" +
+                                                ".* com.ibm.websphere.appserver.jsfProvider-2.2.0.[MyFaces|Container].*", 5000));
+    }
+}

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/servers/jsf.container.2.2_fat.featureconflict/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/servers/jsf.container.2.2_fat.featureconflict/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/servers/jsf.container.2.2_fat.featureconflict/server.xml
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/servers/jsf.container.2.2_fat.featureconflict/server.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <!-- This server configuration is invalid, we we will use it to verify that  -->
+    <!-- the jsf-2.2 and jsfContainer-2.2 features cannot be loaded at the same time -->
+	<featureManager>
+		<feature>jsfContainer-2.2</feature>
+		<feature>jsf-2.2</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+</server>


### PR DESCRIPTION
A user should not be able to enable jsf-2.2 and jsfContainer-2.2 features in the same server, so we need to use private features to ensure that these two public features conflict with each other.

Additionally, the JSF Container integration jar is not a traditional bundle, but it still needs to be declared as part of the jsfContainer-2.2 feature so that the integration jar is not minified out of the server.