### PR TITLE
Issue #81 - Add more CB FAT tests to exercise retries with CBs in particular

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDICircuitBreakerTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDICircuitBreakerTest.java
@@ -56,6 +56,48 @@ public class CDICircuitBreakerTest extends LoggingTest {
                                          "SUCCESS");
     }
 
+    @Test
+    public void testCBSyncFallback() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBSyncFallback",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testCBSyncRetryCircuitOpens() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBSyncRetryCircuitOpens",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testCBSyncRetryCircuitClosed() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBSyncRetryCircuitClosed",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testCBAsyncRetryCircuitOpens() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBAsyncRetryCircuitOpens",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testCBAsyncRetryCircuitClosed() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBAsyncRetryCircuitClosed",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testCBFailureThresholdWithRoll() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBFailureThresholdWithRoll",
+                                         "SUCCESS");
+    }
+
     /** {@inheritDoc} */
     @Override
     protected SharedServer getSharedServer() {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/CircuitBreakerServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/CircuitBreakerServlet.java
@@ -2,6 +2,7 @@ package com.ibm.ws.microprofile.faulttolerance_fat.cdi;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /*******************************************************************************
@@ -45,6 +46,9 @@ public class CircuitBreakerServlet extends FATServlet {
     CircuitBreakerBean bean;
 
     /**
+     * Test the operation of the requestVolumeThreshold on a CircuitBreaker configured on a synchronous service
+     * that is configured with a Timeout.
+     *
      * @throws InterruptedException
      * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
      */
@@ -77,6 +81,8 @@ public class CircuitBreakerServlet extends FATServlet {
     }
 
     /**
+     * Test the operation of the requestVolumeThreshold on a CircuitBreaker configured on a synchronous service.
+     *
      * @throws InterruptedException
      * @throws ConnectException
      * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
@@ -112,6 +118,11 @@ public class CircuitBreakerServlet extends FATServlet {
         }
     }
 
+    /**
+     * Test the behaviour of an asynchronous service configured with a CircuitBreaker.
+     *
+     * @throws Exception
+     */
     public void testCBAsync() throws Exception {
         for (int i = 0; i < 3; i++) {
             try {
@@ -132,6 +143,11 @@ public class CircuitBreakerServlet extends FATServlet {
         }
     }
 
+    /**
+     * Test the behaviour of an asynchronous service configured with a CircuitBreaker and Fallback method.
+     *
+     * @throws Exception
+     */
     public void testCBAsyncFallback() throws Exception {
         for (int i = 0; i < 3; i++) {
             assertThat(bean.serviceD().get(), is("serviceDFallback"));
@@ -148,6 +164,199 @@ public class CircuitBreakerServlet extends FATServlet {
 
         // However, we don't expect the call to have reached the serviceD method
         assertThat(bean.getExecutionCounterD(), is(3));
+    }
+
+    /**
+     * Test the behaviour of a service configured with a CircuitBreaker and Fallback method. This is the
+     * synchronous version of testCBAsyncFallback.
+     *
+     * @throws Exception
+     */
+    public void testCBSyncFallback() throws Exception {
+        String result = null;
+        for (int i = 0; i < 3; i++) {
+            try {
+                result = bean.serviceE();
+                assertThat(result, is("serviceEFallback"));
+            } catch (ConnectException e) {
+                // We should have fallen back, assert if a ConnectException is thrown
+                throw new AssertionError("ConnectException not expected");
+            } catch (Exception ue) {
+                // We should have fallen back, assert if an unexpected Exception is thrown
+                throw new AssertionError("Unexpected exception " + ue);
+            }
+        }
+
+        // Confirm that the service was called 3 times.
+        assertThat(bean.getExecutionCounterE(), is(3));
+
+        // Circuit should now be open. Attempt to call serviceE once more.
+        try {
+            result = bean.serviceE();
+        } catch (ConnectException e) {
+            // We should have fallen back, assert if a ConnectException is thrown
+            throw new AssertionError("ConnectException not expected");
+        } catch (Exception ue) {
+            // We should have fallen back, assert if an unexpected Exception is thrown
+            throw new AssertionError("Unexpected exception " + ue);
+        }
+
+        // CB is open, expect to fall back
+        assertThat(result, is("serviceEFallback"));
+
+        // However, we don't expect the call to have reached the serviceE method because the Circuit is open
+        // so the counter should not have been further incremented.
+        assertThat(bean.getExecutionCounterE(), is(3));
+    }
+
+    /**
+     * Test the behaviour of a service configured with a CircuitBreaker and Retry annotation. In this test
+     * maxRetries is set sufficiently high that the Circuit will open before maxRetries is reached and
+     * a CircuitBreakerOpenException will be caught.
+     *
+     * @throws Exception
+     */
+    public void testCBSyncRetryCircuitOpens() throws Exception {
+        String result = null;
+
+        try {
+            result = bean.serviceF();
+            throw new AssertionError("serviceF should be retried");
+        } catch (CircuitBreakerOpenException cboe) {
+            // Confirm that the service was called 3 times before this exception was thrown.
+            assertThat(bean.getExecutionCounterF(), is(3));
+        } catch (ConnectException e) {
+            // We should have retried or thrown a CircuitBreakerOpenException, assert if a ConnectException is thrown
+            throw new AssertionError("ConnectException not expected");
+        } catch (Exception ue) {
+            // We should have retried or thrown a CircuitBreakerOpenException, assert if an unexpected Exception is thrown
+            throw new AssertionError("Unexpected exception " + ue);
+        }
+    }
+
+    /**
+     * Test the behaviour of a service configured with a CircuitBreaker and Retry annotation. In this test
+     * maxRetries is set sufficiently low that the Circuit will remain closed after maxRetries is reached and
+     * a ConnectionException will be caught.
+     *
+     * @throws Exception
+     */
+    public void testCBSyncRetryCircuitClosed() throws Exception {
+        String result = null;
+
+        try {
+            result = bean.serviceG();
+            throw new AssertionError("serviceG should be retried");
+        } catch (CircuitBreakerOpenException cboe) {
+            throw new AssertionError("CircuitBreakerOpenException not expected");
+        } catch (ConnectException e) {
+            // Confirm that the service was called 2 times before this exception was thrown.
+            assertThat(bean.getExecutionCounterG(), is(2));
+        } catch (Exception ue) {
+            // We should have retried or thrown a ConnectionException, assert if an unexpected Exception is thrown
+            throw new AssertionError("Unexpected exception " + ue);
+        }
+    }
+
+    /**
+     * The Asynchronous equivalent of testCBSyncRetryCircuitOpens, to test the behaviour of a service configured
+     * with CircuitBreaker, Retry and Asynchronous annotations. In this test maxRetries is set sufficiently high
+     * that the Circuit will open before maxRetries is reached and a CircuitBreakerOpenException will be thrown.
+     *
+     * @throws Exception
+     */
+    public void testCBAsyncRetryCircuitOpens() throws Exception {
+        Future<String> future = null;
+        try {
+            future = bean.serviceH();
+        } catch (Exception ue) {
+            // Assert if an unexpected Exception is thrown
+            throw new AssertionError("Unexpected exception " + ue);
+        }
+
+        try {
+            String result = future.get();
+            throw new AssertionError("serviceH should be retried");
+        } catch (ExecutionException ee) {
+            // The Service will be retried three times. On the third retry a CircuitBreakerOpenException
+            // will be thrown. This will be wrapped by a java.util.ExecutionException and caught here.
+            assertTrue("Cause was not CircuitBreakerOpenException", ee.getCause().toString().contains("CircuitBreakerOpenException"));
+            // Confirm that the service was called 3 times before this exception was thrown.
+            assertThat(bean.getExecutionCounterH(), is(3));
+        } catch (Exception ue) {
+            // We should have retried or thrown an ExecutionException, assert if an unexpected Exception is thrown
+            throw new AssertionError("Unexpected exception " + ue);
+        }
+    }
+
+    /**
+     * The Asynchronous equivalent of testCBSyncRetryCircuitClosed, to test the behaviour of a service configured
+     * with CircuitBreaker, Retry and Asynchronous annotations. In this test maxRetries is set sufficiently low
+     * that the Circuit will remain closed after maxRetries is reached and a ConnectionException will be thrown.
+     *
+     * @throws Exception
+     */
+    public void testCBAsyncRetryCircuitClosed() throws Exception {
+        Future<String> future = null;
+        try {
+            future = bean.serviceI();
+        } catch (Exception ue) {
+            // Assert if an unexpected Exception is thrown
+            throw new AssertionError("Unexpected exception " + ue);
+        }
+
+        try {
+            String result = future.get();
+            throw new AssertionError("serviceI should be retried");
+        } catch (ExecutionException ee) {
+            // The Service will be retried just once. After maxRetries is exceeded a ConnectException
+            // will be thrown. This will be wrapped by a java.util.ExecutionException and caught here.
+            assertTrue("Cause was not ConnectException", ee.getCause().toString().contains("ConnectException"));
+            // Confirm that the service was called 2 times before this exception was thrown.
+            assertThat(bean.getExecutionCounterI(), is(2));
+        } catch (Exception ue) {
+            // We should have retried or thrown a ConnectException, assert if an unexpected Exception is thrown
+            throw new AssertionError("Unexpected exception " + ue);
+        }
+    }
+
+    /**
+     * An adaption of testCBFailureThresholdWithException, to test the CircuitBreaker behaviour is as expected
+     * when the service initially succeeds but then begins to fail.
+     *
+     * @throws InterruptedException
+     * @throws ConnectException
+     */
+    public void testCBFailureThresholdWithRoll() throws InterruptedException, ConnectException {
+
+        // FaultTolerance object with circuit breaker, should fail 3 times
+        for (int i = 0; i < 5; i++) {
+            try {
+                bean.serviceJ();
+                if (i > 1)
+                    throw new AssertionError("ConnectException not caught");
+            } catch (ConnectException e) {
+                if (!e.getMessage().equals("ConnectException: serviceJ exception: " + (i + 1))) {
+                    throw new AssertionError("ConnectException bad message: " + e.getMessage());
+                }
+            }
+        }
+
+        // The service should have failed 3 times in succession, so the Circuit should be Open.
+        try {
+            bean.serviceJ();
+            throw new AssertionError("CircuitBreakerOpenException not caught");
+        } catch (CircuitBreakerOpenException e) {
+            //expected
+        }
+
+        //allow time for the circuit to re-close
+        Thread.sleep(3000);
+
+        String res = bean.serviceJ();
+        if (!"serviceJ: 6".equals(res)) {
+            throw new AssertionError("Bad Result: " + res);
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/CircuitBreakerBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/CircuitBreakerBean.java
@@ -19,6 +19,7 @@ import javax.enterprise.context.RequestScoped;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
 import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
@@ -29,6 +30,12 @@ public class CircuitBreakerBean {
     private int executionCounterA = 0;
     private int executionCounterB = 0;
     private int executionCounterD = 0;
+    private int executionCounterE = 0;
+    private int executionCounterF = 0;
+    private int executionCounterG = 0;
+    private int executionCounterH = 0;
+    private int executionCounterI = 0;
+    private int executionCounterJ = 0;
 
     @CircuitBreaker(delay = 1, delayUnit = ChronoUnit.SECONDS, requestVolumeThreshold = 3, failureRatio = 1.0)
     @Timeout(value = 3, unit = ChronoUnit.SECONDS)
@@ -53,6 +60,7 @@ public class CircuitBreakerBean {
         System.out.println("serviceB: " + executionCounterB);
 
         if (executionCounterB <= 3) {
+            System.out.println("serviceB: throw ConnectException on execution " + executionCounterB);
             throw new ConnectException("serviceB exception: " + executionCounterB);
         }
         return "serviceB: " + executionCounterB;
@@ -72,11 +80,88 @@ public class CircuitBreakerBean {
         throw new ConnectException("serviceD: " + executionCounterD);
     }
 
+    @CircuitBreaker(requestVolumeThreshold = 3, failureRatio = 1.0)
+    @Fallback(fallbackMethod = "serviceEFallback")
+    public String serviceE() throws ConnectException {
+        executionCounterE++;
+        throw new ConnectException("serviceE: " + executionCounterE);
+    }
+
+    @CircuitBreaker(requestVolumeThreshold = 3, failureRatio = 1.0)
+    @Retry(retryOn = { ConnectException.class }, maxRetries = 7)
+    public String serviceF() throws ConnectException {
+        executionCounterF++;
+        throw new ConnectException("serviceF: " + executionCounterF);
+    }
+
+    @CircuitBreaker(requestVolumeThreshold = 3, failureRatio = 1.0)
+    @Retry(retryOn = { ConnectException.class }, maxRetries = 1)
+    public String serviceG() throws ConnectException {
+        executionCounterG++;
+        throw new ConnectException("serviceG: " + executionCounterG);
+    }
+
+    @Asynchronous
+    @CircuitBreaker(requestVolumeThreshold = 3, failureRatio = 1.0)
+    @Retry(retryOn = { ConnectException.class }, maxRetries = 7)
+    public Future<String> serviceH() throws ConnectException {
+        executionCounterH++;
+        throw new ConnectException("serviceH: " + executionCounterH);
+    }
+
+    @Asynchronous
+    @CircuitBreaker(requestVolumeThreshold = 3, failureRatio = 1.0)
+    @Retry(retryOn = { ConnectException.class }, maxRetries = 1)
+    public Future<String> serviceI() throws ConnectException {
+        executionCounterI++;
+        throw new ConnectException("serviceI: " + executionCounterI);
+    }
+
+    @CircuitBreaker(delay = 2, delayUnit = ChronoUnit.SECONDS, requestVolumeThreshold = 3, failureRatio = 1.0)
+    public String serviceJ() throws ConnectException {
+        executionCounterJ++;
+        System.out.println("serviceJ: " + executionCounterJ);
+
+        if (executionCounterJ > 2 && executionCounterJ < 6) {
+            System.out.println("serviceJ: throw ConnectException on execution " + executionCounterJ);
+            throw new ConnectException("serviceJ exception: " + executionCounterJ);
+        }
+        return "serviceJ: " + executionCounterJ;
+    }
+
     public Future<String> serviceDFallback() {
         return CompletableFuture.completedFuture("serviceDFallback");
     }
 
+    public String serviceEFallback() {
+        return "serviceEFallback";
+    }
+
     public int getExecutionCounterD() {
         return executionCounterD;
+    }
+
+    public int getExecutionCounterE() {
+        return executionCounterE;
+    }
+
+    public int getExecutionCounterF() {
+        return executionCounterF;
+    }
+
+    public int getExecutionCounterG() {
+        return executionCounterG;
+    }
+
+    public int getExecutionCounterH() {
+        return executionCounterH;
+    }
+
+    public int getExecutionCounterI() {
+        return executionCounterI;
+    }
+
+    public int getExecutionCounterJ() {
+        return executionCounterJ;
     }
 }


### PR DESCRIPTION
Improve FAT coverage of Fault Tolerance function by adding more CircuitBreaker tests. In particular test the combination of the @CircuitBreaker, @Retry and @Fallback annotations.

With refererence to issue #81, this PR adds test coverage for...

CircuitBreaker + Fallback
CircuitBreaker + Retry
Asynchronous + Circuit Breaker