### PR TITLE
Issue #388 : Support loginConfig annotation with the mp jwt.

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -38,8 +38,8 @@
             required="false" type="Boolean"  default="true" />
         <AD id="hostNameVerificationEnabled" name="internal" description="internal use only" required="false" type="Boolean" default="false"/>
         <AD id="clockSkew" name="%clockSkew" description="%clockSkew.desc" required="false" type="String" default="5m" ibm:type="duration" />
-        <AD id="ignoreApplicationAuthMethod" name="internal"  description="internal use only"
-            required="false" type="Boolean"  default="false" />
+        <AD id="ignoreApplicationAuthMethod" name="%ignoreApplicationAuthMethod"  description="ignoreApplicationAuthMethod.desc"
+            required="false" type="Boolean"  default="true" />
     </OCD>
 
                

--- a/dev/com.ibm.ws.security.mp.jwt/resources/com/ibm/ws/security/mp/jwt/resources/MicroProfileJwtMessages.nlsprops
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/com/ibm/ws/security/mp/jwt/resources/MicroProfileJwtMessages.nlsprops
@@ -146,3 +146,7 @@ ERROR_CREATING_JWT.useraction=Verify that the specified MicroProfile JWT configu
 MP_JWT_FRONT_END_ERROR=CWWKS5525E: An error was encountered while authenticating a user by using MicroProfile JSON Web Token (JWT).
 MP_JWT_FRONT_END_ERROR.explanation=A problem occurred while authenticating a user. There might have been a connection issue between the application and a third-party service provider, or a problem with authentication data.
 MP_JWT_FRONT_END_ERROR.useraction=Contact the system administrator to resolve the problem.
+
+MPJWT_NOT_FOUND_IN_APPLICATION=CWWKS5526E: The MicroProfile JWT feature cannot perform authentication because it is expecting [{0}] authentication type in the application, but found [{1}]. The [{2}] attribute is set to [{3}]. 
+MPJWT_NOT_FOUND_IN_APPLICATION.explanation=To perform authentication successfully, do one of the following. a) Make sure that the ignoreApplicationAuthMethod attribute is "true" b) loginConfig annotation is set to MP-JWT in the application.
+MPJWT_NOT_FOUND_IN_APPLICATION.useraction=Ensure that the server or application configuration is updated.

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/MicroProfileJwtConfig.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/MicroProfileJwtConfig.java
@@ -22,4 +22,6 @@ public interface MicroProfileJwtConfig {
 
     public String getGroupNameAttribute();
 
+    public boolean ignoreApplicationAuthMethod();
+
 }

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/MicroProfileJwtConfigImpl.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/MicroProfileJwtConfigImpl.java
@@ -100,6 +100,9 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig, JwtCons
     public static final String CFG_KEY_CLOCK_SKEW = "clockSkew";
     private long clockSkewMilliSeconds;
 
+    public static final String CFG_KEY_IGNORE_APP_AUTH_METHOD = "ignoreApplicationAuthMethod";
+    protected boolean ignoreApplicationAuthMethod = true;
+
     protected CommonConfigUtils configUtils = new CommonConfigUtils();
 
     @Reference(service = MicroProfileJwtService.class, name = KEY_MP_JWT_SERVICE, cardinality = ReferenceCardinality.MANDATORY)
@@ -157,6 +160,7 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig, JwtCons
         this.trustAliasName = configUtils.getConfigAttribute(props, KEY_TRUSTED_ALIAS);
         this.hostNameVerificationEnabled = configUtils.getBooleanConfigAttribute(props, CFG_KEY_HOST_NAME_VERIFICATION_ENABLED, hostNameVerificationEnabled);
         this.tokenReuse = configUtils.getBooleanConfigAttribute(props, CFG_KEY_TOKEN_REUSE, tokenReuse);
+        this.ignoreApplicationAuthMethod = configUtils.getBooleanConfigAttribute(props, CFG_KEY_IGNORE_APP_AUTH_METHOD, ignoreApplicationAuthMethod);
         jwkSet = null; // the jwkEndpoint may have been changed during dynamic update
         consumerUtils = null; // the parameters in consumerUtils may have been changed during dynamic changing
 
@@ -448,6 +452,13 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig, JwtCons
     @Override
     public boolean getTokenReuse() {
         return this.tokenReuse;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean ignoreApplicationAuthMethod() {
+        // TODO Auto-generated method stub
+        return this.ignoreApplicationAuthMethod;
     }
 
 }


### PR DESCRIPTION
Adding the runtime support to look at the application configuration. If the loginConfig specifies MP-JWT as the authMethod, then the TAI will
intercept the authentication request. The mp jwt configuration attribute ignoreApplicationAuthMethod needs to be set to "false" to enable this support.