### PR TITLE
Issue #592 more updates to tracking elapsed time and tests

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -168,11 +168,18 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
         // notify listener: taskStarting
         if (task instanceof ManagedTask) {
             ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
-            if (listener != null) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
-                    Tr.event(this, tc, "taskStarting", managedExecutor, task);
-                listener.taskStarting(future, managedExecutor, task);
-            }
+            if (listener != null)
+                try {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                        Tr.event(this, tc, "taskStarting", managedExecutor, task);
+                    listener.taskStarting(future, managedExecutor, task);
+                } catch (Error x) {
+                    threadContextDescriptor.taskStopping(contextAppliedToThread);
+                    throw x;
+                } catch (RuntimeException x) {
+                    threadContextDescriptor.taskStopping(contextAppliedToThread);
+                    throw x;
+                }
         }
 
         return contextAppliedToThread;

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -424,26 +424,22 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         } catch (InterruptedException x) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "enqueue", x);
-            if (policyTaskFuture.abort(x) && policyTaskFuture.callback != null)
-                policyTaskFuture.callback.onEnd(policyTaskFuture.task, policyTaskFuture, null, true, 0, x);
+            policyTaskFuture.abort(x);
             throw new RejectedExecutionException(x);
         } catch (RejectedExecutionException x) { // redundant with RuntimeException code path, but added to allow FFDCIgnore
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "enqueue", x);
-            if (policyTaskFuture.abort(x) && policyTaskFuture.callback != null)
-                policyTaskFuture.callback.onEnd(policyTaskFuture.task, policyTaskFuture, null, true, 0, x);
+            policyTaskFuture.abort(x);
             throw x;
         } catch (RuntimeException x) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "enqueue", x);
-            if (policyTaskFuture.abort(x) && policyTaskFuture.callback != null)
-                policyTaskFuture.callback.onEnd(policyTaskFuture.task, policyTaskFuture, null, true, 0, x);
+            policyTaskFuture.abort(x);
             throw x;
         } catch (Error x) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "enqueue", x);
-            if (policyTaskFuture.abort(x) && policyTaskFuture.callback != null)
-                policyTaskFuture.callback.onEnd(policyTaskFuture.task, policyTaskFuture, null, true, 0, x);
+            policyTaskFuture.abort(x);
             throw x;
         }
         return enqueued;
@@ -934,8 +930,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             } else {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(this, tc, "Cancel task due to policy executor state " + state);
-                future.cancel(false);
                 future.nsRunEnd = System.nanoTime();
+                future.cancel(false);
                 if (future.callback != null)
                     future.callback.onEnd(future.task, future, null, true, 0, null); // aborted, queued task will never run
             }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/FailingCallback.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/FailingCallback.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import com.ibm.ws.threading.PolicyTaskFuture;
+
+/**
+ * Callback that intentionally raises RuntimeException subclasses.
+ */
+public class FailingCallback extends ParameterInfoCallback {
+    public final Class<?>[] failureClass = new Class<?>[NUM_CALLBACKS];
+
+    private RuntimeException newRuntimeException(Class<?> c) {
+        try {
+            return (RuntimeException) failureClass[START].newInstance();
+        } catch (IllegalAccessException x) {
+            return new RuntimeException(x);
+        } catch (InstantiationException x) {
+            return new RuntimeException(x);
+        }
+    }
+
+    @Override
+    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {
+        super.onCancel(task, future, timedOut, whileRunning);
+        if (failureClass[CANCEL] != null)
+            throw newRuntimeException(failureClass[CANCEL]);
+    }
+
+    @Override
+    public void onEnd(Object task, PolicyTaskFuture<?> future, Object startObj, boolean aborted, int pending, Throwable failure) {
+        super.onEnd(task, future, startObj, aborted, pending, failure);
+        if (failureClass[END] != null)
+            throw newRuntimeException(failureClass[END]);
+    }
+
+    @Override
+    public Object onStart(Object task, PolicyTaskFuture<?> future) {
+        Object o = super.onStart(task, future);
+        if (failureClass[START] != null)
+            throw newRuntimeException(failureClass[START]);
+        return o;
+    }
+
+    @Override
+    public void onSubmit(Object task, PolicyTaskFuture<?> future, int invokeAnyCount) {
+        super.onSubmit(task, future, invokeAnyCount);
+        if (failureClass[SUBMIT] != null)
+            throw newRuntimeException(failureClass[SUBMIT]);
+    }
+}


### PR DESCRIPTION
Minor adjustments to when timestamps are recorded for tracking elapsed time so that callbacks can experience more consistent results for the getElapsed*Time methods.
Additions to existing test cases to validate getElapsed*Time methods.
New test case and infrastructure class for causing a failure during onSubmit and validating the behavior of getElapsed*Time on this path for a single task submit (multiple submit will be covered in separate pull).
Updates to support the possibility of onSubmit callback failing, sending it through the same abort processing used elsewhere.