### PR TITLE
Issue #81 - Add FATs to test Fault Tolerance configuration

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIBulkheadTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIBulkheadTest.java
@@ -62,6 +62,20 @@ public class CDIBulkheadTest extends LoggingTest {
     }
 
     @Test
+    public void testAsyncBulkheadSmallConfig() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/asyncbulkhead?testMethod=testAsyncBulkheadSmallConfig",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testAsyncBulkheadSmallClassScopeConfig() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/asyncbulkhead?testMethod=testAsyncBulkheadSmallClassScopeConfig",
+                                         "SUCCESS");
+    }
+
+    @Test
     public void testSyncBulkheadSmall() throws Exception {
         WebBrowser browser = createWebBrowserForTestCase();
         getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/bulkhead?testMethod=testSyncBulkheadSmall",

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDICircuitBreakerTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDICircuitBreakerTest.java
@@ -98,6 +98,27 @@ public class CDICircuitBreakerTest extends LoggingTest {
                                          "SUCCESS");
     }
 
+    @Test
+    public void testCBFailureThresholdConfig() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBFailureThresholdConfig",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testCBFailureThresholdClassScopeConfig() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBFailureThresholdClassScopeConfig",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testCBDelayConfig() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/circuitbreaker?testMethod=testCBDelayConfig",
+                                         "SUCCESS");
+    }
+
     /** {@inheritDoc} */
     @Override
     protected SharedServer getSharedServer() {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIRetryTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIRetryTest.java
@@ -73,6 +73,18 @@ public class CDIRetryTest extends LoggingTest {
         getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/retry?testMethod=testRetryDurationZero", "SUCCESS");
     }
 
+    @Test
+    public void testRetryMaxRetriesConfig() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/retry?testMethod=testRetryMaxRetriesConfig", "SUCCESS");
+    }
+
+    @Test
+    public void testRetryMaxRetriesClassScopeConfig() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/retry?testMethod=testRetryMaxRetriesClassScopeConfig", "SUCCESS");
+    }
+
     /**
      * Not really related to retry but it's easiest to test it here
      */

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDITimeoutTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDITimeoutTest.java
@@ -78,6 +78,20 @@ public class CDITimeoutTest extends LoggingTest {
         getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/timeout?testMethod=testNonInterruptableDoesntTimeout", "SUCCESS");
     }
 
