### PR TITLE
prototype of managed executor invokeAll via policy executor

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -346,6 +346,36 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
         return list;
     }
 
+    /**
+     * Capture context for a list of tasks and create callbacks that apply context and notify the ManagedTaskListener, if any.
+     *
+     * @param tasks collection of tasks.
+     * @return list of callbacks.
+     */
+    private <T> PolicyTaskCallback[] createCallbacks(Collection<? extends Callable<T>> tasks) {
+        WSContextService contextSvc = AccessController.doPrivileged(contextSvcAccessor);
+
+        int numTasks = tasks.size();
+        PolicyTaskCallback[] callbacks = new PolicyTaskCallback[numTasks];
+
+        if (numTasks == 1)
+            callbacks[0] = new TaskLifeCycleCallback(this, contextSvc.captureThreadContext(getExecutionProperties(tasks.iterator().next())));
+        else {
+            // Thread context capture is expensive, so reuse callbacks when execution properties match
+            Map<Map<String, String>, TaskLifeCycleCallback> execPropsToCallback = new HashMap<Map<String, String>, TaskLifeCycleCallback>();
+            int t = 0;
+            for (Callable<T> task : tasks) {
+                Map<String, String> execProps = getExecutionProperties(task);
+                TaskLifeCycleCallback callback = execPropsToCallback.get(execProps);
+                if (callback == null)
+                    execPropsToCallback.put(execProps, callback = new TaskLifeCycleCallback(this, contextSvc.captureThreadContext(execProps)));
+                callbacks[t++] = callback;
+            }
+        }
+
+        return callbacks;
+    }
+
     /** {@inheritDoc} */
     @Override
     public Object createResource(final ResourceInfo ref) throws Exception {
@@ -405,6 +435,10 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
     @FFDCIgnore(InterruptedException.class)
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        // TODO replace this temporary prototype code
+        if (policyExecutor != null)
+            return policyExecutor.invokeAll(tasks, createCallbacks(tasks));
+
         ExecutorService execSvc = getExecSvc();
 
         ArrayList<SubmittedTask<T>> tasksToSubmit = contextualize(tasks, true);
@@ -433,6 +467,10 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
     @FFDCIgnore(InterruptedException.class)
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        // TODO replace this temporary prototype code
+        if (policyExecutor != null)
+            return policyExecutor.invokeAll(tasks, createCallbacks(tasks), timeout, unit);
+
         ExecutorService execSvc = getExecSvc();
 
         ArrayList<SubmittedTask<T>> tasksToSubmit = contextualize(tasks, true);

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -10,9 +10,12 @@
  *******************************************************************************/
 package com.ibm.ws.threading;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * <p>Policy executors are backed by the Liberty global thread pool, but allow
@@ -62,6 +65,26 @@ public interface PolicyExecutor extends ExecutorService {
      * @throws UnsupportedOperationException if invoked on a policyExecutor instance created from server configuration.
      */
     PolicyExecutor coreConcurrency(int core);
+
+    /**
+     * Invokes a group of tasks with a callback per task to be invoked at various points in the task's life cycle.
+     * The first task is paired with the first callback. The second task is paired with the second callback. An so forth.
+     * It is okay to include the same callback at multiple positions or to include null callbacks at some positions.
+     *
+     * @throws ArrayIndexOutOfBoundsException if the size of the callbacks array is less than the number of tasks.
+     * @see java.util.concurrent.ExecutorService#invokeAll(java.util.Collection)
+     */
+    <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, PolicyTaskCallback[] callbacks) throws InterruptedException;
+
+    /**
+     * Invokes a group of tasks with a callback per task to be invoked at various points in the task's life cycle.
+     * The first task is paired with the first callback. The second task is paired with the second callback. An so forth.
+     * It is okay to include the same callback at multiple positions or to include null callbacks at some positions.
+     *
+     * @throws ArrayIndexOutOfBoundsException if the size of the callbacks array is less than the number of tasks.
+     * @see java.util.concurrent.ExecutorService#invokeAll(java.util.Collection, long, java.util.concurrent.TimeUnit)
+     */
+    <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, PolicyTaskCallback[] callbacks, long timeout, TimeUnit unit) throws InterruptedException;
 
     /**
      * Specifies the maximum number of tasks from this policy executor that can be running

--- a/dev/com.ibm.ws.threading_policy_fat/build.gradle
+++ b/dev/com.ibm.ws.threading_policy_fat/build.gradle
@@ -18,7 +18,19 @@ task copyFeatureBundle {
     }
   }
 }
-      
+
+task copyInternalThreadingBundle {
+  dependsOn copyFeatureBundles
+  doLast {
+    copy {
+      from rootProject.project('com.ibm.ws.threading').buildDir
+      include 'com.ibm.ws.threading.jar'
+      into "${buildDir}/autoFVT/lib"
+    }
+  }
+}
+
 autoFVT {
+  dependsOn copyInternalThreadingBundle
   dependsOn copyFeatureBundle
 }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/SelfGetterTask.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/SelfGetterTask.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.ibm.ws.threading.PolicyTaskCallback;
+
+/**
+ * Task which obtains its own Future from a callback and later invokes get() on that Future when it runs.
+ * This is clearly an error path, as a task cannot successfully await its own completion.
+ * The executor should detect this and immediately interrupt the get() operation to prevent hangs.
+ */
+public class SelfGetterTask extends PolicyTaskCallback implements Callable<Object> {
+    private Future<?> future;
+    private final long timeout;
+    private final TimeUnit unit;
+
+    public SelfGetterTask() {
+        this.timeout = -1;
+        this.unit = null;
+    }
+
+    public SelfGetterTask(long timeout, TimeUnit unit) {
+        this.timeout = timeout;
+        this.unit = unit;
+    }
+
+    @Override
+    public Object call() throws ExecutionException, InterruptedException, TimeoutException {
+        System.out.println("> call " + toString());
+        try {
+            Object result;
+            if (timeout == -1 || unit == null)
+                result = future.get();
+            else
+                result = future.get(timeout, unit);
+            System.out.println("< call " + toString() + " " + result);
+            return result;
+        } catch (ExecutionException x) {
+            System.out.println("< call " + toString() + " " + x);
+            throw x;
+        } catch (InterruptedException x) {
+            System.out.println("< call " + toString() + " " + x);
+            return x; // expected, so we return as a result rather than an exception
+        } catch (RuntimeException x) {
+            System.out.println("< call " + toString() + " " + x);
+            throw x;
+        }
+    }
+
+    @Override
+    public void onSubmit(Object task, Future<?> future) {
+        this.future = future;
+    }
+}


### PR DESCRIPTION
An initial set of changes to allow us to experiment with having managed executor's invokeAll use a policy executor.