### PR TITLE
Generate and validate FAT feature dependencies

### DIFF
--- a/dev/build.example_fat/publish/servers/FATServer/server.xml
+++ b/dev/build.example_fat/publish/servers/FATServer/server.xml
@@ -12,6 +12,7 @@
 
 	<featureManager>
 		<feature>servlet-3.1</feature>
+		<feature>jsf-2.2</feature>
 	    <feature>componenttest-1.0</feature>
     </featureManager>
     

--- a/dev/cnf/gradle/scripts/fat.gradle
+++ b/dev/cnf/gradle/scripts/fat.gradle
@@ -62,9 +62,26 @@ task addRequiredLibraries {
   }
 }
 
+task copyFeatureBundles {
+  shouldRunAfter assemble
+  enabled file("${projectDir}/test-bundles").exists()
+  doLast {
+    file("${buildDir}/buildfiles").eachLine { String line ->
+      if(!line.contains(project.name + ".jar")) {
+        copy {
+          from line
+          into "${buildDir}/autoFVT/publish/files/bundles"
+        }
+      }
+    }
+  }
+}
+
 task autoFVT {
   dependsOn jar
   dependsOn copyMavenLibs
+  dependsOn addRequiredLibraries
+  dependsOn copyFeatureBundles
   enabled new File("${projectDir}/fat").exists()
 
   // For now we are just forcing the autoFVT create every time, this will be fixed
@@ -190,6 +207,45 @@ task autoFVT {
       include 'test-applications/**', 'test-bundles/**', 'test-resourceadapters/**'
       exclude '**/*.java'
     }
+    
+    // Produce a list of features tested by this FAT
+    def featureDeps = [] as Set
+    // Include features added explictly via bnd.bnd
+    def testedFeatures = bnd('tested.features')
+    if(testedFeatures != null)
+      testedFeatures.split(',').each{ featureDeps.add(it.trim().toLowerCase()) }
+    // Scan publish/ dir for features
+    if(file("${autoFvtDir}/publish/").exists()) {
+      file("${autoFvtDir}/publish/").eachFileRecurse(groovy.io.FileType.FILES) {
+        if(it.name.endsWith('.xml')) {
+          file(it).eachLine { line ->
+            if(line.contains("<feature>")) {
+              def feature = (line =~ /.*<feature>(.*)<\/feature>.*/)[0][1]
+              featureDeps.add(feature.trim().toLowerCase())
+            }
+          }
+        }
+      }
+    }
+    // Scan FAT files dir for features
+    if(file("${autoFvtDir}/lib/LibertyFATTestFiles").exists()){
+      file("${autoFvtDir}/lib/LibertyFATTestFiles").eachFileRecurse(groovy.io.FileType.FILES) {
+        if(it.name.endsWith('.xml')) {
+          file(it).eachLine { line ->
+            if(line.contains("<feature>")) {
+              def feature = (line =~ /.*<feature>(.*)<\/feature>.*/)[0][1]
+              featureDeps.add(feature.trim().toLowerCase())
+            }
+          }
+        }
+      }
+    }
+    if(featureDeps.size() > 0) {
+      println "This FAT tests the following features: " + featureDeps
+      new File("${autoFvtDir}/fat-feature-deps.json").write(new groovy.json.JsonBuilder(featureDeps).toPrettyString())
+    } else {
+      println "This FAT does not test any features."
+    }
   }
 }
 
