### PR TITLE
Issue #388 : Support loginConfig annotation with the mp jwt.

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -38,7 +38,7 @@
             required="false" type="Boolean"  default="true" />
         <AD id="hostNameVerificationEnabled" name="internal" description="internal use only" required="false" type="Boolean" default="false"/>
         <AD id="clockSkew" name="%clockSkew" description="%clockSkew.desc" required="false" type="String" default="5m" ibm:type="duration" />
-        <AD id="ignoreApplicationAuthMethod" name="%ignoreApplicationAuthMethod"  description="ignoreApplicationAuthMethod.desc"
+        <AD id="ignoreApplicationAuthMethod" name="%ignoreApplicationAuthMethod"  description="%ignoreApplicationAuthMethod.desc"
             required="false" type="Boolean"  default="true" />
     </OCD>
 

--- a/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -38,8 +38,8 @@
             required="false" type="Boolean"  default="true" />
         <AD id="hostNameVerificationEnabled" name="internal" description="internal use only" required="false" type="Boolean" default="false"/>
         <AD id="clockSkew" name="%clockSkew" description="%clockSkew.desc" required="false" type="String" default="5m" ibm:type="duration" />
-        <AD id="ignoreApplicationAuthMethod" name="internal"  description="internal use only"
-            required="false" type="Boolean"  default="false" />
+        <AD id="ignoreApplicationAuthMethod" name="%ignoreApplicationAuthMethod"  description="ignoreApplicationAuthMethod.desc"
+            required="false" type="Boolean"  default="true" />
     </OCD>
 
                

--- a/dev/com.ibm.ws.security.mp.jwt/resources/com/ibm/ws/security/mp/jwt/resources/MicroProfileJwtMessages.nlsprops
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/com/ibm/ws/security/mp/jwt/resources/MicroProfileJwtMessages.nlsprops
@@ -146,3 +146,7 @@ ERROR_CREATING_JWT.useraction=Verify that the specified MicroProfile JWT configu
 MP_JWT_FRONT_END_ERROR=CWWKS5525E: An error was encountered while authenticating a user by using MicroProfile JSON Web Token (JWT).
 MP_JWT_FRONT_END_ERROR.explanation=A problem occurred while authenticating a user. There might have been a connection issue between the application and a third-party service provider, or a problem with authentication data.
 MP_JWT_FRONT_END_ERROR.useraction=Contact the system administrator to resolve the problem.
+
+MPJWT_NOT_FOUND_IN_APPLICATION=CWWKS5526E: The MicroProfile JWT feature cannot perform authentication because it is expecting [{0}] authentication type in the application, but found [{1}]. The [{2}] attribute is set to [{3}]. 
+MPJWT_NOT_FOUND_IN_APPLICATION.explanation=To perform authentication successfully, do one of the following. a) Make sure that the ignoreApplicationAuthMethod attribute is "true" b) loginConfig annotation is set to MP-JWT in the application.
+MPJWT_NOT_FOUND_IN_APPLICATION.useraction=Ensure that the server or application configuration is updated.

--- a/dev/com.ibm.ws.security.mp.jwt/resources/com/ibm/ws/security/mp/jwt/resources/MicroProfileJwtMessages.nlsprops
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/com/ibm/ws/security/mp/jwt/resources/MicroProfileJwtMessages.nlsprops
@@ -147,6 +147,6 @@ MP_JWT_FRONT_END_ERROR=CWWKS5525E: An error was encountered while authenticating
 MP_JWT_FRONT_END_ERROR.explanation=A problem occurred while authenticating a user. There might have been a connection issue between the application and a third-party service provider, or a problem with authentication data.
 MP_JWT_FRONT_END_ERROR.useraction=Contact the system administrator to resolve the problem.
 
-MPJWT_NOT_FOUND_IN_APPLICATION=CWWKS5526E: The MicroProfile JWT feature cannot perform authentication because it is expecting [{0}] authentication type in the application, but found [{1}]. The [{2}] attribute is set to [{3}]. 
+MPJWT_NOT_FOUND_IN_APPLICATION=CWWKS5526W: The MicroProfile JWT feature cannot perform authentication because it is expecting [{0}] authentication type in the application, but found [{1}]. The [{2}] attribute is set to [{3}]. 
 MPJWT_NOT_FOUND_IN_APPLICATION.explanation=To perform authentication successfully, do one of the following. a) Make sure that the ignoreApplicationAuthMethod attribute is "true" b) loginConfig annotation is set to MP-JWT in the application.
 MPJWT_NOT_FOUND_IN_APPLICATION.useraction=Ensure that the server or application configuration is updated.

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/MicroProfileJwtConfig.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/MicroProfileJwtConfig.java
@@ -22,4 +22,6 @@ public interface MicroProfileJwtConfig {
 
     public String getGroupNameAttribute();
 
+    public boolean ignoreApplicationAuthMethod();
+
 }

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/MicroProfileJwtConfigImpl.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/MicroProfileJwtConfigImpl.java
@@ -100,6 +100,9 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig, JwtCons
     public static final String CFG_KEY_CLOCK_SKEW = "clockSkew";
     private long clockSkewMilliSeconds;
 
+    public static final String CFG_KEY_IGNORE_APP_AUTH_METHOD = "ignoreApplicationAuthMethod";
+    protected boolean ignoreApplicationAuthMethod = true;
+
     protected CommonConfigUtils configUtils = new CommonConfigUtils();
 
     @Reference(service = MicroProfileJwtService.class, name = KEY_MP_JWT_SERVICE, cardinality = ReferenceCardinality.MANDATORY)
