### PR TITLE
Revert "Convert default JAX-RS 2.1 JSON provider to use the jsonp-1.1 feature"

### DIFF
--- a/dev/com.ibm.websphere.appserver.jaxrs.common-2.1/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.jaxrs.common-2.1/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
@@ -11,7 +11,6 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.websphere.appserver.globalhandler-1.0, \
  com.ibm.websphere.appserver.javax.annotation-1.2; apiJar=false, \
  com.ibm.websphere.appserver.json-1.0, \
- com.ibm.websphere.appserver.jsonp-1.1, \
  com.ibm.websphere.appserver.internal.slf4j-1.7.7
 -bundles=com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
  com.ibm.ws.org.apache.xml.resolver.1.2, \

--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/component/JaxRsProviderFactory.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/component/JaxRsProviderFactory.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import javax.json.spi.JsonProvider;
-
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -35,11 +33,6 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
  *******************************************************************************/
 @Component(immediate = true, property = { "service.vendor=IBM" }, configurationPolicy = ConfigurationPolicy.IGNORE)
 public class JaxRsProviderFactory implements JaxRsProviderFactoryService {
-    
-    // referencing the JsonProvider OSGI service reference ensures that the implementation
-    // service is available when ProviderFactory sets up the out-of-the-box providers
-    @Reference
-    private JsonProvider jsonpProvider;
 
     private static JaxRsProviderFactory serviceInstance = null;
 

--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -45,7 +45,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.activation.DataSource;
-import javax.json.spi.JsonProvider;
 import javax.ws.rs.Produces;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.core.Application;
@@ -92,9 +91,6 @@ import org.codehaus.jackson.map.SerializationConfig;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
 import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceReference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -232,11 +228,26 @@ public abstract class ProviderFactory {
 
     // Liberty Change for CXF Begin
     private static Object createJsonpProvider() {
-        
-        BundleContext bc = FrameworkUtil.getBundle(ProviderFactory.class).getBundleContext();
-        ServiceReference<JsonProvider> sr = bc.getServiceReference(JsonProvider.class);
-        JsonProvider jsonProvider = (JsonProvider)bc.getService(sr);
-        return new JsonPProvider(jsonProvider);
+
+        // We can only create the JSON-P provider if the jsonp feature is provisioned. This usually
+        // requires the user to explicitly add the jsonp-1.0 feature in the server.xml (or some feature
+        // that includes it).  The following classloading code checks to see if this bundle can load
+        // (via dynamic import) the JSON-P classes.  If so, then it returns the JSON-P provider.  If not,
+        // it returns null.
+        JsonPProvider provider = null;
+        ClassLoader cl = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+
+            @Override
+            public ClassLoader run() {
+                return ProviderFactory.class.getClassLoader();
+            }
+        });
+        Class<?> c = ProviderFactory.loadClass(cl, JSONPCLASS);
+        if (c != null) {
+            provider = new JsonPProvider();
+        }
+
+        return provider;
     }
 
     //JsonPProvider and IBM JSON4J Provider handle


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#58

This introduced a hard failure in the `com.ibm.ws.security.mp.jwt_fat_tck` bucket due to bundle resolution issues:

