### PR TITLE
replace queueFullAction with runIfQueueFull and maxConcurrencyAppliesToCallerThread

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -59,7 +59,6 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.ws.threading.PolicyExecutor;
-import com.ibm.ws.threading.PolicyExecutor.QueueFullAction;
 import com.ibm.ws.threading.PolicyExecutorProvider;
 import com.ibm.ws.threading.PolicyTaskCallback;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
@@ -244,14 +243,18 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
             String maxConcurrency = (String) properties.get("maxConcurrency");
             if (maxConcurrency != null)
                 policyExecutor.maxConcurrency(Integer.parseInt(maxConcurrency));
+            String maxConcurrencyAppliesToCallerThread = (String) properties.get("maxConcurrencyAppliesToCallerThread");
+            if (maxConcurrencyAppliesToCallerThread != null)
+                policyExecutor.maxConcurrencyAppliesToCallerThread(Boolean.parseBoolean(maxConcurrencyAppliesToCallerThread));
             String maxQueueSize = (String) properties.get("maxQueueSize");
             if (maxQueueSize != null)
                 policyExecutor.maxQueueSize(Integer.parseInt(maxQueueSize));
             String maxWaitForEnqueue = (String) properties.get("maxWaitForEnqueue");
             if (maxWaitForEnqueue != null)
                 policyExecutor.maxWaitForEnqueue(Long.parseLong(maxWaitForEnqueue));
-            String queueFullAction = (String) properties.get("queueFullAction");
-            policyExecutor.queueFullAction("CallerRuns".equals(queueFullAction) ? QueueFullAction.CallerRuns : QueueFullAction.Abort);
+            String runIfQueueFull = (String) properties.get("runIfQueueFull");
+            if (runIfQueueFull != null)
+                policyExecutor.runIfQueueFull(Boolean.parseBoolean(runIfQueueFull));
         }
 
         if (trace && tc.isEntryEnabled())

--- a/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
@@ -22,18 +22,16 @@
   <variable name="onError" value="FAIL"/>
 
   <!-- TODO remove the internal attribute once managed executors are switched over to using policy executor -->
-  <!-- TODO queueFullAction needs to be removed once runIfQueueFull/maxConcurrencyAppliesToCallerThread are implemented. Until then,
-       queueFullAction only partially approximates the behavior for some scenarios -->
 
   <managedExecutorService id="DefaultManagedExecutorService" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   maxConcurrency="1" maxQueueSize="1" maxWaitForEnqueue="120000" queueFullAction="CallerRuns"/>
+   maxConcurrency="1" maxQueueSize="1" maxWaitForEnqueue="120000"/>
 
   <managedScheduledExecutorService id="DefaultManagedScheduledExecutorService" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   maxConcurrency="2" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" queueFullAction="CallerRuns" runIfQueueFull="true"/>
+   maxConcurrency="2" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" runIfQueueFull="true"/>
 
   <managedExecutorService id="executor1" jndiName="concurrent/executor1" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   maxConcurrency="1" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" maxWaitForEnqueue="0" queueFullAction="Abort"/>
+   maxConcurrency="1" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" maxWaitForEnqueue="0" runIfQueueFull="false"/>
 
   <managedScheduledExecutorService jndiName="concurrent/scheduledExecutor2" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   coreConcurrency="1" maxConcurency="2" maxConcurrencyAppliesToCallerThread="false" maxQueueSize="2" queueFullAction="CallerRuns" runIfQueueFull="false"/>
+   coreConcurrency="1" maxConcurency="2" maxConcurrencyAppliesToCallerThread="false" maxQueueSize="2" runIfQueueFull="false"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
@@ -43,7 +43,6 @@ import com.ibm.ws.microprofile.faulttolerance.spi.RetryPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.TimeoutPolicy;
 import com.ibm.ws.microprofile.faulttolerance.utils.FTDebug;
 import com.ibm.ws.threading.PolicyExecutor;
-import com.ibm.ws.threading.PolicyExecutor.QueueFullAction;
 import com.ibm.ws.threading.PolicyExecutorProvider;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
@@ -101,7 +100,6 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
 
             //TODO make the ID more human readable
             PolicyExecutor policyExecutor = policyExecutorProvider.create("FaultTolerance_" + UUID.randomUUID().toString());
