### PR TITLE
prototype managed executor submits use policy executor

### DIFF
--- a/dev/com.ibm.ws.concurrent/.classpath
+++ b/dev/com.ibm.ws.concurrent/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="src" path="/com.ibm.ws.threading"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent/bnd.bnd
@@ -77,4 +77,5 @@ instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 	com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest,\
 	com.ibm.ws.org.apache.felix.scr;version=latest,\
 	com.ibm.ws.bnd.annotations;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.threading;version=latest

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -1,0 +1,216 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.internal;
+
+import java.security.AccessController;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+
+import javax.enterprise.concurrent.AbortedException;
+import javax.enterprise.concurrent.ManagedTask;
+import javax.enterprise.concurrent.ManagedTaskListener;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.threading.PolicyTaskCallback;
+import com.ibm.wsspi.threadcontext.ThreadContext;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
+import com.ibm.wsspi.threadcontext.ThreadContextProvider;
+
+/**
+ * Callback that uses the notifications it receives about about task life cycle
+ * to apply and remove thread context and send events to a ManagedTaskListener.
+ * TODO always use policy executor and remove SubmittedTask, where much of this implementation is copied from,
+ * if the life cycle callback is able to achieve the same behavior.
+ */
+public class TaskLifeCycleCallback extends PolicyTaskCallback {
+    private static final TraceComponent tc = Tr.register(TaskLifeCycleCallback.class);
+
+    /**
+     * Managed executor to which the task was submitted.
+     */
+    private final ManagedExecutorServiceImpl managedExecutor;
+
+    /**
+     * Represents thread context captured from the submitting thread.
+     */
+    private final ThreadContextDescriptor threadContextDescriptor;
+
+    /**
+     * Construct a new task life cycle callback. A single instance can be used for multiple tasks.
+     *
+     * @param managedExecutor the managed executor to which the task was submitted.
+     * @param threadContextDescriptor represents thread context captured from the submitting thread.
+     */
+    TaskLifeCycleCallback(ManagedExecutorServiceImpl managedExecutor, ThreadContextDescriptor threadContextDescriptor) {
+        this.managedExecutor = managedExecutor;
+        this.threadContextDescriptor = threadContextDescriptor;
+    }
+
+    /**
+     * Returns the task name.
+     *
+     * @param task the task.
+     * @return the task name.
+     */
+    @Trivial
+    final String getName(Object task) {
+        Map<String, String> execProps = threadContextDescriptor.getExecutionProperties();
+        String taskName = execProps == null ? null : execProps.get(ManagedTask.IDENTITY_NAME);
+        return taskName == null ? task.toString() : taskName;
+    }
+
+    @Override
+    public void onCancel(Object task, Future<?> future, boolean timedOut, boolean whileRunning) {
+        // Tasks that are canceled while running have the taskAborted notification sent on the thread of execution instead.
+
+        // notify listener: taskAborted (if task was canceled before it started)
+        if (!whileRunning && task instanceof ManagedTask) {
+            ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
+            if (listener != null) {
+                Throwable failure = null;
+                ThreadContextProvider tranContextProvider = AccessController.doPrivileged(managedExecutor.tranContextProviderAccessor);
+                ThreadContext suspendTranContext = tranContextProvider == null ? null : tranContextProvider.captureThreadContext(AbstractTask.XPROPS_SUSPEND_TRAN, null);
+                if (suspendTranContext != null)
+                    suspendTranContext.taskStarting();
+                try {
+                    CancellationException x = new CancellationException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
+
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                        Tr.event(this, tc, "taskAborted", managedExecutor, task, x);
+                    listener.taskAborted(future, managedExecutor, task, x);
+                } catch (RuntimeException x) {
+                    failure = x;
+                    throw x;
+                } catch (Error x) {
+                    failure = x;
+                    throw x;
+                } finally {
+                    try {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                            Tr.event(this, tc, "taskDone", managedExecutor, task, failure);
+                        listener.taskDone(future, managedExecutor, task, failure);
+                    } finally {
+                        if (suspendTranContext != null)
+                            suspendTranContext.taskStopping();
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onEnd(Object task, Future<?> future, Object startObj, int pending, Throwable failure) {
+        if (pending >= 0 && task instanceof ManagedTask) {
+            ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
+            if (listener != null) {
+                // notify listener: taskAborted (if canceled while running)
+                try {
+                    boolean canceled = future.isCancelled();
+                    if (canceled) {
+                        CancellationException x = new CancellationException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
+
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                            Tr.event(this, tc, "taskAborted", managedExecutor, task, x);
+                        listener.taskAborted(future, managedExecutor, task, x);
+                    }
+                } catch (Throwable x) {
+                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                    if (failure == null)
+                        failure = x;
+                }
+
+                // notify listener: taskDone
+                try {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                        Tr.event(this, tc, "taskDone", managedExecutor, task, failure);
+                    listener.taskDone(future, managedExecutor, task, failure);
+                } catch (Throwable x) {
+                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                }
+            }
+        }
+
+        // Restore thread context
+        if (pending <= 0 && startObj != null) {
+            @SuppressWarnings("unchecked")
+            ArrayList<ThreadContext> contextAppliedToThread = (ArrayList<ThreadContext>) startObj;
+            threadContextDescriptor.taskStopping(contextAppliedToThread);
+        }
+    }
+
+    @Override
+    public Object onStart(Object task, Future<?> future) {
+        AbortedException failure = null;
+        try {
+            // EE Concurrency 3.1.6.1: No task submitted to an executor can run if task's component is not started.
+            // ThreadContextDescriptor.taskStarting covers this requirement for us.
+            ArrayList<ThreadContext> contextAppliedToThread = threadContextDescriptor.taskStarting();
+
+            // notify listener: taskStarting
+            if (task instanceof ManagedTask) {
+                ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
+                if (listener != null) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                        Tr.event(this, tc, "taskStarting", managedExecutor, task);
+                    listener.taskStarting(future, managedExecutor, task);
+                }
+            }
+
+            return contextAppliedToThread;
+        } catch (Error x) {
+            failure = new AbortedException(x);
+            throw x;
+        } catch (RuntimeException x) {
+            failure = new AbortedException(x);
+            throw x;
+        } finally {
+            // notify listener: taskAborted (due to exception from taskStarting)
+            if (failure != null && task instanceof ManagedTask) {
+                ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
+                if (listener != null) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                        Tr.event(this, tc, "taskAborted", managedExecutor, task, failure);
+                    listener.taskAborted(future, managedExecutor, task, failure);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onSubmit(Object task, Future<?> future) {
+        // notify listener: taskSubmitted
+        if (task instanceof ManagedTask) {
+            ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
+            if (listener != null) {
+                ThreadContextProvider tranContextProvider = AccessController.doPrivileged(managedExecutor.tranContextProviderAccessor);
+                ThreadContext suspendTranContext = tranContextProvider == null ? null : tranContextProvider.captureThreadContext(AbstractTask.XPROPS_SUSPEND_TRAN, null);
+                if (suspendTranContext != null)
+                    suspendTranContext.taskStarting();
+                try {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                        Tr.event(this, tc, "taskSubmitted", managedExecutor, task);
+                    listener.taskSubmitted(future, managedExecutor, task);
+                } finally {
+                    if (suspendTranContext != null)
+                        suspendTranContext.taskStopping();
+                }
+
+                if (future.isCancelled())
+                    throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
@@ -34,11 +34,12 @@ public abstract class PolicyTaskCallback {
      * @param task the Callable or Runnable task.
      * @param future the future for the task that has stopped running.
      * @param startObj result, if any, of previous onStart callback.
-     * @param pendingCompletionServices indicates whether any completion services are pending.
-     *            If true, a subsequent onEnd callback will be sent with a false value after the completion services have been processed.
+     * @param pending a positive value indicates that additional work, such as completion services are pending on the task's thread of execution.
+     *            The value 0 indicate that no additional work is pending. A negative value indicates that work that was previously pending is done.
+     *            If positive, a subsequent onEnd callback will be sent with a negative value after the additional work ends.
      * @param failure failure, if any, that occurred while trying to run the task.
      */
-    public void onEnd(Object task, Future<?> future, Object startObj, boolean pendingCompletionServices, Throwable failure) {}
+    public void onEnd(Object task, Future<?> future, Object startObj, int pending, Throwable failure) {}
 
     /**
      * Invoked before a task starts running. This callback is invoked synchronously on the task's thread of execution.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ *     IBM Corporation - PRESUBMIT API and implementation
  *******************************************************************************/
 package com.ibm.ws.threading.internal;
 
@@ -39,7 +39,7 @@ public class PolicyTaskFutureImpl<T> implements Future<T> {
     private static final TraceComponent tc = Tr.register(PolicyTaskFutureImpl.class);
 
     // state constants
-    private static final int SUBMITTED = 0, RUNNING = 1, SUCCESSFUL = 2, FAILED = 3, CANCELING = 4, CANCELED = 5;
+    private static final int PRESUBMIT = 0, SUBMITTED = 1, RUNNING = 2, SUCCESSFUL = 3, FAILED = 4, CANCELING = 5, CANCELED = 6;
 
     /**
      * The task, if a Callable. It is wrapped with interceptors, if any.
@@ -67,12 +67,13 @@ public class PolicyTaskFutureImpl<T> implements Future<T> {
     private final Runnable runnable;
 
     /**
-     * Represents the state of the future, and allows for waiters. Initial state is SUBMITTED.
+     * Represents the state of the future, and allows for waiters. PRESUBMIT state is SUBMITTED.
      * State transitions in one direction only:
-     * SUBMITTED --> CANCELED,
-     * SUBMITTED --> RUNNING --> SUCCESSFUL,
-     * SUBMITTED --> RUNNING --> CANCELING --> CANCELED,
-     * SUBMITTED --> RUNNING --> FAILED.
+     * PRESUBMIT --> CANCELED
+     * PRESUBMIT --> SUBMITTED --> CANCELED,
+     * PRESUBMIT --> SUBMITTED --> RUNNING --> SUCCESSFUL,
+     * PRESUBMIT --> SUBMITTED --> RUNNING --> CANCELING --> CANCELED,
+     * PRESUBMIT --> SUBMITTED --> RUNNING --> FAILED.
      * Always set the result before updating the state, so that get() operations that await state can rely on the result being available.
      */
     private final State state = new State();
@@ -94,7 +95,7 @@ public class PolicyTaskFutureImpl<T> implements Future<T> {
 
     /**
      * Result of the task. Can be a value, an exception, or other indicator (the state distinguishes).
-     * Initialized to the state field as a way of indicating a result is not set. This allows the possibility of null results.
+     * PRESUBMITized to the state field as a way of indicating a result is not set. This allows the possibility of null results.
      */
     private final AtomicReference<Object> result = new AtomicReference<Object>(state);
 
@@ -217,6 +218,10 @@ public class PolicyTaskFutureImpl<T> implements Future<T> {
             return compareAndSetState(SUBMITTED, RUNNING);
         }
 
+        private boolean setSubmitted() {
+            return compareAndSetState(PRESUBMIT, SUBMITTED);
+        }
+
         @Override
         protected final int tryAcquireShared(int ignored) {
             return getState() > RUNNING ? 1 : -1;
@@ -226,7 +231,7 @@ public class PolicyTaskFutureImpl<T> implements Future<T> {
         protected final boolean tryReleaseShared(int newState) {
             int oldState;
             while (!compareAndSetState(oldState = getState(), newState));
-            return oldState == RUNNING || oldState == SUBMITTED;
+            return oldState <= RUNNING;
         }
     }
 
@@ -276,6 +281,16 @@ public class PolicyTaskFutureImpl<T> implements Future<T> {
     }
 
     /**
+     * Invoked to indicate the task was successfully submitted.
+     * Typically, this means the task has been successfully added to the task queue.
+     * However, it can also mean the task has been accepted to run on the submitter's thread.
+     */
+    @Trivial
+    final void accept() {
+        state.setSubmitted();
+    }
+
+    /**
      * Await completion of the future. Completion could be successful, exceptional, or by cancellation.
      */
     void await() throws InterruptedException {
@@ -300,6 +315,12 @@ public class PolicyTaskFutureImpl<T> implements Future<T> {
                 executor.maxQueueSizeConstraint.release();
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(this, tc, "canceled from queue");
+                if (callback != null)
+                    callback.onCancel(task, this, false, false);
+            } else if (state.get() == PRESUBMIT) {
+                state.releaseShared(CANCELED);
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "canceled during pre-submit");
                 if (callback != null)
                     callback.onCancel(task, this, false, false);
             } else if (interruptIfRunning) {
@@ -468,6 +489,9 @@ public class PolicyTaskFutureImpl<T> implements Future<T> {
         StringBuilder b = new StringBuilder("PolicyTaskFuture@").append(Integer.toHexString(hashCode())).append(" for ").append(task).append(' ');
         int s = state.get();
         switch (s) {
+            case PRESUBMIT:
+                b.append("PRESUBMIT");
+                break;
             case SUBMITTED:
                 b.append("SUBMITTED");
                 break;

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - PRESUBMIT API and implementation
+ *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.threading.internal;
 


### PR DESCRIPTION
Put an initial prototype in place where we can experiment with having managed executor use policy executor for submit of Callable/Runnable when an internal property is set for that purpose.