### PR TITLE
Update CXF rt-core version

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -3,7 +3,7 @@ net.sf.jtidy:jtidy:9.3.8
 com.ibm.ws.org.apache.cxf:cxf-api:2.6.2.ibm-s20170216-1739
 com.ibm.ws.org.apache.cxf:cxf-rt-bindings-soap:2.6.2.ibm-s20170216-1739
 com.ibm.ws.org.apache.cxf:cxf-rt-bindings-xml:2.6.2.ibm-s20170216-1739
-com.ibm.ws.org.apache.cxf:cxf-rt-core:2.6.2.ibm-s20170216-1739
+com.ibm.ws.org.apache.cxf:cxf-rt-core:2.6.2.ibm-s20170927-0015
 com.ibm.ws.org.apache.cxf:cxf-rt-databinding-jaxb:2.6.2.ibm-s20170216-1739
 com.ibm.ws.org.apache.cxf:cxf-rt-frontend-jaxws:2.6.2.ibm-s20170216-1739
 com.ibm.ws.org.apache.cxf:cxf-rt-frontend-simple:2.6.2.ibm-s20170216-1739

--- a/dev/com.ibm.ws.org.apache.cxf.jaxws/cxf-rt-core.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.jaxws/cxf-rt-core.bnd
@@ -43,15 +43,15 @@ Import-Package: \
 DynamicImport-Package: com.ctc.wstx.*
 
 Include-Resource:\
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/cxf/**, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/services/**, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/schemas/**, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/spring.handlers, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/spring.schemas, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/DEPENDENCIES, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/LICENSE, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/META-INF/NOTICE, \
- @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170216-1739;EXACT}!/org/apache/cxf/**
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/cxf/**, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/services/**, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/schemas/**, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/spring.handlers, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/spring.schemas, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/DEPENDENCIES, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/LICENSE, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/META-INF/NOTICE, \
+ @${repo;org.apache.cxf.cxf-rt-core;2.6.2.ibm-s20170927-0015;EXACT}!/org/apache/cxf/**
  
  
 # Remove the resources (blueprint/metadata configuration files) in the OSGI-INF directory


### PR DESCRIPTION
The updated code in this module guards against loading 
bus-extensions.txt files from JAX-RS bundles.  The JAX-RS CXF bundles
have bus-extensions.txt files that will conflict with those used by
JAX-WS causing runtime failures.  Bypassing the JAX-RS bundles allows
the JAX-WS runtime to run successfully.