### PR TITLE
Be more selective about when to restart an app

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -1557,16 +1557,25 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
             success = true;
         } else {
 
+            // we only want to process *.class files
+            List<String> classFilePaths = new ArrayList<String>();
+            for (String path : notification.getPaths()) {
+                if (path.endsWith(".class")) {
+                    classFilePaths.add(path);
+                }
+            }
+
+            if (classFilePaths.isEmpty()) {
+                // no class files to process, we must return true.
+                return true;
+            }
+
             // This classloader is associated with a container that has classes being modified.
             // Success depends on whether we can redefine those classes or not.
             if (redefiner != null && redefiner.canRedefine()) {
                 success = true;
                 Set<ClassDefinition> classesToRedefine = new HashSet<ClassDefinition>();
-                for (String path : notification.getPaths()) {
-                    if (!path.endsWith(".class")) {
-                        // do not attempt to redefine non-class files
-                        continue;
-                    }
+                for (String path : classFilePaths) {
 
                     String className = convertToClassName(path);
                     // We only want to redefine classes that have been loaded.  Unloaded classes
@@ -1603,7 +1612,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
                 }
 
             } else {
-                // redefiner is null or cannot redefine classes, so we must return false
+                // classes were changed, but redefiner is null or cannot redefine classes, so we must return false
                 success = false;
             }
         }


### PR DESCRIPTION
Currently, when an app is deployed/extracted to a Liberty server (without using loose config), the app will restart on changes to things like JSPs, that should not require a restart.

We should be more selective.  If the user modifies something fairly critical to the app - like the web.xml, ejb-jar.xml, bindings files, etc. - then we still need to restart the app.  But for files like JSPs, static content, etc. we should not restart the app.

For class file changes, we should restart the app, but we should also prepare the way for a "hot re-deploy" scenario where we could re-define the class if only minor changes are made to it (i.e. only changing the internals of a method body).  