### PR TITLE
doPriv around getBundleContext() call

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/JAXRSClientImpl.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/JAXRSClientImpl.java
@@ -11,6 +11,8 @@
 package com.ibm.ws.jaxrs20.client;
 
 import java.net.URI;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -85,8 +87,15 @@ public class JAXRSClientImpl extends ClientImpl {
         }
 
         try {
-            Bundle b = FrameworkUtil.getBundle(JAXRSClientImpl.class);
-            BundleContext bc = b == null ? null : b.getBundleContext();
+            BundleContext bc = AccessController.doPrivileged(new PrivilegedExceptionAction<BundleContext>() {
+
+                @Override
+                public BundleContext run() throws Exception {
+                    Bundle b = FrameworkUtil.getBundle(JAXRSClientImpl.class);
+                    return b == null ? null : b.getBundleContext();
+                }
+            });
+
             if (bc != null) {
                 final List<Object> providers = new ArrayList<>();
                 // we don't send feature list for client APIs

--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -224,13 +224,19 @@ public abstract class ProviderFactory {
 
     // Liberty Change for CXF Begin
     private static Object createJsonpProvider() {
-        JsonProvider jsonProvider = null;
-        Bundle b = FrameworkUtil.getBundle(ProviderFactory.class);
-        if(b != null) {
-            BundleContext bc = b.getBundleContext();
-            ServiceReference<JsonProvider> sr = bc.getServiceReference(JsonProvider.class);
-            jsonProvider = (JsonProvider)bc.getService(sr);
-        }
+        JsonProvider jsonProvider = AccessController.doPrivileged(new PrivilegedAction<JsonProvider>(){
+
+            @Override
+            public JsonProvider run() {
+                Bundle b = FrameworkUtil.getBundle(ProviderFactory.class);
+                if(b != null) {
+                    BundleContext bc = b.getBundleContext();
+                    ServiceReference<JsonProvider> sr = bc.getServiceReference(JsonProvider.class);
+                    return (JsonProvider)bc.getService(sr);
+                }
+                return null;
+            }});
+        
         return new JsonPProvider(jsonProvider);
     }
     // Liberty Change for CXF End
@@ -252,13 +258,19 @@ public abstract class ProviderFactory {
     }
     
     private static Object createJsonbProvider() {
-        JsonbProvider jsonbProvider = null;
-        Bundle b = FrameworkUtil.getBundle(ProviderFactory.class);
-        if(b != null) {
-            BundleContext bc = b.getBundleContext();
-            ServiceReference<JsonbProvider> sr = bc.getServiceReference(JsonbProvider.class);
-            jsonbProvider = (JsonbProvider)bc.getService(sr);
-        }
+        JsonbProvider jsonbProvider = AccessController.doPrivileged(new PrivilegedAction<JsonbProvider>(){
+
+            @Override
+            public JsonbProvider run() {
+                Bundle b = FrameworkUtil.getBundle(ProviderFactory.class);
+                if(b != null) {
+                    BundleContext bc = b.getBundleContext();
+                    ServiceReference<JsonbProvider> sr = bc.getServiceReference(JsonbProvider.class);
+                    return (JsonbProvider)bc.getService(sr);
+                }
+                return null;
+            }});
+        
         return new JsonBProvider(jsonbProvider);
     }
 


### PR DESCRIPTION
Java 2 security testing exposed that the JAXRSClientImpl was making a call to getBundleContext(), which requires Java 2 security permission.  It should be in a doPriv.