### PR TITLE
Ship only ga features in Open Liberty

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -21,23 +21,96 @@ if (releaseVersionOverride != null) {
     releaseVersion = releaseVersionOverride
 }
 
+String packageDir = "${buildDir}/openliberty"
+
+task packageOpenLiberty {
+    dependsOn parent.subprojects.assemble
+    doLast {
+        // Create server in order to minify an image that only includes kind=ga features
+        String serverName = "packageOpenLiberty"
+        exec {
+            workingDir "${projectDir}/wlp/bin"
+            commandLine "./server", "create", serverName
+        }
+
+        try {
+            String features = ""
+            fileTree(dir: "${rootDir}", include: '*/*.feature').visit { element ->
+                if (element.isDirectory()) {
+                    return
+                }
+
+                File featureFile = element.getFile()
+                if (featureFile.text.contains("kind=ga")) {
+                    for (String line : featureFile.text.split("\\n")) {
+                        if (line.contains("IBM-ShortName:")) {
+                            String shortname = line.substring(14)
+                            shortname = shortname.replaceAll("\\s+", "")
+                            features += "\n<feature>" + shortname + "</feature>"
+                            break
+                        }
+                    }
+                }
+            }
+
+            def serverXml = file("${projectDir}/wlp/usr/servers/${serverName}/server.xml")
+            serverXml.text = """<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+<featureManager>${features}
+</featureManager>
+</server>
+"""
+
+            String archive = "${buildDir}/openliberty.zip"
+            delete archive
+            exec {
+                workingDir "${projectDir}/wlp/bin"
+                commandLine "./server", "package", serverName, "--archive=${archive}", "--include=minify"
+            }
+
+            // Postprocess to remove unwanted files
+            delete packageDir
+            copy {
+                from(zipTree(file(archive)))
+                exclude 'wlp/usr/servers/**'
+                exclude 'wlp/lib/versions/package_*'
+                into packageDir
+            }
+
+        } finally {
+            delete "${projectDir}/wlp/usr/servers/${serverName}"
+        }
+    }
+}
+
+// Includes only kind=ga features.
 task zipOpenLiberty(type: Zip) {
-  dependsOn parent.subprojects.assemble
-  baseName 'openliberty'
-  from projectDir
-  include 'wlp/**'
-  destinationDir distsDir
-  version releaseVersion
-  doLast {
-    //TODO: need a better mechanism for 'stowaway properties' that need to be used in future gradle invocations
-    def props = new Properties()
-    file("${rootDir}/generated.properties").withInputStream { props.load(it) }
+    dependsOn packageOpenLiberty
+    baseName 'openliberty'
+    from packageDir
+    destinationDir distsDir
+    version releaseVersion
+    doLast {
+        //TODO: need a better mechanism for 'stowaway properties' that need to be used in future gradle invocations
+        def props = new Properties()
+        file("${rootDir}/generated.properties").withInputStream { props.load(it) }
 
-    props.setProperty('zipopenliberty.archivename', archivePath.toString())
+        props.setProperty('zipopenliberty.archivename', archivePath.toString())
 
-    File propsFile = new File("${rootDir}/generated.properties")
-    props.store(propsFile.newWriter(), null)
-  }
+        File propsFile = new File("${rootDir}/generated.properties")
+        props.store(propsFile.newWriter(), null)
+    }
+}
+publish.dependsOn zipOpenLiberty
+
+// Includes all features.
+task zipOpenLibertyAll(type: Zip) {
+    dependsOn parent.subprojects.assemble
+    baseName 'openliberty-all'
+    from projectDir
+    include 'wlp/**'
+    destinationDir distsDir
+    version releaseVersion
 }
 
 task copyPropertiesToBuildImage (type:Copy) {
@@ -91,7 +164,7 @@ publishing {
         maven(MavenPublication) {
             artifactId 'openliberty'
             version project.version
-            artifact zipOpenLiberty
+            artifact zipOpenLibertyAll
         }
     }
 }

--- a/dev/com.ibm.websphere.appserver.jdbc-4.2/build.gradle
+++ b/dev/com.ibm.websphere.appserver.jdbc-4.2/build.gradle
@@ -1,0 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/

--- a/dev/com.ibm.websphere.appserver.jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
@@ -34,7 +34,6 @@ IBM-ShortName: jsp-2.2
 IBM-SPI-Package: com.ibm.wsspi.jsp.taglib.config
 Subsystem-Name: JavaServer Pages 2.2
 -features=com.ibm.websphere.appserver.javax.jsp-2.2, \
- com.ibm.ws.org.apache.jasper.el-2.2, \
  com.ibm.websphere.appserver.javax.el-2.2, \
  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:=3.1, \
  com.ibm.websphere.appserver.javaeeCompatible-6.0
@@ -43,7 +42,8 @@ Subsystem-Name: JavaServer Pages 2.2
  com.ibm.websphere.javaee.jstl.1.2; location:="dev/api/spec/,lib/", \
  com.ibm.ws.jsp.jasper, \
  com.ibm.ws.jsp, \
- com.ibm.ws.jsp.jstl.facade
+ com.ibm.ws.jsp.jstl.facade, \
+ com.ibm.ws.org.apache.jasper.el.2.2
 -jars=com.ibm.websphere.appserver.spi.jsp; location:=dev/spi/ibm/, \
  com.ibm.websphere.javaee.jsp.tld.2.2; location:=dev/api/spec/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip


### PR DESCRIPTION
We decided the best way to ship kind=ga features (and no kind=beta or kind=noship) is to parse the .features for a list of GA features and dump that into a server.xml to be run through minify packaging. The resulting archive is unzipped in order to exclude undesired files that packaging adds, and then zip again with the usual task to get the image naming correct and publishing works as it did before.