### PR TITLE
Update other spots where rt-core is used

### DIFF
--- a/dev/com.ibm.ws.jaxws.clientcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.clientcontainer/bnd.bnd
@@ -112,7 +112,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/clientcontainer/internal/resources/
 
 -buildpath: \
 	org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739, \
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739, \
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015, \
 	org.apache.cxf.cxf-rt-frontend-simple;strategy=exact;version=2.6.2.ibm-s20170216-1739, \
 	org.apache.cxf.cxf-rt-frontend-jaxws;strategy=exact;version=2.6.2.ibm-s20170216-1739, \
 	org.apache.cxf.cxf-rt-transports-http;strategy=exact;version=2.6.2.ibm-s20170216-1739, \

--- a/dev/com.ibm.ws.jaxws.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.common/bnd.bnd
@@ -196,7 +196,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/internal/resources/*.class
 	com.ibm.ws.logging;version=latest,\
 	org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-bindings-soap;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015,\
 	org.apache.cxf.cxf-rt-databinding-jaxb;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-jaxws;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-simple;strategy=exact;version=2.6.2.ibm-s20170216-1739,\

--- a/dev/com.ibm.ws.jaxws.ejb/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.ejb/bnd.bnd
@@ -71,7 +71,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/ejb/internal/resources/*.class
 -buildpath: \
     org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-bindings-soap;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015,\
 	org.apache.cxf.cxf-rt-databinding-jaxb;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-jaxws;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-simple;strategy=exact;version=2.6.2.ibm-s20170216-1739,\

--- a/dev/com.ibm.ws.jaxws.security/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.security/bnd.bnd
@@ -45,7 +45,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/security/internal/resources/*.class
 -buildpath: \
     org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-bindings-soap;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015,\
 	org.apache.cxf.cxf-rt-databinding-jaxb;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-jaxws;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-simple;strategy=exact;version=2.6.2.ibm-s20170216-1739,\

--- a/dev/com.ibm.ws.jaxws.web/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.web/bnd.bnd
@@ -65,7 +65,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/web/internal/resources/*.class
 -buildpath: \
     org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-bindings-soap;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015,\
 	org.apache.cxf.cxf-rt-databinding-jaxb;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-jaxws;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-frontend-simple;strategy=exact;version=2.6.2.ibm-s20170216-1739,\

--- a/dev/com.ibm.ws.jaxws.wsat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.wsat/bnd.bnd
@@ -50,7 +50,7 @@ Service-Component: \
 -buildpath: \
     org.apache.cxf.cxf-api;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	org.apache.cxf.cxf-rt-bindings-soap;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
-	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
+	org.apache.cxf.cxf-rt-core;strategy=exact;version=2.6.2.ibm-s20170927-0015,\
 	org.apache.cxf.cxf-rt-ws-policy;strategy=exact;version=2.6.2.ibm-s20170216-1739,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\


### PR DESCRIPTION
From the delivery of #275, the version was upgraded in the bundle we package, but not the other compile-time dependencies.

This should likely be reworked so only one project depends on the imported jar and the others just depend on that.