### PR TITLE
policy executor tasks that abort before enqueue

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
@@ -70,16 +70,16 @@ public abstract class PolicyTaskCallback {
     public void onSubmit(Object task, Future<?> future, int invokeAnyCount) {}
 
     /**
-     * Invoked to raise an ExecutionException for an aborted task.
-     * For example, a task is aborted when the onStart callback raises a runtime exception.
+     * Invoked to raise an exception for an aborted task.
+     * For example, a task is aborted when the onStart callback raises a runtime exception
+     * or when the executor is interrupted while waiting to enqueue a task.
      * This method gives the callback the opportunity to use a different exception,
      * such as javax.enteprise.concurrent.AbortedException to distinguish aborted tasks
-     * from tasks that failed during normal execution.
+     * from tasks that failed during normal execution or were rejected for other reasons.
+     * The default implementation of this method does nothing, in which case the policy executor raises RejectedExecutionException.
      *
      * @param x the exception
      * @throws ExecutionException
      */
-    public void raiseAbortedException(Throwable x) throws ExecutionException {
-        throw new ExecutionException(x);
-    }
+    public void raiseAbortedException(Throwable x) throws ExecutionException {}
 }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ParameterInfoCallback.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ParameterInfoCallback.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import com.ibm.ws.threading.PolicyTaskCallback;
