### PR TITLE
make getElapsedRunTime consistent for onEnd callback and add more tests

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -451,11 +451,12 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
 
     /** {@inheritDoc} */
     @FFDCIgnore(InterruptedException.class)
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
         // TODO replace this temporary prototype code
         if (policyExecutor != null)
-            return policyExecutor.invokeAll(tasks, createCallbacks(tasks));
+            return (List) policyExecutor.invokeAll(tasks, createCallbacks(tasks));
 
         ExecutorService execSvc = getExecSvc();
 
@@ -483,11 +484,12 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
 
     /** {@inheritDoc} */
     @FFDCIgnore(InterruptedException.class)
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
         // TODO replace this temporary prototype code
         if (policyExecutor != null)
-            return policyExecutor.invokeAll(tasks, createCallbacks(tasks), timeout, unit);
+            return (List) policyExecutor.invokeAll(tasks, createCallbacks(tasks), timeout, unit);
 
         ExecutorService execSvc = getExecSvc();
 

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -49,7 +48,7 @@ public interface PolicyExecutor extends ExecutorService {
      * @throws ArrayIndexOutOfBoundsException if the size of the callbacks array is less than the number of tasks.
      * @see java.util.concurrent.ExecutorService#invokeAll(java.util.Collection)
      */
-    <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, PolicyTaskCallback[] callbacks) throws InterruptedException;
+    <T> List<PolicyTaskFuture<T>> invokeAll(Collection<? extends Callable<T>> tasks, PolicyTaskCallback[] callbacks) throws InterruptedException;
 
     /**
      * Submits and invokes a group of tasks with a callback per task to be invoked at various points in the task's life cycle.
@@ -59,7 +58,7 @@ public interface PolicyExecutor extends ExecutorService {
      * @throws ArrayIndexOutOfBoundsException if the size of the callbacks array is less than the number of tasks.
      * @see java.util.concurrent.ExecutorService#invokeAll(java.util.Collection, long, java.util.concurrent.TimeUnit)
      */
-    <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, PolicyTaskCallback[] callbacks, long timeout, TimeUnit unit) throws InterruptedException;
+    <T> List<PolicyTaskFuture<T>> invokeAll(Collection<? extends Callable<T>> tasks, PolicyTaskCallback[] callbacks, long timeout, TimeUnit unit) throws InterruptedException;
 
     /**
      * Submits and awaits successful completion of any task within a group of tasks.
@@ -167,12 +166,12 @@ public interface PolicyExecutor extends ExecutorService {
      *
      * @see java.util.concurrent.ExecutorService#submit(java.util.concurrent.Callable)
      */
-    <T> Future<T> submit(Callable<T> task, PolicyTaskCallback callback);
+    <T> PolicyTaskFuture<T> submit(Callable<T> task, PolicyTaskCallback callback);
 
     /**
      * Submit a Runnable task with a callback to be invoked at various points in the task's life cycle.
      *
      * @see java.util.concurrent.ExecutorService#submit(java.lang.Runnable, java.lang.Object)
      */
-    <T> Future<T> submit(Runnable task, T result, PolicyTaskCallback callback);
+    <T> PolicyTaskFuture<T> submit(Runnable task, T result, PolicyTaskCallback callback);
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskFuture.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskFuture.java
@@ -46,7 +46,7 @@ public interface PolicyTaskFuture<T> extends Future<T> {
 
     /**
      * Computes the estimated interval of time during which task execution and processing related to task execution occurs.
-     * This includes the processing of callbacks such as onStart/onEnd. A positive interval can be computed even if the task does
+     * This includes the processing of the onStart callback. A positive interval can be computed even if the task does
      * end up executing, for example, if the onStart callback cancels it. The value returned is an estimate.
      * No guarantee is made that the same exact value will be returned for subsequent invocations.
      *

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -512,6 +512,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
         if (!state.setRunning()) {
             if (trace && tc.isDebugEnabled())
                 Tr.debug(this, tc, "unable to run", state.get());
+            nsRunEnd = System.nanoTime();
             if (callback != null)
                 callback.onEnd(task, this, null, true, 0, null); // aborted, queued task will never run
             return;
@@ -547,6 +548,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                     Tr.debug(this, tc, "run", t);
             }
 
+            nsRunEnd = System.nanoTime();
             if (callback != null)
                 try {
                     callback.onEnd(task, this, callbackContext, aborted, 0, null);
@@ -561,6 +563,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                     latch.countDown();
             }
 
+            nsRunEnd = System.nanoTime();
             if (callback != null)
                 callback.onEnd(task, this, callbackContext, aborted, 0, x);
         } finally {


### PR DESCRIPTION
Record the timestamp for a completed task before invoking the onEnd callback so that the callback can rely on having a consistent value that will not change after that point, which better reflects the fact that the task has ended.  Adding a number of tests for the getElapsed*Time methods interspersed throughout existing tests where sleeps or waits are already happening so that we don't need to lengthen the run time of the test bucket in order to get coverage.