### PR TITLE
Ignore missing wlp/lafiles/ dir during runnable jar packaging

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageProcessor.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageProcessor.java
@@ -373,9 +373,6 @@ public class PackageProcessor implements ArchiveProcessor {
         if (lafilesDir.exists()) {
             DirEntryConfig lafilesDirConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX + "lafiles", lafilesDir, true, PatternStrategy.IncludePreference);
             entryConfigs.add(lafilesDirConfig);
-        } else if (isJarPackage) {
-            // Output error and stop
-            throw new FileNotFoundException(lafilesDir.toString());
         }
 
         /*


### PR DESCRIPTION
For issue #278 