### PR TITLE
Allow class config to override method annotations

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/config/AbstractAnnotationConfig.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/config/AbstractAnnotationConfig.java
@@ -27,7 +27,6 @@ public class AbstractAnnotationConfig<T extends Annotation> {
     private static final TraceComponent tc = Tr.register(AbstractAnnotationConfig.class);
 
     private final Class<T> annotationType;
-    private final String keyPrefix;
     private final T annotation;
     private final Class<?> annotatedClass;
     private final String targetName;
@@ -40,10 +39,8 @@ public class AbstractAnnotationConfig<T extends Annotation> {
     public AbstractAnnotationConfig(Method annotatedMethod, Class<?> annotatedClass, T annotation, Class<T> annotationType) {
         this.annotationType = annotationType;
         if (annotatedMethod == null) {
-            this.keyPrefix = getPropertyKeyPrefix(annotatedClass);
             this.targetName = annotatedClass.getName();
         } else {
-            this.keyPrefix = getPropertyKeyPrefix(annotatedMethod);
             this.targetName = annotatedClass.getName() + "." + annotatedMethod.getName();
         }
         this.annotation = annotation;
@@ -87,20 +84,28 @@ public class AbstractAnnotationConfig<T extends Annotation> {
 
         protected <P> P readConfigValue(Class<P> type) {
             Config mpConfig = ConfigProvider.getConfig(annotatedClass.getClassLoader());
+            P configValue = null;
 
-            String key = getPropertyKey(keyPrefix, parameterName);
-            P configValue = mpConfig.getOptionalValue(key, type).orElse(null);
+            if (annotatedMethod != null) {
+                String key = getPropertyKey(getPropertyKeyPrefix(annotatedMethod), parameterName);
+                configValue = mpConfig.getOptionalValue(key, type).orElse(null);
+            }
 
             if (configValue == null) {
-                key = getPropertyKey("", parameterName);
+                String key = getPropertyKey(getPropertyKeyPrefix(annotatedClass), parameterName);
+                configValue = mpConfig.getOptionalValue(key, type).orElse(null);
+            }
+
+            if (configValue == null) {
+                String key = getPropertyKey("", parameterName);
                 configValue = mpConfig.getOptionalValue(key, type).orElse(null);
             }
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 if (configValue != null) {
-                    Tr.debug(tc, "Found config value for " + getPropertyKey(keyPrefix, parameterName), configValue);
+                    Tr.debug(tc, "Found config value for " + getPropertyKey(targetName, parameterName), configValue);
                 } else {
-                    Tr.debug(tc, "No config value found for " + getPropertyKey(keyPrefix, parameterName));
+                    Tr.debug(tc, "No config value found for " + getPropertyKey(targetName, parameterName));
                 }
             }
 
@@ -135,12 +140,12 @@ public class AbstractAnnotationConfig<T extends Annotation> {
                     result = annotatedClass.getClassLoader().loadClass(configValue);
                 } catch (ClassNotFoundException ex) {
                     throw new FaultToleranceException(Tr.formatMessage(tc, "Cannot load class {0} specified in config for {1}",
-                                                                       configValue, getPropertyKey(keyPrefix, parameterName)));
+                                                                       configValue, getPropertyKey(targetName, parameterName)));
                 }
 
                 if (!parameterClass.isAssignableFrom(result)) {
                     throw new FaultToleranceException(Tr.formatMessage(tc, "Class {0} cannot be assigned to type {1}, as specified in config for {2}",
-                                                                       configValue, parameterClass.getName(), getPropertyKey(keyPrefix, parameterName)));
+                                                                       configValue, parameterClass.getName(), getPropertyKey(targetName, parameterName)));
                 }
             }
 
