### PR TITLE
test interrupt of policy executor timed invokeAny and also test invalid args

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -789,6 +789,9 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         long stop = System.nanoTime() + unit.toNanos(timeout);
         long qWait, remaining;
 
+        if (taskCount == 0) // JavaDoc doesn't specify what to do in this case. Match observed behavior of ThreadPoolExecutor for now.
+            throw new IllegalArgumentException();
+
         // Satisfy requirement of JavaDoc:
         for (Callable<T> task : tasks)
             if (task == null)


### PR DESCRIPTION
Test coverage to ensure that interrupt of policy executor's timed invokeAny method behaves as expected while it is either awaiting a queue position or waiting for a task to complete successfully.