### PR TITLE
Elapsed queue time for tasks that run on submitter and onSubmit failure with a group of tasks

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -168,11 +168,18 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
         // notify listener: taskStarting
         if (task instanceof ManagedTask) {
             ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
-            if (listener != null) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
-                    Tr.event(this, tc, "taskStarting", managedExecutor, task);
-                listener.taskStarting(future, managedExecutor, task);
-            }
+            if (listener != null)
+                try {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                        Tr.event(this, tc, "taskStarting", managedExecutor, task);
+                    listener.taskStarting(future, managedExecutor, task);
+                } catch (Error x) {
+                    threadContextDescriptor.taskStopping(contextAppliedToThread);
+                    throw x;
+                } catch (RuntimeException x) {
+                    threadContextDescriptor.taskStopping(contextAppliedToThread);
+                    throw x;
+                }
         }
 
         return contextAppliedToThread;

--- a/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -34,6 +35,7 @@ import javax.annotation.Resource;
 import javax.enterprise.concurrent.AbortedException;
 import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.naming.NamingException;
 import javax.servlet.annotation.WebServlet;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
@@ -41,6 +43,7 @@ import javax.transaction.UserTransaction;
 import org.junit.After;
 import org.junit.Test;
 
+import componenttest.annotation.ExpectedFFDC;
 import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
@@ -51,6 +54,8 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
 
     // Constants for ManagedTaskListener events, to be used as array indices
     static final int SUBMITTED = 0, ABORTED = 1, STARTING = 2, DONE = 3;
+
+    static final int MIGHT_START = -1, NOT_STARTED = 0, STARTED = 1;
 
     // Futures to cancel between tests, to reduce the chance of failures in one test method interfering with others
     private final Set<Future<?>> cancelAfterTest = Collections.newSetFromMap(new ConcurrentHashMap<Future<?>, Boolean>());
