### PR TITLE
Validate JSF API and Impl versions in jsfContainer

### DIFF
--- a/dev/com.ibm.ws.jsfContainer.2.2/src/com/ibm/ws/jsf/container/JSFContainer.java
+++ b/dev/com.ibm.ws.jsfContainer.2.2/src/com/ibm/ws/jsf/container/JSFContainer.java
@@ -10,17 +10,22 @@
  *******************************************************************************/
 package com.ibm.ws.jsf.container;
 
-import javax.faces.application.Application;
+import java.util.logging.Logger;
 
 public class JSFContainer {
 
+    private static final Logger log = Logger.getLogger("com.ibm.ws.jsf.container");
+
+    public static final String MOJARRA_APP_FACTORY = "com.sun.faces.application.ApplicationFactoryImpl";
+    public static final String MYFACES_APP_FACTORY = "org.apache.myfaces.application.ApplicationFactoryImpl";
+
+    public static enum JSF_PROVIDER {
+        MOJARRA,
+        MYFACES
+    }
+
     public static boolean isBeanValidationEnabled() {
-        try {
-            Class.forName("com.ibm.ws.beanvalidation.accessor.BeanValidationAccessor");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
+        return tryLoad("com.ibm.ws.beanvalidation.accessor.BeanValidationAccessor") != null;
     }
 
     public static void initializeBeanValidation() {
@@ -34,24 +39,30 @@ public class JSFContainer {
         }
     }
 
-    public static boolean isCDIEnabled() {
+    public static Class<?> tryLoad(String className) {
         try {
-            Class.forName("javax.enterprise.inject.spi.BeanManager");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
+            return Class.forName(className, false, JSFContainer.class.getClassLoader());
+        } catch (ClassNotFoundException notFound) {
+            return null;
         }
     }
 
-    public static void initializeCDI(Application application) {
-        try {
-            // Cannot directly reference class because it would trigger a classload of classes
-            // that may not be available if the cdi-1.X feature is not enabled
-            Class<?> CDIJSFInitializer = Class.forName("com.ibm.ws.jsf.container.cdi.CDIJSFInitializer");
-            CDIJSFInitializer.getMethod("initialize", Application.class).invoke(null, application);
-        } catch (ReflectiveOperationException e) {
-            e.printStackTrace();
+    public static JSF_PROVIDER getJSFProvider() throws ClassNotFoundException {
+        // First check manifest for the 'Implementation-Title' header
+        String implTitle = javax.faces.application.ApplicationFactory.class.getPackage().getImplementationTitle();
+        if (implTitle != null) {
+            if (implTitle.toUpperCase().contains("MOJARRA"))
+                return JSF_PROVIDER.MOJARRA;
+            if (implTitle.toUpperCase().contains("MYFACES"))
+                return JSF_PROVIDER.MYFACES;
         }
-    }
 
+        // Fall back to classloading checks
+        if (tryLoad(MOJARRA_APP_FACTORY) != null)
+            return JSF_PROVIDER.MOJARRA;
+        if (tryLoad(MYFACES_APP_FACTORY) != null)
+            return JSF_PROVIDER.MYFACES;
+
+        throw new ClassNotFoundException();
+    }
 }

--- a/dev/com.ibm.ws.jsfContainer.2.2/src/com/ibm/ws/jsf/container/application/JSFContainerApplicationFactory.java
+++ b/dev/com.ibm.ws.jsfContainer.2.2/src/com/ibm/ws/jsf/container/application/JSFContainerApplicationFactory.java
@@ -10,54 +10,69 @@
  *******************************************************************************/
 package com.ibm.ws.jsf.container.application;
 
+import static com.ibm.ws.jsf.container.JSFContainer.MOJARRA_APP_FACTORY;
+import static com.ibm.ws.jsf.container.JSFContainer.MYFACES_APP_FACTORY;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.faces.application.Application;
 import javax.faces.application.ApplicationFactory;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 import com.ibm.ws.jsf.container.JSFContainer;
+import com.ibm.ws.jsf.container.JSFContainer.JSF_PROVIDER;
+import com.ibm.ws.jsf.container.cdi.CDIJSFInitializer;
 
 public class JSFContainerApplicationFactory extends ApplicationFactory {
 
+    private static final String clazz = JSFContainerApplicationFactory.class.getCanonicalName();
     private static final Logger log = Logger.getLogger("com.ibm.ws.jsf.container.application");
-    static final String MOJARRA_APP_FACTORY = "com.sun.faces.application.ApplicationFactoryImpl";
-    static final String MYFACES_APP_FACTORY = "org.apache.myfaces.application.ApplicationFactoryImpl";
 
-    private static volatile boolean initialized = false;
-
-    private ApplicationFactory delegate;
+    private final ApplicationFactory delegate;
+    private final JSF_PROVIDER providerType;
+    private volatile boolean initialized = false;
+    private volatile String appName = null;
 
     public JSFContainerApplicationFactory() {
-        // TODO: Find a more elegant way to detect which provider is available.
-        // Perhaps checking manifest at the time integration jar is applied to app classpath
         try {
-            delegate = (ApplicationFactory) Class.forName(MOJARRA_APP_FACTORY).newInstance();
-            return;
-        } catch (ReflectiveOperationException ignore) {
+            providerType = JSFContainer.getJSFProvider();
+            // TODO check for user-defined app factory
+            delegate = (providerType == JSF_PROVIDER.MOJARRA) ? //
+                            (ApplicationFactory) Class.forName(MOJARRA_APP_FACTORY).newInstance() : //
+                            (ApplicationFactory) Class.forName(MYFACES_APP_FACTORY).newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw noJsfProviderFound();
         }
-        try {
-            delegate = (ApplicationFactory) Class.forName(MYFACES_APP_FACTORY).newInstance();
-        } catch (ReflectiveOperationException ignore) {
-        }
-        if (delegate == null)
-            throw new IllegalStateException("No JSF implementations found.  One of the following ApplicationFactory implementations must be available: "
-                                            + MOJARRA_APP_FACTORY + " or " + MYFACES_APP_FACTORY);
     }
 
     @Override
     public Application getApplication() {
         Application a = delegate.getApplication();
+        // Perform lazy initialization of CDI and Bval integration because this is
+        // the earliest point where we have a valid reference to an Application object
         if (!initialized) {
-            synchronized (JSFContainerApplicationFactory.class) {
+            synchronized (this) {
                 if (!initialized) {
+                    try {
+                        appName = InitialContext.doLookup("java:app/AppName");
+                    } catch (NamingException e) {
+                        throw new RuntimeException("[TODO_NLS] Unable to obtain application name from JSF application " + a, e);
+                    }
+
                     if (log.isLoggable(Level.FINEST))
                         log.logp(Level.FINEST, JSFContainerApplicationFactory.class.getName(), "getApplication",
-                                 "Performing first time initialization checks on: " + a);
-                    if (JSFContainer.isCDIEnabled())
-                        JSFContainer.initializeCDI(a);
+                                 "Performing first time initialization checks on: " + appName);
+
+                    serviceabilityChecks();
+
+                    // CDI will always be enabled with the jsfContainer feature
+                    CDIJSFInitializer.initialize(a, appName);
+
                     if (JSFContainer.isBeanValidationEnabled())
                         JSFContainer.initializeBeanValidation();
+
                     initialized = true;
                 }
             }
@@ -73,5 +88,48 @@ public class JSFContainerApplicationFactory extends ApplicationFactory {
     @Override
     public ApplicationFactory getWrapped() {
         return delegate.getWrapped();
+    }
+
+    private void serviceabilityChecks() {
+        final String m = "serviceabilityChecks";
+        // Log which JSF provider is being used
+        if (log.isLoggable(Level.INFO))
+            log.logp(Level.INFO, clazz, m, "[TODO_NLS] Initializing Liberty JSF integrations for " + providerType + " on application " + appName);
+
+        if (!log.isLoggable(Level.WARNING))
+            return;
+
+        // Check version of JSF spec
+        String apiVersion = javax.faces.application.ApplicationFactory.class.getPackage().getSpecificationVersion();
+        if (apiVersion != null && !isVersionValid(apiVersion))
+            log.logp(Level.WARNING, clazz, m,
+                     "[TODO_NLS] The JSF specification API version available to application " + appName + " should be within [2.2,2.3) but was " + apiVersion);
+
+        // Check version of JSF impl
+        Class<?> appFactoryClass = delegate.getClass();
+        while (appFactoryClass != Object.class
+               && !appFactoryClass.getCanonicalName().equals(MYFACES_APP_FACTORY)
+               && !appFactoryClass.getCanonicalName().equals(MOJARRA_APP_FACTORY))
+            appFactoryClass = appFactoryClass.getSuperclass();
+        String appFactoryClassName = appFactoryClass.getCanonicalName();
+        if (appFactoryClassName.equals(MYFACES_APP_FACTORY) || appFactoryClassName.equals(MOJARRA_APP_FACTORY)) {
+            String implVersion = appFactoryClass.getPackage().getSpecificationVersion();
+            if (implVersion != null && !isVersionValid(implVersion))
+                log.logp(Level.WARNING, clazz, m,
+                         "[TODO_NLS] The JSF implementation version available to application " + appName + " should be within [2.2,2.3) but was " + implVersion);
+        }
+    }
+
+    private static boolean isVersionValid(String version) {
+        // A simple way of checking that version is within [2.2,2.3)
+        return version.equals("2.2") || version.startsWith("2.2.");
+    }
+
+    private IllegalStateException noJsfProviderFound() {
+        String message = "No JSF implementations found.  One of the following javax.faces.application.ApplicationFactory implementations must be available: "
+                         + MOJARRA_APP_FACTORY + " or " + MYFACES_APP_FACTORY;
+        if (log.isLoggable(Level.SEVERE))
+            log.severe(message);
+        return new IllegalStateException(message);
     }
 }

--- a/dev/com.ibm.ws.jsfContainer.2.2/src/com/ibm/ws/jsf/container/cdi/CDIJSFInitializer.java
+++ b/dev/com.ibm.ws.jsfContainer.2.2/src/com/ibm/ws/jsf/container/cdi/CDIJSFInitializer.java
@@ -25,9 +25,8 @@ public class CDIJSFInitializer {
 
     private static final Logger log = Logger.getLogger("com.ibm.ws.jsf.container.cdi");
 
-    public static void initialize(Application application) {
+    public static void initialize(Application application, String appname) {
         try {
-            String appname = InitialContext.doLookup("java:app/AppName");
             BeanManager beanManager = InitialContext.doLookup("java:comp/BeanManager");
             if (beanManager != null) {
                 if (log.isLoggable(Level.FINEST))

--- a/dev/com.ibm.ws.jsfContainer.2.2/test/com/ibm/ws/jsf/container/application/JSFContainerApplicationFactoryTest.java
+++ b/dev/com.ibm.ws.jsfContainer.2.2/test/com/ibm/ws/jsf/container/application/JSFContainerApplicationFactoryTest.java
@@ -12,20 +12,22 @@ package com.ibm.ws.jsf.container.application;
 
 import org.junit.Test;
 
+import com.ibm.ws.jsf.container.JSFContainer;
+
 public class JSFContainerApplicationFactoryTest {
 
     @Test
     public void verifyMojarraAppFactory() throws ClassNotFoundException {
         // Verify the name of the Mojarra ApplicationFactoryImpl is unchanged,
         // since we can't have a proper compile-time dependency on the class
-        Class.forName(JSFContainerApplicationFactory.MOJARRA_APP_FACTORY);
+        Class.forName(JSFContainer.MOJARRA_APP_FACTORY);
     }
 
     @Test
     public void verifyMyFacesAppFactory() throws ClassNotFoundException {
         // Verify the name of the MyFaces ApplicationFactoryImpl is unchanged,
         // since we can't have a proper compile-time dependency on the class
-        Class.forName(JSFContainerApplicationFactory.MYFACES_APP_FACTORY);
+        Class.forName(JSFContainer.MYFACES_APP_FACTORY);
     }
 
 }

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/servers/jsf.container.2.2_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/servers/jsf.container.2.2_fat/bootstrap.properties
@@ -9,3 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all


### PR DESCRIPTION
The jsfContainer-2.2 feature should only work with JSF 2.2 API and implementations.  If a user provides any other version of JSF API and/or implementation, a warning message should be printed in logs indicating what versions should be used instead.