### PR TITLE
Add TrustedProxyEnable and TrustedProxyGroup as config options in the

### DIFF
--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype-mbeans.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype-mbeans.properties
@@ -102,7 +102,7 @@ plugin.ESIEnableToPassCookies.name=Override the ESIEnableToPassCookies property
 plugin.ESIEnableToPassCookies.desc=ESIEnableToPassCookies allows forwarding of session cookies to WebSphere Application Server. This property provides the option to override the value in the web server plugin configuration file.
 
 plugin.trustedProxyEnable.name=Override the TrustedProxyEnable property
-plugin.trustedProxyEnable.desc=Required for trusted proxies to be used. This property provides the option to override the value in the web server plugin configuration file.
+plugin.trustedProxyEnable.desc=Enables trusted proxies to be used. When specified, this property overrides the value in the web server plug-in configuration file.
 
 plugin.trustedProxyGroup.name=Override the TrustedProxyGroup property
-plugin.trustedProxyGroup.desc=A comma-separated list of trusted proxies. This property provides the option to override the value in the web server plugin configuration file.
+plugin.trustedProxyGroup.desc=A comma-separated list of trusted proxies. When specified, this property overrides the value in the web server plug-in configuration file.

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype-mbeans.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype-mbeans.properties
@@ -100,3 +100,9 @@ plugin.ESIInvalidationMonitor.desc=ESIInvalidationMonitor specifies if the ESI p
 
 plugin.ESIEnableToPassCookies.name=Override the ESIEnableToPassCookies property
 plugin.ESIEnableToPassCookies.desc=ESIEnableToPassCookies allows forwarding of session cookies to WebSphere Application Server. This property provides the option to override the value in the web server plugin configuration file.
+
+plugin.trustedProxyEnable.name=Override the TrustedProxyEnable property
+plugin.trustedProxyEnable.desc=Required for trusted proxies to be used. This property provides the option to override the value in the web server plugin configuration file.
+
+plugin.trustedProxyGroup.name=Override the TrustedProxyGroup property
+plugin.trustedProxyGroup.desc=A comma-separated list of trusted proxies. This property provides the option to override the value in the web server plugin configuration file.

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype-mbeans.xml
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype-mbeans.xml
@@ -72,6 +72,10 @@
         	id="ESIInvalidationMonitor" required="false" type="Boolean" default="false" />
         <AD name="%plugin.ESIEnableToPassCookies.name" description="%plugin.ESIEnableToPassCookies.desc" 
         	id="ESIEnableToPassCookies" required="false" type="Boolean" default="false" />
+        <AD name="%plugin.trustedProxyEnable.name" description="%plugin.trustedProxyEnable.desc" 
+        	id="trustedProxyEnable" required="false" type="Boolean" />
+        <AD name="%plugin.trustedProxyGroup.name" description="%plugin.trustedProxyGroup.desc" 
+        	id="trustedProxyGroup" required="false" type="String" />
     </OCD>
 
     <Designate pid="com.ibm.ws.generatePluginConfig">

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -249,6 +249,13 @@ public class PluginGenerator {
             // add in hardcoded properties and any extra properties from the user configuration
             if (!pcd.extraConfigProperties.isEmpty())
             {
+                if(pcd.TrustedProxyEnable != null) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Overriding TrustedProxyEnable from extra config properties with the specified value");
+                    }
+                    pcd.extraConfigProperties.put("TrustedProxyEnable", pcd.TrustedProxyEnable.toString());
+                }
+                
                 for (String key : pcd.extraConfigProperties.keySet()) {
                     String value = (String)pcd.extraConfigProperties.get(key);
                     rootElement.setAttribute(key, value);                    
@@ -338,20 +345,20 @@ public class PluginGenerator {
                 }
             }
 
-            if (pcd.TrustedProxyList != null) {
+            if (pcd.TrustedProxyGroup != null) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "Adding custom property TrustedProxyGroup element and its associated proxy servers");
                 }
 
                 Element tproxyGroupElem = output.createElement("TrustedProxyGroup");
                 rootElement.appendChild(tproxyGroupElem);
-                for (String trustedProxy : pcd.TrustedProxyList) {
+                for (String trustedProxy : pcd.TrustedProxyGroup) {
                     Element tproxyElem = output.createElement("TrustedProxy");
                     if (trustedProxy.indexOf(":") != -1) {
                         // IPV6
-                        tproxyElem.setAttribute("Name", "[" + trustedProxy + "]" );
+                        tproxyElem.setAttribute("Name", "[" + trustedProxy.trim() + "]" );
                     } else {
-                        tproxyElem.setAttribute("Name", trustedProxy );
+                        tproxyElem.setAttribute("Name", trustedProxy.trim() );
                     }
                     tproxyGroupElem.appendChild(tproxyElem);
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -1412,7 +1419,8 @@ public class PluginGenerator {
         protected Integer postBufferSize = Integer.valueOf(0);
         protected Boolean GetDWLMTable = Boolean.FALSE;
         protected Integer HTTPMaxHeaders = Integer.valueOf(300);
-        protected String[] TrustedProxyList = null;
+        protected Boolean TrustedProxyEnable = null;
+        protected String[] TrustedProxyGroup = null;
       
         // properties from server configuration -  see metatype-mbeans.properties file
         // properties that exist in metatype file should not have defaults specified here
@@ -1484,6 +1492,12 @@ public class PluginGenerator {
             if(config.get("ESIEnableToPassCookies") != null){
                 ESIEnableToPassCookies =  (Boolean) config.get("ESIEnableToPassCookies");
             }// PI76699 End
+            TrustedProxyEnable = (Boolean) config.get("trustedProxyEnable");
+            String proxyList = (String) config.get("trustedProxyGroup");
+            if(proxyList != null) {
+                TrustedProxyGroup = proxyList.split(",");
+            }
+            
             
             // populate extra properties map with default values but allow override from user config
             extraConfigProperties.put("ASDisableNagle", "false");
@@ -1564,7 +1578,8 @@ public class PluginGenerator {
                 Tr.debug(trace, "   CertLabel               : " + CertLabel);
                 Tr.debug(trace, "   KeyringLocation         : " + KeyringLocation);
                 Tr.debug(trace, "   StashfileLocation       : " + StashfileLocation);
-                Tr.debug(trace, "   TrustedProxyList        : " + traceList(TrustedProxyList));
+                Tr.debug(trace, "   TrustedProxyEnable      : " + TrustedProxyEnable);
+                Tr.debug(trace, "   TrustedProxyGroup       : " + traceList(TrustedProxyGroup));
                 if (!extraConfigProperties.isEmpty())
                     Tr.debug(trace, "   AdditionalConfigProps   : " + extraConfigProperties.toString());
             }


### PR DESCRIPTION
pluginConfiguration stanza of the server.xml.

TrustedProxyEnable is a boolean needed to use trusted proxies.
TrustedProxyGroup is a comma-separated list of trusted proxies.