### PR TITLE
399: Upgrade Jackson in JAXRS2.0 to 1.9.13

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -60,6 +60,10 @@ com.ibm.ws.org.codehaus.jackson:jackson-core-asl:1.6.2
 com.ibm.ws.org.codehaus.jackson:jackson-jaxrs:1.6.2
 com.ibm.ws.org.codehaus.jackson:jackson-mapper-asl:1.6.2
 com.ibm.ws.org.codehaus.jackson:jackson-xc:1.6.2
+com.ibm.ws.org.codehaus.jackson:jackson-core-asl:1.9.13
+com.ibm.ws.org.codehaus.jackson:jackson-jaxrs:1.9.13
+com.ibm.ws.org.codehaus.jackson:jackson-mapper-asl:1.9.13
+com.ibm.ws.org.codehaus.jackson:jackson-xc:1.9.13
 com.ibm.ws.org.objenesis:objenesis:1.0
 com.ibm.ws.commons-collections:commons-collections:3.2.1
 com.ibm.ws.commons-fileupload:commons-fileupload:1.2.1

--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -135,10 +135,10 @@ Private-Package:\
    com.ibm.ws.jaxrs20.*, \
 
 Include-Resource: \
-  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-xc;1.6.2}, \
-  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-mapper-asl;1.6.2}, \
-  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-jaxrs;1.6.2}, \
-  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-core-asl;1.6.2}, \
+  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-xc;1.9.13}, \
+  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-mapper-asl;1.9.13}, \
+  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-jaxrs;1.9.13}, \
+  @${repo;com.ibm.ws.org.codehaus.jackson:jackson-core-asl;1.9.13}, \
   @${repo;org.apache.cxf.cxf-rt-rs-service-description;3.1.11;EXACT}, \
   @${repo;org.apache.cxf.cxf-tools-wadlto-jaxrs;3.1.11;EXACT}, \
   @${repo;org.apache.cxf.cxf-tools-common;3.1.11;EXACT}, \


### PR DESCRIPTION
Issue #399 identified that the version of Jackson we ship with the `jaxrs-2.0` feature does not support the Java 8 LocalDate type.  More recent versions of Jackson code does.  This PR is intended to upgrade to the latest Jackson 1.X version (1.9.13).  