### PR TITLE
Fix task so server scripts have the correct permissions

### DIFF
--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -155,6 +155,7 @@ subprojects {
         copy {
           from "${rootDir}/cnf/resources/bin"
           into "${rootDir}/build.image/wlp/bin/" + bnd('publish.tool.script.subdir', '')
+          fileMode 0755
           rename 'tool(.*)', bnd('publish.tool.script') + '$1'
           filter(org.apache.tools.ant.filters.ReplaceTokens,
                  tokens: [TOOL_JAR: bnd('publish.tool.script.subdir', '') + 'tools/' + bnd('publish.tool.jar'),


### PR DESCRIPTION
Update the publishToolJars script in the stabilization stream to set the file permissions of the server scripts.