@@ -205,21 +261,6 @@ task zipProjectFVT(type: Zip) {
   baseName project.name
   into project.name + '/build/lib', {from "${distsDir}/autoFVT.zip"}
   into project.name, {from 'build-test.xml'}
-}
-
-task copyFeatureBundles {
-  shouldRunAfter assemble
-  enabled file("${projectDir}/test-bundles").exists()
-  doLast {
-    file("${buildDir}/buildfiles").eachLine { String line ->
-      if(!line.contains(project.name + ".jar")) {
-        copy {
-          from line
-          into "${buildDir}/autoFVT/publish/files/bundles"
-        }
-      }
-    }
-  }
 }
 
 task runfat(type: Exec) {
@@ -249,11 +290,6 @@ compileJava {
 
 assemble {
   dependsOn zipProjectFVT
-}
-
-autoFVT {
-  dependsOn addRequiredLibraries
-  dependsOn copyFeatureBundles
 }
 
 task buildandrun {

--- a/dev/cnf/gradle/scripts/fat.gradle
+++ b/dev/cnf/gradle/scripts/fat.gradle
@@ -121,6 +121,13 @@ task autoFVT {
       include '*.jar'
       into "${autoFvtDir}/build/lib"
     }
+    
+    // Include JSON-P processor implementation
+    copy {
+      from rootProject.project('com.ibm.ws.org.glassfish.json').buildDir
+      include '*.jar'
+      into "${autoFvtDir}/lib"
+    }
 
     // Copy the DDL files
     // TODO: Consider if this can be removed, it looks like there's only a single project for this rule
@@ -198,7 +205,7 @@ task autoFVT {
       include 'com.ibm.ws.logging.core.jar'
       into "${autoFvtDir}/lib"
     }
-      
+    
     // Copy all non-java app resourecs, such as *.html or *.jsp
     copy {
       includeEmptyDirs = false

--- a/dev/com.ibm.ws.concurrent_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat/bnd.bnd
@@ -21,6 +21,10 @@ src: \
 
 test.project: true
 
+# Declare additional tested features not present in the original server.xml's
+tested.features: \
+  osgiconsole-1.0
+
 -buildpath: \
   com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
   com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.opentracing_fat/build.gradle
+++ b/dev/com.ibm.ws.opentracing_fat/build.gradle
@@ -21,3 +21,10 @@ addRequiredLibraries {
         }
     }
 }
+
+autoFVT {
+	doLast {
+		// Manually clear out JSON-P 1.0 (automatically added to all FATs) because we want to use JSON-P 1.1
+		delete "${buildDir}/autoFVT/lib/com.ibm.ws.org.glassfish.json.1.0.jar"
+	}
+}

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -49,7 +49,8 @@ Export-Package: \
 	componenttest.vulnerability;version=1.0.16
 	
 Private-Package: \
-	componenttest.annotation.processor
+	componenttest.annotation.processor,\
+	componenttest.depchain
 
 test.project: true
 

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -69,10 +69,10 @@ test.project: true
 	com.ibm.ws.timedexit.internal;version=latest,\
 	httpunit:httpunit;version=1.5.4,\
     net.sf.jtidy:jtidy;version=9.3.8,\
-    org.glassfish:javax.json;version=1.0.4,\
     org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-impl-base;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-spi;version=1.2.3,\
 	org.apache.derby:derbynet;version=10.11.1.1,\
 	org.jmock:jmock;strategy=exact;version=2.5.1,\
-	org.hamcrest:hamcrest-all;version=1.3
+	org.hamcrest:hamcrest-all;version=1.3,\
+	com.ibm.ws.org.glassfish.json.1.0;version=latest

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -69,6 +69,7 @@ test.project: true
 	com.ibm.ws.timedexit.internal;version=latest,\
 	httpunit:httpunit;version=1.5.4,\
     net.sf.jtidy:jtidy;version=9.3.8,\
+    org.glassfish:javax.json;version=1.0.4,\
     org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-impl-base;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-spi;version=1.2.3,\

--- a/dev/fattest.simplicity/src/componenttest/depchain/Feature.java
+++ b/dev/fattest.simplicity/src/componenttest/depchain/Feature.java
@@ -1,0 +1,125 @@
+package componenttest.depchain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class Feature {
+    private static final Class<?> c = Feature.class;
+    private String shortName;
+    private String symbolicName;
+    private final List<String> enables = new ArrayList<String>();
+    private final List<String> includes = new ArrayList<String>();
+    private final List<String> autoProvision = new ArrayList<String>();
+
+    private final Type type;
+    private Boolean isProvisioned = null;
+
+    public static enum Type {
+        FEATURE,
+        AUTO_FEATURE,
+        KERNEL_FEATURE,
+        PROTECTED_FEATURE
+    }
+
+    public Feature(Element e) {
+        if (e.getNodeName().equals("feature")) {
+            shortName = e.getAttribute("name");
+            type = Type.FEATURE;
+        } else if (e.getNodeName().equals("kernelFeature")) {
+            type = Type.KERNEL_FEATURE;
+        } else if (e.getNodeName().equals("autoFeature")) {
+            type = Type.AUTO_FEATURE;
+        } else if (e.getNodeName().equals("protectedFeature")) {
+            type = Type.PROTECTED_FEATURE;
+        } else { // in case a new feature type get created:
+            type = Type.FEATURE;
+        }
+        NodeList nl = e.getChildNodes();
+        for (int i = 0; i < nl.getLength(); i++) {
+            Node n = nl.item(i);
+            if (n instanceof Element) {
+                Element child = (Element) n;
+                String nodeName = child.getNodeName();
+
+                String content = child.getTextContent().trim();
+                if ("symbolicName".equals(nodeName)) {
+                    symbolicName = content;
+                } else if ("enables".equals(nodeName)) {
+                    enables.add(content);
+                } else if ("include".equals(nodeName)) {
+                    includes.add(child.getAttribute("symbolicName"));
+                } else if ("autoProvision".equals(nodeName)) {
+                    autoProvision.add(child.getAttribute("autoProvision"));
+                }
+            }
+        }
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public String getSymbolicName() {
+        return symbolicName;
+    }
+
+    public List<String> getEnables() {
+        return enables;
+    }
+
+    public List<String> getInclude() {
+        return includes;
+    }
+
+//    (&amp;(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.transaction-1.2))</autoProvision>
+//    (&amp;(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.iioptransport-1.0))</autoProvision>
+    public boolean isProvisioned(Map<String, Feature> featureMap, Set<String> installedFeatures) {
+        if (isProvisioned != null)
+            return isProvisioned;
+        if (type != Type.AUTO_FEATURE) {
+            isProvisioned = Boolean.TRUE;
+            return isProvisioned;
+        }
+
+        // Must be an auto feature, check if required features are enabled
+        for (String conditionFeature : autoProvision) {
+            boolean anyOf = conditionFeature.contains("|");
+            boolean isProvisioned = !anyOf;
+            for (String identity : conditionFeature.split("osgi.identity=")) {
+                int trimAt = identity.indexOf(')');
+                if (trimAt < 1)
+                    continue;
+                identity = identity.substring(0, trimAt);
+                if (Pattern.matches("[\\-\\w\\.]+", identity)) {
+                    boolean installed = installedFeatures.contains(identity.toLowerCase());
+                    if (anyOf)
+                        isProvisioned |= installed;
+                    else
+                        isProvisioned &= installed;
+                }
+            }
+            if (!isProvisioned)
+                return false;
+        }
+        return true;
+    }
+
+    public Type getFeatureType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return "{ " + (shortName == null ? "" : ("shortName=" + shortName + ", ")) +
+               "symbolicName=" + symbolicName +
+               ", enables=" + enables +
+               ", includes=" + includes + '}';
+    }
+}

--- a/dev/fattest.simplicity/src/componenttest/depchain/FeatureDependencyProcessor.java
+++ b/dev/fattest.simplicity/src/componenttest/depchain/FeatureDependencyProcessor.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.depchain;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.json.JsonArray;
+import javax.json.JsonString;
+import javax.json.JsonValue;
+import javax.json.spi.JsonProvider;
+
+import com.ibm.websphere.simplicity.RemoteFile;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.depchain.Feature.Type;
+import componenttest.topology.impl.LibertyFileManager;
+import componenttest.topology.impl.LibertyServer;
+
+public class FeatureDependencyProcessor {
+
+    private static final Class<?> c = FeatureDependencyProcessor.class;
+    public static final boolean DEBUG = true;
+
+    // If dependency validation fails, one reason could be an out of date featureList.xml.
+    // Allow for the featureList.xml to be recomputed at maximum once per JVM lifespan
+    private static boolean hasRetry = true;
+
+    public static void validateTestedFeatures(LibertyServer server, RemoteFile serverLog) throws Exception {
+        final String m = "validateTestedFeatures";
+        // Load the tested feature data, if it exists
+        File testedFeaturesFile = new File("fat-feature-deps.json");
+        if (!testedFeaturesFile.exists()) {
+            Log.info(c, m, "No tested feature data for this server.  Skipping feature validation");
+            return;
+        }
+
+        // Scrape messages.log to see what features were installed
+        List<String> installedFeaturesRaw = LibertyFileManager.findStringsInFile("CWWKF0012I: .*", serverLog);
+        if (installedFeaturesRaw == null || installedFeaturesRaw.size() == 0)
+            return;
+        Set<String> installedFeatures = new HashSet<String>();
+        for (String f : installedFeaturesRaw)
+            for (String installedFeature : f.substring(0, f.lastIndexOf(']')).substring(f.lastIndexOf('[') + 1).split(","))
+                installedFeatures.add(installedFeature.trim().toLowerCase());
+        Log.info(c, m, "Installed features are: " + installedFeatures);
+
+        // Make sure that any features installed in the server are known to the test dependency graph
+        File featureListFile = FeatureList.get(server);
+        Set<String> testedFeatures = getTestedFeatures(testedFeaturesFile, featureListFile);
+        Set<String> untestedFeatures = new HashSet<String>();
+        for (String installedFeature : installedFeatures) {
+            if (installedFeature.startsWith("usr:") || installedFeature.contains("test"))
+                continue; // Don't need to validate user/test features
+            if (!testedFeatures.contains(installedFeature))
+                untestedFeatures.add(installedFeature);
+        }
+        if (!untestedFeatures.isEmpty()) {
+            if (hasRetry) {
+                prepForRetry(featureListFile);
+                validateTestedFeatures(server, serverLog);
+            } else {
+                Exception e = new Exception("Installed feature(s) " + untestedFeatures +
+                                            " were not defined in the autoFVT/fat-feature-deps.json file! " +
+                                            "To correct this, add " + untestedFeatures + " to the 'tested.features' " +
+                                            "property in the bnd.bnd file for this FAT so that an accurate test depdendency " +
+                                            "graph can be generated in the future.");
+                Log.error(c, m, e);
+                throw e;
+            }
+        } else {
+            Log.info(c, m, "Validated that all installed features were present in test dependencies JSON file.");
+        }
+    }
+
+    private static Set<String> getTestedFeatures(File testedFeaturesFile, File featureList) throws Exception {
+        final String m = "getTestedFeatures";
+
+        JsonProvider provider = new org.glassfish.json.JsonProviderImpl();
+        JsonArray testedFeaturesJson = provider.createReader(new FileInputStream(testedFeaturesFile)).readArray();
+
+        Set<String> staticTestedFeatures = new HashSet<String>();
+        staticTestedFeatures.add("timedexit-1.0"); // Manually add timedexit because it's included from an external location
+        for (JsonValue testedFeature : testedFeaturesJson)
+            staticTestedFeatures.add(((JsonString) testedFeature).getString().trim().toLowerCase());
+
+        FeatureMap featureMap = FeatureMap.instance(featureList);
+
+        Set<String> testedFeatures = new HashSet<String>();
+        for (String staticFeature : staticTestedFeatures)
+            testedFeatures.addAll(getEnabledFeatures(staticFeature, testedFeatures, featureMap));
+        // Account for auto-features enabling other public features
+        // Continue to iterate auto-feature resolution until no more features are enabled
+        boolean featuresAdded = true;
+        while (featuresAdded) {
+            for (Feature f : featureMap.values()) {
+                if (DEBUG && f.getFeatureType() == Type.AUTO_FEATURE)
+                    Log.info(c, m, "Found auto feature: " + f);
+                if (f.getFeatureType() == Type.AUTO_FEATURE && f.isProvisioned(featureMap, testedFeatures))
+                    featuresAdded = testedFeatures.addAll(getEnabledFeatures(f.getSymbolicName(), testedFeatures, featureMap));
+            }
+            if (DEBUG)
+                Log.info(c, m, "After auto-feature calculation: " + testedFeatures);
+        }
+
+        Log.info(c, m, "Static tested features are:   " + staticTestedFeatures);
+        Log.info(c, m, "Computed Tested features are: " + testedFeatures);
+        return testedFeatures;
+    }
+
+    private static Set<String> getEnabledFeatures(String feature, Set<String> enabledFeatures, FeatureMap featureMap) {
+        Feature f = featureMap.get(feature);
+
+        // Sometimes features in OpenLiberty tolerate features that exist in WAS Liberty
+        // so feature definitions may not be found for these features
+        if (f == null)
+            return Collections.emptySet();
+
+        // If we have already processed this feature, don't process it again
+        if (enabledFeatures.contains(feature.toLowerCase()))
+            return enabledFeatures;
+
+        if (DEBUG)
+            Log.info(c, "getEnabledFeatures", "For feature=" + feature + " got obj: " + f);
+        enabledFeatures.add(f.getSymbolicName().toLowerCase());
+        if (f.getShortName() != null)
+            enabledFeatures.add(f.getShortName().toLowerCase());
+        for (String enabledFeature : f.getEnables())
+            enabledFeatures.addAll(getEnabledFeatures(enabledFeature, enabledFeatures, featureMap));
+        for (String includedFeature : f.getInclude())
+            enabledFeatures.addAll(getEnabledFeatures(includedFeature, enabledFeatures, featureMap));
+        return enabledFeatures;
+    }
+
+    private static void prepForRetry(File featureList) throws IOException {
+        final String m = "prepForRetry";
+        Log.info(c, m, "WARNING: Tested feature validation failed.  Prepping for retry.");
+
+        hasRetry = false;
+        FeatureMap.reset();
+        FeatureList.reset();
+    }
+
+}

--- a/dev/fattest.simplicity/src/componenttest/depchain/FeatureList.java
+++ b/dev/fattest.simplicity/src/componenttest/depchain/FeatureList.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.depchain;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Scanner;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.topology.impl.LibertyServer;
+
+public class FeatureList {
+
+    private static final Class<?> c = FeatureList.class;
+
+    private static File featureList = null;
+
+    @SuppressWarnings("resource")
+    public static File get(LibertyServer server) throws Exception {
+        final String m = "createFeatureList";
+
+        featureList = new File(server.getUserDir() + "/servers", "fatFeatureList.xml");
+        if (featureList.exists())
+            return featureList;
+
+        // If fat-featureList.xml doesn't exist already, generate it
+        Log.info(c, m, "fatFeatureList.xml not found.  Need to generate.");
+        String featureListJar = findRunnableJar(server.getInstallRoot());
+        Process featureListProc = Runtime.getRuntime().exec("java -jar " + featureListJar + " " + featureList.getAbsolutePath());
+        int rc = featureListProc.waitFor();
+        String cmdOutput;
+        try (Scanner s = new Scanner(featureListProc.getInputStream()).useDelimiter("\\A")) {
+            cmdOutput = s.hasNext() ? s.next() : "";
+        }
+        if (rc != 0) {
+            Log.info(c, m, "Got non-zero return code " + rc + " from running featureList generation:");
+            Log.info(c, m, cmdOutput);
+            throw new Exception(cmdOutput);
+        }
+        return featureList;
+    }
+
+    private static String findRunnableJar(String wlpInstallDir) {
+        String featureListJar = wlpInstallDir + "/bin/tools/ws-featureList.jar";
+        if (new File(featureListJar).exists())
+            return featureListJar;
+
+        // Depending on OS, the featureList jar may have a lowercase or uppercase L
+        featureListJar = wlpInstallDir + "/bin/tools/ws-featurelist.jar";
+        if (new File(featureListJar).exists())
+            return featureListJar;
+
+        throw new IllegalStateException("Unable to generate feature dependencies because ws-featureList.jar could not be found at: " + featureListJar);
+    }
+
+    public static void reset() throws IOException {
+        if (featureList != null)
+            if (!featureList.delete())
+                throw new IOException("Unable to delete old featureList.xml at: " + featureList.getAbsolutePath());
+        featureList = null;
+    }
+}

--- a/dev/fattest.simplicity/src/componenttest/depchain/FeatureMap.java
+++ b/dev/fattest.simplicity/src/componenttest/depchain/FeatureMap.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.depchain;
+
+import java.io.File;
+import java.util.HashMap;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+public class FeatureMap extends HashMap<String, Feature> {
+
+    private static final long serialVersionUID = 1L;
+    private static Class<?> c = FeatureMap.class;
+    private static FeatureMap instance = null;
+
+    public static FeatureMap instance(File featureList) throws Exception {
+        if (instance != null)
+            return instance;
+        return instance = new FeatureMap(featureList);
+    }
+
+    public static void reset() {
+        instance = null;
+    }
+
+    private FeatureMap(File featureList) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(featureList);
+        NodeList nodes = doc.getDocumentElement().getChildNodes();
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node n = nodes.item(i);
+            if ((n instanceof Element) && (!"defaultConfiguration".equals(n.getNodeName()))) {
+                // Parse the feature data from the XML element
+                Feature feature = new Feature((Element) n);
+                this.put(feature.getSymbolicName(), feature);
+                if (feature.getShortName() != null)
+                    this.put(feature.getShortName(), feature);
+                if (FeatureDependencyProcessor.DEBUG)
+                    Log.debug(c, "Found feature: " + feature);
+            }
+        }
+    }
+
+    @Override
+    public Feature get(Object key) {
+        // Keys are case insensitive
+        Feature f = super.get(key);
+        if (f != null || key == null || !(key instanceof String))
+            return f;
+        return super.get(((String) key).toLowerCase());
+    }
+
+    @Override
+    public Feature put(String key, Feature value) {
+        // Keys are case insensitive
+        return super.put(key.toLowerCase(), value);
+    }
+
+}

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyFileManager.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyFileManager.java
@@ -165,8 +165,8 @@ public class LibertyFileManager {
      * @return List of Strings which match the pattern. No match results in an empty list.
      * @throws Exception
      */
-    static List<String> findStringsInFile(String regexp,
-                                          RemoteFile fileToSearch) throws Exception {
+    public static List<String> findStringsInFile(String regexp,
+                                                 RemoteFile fileToSearch) throws Exception {
         final String method = "findStringsInFile";
         Log.entering(c, method);
 

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1682,16 +1682,19 @@ public class LibertyServer implements LogMonitorClient {
         testedFeatures.add("timedexit-1.0"); // Manually add timedexit because it's included from an external location
         for (JsonValue testedFeature : testedFeaturesJson)
             testedFeatures.add(((JsonString) testedFeature).getString().trim().toLowerCase());
+        Set<String> untestedFeatures = new HashSet<String>();
         for (String installedFeature : installedFeatures) {
             if (installedFeature.startsWith("usr:"))
                 continue; // Don't need to validate user features
             if (!testedFeatures.contains(installedFeature))
-                throw new Exception("Installed feature '" + installedFeature +
-                                    "' was not defined in the autoFVT/fat-feature-deps.json file! " +
-                                    "To correct this, add " + installedFeature + " to the 'tested.features' " +
-                                    "property in the bnd.bnd file for this FAT so that an accurate test depdendency " +
-                                    "graph can be generated in the future.");
+                untestedFeatures.add(installedFeature);
         }
+        if (!untestedFeatures.isEmpty())
+            throw new Exception("Installed feature(s) " + untestedFeatures +
+                                " were not defined in the autoFVT/fat-feature-deps.json file! " +
+                                "To correct this, add " + untestedFeatures + " to the 'tested.features' " +
+                                "property in the bnd.bnd file for this FAT so that an accurate test depdendency " +
+                                "graph can be generated in the future.");
         Log.info(c, m, "Validated that all installed features were present in test dependencies JSON file.");
     }
 


### PR DESCRIPTION
At build time, inspect most *.xml files right before packaging autoFVT.zip and search for `<feature>` tokens to generate a JSON file of features tested by the FAT.  An example JSON from the example FAT is:
```json
[
    "servlet-3.1",
    "componenttest-1.0"
]
```

At run time, whenever a LibertyServer is started or has its configuration updated, verify that no unexpected features are being installed.  Namely, ensure that all installed features are present in the example JSON file produced at build time.  If unexpected features are found, blow up.  These sort of issues ought to be caught at dev time by whoever is writing the FAT.