+    @Test
+    public void testTimeoutConfig() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/timeout?testMethod=testTimeoutConfig",
+                                         "SUCCESS");
+    }
+
+    @Test
+    public void testTimeoutClassScopeConfig() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/timeout?testMethod=testTimeoutClassScopeConfig",
+                                         "SUCCESS");
+    }
+
     /** {@inheritDoc} */
     @Override
     protected SharedServer getSharedServer() {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/resources/META-INF/microprofile-config.properties
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/resources/META-INF/microprofile-config.properties
@@ -11,4 +11,14 @@
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.FallbackBeanWithoutRetry/connectB/Fallback/value=com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.MyFallbackHandler2
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.FallbackBeanWithoutRetry/connectC/Fallback/fallbackMethod=connectFallback2
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanC/connectC2/Retry/abortOn=java.lang.IllegalArgumentException,com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanC/connectCMaxRetries1/Retry/maxRetries=4
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanD/Retry/maxRetries=4
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.CircuitBreakerBean/serviceK/CircuitBreaker/requestVolumeThreshold=3
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.CircuitBreakerBean2/CircuitBreaker/requestVolumeThreshold=3
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.CircuitBreakerBean/serviceL/CircuitBreaker/delay=2000
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.CircuitBreakerBean/serviceL/CircuitBreaker/delayUnit=MILLIS
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.AsyncBulkheadBean/connectC/Bulkhead/value=2
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.AsyncBulkheadBean2/Bulkhead/value=2
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.TimeoutBean/connectG/Timeout/value=500
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.TimeoutBean2/Timeout/value=500
 test/AsyncConfigValue=configuredAsyncValue

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/RetryServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/RetryServlet.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanB;
 import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanC;
+import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanD;
 import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
 import com.ibm.ws.microprofile.faulttolerance_fat.util.DisconnectException;
 
@@ -43,6 +44,9 @@ public class RetryServlet extends FATServlet {
 
     @Inject
     RetryBeanC beanC;
+
+    @Inject
+    RetryBeanD beanD;
 
     public void testRetry(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         //should be retried 3 times as per default
@@ -147,6 +151,46 @@ public class RetryServlet extends FATServlet {
             // Expected
         }
         assertThat(beanC.getConnectCount(), is(6));
+    }
+
+    /**
+     * Test method level override of maxRetries attribute on Retry annotation on a synchronous service.
+     *
+     * The method will not be executed the expected number of times unless the configuration overrides the value
+     * set on the connectCMaxRetries1 method.
+     *
+     * @param request
+     * @param response
+     * @throws Exception
+     */
+    public void testRetryMaxRetriesConfig(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        try {
+            beanC.connectCMaxRetries1();
+            fail("Exception not thrown");
+        } catch (ConnectException e) {
+            // Expected
+        }
+        assertThat(beanC.getConnectCount(), is(5));
+    }
+
+    /**
+     * Test class level override of maxRetries attribute on Retry annotation on a synchronous service.
+     *
+     * The method will not be executed the expected number of times unless the configuration overrides the value
+     * set on beanD.
+     *
+     * @param request
+     * @param response
+     * @throws Exception
+     */
+    public void testRetryMaxRetriesClassScopeConfig(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        try {
+            beanD.connectDMaxRetries2();
+            fail("Exception not thrown");
+        } catch (ConnectException e) {
+            // Expected
+        }
+        assertThat(beanD.getConnectCount(), is(5));
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/AsyncBulkheadBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/AsyncBulkheadBean.java
@@ -29,6 +29,7 @@ public class AsyncBulkheadBean {
     private final AtomicInteger connectBCounter = new AtomicInteger(0);
     private final AtomicInteger connectATokens = new AtomicInteger(0);
     private final AtomicInteger connectBTokens = new AtomicInteger(0);
+    private final AtomicInteger connectCTokens = new AtomicInteger(0);
 
     @Bulkhead(value = 2, waitingTaskQueue = 2)
     public Future<Boolean> connectA(String data) throws InterruptedException {
@@ -67,6 +68,28 @@ public class AsyncBulkheadBean {
         } finally {
             connectBTokens.decrementAndGet();
             System.out.println("connectB complete " + data);
+        }
+    }
+
+    /**
+     * Set the Bulkhead value to 3 - which would lead to failure - but this bean's config
+     * will be overridden to a value of 2 in microprofile-config.properties, which is what the test expects.
+     * If the value were 3, then the method will throw a RuntimeException reporting the instantiation of too
+     * many threads.
+     */
+    @Bulkhead(value = 3, waitingTaskQueue = 2)
+    public Future<Boolean> connectC(String data) throws InterruptedException {
+        System.out.println("connectC starting " + data);
+        int token = connectCTokens.incrementAndGet();
+        try {
+            if (token > 2) {
+                throw new RuntimeException("Too many threads in connectC[" + data + "]: " + token);
+            }
+            Thread.sleep(TestConstants.WORK_TIME);
+            return CompletableFuture.completedFuture(Boolean.TRUE);
+        } finally {
+            connectCTokens.decrementAndGet();
+            System.out.println("connectC complete " + data);
         }
     }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/AsyncBulkheadBean2.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/AsyncBulkheadBean2.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.RequestScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+
+import com.ibm.ws.microprofile.faulttolerance_fat.cdi.TestConstants;
+
+@RequestScoped
+@Asynchronous
+/**
+ * Set the Bulkhead value to 3 - which would lead to test failure - but this bean's config
+ * will be overridden to a value of 2 in microprofile-config.properties, which is what the test expects.
+ * If the value were 3, then the bean will throw a RuntimeException reporting the instantiation of too
+ * many threads.
+ */
+@Bulkhead(value = 3, waitingTaskQueue = 2)
+public class AsyncBulkheadBean2 {
+
+    private final AtomicInteger connectATokens = new AtomicInteger(0);
+
+    // Inherit class Bulkhead Policy
+    public Future<Boolean> connectA(String data) throws InterruptedException {
+        System.out.println("connectA starting " + data);
+        int token = connectATokens.incrementAndGet();
+        try {
+            if (token > 2) {
+                throw new RuntimeException("Too many threads in connectA[" + data + "]: " + token);
+            }
+            Thread.sleep(TestConstants.WORK_TIME);
+            return CompletableFuture.completedFuture(Boolean.TRUE);
+        } finally {
+            connectATokens.decrementAndGet();
+            System.out.println("connectA complete " + data);
+        }
+    }
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/CircuitBreakerBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/CircuitBreakerBean.java
@@ -36,6 +36,8 @@ public class CircuitBreakerBean {
     private int executionCounterH = 0;
     private int executionCounterI = 0;
     private int executionCounterJ = 0;
+    private int executionCounterK = 0;
+    private int executionCounterL = 0;
 
     @CircuitBreaker(delay = 1, delayUnit = ChronoUnit.SECONDS, requestVolumeThreshold = 3, failureRatio = 1.0)
     @Timeout(value = 3, unit = ChronoUnit.SECONDS)
@@ -129,6 +131,36 @@ public class CircuitBreakerBean {
         return "serviceJ: " + executionCounterJ;
     }
 
+    /**
+     * Set the requestVolumeThreshold to 5 - which would lead to test failure - but this bean's config
+     * will be overridden in microprofile-config.properties to a value of 3.
+     */
+    @CircuitBreaker(delay = 2, delayUnit = ChronoUnit.SECONDS, requestVolumeThreshold = 5, failureRatio = 1.0)
+    public String serviceK() throws ConnectException {
+        executionCounterK++;
+
+        if (executionCounterK <= 5) {
+            throw new ConnectException("serviceK exception: " + executionCounterK);
+        }
+        return "serviceK: " + executionCounterK;
+    }
+
+    /**
+     * Set the delay to 1 minute - which would lead to test failure - but this bean's config
+     * will be overridden.
+     */
+    @CircuitBreaker(delay = 1, delayUnit = ChronoUnit.MINUTES, requestVolumeThreshold = 3, failureRatio = 1.0)
+    public String serviceL() throws ConnectException {
+        executionCounterL++;
+        System.out.println("serviceL: " + executionCounterL);
+
+        if (executionCounterL <= 3) {
+            System.out.println("serviceL: throw ConnectException on execution " + executionCounterL);
+            throw new ConnectException("serviceL exception: " + executionCounterL);
+        }
+        return "serviceL: " + executionCounterL;
+    }
+
     public Future<String> serviceDFallback() {
         return CompletableFuture.completedFuture("serviceDFallback");
     }
@@ -163,5 +195,9 @@ public class CircuitBreakerBean {
 
     public int getExecutionCounterJ() {
         return executionCounterJ;
+    }
+
+    public int getExecutionCounterK() {
+        return executionCounterK;
     }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/CircuitBreakerBean2.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/CircuitBreakerBean2.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans;
+
+import java.time.temporal.ChronoUnit;
+
+import javax.enterprise.context.RequestScoped;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
+
+@RequestScoped
+/**
+ * Set the requestVolumeThreshold to 5 - which would lead to test failure - but this bean's config
+ * will be overridden in microprofile-config.properties.
+ */
+@CircuitBreaker(delay = 2, delayUnit = ChronoUnit.SECONDS, requestVolumeThreshold = 5, failureRatio = 1.0)
+public class CircuitBreakerBean2 {
+
+    private int executionCounterA = 0;
+
+    // Inherit class CircuitBreaker Policy
+    public String serviceA() throws ConnectException {
+        executionCounterA++;
+
+        if (executionCounterA <= 5) {
+            throw new ConnectException("serviceA exception: " + executionCounterA);
+        }
+        return "serviceA: " + executionCounterA;
+    }
+
+    public int getExecutionCounterA() {
+        return executionCounterA;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/RetryBeanC.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/RetryBeanC.java
@@ -56,6 +56,17 @@ public class RetryBeanC {
         throw new ConnectException("RetryBeanC Connect: " + connectCount);
     }
 
+    /**
+     * Set the maxRetries to 1 - which would lead to test failure - but this method's config
+     * will be overridden to 4 in microprofile-config.properties so that the connectCMaxRetries1 method will
+     * be executed the number of times expected by the test.
+     */
+    @Retry(maxRetries = 1)
+    public void connectCMaxRetries1() throws ConnectException {
+        connectCount++;
+        throw new ConnectException("RetryBeanC Connect: " + connectCount);
+    }
+
     public int getConnectCount() {
         return connectCount;
     }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/RetryBeanD.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/RetryBeanD.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans;
+
+import javax.enterprise.context.RequestScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
+
+@RequestScoped
+/**
+ * Set the maxRetries to 2 - which would lead to test failure - but this bean's config
+ * will be overridden to 4 in microprofile-config.properties so that the connectDMaxRetries2 method will
+ * be executed the number of times expected by the test.
+ */
+@Retry(maxRetries = 2)
+public class RetryBeanD extends RetryBeanA {
+
+    private int connectCount = 0;
+
+    // Inherit class Retry Policy
+    public void connectDMaxRetries2() throws ConnectException {
+        connectCount++;
+        throw new ConnectException("RetryBeanD Connect: " + connectCount);
+    }
+
+    public int getConnectCount() {
+        return connectCount;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/TimeoutBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/TimeoutBean.java
@@ -102,6 +102,24 @@ public class TimeoutBean {
     }
 
     /**
+     * Set the Timeout value to 5 seconds - which would lead to test failure - but this method's config
+     * will be overridden to 500 millis in microprofile-config.properties so that the bean will
+     * generate a TimeoutException as expected by the test.
+     */
+    @Timeout(5000)
+    public Connection connectG() throws ConnectException {
+        try {
+            Thread.sleep(2000);
+            throw new ConnectException("Timeout did not interrupt");
+        } catch (InterruptedException e) {
+            //expected
+            System.out.println("TimeoutBean Interrupted");
+        }
+        return null;
+
+    }
+
+    /**
      * Used for testing timeout with workloads which are not interruptable
      *
      * @param milliseconds number of milliseconds to busy wait for

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/TimeoutBean2.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/TimeoutBean2.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans;
+
+import javax.enterprise.context.RequestScoped;
+
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
+import com.ibm.ws.microprofile.faulttolerance_fat.util.Connection;
+
+@RequestScoped
+/**
+ * Set the Timeout value to 5 seconds - which would lead to test failure - but this bean's config
+ * will be overridden to 500 millis in microprofile-config.properties so that the bean will
+ * generate a TimeoutException as expected by the test.
+ */
+@Timeout(5000)
+public class TimeoutBean2 {
+
+    public Connection connectA() throws ConnectException {
+        try {
+            Thread.sleep(2000);
+            throw new ConnectException("Timeout did not interrupt");
+        } catch (InterruptedException e) {
+            //expected
+            System.out.println("TimeoutBean Interrupted");
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Improve FAT coverage of Fault Tolerance function by adding tests for Fault Tolerance configuration.

With refererence to issue #81, this PR adds test coverage for...

Retry config
CircuitBreaker config
Bulkhead config
Timeout config