### PR TITLE
Improve performance when injecting values from MP config

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.cdi/src/com/ibm/ws/microprofile/config/cdi/ConfigBean.java
+++ b/dev/com.ibm.ws.microprofile.config.cdi/src/com/ibm/ws/microprofile/config/cdi/ConfigBean.java
@@ -19,7 +19,7 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.PassivationCapable;
 
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.spi.ConfigBuilder;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 
 /**
@@ -38,13 +38,10 @@ public class ConfigBean extends AbstractConfigBean<Config> implements Bean<Confi
     /** {@inheritDoc} */
     @Override
     public Config create(CreationalContext<Config> creationalContext) {
-        ConfigBuilder builder = ConfigProviderResolver.instance().getBuilder();
-        builder.addDiscoveredConverters();
-        builder.addDefaultSources();
-        builder.addDiscoveredSources();
-        Config config = builder.build();
-
-        return config;
+        // Although this is a request scoped bean, this config instance will be cached per classloader, so you don't really get a new config object per request
+        // However, the config object is updated with new values dynamically, so the user shouldn't notice any difference.
+        // This also means that injecting config gives the same result as calling getConfig() in user code
+        return ConfigProvider.getConfig();
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.microprofile.config.cdi/src/com/ibm/ws/microprofile/config/cdi/ConfigPropertyBean.java
+++ b/dev/com.ibm.ws.microprofile.config.cdi/src/com/ibm/ws/microprofile/config/cdi/ConfigPropertyBean.java
@@ -26,8 +26,7 @@ import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.inject.spi.PassivationCapable;
 
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.spi.ConfigBuilder;
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -59,42 +58,30 @@ public class ConfigPropertyBean<T> extends AbstractConfigBean<T> implements Bean
         BeanManager beanManager = cdi.getBeanManager();
         InjectionPoint injectionPoint = getInjectionPoint(beanManager, creationalContext);
 
-        //TODO when we get the Config to work in the correct CDI scopes, we'll want CDI to provide the Config here
-//        Set<Bean<?>> beans = beanManager.getBeans(Config.class);
-//        Bean<?> bean = beanManager.resolve(beans);
-//
-//        Config config = (Config) beanManager.getReference(bean, Config.class, creationalContext);
-
-        //TODO for now we'll just get a new one so we can manually release it again straight away
-        ConfigBuilder builder = ConfigProviderResolver.instance().getBuilder();
-        builder.addDiscoveredConverters();
-        builder.addDefaultSources();
-        builder.addDiscoveredSources();
-        Config config = builder.build();
+        // Note the config is cached per thread context class loader
+        // This shouldn't matter though as the config object is updated with values dynamically
+        // Also means that injecting config does things the same way as calling `getConfig().getValue()`
+        Config config = ConfigProvider.getConfig();
 
         T instance = null;
 
-        try {
-            Type ipType = injectionPoint.getType();
-            if (ipType instanceof ParameterizedType) {
-                ParameterizedType pType = (ParameterizedType) ipType;
-                Type rType = pType.getRawType();
-                if (rType == Optional.class) {
-                    Type[] tArgs = pType.getActualTypeArguments();
-                    Type aType = tArgs[0];
-                    Class<?> aClass = (Class<?>) aType;
-                    instance = (T) getOptional(config, injectionPoint, aClass);
-                } else {
-                    throw new IllegalArgumentException(Tr.formatMessage(tc, "unable.to.determine.injection.type.CWMCG5001E", ipType));
-                }
-            } else if (ipType instanceof Class) {
-                Class<T> ipClass = (Class<T>) ipType;
-                instance = ConfigProducer.newValue(config, injectionPoint, ipClass, false);
+        Type ipType = injectionPoint.getType();
+        if (ipType instanceof ParameterizedType) {
+            ParameterizedType pType = (ParameterizedType) ipType;
+            Type rType = pType.getRawType();
+            if (rType == Optional.class) {
+                Type[] tArgs = pType.getActualTypeArguments();
+                Type aType = tArgs[0];
+                Class<?> aClass = (Class<?>) aType;
+                instance = (T) getOptional(config, injectionPoint, aClass);
             } else {
                 throw new IllegalArgumentException(Tr.formatMessage(tc, "unable.to.determine.injection.type.CWMCG5001E", ipType));
             }
-        } finally {
-            ConfigProviderResolver.instance().releaseConfig(config);
+        } else if (ipType instanceof Class) {
+            Class<T> ipClass = (Class<T>) ipType;
+            instance = ConfigProducer.newValue(config, injectionPoint, ipClass, false);
+        } else {
+            throw new IllegalArgumentException(Tr.formatMessage(tc, "unable.to.determine.injection.type.CWMCG5001E", ipType));
         }
         return instance;
     }


### PR DESCRIPTION
Previously we were manually building a new Config object for each
creation of an injected config value. Manually calling the builder like
this bypasses the cache in ConfigProviderResolverImpl.