### PR TITLE
runIfQueueFull via managed executor

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
@@ -27,11 +27,16 @@
    maxConcurrency="1" maxQueueSize="1" maxWaitForEnqueue="120000"/>
 
   <managedScheduledExecutorService id="DefaultManagedScheduledExecutorService" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   maxConcurrency="2" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" runIfQueueFull="true"/>
+   coreConcurrency="0" maxConcurrency="4" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" runIfQueueFull="true"/>
 
-  <managedExecutorService id="executor1" jndiName="concurrent/executor1" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
+  <managedExecutorService id="executor1" jndiName="concurrent/executor1" contextServiceRef="jeeMetadataOnly" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
    maxConcurrency="1" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" maxWaitForEnqueue="0" runIfQueueFull="false"/>
 
-  <managedScheduledExecutorService jndiName="concurrent/scheduledExecutor2" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
+  <managedScheduledExecutorService jndiName="concurrent/scheduledExecutor2" contextServiceRef="jeeMetadataOnly" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
    coreConcurrency="1" maxConcurency="2" maxConcurrencyAppliesToCallerThread="false" maxQueueSize="2" runIfQueueFull="false"/>
+
+  <contextService id="jeeMetadataOnly">
+    <jeeMetadataContext/>
+  </contextService>
+
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
@@ -378,9 +378,9 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
 
         TaskListener listener;
         Future<Integer> future = futures.get(0);