+
+/**
+ * Callback that records information about the parameters that are supplied to it.
+ */
+public class ParameterInfoCallback extends PolicyTaskCallback {
+    public static final int SUBMIT = 0, START = 1, CANCEL = 2, END = 3;
+    public final Future<?>[] future = new Future<?>[END + 1];
+    public final Boolean[] isCanceled = new Boolean[END + 1];
+    public final Boolean[] isDone = new Boolean[END + 1];
+    public final Object[] result = new Object[END + 1];
+    public Object startContext;
+    public final Object[] task = new Object[END + 1];
+
+    @Override
+    public void onCancel(Object task, Future<?> future, boolean timedOut, boolean whileRunning) {
+        System.out.println("onCancel " + future);
+        this.future[CANCEL] = future;
+        this.isCanceled[CANCEL] = future.isCancelled();
+        this.isDone[CANCEL] = future.isDone();
+        this.task[CANCEL] = task;
+        try {
+            this.result[CANCEL] = future.get(1, TimeUnit.NANOSECONDS);
+        } catch (Throwable x) {
+            this.result[CANCEL] = x;
+        }
+    }
+
+    @Override
+    public void onEnd(Object task, Future<?> future, Object startObj, boolean aborted, int pending, Throwable failure) {
+        System.out.println("onEnd " + future);
+        this.future[END] = future;
+        this.isCanceled[END] = future.isCancelled();
+        this.isDone[END] = future.isDone();
+        this.task[END] = task;
+        try {
+            this.result[END] = future.get(1, TimeUnit.NANOSECONDS);
+        } catch (Throwable x) {
+            this.result[END] = x;
+        }
+    }
+
+    @Override
+    public Object onStart(Object task, Future<?> future) {
+        System.out.println("onStart " + future);
+        this.future[START] = future;
+        this.isCanceled[START] = future.isCancelled();
+        this.isDone[START] = future.isDone();
+        this.task[START] = task;
+        return this;
+    }
+
+    @Override
+    public void onSubmit(Object task, Future<?> future, int invokeAnyCount) {
+        System.out.println("onSubmit " + future);
+        this.future[SUBMIT] = future;
+        this.isCanceled[SUBMIT] = future.isCancelled();
+        this.isDone[SUBMIT] = future.isDone();
+        this.task[SUBMIT] = task;
+    }
+}

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -452,8 +452,8 @@ public class PolicyExecutorServlet extends FATServlet {
         assertTrue(blockerRunning.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 
         // Use up the queue position
-        Callable<Integer> task2 = new SharedIncrementTask();
-        Future<Integer> queuedFuture = executor.submit(task2);
+        Runnable task2 = new SharedIncrementTask();
+        Future<?> queuedFuture = executor.submit(task2);
 
         // abort due to queue at capacity
         Runnable task3 = new SharedIncrementTask();
@@ -530,7 +530,8 @@ public class PolicyExecutorServlet extends FATServlet {
 
         List<Runnable> canceledFromQueue = executor.shutdownNow();
         assertEquals(1, canceledFromQueue.size());
-        assertEquals(queuedFuture, canceledFromQueue.get(0));
+        assertEquals(task2, canceledFromQueue.get(0));
+        assertTrue(queuedFuture.isCancelled());
         assertTrue(blockerFuture.isCancelled());
     }
 

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -432,6 +432,108 @@ public class PolicyExecutorServlet extends FATServlet {
         assertTrue(executor.isTerminated());
     }
 
+    // Verify that the onEnd(aborted) callback is sent for tasks that abort after they are submitted
+    // but before they start to run. This test covers a task that is aborted to due to exceeding the
+    // maximum queue size and a task that is aborted due to being interrupted while waiting for a
+    // queue position.
+    @Test
+    public void testCallbacksForAbortedTasks() throws Exception {
+        PolicyExecutor executor = provider.create("testCallbacksForAbortedTasks")
+                        .maxConcurrency(1)
+                        .maxQueueSize(1)
+                        .queueFullAction(QueueFullAction.Abort);
+
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch blockerRunning = new CountDownLatch(1);
+
+        // Use up maxConcurrency
+        CountDownTask task1 = new CountDownTask(blockerRunning, blocker, TimeUnit.MINUTES.toNanos(20));
+        Future<Boolean> blockerFuture = executor.submit(task1);
+        assertTrue(blockerRunning.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // Use up the queue position
+        Callable<Integer> task2 = new SharedIncrementTask();
+        Future<Integer> queuedFuture = executor.submit(task2);
+
+        // abort due to queue at capacity
+        Runnable task3 = new SharedIncrementTask();
+        ParameterInfoCallback callback = new ParameterInfoCallback();
+        try {
+            fail("Submit should fail with queue at capacity. Instead: " + executor.submit(task3, "Result that should never be returned", callback));
+        } catch (RejectedExecutionException x) {
+            if (!x.getMessage().startsWith("CWWKE1201E"))
+                throw x;
+        }
+
+        // task successfully submits
+        assertFalse(callback.isCanceled[ParameterInfoCallback.SUBMIT]);
+        assertFalse(callback.isDone[ParameterInfoCallback.SUBMIT]);
+        assertEquals(task3, callback.task[ParameterInfoCallback.SUBMIT]);
+
+        // task does not start
+        assertNull(callback.future[ParameterInfoCallback.START]);
+        assertNull(callback.task[ParameterInfoCallback.START]);
+
+        // task is not canceled
+        assertNull(callback.future[ParameterInfoCallback.CANCEL]);
+        assertNull(callback.task[ParameterInfoCallback.CANCEL]);
+
+        // task is aborted
+        assertEquals(task3, callback.task[ParameterInfoCallback.END]);
+        assertEquals(callback.future[ParameterInfoCallback.SUBMIT], callback.future[ParameterInfoCallback.END]);
+        assertFalse(callback.isCanceled[ParameterInfoCallback.END]);
+        assertTrue(callback.isDone[ParameterInfoCallback.END]);
+        assertNull(callback.startContext);
+        Object result = callback.result[ParameterInfoCallback.END];
+        if (!(result instanceof RejectedExecutionException))
+            if (result instanceof Throwable)
+                throw new Exception("Unexpected failure. See cause.", (Throwable) result);
+            else
+                fail("result: " + result);
+
+        // interrupt wait for enqueue
+        Callable<Integer> task4 = new SharedIncrementTask();
+        executor.maxWaitForEnqueue(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS));
+        Thread.currentThread().interrupt();
+        try {
+            executor.submit(task4, callback = new ParameterInfoCallback());
+        } catch (RejectedExecutionException x) {
+            if (!(x.getCause() instanceof InterruptedException))
+                throw x;
+        }
+
+        // task successfully submits
+        assertFalse(callback.isCanceled[ParameterInfoCallback.SUBMIT]);
+        assertFalse(callback.isDone[ParameterInfoCallback.SUBMIT]);
+        assertEquals(task4, callback.task[ParameterInfoCallback.SUBMIT]);
+
+        // task does not start
+        assertNull(callback.future[ParameterInfoCallback.START]);
+        assertNull(callback.task[ParameterInfoCallback.START]);
+
+        // task is not canceled
+        assertNull(callback.future[ParameterInfoCallback.CANCEL]);
+        assertNull(callback.task[ParameterInfoCallback.CANCEL]);
+
+        // task is aborted
+        assertEquals(task4, callback.task[ParameterInfoCallback.END]);
+        assertEquals(callback.future[ParameterInfoCallback.SUBMIT], callback.future[ParameterInfoCallback.END]);
+        assertFalse(callback.isCanceled[ParameterInfoCallback.END]);
+        assertTrue(callback.isDone[ParameterInfoCallback.END]);
+        assertNull(callback.startContext);
+        result = callback.result[ParameterInfoCallback.END];
+        if (!(result instanceof RejectedExecutionException) || !(((RejectedExecutionException) result).getCause() instanceof InterruptedException))
+            if (result instanceof Throwable)
+                throw new Exception("Unexpected failure. See cause.", (Throwable) result);
+            else
+                fail("result: " + result);
+
+        List<Runnable> canceledFromQueue = executor.shutdownNow();
+        assertEquals(1, canceledFromQueue.size());
+        assertEquals(queuedFuture, canceledFromQueue.get(0));
+        assertTrue(blockerFuture.isCancelled());
+    }
+
     // Verify that it is not possible to cancel tasks that are done.
     @Test
     public void testCancelAfterDone() throws Exception {


### PR DESCRIPTION
Implement code path and add tests for abort that occurs before a task is enqueued.  Need to complete the Future implementation for this path because it is possible for the Future to be used from the callback.