### PR TITLE
Fix local packageOpenLiberty step

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.boot.core/bnd.bnd
@@ -26,7 +26,10 @@ Export-Package: \
 	com.ibm.ws.kernel.productinfo,\
 	com.ibm.ws.kernel.provisioning,\
 	com.ibm.wsspi.kernel.embeddable
-
+	
+Private-Package:\
+    com.ibm.ws.kernel.boot.resources
+	
 instrument.disabled: true
 
 publish.wlp.jar.disabled: true

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/resources/package-info.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/resources/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.16
+ */
+@org.osgi.annotation.versioning.Version("1.0.16")
+package com.ibm.ws.kernel.boot.resources;


### PR DESCRIPTION
When running `./gradlew releaseNeeded` locally, some people have been hitting the following issue:

```
:build.image:packageOpenLibertyException in thread "main" java.lang.NoClassDefFoundError: com.ibm.ws.kernel.boot.internal.BootstrapConstants (initialization failure)
        at java.lang.J9VMInternals.initializationAlreadyFailed(J9VMInternals.java:91)
        at com.ibm.ws.kernel.boot.Launcher.createPlatform(Launcher.java:174)
        at com.ibm.ws.kernel.boot.cmdline.EnvCheck.main(EnvCheck.java:59)
        at com.ibm.ws.kernel.boot.cmdline.EnvCheck.main(EnvCheck.java:35)
Caused by: java.util.MissingResourceException: Can't find bundle for base name com.ibm.ws.kernel.boot.resources.LauncherMessages, locale en_US
        at java.util.ResourceBundle.throwMissingResourceException(ResourceBundle.java:1590)
        at java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1406)
        at java.util.ResourceBundle.getBundle(ResourceBundle.java:784)
        at com.ibm.ws.kernel.boot.internal.BootstrapConstants.<clinit>(BootstrapConstants.java:17)
        at com.ibm.ws.kernel.boot.BootstrapConfig.createConfigDirectory(BootstrapConfig.java:910)
        at com.ibm.ws.kernel.boot.BootstrapConfig.verifyProcess(BootstrapConfig.java:830)
        at com.ibm.ws.kernel.boot.Launcher.createPlatform(Launcher.java:100)
        ... 2 more
 FAILED

FAILURE: Build failed with an exception.

* Where:
Build file 'C:\devel\projects\libertyGit\open-liberty\dev\build.image\build.gradle' line: 32

* What went wrong:
Execution failed for task ':build.image:packageOpenLiberty'.
> Process 'command 'cmd'' finished with non-zero exit value 1
```