### PR TITLE
Separate internal and external maven locals

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -18,7 +18,6 @@ com.ibm.ws.componenttest:mantis-collections:2.5.0
 com.ibm.ws.componenttest:mantis-nls-standalone:2.5.0
 com.ibm.ws.componenttest:provider.api:1.0.0
 com.ibm.ws.componenttest:public.api:1.0.0
-com.ibm.ws.org.objenesis:objenesis:1.0
 com.netflix.archaius:archaius2-api:2.1.10
 com.netflix.archaius:archaius2-core:2.1.10
 com.nimbusds:nimbus-jose-jwt:4.23
@@ -100,8 +99,7 @@ org.apache.cxf:cxf-rt-rs-service-description:3.1.11
 org.apache.cxf:cxf-rt-transports-http:3.1.11
 org.apache.cxf:cxf-tools-common:3.1.11
 org.apache.cxf:cxf-tools-wadlto-jaxrs:3.1.11
-org.apache.derby:derby:10.7.1.1
-org.apache.derby:derby:10.11.1
+org.apache.derby:derby:10.11.1.1
 org.apache.derby:derbynet:10.11.1.1
 org.apache.felix:org.apache.felix.gogo.command:0.16.0
 org.apache.felix:org.apache.felix.gogo.runtime:0.16.2

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -64,7 +64,6 @@ com.ibm.ws.org.objenesis:objenesis:1.0
 com.ibm.ws.commons-collections:commons-collections:3.2.1
 com.ibm.ws.commons-fileupload:commons-fileupload:1.2.1
 com.ibm.ws.commons-io:commons-io:1.4
