### PR TITLE
policy executor untimed invokeAny optimization for single task

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -19,13 +19,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -38,6 +36,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.threading.PolicyExecutor;
+import com.ibm.ws.threading.internal.PolicyTaskFutureImpl.InvokeAnyCompletionTracker;
 
 /**
  * Policy executors are backed by the Liberty global thread pool,
@@ -57,9 +56,9 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
     private final AtomicInteger coreConcurrencyAvailable = new AtomicInteger();
 
-    private ExecutorServiceImpl globalExecutor;
+    ExecutorServiceImpl globalExecutor;
 
-    private String identifier;
+    String identifier;
 
     private int maxConcurrency;
 
@@ -67,7 +66,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
     private int maxQueueSize;
 
-    private final ReduceableSemaphore maxQueueSizeConstraint = new ReduceableSemaphore(0, false);
+    final ReduceableSemaphore maxQueueSizeConstraint = new ReduceableSemaphore(0, false);
 
     private final AtomicLong maxWaitForEnqueueNS = new AtomicLong();
 
@@ -78,7 +77,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
      */
     private final ConcurrentHashMap<String, PolicyExecutorImpl> providerCreated;
 
-    private final ConcurrentLinkedQueue<PolicyTaskFuture<?>> queue = new ConcurrentLinkedQueue<PolicyTaskFuture<?>>();
+    final ConcurrentLinkedQueue<PolicyTaskFutureImpl<?>> queue = new ConcurrentLinkedQueue<PolicyTaskFutureImpl<?>>();
 
     private final AtomicReference<QueueFullAction> queueFullAction = new AtomicReference<QueueFullAction>();
 
@@ -88,7 +87,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
      * because it is needed only for the life cycle methods which are unavailable to
      * server-configured policy executors.
      */
-    private final Set<PolicyTaskFuture<?>> running = Collections.newSetFromMap(new ConcurrentHashMap<PolicyTaskFuture<?>, Boolean>());
+    private final Set<PolicyTaskFutureImpl<?>> running = Collections.newSetFromMap(new ConcurrentHashMap<PolicyTaskFutureImpl<?>, Boolean>());
 
     /**
      * Latch that awaits the shutdown method progressing to ENQUEUE_STOPPED state.
@@ -122,123 +121,6 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     }
 
     /**
-     * Tracks completion of an invokeAny operation.
-     */
-    private static class InvokeAnyCompletionTracker {
-        /**
-         * Count of pending tasks that have not completed or been canceled.
-         */
-        private final AtomicInteger pending;
-
-        /**
-         * Populated with first successful result. When set to the tracker instance, it means no successful result has been obtained yet.
-         */
-        private final AtomicReference<Object> result;
-
-        /**
-         * Thread of execution for the invokeAny operation.
-         */
-        private Thread thread;
-
-        private InvokeAnyCompletionTracker(int numTasks, Thread thread) {
-            pending = new AtomicInteger(numTasks);
-            result = new AtomicReference<Object>(this);
-            this.thread = thread;
-        }
-
-        private synchronized void notifyInvokeAny() {
-            if (thread != null) {
-                thread.interrupt();
-                thread = null;
-            }
-        }
-    }
-
-    /**
-     * A wrapper for FutureTask that allows us to immediately free up a queue position upon cancel
-     * and ensures that we only provide implementation of the Future methods rather than all methods
-     * of FutureTask to the invoker.
-     *
-     * @param <T> return type of underlying task.
-     */
-    private class PolicyTaskFuture<T> implements Future<T> {
-        private final FutureTask<T> futureTask;
-        private final Object task;
-        private final InvokeAnyCompletionTracker tracker;
-
-        private PolicyTaskFuture(Callable<T> task) {
-            this.futureTask = new FutureTask<T>(globalExecutor.wrap(task));
-            this.task = task;
-            this.tracker = null;
-        }
-
-        private PolicyTaskFuture(Callable<T> task, InvokeAnyCompletionTracker tracker) {
-            this.futureTask = new FutureTask<T>(globalExecutor.wrap(task));
-            this.task = task;
-            this.tracker = tracker;
-        }
-
-        private PolicyTaskFuture(Runnable task, T result) {
-            this.futureTask = new FutureTask<T>(globalExecutor.wrap(task), result);
-            this.task = task;
-            this.tracker = null;
-        }
-
-        @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-            boolean canceled = futureTask.cancel(mayInterruptIfRunning);
-            if (canceled) {
-                if (queue.remove(this))
-                    maxQueueSizeConstraint.release();
-                if (tracker != null && tracker.pending.decrementAndGet() == 0)
-                    tracker.notifyInvokeAny();
-            }
-            return canceled;
-        }
-
-        @Override
-        public T get() throws ExecutionException, InterruptedException {
-            return futureTask.get();
-        }
-
-        @Override
-        public T get(long timeout, TimeUnit unit) throws ExecutionException, InterruptedException, TimeoutException {
-            return futureTask.get(timeout, unit);
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return futureTask.isCancelled();
-        }
-
-        @Override // to auto-add trace
-        public boolean isDone() {
-            return futureTask.isDone();
-        }
-
-        @FFDCIgnore(value = { CancellationException.class, ExecutionException.class, InterruptedException.class })
-        private void notifyInvokeAny() {
-            try {
-                tracker.result.compareAndSet(tracker, futureTask.get());
-                tracker.notifyInvokeAny();
-            } catch (CancellationException x) { // no-op
-            } catch (ExecutionException x) {
-                if (tracker.pending.decrementAndGet() == 0)
-                    tracker.notifyInvokeAny();
-            } catch (InterruptedException x) {
-                if (tracker.pending.decrementAndGet() == 0)
-                    tracker.notifyInvokeAny();
-            }
-        }
-
-        @Trivial
-        @Override
-        public String toString() {
-            return new StringBuilder("PolicyTaskFuture@").append(Integer.toHexString(hashCode())).append(" for ").append(task).append(" on ").append(identifier).toString();
-        }
-    }
-
-    /**
      * Polling tasks run on the global thread pool.
      * Their role is to run tasks that are queued up on the policy executor.
      */
