### PR TITLE
Increase core threads for FaultTolerance tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/CDIFaultTolerance/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/CDIFaultTolerance/server.xml
@@ -21,6 +21,16 @@
 		<feature>servlet-3.1</feature>
 		<feature>mpFaultTolerance-1.0</feature>
 	</featureManager>
+
+	<!-- Usually, we recommend customers not to change this, however our Async 
+		Timeout tests are quite sensitive to timing. We were filling up the threadpool, 
+		and then the test was complaining that the timeout didn't fire quickly enough.
+		 
+		Liberty would notice that the pool was full and quickly add more threads, 
+		but we'd get test failures because the timeout fired a few seconds late. 
+		We could increase the size of the timing window instead, but that would make 
+		the test run take longer, so instead I'm setting a minimum number of threads. -->
+	<executor coreThreads="20"/>
 	
-	    <logging traceSpecification="FAULTTOLERANCE=all=enabled:logservice=all=enabled:*=info=enabled:com.ibm.websphere.microprofile.faulttolerance.*=all=enabled:com.ibm.ws.threading.Policy*=all:com.ibm.ws.threading.internal.Policy*=all"/>
+	    <logging traceSpecification="FAULTTOLERANCE=all=enabled:logservice=all=enabled:*=info=enabled:com.ibm.websphere.microprofile.faulttolerance.*=all=enabled:com.ibm.ws.threading.Policy*=all:com.ibm.ws.threading.internal.Policy*=all:com.ibm.ws.threading.internal.ThreadPoolController=event"/>
 </server>


### PR DESCRIPTION
Timeout tests are sensitive to timing. If a test fills the thread pool,
it takes a second or so for the thread pool to notice the increase in
load and add more threads.

By setting a larger number of core threads, we avoid this unpredictable
delay and eliminate a difference in behaviour between test machines with
different numbers of hardware cores which should result in tests passing
or failing more reliably.

Also added light ThreadPoolController trace to help debug timeout tests
in the future.

For issue #214