### PR TITLE
onEnd callback needed after policy executor task aborted

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -119,13 +119,17 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
             if (listener != null) {
                 // notify listener: taskAborted
                 try {
-                    Throwable x = failure;
+                    Throwable x;
                     boolean canceled = future.isCancelled();
                     if (canceled || aborted) {
-                        if (canceled && !(x instanceof CancellationException))
+                        if (failure instanceof CancellationException)
+                            x = failure;
+                        else if (canceled)
                             x = new CancellationException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
                         else if (aborted)
-                            x = new AbortedException(x);
+                            x = new AbortedException(failure);
+                        else
+                            x = failure;
                         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
                             Tr.event(this, tc, "taskAborted", managedExecutor, task, x);
                         listener.taskAborted(future, managedExecutor, task, x);

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -49,7 +49,7 @@ public class PolicyTaskFutureImpl<T> implements Future<T> {
     /**
      * Optional callback for life cycle events.
      */
-    private final PolicyTaskCallback callback;
+    final PolicyTaskCallback callback;
 
     /**
      * The policy executor instance.
@@ -433,6 +433,8 @@ public class PolicyTaskFutureImpl<T> implements Future<T> {
         if (!state.setRunning()) {
             if (trace && tc.isDebugEnabled())
                 Tr.debug(this, tc, "unable to run", state.get());
+            if (callback != null)
+                callback.onEnd(task, this, null, true, 0, null); // aborted, queued task will never run
             return;
         }
 


### PR DESCRIPTION
Need to send the onEnd callback when a policy executor task is aborted before it starts. This can happen in a variety of places, all of which need to be covered.