### PR TITLE
missed a bundle version upgrade when the package was upgraded

### DIFF
--- a/dev/com.ibm.websphere.appserver.spi.httptransport/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.httptransport/bnd.bnd
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion: 1.1
+bVersion: 1.2
 
 Bundle-Name: WebSphere HTTP Transport SPI
 Bundle-Description: WebSphere HTTP Transport SPI, version ${bVersion}

--- a/dev/com.ibm.ws.transport.http/build-api-spi.xml
+++ b/dev/com.ibm.ws.transport.http/build-api-spi.xml
@@ -21,7 +21,7 @@
   <property name="spibndfile" value="${basedir}/build/spi.bnd"/>  
   <property name="spi.ibm.symbolic.suffix" value="httptransport"/>
   <property name="spi.ibm.bundleName" value="WebSphere HTTP Transport SPI"/>
-  <property name="spi.ibm.version" value="1.1"/>  
+  <property name="spi.ibm.version" value="1.2"/>  
   <property name="feature.name" value="com.ibm.websphere.appserver.httptransport-1.0"/> 
     
   <import file="../ant_build/public_imports/apibnd_imports.xml"/>


### PR DESCRIPTION
 #251 just missed a spot. the bundle version in the bnd.bnd controls the version of the entire JAR,so like 
com.ibm.websphere.appserver.spi.httptransport_1.2.18.jar

is output when the bVersion=1.2 in the bnd.bnd