### PR TITLE
Issue #184: Don't clobber the HTTPClientPolicy

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/configuration/LibertyJaxRsClientProxyInterceptor.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/configuration/LibertyJaxRsClientProxyInterceptor.java
@@ -141,7 +141,11 @@ public class LibertyJaxRsClientProxyInterceptor extends AbstractPhaseInterceptor
             }
         }
 
-        HTTPClientPolicy clientPolicy = new HTTPClientPolicy();
+        HTTPClientPolicy clientPolicy = httpConduit.getClient();
+        if (clientPolicy == null) {
+            clientPolicy = new HTTPClientPolicy();
+            httpConduit.setClient(clientPolicy);
+        }
         clientPolicy.setProxyServer(host);
         try {
             clientPolicy.setProxyServerPort(iPort);
@@ -174,7 +178,6 @@ public class LibertyJaxRsClientProxyInterceptor extends AbstractPhaseInterceptor
             }
         }
         clientPolicy.setProxyServerType(proxyServerType);
-        httpConduit.setClient(clientPolicy);
 
         ProxyAuthorizationPolicy authPolicy = null;
 


### PR DESCRIPTION
For Issue #184 We shouldn't be creating and setting a new HTTPClientPolicy in the
client proxy interceptor.  Instead, we should be updating the policy
currently on the conduit (only creating/setting a new one if it does not
already exist on the conduit).