### PR TITLE
Fix .classpath problems with two new projects

### DIFF
--- a/dev/com.ibm.websphere.appserver.jsonbContainer-1.0/.classpath
+++ b/dev/com.ibm.websphere.appserver.jsonbContainer-1.0/.classpath
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-applications/SseJsonbApp"/>
+	<classpathentry kind="src" path="test-applications/SseJsonbApp/src"/>
 	<classpathentry kind="src" path="test-applications/BasicSseApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/.classpath
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/.classpath
@@ -5,18 +5,7 @@
 	<classpathentry kind="src" path="test-applications/TestServlet40.jar/src"/>
 	<classpathentry kind="src" path="test-applications/TestGetMapping.war/src"/>
 	<classpathentry kind="src" path="test-applications/TestAddJspFile.war/src"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.org.apache.commons.logging"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.org.apache.commons.codec"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/fattest.simplicity"/>
-	<classpathentry kind="lib" path="lib/jtidy-r938.jar"/>
-	<classpathentry kind="lib" path="lib/commons-httpclient-3.1.jar"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.javaee.servlet.4.0"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.javaee.jsp.2.3"/>
-	<classpathentry kind="lib" path="lib/org.apache.httpcomponents.httpclient_5.0-alpha2.jar"/>
-	<classpathentry kind="lib" path="lib/org.apache.httpcomponents.httpcore_5.0-alpha3.jar"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.javaee.servlet.3.1"/>
-	<classpathentry kind="lib" path="/build.sharedResources/lib/ws-junit/ws-junit.jar"/>
-	<classpathentry kind="lib" path="build/libs/autoFVT/lib/httpunit-1.5.4.jar"/>
-	<classpathentry kind="output" path="build/classes"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Loading the following new projects in eclipse shows errors due to
.classpath problems:

com.ibm.ws.jaxrs.2.1.sse_fat
com.ibm.ws.webcontainer.servlet.4.0_fat

Fixed by correcting src and or dependencies.