### PR TITLE
Exclude IBM JDK jar that includes Tr class

### DIFF
--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -85,6 +85,7 @@ def loadBuildProps() {
   jdkLibs.include 'bin/default/**/vm.jar'
   jdkLibs.include 'lib/**/default/**/vm.jar'
   jdkLibs.include 'lib/*.jar'
+  jdkLibs.exclude 'lib/ibmcfw.jar' //has com.ibm.nws.ejs.ras.Tr, which we don't want
 
   def jdkLibString = ""
   Boolean isFirstPass = true;


### PR DESCRIPTION
fixes #85. 

The ibmcfw jar could potentially contribute the com.ibm.nws.ejs.ras.Tr class, which will conflict with our internal implementation.