@@ -78,6 +83,73 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
     private TransactionSynchronizationRegistry tranSyncRegistry;
 
     /**
+     * Utility method to validate information recorded by TaskListener for a task that is canceled.
+     */
+    private void assertCanceled(ManagedExecutorService executor, Future<?> future, Object task, TaskListener listener, int expectStart) throws Exception {
+        assertTrue(listener.latch[SUBMITTED].await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        if (future == null)
+            future = listener.future[SUBMITTED];
+        else
+            assertEquals(future, listener.future[SUBMITTED]);
+        assertNotNull(future);
+        assertEquals(executor, listener.executor[SUBMITTED]);
+        assertEquals(task, listener.task[SUBMITTED]);
+        assertFalse(listener.isCancelled[SUBMITTED]);
+        assertFalse(listener.isDone[SUBMITTED]);
+        if (listener.failure[SUBMITTED] != null)
+            throw new Exception("Unexpected failure, see cause", listener.failure[SUBMITTED]);
+
+        assertTrue(listener.latch[ABORTED].await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(future, listener.future[ABORTED]);
+        assertEquals(executor, listener.executor[ABORTED]);
+        assertEquals(task, listener.task[ABORTED]);
+        assertNotNull(listener.exception[ABORTED]);
+        if (!(listener.exception[ABORTED] instanceof CancellationException))
+            throw new Exception("Unexpected exception for taskAborted, see cause", listener.exception[ABORTED]);
+        assertTrue(listener.isCancelled[ABORTED]);
+        assertTrue(listener.isDone[ABORTED]);
+
+        if (listener.doGet[ABORTED]) {
+            Throwable failure = listener.failure[ABORTED];
+            if (!(failure instanceof CancellationException))
+                throw new Exception("Unexpected or missing failure. See chained exceptions", failure);
+        } else {
+            if (listener.failure[ABORTED] != null)
+                throw new Exception("Unexpected failure, see cause", listener.failure[ABORTED]);
+        }
+
+        assertTrue(listener.latch[DONE].await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(future, listener.future[DONE]);
+        assertEquals(executor, listener.executor[DONE]);
+        assertEquals(task, listener.task[DONE]);
+        assertNull(listener.exception[DONE]);
+        assertTrue(listener.isCancelled[DONE]);
+        assertTrue(listener.isDone[DONE]);
+
+        if (listener.doGet[DONE]) {
+            Throwable failure = listener.failure[DONE];
+            if (!(failure instanceof CancellationException))
+                throw new Exception("Unexpected or missing failure. See chained exceptions", failure);
+        } else {
+            if (listener.failure[DONE] != null)
+                throw new Exception("Unexpected failure, see cause", listener.failure[DONE]);
+        }
+
+        if (expectStart == NOT_STARTED)
+            assertFalse(listener.invoked[STARTING]);
+        else if (expectStart == STARTED || expectStart == MIGHT_START && listener.latch[STARTING].getCount() == 0) {
+            assertTrue(listener.latch[STARTING].await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+            assertEquals(future, listener.future[STARTING]);
+            assertEquals(executor, listener.executor[STARTING]);
+            assertEquals(task, listener.task[STARTING]);
+            assertFalse(listener.isCancelled[STARTING]);
+            assertFalse(listener.isDone[STARTING]);
+            if (listener.failure[STARTING] != null)
+                throw new Exception("Unexpected failure, see cause", listener.failure[STARTING]);
+        }
+    }
+
+    /**
      * Utility method to validate information recorded by TaskListener for a task that aborts and is rejected upon submit.
      */
     private void assertRejected(ManagedExecutorService executor, Object task, TaskListener listener, Class<? extends Throwable> causeClass,
@@ -103,7 +175,7 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
             assertNull(listener.exception[ABORTED].getCause());
         else {
             Throwable cause = listener.exception[ABORTED].getCause();
-            if (cause == null || !causeClass.isAssignableFrom(cause.getClass()) ||
+            if (cause == null || !causeClass.equals(cause.getClass()) ||
                 causeMessagePrefix != null && (cause.getMessage() == null || !cause.getMessage().startsWith(causeMessagePrefix)))
                 throw new Exception("Unexpected or missing cause of AbortedException. See chained exceptions", listener.exception[ABORTED]);
         }
@@ -115,7 +187,7 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
             if (!(failure instanceof AbortedException))
                 throw new Exception("Unexpected or missing failure. See chained exceptions", failure);
             Throwable cause = failure.getCause();
-            if (cause == null || !causeClass.isAssignableFrom(cause.getClass()) ||
+            if (cause == null || !causeClass.equals(cause.getClass()) ||
                 causeMessagePrefix != null && (cause.getMessage() == null || !cause.getMessage().startsWith(causeMessagePrefix)))
                 throw new Exception("Unexpected or missing cause of AbortedException. See chained exceptions", failure);
         } else {
@@ -138,7 +210,7 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
             if (!(failure instanceof AbortedException))
                 throw new Exception("Unexpected or missing failure. See chained exceptions", failure);
             Throwable cause = failure.getCause();
-            if (cause == null || !causeClass.isAssignableFrom(cause.getClass()) ||
+            if (cause == null || !causeClass.equals(cause.getClass()) ||
                 causeMessagePrefix != null && (cause.getMessage() == null || !cause.getMessage().startsWith(causeMessagePrefix)))
                 throw new Exception("Unexpected or missing cause of AbortedException. See chained exceptions", failure);
         } else {
@@ -207,6 +279,27 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
         }
         if (count > 0)
             System.out.println("Canceled " + count + " futures after previous test");
+    }
+
+    /**
+     * Utility method to reflectively invoke internal method getElapsedAcceptTime on a Future
+     */
+    private static long getElapsedAcceptTime(Future<?> f, TimeUnit unit) throws Exception {
+        return (Long) f.getClass().getMethod("getElapsedAcceptTime", TimeUnit.class).invoke(f, unit);
+    }
+
+    /**
+     * Utility method to reflectively invoke internal method getElapsedQueueTime on a Future
+     */
+    private static long getElapsedQueueTime(Future<?> f, TimeUnit unit) throws Exception {
+        return (Long) f.getClass().getMethod("getElapsedQueueTime", TimeUnit.class).invoke(f, unit);
+    }
+
+    /**
+     * Utility method to reflectively invoke internal method getElapsedRunTime on a Future
+     */
+    private static long getElapsedRunTime(Future<?> f, TimeUnit unit) throws Exception {
+        return (Long) f.getClass().getMethod("getElapsedRunTime", TimeUnit.class).invoke(f, unit);
     }
 
     /**
@@ -298,6 +391,53 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
 
         cancelAfterTest.remove(blockerTaskFuture);
         assertTrue(blockerTaskFuture.cancel(true));
+    }
+
+    /**
+     * Attempt to submit 2 tasks via invokeAll where the second task's ManagedTaskListener fails during taskSubmitted
+     * (force a NamingException by looking up an invalid name). Expect the first task, although submitted, to be canceled
+     * when invokeAll is rejected.
+     */
+    @ExpectedFFDC("java.lang.RuntimeException")
+    @Test
+    public void testFailInvokeAllOnSecondSubmit() throws Exception {
+        TaskListener listener0 = new TaskListener();
+        TaskListener listener1 = new TaskListener().doLookup("concurrent/DoesNotExist", SUBMITTED).doRethrow(true, SUBMITTED);
+        List<CountingTask> tasks = Arrays.asList(new CountingTask(null, listener0, null, null),
+                                                 new CountingTask(null, listener1, null, null));
+
+        try {
+            List<Future<Integer>> futures = scheduledExecutor2.invokeAll(tasks, TIMEOUT_NS, TimeUnit.NANOSECONDS);
+            fail("Should not be able to submit a group of tasks when one fails taskSubmitted. " + futures);
+        } catch (RuntimeException x) {
+            if (!RuntimeException.class.equals(x.getClass()) // exactly match what the ManagedTaskListener raises
+                || !(x.getCause() instanceof NamingException))
+                throw new Exception("Missing or unexpected cause or chained exception, see chained exceptions", x);
+        }
+
+        // First task submits successfully but is canceled before it starts.
+        assertCanceled(scheduledExecutor2, null, tasks.get(0), listener0, NOT_STARTED);
+
+        // Second task fails to submit and is immediately aborted.
+        listener1.failure[SUBMITTED] = null; // failure on submit intentional, suppress to avoid issue during validation
+        assertRejected(scheduledExecutor2, tasks.get(1), listener1, RuntimeException.class, "javax.naming.NameNotFoundException: concurrent/DoesNotExist");
+
+        // invokeAll doesn't return, but we can access the Futures from the ManagedTaskListeners
+        Future<?> future0 = listener0.future[SUBMITTED];
+        Future<?> future1 = listener1.future[SUBMITTED];
+
+        long time;
+
+        assertTrue((time = getElapsedAcceptTime(future0, TimeUnit.NANOSECONDS)) + "ns", time >= 0);
+        assertEquals(time, getElapsedAcceptTime(future0, TimeUnit.NANOSECONDS));
+        assertTrue((time = getElapsedQueueTime(future0, TimeUnit.NANOSECONDS)) + "ns", time >= 0);
+        assertEquals(time, getElapsedQueueTime(future0, TimeUnit.NANOSECONDS));
+        assertEquals(0, getElapsedRunTime(future0, TimeUnit.NANOSECONDS));
+
+        assertTrue((time = getElapsedAcceptTime(future1, TimeUnit.NANOSECONDS)) + "ns", time >= 0);
+        assertEquals(time, getElapsedAcceptTime(future1, TimeUnit.NANOSECONDS));
+        assertEquals(0, getElapsedQueueTime(future1, TimeUnit.NANOSECONDS));
+        assertEquals(0, getElapsedRunTime(future1, TimeUnit.NANOSECONDS));
     }
 
     /**

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskFuture.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskFuture.java
@@ -28,6 +28,7 @@ public interface PolicyTaskFuture<T> extends Future<T> {
      * if the onSubmit callback cancels it. Note that accepts for multiple tasks can overlap, especially if the
      * invokeAll/invokeAny methods are used to submit groups of tasks. The value returned is an estimate.
      * No guarantee is made that the same exact value will be returned for subsequent invocations.
+     * The computed value is based on nanosecond timestamps and is therefore not valid for intervals larger than 292 years.
      *
      * @param unit time unit.
      * @return interval of time in the requested unit.
@@ -38,6 +39,7 @@ public interface PolicyTaskFuture<T> extends Future<T> {
      * Computes the estimated duration of time that the task spends in the queue awaiting execution.
      * A small positive interval can be returned even if the task bypasses the queue and runs on the submitter's thread.
      * The value returned is an estimate. No guarantee is made that the same exact value will be returned for subsequent invocations.
+     * The computed value is based on nanosecond timestamps and is therefore not valid for intervals larger than 292 years.
      *
      * @param unit time unit.
      * @return duration of time in the requested unit.
@@ -49,6 +51,7 @@ public interface PolicyTaskFuture<T> extends Future<T> {
      * This includes the processing of the onStart callback. A positive interval can be computed even if the task does
      * end up executing, for example, if the onStart callback cancels it. The value returned is an estimate.
      * No guarantee is made that the same exact value will be returned for subsequent invocations.
+     * The computed value is based on nanosecond timestamps and is therefore not valid for intervals larger than 292 years.
      *
      * @param unit time unit.
      * @return interval of time in the requested unit.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -424,26 +424,22 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         } catch (InterruptedException x) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "enqueue", x);
-            if (policyTaskFuture.abort(x) && policyTaskFuture.callback != null)
-                policyTaskFuture.callback.onEnd(policyTaskFuture.task, policyTaskFuture, null, true, 0, x);
+            policyTaskFuture.abort(x);
             throw new RejectedExecutionException(x);
         } catch (RejectedExecutionException x) { // redundant with RuntimeException code path, but added to allow FFDCIgnore
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "enqueue", x);
-            if (policyTaskFuture.abort(x) && policyTaskFuture.callback != null)
-                policyTaskFuture.callback.onEnd(policyTaskFuture.task, policyTaskFuture, null, true, 0, x);
+            policyTaskFuture.abort(x);
             throw x;
         } catch (RuntimeException x) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "enqueue", x);
-            if (policyTaskFuture.abort(x) && policyTaskFuture.callback != null)
-                policyTaskFuture.callback.onEnd(policyTaskFuture.task, policyTaskFuture, null, true, 0, x);
+            policyTaskFuture.abort(x);
             throw x;
         } catch (Error x) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "enqueue", x);
-            if (policyTaskFuture.abort(x) && policyTaskFuture.callback != null)
-                policyTaskFuture.callback.onEnd(policyTaskFuture.task, policyTaskFuture, null, true, 0, x);
+            policyTaskFuture.abort(x);
             throw x;
         }
         return enqueued;
@@ -934,8 +930,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             } else {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(this, tc, "Cancel task due to policy executor state " + state);
-                future.cancel(false);
                 future.nsRunEnd = System.nanoTime();
+                future.cancel(false);
                 if (future.callback != null)
                     future.callback.onEnd(future.task, future, null, true, 0, null); // aborted, queued task will never run
             }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/FailingCallback.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/FailingCallback.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import com.ibm.ws.threading.PolicyTaskFuture;
+
+/**
+ * Callback that intentionally raises RuntimeException subclasses.
+ */
+public class FailingCallback extends ParameterInfoCallback {
+    public final Class<?>[] failureClass = new Class<?>[NUM_CALLBACKS];
+
+    private RuntimeException newRuntimeException(Class<?> c) {
+        try {
+            return (RuntimeException) failureClass[START].newInstance();
+        } catch (IllegalAccessException x) {
+            return new RuntimeException(x);
+        } catch (InstantiationException x) {
+            return new RuntimeException(x);
+        }
+    }
+
+    @Override
+    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {
+        super.onCancel(task, future, timedOut, whileRunning);
+        if (failureClass[CANCEL] != null)
+            throw newRuntimeException(failureClass[CANCEL]);
+    }
+
+    @Override
+    public void onEnd(Object task, PolicyTaskFuture<?> future, Object startObj, boolean aborted, int pending, Throwable failure) {
+        super.onEnd(task, future, startObj, aborted, pending, failure);
+        if (failureClass[END] != null)
+            throw newRuntimeException(failureClass[END]);
+    }
+
+    @Override
+    public Object onStart(Object task, PolicyTaskFuture<?> future) {
+        Object o = super.onStart(task, future);
+        if (failureClass[START] != null)
+            throw newRuntimeException(failureClass[START]);
+        return o;
+    }
+
+    @Override
+    public void onSubmit(Object task, PolicyTaskFuture<?> future, int invokeAnyCount) {
+        super.onSubmit(task, future, invokeAnyCount);
+        if (failureClass[SUBMIT] != null)
+            throw newRuntimeException(failureClass[SUBMIT]);
+    }
+}

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -2112,7 +2112,7 @@ public class PolicyExecutorServlet extends FATServlet {
     @Test
     public void testInvokeAllAbortIgnoredWhenConcurrencyUnlimited() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllAbortIgnoredWhenConcurrencyUnlimited")
-                        .maxConcurrencyAppliesToCallerThread(true)
+                        .maxConcurrencyAppliesToCallerThread(false)
                         .maxQueueSize(1)
                         .runIfQueueFull(false);
 
@@ -2133,6 +2133,15 @@ public class PolicyExecutorServlet extends FATServlet {
         }
 
         assertEquals(15, sum);
+
+        // Elapsed time for task that runs on current thread
+        PolicyTaskFuture<Integer> future = (PolicyTaskFuture<Integer>) futures.get(4);
+        long time;
+        assertTrue((time = future.getElapsedAcceptTime(TimeUnit.NANOSECONDS)) + "ns", time >= 0);
+        assertEquals(time, future.getElapsedAcceptTime(TimeUnit.NANOSECONDS)); // consistent value when repeated
+        assertEquals(0, future.getElapsedQueueTime(TimeUnit.NANOSECONDS));
+        assertTrue((time = future.getElapsedRunTime(TimeUnit.NANOSECONDS)) + "ns", time >= 0);
+        assertEquals(time, future.getElapsedRunTime(TimeUnit.NANOSECONDS)); // consistent value when repeated
 
         List<Runnable> canceledFromQueue = executor.shutdownNow();
         assertEquals(0, canceledFromQueue.size());


### PR DESCRIPTION
This pull covers both of the following scenarios:
Elapsed queue time measurement needs to be 0 when the task isn't actually queued.
Also, when a group of tasks is submitted via invokeAll and one of the task submissions fails during onSubmit, the elapsed time for accept/queue/run should reflect that all tasks have aborted/canceled.