### PR TITLE
Cache buses based on module

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/bnd.bnd
@@ -55,6 +55,7 @@ instrument.classesExcludes: com/ibm/ws/jaxrs20/client/internal/resources/*.class
 	com.ibm.ws.artifact;version=latest,\
 	com.ibm.ws.artifact.overlay;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
+	com.ibm.ws.container.service.compat;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.webcontainer.security;version=latest,\
 	com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\


### PR DESCRIPTION
Currently we cache buses per client. This only improves performance if
the same Client makes repeated calls to the same target. This change
allows all Clients in the same module to benefit from targets created by
other Clients in the same module. It also will only clear the cache of
entries from the same module when all Clients in that module are closed
 - so we don't flush the whole cache when we know there are other 
Clients who could use the cache.
one client is closed.