### PR TITLE
The com.ibm.ws.jpa_22_fat bucket must require Java 8 or higher.

### DIFF
--- a/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
@@ -20,7 +20,7 @@ test.project: true
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
-# runtime.minimum.java.level: 1.8
+runtime.minimum.java.level: 1.8
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. org.apache.derby:derbynet)

--- a/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
@@ -11,6 +11,9 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+javac.target: 1.8
+javac.source: 1.8
+
 src: \
 	fat/src,\
 	test-applications/jpa21bootstrap/src,\


### PR DESCRIPTION
Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>