### PR TITLE
issue #142: java.lang.ClassNotFoundException dumped in the ffdc log file when monitor feature enabled traditional PMI

### DIFF
--- a/dev/com.ibm.ws.webcontainer.monitor/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.monitor/bnd.bnd
@@ -21,8 +21,10 @@ Import-Package: \
     javax.servlet; version="[2.6,3)", \
     !*.internal.*,*
 
+Export-Package: \
+	com.ibm.ws.webcontainer.monitor
+
 Private-Package: \
-	com.ibm.ws.webcontainer.monitor, \
 	com.ibm.websphere.webcontainer
 
 Include-Resource: \
@@ -48,4 +50,5 @@ instrument.disabled: true
 	com.ibm.ws.webcontainer;version=latest,\
 	com.ibm.websphere.appserver.spi.logging,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
-	com.ibm.ws.container.service;version=latest
+	com.ibm.ws.container.service;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.webcontainer.monitor/src/com/ibm/ws/webcontainer/monitor/WebContainerMonitor.java
+++ b/dev/com.ibm.ws.webcontainer.monitor/src/com/ibm/ws/webcontainer/monitor/WebContainerMonitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,7 +56,7 @@ public class WebContainerMonitor {
         //Following line with add traditional PMI support
         //If we don't add WebAppMonitorListener to Global Listener, PMI WebAppModule wouldn't work
         if(!PmiRegistry.isDisabled()){
-            WebContainer.addGlobalListener("com.ibm.ws.webcontainer.WebAppMonitorListener");
+            WebContainer.addGlobalListener("com.ibm.ws.webcontainer.monitor.WebAppMonitorListener");
         }
     }
 

--- a/dev/com.ibm.ws.webcontainer.monitor/src/com/ibm/ws/webcontainer/monitor/package-info.java
+++ b/dev/com.ibm.ws.webcontainer.monitor/src/com/ibm/ws/webcontainer/monitor/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.ws.webcontainer.monitor;

--- a/dev/com.ibm.ws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer/bnd.bnd
@@ -152,7 +152,8 @@ DynamicImport-Package: com.ibm.websphere.monitor.meters;version="1.0.0", \
  com.ibm.websphere.monitor.jmx;version="1.0.0", \
  com.ibm.ws.jsp.webcontainerext, \
  com.ibm.wsspi.request.probe.bci, \
- com.ibm.wsspi.probeExtension
+ com.ibm.wsspi.probeExtension, \
+ com.ibm.ws.webcontainer.monitor
 
 Include-Resource: \
   @data, \


### PR DESCRIPTION
Liberty application server dumped java.lang.ClassNotFoundException in the FFDC file when enabled
monitor-1.0 feature with option enableTraditionalPMI="true" set in the server.xml file.

Sample entry in the server.xml file.
<pre>
 &lt;featureManager>
   ...
   &lt;feature>monitor-1.0&lt;/feature>
 &lt;/featureManager>

 &lt;monitor enableTraditionalPMI="true"/>
</pre>
FFDC Exception output:
<pre>
Exception = java.lang.ClassNotFoundException
Source = com.ibm.ws.webcontainer.internal.WebContainer.loadListener
probeid = 1527
Stack Dump = java.lang.ClassNotFoundException:
com.ibm.ws.webcontainer.WebAppMonitorListener
at java.lang.Class.forNameImpl(Native Method)
...
</pre>