### PR TITLE
aborted tasks for policy executor

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
@@ -10,11 +10,15 @@
  *******************************************************************************/
 package com.ibm.ws.threading;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+
+import com.ibm.websphere.ras.annotation.Trivial;
 
 /**
  * Receives notifications at various points in the life cycle of policy executor tasks.
  */
+@Trivial
 public abstract class PolicyTaskCallback {
     /**
      * Invoked when a task's future is canceled.
@@ -34,12 +38,13 @@ public abstract class PolicyTaskCallback {
      * @param task the Callable or Runnable task.
      * @param future the future for the task that has stopped running.
      * @param startObj result, if any, of previous onStart callback.
+     * @param aborted indicates if the task was aborted and did not start.
      * @param pending a positive value indicates that additional work, such as completion services are pending on the task's thread of execution.
      *            The value 0 indicate that no additional work is pending. A negative value indicates that work that was previously pending is done.
      *            If positive, a subsequent onEnd callback will be sent with a negative value after the additional work ends.
      * @param failure failure, if any, that occurred while trying to run the task.
      */
-    public void onEnd(Object task, Future<?> future, Object startObj, int pending, Throwable failure) {}
+    public void onEnd(Object task, Future<?> future, Object startObj, boolean aborted, int pending, Throwable failure) {}
 
     /**
      * Invoked before a task starts running. This callback is invoked synchronously on the task's thread of execution.
@@ -61,4 +66,18 @@ public abstract class PolicyTaskCallback {
      * @param future the future for the submitted task.
      */
     public void onSubmit(Object task, Future<?> future) {}
+
+    /**
+     * Invoked to raise an ExecutionException for an aborted task.
+     * For example, a task is aborted when the onStart callback raises a runtime exception.
+     * This method gives the callback the opportunity to use a different exception,
+     * such as javax.enteprise.concurrent.AbortedException to distinguish aborted tasks
+     * from tasks that failed during normal execution.
+     *
+     * @param x the exception
+     * @throws ExecutionException
+     */
+    public void raiseAbortedException(Throwable x) throws ExecutionException {
+        throw new ExecutionException(x);
+    }
 }


### PR DESCRIPTION
Add support for aborted tasks to policy executor.
Abort is possible when the onStart (corresponds to ManagedTaskListener.taskStarting) event raises an exception or cancels the task.