@@ -157,6 +160,7 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig, JwtCons
         this.trustAliasName = configUtils.getConfigAttribute(props, KEY_TRUSTED_ALIAS);
         this.hostNameVerificationEnabled = configUtils.getBooleanConfigAttribute(props, CFG_KEY_HOST_NAME_VERIFICATION_ENABLED, hostNameVerificationEnabled);
         this.tokenReuse = configUtils.getBooleanConfigAttribute(props, CFG_KEY_TOKEN_REUSE, tokenReuse);
+        this.ignoreApplicationAuthMethod = configUtils.getBooleanConfigAttribute(props, CFG_KEY_IGNORE_APP_AUTH_METHOD, ignoreApplicationAuthMethod);
         jwkSet = null; // the jwkEndpoint may have been changed during dynamic update
         consumerUtils = null; // the parameters in consumerUtils may have been changed during dynamic changing
 
@@ -448,6 +452,13 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig, JwtCons
     @Override
     public boolean getTokenReuse() {
         return this.tokenReuse;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean ignoreApplicationAuthMethod() {
+        // TODO Auto-generated method stub
+        return this.ignoreApplicationAuthMethod;
     }
 
 }

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIRequestHelper.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIRequestHelper.java
@@ -37,21 +37,7 @@ public class TAIRequestHelper {
     public final static String REQ_CONTENT_TYPE_NAME = "Content-Type";
     public final static String REQ_CONTENT_TYPE_APP_FORM_URLENCODED = "application/x-www-form-urlencoded";
     private static final String ACCESS_TOKEN = "access_token";
-
-    //    static public final String KEY_MP_JWT_CONFIG = "microProfileJwtConfig";
-    //    static ConcurrentServiceReferenceMap<String, MicroProfileJwtConfig> microProfileJwtConfigRef = new ConcurrentServiceReferenceMap<String, MicroProfileJwtConfig>(KEY_MP_JWT_CONFIG);
-    //
-    //    public static void setMicroProfileJwtConfigRef(ConcurrentServiceReferenceMap<String, MicroProfileJwtConfig> configRef) {
-    //        microProfileJwtConfigRef = configRef;
-    //    }
-    //
-    //    public MicroProfileJwtConfig getConfig2(String key) {
-    //        return microProfileJwtConfigRef.getService(key);
-    //    }
-    //
-    //    public Iterator<MicroProfileJwtConfig> MicroProfileJwtCongetConfigs2() {
-    //        return microProfileJwtConfigRef.getServices();
-    //    }
+    private static final String AUTHN_TYPE = "MP-JWT";
 
     /**
      * Creates a new {@link MicroProfileJwtTaiRequest} object and sets the object as an attribute in the request object provided.
@@ -86,13 +72,7 @@ public class TAIRequestHelper {
         if (tc.isDebugEnabled()) {
             Tr.entry(tc, methodName, request, mpJwtTaiRequest);
         }
-        // 241526 don't process jmx requests with this interceptor
-        if (isJmxConnectorRequest(request)) {
-            if (tc.isDebugEnabled()) {
-                Tr.exit(tc, methodName, false);
-            }
-            return false;
-        }
+
         String loginHint = getLoginHint(request);
         mpJwtTaiRequest = setTaiRequestConfigInfo(request, loginHint, mpJwtTaiRequest);
         boolean result = false;
@@ -124,7 +104,6 @@ public class TAIRequestHelper {
      */
     private boolean isMpJwtSpecifiedInLoginConfig(HttpServletRequest request) {
 
-        String AUTHN_TYPE = "MP-JWT";
         if (request.getAttribute(APPLICATION_AUTH_METHOD) != null) {
             String loginCfg = (String) request.getAttribute(APPLICATION_AUTH_METHOD);
             if (tc.isDebugEnabled()) {
@@ -133,27 +112,14 @@ public class TAIRequestHelper {
             }
             if (!AUTHN_TYPE.equals(loginCfg)) {
                 String msg = Tr.formatMessage(tc, "MPJWT_NOT_FOUND_IN_APPLICATION", new Object[] { AUTHN_TYPE, loginCfg, "ignoreApplicationAuthMethod", "false" });
-                Tr.error(tc, msg);
+                Tr.warning(tc, msg);
             }
             return (AUTHN_TYPE.equals(loginCfg));
         }
         String msg = Tr.formatMessage(tc, "MPJWT_NOT_FOUND_IN_APPLICATION", new Object[] { AUTHN_TYPE, "null", "ignoreApplicationAuthMethod", "false" });
-        Tr.error(tc, msg);
+        Tr.warning(tc, msg);
         return false;
 
-    }
-
-    boolean isJmxConnectorRequest(HttpServletRequest request) {
-        String methodName = "isJmxConnectorRequest";
-        if (tc.isDebugEnabled()) {
-            Tr.entry(tc, methodName, request);
-        }
-        String ctxPath = request.getContextPath();
-        boolean result = "/IBMJMXConnectorREST".equals(ctxPath);
-        if (tc.isDebugEnabled()) {
-            Tr.exit(tc, methodName, result);
-        }
-        return result;
     }
 
     String getLoginHint(HttpServletRequest request) {


### PR DESCRIPTION
Adding the runtime support to look at the application configuration. If the loginConfig specifies MP-JWT as the authMethod, then the TAI will
intercept the authentication request. The mp jwt configuration attribute ignoreApplicationAuthMethod needs to be set to "false" to enable this support.