### PR TITLE
Sse holdup server shutdown

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/component/LibertySseFeature.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/component/LibertySseFeature.java
@@ -10,48 +10,31 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs20.component;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
-import org.apache.cxf.Bus;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
-import org.apache.cxf.feature.Feature;
-import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
 import org.apache.cxf.jaxrs.sse.SseContextProvider;
 import org.osgi.service.component.annotations.Component;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jaxrs20.providers.api.JaxRsProviderRegister;
 import com.ibm.ws.jaxrs21.sse.LibertySseEventSinkContextProvider;
 
 /**
- * This feature is a DS service, allowing it to be auto registered via
- * the JaxRsWebEndpointConfigurator. It extends CXF's SseFeature, but
- * also provides additional configuration that is more specific to
- * Liberty.
+ * This class registers the SSE providers - specifically the
+ * <code>LibertySseEventSinkContextProvider</code> and
+ * <code>SseContextProvider</code>.
  */
 @Component(immediate = true)
-public class LibertySseFeature extends AbstractFeature implements Feature {
-    @SuppressWarnings("unused")
-    private final static TraceComponent tc = Tr.register(LibertySseFeature.class);
-
-    public LibertySseFeature() {
-        super();
-    }
+public class LibertySseFeature implements JaxRsProviderRegister {
 
     /* (non-Javadoc)
-     * @see org.apache.cxf.feature.Feature#initialize(org.apache.cxf.endpoint.Server, org.apache.cxf.Bus)
+     * @see com.ibm.ws.jaxrs20.providers.api.JaxRsProviderRegister#installProvider(boolean, java.util.List, java.util.Set)
      */
     @Override
-    public void initialize(Server server, Bus bus) {
-        List<Object> providers = new ArrayList<>();
-
-        providers.add(new LibertySseEventSinkContextProvider());
-        providers.add(new SseContextProvider());
-
-        ((ServerProviderFactory)server.getEndpoint().get(ServerProviderFactory.class
-                                                         .getName())).setUserProviders(providers);
+    public void installProvider(boolean clientSide, List<Object> providers, Set<String> features) {
+        if (!clientSide) {
+            providers.add(new LibertySseEventSinkContextProvider());
+            providers.add(new SseContextProvider());
+        }
     }
-
 }

--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs21/sse/LibertySseEventSinkImpl.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs21/sse/LibertySseEventSinkImpl.java
@@ -40,6 +40,7 @@ public class LibertySseEventSinkImpl implements SseEventSink {
     private final MessageBodyWriter<OutboundSseEvent> writer;
     private final Message message;
     private final HttpServletResponse response;
+    private volatile boolean closed;
 
     public LibertySseEventSinkImpl(MessageBodyWriter<OutboundSseEvent> writer, Message message) {
         this.writer = writer;
@@ -49,7 +50,6 @@ public class LibertySseEventSinkImpl implements SseEventSink {
         message.getExchange().put(JAXRSUtils.IGNORE_MESSAGE_WRITERS, "true");
     }
 
-    private volatile boolean closed;
     /* (non-Javadoc)
      * @see javax.ws.rs.sse.SseEventSink#close()
      */

--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs21/sse/LibertySseEventSinkImpl.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs21/sse/LibertySseEventSinkImpl.java
@@ -16,6 +16,7 @@ import java.lang.annotation.Annotation;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -26,6 +27,7 @@ import javax.ws.rs.sse.SseEventSink;
 import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 import org.apache.cxf.message.Message;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -59,7 +61,11 @@ public class LibertySseEventSinkImpl implements SseEventSink {
             closed = true;
             try {
                 response.getOutputStream().close();
-            } catch (IOException ex) {
+                HttpServletRequest req = (HttpServletRequest) message.get(AbstractHTTPDestination.HTTP_REQUEST);
+                if (req != null) {
+                    req.getAsyncContext().complete();
+                }
+            } catch (Exception ex) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "Failed to close response stream", ex);
                 }

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BasicSseTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BasicSseTest.java
@@ -12,7 +12,6 @@ package com.ibm.ws.jaxrs21.sse.fat;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,13 +53,7 @@ public class BasicSseTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKE1102W");
-    }
-
-    @After
-    public void after() throws Exception {
-        //sleep to give connections time to clean up???
-        Thread.sleep(5000);
+        server.stopServer();
     }
 
     @Test

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/SseJsonbTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/SseJsonbTest.java
@@ -12,7 +12,6 @@ package com.ibm.ws.jaxrs21.sse.fat;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,13 +53,7 @@ public class SseJsonbTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKE1102W");
-    }
-
-    @After
-    public void after() throws Exception {
-        //sleep to give connections time to clean up???
-        Thread.sleep(5000);
+        server.stopServer();
     }
 
     @Test


### PR DESCRIPTION
Resolves Issue #623 

The SSE implementation was starting an AsyncContext but not completing it - this left the channel framework thinking there was active work still occurring long after the SSE sink had been closed.  This fix ensures that the AsyncContext is closed.