-            policyExecutor.queueFullAction(QueueFullAction.Abort);
 
             //if there is supposed to be a bulkhead then restrict the size of the policy executor
             if (this.bulkheadPolicy != null) {

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -64,6 +64,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
     private int maxConcurrency;
 
+    private volatile boolean maxConcurrencyAppliesToCallerThread;
+
     private final ReduceableSemaphore maxConcurrencyConstraint = new ReduceableSemaphore(0, false);
 
     private int maxQueueSize;
@@ -81,7 +83,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
     final ConcurrentLinkedQueue<PolicyTaskFutureImpl<?>> queue = new ConcurrentLinkedQueue<PolicyTaskFutureImpl<?>>();
 
-    private final AtomicReference<QueueFullAction> queueFullAction = new AtomicReference<QueueFullAction>();
+    private volatile boolean runIfQueueFull;
 
     /**
      * Tasks that are running on policy executor threads.
@@ -368,8 +370,9 @@ public class PolicyExecutorImpl implements PolicyExecutor {
      *
      * @param policyTaskFuture submitted task and its Future.
      * @param wait amount of time to wait for a queue position.
-     * @param callerRunsOverride indicates if a task should always or may never run on the current thread
-     *            if no queue positions are available. A value of null means the queueFullAction will determine.
+     * @param runIfQueueFullOverride indicates if a task should always or may never run on the current thread
+     *            if no queue positions are available. A value of null means the runIfQueueFull configuration will determine.
+     *            A value of true must only be specified if the caller already has a permit or doesn't need one.
      * @return true if the task was enqueued for later execution by the global thread pool.
      *         If the task instead ran on the current thread, then returns false.
      * @throws RejectedExecutionException if the task is rejected rather than being queued.
@@ -377,7 +380,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
      *             the InterruptedException is chained to the RejectedExecutionException.
      */
     @FFDCIgnore(value = { InterruptedException.class, RejectedExecutionException.class }) // these are raised directly to invoker, who decides how to handle
-    private boolean enqueue(PolicyTaskFutureImpl<?> policyTaskFuture, long wait, Boolean callerRunsOverride) {
+    private boolean enqueue(PolicyTaskFutureImpl<?> policyTaskFuture, long wait, Boolean runIfQueueFullOverride) {
         boolean enqueued;
         try {
             if (wait <= 0 ? maxQueueSizeConstraint.tryAcquire() : maxQueueSizeConstraint.tryAcquire(wait, TimeUnit.NANOSECONDS)) {
@@ -399,17 +402,15 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                 if (state.get() != State.ACTIVE && queue.remove(policyTaskFuture))
                     throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1202.submit.after.shutdown", identifier));
             } else if (state.get() == State.ACTIVE) {
-                QueueFullAction action = Boolean.TRUE.equals(callerRunsOverride) ? QueueFullAction.CallerRuns : queueFullAction.get();
-                if (Boolean.FALSE.equals(callerRunsOverride) && (action == QueueFullAction.CallerRuns || action == QueueFullAction.CallerRunsIfSameExecutor))
-                    action = QueueFullAction.Abort;
-                if (action == QueueFullAction.Abort)
-                    throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1201.queue.full.abort", identifier, maxQueueSize, wait));
-                else if (action == QueueFullAction.CallerRuns) {
+                boolean havePermit = false;
+                // TODO implement the path where we acquire a permit in order to run on submit/execute thread (and don't forget to release it)
+                if (Boolean.TRUE.equals(runIfQueueFullOverride) || //
+                    !Boolean.FALSE.equals(runIfQueueFullOverride) && runIfQueueFull && (havePermit /* = maxConcurrencyConstraint.tryAcquire() TODO enable */)) {
                     policyTaskFuture.accept();
                     runTask(policyTaskFuture);
                     enqueued = false;
                 } else
-                    throw new UnsupportedOperationException("queueFullAction=" + action); // TODO DiscardOldest, CallerRunsIfSameExecutor, and null (which defaults based on maxConcurrency)
+                    throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1201.queue.full.abort", identifier, maxQueueSize, wait));
             } else
                 throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1202.submit.after.shutdown", identifier));
         } catch (InterruptedException x) {
@@ -507,7 +508,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     }
 
     // Submit and run tasks and return list of completed (possibly canceled) tasks.
-    // Because this method is not timed, tasks can run on the current thread if queueFullAction is CallerRuns or a permit is available.
+    // Because this method is not timed, tasks can run on the current thread if maxConcurrencyAppliesToCallerThread is false or a permit is available.
     @FFDCIgnore(value = { RejectedExecutionException.class })
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, PolicyTaskCallback[] callbacks) throws InterruptedException {
@@ -515,8 +516,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
         // Determine if we need a permit to run one or more of the tasks on the current thread, and if so, acquire it,
         int taskCount = tasks.size();
-        boolean useCurrentThread = queueFullAction.get() == QueueFullAction.CallerRuns;
-        boolean havePermit = !useCurrentThread && (useCurrentThread = taskCount > 0 && maxConcurrencyConstraint.tryAcquire());
+        boolean havePermit = false;
+        boolean useCurrentThread = !maxConcurrencyAppliesToCallerThread || (havePermit = taskCount > 0 && maxConcurrencyConstraint.tryAcquire());
 
         List<PolicyTaskFutureImpl<T>> futures = new ArrayList<PolicyTaskFutureImpl<T>>(taskCount);
         try {
@@ -683,9 +684,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
         // Special case to run a single task on the current thread if we can acquire a permit, if a permit is required
         if (taskCount == 1) {
-            boolean useCurrentThread = queueFullAction.get() == QueueFullAction.CallerRuns;
-            boolean havePermit = !useCurrentThread && (useCurrentThread = taskCount > 0 && maxConcurrencyConstraint.tryAcquire());
-            if (useCurrentThread)
+            boolean havePermit = false;
+            if (!maxConcurrencyAppliesToCallerThread || (havePermit = maxConcurrencyConstraint.tryAcquire())) // use current thread
                 try {
                     if (state.get() != State.ACTIVE)
                         throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1202.submit.after.shutdown", identifier));
@@ -881,6 +881,19 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     }
 
     @Override
+    public PolicyExecutor maxConcurrencyAppliesToCallerThread(boolean applyToCallerThread) {
+        if (providerCreated == null)
+            throw new UnsupportedOperationException();
+
+        if (state.get() != State.ACTIVE)
+            throw new IllegalStateException(Tr.formatMessage(tc, "CWWKE1203.config.update.after.shutdown", "maxConcurrencyAppliesToCallerThread", identifier));
+
+        maxConcurrencyAppliesToCallerThread = applyToCallerThread;
+
+        return this;
+    }
+
+    @Override
     public PolicyExecutor maxQueueSize(int max) {
         if (providerCreated == null)
             throw new UnsupportedOperationException();
@@ -921,14 +934,14 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     }
 
     @Override
-    public PolicyExecutor queueFullAction(QueueFullAction action) {
+    public PolicyExecutor runIfQueueFull(boolean runIfFull) {
         if (providerCreated == null)
             throw new UnsupportedOperationException();
 
         if (state.get() != State.ACTIVE)
-            throw new IllegalStateException(Tr.formatMessage(tc, "CWWKE1203.config.update.after.shutdown", "queueFullAction", identifier));
+            throw new IllegalStateException(Tr.formatMessage(tc, "CWWKE1203.config.update.after.shutdown", "runIfQueueFull", identifier));
 
-        queueFullAction.set(action);
+        runIfQueueFull = runIfFull;
 
         return this;
     }
@@ -1081,10 +1094,10 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         final String DOUBLEINDENT = INDENT + INDENT;
         out.println(identifier);
         out.println(INDENT + "coreConcurrency = " + coreConcurrency);
-        out.println(INDENT + "maxConcurrency = " + maxConcurrency);
+        out.println(INDENT + "maxConcurrency = " + maxConcurrency + (maxConcurrencyAppliesToCallerThread ? " + caller threads" : ""));
         out.println(INDENT + "maxQueueSize = " + maxQueueSize);
         out.println(INDENT + "maxWaitForEnqueue = " + TimeUnit.NANOSECONDS.toMillis(maxWaitForEnqueueNS.get()) + " ms");
-        out.println(INDENT + "queueFullAction = " + queueFullAction.toString());
+        out.println(INDENT + "runIfQueueFull = " + runIfQueueFull);
         int numRunningThreads, numRunningPrioritizedThreads;
         synchronized (configLock) {
             numRunningThreads = maxConcurrency - maxConcurrencyConstraint.availablePermits();

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -55,7 +55,6 @@ import javax.servlet.annotation.WebServlet;
 import org.junit.Test;
 
 import com.ibm.ws.threading.PolicyExecutor;
-import com.ibm.ws.threading.PolicyExecutor.QueueFullAction;
 import com.ibm.ws.threading.PolicyExecutorProvider;
 import com.ibm.ws.threading.PolicyTaskCallback;
 
@@ -90,7 +89,7 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testAwaitTerminationOfUnusedExecutor() throws Exception {
         ExecutorService executor1 = provider.create("testAwaitTerminationOfUnusedExecutor-1")
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
         assertFalse(executor1.awaitTermination(0, TimeUnit.MINUTES));
         assertFalse(executor1.isTerminated());
         assertFalse(executor1.isShutdown());
@@ -101,7 +100,7 @@ public class PolicyExecutorServlet extends FATServlet {
 
         ExecutorService executor2 = provider.create("testAwaitTerminationOfUnusedExecutor-2")
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(2))
-                        .queueFullAction(QueueFullAction.CallerRuns);
+                        .runIfQueueFull(true);
         assertFalse(executor2.awaitTermination(0, TimeUnit.HOURS));
         assertFalse(executor2.isTerminated());
         assertFalse(executor2.isShutdown());
@@ -141,7 +140,7 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(2)
                         .maxQueueSize(2)
                         .maxWaitForEnqueue(TimeUnit.SECONDS.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         Future<Boolean> terminationFuture = testThreads.submit(new TerminationAwaitTask(executor, TimeUnit.MINUTES.toNanos(5)));
         assertFalse(terminationFuture.isDone());
@@ -221,8 +220,7 @@ public class PolicyExecutorServlet extends FATServlet {
         ExecutorService executor = provider.create("testAwaitTerminationWhileActiveThenShutdownNow")
                         .maxConcurrency(2)
                         .maxQueueSize(2)
-                        .maxWaitForEnqueue(TimeUnit.SECONDS.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxWaitForEnqueue(TimeUnit.SECONDS.toMillis(1));
 
         Future<Boolean> terminationFuture = testThreads.submit(new TerminationAwaitTask(executor, TimeUnit.MINUTES.toNanos(6)));
         assertFalse(terminationFuture.isDone());
@@ -321,8 +319,7 @@ public class PolicyExecutorServlet extends FATServlet {
         ExecutorService executor = provider.create("testAwaitTerminationWhileActiveThenShutdownThenShutdownNow")
                         .maxConcurrency(1)
                         .maxQueueSize(1)
-                        .maxWaitForEnqueue(TimeUnit.SECONDS.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxWaitForEnqueue(TimeUnit.SECONDS.toMillis(1));
 
         Future<Boolean> terminationFuture = testThreads.submit(new TerminationAwaitTask(executor, TimeUnit.MINUTES.toNanos(7)));
         assertFalse(terminationFuture.isDone());
@@ -440,8 +437,7 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testCallbacksForAbortedTasks() throws Exception {
         PolicyExecutor executor = provider.create("testCallbacksForAbortedTasks")
                         .maxConcurrency(1)
-                        .maxQueueSize(1)
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxQueueSize(1);
 
         CountDownLatch blocker = new CountDownLatch(1);
         CountDownLatch blockerRunning = new CountDownLatch(1);
@@ -1367,7 +1363,7 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(1)
                         .maxQueueSize(1)
                         .maxWaitForEnqueue(TimeUnit.HOURS.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         final int numConfigTasks = 6;
         CountDownLatch beginLatch = new CountDownLatch(numConfigTasks + 1);
@@ -1475,7 +1471,7 @@ public class PolicyExecutorServlet extends FATServlet {
         ExecutorService executor = provider.create("testGroupedSubmits")
                         .maxConcurrency(4)
                         .maxQueueSize(nextGroupOn)
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         final CompletionService<Integer> completionSvc = new ExecutorCompletionService<Integer>(executor);
 
@@ -1558,7 +1554,7 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(1)
                         .maxQueueSize(2)
                         .maxWaitForEnqueue(0)
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         try {
             fail("First instance should not be usable again after identifier reused " + executor1.submit(new SharedIncrementTask(), null));
@@ -1928,16 +1924,17 @@ public class PolicyExecutorServlet extends FATServlet {
         assertEquals(0, canceledFromQueue.size());
     }
 
-    // Use invokeAll where maxQueueSize is constrained to 1 and queueFullAction is Abort and maxConcurrency is unlimited.
+    // Use invokeAll where maxQueueSize is constrained to 1 and runIfQueueFull is false and maxConcurrency is unlimited.
     // Normally, the queue size of 1 would risk having task submissions aborted when tasks are not pulled from the queue
     // for execution quickly enough. However, the fact that the user has specified the untimed invokeAll operation to
     // wait for all tasks to be completed means that the current thread can be used to help complete the tasks in the
-    // even that they cannot be queued, so it is not necessary to resort to the queueFullAction.
+    // event that they cannot be queued, because runIfQueueFull is only for submit/execute and does not apply to invokeAll/Any.
     @Test
     public void testInvokeAllAbortIgnoredWhenConcurrencyUnlimited() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllAbortIgnoredWhenConcurrencyUnlimited")
+                        .maxConcurrencyAppliesToCallerThread(true)
                         .maxQueueSize(1)
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         AtomicInteger counter = new AtomicInteger();
         List<Callable<Integer>> tasks = Arrays.<Callable<Integer>> asList(new SharedIncrementTask(counter), new SharedIncrementTask(counter), new SharedIncrementTask(counter),
@@ -1983,7 +1980,8 @@ public class PolicyExecutorServlet extends FATServlet {
         }
 
         executor = provider.create("testInvokeAllAfterShutdownNow")
-                        .queueFullAction(QueueFullAction.CallerRuns);
+                        .maxConcurrencyAppliesToCallerThread(false)
+                        .runIfQueueFull(true);
         executor.shutdownNow();
 
         try {
@@ -2003,14 +2001,14 @@ public class PolicyExecutorServlet extends FATServlet {
 
     // Use invokeAll where one or more tasks must run on the current thread due to the queue being full.
     // To achieve this, we constrain maxConcurrency and maxQueueSize to 1 and supply 4 tasks to invokeAll,
-    // where the first task blocks until all others start. This maxConcurrency to be exceeded, which is only
-    // possible due to the CallerRuns queueFullAction.
+    // where the first task blocks until all others start. This causes maxConcurrency to be exceeded, which is only
+    // possible due to the maxConcurrencyAppliesToCallerThread=false property.
     @Test
     public void testInvokeAllCallerRunsWhenQueueFull() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllCallerRunsWhenQueueFull")
                         .maxConcurrency(1)
-                        .maxQueueSize(1)
-                        .queueFullAction(QueueFullAction.CallerRuns);
+                        .maxConcurrencyAppliesToCallerThread(false)
+                        .maxQueueSize(1);
 
         CountDownLatch beginLatch = new CountDownLatch(3);
         CountDownLatch ignore = new CountDownLatch(0);
@@ -2043,8 +2041,7 @@ public class PolicyExecutorServlet extends FATServlet {
     @Test
     public void testInvokeAllInterruptedWhileRunningTaskAfterOtherTasksSubmitted() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllInterruptedWhileRunningTaskAfterOtherTasksSubmitted")
-                        .maxConcurrency(2)
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxConcurrency(2);
 
         CountDownLatch beginLatch = new CountDownLatch(2);
         CountDownLatch blocker = new CountDownLatch(1);
@@ -2080,8 +2077,8 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testInvokeAllInterruptedWhileRunningTaskThatCannotBeSubmitted() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllInterruptedWhileRunningTaskThatCannotBeSubmitted")
                         .maxConcurrency(1)
-                        .maxQueueSize(1)
-                        .queueFullAction(QueueFullAction.CallerRuns);
+                        .maxConcurrencyAppliesToCallerThread(false)
+                        .maxQueueSize(1);
 
         // Invoke 4 tasks.
         // The first will start running and block.
@@ -2128,9 +2125,9 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testInvokeAllOfOneAndNone() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllOfOneAndNone")
                         .maxConcurrency(1)
+                        .maxConcurrencyAppliesToCallerThread(true)
                         .maxQueueSize(2)
-                        .maxWaitForEnqueue(TimeUnit.SECONDS.toMillis(10))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxWaitForEnqueue(TimeUnit.SECONDS.toMillis(10));
 
         long threadId = Thread.currentThread().getId();
         List<Future<Long>> futures;
@@ -2157,8 +2154,8 @@ public class PolicyExecutorServlet extends FATServlet {
         } catch (InterruptedException x) {
         } // pass
 
-        // If using CallerRuns, we don't need a permit
-        executor.queueFullAction(QueueFullAction.CallerRuns);
+        // If using maxConcurrencyAppliesToCallerThread=false, we don't need a permit
+        executor.maxConcurrencyAppliesToCallerThread(false);
         futures = executor.invokeAll(Collections.singleton(new ThreadIdTask()));
         assertEquals(1, futures.size());
         assertEquals(Long.valueOf(threadId), futures.get(0).get(0, TimeUnit.MINUTES));
@@ -2177,8 +2174,8 @@ public class PolicyExecutorServlet extends FATServlet {
         PolicyExecutor executor = provider.create("testInvokeAllOnCurrentThread")
                         .coreConcurrency(1)
                         .maxConcurrency(1)
-                        .maxQueueSize(10)
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxConcurrencyAppliesToCallerThread(true)
+                        .maxQueueSize(10);
 
         long threadId = Thread.currentThread().getId();
 
@@ -2198,13 +2195,13 @@ public class PolicyExecutorServlet extends FATServlet {
         assertEquals(0, canceledFromQueue.size());
     }
 
-    // Use invokeAll where all tasks run on the current thread even without a maxConcurrency permit due to the CallerRuns action.
+    // Use invokeAll where all tasks run on the current thread even without a maxConcurrency permit due maxConcurrencyAppliesToCallerThread=false.
     @Test
     public void testInvokeAllOnCurrentThreadCallerRunsWithoutPermit() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllOnCurrentThreadCallerRunsWithoutPermit")
                         .maxConcurrency(1)
-                        .maxQueueSize(10)
-                        .queueFullAction(QueueFullAction.CallerRuns);
+                        .maxConcurrencyAppliesToCallerThread(false)
+                        .maxQueueSize(10);
 
         // Use up the only permit
         CountDownLatch beginLatch = new CountDownLatch(1);
@@ -2237,8 +2234,7 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testInvokeAllInvalidParameters() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllInvalidParameters")
                         .maxConcurrency(2)
-                        .maxWaitForEnqueue(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxWaitForEnqueue(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS));
 
         // Null list of tasks
         try {
@@ -2284,8 +2280,7 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testInvokeAllTasksThatRaiseExceptions() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllTasksThatRaiseExceptions")
                         .maxConcurrency(1)
-                        .maxQueueSize(1)
-                        .queueFullAction(QueueFullAction.CallerRuns);
+                        .maxQueueSize(1);
 
         final CountDownLatch beginLatch = new CountDownLatch(1);
         CountDownLatch blocker = new CountDownLatch(1);
@@ -2368,9 +2363,9 @@ public class PolicyExecutorServlet extends FATServlet {
         PolicyExecutor executor = provider.create("testInvokeAllTimed")
                         .coreConcurrency(2)
                         .maxConcurrency(3)
+                        .maxConcurrencyAppliesToCallerThread(true) // meaningless for timed invokeAll, which never runs on caller thread
                         .maxQueueSize(2)
-                        .maxWaitForEnqueue(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxWaitForEnqueue(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS));
 
         List<Future<Integer>> futures;
         Future<Integer> future;
@@ -2503,8 +2498,7 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testInvokeAllTimedInvalidParameters() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllTimedInvalidParameters")
                         .maxConcurrency(2)
-                        .maxWaitForEnqueue(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxWaitForEnqueue(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS));
 
         // Null list of tasks
         try {
@@ -2611,15 +2605,16 @@ public class PolicyExecutorServlet extends FATServlet {
     // Using timed invokeAll where the timeout is much longer than the maxWaitForEnqueue and maxConcurrency is less
     // than the number of tasks submitted, submit several tasks that start and block. Should be rejected waiting
     // for a queue position and all in-progress tasks should cancel before returning from invokeAll.
-    // Rejection should occur even if QueueFullAction is CallerRuns because timed invokeAll disallows having
-    // the caller run tasks such that the timing can be honored.
+    // Rejection should occur even if maxConcurrencyAppliesToCallerThread is false and runIfQueueFull is true
+    // because timed invokeAll disallows having the caller run tasks so that the timing can be honored.
     @Test
     public void testInvokeAllTimedTimeoutWaitForEnqueue() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllTimedTimeoutWaitForEnqueue")
                         .maxConcurrency(1)
+                        .maxConcurrencyAppliesToCallerThread(false)
                         .maxQueueSize(1)
                         .maxWaitForEnqueue(200)
-                        .queueFullAction(QueueFullAction.CallerRuns);
+                        .runIfQueueFull(true);
 
         List<CountDownTask> blockingTasks = new LinkedList<CountDownTask>();
         CountDownLatch beginLatch = new CountDownLatch(3);
@@ -2654,9 +2649,9 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testInvokeAllTimeoutWaitForEnqueue() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllTimeoutWaitForEnqueue")
                         .maxConcurrency(1)
+                        .maxConcurrencyAppliesToCallerThread(true)
                         .maxQueueSize(2)
-                        .maxWaitForEnqueue(200)
-                        .queueFullAction(QueueFullAction.Abort); // Avoid CallerRuns so that tasks require separate threads
+                        .maxWaitForEnqueue(200);
 
         // Use up the only maxConcurrency permit to prevent invokeAll from acquiring it and running the tasks on the current thread
         CountDownLatch blockingLatch = new CountDownLatch(1);
@@ -2782,7 +2777,7 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(1)
                         .maxQueueSize(1)
                         .maxWaitForEnqueue(500)
-                        .queueFullAction(QueueFullAction.CallerRuns); // must be ignored for invokeAny with multiple tasks
+                        .runIfQueueFull(true); // does not apply to invokeAny/All
 
         // Use up maxConcurrency
         CountDownLatch blocker = new CountDownLatch(1);
@@ -2939,8 +2934,7 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testInvokeAnyInvalidParameters() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAnyInvalidParameters")
                         .maxConcurrency(2)
-                        .maxWaitForEnqueue(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxWaitForEnqueue(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS));
 
         // Null list of tasks
         try {
@@ -3067,8 +3061,8 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testInvokeAnyOfOne() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAnyOfOne")
                         .maxConcurrency(1)
-                        .maxQueueSize(1)
-                        .queueFullAction(QueueFullAction.Abort); // require a permit
+                        .maxConcurrencyAppliesToCallerThread(true) // require a permit
+                        .maxQueueSize(1);
 
         Set<Callable<Long>> oneTask = Collections.<Callable<Long>> singleton(new ThreadIdTask());
         Long curThreadId = Thread.currentThread().getId();
@@ -3100,7 +3094,7 @@ public class PolicyExecutorServlet extends FATServlet {
 
         assertTrue(blockerFuture.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 
-        executor.queueFullAction(QueueFullAction.CallerRuns);
+        executor.maxConcurrencyAppliesToCallerThread(false);
 
         // Use up the permit
         blockerFuture = executor.submit(new CountDownTask(new CountDownLatch(0), new CountDownLatch(1), TIMEOUT_NS));
@@ -3149,6 +3143,7 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testInvokeAnyShutdownNowWhileEnqueued() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAnyShutdownNowWhileEnqueued")
                         .maxConcurrency(1)
+                        .maxConcurrencyAppliesToCallerThread(true)
                         .maxQueueSize(2);
 
         CountDownLatch blocker = new CountDownLatch(1);
@@ -3530,8 +3525,7 @@ public class PolicyExecutorServlet extends FATServlet {
         PolicyExecutor executor = provider.create("testInvokeAnyTimedTimeoutDuringWaitForEnqueue")
                         .maxConcurrency(1)
                         .maxQueueSize(1)
-                        .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(4))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(4));
 
         AtomicInteger counter = new AtomicInteger();
 
@@ -3651,8 +3645,7 @@ public class PolicyExecutorServlet extends FATServlet {
         PolicyExecutor executor = provider.create("testMultipleLayersOfInvokeAll")
                         .coreConcurrency(0) // everything could run on the current thread if it needs to
                         .maxConcurrency(3)
-                        .maxQueueSize(4) // just enough to ensure we can cover a 16 element array
-                        .queueFullAction(QueueFullAction.CallerRuns);
+                        .maxQueueSize(4); // just enough to ensure we can cover a 16 element array
 
         int[] array1 = new int[] { 25, 85, 95, 25, 45, 15, 75, 75, 65, 35, 95, 105, 45, 35, 85, 25 };
         System.out.println("Searching for minimum of " + Arrays.toString(array1));
@@ -3676,7 +3669,7 @@ public class PolicyExecutorServlet extends FATServlet {
                         .coreConcurrency(8) // just enough to ensure we can cover a 16 element array
                         .maxConcurrency(8)
                         .maxQueueSize(8) // also just enough to ensure we can cover a 16 element array
-                        .queueFullAction(QueueFullAction.Abort); // TODO in the future, this sort of test is a good candidate for CallerRuns
+        ; // TODO in the future, this sort of test is a good candidate for runIfQueueFull=true
 
         int[] array1 = new int[] { 2, 9, 3, 5, 1, 3, 6, 3, 8, 0, 4, 4, 10, 2, 1, 8 };
         System.out.println("Searching for minimum of " + Arrays.toString(array1));
@@ -3943,8 +3936,7 @@ public class PolicyExecutorServlet extends FATServlet {
         PolicyExecutor executor = provider.create("testShutdownDuringTimedInvokeAll")
                         .maxConcurrency(1)
                         .maxQueueSize(2)
-                        .maxWaitForEnqueue(TimeUnit.SECONDS.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxWaitForEnqueue(TimeUnit.SECONDS.toMillis(1));
 
         AtomicInteger completedAfterShutdown = new AtomicInteger();
         CountDownLatch unused = new CountDownLatch(0);
@@ -3979,7 +3971,7 @@ public class PolicyExecutorServlet extends FATServlet {
     public void testShutdownNowDuringInvokeAll() throws Exception {
         PolicyExecutor executor = provider.create("testShutdownNowDuringInvokeAll")
                         .maxConcurrency(2)
-                        .queueFullAction(QueueFullAction.Abort);
+                        .maxConcurrencyAppliesToCallerThread(true);
 
         CountDownLatch blocker = new CountDownLatch(1);
         CountDownLatch task3BeginLatch = new CountDownLatch(1);
@@ -4031,7 +4023,7 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(2)
                         .maxQueueSize(1)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         CountDownLatch beginLatch = new CountDownLatch(3);
         CountDownLatch continueLatch = new CountDownLatch(1);
@@ -4043,16 +4035,15 @@ public class PolicyExecutorServlet extends FATServlet {
         Future<Boolean> future2 = executor.submit(task);
         //This task should be queued since we should be at max concurrency
         Future<Boolean> future3 = executor.submit(task);
-        Future<Boolean> future4 = null;
 
         //Shorten maxWaitForEnqueue so we the test doesn't have to wait long for the timeout
         executor.maxWaitForEnqueue(200);
 
         try {
             //This task should be aborted since the queue should be full, triggering a RejectedExecutionException
-            future4 = executor.submit(task);
+            Future<Boolean> future4 = executor.submit(task);
 
-            fail("The fourth task should have thrown a RejectedExecutionException when attempting to queue");
+            fail("The fourth task should have thrown a RejectedExecutionException when attempting to queue. Instead " + future4);
 
         } catch (RejectedExecutionException x) {
         } //expected
@@ -4082,7 +4073,7 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(1)
                         .maxQueueSize(1)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         CountDownLatch beginLatch1 = new CountDownLatch(2);
         CountDownLatch continueLatch1 = new CountDownLatch(1);
@@ -4165,12 +4156,12 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(1)
                         .maxQueueSize(1)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
         PolicyExecutor executor2 = provider.create("testMaxConcurrencyMultipleExecutors-2")
                         .maxConcurrency(1)
                         .maxQueueSize(1)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         CountDownLatch beginLatch = new CountDownLatch(3);
         CountDownLatch continueLatch = new CountDownLatch(1);
@@ -4219,7 +4210,7 @@ public class PolicyExecutorServlet extends FATServlet {
         PolicyExecutor executor = provider.create("testConcurrentUpdateMaxConcurrency")
                         .maxConcurrency(2)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort)
+                        .runIfQueueFull(false)
                         .maxQueueSize(1);
 
         int numSubmitted = 8;
@@ -4328,7 +4319,7 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(2)
                         .maxQueueSize(-1)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         CountDownLatch beginLatch1 = new CountDownLatch(2);
         CountDownLatch continueLatch1 = new CountDownLatch(1);
@@ -4409,7 +4400,6 @@ public class PolicyExecutorServlet extends FATServlet {
         PolicyExecutor executor = provider.create("testConcurrentUpdateMaxConcurrencyAndSubmit")
                         .maxConcurrency(4)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort)
                         .maxQueueSize(2);
 
         int numSubmitted = 6;
@@ -4494,7 +4484,7 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(2)
                         .maxQueueSize(2)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         CountDownLatch beginLatch = new CountDownLatch(2);
         CountDownLatch continueLatch = new CountDownLatch(1);
@@ -4576,12 +4566,12 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(1)
                         .maxQueueSize(1)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
         PolicyExecutor executor2 = provider.create("testQueueSizeMultipleExecutors-2")
                         .maxConcurrency(1)
                         .maxQueueSize(1)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         CountDownLatch beginLatch = new CountDownLatch(100);
         CountDownLatch continueLatch = new CountDownLatch(1);
@@ -4627,7 +4617,6 @@ public class PolicyExecutorServlet extends FATServlet {
         PolicyExecutor executor = provider.create("testConcurrentUpdateMaxQueueSize")
                         .maxConcurrency(2)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort)
                         .maxQueueSize(1);
 
         int numSubmitted = 8;
@@ -4737,7 +4726,7 @@ public class PolicyExecutorServlet extends FATServlet {
                         .maxConcurrency(1)
                         .maxQueueSize(1)
                         .maxWaitForEnqueue(TimeUnit.HOURS.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort);
+                        .runIfQueueFull(false);
 
         CountDownLatch beginLatch1 = new CountDownLatch(50);
         CountDownLatch continueLatch1 = new CountDownLatch(1);
@@ -4783,7 +4772,6 @@ public class PolicyExecutorServlet extends FATServlet {
         PolicyExecutor executor = provider.create("testMaxQueueSizeAndMaxConcurrencyConcurrentUpdate")
                         .maxConcurrency(2)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort)
                         .maxQueueSize(2);
 
         int numSubmitted = 16;
@@ -4904,7 +4892,6 @@ public class PolicyExecutorServlet extends FATServlet {
         PolicyExecutor executor = provider.create("testConcurrentUpdateMaxQueueSizeAndSubmit")
                         .maxConcurrency(6)
                         .maxWaitForEnqueue(TimeUnit.MINUTES.toMillis(1))
-                        .queueFullAction(QueueFullAction.Abort)
                         .maxQueueSize(2);
 
         int numSubmitted = 6;


### PR DESCRIPTION
Split queueFullAction into runIfQueueFull and maxConcurrencyAppliesToCallerThread.  Note that queueFullAction=CallerRuns was unimplemented for submit/execute which means that the equivalent of runIfQueueFull=true will be unimplemented for submit/execute after this change.