+        assertEquals(Integer.valueOf(1), future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
         assertTrue(future.isDone());
         assertFalse(future.isCancelled());
-        assertEquals(Integer.valueOf(1), future.get());
         cancelAfterTest.remove(future);
 
         assertSuccess(defaultScheduledExecutor, future = futures.get(1), tasks[1], listener = (TaskListener) tasks[1].listener, 1);

--- a/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -58,7 +59,7 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
     @Resource(lookup = "java:comp/DefaultManagedExecutorService")
     private ManagedExecutorService defaultExecutor;
 
-    // max: 2; maxQueue: 1; wait: 0 and submitter runs
+    // max: 4; maxQueue: 1; wait: 0 and submitter runs requiring permit
     @Resource(lookup = "java:comp/DefaultManagedScheduledExecutorService")
     private ManagedScheduledExecutorService defaultScheduledExecutor;
 
@@ -335,5 +336,72 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
         assertTrue("unexpected: " + listener.resultOfLookup[SUBMITTED], listener.resultOfLookup[SUBMITTED] instanceof UserTransaction);
         assertTrue("unexpected: " + listener.resultOfLookup[STARTING], listener.resultOfLookup[STARTING] instanceof UserTransaction);
         assertTrue("unexpected: " + listener.resultOfLookup[DONE], listener.resultOfLookup[DONE] instanceof UserTransaction);
+    }
+
+    /**
+     * When runIfQueueFull is true, it should be possible to submit maxConcurrency number of tasks, even if the maxQueueSize is less
+     * than maxConcurrency because tasks that cannot be enqueued will run on the submitter's thread.
+     */
+    @Test
+    public void testRunWhenQueueFull() throws Exception {
+        CountingTask[] tasks = new CountingTask[4]; // maxConcurrency
+        for (int i = 0; i < 4; i++) {
+            TaskListener listener = i == 0 ? null : new TaskListener().doLookup("java:module/env/concurrent/executor2ref", STARTING, DONE);
+            tasks[i] = new CountingTask(null, listener, null, null);
+        }
+
+        // Occupy the global executor with some other work to increase the chance that tasks submitted to defaultScheduledExecutor
+        // will be unable to queue and run on the submitter's thread.
+        CountingTask blockerTask1 = new CountingTask(null, null, new CountDownLatch(1), new CountDownLatch(1));
+        CountingTask blockerTask2 = new CountingTask(null, null, new CountDownLatch(1), new CountDownLatch(1));
+        Future<Integer> blockerTask1Future = scheduledExecutor2.submit(blockerTask1);
+        cancelAfterTest.add(blockerTask1Future);
+        Future<Integer> blockerTask2Future = scheduledExecutor2.submit(blockerTask2);
+        cancelAfterTest.add(blockerTask2Future);
+
+        // Submit as many tasks as we have maxConcurrency, even though maxQueueSize is only 1
+        List<Future<Integer>> futures = new ArrayList<Future<Integer>>(4);
+        for (int i = 0; i < 4; i++) {
+            Future<Integer> future = defaultScheduledExecutor.submit(tasks[i]);
+            cancelAfterTest.add(future);
+            futures.add(future);
+        }
+
+        // Any tasks that ran on the current thread should already report being done.
+        long curThreadId = Thread.currentThread().getId();
+        if (((TaskListener) tasks[1].listener).threadId[STARTING] == curThreadId)
+            assertTrue(futures.get(1).isDone());
+        if (((TaskListener) tasks[2].listener).threadId[STARTING] == curThreadId)
+            assertTrue(futures.get(2).isDone());
+        if (((TaskListener) tasks[3].listener).threadId[STARTING] == curThreadId)
+            assertTrue(futures.get(3).isDone());
+
+        TaskListener listener;
+        Future<Integer> future = futures.get(0);
+        assertTrue(future.isDone());
+        assertFalse(future.isCancelled());
+        assertEquals(Integer.valueOf(1), future.get());
+        cancelAfterTest.remove(future);
+
+        assertSuccess(defaultScheduledExecutor, future = futures.get(1), tasks[1], listener = (TaskListener) tasks[1].listener, 1);
+        assertEquals(scheduledExecutor2, listener.resultOfLookup[STARTING]);
+        assertEquals(scheduledExecutor2, listener.resultOfLookup[DONE]);
+        cancelAfterTest.remove(future);
+
+        assertSuccess(defaultScheduledExecutor, future = futures.get(2), tasks[2], listener = (TaskListener) tasks[2].listener, 1);
+        assertEquals(scheduledExecutor2, listener.resultOfLookup[STARTING]);
+        assertEquals(scheduledExecutor2, listener.resultOfLookup[DONE]);
+        cancelAfterTest.remove(future);
+
+        assertSuccess(defaultScheduledExecutor, future = futures.get(3), tasks[3], listener = (TaskListener) tasks[3].listener, 1);
+        assertEquals(scheduledExecutor2, listener.resultOfLookup[STARTING]);
+        assertEquals(scheduledExecutor2, listener.resultOfLookup[DONE]);
+        cancelAfterTest.remove(future);
+
+        cancelAfterTest.remove(blockerTask1Future);
+        assertTrue(blockerTask1Future.cancel(true));
+
+        cancelAfterTest.remove(blockerTask2Future);
+        assertTrue(blockerTask2Future.cancel(true));
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/TaskListener.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/TaskListener.java
@@ -46,6 +46,7 @@ class TaskListener implements ManagedTaskListener {
     final Boolean[] resultOfCancel = new Boolean[NUM_EVENTS];
     final Object[] resultOfLookup = new Object[NUM_EVENTS];
     final Object[] task = new Object[NUM_EVENTS];
+    final long[] threadId = new long[NUM_EVENTS];
 
     TaskListener() {
         doGet[ConcurrentPolicyFATServlet.DONE] = true;
@@ -102,6 +103,7 @@ class TaskListener implements ManagedTaskListener {
         this.future[event] = future;
         this.invoked[event] = true;
         this.task[event] = task;
+        this.threadId[event] = Thread.currentThread().getId();
 
         try {
             futureToString[event] = future.toString();


### PR DESCRIPTION
Add a test cause of runIfQueueFull=true for managed executors.
It won't be possible to guarantee the code path will be exercised every time the test runs, but we can write it in a way that will only pass 100% of the time based on the behavior of runIfQueueFull=true causing a submitted task to run on the current thread when the queue is at capacity.