@@ -178,12 +183,12 @@ public class AbstractAnnotationConfig<T extends Annotation> {
                         result[i] = annotatedClass.getClassLoader().loadClass(configValue[i]);
                     } catch (ClassNotFoundException ex) {
                         throw new FaultToleranceException(Tr.formatMessage(tc, "Cannot load class {0} specified in config for {1}", configValue[i],
-                                                                           getPropertyKey(keyPrefix, parameterName)));
+                                                                           getPropertyKey(targetName, parameterName)));
                     }
 
                     if (!parameterClass.isAssignableFrom(result[i])) {
                         throw new FaultToleranceException(Tr.formatMessage(tc, "Class {0} cannot be assigned to type {1}, as specified in config for {2}",
-                                                                           configValue[i], parameterClass.getName(), getPropertyKey(keyPrefix, parameterName)));
+                                                                           configValue[i], parameterClass.getName(), getPropertyKey(targetName, parameterName)));
                     }
                 }
             }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIRetryTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIRetryTest.java
@@ -85,6 +85,12 @@ public class CDIRetryTest extends LoggingTest {
         getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/retry?testMethod=testRetryMaxRetriesClassScopeConfig", "SUCCESS");
     }
 
+    @Test
+    public void testRetryMaxRetriesClassLevelConfigForMethodAnnotation() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/retry?testMethod=testRetryMaxRetriesClassLevelConfigForMethodAnnotation", "SUCCESS");
+    }
+
     /**
      * Not really related to retry but it's easiest to test it here
      */

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/resources/META-INF/microprofile-config.properties
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/resources/META-INF/microprofile-config.properties
@@ -13,6 +13,7 @@ com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.FallbackBeanWithoutRetry/co
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanC/connectC2/Retry/abortOn=java.lang.IllegalArgumentException,com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanC/connectCMaxRetries1/Retry/maxRetries=4
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanD/Retry/maxRetries=4
+com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanE/Retry/maxRetries=6
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.CircuitBreakerBean/serviceK/CircuitBreaker/requestVolumeThreshold=3
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.CircuitBreakerBean2/CircuitBreaker/requestVolumeThreshold=3
 com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.CircuitBreakerBean/serviceL/CircuitBreaker/delay=2000

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/RetryServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/RetryServlet.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanB;
 import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanC;
 import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanD;
+import com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans.RetryBeanE;
 import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
 import com.ibm.ws.microprofile.faulttolerance_fat.util.DisconnectException;
 
@@ -47,6 +48,9 @@ public class RetryServlet extends FATServlet {
 
     @Inject
     RetryBeanD beanD;
+
+    @Inject
+    RetryBeanE beanE;
 
     public void testRetry(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         //should be retried 3 times as per default
@@ -191,6 +195,21 @@ public class RetryServlet extends FATServlet {
             // Expected
         }
         assertThat(beanD.getConnectCount(), is(5));
+    }
+
+    /**
+     * Test that the Class-level annotation can be overridden by config at the method level
+     *
+     * Retry/maxRetries is set to 6 for this method in the config
+     */
+    public void testRetryMaxRetriesClassLevelConfigForMethodAnnotation() {
+        try {
+            beanE.connect();
+            fail("Exception not thrown");
+        } catch (ConnectException e) {
+            // Expected
+        }
+        assertThat(beanE.getConnectCount(), is(7));
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/RetryBeanE.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/RetryBeanE.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans;
+
+import javax.enterprise.context.RequestScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
+
+@RequestScoped
+public class RetryBeanE {
+
+    private int connectCount = 0;
+
+    /**
+     * Max retries is set to 6 at the class level in config, which should affect this method
+     */
+    @Retry(maxRetries = 2)
+    public void connect() throws ConnectException {
+        connectCount++;
+        throw new ConnectException("RetryBeanE Connect: " + connectCount);
+    }
+
+    public int getConnectCount() {
+        return connectCount;
+    }
+}


### PR DESCRIPTION
Values set on Fault Tolerance annotations on methods should be
configurable at the class level. I.e. if several methods have @Retry
annotation, configuring Retry/maxRetries for the class should affect all
of those methods.

For issue #186