### PR TITLE
Change client.bat to properly set JVM options

### DIFF
--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client.bat
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client.bat
@@ -300,6 +300,9 @@ goto:eof
   if exist "%JAVA_HOME%\lib\modules" (
     call:mergeJVMOptions "%WLP_INSTALL_DIR%\lib\platform\java\java9.options"
   )
+  
+  set JVM_OPTIONS=!JVM_OPTIONS!%JVM_TEMP_OPTIONS%
+  
 goto:eof
 
 @REM


### PR DESCRIPTION
Made changes to client.bat to properly set the JVM Options after parsing client.jvm.options or any other JVM related options file. This behavior mimics what is done in server.bat.

Fixes #601 

#build