```
[9/28/17 3:39:37:305 UTC] 00000014 LogService-141-com.ibm.ws.security.mp.jwt.cdi                E CWWKE0702E: Could not resolve module: com.ibm.ws.security.mp.jwt.cdi [141]
  Unresolved requirement: Import-Package: javax.json; version="[1.0.0,2.0.0)"

[9/28/17 3:39:37:314 UTC] 00000014 LogService-143-com.ibm.ws.security.mp.jwt                    E CWWKE0702E: Could not resolve module: com.ibm.ws.security.mp.jwt [143]
  Unresolved requirement: Import-Package: javax.json; version="[1.0.0,2.0.0)"

[9/28/17 3:39:37:334 UTC] 00000014 LogService-149-com.ibm.ws.jaxrs.2.0.client                   E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.0.client [149]
  Unresolved requirement: Import-Package: org.apache.cxf.bus.extension; version="3.1.11"
    -> Export-Package: org.apache.cxf.bus.extension; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; bundle-version="1.0.18.integration-SNAPSHOT"; version="3.2.0.SNAPSHOT"; uses:="org.apache.cxf,org.apache.cxf.common.i18n,org.apache.cxf.configuration,org.apache.cxf.feature,org.apache.cxf.interceptor,org.apache.cxf.resource"
       com.ibm.ws.jaxrs.2.1.common [156]
         Unresolved requirement: Import-Package: javax.json; version="[1.0.0,2.0.0)"
  Unresolved requirement: Import-Package: org.apache.cxf; version="3.1.11"
    -> Export-Package: org.apache.cxf; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; bundle-version="1.0.18.integration-SNAPSHOT"; version="3.2.0.SNAPSHOT"; uses:="org.apache.cxf.common.i18n,org.apache.cxf.feature,org.apache.cxf.interceptor"

[9/28/17 3:39:37:356 UTC] 00000014 LogService-152-com.ibm.ws.jaxrs.2.0.tools                    E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.0.tools [152]
  Unresolved requirement: Import-Package: org.apache.cxf.tools.wadlto; version="[3.1.0,4.0.0)"
    -> Export-Package: org.apache.cxf.tools.wadlto; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; bundle-version="1.0.18.integration-SNAPSHOT"; version="3.2.0.SNAPSHOT"; uses:="org.apache.cxf.tools.common"
       com.ibm.ws.jaxrs.2.1.common [156]
         Unresolved requirement: Import-Package: javax.json; version="[1.0.0,2.0.0)"
  Unresolved requirement: Import-Package: org.apache.cxf.tools.common; version="[3.1.0,4.0.0)"
    -> Export-Package: org.apache.cxf.tools.common; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; bundle-version="1.0.18.integration-SNAPSHOT"; version="3.2.0.SNAPSHOT"; uses:="javax.xml.namespace,org.apache.cxf.common.i18n,org.apache.cxf.tools.common.model,org.apache.cxf.tools.common.toolspec,org.apache.cxf.tools.common.toolspec.parser,org.apache.cxf.tools.util,org.xml.sax"

[9/28/17 3:39:37:366 UTC] 00000014 LogService-155-com.ibm.ws.jaxrs.2.0.server                   E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.0.server [155]
  Unresolved requirement: Import-Package: org.apache.cxf; version="[3.0.2,4.0.0)"
    -> Export-Package: org.apache.cxf; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; bundle-version="1.0.18.integration-SNAPSHOT"; version="3.2.0.SNAPSHOT"; uses:="org.apache.cxf.common.i18n,org.apache.cxf.feature,org.apache.cxf.interceptor"
       com.ibm.ws.jaxrs.2.1.common [156]
         Unresolved requirement: Import-Package: javax.json; version="[1.0.0,2.0.0)"
  Unresolved requirement: Import-Package: org.apache.cxf.common.classloader; version="[3.0.2,4.0.0)"
    -> Export-Package: org.apache.cxf.common.classloader; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; bundle-version="1.0.18.integration-SNAPSHOT"; version="3.2.0.SNAPSHOT"

[9/28/17 3:39:37:374 UTC] 00000014 LogService-156-com.ibm.ws.jaxrs.2.1.common                   E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.1.common [156]
  Unresolved requirement: Import-Package: javax.json; version="[1.0.0,2.0.0)"

[9/28/17 3:39:37:386 UTC] 00000014 LogService-157-com.ibm.ws.jaxrs.2.0.web                      E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.0.web [157]
  Unresolved requirement: Import-Package: com.ibm.ws.jaxrs20.metadata; version="[1.0.0,2.0.0)"
    -> Export-Package: com.ibm.ws.jaxrs20.metadata; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; bundle-version="1.0.18.integration-SNAPSHOT"; version="1.0.16"; uses:="com.ibm.websphere.csi,com.ibm.websphere.ras.annotation,com.ibm.ws.container.service.app.deploy,com.ibm.ws.jaxrs20.bus,com.ibm.ws.jaxrs20.support,com.ibm.ws.ras.instrument.annotation,com.ibm.ws.runtime.metadata,com.ibm.wsspi.adaptable.module,com.ibm.wsspi.injectionengine,javax.ws.rs.core,org.apache.cxf,org.apache.cxf.jaxrs.lifecycle"
       com.ibm.ws.jaxrs.2.1.common [156]
         Unresolved requirement: Import-Package: javax.json; version="[1.0.0,2.0.0)"
  Unresolved requirement: Import-Package: org.apache.cxf.jaxrs.utils; version="[3.0.2,4.0.0)"
    -> Export-Package: org.apache.cxf.jaxrs.utils; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; bundle-version="1.0.18.integration-SNAPSHOT"; version="3.2.0.SNAPSHOT"; uses:="com.ibm.websphere.ras.annotation,com.ibm.ws.ras.instrument.annotation,com.ibm.wsspi.adaptable.module,javax.servlet.http,javax.ws.rs,javax.ws.rs.core,javax.ws.rs.ext,javax.xml.namespace,org.apache.cxf,org.apache.cxf.feature,org.apache.cxf.jaxrs,org.apache.cxf.jaxrs.ext.multipart,org.apache.cxf.jaxrs.impl,org.apache.cxf.jaxrs.impl.tl,org.apache.cxf.jaxrs.model,org.apache.cxf.jaxrs.provider,org.apache.cxf.message,org.w3c.dom"

[9/28/17 3:39:37:659 UTC] 00000014 LogService-160-com.ibm.ws.jaxrs.2.0.security                 E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.0.security [160]
  Unresolved requirement: Import-Package: com.ibm.ws.jaxrs20.api; version="[1.0.0,2.0.0)"
    -> Export-Package: com.ibm.ws.jaxrs20.api; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; provide="true"; bundle-version="1.0.18.integration-SNAPSHOT"; version="1.0.16"; uses:="com.ibm.websphere.ras.annotation,com.ibm.ws.container.service.app.deploy.extended,com.ibm.ws.jaxrs20.endpoint,com.ibm.ws.jaxrs20.metadata,com.ibm.ws.jaxrs20.metadata.builder,com.ibm.ws.ras.instrument.annotation,com.ibm.ws.runtime.metadata,com.ibm.wsspi.adaptable.module,javax.net.ssl,javax.servlet.http,javax.ws.rs.core,org.apache.cxf,org.apache.cxf.bus.extension,org.apache.cxf.message"
       com.ibm.ws.jaxrs.2.1.common [156]
         Unresolved requirement: Import-Package: javax.json; version="[1.0.0,2.0.0)"

[9/28/17 3:39:37:702 UTC] 00000014 LogService-162-com.ibm.ws.jaxrs.2.0.cdi                      E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.0.cdi [162]
  Unresolved requirement: Import-Package: com.ibm.ws.jaxrs20.api; version="[1.0.0,2.0.0)"
    -> Export-Package: com.ibm.ws.jaxrs20.api; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; provide="true"; bundle-version="1.0.18.integration-SNAPSHOT"; version="1.0.16"; uses:="com.ibm.websphere.ras.annotation,com.ibm.ws.container.service.app.deploy.extended,com.ibm.ws.jaxrs20.endpoint,com.ibm.ws.jaxrs20.metadata,com.ibm.ws.jaxrs20.metadata.builder,com.ibm.ws.ras.instrument.annotation,com.ibm.ws.runtime.metadata,com.ibm.wsspi.adaptable.module,javax.net.ssl,javax.servlet.http,javax.ws.rs.core,org.apache.cxf,org.apache.cxf.bus.extension,org.apache.cxf.message"
       com.ibm.ws.jaxrs.2.1.common [156]
         Unresolved requirement: Import-Package: javax.json; version="[1.0.0,2.0.0)"
  Unresolved requirement: Import-Package: com.ibm.ws.jaxrs20.bus; version="[1.0.0,2.0.0)"
    -> Export-Package: com.ibm.ws.jaxrs20.bus; bundle-symbolic-name="com.ibm.ws.jaxrs.2.1.common"; bundle-version="1.0.18.integration-SNAPSHOT"; version="1.0.0"; uses:="com.ibm.websphere.ras.annotation,com.ibm.ws.jaxrs20.api,com.ibm.ws.jaxrs20.metadata,com.ibm.ws.ras.instrument.annotation,org.apache.cxf,org.apache.cxf.bus,org.apache.cxf.bus.extension"
```

The personal build for #58 also showed a FAT failure in a related test project for:

```
java.lang.Exception: Errors/warnings were found in server jaxrs20.service.JaxRsJsonPTest logs:
 <br>[9/26/17 18:00:57:460 UTC] 00000014 LogService-77-com.ibm.ws.jaxrs.2.0.client                    E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.0.client [77]
 <br>[9/26/17 18:00:57:468 UTC] 00000014 LogService-80-com.ibm.ws.jaxrs.2.0.tools                     E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.0.tools [80]
 <br>[9/26/17 18:00:57:472 UTC] 00000014 LogService-83-com.ibm.ws.jaxrs.2.0.server                    E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.0.server [83]
 <br>[9/26/17 18:00:57:474 UTC] 00000014 LogService-84-com.ibm.ws.jaxrs.2.1.common                    E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.1.common [84]
 <br>[9/26/17 18:00:57:480 UTC] 00000014 LogService-85-com.ibm.ws.jaxrs.2.0.web                       E CWWKE0702E: Could not resolve module: com.ibm.ws.jaxrs.2.0.web [85]
```