@@ -254,7 +136,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         @Override
         public void run() {
             boolean canRun;
-            PolicyTaskFuture<?> next;
+            PolicyTaskFutureImpl<?> next;
             do {
                 // Check the state to reduce the possibility of removing a queued task that we will not be able to run
                 State currentState = state.get();
@@ -490,7 +372,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
      *             the InterruptedException is chained to the RejectedExecutionException.
      */
     @FFDCIgnore(value = { InterruptedException.class, RejectedExecutionException.class }) // these are raised directly to invoker, who decides how to handle
-    private boolean enqueue(PolicyTaskFuture<?> policyTaskFuture, long wait, Boolean callerRunsOverride) {
+    private boolean enqueue(PolicyTaskFutureImpl<?> policyTaskFuture, long wait, Boolean callerRunsOverride) {
         boolean enqueued;
         try {
             if (wait <= 0 ? maxQueueSizeConstraint.tryAcquire() : maxQueueSizeConstraint.tryAcquire(wait, TimeUnit.NANOSECONDS)) {
@@ -568,7 +450,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
     @Override
     public void execute(Runnable command) {
-        enqueue(new PolicyTaskFuture<Void>(command, null), maxWaitForEnqueueNS.get(), null);
+        enqueue(new PolicyTaskFutureImpl<Void>(this, command, null), maxWaitForEnqueueNS.get(), null);
     }
 
     /**
@@ -600,7 +482,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     // Submit and run tasks and return list of completed (possibly canceled) tasks.
     // Because this method is not timed, tasks can run on the current thread if queueFullAction is CallerRuns or a permit is available.
     @Override
-    @FFDCIgnore(value = { CancellationException.class, ExecutionException.class, RejectedExecutionException.class })
+    @FFDCIgnore(value = { RejectedExecutionException.class })
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
@@ -619,7 +501,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             // submit tasks (except the last if we are able to run tasks on the current thread)
             int t = 0, numToSubmitAsync = useCurrentThread ? taskCount - 1 : taskCount;
             for (Callable<T> task : tasks) {
-                PolicyTaskFuture<T> taskFuture = new PolicyTaskFuture<T>(task);
+                PolicyTaskFutureImpl<T> taskFuture = new PolicyTaskFutureImpl<T>(this, task);
                 if (t++ < numToSubmitAsync) {
                     boolean enqueued;
                     if (useCurrentThread)
@@ -628,13 +510,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                         enqueued = enqueue(taskFuture, maxWaitForEnqueueNS.get(), null);
 
                     if (!enqueued) // must immediately return if ran on current thread and was interrupted
-                        try {
-                            taskFuture.get();
-                        } catch (CancellationException x) {
-                        } catch (ExecutionException x) {
-                            if (x.getCause() instanceof InterruptedException)
-                                throw (InterruptedException) x.getCause();
-                        }
+                        taskFuture.throwIfInterrupted();
                 }
                 futures.add(taskFuture);
             }
@@ -642,7 +518,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             // run on current thread if possible
             if (useCurrentThread)
                 for (t = numToSubmitAsync; t >= 0; t--) {
-                    PolicyTaskFuture<T> taskFuture = (PolicyTaskFuture<T>) futures.get(t);
+                    PolicyTaskFutureImpl<T> taskFuture = (PolicyTaskFutureImpl<T>) futures.get(t);
                     State currentState = state.get();
                     if (t == numToSubmitAsync) { // we intentionally avoided submitting the last task
                         if (currentState != State.ACTIVE)
@@ -660,28 +536,14 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                     runTask(taskFuture);
 
                     // must immediately return if current thread is interrupted
-                    try {
-                        taskFuture.get();
-                    } catch (CancellationException x) {
-                    } catch (ExecutionException x) {
-                        if (x.getCause() instanceof InterruptedException)
-                            throw (InterruptedException) x.getCause();
-                    }
+                    taskFuture.throwIfInterrupted();
                 }
 
             // wait for completion
-            for (Future<T> future : futures)
-                try {
-                    if (!future.isDone())
-                        future.get();
-                    taskCount--;
-                } catch (CancellationException x) {
-                    if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "task is canceled", x);
-                } catch (ExecutionException x) {
-                    if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "task completed exceptionally", x);
-                }
+            for (Future<T> future : futures) {
+                ((PolicyTaskFutureImpl<T>) future).await();
+                taskCount--;
+            }
         } catch (RejectedExecutionException x) {
             if (trace && tc.isDebugEnabled())
                 Tr.debug(this, tc, "rejected", x);
@@ -719,7 +581,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     // Submit and run tasks within allotted interval and return list of completed (possibly canceled) tasks.
     // Because this method is timed, tasks will never run on the invoker's current thread.
     @Override
-    @FFDCIgnore(value = { CancellationException.class, ExecutionException.class, RejectedExecutionException.class, TimeoutException.class })
+    @FFDCIgnore(value = { RejectedExecutionException.class })
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
@@ -736,7 +598,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         try {
             // submit all tasks
             for (Callable<T> task : tasks) {
-                PolicyTaskFuture<T> taskFuture = new PolicyTaskFuture<T>(task);
+                PolicyTaskFutureImpl<T> taskFuture = new PolicyTaskFutureImpl<T>(this, task);
                 remaining = stop - System.nanoTime();
                 if (remaining <= 0)
                     throw new RejectedExecutionException("timed out before all tasks could be submitted"); // TODO NLS message for timed out
@@ -749,18 +611,10 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
             // wait for completion
             for (Future<T> future : futures)
-                try {
-                    future.get(stop - System.nanoTime(), TimeUnit.NANOSECONDS);
+                if (((PolicyTaskFutureImpl<T>) future).await(stop - System.nanoTime(), TimeUnit.NANOSECONDS))
                     taskCount--;
-                } catch (CancellationException x) {
-                    if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "task is canceled", x);
-                } catch (ExecutionException x) {
-                    if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "task completed exceptionally", x);
-                } catch (TimeoutException x) {
-                    break; // stop waiting
-                }
+                else
+                    break;
         } catch (RejectedExecutionException x) {
             if (trace && tc.isDebugEnabled())
                 Tr.debug(this, tc, "rejected", x);
@@ -782,8 +636,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         throw new UnsupportedOperationException();
     }
 
-    @FFDCIgnore(value = { CancellationException.class, RejectedExecutionException.class })
     @Override
+    @FFDCIgnore(value = { RejectedExecutionException.class })
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         int taskCount = tasks.size();
         long stop = System.nanoTime() + unit.toNanos(timeout);
@@ -797,16 +651,16 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             if (task == null)
                 throw new NullPointerException();
 
-        InvokeAnyCompletionTracker tracker = new InvokeAnyCompletionTracker(taskCount, Thread.currentThread());
-        ArrayList<Future<T>> futures = new ArrayList<Future<T>>(taskCount);
+        InvokeAnyCompletionTracker tracker = new InvokeAnyCompletionTracker(taskCount);
+        ArrayList<PolicyTaskFutureImpl<T>> futures = new ArrayList<PolicyTaskFutureImpl<T>>(taskCount);
         try {
             // submit all tasks
             for (Callable<T> task : tasks) {
-                PolicyTaskFuture<T> taskFuture = new PolicyTaskFuture<T>(task, tracker);
+                PolicyTaskFutureImpl<T> taskFuture = new PolicyTaskFutureImpl<T>(this, task, tracker);
                 remaining = stop - System.nanoTime();
 
                 // check if done before enqueuing more tasks
-                if (tracker.result.get() != tracker)
+                if (tracker.hasSuccessfulResult())
                     break;
 
                 if (remaining <= 0)
@@ -828,29 +682,9 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             } else
                 throw x;
         } finally {
-            synchronized (tracker) {
-                tracker.thread = null;
-            }
-
-            boolean allTasksDone = tracker.pending.get() == 0;
-            if (!allTasksDone)
-                for (Future<T> f : futures)
-                    f.cancel(true);
-
-            Object result = tracker.result.get();
-            if (result != tracker)
-                return (T) result;
-            else if (allTasksDone) { // cause ExecutionException (preferred) or CancellationException to be raised
-                CancellationException cx = null;
-                for (Future<T> f : futures)
-                    try {
-                        f.get();
-                    } catch (CancellationException x) {
-                        cx = x;
-                    }
-                if (cx != null)
-                    throw cx;
-            } // else allow original exception to be raised (InterruptedException or TimeoutException)
+            T result = tracker.completeInvokeAny(futures);
+            if (result != null || tracker.hasSuccessfulResult())
+                return result;
         }
     }
 
@@ -979,16 +813,14 @@ public class PolicyExecutorImpl implements PolicyExecutor {
      * @param future the future for the task.
      * @return Exception that occurred while running the task. Otherwise null.
      */
-    void runTask(PolicyTaskFuture<?> future) {
+    void runTask(PolicyTaskFutureImpl<?> future) {
         try {
             if (providerCreated != null) // the following code only matters when life cycle operations are permitted
                 running.add(future); // intentionally done before checking state to avoid missing cancels on shutdownNow
 
             State currentState = state.get();
             if (currentState == State.ACTIVE || currentState == State.ENQUEUE_STOPPING || currentState == State.ENQUEUE_STOPPED) {
-                future.futureTask.run();
-                if (future.tracker != null)
-                    future.notifyInvokeAny();
+                future.run();
             } else {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(this, tc, "Cancel task due to policy executor state " + currentState);
@@ -1053,11 +885,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             // Remove and cancel all queued tasks. The maxQueueSizeConstraint should prevent queueing more,
             // apart from a timing window where a task is being scheduled during shutdown, which is
             // covered by checking the state before returning from submit.
-            for (PolicyTaskFuture<?> f = queue.poll(); f != null; f = queue.poll()) {
+            for (PolicyTaskFutureImpl<?> f = queue.poll(); f != null; f = queue.poll()) {
                 if (f.cancel(false)) {
-                    // It would be wrong to return FutureTask as the Runnable.
-                    // Presumably the list of tasks that didn't run is being returned so that the invoker can decide what to do
-                    // with them, which includes having the option to run them, which is not an option for a canceled FutureTask.
                     if (f.task instanceof Runnable)
                         queuedTasks.add((Runnable) f.task);
                     else
@@ -1066,7 +895,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             }
 
             // Cancel tasks that are running
-            for (Iterator<PolicyTaskFuture<?>> it = running.iterator(); it.hasNext();)
+            for (Iterator<PolicyTaskFutureImpl<?>> it = running.iterator(); it.hasNext();)
                 it.next().cancel(true);
 
             if (state.compareAndSet(State.TASKS_CANCELING, State.TASKS_CANCELED))
@@ -1087,21 +916,21 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        PolicyTaskFuture<T> policyTaskFuture = new PolicyTaskFuture<T>(task);
+        PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task);
         enqueue(policyTaskFuture, maxWaitForEnqueueNS.get(), null);
         return policyTaskFuture;
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        PolicyTaskFuture<T> policyTaskFuture = new PolicyTaskFuture<T>(task, result);
+        PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task, result);
         enqueue(policyTaskFuture, maxWaitForEnqueueNS.get(), null);
         return policyTaskFuture;
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        PolicyTaskFuture<?> policyTaskFuture = new PolicyTaskFuture<Void>(task, null);
+        PolicyTaskFutureImpl<?> policyTaskFuture = new PolicyTaskFutureImpl<Void>(this, task, null);
         enqueue(policyTaskFuture, maxWaitForEnqueueNS.get(), null);
         return policyTaskFuture;
     }
@@ -1129,7 +958,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         if (running.isEmpty()) {
             out.println(DOUBLEINDENT + "None");
         } else {
-            for (PolicyTaskFuture<?> task : running) {
+            for (PolicyTaskFutureImpl<?> task : running) {
                 out.println(DOUBLEINDENT + task.toString());
             }
         }
@@ -1138,7 +967,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         if (queue.isEmpty()) {
             out.println(DOUBLEINDENT + "None");
         } else {
-            for (PolicyTaskFuture<?> task : queue) {
+            for (PolicyTaskFutureImpl<?> task : queue) {
                 if (counter-- > 0)
                     out.println(DOUBLEINDENT + task.toString());
                 else

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -1,0 +1,460 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.threading.internal;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.AbstractQueuedSynchronizer;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+/**
+ * Allows the policy executor to tie into internal state and other details of a Future implementation.
+ * This enables us to, for example, immediately free up a queue position upon cancel.
+ *
+ * @param <T> type of the result.
+ */
+public class PolicyTaskFutureImpl<T> implements Future<T> {
+    private static final TraceComponent tc = Tr.register(PolicyTaskFutureImpl.class);
+
+    // state constants
+    private static final int SUBMITTED = 0, RUNNING = 1, SUCCESSFUL = 2, FAILED = 3, CANCELING = 4, CANCELED = 5;
+
+    /**
+     * The task, if a Callable. It is wrapped with interceptors, if any.
+     */
+    private final Callable<T> callable;
+
+    /**
+     * The policy executor instance.
+     */
+    private final PolicyExecutorImpl executor;
+
+    /**
+     * Predefined result, if any, for Runnable tasks.
+     */
+    private final T predefinedResult;
+
+    /**
+     * The task, if a Runnable. It is wrapped with interceptors, if any.
+     */
+    private final Runnable runnable;
+
+    /**
+     * Represents the state of the future, and allows for waiters. Initial state is SUBMITTED.
+     * State transitions in one direction only:
+     * SUBMITTED --> CANCELED,
+     * SUBMITTED --> RUNNING --> SUCCESSFUL,
+     * SUBMITTED --> RUNNING --> CANCELING --> CANCELED,
+     * SUBMITTED --> RUNNING --> FAILED.
+     * Always set the result before updating the state, so that get() operations that await state can rely on the result being available.
+     */
+    private final State state = new State();
+
+    /**
+     * The Callable or Runnable task. It is not wrapped with interceptors.
+     */
+    final Object task;
+
+    /**
+     * Thread of execution, while running.
+     */
+    private volatile Thread thread;
+
+    /**
+     * Tracker for invokeAny futures. Otherwise null.
+     */
+    private final InvokeAnyCompletionTracker tracker;
+
+    /**
+     * Result of the task. Can be a value, an exception, or other indicator (the state distinguishes).
+     * Initialized to the state field as a way of indicating a result is not set. This allows the possibility of null results.
+     */
+    private final AtomicReference<Object> result = new AtomicReference<Object>(state);
+
+    /**
+     * Privileged action that interrupts a thread.
+     */
+    @Trivial
+    private static class InterruptAction implements PrivilegedAction<Void> {
+        private final Thread thread;
+
+        private InterruptAction(Thread t) {
+            thread = t;
+        }
+
+        @Override
+        public Void run() {
+            thread.interrupt();
+            return null;
+        }
+    }
+
+    /**
+     * Tracks completion of an invokeAny operation. The invokeAny method follows a pattern of constructing an instance
+     * of this tracker class from its thread of execution and later invoking completeInvokeAny at the end of the operation.
+     */
+    static class InvokeAnyCompletionTracker {
+        /**
+         * Count of pending tasks that have not completed or been canceled.
+         */
+        private final AtomicInteger pending;
+
+        /**
+         * Populated with first successful result. When set to the tracker instance, it means no successful result has been obtained yet.
+         */
+        private final AtomicReference<Object> result;
+
+        /**
+         * Thread of execution for the invokeAny operation.
+         */
+        private Thread thread;
+
+        InvokeAnyCompletionTracker(int numTasks) {
+            pending = new AtomicInteger(numTasks);
+            result = new AtomicReference<Object>(this);
+            thread = Thread.currentThread();
+        }
+
+        /**
+         * Completes the processing for the invokeAny method for which this tracker was created.
+         *
+         * @param <T>
+         *
+         * @param futures futures for tasks submitted to invokeAny.
+         * @return result of a task that completed successfully. If none completed successfully or exceptionally or were canceled, then returns null.
+         *         The result should be used in combination with hasSuccessfulResult in order to disambiguate null values.
+         * @throws CancellationException if no task completed successfully or exceptionally but at least one was canceled.
+         * @throws ExecutionException if no task completed successfully but at least one completed exceptionally.
+         */
+        @SuppressWarnings("unchecked")
+        <T> T completeInvokeAny(ArrayList<PolicyTaskFutureImpl<T>> futures) throws CancellationException, ExecutionException {
+            synchronized (this) {
+                thread = null;
+            }
+
+            boolean allTasksDone = pending.get() == 0;
+            if (!allTasksDone)
+                for (Future<?> f : futures)
+                    f.cancel(true);
+
+            Object result = this.result.get();
+            if (result != this)
+                return (T) result;
+            else if (allTasksDone) { // cause ExecutionException (preferred) or CancellationException to be raised
+                boolean canceled = false;
+                for (PolicyTaskFutureImpl<?> f : futures) {
+                    int s = f.state.get();
+                    if (s == FAILED)
+                        throw new ExecutionException((Throwable) f.result.get());
+                    else if (s == CANCELED || s == CANCELING)
+                        canceled = true;
+                }
+                if (canceled)
+                    throw new CancellationException();
+            } // else allow original exception to be raised (InterruptedException or TimeoutException)
+            return null;
+        }
+
+        /**
+         * @return true if a successful result has been recorded, otherwise false.
+         */
+        boolean hasSuccessfulResult() {
+            return result.get() != this;
+        }
+
+        /**
+         * Interrupts the thread on which invokeAny is running so that it can complete.
+         */
+        private synchronized void notifyInvokeAny() {
+            if (thread != null)
+                try {
+                    AccessController.doPrivileged(new InterruptAction(thread));
+                } finally {
+                    thread = null;
+                }
+        }
+    }
+
+    /**
+     * Awaitable state. Specifically, allows awaiting the transition from SUBMITTED/RUNNING to a SUCCESSFUL/CANCELING/CANCELED/FAILED state.
+     */
+    @Trivial
+    private static class State extends AbstractQueuedSynchronizer {
+        private static final long serialVersionUID = 1L;
+
+        private final int get() {
+            return getState();
+        }
+
+        private boolean setRunning() {
+            return compareAndSetState(SUBMITTED, RUNNING);
+        }
+
+        @Override
+        protected final int tryAcquireShared(int ignored) {
+            return getState() > RUNNING ? 1 : -1;
+        }
+
+        @Override
+        protected final boolean tryReleaseShared(int newState) {
+            int oldState;
+            while (!compareAndSetState(oldState = getState(), newState));
+            return oldState == RUNNING || oldState == SUBMITTED;
+        }
+    }
+
+    PolicyTaskFutureImpl(PolicyExecutorImpl executor, Callable<T> task) {
+        if (task == null)
+            throw new NullPointerException();
+        this.callable = executor.globalExecutor.wrap(task);
+        this.executor = executor;
+        this.predefinedResult = null;
+        this.runnable = null;
+        this.task = task;
+        this.tracker = null;
+    }
+
+    PolicyTaskFutureImpl(PolicyExecutorImpl executor, Callable<T> task, InvokeAnyCompletionTracker tracker) {
+        if (task == null)
+            throw new NullPointerException();
+        this.callable = executor.globalExecutor.wrap(task);
+        this.executor = executor;
+        this.predefinedResult = null;
+        this.runnable = null;
+        this.task = task;
+        this.tracker = tracker;
+    }
+
+    PolicyTaskFutureImpl(PolicyExecutorImpl executor, Runnable task, T predefinedResult) {
+        if (task == null)
+            throw new NullPointerException();
+        this.callable = null;
+        this.executor = executor;
+        this.predefinedResult = predefinedResult;
+        this.runnable = executor.globalExecutor.wrap(task);
+        this.task = task;
+        this.tracker = null;
+    }
+
+    /**
+     * Await completion of the future. Completion could be successful, exceptional, or by cancellation.
+     */
+    void await() throws InterruptedException {
+        if (state.get() <= RUNNING)
+            state.acquireSharedInterruptibly(1);
+    }
+
+    /**
+     * Await completion of the future. Completion could be successful, exceptional, or by cancellation.
+     *
+     * @return true if completed before the specified interval elapses, otherwise false.
+     */
+    boolean await(long time, TimeUnit unit) throws InterruptedException {
+        return state.get() > RUNNING || state.tryAcquireSharedNanos(1, unit.toNanos(time));
+    }
+
+    @Override
+    public boolean cancel(boolean interruptIfRunning) {
+        if (result.compareAndSet(state, CANCELED)) {
+            if (executor.queue.remove(this)) {
+                state.releaseShared(CANCELED);
+                executor.maxQueueSizeConstraint.release();
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "canceled from queue");
+            } else if (interruptIfRunning) {
+                state.releaseShared(CANCELING);
+                Thread t = thread;
+                try {
+                    if (t != null) {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                            Tr.debug(this, tc, "interrupting " + t);
+                        AccessController.doPrivileged(new InterruptAction(t));
+                    }
+                } finally {
+                    state.releaseShared(CANCELED);
+                }
+            } else {
+                state.releaseShared(CANCELED);
+            }
+
+            if (tracker != null && tracker.pending.decrementAndGet() == 0)
+                tracker.notifyInvokeAny();
+
+            return true;
+        } else {
+            // Prevent premature return from cancel that would allow subsequent isCanceled/isDone to return false
+            while (result.get() == state)
+                Thread.yield();
+            return false;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        state.acquireSharedInterruptibly(1);
+        switch (state.get()) {
+            case SUCCESSFUL:
+                return (T) result.get();
+            case FAILED:
+                throw new ExecutionException((Throwable) result.get());
+            case CANCELED:
+            case CANCELING:
+                throw new CancellationException();
+            default: // should be unreachable
+                throw new IllegalStateException(Integer.toString(state.get()));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T get(long time, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        if (state.tryAcquireSharedNanos(1, unit.toNanos(time)))
+            switch (state.get()) {
+                case SUCCESSFUL:
+                    return (T) result.get();
+                case FAILED:
+                    throw new ExecutionException((Throwable) result.get());
+                case CANCELED:
+                case CANCELING:
+                    throw new CancellationException();
+                default: // should be unreachable
+                    throw new IllegalStateException(Integer.toString(state.get()));
+            }
+        else
+            throw new TimeoutException();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        int s = state.get();
+        return s == CANCELED || s == CANCELING;
+    }
+
+    @Override
+    public boolean isDone() {
+        return state.get() > RUNNING;
+    }
+
+    /**
+     * If the task hasn't already been run or canceled, run it on the current thread and record the result/failure,
+     * allowing for possible interruption by the cancel method.
+     */
+    @FFDCIgnore(Throwable.class)
+    void run() {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+        if (!state.setRunning()) {
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(this, tc, "unable to run", state.get());
+            return;
+        }
+
+        thread = Thread.currentThread();
+        try {
+            T t;
+            if (callable == null) {
+                runnable.run();
+                t = predefinedResult;
+            } else {
+                t = callable.call();
+            }
+
+            if (result.compareAndSet(state, t)) {
+                state.releaseShared(SUCCESSFUL);
+                if (tracker != null && tracker.result.compareAndSet(tracker, t))
+                    tracker.notifyInvokeAny();
+            }
+
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(this, tc, "run", t);
+        } catch (Throwable x) {
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(this, tc, "run", x);
+            if (result.compareAndSet(state, x)) {
+                state.releaseShared(FAILED);
+                if (tracker != null && tracker.pending.decrementAndGet() == 0)
+                    tracker.notifyInvokeAny();
+            }
+        } finally {
+            thread = null;
+            // Prevent accidental interrupt of subsequent operations by awaiting the transition from CANCELING to CANCELED
+            while (state.get() == CANCELING)
+                Thread.yield();
+        }
+    }
+
+    /**
+     * @throws InterruptedException if the task failed with InterruptedException.
+     */
+    @Trivial
+    void throwIfInterrupted() throws InterruptedException {
+        if (state.get() == FAILED) {
+            Object x = result.get();
+            if (x instanceof InterruptedException) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "interrupted", x);
+                throw (InterruptedException) x;
+            }
+        }
+    }
+
+    /**
+     * String representation for debug purposes.
+     *
+     * @return output of the form: PolicyTaskFuture@12345678 for org.example.MyTask@23456789 SUCCESSFUL on MyPolicyExecutor: My Successful Task Result
+     */
+    @Trivial
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder("PolicyTaskFuture@").append(Integer.toHexString(hashCode())).append(" for ").append(task).append(' ');
+        int s = state.get();
+        switch (s) {
+            case SUBMITTED:
+                b.append("SUBMITTED");
+                break;
+            case RUNNING:
+                b.append("RUNNING");
+                break;
+            case SUCCESSFUL:
+                b.append("SUCCESSFUL");
+                break;
+            case FAILED:
+                b.append("FAILED");
+                break;
+            case CANCELING:
+                b.append("CANCELING");
+                break;
+            case CANCELED:
+                b.append("CANCELED");
+                break;
+            default:
+                b.append(s); // should be unreachable
+        }
+        b.append(" on ").append(executor.identifier);
+        if (s == SUCCESSFUL || s == FAILED)
+            b.append(": ").append(result.get());
+        return b.toString();
+    }
+}

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -2718,7 +2718,7 @@ public class PolicyExecutorServlet extends FATServlet {
         CountDownLatch blocker = new CountDownLatch(1);
         CountDownLatch blockerStarted = new CountDownLatch(1);
         Future<Boolean> blockerFuture = executor.submit(new CountDownTask(blockerStarted, blocker, TIMEOUT_NS * 2));
-        //assertTrue(blockerStarted.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertTrue(blockerStarted.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 
         AtomicInteger counter = new AtomicInteger(0);
         List<Callable<Integer>> tasks = Arrays.<Callable<Integer>> asList(new SharedIncrementTask(counter), new SharedIncrementTask(counter));

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,6 +43,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -2587,6 +2589,31 @@ public class PolicyExecutorServlet extends FATServlet {
         assertEquals(0, canceledFromQueue.size());
     }
 
+    // Submit task via timed invokeAny that interrupts itself in order to test appropriate handling of InterruptedException during execution.
+    // ExecutionException with chained InterruptedException must be raised, rather than InterruptedException being raised directly to caller.
+    // The former is consistent with a task failing and the latter would indicate that the invokeAny operation itself was interrupted.
+    @Test
+    public void testInvokeAnyTimedInterruptRunningTask() throws Exception {
+        PolicyExecutor executor = provider.create("testInvokeAnyTimedInterruptRunningTask");
+
+        try {
+            fail("Task should fail during execution and raise exception. Instead: " + executor.invokeAny(Collections.singleton(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws InterruptedException {
+                    Thread.currentThread().interrupt();
+                    TimeUnit.SECONDS.sleep(1); // raise InterruptedException
+                    return false;
+                }
+            }), TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        } catch (ExecutionException x) {
+            if (!(x.getCause() instanceof InterruptedException))
+                throw x;
+        }
+
+        List<Runnable> canceledFromQueue = executor.shutdownNow();
+        assertEquals(0, canceledFromQueue.size());
+    }
+
     // Submit a group of tasks to timed invokeAny, one of which raises an exception and another of which blocks.
     // Interrupt the invokeAny operation before it completes. Expect InterruptedException.
     @Test
@@ -2650,6 +2677,110 @@ public class PolicyExecutorServlet extends FATServlet {
 
         List<Runnable> canceledFromQueue = executor.shutdownNow();
         assertEquals(0, canceledFromQueue.size()); // third task should have already been canceled upon invokeAny terminating with InterruptedException
+    }
+
+    // Submit a group of tasks via timed invokeAny, where one of the tasks promptly returns a null result, and another returns a non-null result after a delay.
+    // Verify that the result of invokeAny is null. This test verifies that the implementation is not limited to awaiting non-null results, and handles null properly.
+    // Also verifies that the other task ends before it otherwise would have due to the implicit cancel/interrupt upon return of invokeAny.
+    @Test
+    public void testInvokeAnyTimedNullSuccessfulResult() throws Exception {
+        PolicyExecutor executor = provider.create("testInvokeAnyTimedNullSuccessfulResult");
+
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownTask task1 = new CountDownTask(new CountDownLatch(0), blocker, TIMEOUT_NS * 3);
+
+        SharedIncrementTask task2 = new SharedIncrementTask();
+
+        List<Callable<Boolean>> tasks = Arrays.asList(task1, Executors.callable(task2, (Boolean) null));
+
+        assertNull(executor.invokeAny(tasks, TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // Another way to verify that task2 completed
+        assertEquals(1, task2.count());
+
+        // Verify that task1 ends prior to when it would have otherwise completed. This is due to cancel/interruption upon return from invokeAny.
+        for (long start = System.nanoTime(); task1.executionThreads.peek() != null && System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(100));
+        assertNull(task1.executionThreads.peek());
+
+        List<Runnable> canceledFromQueue = executor.shutdownNow();
+        assertEquals(0, canceledFromQueue.size());
+    }
+
+    // Submit a group of tasks via timed invokeAny. Allow the tasks to be enqueued, but blocked from starting because another thread
+    // holds the only permit against maxConcurrency. Then invoke shutdownNow on the executor, all of the queued tasks should be canceled
+    // without starting, allowing invokeAny to raise a CancellationException before reaching the timeout.
+    @Test
+    public void testInvokeAnyTimedShutdownNowWhileEnqueued() throws Exception {
+        PolicyExecutor executor = provider.create("testInvokeAnyTimedShutdownNowWhileEnqueued")
+                        .maxConcurrency(1)
+                        .maxQueueSize(2);
+
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch blockerStarted = new CountDownLatch(1);
+        Future<Boolean> blockerFuture = executor.submit(new CountDownTask(blockerStarted, blocker, TIMEOUT_NS * 2));
+        //assertTrue(blockerStarted.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        AtomicInteger counter = new AtomicInteger(0);
+        List<Callable<Integer>> tasks = Arrays.<Callable<Integer>> asList(new SharedIncrementTask(counter), new SharedIncrementTask(counter));
+
+        final CountDownLatch noQueueCapacityRemains = new CountDownLatch(1);
+        // TODO Update in future user story. Temporarily use internals while lacking the callback to decrement the above latch once queue capacity is used up.
+        Field f = executor.getClass().getDeclaredField("maxQueueSizeConstraint");
+        f.setAccessible(true);
+        final Semaphore q = (Semaphore) f.get(executor);
+        testThreads.submit(new Callable<Void>() {
+            @Override
+            public Void call() throws InterruptedException {
+                for (long start = System.nanoTime(); q.availablePermits() > 0 && System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(100));
+                noQueueCapacityRemains.countDown();
+                return null;
+            }
+        });
+
+        Future<List<Runnable>> shutdownFuture = testThreads.submit(new ShutdownTask(executor, true, new CountDownLatch(0), noQueueCapacityRemains, TIMEOUT_NS));
+
+        // How do we know that tasks made it into the queue? We could see RejectedExecutionException due to not allowing tasks to be queued
+        long start = System.nanoTime();
+        try {
+            fail("Should not succeed after shutdownNow: " + executor.invokeAny(tasks, TIMEOUT_NS * 3, TimeUnit.NANOSECONDS));
+        } catch (CancellationException x) { // pass
+        }
+        long duration = System.nanoTime() - start;
+
+        // invokeAny must return prematurely due to cancel by shutdownNow
+        assertTrue(duration + "ns", duration < TIMEOUT_NS);
+
+        List<Runnable> canceledFromQueue = shutdownFuture.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals(2, canceledFromQueue.size());
+    }
+
+    // Submit a group of tasks via timed invokeAny. Have all of the tasks block and then invoke shutdownNow on the executor.
+    // All of the tasks should be canceled and interrupted, allowing invokeAny to raise a CancellationException before reaching the timeout.
+    @Test
+    public void testInvokeAnyTimedShutdownNowWhileRunning() throws Exception {
+        PolicyExecutor executor = provider.create("testInvokeAnyTimedShutdownNowWhileRunning");
+
+        final int numTasks = 3;
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch allInvokeAnyTasksBeginLatch = new CountDownLatch(numTasks);
+        List<Callable<Boolean>> tasks = new ArrayList<Callable<Boolean>>(numTasks);
+        for (int i = 0; i < numTasks; i++)
+            tasks.add(new CountDownTask(allInvokeAnyTasksBeginLatch, blocker, TIMEOUT_NS * 2));
+
+        Future<List<Runnable>> shutdownFuture = testThreads.submit(new ShutdownTask(executor, true, new CountDownLatch(0), allInvokeAnyTasksBeginLatch, TIMEOUT_NS));
+
+        long start = System.nanoTime();
+        try {
+            fail("Should not succeed after shutdownNow: " + executor.invokeAny(tasks, TIMEOUT_NS * 3, TimeUnit.NANOSECONDS));
+        } catch (CancellationException x) { // pass
+        }
+        long duration = System.nanoTime() - start;
+
+        // invokeAny must return prematurely due to cancel/interrupt by shutdownNow
+        assertTrue(duration + "ns", duration < TIMEOUT_NS);
+
+        List<Runnable> canceledFromQueue = shutdownFuture.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals(0, canceledFromQueue.size());
     }
 
     // Submit a group of tasks to timed invokeAny, where there are insufficient queue positions to


### PR DESCRIPTION
Add the optimized part of untimed invokeAny where it is supplied with a single task and can run it on the same thread as long as a maxConcurrency permit is available or the executor is configured to not require a permit for running on the caller's thread.