### PR TITLE
Skip building FATs for standard top-level build

### DIFF
--- a/dev/cnf/gradle/scripts/fat.gradle
+++ b/dev/cnf/gradle/scripts/fat.gradle
@@ -296,15 +296,39 @@ task runfat(type: Exec) {
   }
 }
 
+def buildFatEnabled = true; // TODO set this to false once build machines have been updated
+gradle.startParameter.taskNames.each {
+	if(it.contains("fat")) {
+		buildFatEnabled = true;
+	}
+}
+
 compileJava {
   dependsOn cleanFat
 }
 
 assemble {
   dependsOn zipProjectFVT
+  // Skip out on 'assemble' unless top-level gradle invocation contains "fat"
+  if(!buildFatEnabled) {
+    enabled = false;
+    dependsOn = [];
+  }
+}
+
+build {
+  // Skip out on 'assemble' unless top-level gradle invocation contains "fat"
+  if(!buildFatEnabled) {
+    enabled = false;
+    dependsOn = [];
+  }
+}
+
+task buildfat {
+  dependsOn build
 }
 
 task buildandrun {
-  dependsOn build
+  dependsOn buildfat
   dependsOn runfat
 }


### PR DESCRIPTION
Normally to build the product the top level command invoked is something
like './gradlew build' or './gradlew assemble', which will build all
product code and all FAT projects.  As the amount of FAT projects
increase, we do not want to waste time building each FAT for standard
developer builds, and instead only build them when we want to run a FAT.