### PR TITLE
Turned off the beta flag

### DIFF
--- a/dev/cnf/resources/bnd/liberty-release.props
+++ b/dev/cnf/resources/bnd/liberty-release.props
@@ -1,6 +1,6 @@
 -include= ${workspace}/generated.properties
 
-releaseTypeGA=false
+releaseTypeGA=true
 libertyServiceVersion=17.0.0.3
 libertyBetaVersion=2017.9.0.0
 libertyRelease=${if;${releaseTypeGA};${libertyServiceVersion};${libertyBetaVersion}}


### PR DESCRIPTION
This is for fixing the product version that is displayed:

After this fix I get:
C:\testwlp6\wlp\bin>productInfo version
Product name: Open Liberty
Product version: 17.0.0.3
Product edition: Open
