### PR TITLE
Update CXF rt-core version

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -3,7 +3,7 @@ net.sf.jtidy:jtidy:9.3.8
 com.ibm.ws.org.apache.cxf:cxf-api:2.6.2.ibm-s20170216-1739
 com.ibm.ws.org.apache.cxf:cxf-rt-bindings-soap:2.6.2.ibm-s20170216-1739
 com.ibm.ws.org.apache.cxf:cxf-rt-bindings-xml:2.6.2.ibm-s20170216-1739
-com.ibm.ws.org.apache.cxf:cxf-rt-core:2.6.2.ibm-s20170216-1739
+com.ibm.ws.org.apache.cxf:cxf-rt-core:2.6.2.ibm-s20170927-0015
 com.ibm.ws.org.apache.cxf:cxf-rt-databinding-jaxb:2.6.2.ibm-s20170216-1739
 com.ibm.ws.org.apache.cxf:cxf-rt-frontend-jaxws:2.6.2.ibm-s20170216-1739
 com.ibm.ws.org.apache.cxf:cxf-rt-frontend-simple:2.6.2.ibm-s20170216-1739

--- a/dev/com.ibm.ws.jaxws.clientcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.clientcontainer/bnd.bnd
@@ -112,7 +112,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/clientcontainer/internal/resources/
 
 -buildpath: \
 	org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739, \
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739, \
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015, \
 	org.apache.cxf.cxf-rt-frontend-simple;strategy=exact;version=2.6.2.ibm-s20170216-1739, \
 	org.apache.cxf.cxf-rt-frontend-jaxws;strategy=exact;version=2.6.2.ibm-s20170216-1739, \
 	org.apache.cxf.cxf-rt-transports-http;strategy=exact;version=2.6.2.ibm-s20170216-1739, \

--- a/dev/com.ibm.ws.jaxws.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.common/bnd.bnd
@@ -196,7 +196,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/internal/resources/*.class
 	com.ibm.ws.logging;version=latest,\
 	org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-bindings-soap;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015,\
 	org.apache.cxf.cxf-rt-databinding-jaxb;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-jaxws;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-simple;strategy=exact;version=2.6.2.ibm-s20170216-1739,\

--- a/dev/com.ibm.ws.jaxws.ejb/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.ejb/bnd.bnd
@@ -71,7 +71,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/ejb/internal/resources/*.class
 -buildpath: \
     org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-bindings-soap;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015,\
 	org.apache.cxf.cxf-rt-databinding-jaxb;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-jaxws;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-simple;strategy=exact;version=2.6.2.ibm-s20170216-1739,\

--- a/dev/com.ibm.ws.jaxws.security/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.security/bnd.bnd
@@ -45,7 +45,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/security/internal/resources/*.class
 -buildpath: \
     org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-bindings-soap;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015,\
 	org.apache.cxf.cxf-rt-databinding-jaxb;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-jaxws;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-simple;strategy=exact;version=2.6.2.ibm-s20170216-1739,\

--- a/dev/com.ibm.ws.jaxws.web/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.web/bnd.bnd
@@ -65,7 +65,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/web/internal/resources/*.class
 -buildpath: \
     org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-bindings-soap;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015,\
 	org.apache.cxf.cxf-rt-databinding-jaxb;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-jaxws;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-simple;strategy=exact;version=2.6.2.ibm-s20170216-1739,\

--- a/dev/com.ibm.ws.jaxws.wsat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.wsat/bnd.bnd
@@ -50,7 +50,7 @@ Service-Component: \
 -buildpath: \
     org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-bindings-soap;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015,\
 	org.apache.cxf.cxf-rt-ws-policy;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\

--- a/dev/com.ibm.ws.org.apache.cxf.jaxws/cxf-rt-core.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.jaxws/cxf-rt-core.bnd
@@ -43,15 +43,15 @@ Import-Package: \
 DynamicImport-Package: com.ctc.wstx.*
 
 Include-Resource:\
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/cxf/**, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/services/**, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/schemas/**, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/spring.handlers, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/spring.schemas, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/DEPENDENCIES, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/LICENSE, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/NOTICE, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/org/apache/cxf/**
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/cxf/**, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/services/**, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/schemas/**, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/spring.handlers, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/spring.schemas, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/DEPENDENCIES, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/LICENSE, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/NOTICE, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/org/apache/cxf/**
  
  
 # Remove the resources (blueprint/metadata configuration files) in the OSGI-INF directory


### PR DESCRIPTION
The updated code in this module guards against loading 
bus-extensions.txt files from JAX-RS bundles.  The JAX-RS CXF bundles
have bus-extensions.txt files that will conflict with those used by
JAX-WS causing runtime failures.  Bypassing the JAX-RS bundles allows
the JAX-WS runtime to run successfully.