-org.apache.derby:derby:10.11.1
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 org.eclipse:yasson:1.0.0
 com.ibm.ws.org.eclipse.jdt.core.compiler:ecj:4.4.2

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo/build.gradle
@@ -16,7 +16,7 @@ addRequiredLibraries {
 			derbyEmbedded
 		}
 		dependencies {
-			derbyEmbedded 'org.apache.derby:derby:10.11.1'
+			derbyEmbedded 'org.apache.derby:derby:10.11.1.1'
 		}
 		copy {
 			from configurations.derbyEmbedded

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/build.gradle
@@ -19,7 +19,7 @@ addRequiredLibraries {
     }
     // Define G:A:V coordinates of each dependency
     dependencies {
-      derby 'org.apache.derby:derby:10.11.1'
+      derby 'org.apache.derby:derby:10.11.1.1'
     }
     // Copy the dependencies wherever they may be needed
     copy {

--- a/dev/com.ibm.ws.concurrent_fat_demo/build.gradle
+++ b/dev/com.ibm.ws.concurrent_fat_demo/build.gradle
@@ -16,7 +16,7 @@ addRequiredLibraries {
 			derbyEmbedded
 		}
 		dependencies {
-			derbyEmbedded 'org.apache.derby:derby:10.11.1'
+			derbyEmbedded 'org.apache.derby:derby:10.11.1.1'
 		}
 		copy {
 			from configurations.derbyEmbedded

--- a/dev/com.ibm.ws.jca_fat_derbyra/build.gradle
+++ b/dev/com.ibm.ws.jca_fat_derbyra/build.gradle
@@ -19,7 +19,7 @@ addRequiredLibraries {
     }
     // Define G:A:V coordinates of each dependency
     dependencies {
-      derby 'org.apache.derby:derby:10.11.1'
+      derby 'org.apache.derby:derby:10.11.1.1'
     }
     // Copy the dependencies wherever they may be needed
     copy {

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterSecurityTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterSecurityTest.java
@@ -59,7 +59,7 @@ public class DerbyResourceAdapterSecurityTest extends FATServletClient {
         rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml"));
         rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/wlp-ra.xml"));
 
-        rar.addAsLibrary(new File("publish/servers/com.ibm.ws.jca.fat.derbyra.security/derby/derby-10.11.1.jar"));
+        rar.addAsLibrary(new File("publish/servers/com.ibm.ws.jca.fat.derbyra.security/derby/derby-10.11.1.1.jar"));
 
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "loginModule.jar");
         jar.addPackage("com.ibm.ws.jca.fat.security.login");

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -60,7 +60,7 @@ public class DerbyResourceAdapterTest extends FATServletClient {
         rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");
         rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml"));
         rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/wlp-ra.xml"));
-        rar.addAsLibrary(new File("publish/servers/com.ibm.ws.jca.fat.derbyra/derby/derby-10.11.1.jar"));
+        rar.addAsLibrary(new File("publish/servers/com.ibm.ws.jca.fat.derbyra/derby/derby-10.11.1.1.jar"));
 
         ShrinkHelper.exportToServer(server, "connectors", rar);
 

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/build.gradle
@@ -19,7 +19,7 @@ addRequiredLibraries {
     }
     // Define G:A:V coordinates of each dependency
     dependencies {
-      derby 'org.apache.derby:derby:10.11.1'
+      derby 'org.apache.derby:derby:10.11.1.1'
     }
     // Copy the dependencies wherever they may be needed
     copy {

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -47,7 +47,7 @@ public class JDBCLoadFromAppTest extends FATServletClient {
     public static void setUp() throws Exception {
         WebArchive derbyApp = ShrinkWrap.create(WebArchive.class, "derbyApp.war")
                         .addPackage("web.derby") //
-                        .addAsLibrary(new File("publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/derby/derby-10.11.1.jar")) //
+                        .addAsLibrary(new File("publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/derby/derby-10.11.1.1.jar")) //
                         .addPackage("jdbc.driver.proxy"); // delegates to the Derby JDBC driver
         ShrinkHelper.exportAppToServer(server, derbyApp);
 

--- a/dev/com.ibm.ws.jdbc_fat_v41/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_v41/bnd.bnd
@@ -22,4 +22,4 @@ test.project: true
     com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
-	org.apache.derby:derby;version=10.11.1
+	org.apache.derby:derby;version=10.11.1.1

--- a/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
@@ -28,4 +28,4 @@ test.project: true
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.persistence.2.2;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
-	org.apache.derby:derby;version=10.11.1
+	org.apache.derby:derby;version=10.11.1.1

--- a/dev/com.ibm.ws.jpa_22_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa_22_fat/build.gradle
@@ -22,7 +22,7 @@ addRequiredLibraries {
     }
     // Define G:A:V coordinates of each dependency
     dependencies {
-      derby 'org.apache.derby:derby:10.11.1'
+      derby 'org.apache.derby:derby:10.11.1.1'
     }
     // Copy the dependencies wherever they may be needed
     copy {

--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -70,8 +70,8 @@ def loadBuildProps() {
   }
   
   def fetchRepoPublic = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemotePublic;releaseUrl=https://repo.maven.apache.org/maven2/;index=${build}/oss_dependencies.maven')
-  def fetchRepoIBM = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemoteIBM;releaseUrl=http://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/wasliberty-open-liberty/;index=${build}/oss_ibm.maven')
-  def fetchRepoIBMJava = fetchRepoIBM //Not yet supported to not have this set via gradle.startup.properties
+  def fetchRepoIBM = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemoteIBM;local=~/.ibmdhe/repository;releaseUrl=http://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/wasliberty-open-liberty/;index=${build}/oss_ibm.maven')
+  def fetchRepoIBMJava = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = DummyRepo') //Not yet supported to not have this set via gradle.startup.properties
   def pushRepoIBM = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemotePublish')
 
   def javaHome = org.gradle.internal.jvm.Jvm.current().getJavaHome()
@@ -112,8 +112,8 @@ def loadBuildProps() {
     def artifactoryExists = true;
     def repoURL = ('https://' + props.getProperty('artifactory.download.server') + '/artifactory/wasliberty-open-liberty')
     def uploadRepoURL = ('https://' + props.getProperty('artifactory.upload.server') + '/artifactory/wasliberty-open-liberty')
-    fetchRepoPublic = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemotePublic;releaseUrl='+ repoURL +';snapshotUrl='+ repoURL +';index=${build}/oss_dependencies.maven')
-    fetchRepoIBM = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemoteIBM;releaseUrl='+ repoURL +';snapshotUrl='+ repoURL +';index=${build}/oss_ibm.maven')
+    fetchRepoPublic = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemotePublic;local=~/.ibmartifactory/repository;releaseUrl='+ repoURL +';snapshotUrl='+ repoURL +';index=${build}/oss_dependencies.maven')
+    fetchRepoIBM = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemoteIBM;local=~/.ibmartifactory/repository;releaseUrl='+ repoURL +';snapshotUrl='+ repoURL +';index=${build}/oss_ibm.maven')
     fetchRepoIBMJava = ('aQute.bnd.repository.maven.provider.MavenBndRepository;local=~/.ibmjava/repository;name = IBMInternalJava;releaseUrl='+ repoURL +';snapshotUrl='+ repoURL +';index=${build}/ibm_java.maven')
     pushRepoIBM = ('aQute.bnd.repository.maven.provider.MavenBndRepository;name = RemotePublish;releaseUrl='+ uploadRepoURL + matrixParams + ';snapshotUrl='+ uploadRepoURL + matrixParams + ';index=${build}/openliberty.maven')
 


### PR DESCRIPTION
By default not having a local specified means it uses .m2.

We're using separate repositories for consistency and speed, but they really need to be separated so that only artifacts directly from maven go into .m2. The connection to DHE will then funnel into .ibmdhe and the connection to our internal store will go to .ibmartifactory. This makes testing easier, and keeps from potentially poisoning the .m2 directory with things not actually on maven central. 