### PR TITLE
Clearup prereq's for CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,19 @@
 # Contributing to Open Liberty
 Anyone can contribute to the Open Liberty project and we welcome your contributions!
 
-There are multiple ways to contribute: report bugs, fix bugs, contribute code, improve upon documentation, etc.  You must follow these prerequisites and guidelines:
-* [Contributor License Agreement](https://github.com/OpenLiberty/open-liberty/blob/master/CONTRIBUTING.md#contributor-license-agreement)
+There are multiple ways to contribute: report bugs, fix bugs, contribute code, improve upon documentation, etc.  You must follow these guidelines:
 * [Raising issues](https://github.com/OpenLiberty/open-liberty/blob/master/CONTRIBUTING.md#raising-issues)
+* [Contributor License Agreement](https://github.com/OpenLiberty/open-liberty/blob/master/CONTRIBUTING.md#contributor-license-agreement)
 * [Coding Standards](https://github.com/OpenLiberty/open-liberty/blob/master/CONTRIBUTING.md#coding-standards)
 
-## Contributor License Agreement
-All contributors must signoff on the [Contributor License Agreement](https://github.com/OpenLiberty/open-liberty/blob/master/cla/open-liberty-cla-individual.pdf) when submitting a new pull request. Instructions how to sign and submit the agreement are here: https://github.com/OpenLiberty/open-liberty/blob/master/cla/open-liberty-cla-individual.pdf.
-
-
 ## Raising issues
-
 Please raise any bug reports on the [Open Liberty project repository's GitHub issue tracker](https://github.com/OpenLiberty/open-liberty/issues). Be sure to search the list to see if your issue has already been raised.
 
 A good bug report is one that make it easy for everyone to understand what you were trying to do and what went wrong. Provide as much context as possible so we can try to recreate the issue.
+
+## Contributor License Agreement
+If you are contributing code changes via a pull request, you must signoff on the [Contributor License Agreement](https://github.com/OpenLiberty/open-liberty/blob/master/cla/open-liberty-cla-individual.pdf). Instructions how to sign and submit the agreement are here: https://github.com/OpenLiberty/open-liberty/blob/master/cla/open-liberty-cla-individual.pdf.
+
 
 ## Coding Standards
 Please ensure you follow the coding standards used throughout the existing code base. Some basic rules include:


### PR DESCRIPTION
Right now the text reads, the contributor must sign the CLA before opening an issue.

Make it clear the CLA is only for PR's