### PR TITLE
policy executor untimed invokeAny tests for interrupt and shutdown

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -633,6 +633,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     }
 
     @Override
+    @FFDCIgnore(value = { RejectedExecutionException.class })
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
         int taskCount = tasks.size();
 


### PR DESCRIPTION
Add test coverage for policyExecutor's untimed invokeAny method, mostly around the area of interrupts and shutdown.