### PR TITLE
Keep a set of all metrics created by the extension and remove them during beforeShutdown

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.cdi/src/io/astefanutti/metrics/cdi/MetricProducer.java
+++ b/dev/com.ibm.ws.microprofile.metrics.cdi/src/io/astefanutti/metrics/cdi/MetricProducer.java
@@ -33,6 +33,7 @@ import javax.interceptor.Interceptor;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.Meter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
@@ -43,8 +44,10 @@ import org.eclipse.microprofile.metrics.Timer;
 /* package-private */ final class MetricProducer {
 
     @Produces
-    private static Counter counter(InjectionPoint ip, MetricRegistry registry, MetricName metricName) {
-        return registry.counter(metricName.metadataOf(ip, Counter.class));
+    private static Counter counter(InjectionPoint ip, MetricRegistry registry, MetricName metricName, MetricsExtension extension) {
+        Metadata metadata = metricName.metadataOf(ip, Counter.class);
+        extension.addMetricName(metadata.getName());
+        return registry.counter(metadata);
     }
 
     @Produces
@@ -61,17 +64,23 @@ import org.eclipse.microprofile.metrics.Timer;
     }
 
     @Produces
-    private static Histogram histogram(InjectionPoint ip, MetricRegistry registry, MetricName metricName) {
-        return registry.histogram(metricName.metadataOf(ip, Histogram.class));
+    private static Histogram histogram(InjectionPoint ip, MetricRegistry registry, MetricName metricName, MetricsExtension extension) {
+        Metadata metadata = metricName.metadataOf(ip, Histogram.class);
+        extension.addMetricName(metadata.getName());
+        return registry.histogram(metadata);
     }
 
     @Produces
-    private static Meter meter(InjectionPoint ip, MetricRegistry registry, MetricName metricName) {
-        return registry.meter(metricName.metadataOf(ip, Meter.class));
+    private static Meter meter(InjectionPoint ip, MetricRegistry registry, MetricName metricName, MetricsExtension extension) {
+        Metadata metadata = metricName.metadataOf(ip, Meter.class);
+        extension.addMetricName(metadata.getName());
+        return registry.meter(metadata);
     }
 
     @Produces
-    private static Timer timer(InjectionPoint ip, MetricRegistry registry, MetricName metricName) {
-        return registry.timer(metricName.metadataOf(ip, Timer.class));
+    private static Timer timer(InjectionPoint ip, MetricRegistry registry, MetricName metricName, MetricsExtension extension) {
+        Metadata metadata = metricName.metadataOf(ip, Timer.class);
+        extension.addMetricName(metadata.getName());
+        return registry.timer(metadata);
     }
 }

--- a/dev/com.ibm.ws.microprofile.metrics.cdi/src/io/astefanutti/metrics/cdi/MetricsExtension.java
+++ b/dev/com.ibm.ws.microprofile.metrics.cdi/src/io/astefanutti/metrics/cdi/MetricsExtension.java
@@ -25,12 +25,12 @@ package io.astefanutti.metrics.cdi;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
@@ -78,7 +78,7 @@ public class MetricsExtension implements Extension, WebSphereCDIExtension {
     private static final AnnotationLiteral<Default> DEFAULT = new AnnotationLiteral<Default>() {};
 
     private final Map<Bean<?>, AnnotatedMember<?>> metrics = new HashMap<>();
-    private final List<String> metricNames = new ArrayList<String>();
+    private final Set<String> metricNames = Collections.synchronizedSortedSet(new TreeSet<String>());
 
     private final MetricsConfigurationEvent configuration = new MetricsConfigurationEvent();
 
@@ -129,7 +129,7 @@ public class MetricsExtension implements Extension, WebSphereCDIExtension {
                 continue;
             Metadata metadata = name.metadataOf(bean.getValue());
             registry.register(metadata.getName(), (Metric) getReference(manager, bean.getValue().getBaseType(), bean.getKey()), metadata);
-            metricNames.add(metadata.getName());
+            addMetricName(metadata.getName());
         }
 
         // Let's clear the collected metric producers
@@ -171,5 +171,9 @@ public class MetricsExtension implements Extension, WebSphereCDIExtension {
                 return true;
         }
         return false;
+    }
+
+    public void addMetricName(String name) {
+        metricNames.add(name);
     }
 }


### PR DESCRIPTION
Fixes #145 