### PR TITLE
New JPA 2.2 Fats

### DIFF
--- a/dev/com.ibm.ws.jpa_22_fat/.classpath
+++ b/dev/com.ibm.ws.jpa_22_fat/.classpath
@@ -4,6 +4,7 @@
 	<classpathentry kind="src" path="test-applications/jpa21bootstrap/src"/>
 	<classpathentry kind="src" path="test-applications/jpa22bootstrap/src"/>
 	<classpathentry kind="src" path="test-applications/cdi/src"/>
+	<classpathentry kind="src" path="test-applications/jpa22query/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jpa_22_fat/.classpath
+++ b/dev/com.ibm.ws.jpa_22_fat/.classpath
@@ -5,6 +5,7 @@
 	<classpathentry kind="src" path="test-applications/jpa22bootstrap/src"/>
 	<classpathentry kind="src" path="test-applications/cdi/src"/>
 	<classpathentry kind="src" path="test-applications/jpa22query/src"/>
+	<classpathentry kind="src" path="test-applications/jpa22timeapi/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jpa_22_fat/.classpath
+++ b/dev/com.ibm.ws.jpa_22_fat/.classpath
@@ -6,6 +6,7 @@
 	<classpathentry kind="src" path="test-applications/cdi/src"/>
 	<classpathentry kind="src" path="test-applications/jpa22query/src"/>
 	<classpathentry kind="src" path="test-applications/jpa22timeapi/src"/>
+	<classpathentry kind="src" path="test-applications/jpa22injection/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
@@ -18,7 +18,8 @@ src: \
 	fat/src,\
 	test-applications/cdi/src,\
 	test-applications/jpa21bootstrap/src,\
-	test-applications/jpa22bootstrap/src
+	test-applications/jpa22bootstrap/src,\
+	test-applications/jpa22query/src
 
 test.project: true
 

--- a/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
@@ -19,6 +19,7 @@ src: \
 	test-applications/cdi/src,\
 	test-applications/jpa21bootstrap/src,\
 	test-applications/jpa22bootstrap/src,\
+	test-applications/jpa22injection/src,\
 	test-applications/jpa22query/src,\
 	test-applications/jpa22timeapi
 

--- a/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
@@ -19,7 +19,8 @@ src: \
 	test-applications/cdi/src,\
 	test-applications/jpa21bootstrap/src,\
 	test-applications/jpa22bootstrap/src,\
-	test-applications/jpa22query/src
+	test-applications/jpa22query/src,\
+	test-applications/jpa22timeapi
 
 test.project: true
 

--- a/dev/com.ibm.ws.jpa_22_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa_22_fat/build.gradle
@@ -16,6 +16,7 @@ addRequiredLibraries {
     def server21Dir = "${buildDir}/autoFVT/publish/servers/JPA21FATServer"
     def server22Dir = "${buildDir}/autoFVT/publish/servers/JPA22FATServer"
     def cdiServerDir = "${buildDir}/autoFVT/publish/servers/CDIFatServer"
+    def server22InjectionDir = "${buildDir}/autoFVT/publish/servers/JPA22InjectionServer"
     def server22QueryDir = "${buildDir}/autoFVT/publish/servers/JPA22QueryServer"
     def server22TimeAPIDir = "${buildDir}/autoFVT/publish/servers/JPA22TimeAPIServer"
 
@@ -47,6 +48,10 @@ addRequiredLibraries {
     copy {
       from configurations.derby
       into server22TimeAPIDir + "/derby"
+    }
+    copy {
+      from configurations.derby
+      into server22InjectionDir + "/derby"
     }
   }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa_22_fat/build.gradle
@@ -13,13 +13,8 @@ apply from: '../cnf/gradle/scripts/fat.gradle'
 // Example of pulling down binary dependencies from Artifactory
 addRequiredLibraries {
   doLast {
-    def server21Dir = "${buildDir}/autoFVT/publish/servers/JPA21FATServer"
-    def server22Dir = "${buildDir}/autoFVT/publish/servers/JPA22FATServer"
-    def cdiServerDir = "${buildDir}/autoFVT/publish/servers/CDIFatServer"
-    def server22InjectionDir = "${buildDir}/autoFVT/publish/servers/JPA22InjectionServer"
-    def server22QueryDir = "${buildDir}/autoFVT/publish/servers/JPA22QueryServer"
-    def server22TimeAPIDir = "${buildDir}/autoFVT/publish/servers/JPA22TimeAPIServer"
-
+    def sharedResources = "${buildDir}/autoFVT/publish/shared/resources"
+ 
     // Define dependency groups
     configurations {
       derby
@@ -29,29 +24,11 @@ addRequiredLibraries {
       derby 'org.apache.derby:derby:10.11.1.1'
     }
     // Copy the dependencies wherever they may be needed
+    
+    // Copy Derby
     copy {
       from configurations.derby
-      into server22Dir + "/derby"
-    }
-    copy {
-      from configurations.derby
-      into server21Dir + "/derby"
-    }
-    copy {
-      from configurations.derby
-      into cdiServerDir + "/derby"
-    }
-    copy {
-      from configurations.derby
-      into server22QueryDir + "/derby"
-    }
-    copy {
-      from configurations.derby
-      into server22TimeAPIDir + "/derby"
-    }
-    copy {
-      from configurations.derby
-      into server22InjectionDir + "/derby"
+      into sharedResources + "/derby"
     }
   }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa_22_fat/build.gradle
@@ -17,6 +17,7 @@ addRequiredLibraries {
     def server22Dir = "${buildDir}/autoFVT/publish/servers/JPA22FATServer"
     def cdiServerDir = "${buildDir}/autoFVT/publish/servers/CDIFatServer"
     def server22QueryDir = "${buildDir}/autoFVT/publish/servers/JPA22QueryServer"
+    def server22TimeAPIDir = "${buildDir}/autoFVT/publish/servers/JPA22TimeAPIServer"
 
     // Define dependency groups
     configurations {
@@ -42,6 +43,10 @@ addRequiredLibraries {
     copy {
       from configurations.derby
       into server22QueryDir + "/derby"
+    }
+    copy {
+      from configurations.derby
+      into server22TimeAPIDir + "/derby"
     }
   }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa_22_fat/build.gradle
@@ -9,14 +9,15 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 apply from: '../cnf/gradle/scripts/fat.gradle'
-	
+
 // Example of pulling down binary dependencies from Artifactory
 addRequiredLibraries {
   doLast {
     def server21Dir = "${buildDir}/autoFVT/publish/servers/JPA21FATServer"
     def server22Dir = "${buildDir}/autoFVT/publish/servers/JPA22FATServer"
     def cdiServerDir = "${buildDir}/autoFVT/publish/servers/CDIFatServer"
-    
+    def server22QueryDir = "${buildDir}/autoFVT/publish/servers/JPA22QueryServer"
+
     // Define dependency groups
     configurations {
       derby
@@ -38,6 +39,9 @@ addRequiredLibraries {
       from configurations.derby
       into cdiServerDir + "/derby"
     }
+    copy {
+      from configurations.derby
+      into server22QueryDir + "/derby"
+    }
   }
 }
-	

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -18,7 +18,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
                 JPA21BootstrapTest.class,
                 JPA22BootstrapTest.class,
-                JPAELInjectionFATTest.class,
+                JPACDIIntegrationTest.class,
                 JPA22QueryTest.class,
                 JPA22Injection.class,
                 JPA22TimeAPITest.class

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -19,7 +19,9 @@ import org.junit.runners.Suite.SuiteClasses;
                 JPA21BootstrapTest.class,
                 JPA22BootstrapTest.class,
                 JPAELInjectionFATTest.class,
-                JPA22QueryTest.class
+                JPA22QueryTest.class,
+                JPA22QueryTest.class,
+                JPA22TimeAPITest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -20,7 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 JPA22BootstrapTest.class,
                 JPAELInjectionFATTest.class,
                 JPA22QueryTest.class,
-                JPA22QueryTest.class,
+                JPA22Injection.class,
                 JPA22TimeAPITest.class
 })
 public class FATSuite {

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -18,7 +18,8 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
                 JPA21BootstrapTest.class,
                 JPA22BootstrapTest.class,
-                JPAELInjectionFATTest.class
+                JPAELInjectionFATTest.class,
+                JPA22QueryTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22Injection.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22Injection.java
@@ -1,0 +1,35 @@
+package com.ibm.ws.jpa;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import jpa22injection.web.JPAInjectionTestServlet;
+
+@RunWith(FATRunner.class)
+public class JPA22Injection extends FATServletClient {
+	public static final String APP_NAME = "jpa22injection";
+    public static final String SERVLET = "TestJPA22Injection";
+    
+    @Server("JPA22InjectionServer")
+    @TestServlet(servlet = JPAInjectionTestServlet.class, path = APP_NAME + "/" + SERVLET)
+    public static LibertyServer server1;
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+    		ShrinkHelper.defaultApp(server1, APP_NAME, "jpa22injection.web", "jpa22injection.entity");
+    		server1.startServer();
+    }
+    
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server1.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22Injection.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22Injection.java
@@ -15,21 +15,21 @@ import jpa22injection.web.JPAInjectionTestServlet;
 
 @RunWith(FATRunner.class)
 public class JPA22Injection extends FATServletClient {
-	public static final String APP_NAME = "jpa22injection";
+    public static final String APP_NAME = "jpa22injection";
     public static final String SERVLET = "TestJPA22Injection";
-    
+
     @Server("JPA22InjectionServer")
     @TestServlet(servlet = JPAInjectionTestServlet.class, path = APP_NAME + "/" + SERVLET)
     public static LibertyServer server1;
-    
+
     @BeforeClass
     public static void setUp() throws Exception {
-    		ShrinkHelper.defaultApp(server1, APP_NAME, "jpa22injection.web", "jpa22injection.entity");
-    		server1.startServer();
+        ShrinkHelper.defaultApp(server1, APP_NAME, "jpa22injection.web", "jpa22injection.entity");
+        server1.startServer();
     }
-    
+
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.stopServer();
+        server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22QueryTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22QueryTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import jpa22query.web.JPAQueryTestServlet;
+
+@RunWith(FATRunner.class)
+public class JPA22QueryTest extends FATServletClient {
+	public static final String APP_NAME = "jpa22query";
+    public static final String SERVLET = "TestJPA22Query";
+    
+    @Server("JPA22QueryServer")
+    @TestServlet(servlet = JPAQueryTestServlet.class, path = APP_NAME + "/" + SERVLET)
+    public static LibertyServer server1;
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+    		ShrinkHelper.defaultApp(server1, APP_NAME, "jpa22query.web", "jpa22query.entity");
+    		server1.startServer();
+    }
+    
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server1.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22QueryTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22QueryTest.java
@@ -26,21 +26,21 @@ import jpa22query.web.JPAQueryTestServlet;
 
 @RunWith(FATRunner.class)
 public class JPA22QueryTest extends FATServletClient {
-	public static final String APP_NAME = "jpa22query";
+    public static final String APP_NAME = "jpa22query";
     public static final String SERVLET = "TestJPA22Query";
-    
+
     @Server("JPA22QueryServer")
     @TestServlet(servlet = JPAQueryTestServlet.class, path = APP_NAME + "/" + SERVLET)
     public static LibertyServer server1;
-    
+
     @BeforeClass
     public static void setUp() throws Exception {
-    		ShrinkHelper.defaultApp(server1, APP_NAME, "jpa22query.web", "jpa22query.entity");
-    		server1.startServer();
+        ShrinkHelper.defaultApp(server1, APP_NAME, "jpa22query.web", "jpa22query.entity");
+        server1.startServer();
     }
-    
+
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.stopServer();
+        server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22TimeAPITest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22TimeAPITest.java
@@ -26,21 +26,21 @@ import jpa22timeapi.web.JPATimeAPITestServlet;
 
 @RunWith(FATRunner.class)
 public class JPA22TimeAPITest extends FATServletClient {
-	public static final String APP_NAME = "jpa22timeapi";
+    public static final String APP_NAME = "jpa22timeapi";
     public static final String SERVLET = "TestJPAAPI";
-    
+
     @Server("JPA22TimeAPIServer")
     @TestServlet(servlet = JPATimeAPITestServlet.class, path = APP_NAME + "/" + SERVLET)
     public static LibertyServer server1;
-    
+
     @BeforeClass
     public static void setUp() throws Exception {
-    		ShrinkHelper.defaultApp(server1, APP_NAME, "jpa22timeapi.web", "jpa22timeapi.entity");
-    		server1.startServer();
+        ShrinkHelper.defaultApp(server1, APP_NAME, "jpa22timeapi.web", "jpa22timeapi.entity");
+        server1.startServer();
     }
-    
+
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.stopServer();
+        server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22TimeAPITest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPA22TimeAPITest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import jpa22timeapi.web.JPATimeAPITestServlet;
+
+@RunWith(FATRunner.class)
+public class JPA22TimeAPITest extends FATServletClient {
+	public static final String APP_NAME = "jpa22timeapi";
+    public static final String SERVLET = "TestJPAAPI";
+    
+    @Server("JPA22TimeAPIServer")
+    @TestServlet(servlet = JPATimeAPITestServlet.class, path = APP_NAME + "/" + SERVLET)
+    public static LibertyServer server1;
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+    		ShrinkHelper.defaultApp(server1, APP_NAME, "jpa22timeapi.web", "jpa22timeapi.entity");
+    		server1.startServer();
+    }
+    
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server1.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPACDIIntegrationTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPACDIIntegrationTest.java
@@ -24,7 +24,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-public class JPAELInjectionFATTest {
+public class JPACDIIntegrationTest {
     public static final String APP_NAME = "cdi";
     public static final String SERVLET = "eli";
 

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/CDIFatServer/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/CDIFatServer/server.xml
@@ -25,8 +25,8 @@
     </dataSource>
     
     <library id="DerbyLib" fat.modify="true">
-    	<fileset dir="${server.config.dir}/derby" includes="*.jar"/>
+    	<fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
     </library>
 
-    <javaPermission codebase="${server.config.dir}derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA21FATServer/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA21FATServer/server.xml
@@ -24,8 +24,8 @@
     </dataSource>
     
     <library id="DerbyLib" fat.modify="true">
-    	<fileset dir="${server.config.dir}/derby" includes="*.jar"/>
+    	<fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
     </library>
 
-    <javaPermission codebase="${server.config.dir}derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22FATServer/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22FATServer/server.xml
@@ -24,8 +24,8 @@
     </dataSource>
     
     <library id="DerbyLib" fat.modify="true">
-    	<fileset dir="${server.config.dir}/derby" includes="*.jar"/>
+    	<fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
     </library>
 
-    <javaPermission codebase="${server.config.dir}derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22InjectionServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22InjectionServer/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22InjectionServer/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22InjectionServer/server.xml
@@ -29,10 +29,10 @@
     </dataSource>
     
     <library id="DerbyLib" fat.modify="true">
-    	<fileset dir="${server.config.dir}/derby" includes="*.jar"/>
+    	<fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
     </library>
     
     <application location="jpa22injection.war" />
     
-    <javaPermission codebase="${server.config.dir}derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22InjectionServer/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22InjectionServer/server.xml
@@ -1,0 +1,38 @@
+<!--
+    Copyright (c) 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="JPA 22 Injection Server">
+
+	<featureManager>
+		<feature>servlet-4.0</feature>
+		<feature>jpa-2.2</feature>
+	    <feature>componenttest-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <dataSource id="DefaultDataSource" fat.modify="true">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/NonTransactionalDataSource" jndiName="jdbc/NonTransactionalDataSource" fat.modify="true" transactional="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <library id="DerbyLib" fat.modify="true">
+    	<fileset dir="${server.config.dir}/derby" includes="*.jar"/>
+    </library>
+    
+    <application location="jpa22injection.war" />
+    
+    <javaPermission codebase="${server.config.dir}derby/derby.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22QueryServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22QueryServer/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22QueryServer/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22QueryServer/server.xml
@@ -1,0 +1,33 @@
+<!--
+    Copyright (c) 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="JPA 22 Query Server">
+
+	<featureManager>
+		<feature>servlet-4.0</feature>
+		<feature>jpa-2.2</feature>
+	    <feature>componenttest-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <dataSource id="DefaultDataSource" fat.modify="true">
+    	<jdbcDriver libraryRef="DerbyLib"/>
+    	<properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <library id="DerbyLib" fat.modify="true">
+    	<fileset dir="${server.config.dir}/derby" includes="*.jar"/>
+    </library>
+    
+    <application location="jpa22query.war" />
+    
+    <javaPermission codebase="${server.config.dir}derby/derby.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22QueryServer/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22QueryServer/server.xml
@@ -24,10 +24,10 @@
     </dataSource>
     
     <library id="DerbyLib" fat.modify="true">
-    	<fileset dir="${server.config.dir}/derby" includes="*.jar"/>
+    	<fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
     </library>
     
     <application location="jpa22query.war" />
     
-    <javaPermission codebase="${server.config.dir}derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22TimeAPIServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22TimeAPIServer/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22TimeAPIServer/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22TimeAPIServer/server.xml
@@ -1,0 +1,33 @@
+<!--
+    Copyright (c) 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="JPA 22 Time API Server">
+
+	<featureManager>
+		<feature>servlet-4.0</feature>
+		<feature>jpa-2.2</feature>
+	    <feature>componenttest-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <dataSource id="DefaultDataSource" fat.modify="true">
+    	<jdbcDriver libraryRef="DerbyLib"/>
+    	<properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <library id="DerbyLib" fat.modify="true">
+    	<fileset dir="${server.config.dir}/derby" includes="*.jar"/>
+    </library>
+    
+    <application location="jpa22timeapi.war" />
+    
+    <javaPermission codebase="${server.config.dir}derby/derby.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22TimeAPIServer/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA22TimeAPIServer/server.xml
@@ -24,10 +24,10 @@
     </dataSource>
     
     <library id="DerbyLib" fat.modify="true">
-    	<fileset dir="${server.config.dir}/derby" includes="*.jar"/>
+    	<fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
     </library>
     
     <application location="jpa22timeapi.war" />
     
-    <javaPermission codebase="${server.config.dir}derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/cdi/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/cdi/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -3,12 +3,15 @@
   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd"
   version="2.2">
     <persistence-unit name="JPAPU">
+    <class>cdi.model.ConvertableWidget</class>
     <class>cdi.model.Widget</class>
+    <class>cdi.model.IntToStringConverter</class>
     <exclude-unlisted-classes>true</exclude-unlisted-classes>
     	<properties>
 			<!-- EclipseLink should create the database schema automatically -->
 			<property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
 			<property name="eclipselink.ddl-generation.output-mode" value="both" />
+			<property name="eclipselink.cache.shared.default" value="false"/>
 		</properties>
     </persistence-unit>
 </persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/cdi/src/cdi/model/ConvertableWidget.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/cdi/src/cdi/model/ConvertableWidget.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package cdi.model;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class ConvertableWidget {
+    private int id;
+    private String name;
+    private int numberOfSides;
+    private String description;
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the id
+     */
+    @Id
+    @GeneratedValue
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the name
+     */
+    @Column
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param numberOfSides the number of sides to set
+     */
+    public void setNumberOfSides(int numberOfSides) {
+        this.numberOfSides = numberOfSides;
+    }
+
+    /**
+     * @return the number of sides
+     */
+    @Column
+    @Convert(converter = IntToStringConverter.class)
+    public int getNumberOfSides() {
+        return numberOfSides;
+    }
+
+    /**
+     * @param description the description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * @return the description
+     */
+    @Column
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Widget) {
+            Widget widget = (Widget) obj;
+            if (getId() == widget.getId() &&
+                getName().equals(widget.getName()) &&
+                getDescription().equals(widget.getDescription())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "[id=" + id + ", name=" + name +
+               ", numberOfSides=" + numberOfSides +
+               ", description=" + description + ']';
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/cdi/src/cdi/model/IntToStringConverter.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/cdi/src/cdi/model/IntToStringConverter.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package cdi.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Named
+@Converter
+public class IntToStringConverter implements AttributeConverter<Integer, String> {
+    private LoggingService logger;
+
+    public IntToStringConverter() {
+        // Default logger to avoid NPEs if injection fails.
+        logger = new LoggingService() {
+
+            private final List<String> _messages = Arrays.asList(new String[] { "injection failed" });
+
+            @Override
+            public void log(String s) {
+                System.out.println("Default logger - injection failed: " + s);
+            }
+
+            @Override
+            public List<String> getAndClearMessages() {
+                return _messages;
+            }
+
+        };
+        System.out.println("IntToStringConverter <init>");
+    }
+
+    @Inject
+    public void setLoggingService(LoggingService ls) {
+        logger = ls;
+        logger.log(msg("injection"));
+    }
+
+    private static String msg(String s) {
+        return "IntToStringConverter-" + s;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.persistence.AttributeConverter#convertToDatabaseColumn(java.lang.Object)
+     */
+    @Override
+    public String convertToDatabaseColumn(Integer i) {
+        logger.log(msg("convertToDatabaseColumn:" + i));
+
+        if (i == null) {
+            return null;
+        } else {
+            return i.toString();
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.persistence.AttributeConverter#convertToEntityAttribute(java.lang.Object)
+     */
+    @Override
+    public Integer convertToEntityAttribute(String s) {
+        logger.log(msg("convertToEntityAttribute:" + s));
+
+        if (s == null) {
+            return null;
+        } else {
+            return new Integer(s);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/cdi/src/cdi/web/ELIServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/cdi/src/cdi/web/ELIServlet.java
@@ -33,8 +33,6 @@ import cdi.model.ConvertableWidget;
 import cdi.model.LoggingService;
 import cdi.model.Widget;
 import componenttest.app.FATServlet;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = { "/eli" })
@@ -61,11 +59,7 @@ public class ELIServlet extends FATServlet {
      * 4) Order of invocation is: Injection, then PrePersist, then PostPersist.
      */
     @Test
-    @Mode(TestMode.LITE)
     public void testInjectionOccursBeforePostConstructAndInsertionCallbacks() throws Exception {
-        final String TNAME = "testInjectionOccursBeforePostConstructAndInsertionCallbacks";
-        svLogger.logp(Level.INFO, CLASS_NAME, TNAME, TNAME + "().enter");
-
         List<String> loggerMessages = null;
         em.clear();
 
@@ -100,16 +94,10 @@ public class ELIServlet extends FATServlet {
         for (int index = 0; index < orderCorrect.length; index++) {
             Assert.assertTrue("Callback order incorrect at index: " + index, orderCorrect[index]);
         }
-
-        svLogger.logp(Level.INFO, CLASS_NAME, TNAME, TNAME + "().exit");
     }
 
     @Test
-    @Mode(TestMode.LITE)
     public void testInjectionOccursBeforeInsertAndFindCallbacks() throws Exception {
-        final String TNAME = "testInjectionOccursBeforeInsertAndFindCallbacks";
-        svLogger.logp(Level.INFO, CLASS_NAME, TNAME, TNAME + "().enter");
-
         List<String> loggerMessages = null;
         em.clear();
 
@@ -163,16 +151,10 @@ public class ELIServlet extends FATServlet {
         for (int index = 0; index < searchMessages.size(); index++) {
             Assert.assertTrue("Failed to find: \"" + searchMessages.get(index) + "\"", foundMessages[index]);
         }
-
-        svLogger.logp(Level.INFO, CLASS_NAME, TNAME, TNAME + "().exit");
     }
 
     @Test
-    @Mode(TestMode.LITE)
     public void testInjectionOccursBeforeInsertAndUpdateCallbacks() throws Exception {
-        final String TNAME = "testInjectionOccursBeforeInsertAndUpdateCallbacks";
-        svLogger.logp(Level.INFO, CLASS_NAME, TNAME, TNAME + "().enter");
-
         List<String> loggerMessages = null;
         em.clear();
 
@@ -236,16 +218,10 @@ public class ELIServlet extends FATServlet {
         for (int index = 0; index < orderCorrect.length; index++) {
             Assert.assertTrue("Callback order incorrect at index: " + index, orderCorrect[index]);
         }
-
-        svLogger.logp(Level.INFO, CLASS_NAME, TNAME, TNAME + "().exit");
     }
 
     @Test
-    @Mode(TestMode.LITE)
     public void testInjectionOccursBeforeInsertAndRemoveCallbacks() throws Exception {
-        final String TNAME = "testInjectionOccursBeforeInsertAndRemoveCallbacks";
-        svLogger.logp(Level.INFO, CLASS_NAME, TNAME, TNAME + "().enter");
-
         List<String> loggerMessages = null;
         em.clear();
 
@@ -309,16 +285,10 @@ public class ELIServlet extends FATServlet {
         for (int index = 0; index < orderCorrect.length; index++) {
             Assert.assertTrue("Callback order incorrect at index: " + index, orderCorrect[index]);
         }
-
-        svLogger.logp(Level.INFO, CLASS_NAME, TNAME, TNAME + "().exit");
     }
 
     @Test
-    @Mode(TestMode.LITE)
     public void testConverterCDIInjection() throws Exception {
-        final String TNAME = "testConverterCDIInjection";
-        svLogger.logp(Level.INFO, CLASS_NAME, TNAME, TNAME + "().enter");
-
         List<String> loggerMessages = null;
         em.clear();
 
@@ -377,8 +347,6 @@ public class ELIServlet extends FATServlet {
         for (int index = 0; index < searchMessages.size(); index++) {
             Assert.assertTrue("Failed to find: \"" + searchMessages.get(index) + "\"", foundMessages[index]);
         }
-
-        svLogger.logp(Level.INFO, CLASS_NAME, TNAME, TNAME + "().exit");
     }
 
     // Support methods

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa21bootstrap/src/jpa21bootstrap/web/TestJPA21BootstrapServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa21bootstrap/src/jpa21bootstrap/web/TestJPA21BootstrapServlet.java
@@ -20,8 +20,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import jpa21bootstrap.entity.SimpleTestEntity;
 
 @SuppressWarnings("serial")
@@ -34,49 +32,18 @@ public class TestJPA21BootstrapServlet extends FATServlet {
     private UserTransaction tx;
 
     @Test
-    @Mode(TestMode.LITE)
     public void bootstrapTest21() throws Exception {
-        System.out.println("STARTING bootstrapTest21...");
+        tx.begin();
+        SimpleTestEntity entity = new SimpleTestEntity();
+        entity.setStrData("Cat Dog");
+        em.persist(entity);
+        tx.commit();
 
-        try {
-            tx.begin();
-            SimpleTestEntity entity = new SimpleTestEntity();
-            entity.setStrData("Cat Dog");
-            em.persist(entity);
-            tx.commit();
+        em.clear();
 
-            em.clear();
-
-            SimpleTestEntity findEntity = em.find(SimpleTestEntity.class, entity.getId());
-            Assert.assertNotNull(findEntity);
-            Assert.assertNotSame(entity, findEntity);
-            Assert.assertEquals(entity.getId(), findEntity.getId());
-        } finally {
-            System.out.println("ENDING bootstrapTest21.");
-        }
-
+        SimpleTestEntity findEntity = em.find(SimpleTestEntity.class, entity.getId());
+        Assert.assertNotNull(findEntity);
+        Assert.assertNotSame(entity, findEntity);
+        Assert.assertEquals(entity.getId(), findEntity.getId());
     }
-
-//    @Test
-//    public void testServer1() throws Exception {
-//        System.out.println("Test is running.");
-//    }
-//
-//    @Test
-//    @Mode(TestMode.LITE)
-//    public void liteTest() throws Exception {
-//        System.out.println("LITE test is running.");
-//    }
-//
-//    @Test
-//    @Mode(TestMode.FULL)
-//    public void testFull() throws Exception {
-//        System.out.println("This test should only run in Full or higher mode!");
-//    }
-//
-//    @Test
-//    @Mode(TestMode.QUARANTINE)
-//    public void testQuarantine() throws Exception {
-//        System.out.println("This test should only run in Quarantine mode!");
-//    }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22bootstrap/src/jpa22bootstrap/web/TestJPA22BootstrapServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22bootstrap/src/jpa22bootstrap/web/TestJPA22BootstrapServlet.java
@@ -20,8 +20,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import jpa22bootstrap.entity.SimpleTestEntity;
 
 @SuppressWarnings("serial")
@@ -34,49 +32,18 @@ public class TestJPA22BootstrapServlet extends FATServlet {
     private UserTransaction tx;
 
     @Test
-    @Mode(TestMode.LITE)
     public void bootstrapTest22() throws Exception {
-        System.out.println("STARTING bootstrapTest22...");
+        tx.begin();
+        SimpleTestEntity entity = new SimpleTestEntity();
+        entity.setStrData("Foo Bar");
+        em.persist(entity);
+        tx.commit();
 
-        try {
-            tx.begin();
-            SimpleTestEntity entity = new SimpleTestEntity();
-            entity.setStrData("Foo Bar");
-            em.persist(entity);
-            tx.commit();
+        em.clear();
 
-            em.clear();
-
-            SimpleTestEntity findEntity = em.find(SimpleTestEntity.class, entity.getId());
-            Assert.assertNotNull(findEntity);
-            Assert.assertNotSame(entity, findEntity);
-            Assert.assertEquals(entity.getId(), findEntity.getId());
-        } finally {
-            System.out.println("ENDING bootstrapTest22.");
-        }
-
+        SimpleTestEntity findEntity = em.find(SimpleTestEntity.class, entity.getId());
+        Assert.assertNotNull(findEntity);
+        Assert.assertNotSame(entity, findEntity);
+        Assert.assertEquals(entity.getId(), findEntity.getId());
     }
-
-//    @Test
-//    public void testServer1() throws Exception {
-//        System.out.println("Test is running.");
-//    }
-//
-//    @Test
-//    @Mode(TestMode.LITE)
-//    public void liteTest() throws Exception {
-//        System.out.println("LITE test is running.");
-//    }
-//
-//    @Test
-//    @Mode(TestMode.FULL)
-//    public void testFull() throws Exception {
-//        System.out.println("This test should only run in Full or higher mode!");
-//    }
-//
-//    @Test
-//    @Mode(TestMode.QUARANTINE)
-//    public void testQuarantine() throws Exception {
-//        System.out.println("This test should only run in Quarantine mode!");
-//    }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,40 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd"
+  version="2.2">
+    <persistence-unit name="JPAPU-1">
+        <class>jpa22injection.entity.InjectEntityA</class>
+        <exclude-unlisted-classes/>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="JPAPU-2">
+        <class>jpa22injection.entity.InjectEntityB</class>
+        <exclude-unlisted-classes/>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+    
+    <persistence-unit name="JPAPU-1RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>jdbc/NonTransactionalDataSource</non-jta-data-source>
+        <class>jpa22injection.entity.InjectEntityA</class>
+        <exclude-unlisted-classes/>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="JPAPU-2RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>jdbc/NonTransactionalDataSource</non-jta-data-source>
+        <class>jpa22injection.entity.InjectEntityB</class>
+        <exclude-unlisted-classes/>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/entity/InjectEntityA.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/entity/InjectEntityA.java
@@ -1,0 +1,43 @@
+package jpa22injection.entity;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name="Inject_Ent_A")
+public class InjectEntityA {
+	@Id
+	@GeneratedValue
+	private long id;
+	
+	@Basic
+	private String strData;
+	
+	public InjectEntityA() {
+		
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getStrData() {
+		return strData;
+	}
+
+	public void setStrData(String strData) {
+		this.strData = strData;
+	}
+
+	@Override
+	public String toString() {
+		return "InjectEntityA [id=" + id + ", strData=" + strData + "]";
+	}
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/entity/InjectEntityA.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/entity/InjectEntityA.java
@@ -7,37 +7,37 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Entity
-@Table(name="Inject_Ent_A")
+@Table(name = "Inject_Ent_A")
 public class InjectEntityA {
-	@Id
-	@GeneratedValue
-	private long id;
-	
-	@Basic
-	private String strData;
-	
-	public InjectEntityA() {
-		
-	}
+    @Id
+    @GeneratedValue
+    private long id;
 
-	public long getId() {
-		return id;
-	}
+    @Basic
+    private String strData;
 
-	public void setId(long id) {
-		this.id = id;
-	}
+    public InjectEntityA() {
 
-	public String getStrData() {
-		return strData;
-	}
+    }
 
-	public void setStrData(String strData) {
-		this.strData = strData;
-	}
+    public long getId() {
+        return id;
+    }
 
-	@Override
-	public String toString() {
-		return "InjectEntityA [id=" + id + ", strData=" + strData + "]";
-	}
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getStrData() {
+        return strData;
+    }
+
+    public void setStrData(String strData) {
+        this.strData = strData;
+    }
+
+    @Override
+    public String toString() {
+        return "InjectEntityA [id=" + id + ", strData=" + strData + "]";
+    }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/entity/InjectEntityB.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/entity/InjectEntityB.java
@@ -7,37 +7,37 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Entity
-@Table(name="Inject_Ent_B")
+@Table(name = "Inject_Ent_B")
 public class InjectEntityB {
-	@Id
-	@GeneratedValue
-	private long id;
-	
-	@Basic
-	private String strData;
-	
-	public InjectEntityB() {
-		
-	}
+    @Id
+    @GeneratedValue
+    private long id;
 
-	public long getId() {
-		return id;
-	}
+    @Basic
+    private String strData;
 
-	public void setId(long id) {
-		this.id = id;
-	}
+    public InjectEntityB() {
 
-	public String getStrData() {
-		return strData;
-	}
+    }
 
-	public void setStrData(String strData) {
-		this.strData = strData;
-	}
+    public long getId() {
+        return id;
+    }
 
-	@Override
-	public String toString() {
-		return "InjectEntityB [id=" + id + ", strData=" + strData + "]";
-	}
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getStrData() {
+        return strData;
+    }
+
+    public void setStrData(String strData) {
+        this.strData = strData;
+    }
+
+    @Override
+    public String toString() {
+        return "InjectEntityB [id=" + id + ", strData=" + strData + "]";
+    }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/entity/InjectEntityB.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/entity/InjectEntityB.java
@@ -1,0 +1,43 @@
+package jpa22injection.entity;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name="Inject_Ent_B")
+public class InjectEntityB {
+	@Id
+	@GeneratedValue
+	private long id;
+	
+	@Basic
+	private String strData;
+	
+	public InjectEntityB() {
+		
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getStrData() {
+		return strData;
+	}
+
+	public void setStrData(String strData) {
+		this.strData = strData;
+	}
+
+	@Override
+	public String toString() {
+		return "InjectEntityB [id=" + id + ", strData=" + strData + "]";
+	}
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/web/JPAInjectionTestServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/web/JPAInjectionTestServlet.java
@@ -1,0 +1,161 @@
+package jpa22injection.web;
+
+import javax.annotation.Resource;
+import javax.naming.InitialContext;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceUnit;
+import javax.servlet.annotation.WebServlet;
+import javax.transaction.UserTransaction;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import jpa22injection.entity.InjectEntityA;
+import jpa22injection.entity.InjectEntityB;
+import junit.framework.Assert;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestJPA22Injection")
+@PersistenceContext(name="em1", unitName="JPAPU-1")
+@PersistenceContext(name="em2", unitName="JPAPU-2")
+@PersistenceUnit(name="em1RL", unitName="JPAPU-1RL")
+@PersistenceUnit(name="em2RL", unitName="JPAPU-2RL")
+public class JPAInjectionTestServlet  extends FATServlet {
+	@Resource
+	private UserTransaction tx;
+	
+	/**
+	 * Verify that the @PersistenceContext annotation is repeatable, and that consumable
+	 * EntityManagers are provided in the scenario that this capability is utilized in.
+	 * 
+	 */
+	@Test
+	@Mode(TestMode.LITE)
+	public void testInjectPersistenceContext() throws Exception {
+		final String testName = "testInjectPersistenceContext";		
+		System.out.println("STARTING " + testName + " ...");
+		
+		try {
+			InitialContext ic = new InitialContext();
+			Assert.assertNotNull(ic);
+			
+			EntityManager em1 = (EntityManager) ic.lookup("java:comp/env/em1");
+			Assert.assertNotNull(em1);
+			
+			EntityManager em2 = (EntityManager) ic.lookup("java:comp/env/em2");
+			Assert.assertNotNull(em2);
+			
+			// Persist entities which are appropriate to their respective persistence units
+			tx.begin();
+			InjectEntityA entA1 = new InjectEntityA();
+			entA1.setStrData("A1");
+			em1.persist(entA1);	
+			
+			InjectEntityB entB1 = new InjectEntityB();
+			entB1.setStrData("B1");
+			em2.persist(entB1);
+			tx.commit();
+			
+			em1.clear();
+			em2.clear();
+			
+			// Verify persistence
+			InjectEntityA findA1 = em1.find(InjectEntityA.class, entA1.getId());
+			Assert.assertNotNull(findA1);
+			
+			InjectEntityB findB1 = em2.find(InjectEntityB.class, entB1.getId());
+			Assert.assertNotNull(findB1);
+			
+			// Confirm that correct persistence units are associated with the persistence contexts
+			// by attempting to use an entity that is not a member of the associated persistence unit
+			try {
+				InjectEntityA findA1_wrong = em2.find(InjectEntityA.class, entA1.getId());
+				Assert.fail("No exception was thrown.");
+			} catch (IllegalArgumentException iae) {
+				// Expected
+			}
+			
+			try {
+				InjectEntityB findB1_wrong = em1.find(InjectEntityB.class, entB1.getId());
+				Assert.fail("No exception was thrown.");
+			} catch (IllegalArgumentException iae) {
+				// Expected
+			}
+		} finally {
+			System.out.println("ENDING " + testName);
+		}
+	}
+	
+	/**
+	 * Verify that the @PersistenceUnit annotation is repeatable, and that consumable
+	 * EntityManagerFactory's are provided in the scenario that this capability is utilized in.
+	 * 
+	 */
+	@Test
+	@Mode(TestMode.LITE)
+	public void testInjectPersistenceUnit() throws Exception {
+		final String testName = "testInjectPersistenceUnit";		
+		System.out.println("STARTING " + testName + " ...");
+		
+		try {
+			InitialContext ic = new InitialContext();
+			Assert.assertNotNull(ic);
+			
+			EntityManagerFactory emf1 = (EntityManagerFactory) ic.lookup("java:comp/env/em1RL");
+			Assert.assertNotNull(emf1);
+			EntityManager em1 = emf1.createEntityManager();
+					
+			EntityManagerFactory emf2 = (EntityManagerFactory) ic.lookup("java:comp/env/em2RL");
+			Assert.assertNotNull(emf2);
+			EntityManager em2 = emf2.createEntityManager();
+			
+			// Persist entities which are appropriate to their respective persistence units
+			em1.getTransaction().begin();
+			InjectEntityA entA1 = new InjectEntityA();
+			entA1.setStrData("A1");
+			em1.persist(entA1);
+			em1.getTransaction().commit();
+			
+			em2.getTransaction().begin();
+			InjectEntityB entB1 = new InjectEntityB();
+			entB1.setStrData("B1");
+			em2.persist(entB1);
+			em2.getTransaction().commit();
+			
+			em1.clear();
+			em2.clear();
+			
+			// Verify persistence
+			InjectEntityA findA1 = em1.find(InjectEntityA.class, entA1.getId());
+			Assert.assertNotNull(findA1);
+			
+			InjectEntityB findB1 = em2.find(InjectEntityB.class, entB1.getId());
+			Assert.assertNotNull(findB1);
+			
+			// Confirm that correct persistence units are associated with the persistence contexts
+			// by attempting to use an entity that is not a member of the associated persistence unit
+			try {
+				InjectEntityA findA1_wrong = em2.find(InjectEntityA.class, entA1.getId());
+				Assert.fail("No exception was thrown.");
+			} catch (IllegalArgumentException iae) {
+				// Expected
+			}
+			
+			try {
+				InjectEntityB findB1_wrong = em1.find(InjectEntityB.class, entB1.getId());
+				Assert.fail("No exception was thrown.");
+			} catch (IllegalArgumentException iae) {
+				// Expected
+			}
+			
+			em1.close();
+			em2.close();
+		} finally {
+			System.out.println("ENDING " + testName);
+		}
+	}
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/web/JPAInjectionTestServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/web/JPAInjectionTestServlet.java
@@ -20,142 +20,142 @@ import junit.framework.Assert;
 
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/TestJPA22Injection")
-@PersistenceContext(name="em1", unitName="JPAPU-1")
-@PersistenceContext(name="em2", unitName="JPAPU-2")
-@PersistenceUnit(name="em1RL", unitName="JPAPU-1RL")
-@PersistenceUnit(name="em2RL", unitName="JPAPU-2RL")
-public class JPAInjectionTestServlet  extends FATServlet {
-	@Resource
-	private UserTransaction tx;
-	
-	/**
-	 * Verify that the @PersistenceContext annotation is repeatable, and that consumable
-	 * EntityManagers are provided in the scenario that this capability is utilized in.
-	 * 
-	 */
-	@Test
-	@Mode(TestMode.LITE)
-	public void testInjectPersistenceContext() throws Exception {
-		final String testName = "testInjectPersistenceContext";		
-		System.out.println("STARTING " + testName + " ...");
-		
-		try {
-			InitialContext ic = new InitialContext();
-			Assert.assertNotNull(ic);
-			
-			EntityManager em1 = (EntityManager) ic.lookup("java:comp/env/em1");
-			Assert.assertNotNull(em1);
-			
-			EntityManager em2 = (EntityManager) ic.lookup("java:comp/env/em2");
-			Assert.assertNotNull(em2);
-			
-			// Persist entities which are appropriate to their respective persistence units
-			tx.begin();
-			InjectEntityA entA1 = new InjectEntityA();
-			entA1.setStrData("A1");
-			em1.persist(entA1);	
-			
-			InjectEntityB entB1 = new InjectEntityB();
-			entB1.setStrData("B1");
-			em2.persist(entB1);
-			tx.commit();
-			
-			em1.clear();
-			em2.clear();
-			
-			// Verify persistence
-			InjectEntityA findA1 = em1.find(InjectEntityA.class, entA1.getId());
-			Assert.assertNotNull(findA1);
-			
-			InjectEntityB findB1 = em2.find(InjectEntityB.class, entB1.getId());
-			Assert.assertNotNull(findB1);
-			
-			// Confirm that correct persistence units are associated with the persistence contexts
-			// by attempting to use an entity that is not a member of the associated persistence unit
-			try {
-				InjectEntityA findA1_wrong = em2.find(InjectEntityA.class, entA1.getId());
-				Assert.fail("No exception was thrown.");
-			} catch (IllegalArgumentException iae) {
-				// Expected
-			}
-			
-			try {
-				InjectEntityB findB1_wrong = em1.find(InjectEntityB.class, entB1.getId());
-				Assert.fail("No exception was thrown.");
-			} catch (IllegalArgumentException iae) {
-				// Expected
-			}
-		} finally {
-			System.out.println("ENDING " + testName);
-		}
-	}
-	
-	/**
-	 * Verify that the @PersistenceUnit annotation is repeatable, and that consumable
-	 * EntityManagerFactory's are provided in the scenario that this capability is utilized in.
-	 * 
-	 */
-	@Test
-	@Mode(TestMode.LITE)
-	public void testInjectPersistenceUnit() throws Exception {
-		final String testName = "testInjectPersistenceUnit";		
-		System.out.println("STARTING " + testName + " ...");
-		
-		try {
-			InitialContext ic = new InitialContext();
-			Assert.assertNotNull(ic);
-			
-			EntityManagerFactory emf1 = (EntityManagerFactory) ic.lookup("java:comp/env/em1RL");
-			Assert.assertNotNull(emf1);
-			EntityManager em1 = emf1.createEntityManager();
-					
-			EntityManagerFactory emf2 = (EntityManagerFactory) ic.lookup("java:comp/env/em2RL");
-			Assert.assertNotNull(emf2);
-			EntityManager em2 = emf2.createEntityManager();
-			
-			// Persist entities which are appropriate to their respective persistence units
-			em1.getTransaction().begin();
-			InjectEntityA entA1 = new InjectEntityA();
-			entA1.setStrData("A1");
-			em1.persist(entA1);
-			em1.getTransaction().commit();
-			
-			em2.getTransaction().begin();
-			InjectEntityB entB1 = new InjectEntityB();
-			entB1.setStrData("B1");
-			em2.persist(entB1);
-			em2.getTransaction().commit();
-			
-			em1.clear();
-			em2.clear();
-			
-			// Verify persistence
-			InjectEntityA findA1 = em1.find(InjectEntityA.class, entA1.getId());
-			Assert.assertNotNull(findA1);
-			
-			InjectEntityB findB1 = em2.find(InjectEntityB.class, entB1.getId());
-			Assert.assertNotNull(findB1);
-			
-			// Confirm that correct persistence units are associated with the persistence contexts
-			// by attempting to use an entity that is not a member of the associated persistence unit
-			try {
-				InjectEntityA findA1_wrong = em2.find(InjectEntityA.class, entA1.getId());
-				Assert.fail("No exception was thrown.");
-			} catch (IllegalArgumentException iae) {
-				// Expected
-			}
-			
-			try {
-				InjectEntityB findB1_wrong = em1.find(InjectEntityB.class, entB1.getId());
-				Assert.fail("No exception was thrown.");
-			} catch (IllegalArgumentException iae) {
-				// Expected
-			}
-			
-			em1.close();
-			em2.close();
-		} finally {
-			System.out.println("ENDING " + testName);
-		}
-	}
+@PersistenceContext(name = "em1", unitName = "JPAPU-1")
+@PersistenceContext(name = "em2", unitName = "JPAPU-2")
+@PersistenceUnit(name = "em1RL", unitName = "JPAPU-1RL")
+@PersistenceUnit(name = "em2RL", unitName = "JPAPU-2RL")
+public class JPAInjectionTestServlet extends FATServlet {
+    @Resource
+    private UserTransaction tx;
+
+    /**
+     * Verify that the @PersistenceContext annotation is repeatable, and that consumable
+     * EntityManagers are provided in the scenario that this capability is utilized in.
+     * 
+     */
+    @Test
+    @Mode(TestMode.LITE)
+    public void testInjectPersistenceContext() throws Exception {
+        final String testName = "testInjectPersistenceContext";
+        System.out.println("STARTING " + testName + " ...");
+
+        try {
+            InitialContext ic = new InitialContext();
+            Assert.assertNotNull(ic);
+
+            EntityManager em1 = (EntityManager) ic.lookup("java:comp/env/em1");
+            Assert.assertNotNull(em1);
+
+            EntityManager em2 = (EntityManager) ic.lookup("java:comp/env/em2");
+            Assert.assertNotNull(em2);
+
+            // Persist entities which are appropriate to their respective persistence units
+            tx.begin();
+            InjectEntityA entA1 = new InjectEntityA();
+            entA1.setStrData("A1");
+            em1.persist(entA1);
+
+            InjectEntityB entB1 = new InjectEntityB();
+            entB1.setStrData("B1");
+            em2.persist(entB1);
+            tx.commit();
+
+            em1.clear();
+            em2.clear();
+
+            // Verify persistence
+            InjectEntityA findA1 = em1.find(InjectEntityA.class, entA1.getId());
+            Assert.assertNotNull(findA1);
+
+            InjectEntityB findB1 = em2.find(InjectEntityB.class, entB1.getId());
+            Assert.assertNotNull(findB1);
+
+            // Confirm that correct persistence units are associated with the persistence contexts
+            // by attempting to use an entity that is not a member of the associated persistence unit
+            try {
+                InjectEntityA findA1_wrong = em2.find(InjectEntityA.class, entA1.getId());
+                Assert.fail("No exception was thrown.");
+            } catch (IllegalArgumentException iae) {
+                // Expected
+            }
+
+            try {
+                InjectEntityB findB1_wrong = em1.find(InjectEntityB.class, entB1.getId());
+                Assert.fail("No exception was thrown.");
+            } catch (IllegalArgumentException iae) {
+                // Expected
+            }
+        } finally {
+            System.out.println("ENDING " + testName);
+        }
+    }
+
+    /**
+     * Verify that the @PersistenceUnit annotation is repeatable, and that consumable
+     * EntityManagerFactory's are provided in the scenario that this capability is utilized in.
+     * 
+     */
+    @Test
+    @Mode(TestMode.LITE)
+    public void testInjectPersistenceUnit() throws Exception {
+        final String testName = "testInjectPersistenceUnit";
+        System.out.println("STARTING " + testName + " ...");
+
+        try {
+            InitialContext ic = new InitialContext();
+            Assert.assertNotNull(ic);
+
+            EntityManagerFactory emf1 = (EntityManagerFactory) ic.lookup("java:comp/env/em1RL");
+            Assert.assertNotNull(emf1);
+            EntityManager em1 = emf1.createEntityManager();
+
+            EntityManagerFactory emf2 = (EntityManagerFactory) ic.lookup("java:comp/env/em2RL");
+            Assert.assertNotNull(emf2);
+            EntityManager em2 = emf2.createEntityManager();
+
+            // Persist entities which are appropriate to their respective persistence units
+            em1.getTransaction().begin();
+            InjectEntityA entA1 = new InjectEntityA();
+            entA1.setStrData("A1");
+            em1.persist(entA1);
+            em1.getTransaction().commit();
+
+            em2.getTransaction().begin();
+            InjectEntityB entB1 = new InjectEntityB();
+            entB1.setStrData("B1");
+            em2.persist(entB1);
+            em2.getTransaction().commit();
+
+            em1.clear();
+            em2.clear();
+
+            // Verify persistence
+            InjectEntityA findA1 = em1.find(InjectEntityA.class, entA1.getId());
+            Assert.assertNotNull(findA1);
+
+            InjectEntityB findB1 = em2.find(InjectEntityB.class, entB1.getId());
+            Assert.assertNotNull(findB1);
+
+            // Confirm that correct persistence units are associated with the persistence contexts
+            // by attempting to use an entity that is not a member of the associated persistence unit
+            try {
+                InjectEntityA findA1_wrong = em2.find(InjectEntityA.class, entA1.getId());
+                Assert.fail("No exception was thrown.");
+            } catch (IllegalArgumentException iae) {
+                // Expected
+            }
+
+            try {
+                InjectEntityB findB1_wrong = em1.find(InjectEntityB.class, entB1.getId());
+                Assert.fail("No exception was thrown.");
+            } catch (IllegalArgumentException iae) {
+                // Expected
+            }
+
+            em1.close();
+            em2.close();
+        } finally {
+            System.out.println("ENDING " + testName);
+        }
+    }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/web/JPAInjectionTestServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22injection/src/jpa22injection/web/JPAInjectionTestServlet.java
@@ -12,8 +12,6 @@ import javax.transaction.UserTransaction;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import jpa22injection.entity.InjectEntityA;
 import jpa22injection.entity.InjectEntityB;
 import junit.framework.Assert;
@@ -31,131 +29,109 @@ public class JPAInjectionTestServlet extends FATServlet {
     /**
      * Verify that the @PersistenceContext annotation is repeatable, and that consumable
      * EntityManagers are provided in the scenario that this capability is utilized in.
-     * 
+     *
      */
     @Test
-    @Mode(TestMode.LITE)
     public void testInjectPersistenceContext() throws Exception {
-        final String testName = "testInjectPersistenceContext";
-        System.out.println("STARTING " + testName + " ...");
+        EntityManager em1 = (EntityManager) InitialContext.doLookup("java:comp/env/em1");
+        Assert.assertNotNull(em1);
+
+        EntityManager em2 = (EntityManager) InitialContext.doLookup("java:comp/env/em2");
+        Assert.assertNotNull(em2);
+
+        // Persist entities which are appropriate to their respective persistence units
+        tx.begin();
+        InjectEntityA entA1 = new InjectEntityA();
+        entA1.setStrData("A1");
+        em1.persist(entA1);
+
+        InjectEntityB entB1 = new InjectEntityB();
+        entB1.setStrData("B1");
+        em2.persist(entB1);
+        tx.commit();
+
+        em1.clear();
+        em2.clear();
+
+        // Verify persistence
+        InjectEntityA findA1 = em1.find(InjectEntityA.class, entA1.getId());
+        Assert.assertNotNull(findA1);
+
+        InjectEntityB findB1 = em2.find(InjectEntityB.class, entB1.getId());
+        Assert.assertNotNull(findB1);
+
+        // Confirm that correct persistence units are associated with the persistence contexts
+        // by attempting to use an entity that is not a member of the associated persistence unit
+        try {
+            InjectEntityA findA1_wrong = em2.find(InjectEntityA.class, entA1.getId());
+            Assert.fail("No exception was thrown.");
+        } catch (IllegalArgumentException iae) {
+            // Expected
+        }
 
         try {
-            InitialContext ic = new InitialContext();
-            Assert.assertNotNull(ic);
-
-            EntityManager em1 = (EntityManager) ic.lookup("java:comp/env/em1");
-            Assert.assertNotNull(em1);
-
-            EntityManager em2 = (EntityManager) ic.lookup("java:comp/env/em2");
-            Assert.assertNotNull(em2);
-
-            // Persist entities which are appropriate to their respective persistence units
-            tx.begin();
-            InjectEntityA entA1 = new InjectEntityA();
-            entA1.setStrData("A1");
-            em1.persist(entA1);
-
-            InjectEntityB entB1 = new InjectEntityB();
-            entB1.setStrData("B1");
-            em2.persist(entB1);
-            tx.commit();
-
-            em1.clear();
-            em2.clear();
-
-            // Verify persistence
-            InjectEntityA findA1 = em1.find(InjectEntityA.class, entA1.getId());
-            Assert.assertNotNull(findA1);
-
-            InjectEntityB findB1 = em2.find(InjectEntityB.class, entB1.getId());
-            Assert.assertNotNull(findB1);
-
-            // Confirm that correct persistence units are associated with the persistence contexts
-            // by attempting to use an entity that is not a member of the associated persistence unit
-            try {
-                InjectEntityA findA1_wrong = em2.find(InjectEntityA.class, entA1.getId());
-                Assert.fail("No exception was thrown.");
-            } catch (IllegalArgumentException iae) {
-                // Expected
-            }
-
-            try {
-                InjectEntityB findB1_wrong = em1.find(InjectEntityB.class, entB1.getId());
-                Assert.fail("No exception was thrown.");
-            } catch (IllegalArgumentException iae) {
-                // Expected
-            }
-        } finally {
-            System.out.println("ENDING " + testName);
+            InjectEntityB findB1_wrong = em1.find(InjectEntityB.class, entB1.getId());
+            Assert.fail("No exception was thrown.");
+        } catch (IllegalArgumentException iae) {
+            // Expected
         }
     }
 
     /**
      * Verify that the @PersistenceUnit annotation is repeatable, and that consumable
      * EntityManagerFactory's are provided in the scenario that this capability is utilized in.
-     * 
+     *
      */
     @Test
-    @Mode(TestMode.LITE)
     public void testInjectPersistenceUnit() throws Exception {
-        final String testName = "testInjectPersistenceUnit";
-        System.out.println("STARTING " + testName + " ...");
+        EntityManagerFactory emf1 = (EntityManagerFactory) InitialContext.doLookup("java:comp/env/em1RL");
+        Assert.assertNotNull(emf1);
+        EntityManager em1 = emf1.createEntityManager();
+
+        EntityManagerFactory emf2 = (EntityManagerFactory) InitialContext.doLookup("java:comp/env/em2RL");
+        Assert.assertNotNull(emf2);
+        EntityManager em2 = emf2.createEntityManager();
+
+        // Persist entities which are appropriate to their respective persistence units
+        em1.getTransaction().begin();
+        InjectEntityA entA1 = new InjectEntityA();
+        entA1.setStrData("A1");
+        em1.persist(entA1);
+        em1.getTransaction().commit();
+
+        em2.getTransaction().begin();
+        InjectEntityB entB1 = new InjectEntityB();
+        entB1.setStrData("B1");
+        em2.persist(entB1);
+        em2.getTransaction().commit();
+
+        em1.clear();
+        em2.clear();
+
+        // Verify persistence
+        InjectEntityA findA1 = em1.find(InjectEntityA.class, entA1.getId());
+        Assert.assertNotNull(findA1);
+
+        InjectEntityB findB1 = em2.find(InjectEntityB.class, entB1.getId());
+        Assert.assertNotNull(findB1);
+
+        // Confirm that correct persistence units are associated with the persistence contexts
+        // by attempting to use an entity that is not a member of the associated persistence unit
+        try {
+            InjectEntityA findA1_wrong = em2.find(InjectEntityA.class, entA1.getId());
+            Assert.fail("No exception was thrown.");
+        } catch (IllegalArgumentException iae) {
+            // Expected
+        }
 
         try {
-            InitialContext ic = new InitialContext();
-            Assert.assertNotNull(ic);
-
-            EntityManagerFactory emf1 = (EntityManagerFactory) ic.lookup("java:comp/env/em1RL");
-            Assert.assertNotNull(emf1);
-            EntityManager em1 = emf1.createEntityManager();
-
-            EntityManagerFactory emf2 = (EntityManagerFactory) ic.lookup("java:comp/env/em2RL");
-            Assert.assertNotNull(emf2);
-            EntityManager em2 = emf2.createEntityManager();
-
-            // Persist entities which are appropriate to their respective persistence units
-            em1.getTransaction().begin();
-            InjectEntityA entA1 = new InjectEntityA();
-            entA1.setStrData("A1");
-            em1.persist(entA1);
-            em1.getTransaction().commit();
-
-            em2.getTransaction().begin();
-            InjectEntityB entB1 = new InjectEntityB();
-            entB1.setStrData("B1");
-            em2.persist(entB1);
-            em2.getTransaction().commit();
-
-            em1.clear();
-            em2.clear();
-
-            // Verify persistence
-            InjectEntityA findA1 = em1.find(InjectEntityA.class, entA1.getId());
-            Assert.assertNotNull(findA1);
-
-            InjectEntityB findB1 = em2.find(InjectEntityB.class, entB1.getId());
-            Assert.assertNotNull(findB1);
-
-            // Confirm that correct persistence units are associated with the persistence contexts
-            // by attempting to use an entity that is not a member of the associated persistence unit
-            try {
-                InjectEntityA findA1_wrong = em2.find(InjectEntityA.class, entA1.getId());
-                Assert.fail("No exception was thrown.");
-            } catch (IllegalArgumentException iae) {
-                // Expected
-            }
-
-            try {
-                InjectEntityB findB1_wrong = em1.find(InjectEntityB.class, entB1.getId());
-                Assert.fail("No exception was thrown.");
-            } catch (IllegalArgumentException iae) {
-                // Expected
-            }
-
-            em1.close();
-            em2.close();
-        } finally {
-            System.out.println("ENDING " + testName);
+            InjectEntityB findB1_wrong = em1.find(InjectEntityB.class, entB1.getId());
+            Assert.fail("No exception was thrown.");
+        } catch (IllegalArgumentException iae) {
+            // Expected
         }
+
+        em1.close();
+        em2.close();
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,11 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd"
+  version="2.2">
+    <persistence-unit name="JPAPU">
+    	<properties>
+			<!-- EclipseLink should create the database schema automatically -->
+			<property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+		</properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/src/jpa22query/entity/Employee.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/src/jpa22query/entity/Employee.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpa22query.entity;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Version;
+
+@Entity
+@Table(name="Q_EMP")
+public class Employee {
+	@Id
+	@GeneratedValue
+	private long id;
+	
+	@Basic private String lastName;
+	@Basic private String firstName;
+	
+	@Basic private int salary;
+	
+	@Version
+	private long version;
+	
+	public Employee() {
+		
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public int getSalary() {
+		return salary;
+	}
+
+	public void setSalary(int salary) {
+		this.salary = salary;
+	}
+
+	public long getVersion() {
+		return version;
+	}
+
+	public void setVersion(long version) {
+		this.version = version;
+	}
+
+	@Override
+	public String toString() {
+		return "Employee [id=" + id + ", lastName=" + lastName + ", firstName=" + firstName + ", salary=" + salary
+				+ ", version=" + version + "]";
+	}
+	
+	
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/src/jpa22query/entity/Employee.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/src/jpa22query/entity/Employee.java
@@ -19,69 +19,71 @@ import javax.persistence.Table;
 import javax.persistence.Version;
 
 @Entity
-@Table(name="Q_EMP")
+@Table(name = "Q_EMP")
 public class Employee {
-	@Id
-	@GeneratedValue
-	private long id;
-	
-	@Basic private String lastName;
-	@Basic private String firstName;
-	
-	@Basic private int salary;
-	
-	@Version
-	private long version;
-	
-	public Employee() {
-		
-	}
+    @Id
+    @GeneratedValue
+    private long id;
 
-	public long getId() {
-		return id;
-	}
+    @Basic
+    private String lastName;
+    @Basic
+    private String firstName;
 
-	public void setId(long id) {
-		this.id = id;
-	}
+    @Basic
+    private int salary;
 
-	public String getLastName() {
-		return lastName;
-	}
+    @Version
+    private long version;
 
-	public void setLastName(String lastName) {
-		this.lastName = lastName;
-	}
+    public Employee() {
 
-	public String getFirstName() {
-		return firstName;
-	}
+    }
 
-	public void setFirstName(String firstName) {
-		this.firstName = firstName;
-	}
+    public long getId() {
+        return id;
+    }
 
-	public int getSalary() {
-		return salary;
-	}
+    public void setId(long id) {
+        this.id = id;
+    }
 
-	public void setSalary(int salary) {
-		this.salary = salary;
-	}
+    public String getLastName() {
+        return lastName;
+    }
 
-	public long getVersion() {
-		return version;
-	}
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
 
-	public void setVersion(long version) {
-		this.version = version;
-	}
+    public String getFirstName() {
+        return firstName;
+    }
 
-	@Override
-	public String toString() {
-		return "Employee [id=" + id + ", lastName=" + lastName + ", firstName=" + firstName + ", salary=" + salary
-				+ ", version=" + version + "]";
-	}
-	
-	
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public int getSalary() {
+        return salary;
+    }
+
+    public void setSalary(int salary) {
+        this.salary = salary;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public void setVersion(long version) {
+        this.version = version;
+    }
+
+    @Override
+    public String toString() {
+        return "Employee [id=" + id + ", lastName=" + lastName + ", firstName=" + firstName + ", salary=" + salary
+               + ", version=" + version + "]";
+    }
+
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/src/jpa22query/web/JPAQueryTestServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/src/jpa22query/web/JPAQueryTestServlet.java
@@ -19,7 +19,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.transaction.UserTransaction;
 
@@ -27,8 +26,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import jpa22query.entity.Employee;
 
 @SuppressWarnings("serial")
@@ -40,85 +37,64 @@ public class JPAQueryTestServlet extends FATServlet {
     @Resource
     private UserTransaction tx;
 
-    private static boolean tablesSetup = false;
+    private static boolean tablesSetup = false; // Expecting non-parallel test execution
 
-    private synchronized void setupTables() throws ServletException {
-        if (tablesSetup)
+    private void setupTables() throws Exception {
+        if (tablesSetup) {
             return;
-
-        try {
-            tx.begin();
-
-            Employee emp1 = new Employee();
-            emp1.setFirstName("John");
-            emp1.setLastName("Doe");
-            emp1.setSalary(10000);
-            em.persist(emp1);
-
-            Employee emp2 = new Employee();
-            emp2.setFirstName("Jane");
-            emp2.setLastName("Doe");
-            emp2.setSalary(20000);
-            em.persist(emp2);
-
-            Employee emp3 = new Employee();
-            emp3.setFirstName("Joe");
-            emp3.setLastName("Cool");
-            emp3.setSalary(5000);
-            em.persist(emp3);
-
-            tx.commit();
-        } catch (Exception e) {
-            throw new ServletException(e);
         }
+
+        tx.begin();
+
+        Employee emp1 = new Employee();
+        emp1.setFirstName("John");
+        emp1.setLastName("Doe");
+        emp1.setSalary(10000);
+        em.persist(emp1);
+
+        Employee emp2 = new Employee();
+        emp2.setFirstName("Jane");
+        emp2.setLastName("Doe");
+        emp2.setSalary(20000);
+        em.persist(emp2);
+
+        Employee emp3 = new Employee();
+        emp3.setFirstName("Joe");
+        emp3.setLastName("Cool");
+        emp3.setSalary(5000);
+        em.persist(emp3);
+
+        tx.commit();
 
         tablesSetup = true;
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
-    @Mode(TestMode.LITE)
     public void testJPA22QueryStream() throws Exception {
-        final String testName = "testJPA22QueryStream";
-
-        System.out.println("STARTING " + testName + " ...");
-
         setupTables();
 
-        try {
-            String qStr = "SELECT e FROM Employee e";
-            Query q = em.createQuery(qStr);
-            Stream empStream = q.getResultStream();
+        String qStr = "SELECT e FROM Employee e";
+        Query q = em.createQuery(qStr);
+        Stream empStream = q.getResultStream();
 
-            final AtomicInteger ai = new AtomicInteger(0);
-            empStream.forEach(t -> ai.set(ai.get() + ((Employee) t).getSalary()));
+        final AtomicInteger ai = new AtomicInteger(0);
+        empStream.forEach(t -> ai.set(ai.get() + ((Employee) t).getSalary()));
 
-            Assert.assertEquals(ai.get(), 35000);
-        } finally {
-            System.out.println("ENDING " + testName);
-        }
+        Assert.assertEquals(ai.get(), 35000);
     }
 
     @Test
-    @Mode(TestMode.LITE)
     public void testJPA22TypedQueryStream() throws Exception {
-        final String testName = "testJPA22TypedQueryStream";
-
-        System.out.println("STARTING " + testName + " ...");
-
         setupTables();
 
-        try {
-            String qStr = "SELECT e FROM Employee e";
-            TypedQuery<Employee> tQuery = em.createQuery(qStr, Employee.class);
-            Stream<Employee> empStream = tQuery.getResultStream();
+        String qStr = "SELECT e FROM Employee e";
+        TypedQuery<Employee> tQuery = em.createQuery(qStr, Employee.class);
+        Stream<Employee> empStream = tQuery.getResultStream();
 
-            final AtomicInteger ai = new AtomicInteger(0);
-            empStream.forEach(t -> ai.set(ai.get() + t.getSalary()));
+        final AtomicInteger ai = new AtomicInteger(0);
+        empStream.forEach(t -> ai.set(ai.get() + t.getSalary()));
 
-            Assert.assertEquals(ai.get(), 35000);
-        } finally {
-            System.out.println("ENDING " + testName);
-        }
+        Assert.assertEquals(ai.get(), 35000);
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/src/jpa22query/web/JPAQueryTestServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/src/jpa22query/web/JPAQueryTestServlet.java
@@ -33,91 +33,92 @@ import jpa22query.entity.Employee;
 
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/TestJPA22Query")
-public class JPAQueryTestServlet  extends FATServlet {
-	@PersistenceContext(unitName="JPAPU")
-	private EntityManager em;
-	
-	@Resource
-	private UserTransaction tx;
-	
-	private static boolean tablesSetup = false;
-	
+public class JPAQueryTestServlet extends FATServlet {
+    @PersistenceContext(unitName = "JPAPU")
+    private EntityManager em;
+
+    @Resource
+    private UserTransaction tx;
+
+    private static boolean tablesSetup = false;
+
     private synchronized void setupTables() throws ServletException {
-    		if (tablesSetup) return;
-    		
-		try {
-			tx.begin();
-			
-			Employee emp1 = new Employee();
-			emp1.setFirstName("John");
-			emp1.setLastName("Doe");
-			emp1.setSalary(10000);
-			em.persist(emp1);
-			
-			Employee emp2 = new Employee();
-			emp2.setFirstName("Jane");
-			emp2.setLastName("Doe");
-			emp2.setSalary(20000);
-			em.persist(emp2);
-			
-			Employee emp3 = new Employee();
-			emp3.setFirstName("Joe");
-			emp3.setLastName("Cool");
-			emp3.setSalary(5000);
-			em.persist(emp3);
-			
-			tx.commit();
-		} catch (Exception e) {
-			throw new ServletException(e);
-		}
-		
-		tablesSetup = true;
+        if (tablesSetup)
+            return;
+
+        try {
+            tx.begin();
+
+            Employee emp1 = new Employee();
+            emp1.setFirstName("John");
+            emp1.setLastName("Doe");
+            emp1.setSalary(10000);
+            em.persist(emp1);
+
+            Employee emp2 = new Employee();
+            emp2.setFirstName("Jane");
+            emp2.setLastName("Doe");
+            emp2.setSalary(20000);
+            em.persist(emp2);
+
+            Employee emp3 = new Employee();
+            emp3.setFirstName("Joe");
+            emp3.setLastName("Cool");
+            emp3.setSalary(5000);
+            em.persist(emp3);
+
+            tx.commit();
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+
+        tablesSetup = true;
     }
-	
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
-	@Test
-	@Mode(TestMode.LITE)
-	public void testJPA22QueryStream() throws Exception {
-		final String testName = "testJPA22QueryStream";
-		
-		System.out.println("STARTING " + testName + " ...");
-		
-		setupTables();
-		
-		try {
-			String qStr = "SELECT e FROM Employee e";
-			Query q = em.createQuery(qStr);
-			Stream empStream = q.getResultStream();
-			
-			final AtomicInteger ai = new AtomicInteger(0);
-			empStream.forEach( t -> ai.set(ai.get() + ((Employee) t).getSalary()));
-			
-			Assert.assertEquals(ai.get(), 35000);
-		} finally {
-			System.out.println("ENDING " + testName);
-		}
-	}
-    
-	@Test
-	@Mode(TestMode.LITE)
-	public void testJPA22TypedQueryStream() throws Exception {
-		final String testName = "testJPA22TypedQueryStream";
-		
-		System.out.println("STARTING " + testName + " ...");
-		
-		setupTables();
-		
-		try {
-			String qStr = "SELECT e FROM Employee e";
-			TypedQuery<Employee> tQuery = em.createQuery(qStr, Employee.class);
-			Stream<Employee> empStream = tQuery.getResultStream();
-			
-			final AtomicInteger ai = new AtomicInteger(0);
-			empStream.forEach( t -> ai.set(ai.get() + t.getSalary()));
-			
-			Assert.assertEquals(ai.get(), 35000);
-		} finally {
-			System.out.println("ENDING " + testName);
-		}
-	}
+    @Test
+    @Mode(TestMode.LITE)
+    public void testJPA22QueryStream() throws Exception {
+        final String testName = "testJPA22QueryStream";
+
+        System.out.println("STARTING " + testName + " ...");
+
+        setupTables();
+
+        try {
+            String qStr = "SELECT e FROM Employee e";
+            Query q = em.createQuery(qStr);
+            Stream empStream = q.getResultStream();
+
+            final AtomicInteger ai = new AtomicInteger(0);
+            empStream.forEach(t -> ai.set(ai.get() + ((Employee) t).getSalary()));
+
+            Assert.assertEquals(ai.get(), 35000);
+        } finally {
+            System.out.println("ENDING " + testName);
+        }
+    }
+
+    @Test
+    @Mode(TestMode.LITE)
+    public void testJPA22TypedQueryStream() throws Exception {
+        final String testName = "testJPA22TypedQueryStream";
+
+        System.out.println("STARTING " + testName + " ...");
+
+        setupTables();
+
+        try {
+            String qStr = "SELECT e FROM Employee e";
+            TypedQuery<Employee> tQuery = em.createQuery(qStr, Employee.class);
+            Stream<Employee> empStream = tQuery.getResultStream();
+
+            final AtomicInteger ai = new AtomicInteger(0);
+            empStream.forEach(t -> ai.set(ai.get() + t.getSalary()));
+
+            Assert.assertEquals(ai.get(), 35000);
+        } finally {
+            System.out.println("ENDING " + testName);
+        }
+    }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/src/jpa22query/web/JPAQueryTestServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22query/src/jpa22query/web/JPAQueryTestServlet.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpa22query.web;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import javax.annotation.Resource;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import javax.persistence.TypedQuery;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.transaction.UserTransaction;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import jpa22query.entity.Employee;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestJPA22Query")
+public class JPAQueryTestServlet  extends FATServlet {
+	@PersistenceContext(unitName="JPAPU")
+	private EntityManager em;
+	
+	@Resource
+	private UserTransaction tx;
+	
+	private static boolean tablesSetup = false;
+	
+    private synchronized void setupTables() throws ServletException {
+    		if (tablesSetup) return;
+    		
+		try {
+			tx.begin();
+			
+			Employee emp1 = new Employee();
+			emp1.setFirstName("John");
+			emp1.setLastName("Doe");
+			emp1.setSalary(10000);
+			em.persist(emp1);
+			
+			Employee emp2 = new Employee();
+			emp2.setFirstName("Jane");
+			emp2.setLastName("Doe");
+			emp2.setSalary(20000);
+			em.persist(emp2);
+			
+			Employee emp3 = new Employee();
+			emp3.setFirstName("Joe");
+			emp3.setLastName("Cool");
+			emp3.setSalary(5000);
+			em.persist(emp3);
+			
+			tx.commit();
+		} catch (Exception e) {
+			throw new ServletException(e);
+		}
+		
+		tablesSetup = true;
+    }
+	
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	@Mode(TestMode.LITE)
+	public void testJPA22QueryStream() throws Exception {
+		final String testName = "testJPA22QueryStream";
+		
+		System.out.println("STARTING " + testName + " ...");
+		
+		setupTables();
+		
+		try {
+			String qStr = "SELECT e FROM Employee e";
+			Query q = em.createQuery(qStr);
+			Stream empStream = q.getResultStream();
+			
+			final AtomicInteger ai = new AtomicInteger(0);
+			empStream.forEach( t -> ai.set(ai.get() + ((Employee) t).getSalary()));
+			
+			Assert.assertEquals(ai.get(), 35000);
+		} finally {
+			System.out.println("ENDING " + testName);
+		}
+	}
+    
+	@Test
+	@Mode(TestMode.LITE)
+	public void testJPA22TypedQueryStream() throws Exception {
+		final String testName = "testJPA22TypedQueryStream";
+		
+		System.out.println("STARTING " + testName + " ...");
+		
+		setupTables();
+		
+		try {
+			String qStr = "SELECT e FROM Employee e";
+			TypedQuery<Employee> tQuery = em.createQuery(qStr, Employee.class);
+			Stream<Employee> empStream = tQuery.getResultStream();
+			
+			final AtomicInteger ai = new AtomicInteger(0);
+			empStream.forEach( t -> ai.set(ai.get() + t.getSalary()));
+			
+			Assert.assertEquals(ai.get(), 35000);
+		} finally {
+			System.out.println("ENDING " + testName);
+		}
+	}
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,11 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd"
+  version="2.2">
+    <persistence-unit name="JPAPU">
+    	<properties>
+			<!-- EclipseLink should create the database schema automatically -->
+			<property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+		</properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/src/jpa22timeapi/entity/TimeAPIEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/src/jpa22timeapi/entity/TimeAPIEntity.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpa22timeapi.entity;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Version;
+
+@Entity
+@Table(name="TimeAPI_ENT")
+public class TimeAPIEntity {
+	@Id @GeneratedValue private long id;
+	
+	@Basic private java.time.LocalDate localDate;
+	@Basic private java.time.LocalDateTime localDateTime;
+	@Basic private java.time.LocalTime localTime;
+	@Basic private java.time.OffsetTime offsetTime;
+	@Basic private java.time.OffsetDateTime offsetDateTime;
+	
+	@Version private long version;
+	
+	public TimeAPIEntity() {
+		
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public java.time.LocalDate getLocalDate() {
+		return localDate;
+	}
+
+	public void setLocalDate(java.time.LocalDate localDate) {
+		this.localDate = localDate;
+	}
+
+	public java.time.LocalDateTime getLocalDateTime() {
+		return localDateTime;
+	}
+
+	public void setLocalDateTime(java.time.LocalDateTime localDateTime) {
+		this.localDateTime = localDateTime;
+	}
+
+	public java.time.LocalTime getLocalTime() {
+		return localTime;
+	}
+
+	public void setLocalTime(java.time.LocalTime localTime) {
+		this.localTime = localTime;
+	}
+
+	public java.time.OffsetTime getOffsetTime() {
+		return offsetTime;
+	}
+
+	public void setOffsetTime(java.time.OffsetTime offsetTime) {
+		this.offsetTime = offsetTime;
+	}
+
+	public java.time.OffsetDateTime getOffsetDateTime() {
+		return offsetDateTime;
+	}
+
+	public void setOffsetDateTime(java.time.OffsetDateTime offsetDateTime) {
+		this.offsetDateTime = offsetDateTime;
+	}
+
+	public long getVersion() {
+		return version;
+	}
+
+	public void setVersion(long version) {
+		this.version = version;
+	}
+
+	@Override
+	public String toString() {
+		return "TimeAPIEntity [id=" + id + ", localDate=" + localDate + ", localDateTime=" + localDateTime
+				+ ", localTime=" + localTime + ", offsetTime=" + offsetTime + ", offsetDateTime=" + offsetDateTime
+				+ ", version=" + version + "]";
+	}
+	
+	
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/src/jpa22timeapi/entity/TimeAPIEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/src/jpa22timeapi/entity/TimeAPIEntity.java
@@ -19,84 +19,91 @@ import javax.persistence.Table;
 import javax.persistence.Version;
 
 @Entity
-@Table(name="TimeAPI_ENT")
+@Table(name = "TimeAPI_ENT")
 public class TimeAPIEntity {
-	@Id @GeneratedValue private long id;
-	
-	@Basic private java.time.LocalDate localDate;
-	@Basic private java.time.LocalDateTime localDateTime;
-	@Basic private java.time.LocalTime localTime;
-	@Basic private java.time.OffsetTime offsetTime;
-	@Basic private java.time.OffsetDateTime offsetDateTime;
-	
-	@Version private long version;
-	
-	public TimeAPIEntity() {
-		
-	}
+    @Id
+    @GeneratedValue
+    private long id;
 
-	public long getId() {
-		return id;
-	}
+    @Basic
+    private java.time.LocalDate localDate;
+    @Basic
+    private java.time.LocalDateTime localDateTime;
+    @Basic
+    private java.time.LocalTime localTime;
+    @Basic
+    private java.time.OffsetTime offsetTime;
+    @Basic
+    private java.time.OffsetDateTime offsetDateTime;
 
-	public void setId(long id) {
-		this.id = id;
-	}
+    @Version
+    private long version;
 
-	public java.time.LocalDate getLocalDate() {
-		return localDate;
-	}
+    public TimeAPIEntity() {
 
-	public void setLocalDate(java.time.LocalDate localDate) {
-		this.localDate = localDate;
-	}
+    }
 
-	public java.time.LocalDateTime getLocalDateTime() {
-		return localDateTime;
-	}
+    public long getId() {
+        return id;
+    }
 
-	public void setLocalDateTime(java.time.LocalDateTime localDateTime) {
-		this.localDateTime = localDateTime;
-	}
+    public void setId(long id) {
+        this.id = id;
+    }
 
-	public java.time.LocalTime getLocalTime() {
-		return localTime;
-	}
+    public java.time.LocalDate getLocalDate() {
+        return localDate;
+    }
 
-	public void setLocalTime(java.time.LocalTime localTime) {
-		this.localTime = localTime;
-	}
+    public void setLocalDate(java.time.LocalDate localDate) {
+        this.localDate = localDate;
+    }
 
-	public java.time.OffsetTime getOffsetTime() {
-		return offsetTime;
-	}
+    public java.time.LocalDateTime getLocalDateTime() {
+        return localDateTime;
+    }
 
-	public void setOffsetTime(java.time.OffsetTime offsetTime) {
-		this.offsetTime = offsetTime;
-	}
+    public void setLocalDateTime(java.time.LocalDateTime localDateTime) {
+        this.localDateTime = localDateTime;
+    }
 
-	public java.time.OffsetDateTime getOffsetDateTime() {
-		return offsetDateTime;
-	}
+    public java.time.LocalTime getLocalTime() {
+        return localTime;
+    }
 
-	public void setOffsetDateTime(java.time.OffsetDateTime offsetDateTime) {
-		this.offsetDateTime = offsetDateTime;
-	}
+    public void setLocalTime(java.time.LocalTime localTime) {
+        this.localTime = localTime;
+    }
 
-	public long getVersion() {
-		return version;
-	}
+    public java.time.OffsetTime getOffsetTime() {
+        return offsetTime;
+    }
 
-	public void setVersion(long version) {
-		this.version = version;
-	}
+    public void setOffsetTime(java.time.OffsetTime offsetTime) {
+        this.offsetTime = offsetTime;
+    }
 
-	@Override
-	public String toString() {
-		return "TimeAPIEntity [id=" + id + ", localDate=" + localDate + ", localDateTime=" + localDateTime
-				+ ", localTime=" + localTime + ", offsetTime=" + offsetTime + ", offsetDateTime=" + offsetDateTime
-				+ ", version=" + version + "]";
-	}
-	
-	
+    public java.time.OffsetDateTime getOffsetDateTime() {
+        return offsetDateTime;
+    }
+
+    public void setOffsetDateTime(java.time.OffsetDateTime offsetDateTime) {
+        this.offsetDateTime = offsetDateTime;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public void setVersion(long version) {
+        this.version = version;
+    }
+
+    @Override
+    public String toString() {
+        return "TimeAPIEntity [id=" + id + ", localDate=" + localDate + ", localDateTime=" + localDateTime
+               + ", localTime=" + localTime + ", offsetTime=" + offsetTime + ", offsetDateTime=" + offsetDateTime
+               + ", version=" + version + "]";
+    }
+
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/src/jpa22timeapi/web/JPATimeAPITestServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/src/jpa22timeapi/web/JPATimeAPITestServlet.java
@@ -27,8 +27,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import jpa22timeapi.entity.TimeAPIEntity;
 
 @SuppressWarnings("serial")
@@ -41,41 +39,33 @@ public class JPATimeAPITestServlet extends FATServlet {
     private UserTransaction tx;
 
     @Test
-    @Mode(TestMode.LITE)
     public void testJPA22TimeAPI() throws Exception {
-        final String testName = "testJPA22TimeAPI";
-        System.out.println("STARTING " + testName + " ...");
+        java.time.LocalDate localDate = LocalDate.now();
+        java.time.LocalDateTime localDateTime = LocalDateTime.now();
+        java.time.LocalTime localTime = LocalTime.now();
+        java.time.OffsetTime offsetTime = OffsetTime.now();
+        java.time.OffsetDateTime offsetDateTime = OffsetDateTime.now();
 
-        try {
-            java.time.LocalDate localDate = LocalDate.now();
-            java.time.LocalDateTime localDateTime = LocalDateTime.now();
-            java.time.LocalTime localTime = LocalTime.now();
-            java.time.OffsetTime offsetTime = OffsetTime.now();
-            java.time.OffsetDateTime offsetDateTime = OffsetDateTime.now();
+        TimeAPIEntity timeEntity = new TimeAPIEntity();
+        timeEntity.setLocalDate(localDate);
+        timeEntity.setLocalDateTime(localDateTime);
+        timeEntity.setLocalTime(localTime);
+        timeEntity.setOffsetDateTime(offsetDateTime);
+        timeEntity.setOffsetTime(offsetTime);
 
-            TimeAPIEntity timeEntity = new TimeAPIEntity();
-            timeEntity.setLocalDate(localDate);
-            timeEntity.setLocalDateTime(localDateTime);
-            timeEntity.setLocalTime(localTime);
-            timeEntity.setOffsetDateTime(offsetDateTime);
-            timeEntity.setOffsetTime(offsetTime);
+        tx.begin();
+        em.persist(timeEntity);
+        tx.commit();
 
-            tx.begin();
-            em.persist(timeEntity);
-            tx.commit();
+        em.clear();
 
-            em.clear();
+        TimeAPIEntity findEntity = em.find(TimeAPIEntity.class, timeEntity.getId());
+        Assert.assertNotNull(findEntity);
 
-            TimeAPIEntity findEntity = em.find(TimeAPIEntity.class, timeEntity.getId());
-            Assert.assertNotNull(findEntity);
-
-            Assert.assertEquals(localDate, findEntity.getLocalDate());
-            Assert.assertEquals(localDateTime, findEntity.getLocalDateTime());
-            Assert.assertEquals(localTime, findEntity.getLocalTime());
-            Assert.assertEquals(offsetTime, findEntity.getOffsetTime());
-            Assert.assertEquals(offsetDateTime, findEntity.getOffsetDateTime());
-        } finally {
-            System.out.println("ENDING " + testName);
-        }
+        Assert.assertEquals(localDate, findEntity.getLocalDate());
+        Assert.assertEquals(localDateTime, findEntity.getLocalDateTime());
+        Assert.assertEquals(localTime, findEntity.getLocalTime());
+        Assert.assertEquals(offsetTime, findEntity.getOffsetTime());
+        Assert.assertEquals(offsetDateTime, findEntity.getOffsetDateTime());
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/src/jpa22timeapi/web/JPATimeAPITestServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/src/jpa22timeapi/web/JPATimeAPITestServlet.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpa22timeapi.web;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+
+import javax.annotation.Resource;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.servlet.annotation.WebServlet;
+import javax.transaction.UserTransaction;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import jpa22timeapi.entity.TimeAPIEntity;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestJPAAPI")
+public class JPATimeAPITestServlet extends FATServlet {
+	@PersistenceContext(unitName="JPAPU")
+	private EntityManager em;
+	
+	@Resource
+	private UserTransaction tx;
+	
+	@Test
+	@Mode(TestMode.LITE)
+	public void testJPA22TimeAPI() throws Exception {
+		final String testName = "testJPA22TimeAPI";		
+		System.out.println("STARTING " + testName + " ...");
+		
+		try {
+			java.time.LocalDate localDate = LocalDate.now();
+			java.time.LocalDateTime localDateTime = LocalDateTime.now();
+			java.time.LocalTime localTime = LocalTime.now();
+			java.time.OffsetTime offsetTime = OffsetTime.now();
+			java.time.OffsetDateTime offsetDateTime = OffsetDateTime.now();
+			
+			TimeAPIEntity timeEntity = new TimeAPIEntity();
+			timeEntity.setLocalDate(localDate);
+			timeEntity.setLocalDateTime(localDateTime);
+			timeEntity.setLocalTime(localTime);
+			timeEntity.setOffsetDateTime(offsetDateTime);
+			timeEntity.setOffsetTime(offsetTime);
+			
+			tx.begin();
+			em.persist(timeEntity);
+			tx.commit();
+			
+			em.clear();
+			
+			TimeAPIEntity findEntity = em.find(TimeAPIEntity.class, timeEntity.getId());
+			Assert.assertNotNull(findEntity);
+			
+			Assert.assertEquals(localDate, findEntity.getLocalDate());
+			Assert.assertEquals(localDateTime, findEntity.getLocalDateTime());
+			Assert.assertEquals(localTime, findEntity.getLocalTime());
+			Assert.assertEquals(offsetTime, findEntity.getOffsetTime());
+			Assert.assertEquals(offsetDateTime, findEntity.getOffsetDateTime());
+		} finally {
+			System.out.println("ENDING " + testName);
+		}
+	}
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/src/jpa22timeapi/web/JPATimeAPITestServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22timeapi/src/jpa22timeapi/web/JPATimeAPITestServlet.java
@@ -34,48 +34,48 @@ import jpa22timeapi.entity.TimeAPIEntity;
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/TestJPAAPI")
 public class JPATimeAPITestServlet extends FATServlet {
-	@PersistenceContext(unitName="JPAPU")
-	private EntityManager em;
-	
-	@Resource
-	private UserTransaction tx;
-	
-	@Test
-	@Mode(TestMode.LITE)
-	public void testJPA22TimeAPI() throws Exception {
-		final String testName = "testJPA22TimeAPI";		
-		System.out.println("STARTING " + testName + " ...");
-		
-		try {
-			java.time.LocalDate localDate = LocalDate.now();
-			java.time.LocalDateTime localDateTime = LocalDateTime.now();
-			java.time.LocalTime localTime = LocalTime.now();
-			java.time.OffsetTime offsetTime = OffsetTime.now();
-			java.time.OffsetDateTime offsetDateTime = OffsetDateTime.now();
-			
-			TimeAPIEntity timeEntity = new TimeAPIEntity();
-			timeEntity.setLocalDate(localDate);
-			timeEntity.setLocalDateTime(localDateTime);
-			timeEntity.setLocalTime(localTime);
-			timeEntity.setOffsetDateTime(offsetDateTime);
-			timeEntity.setOffsetTime(offsetTime);
-			
-			tx.begin();
-			em.persist(timeEntity);
-			tx.commit();
-			
-			em.clear();
-			
-			TimeAPIEntity findEntity = em.find(TimeAPIEntity.class, timeEntity.getId());
-			Assert.assertNotNull(findEntity);
-			
-			Assert.assertEquals(localDate, findEntity.getLocalDate());
-			Assert.assertEquals(localDateTime, findEntity.getLocalDateTime());
-			Assert.assertEquals(localTime, findEntity.getLocalTime());
-			Assert.assertEquals(offsetTime, findEntity.getOffsetTime());
-			Assert.assertEquals(offsetDateTime, findEntity.getOffsetDateTime());
-		} finally {
-			System.out.println("ENDING " + testName);
-		}
-	}
+    @PersistenceContext(unitName = "JPAPU")
+    private EntityManager em;
+
+    @Resource
+    private UserTransaction tx;
+
+    @Test
+    @Mode(TestMode.LITE)
+    public void testJPA22TimeAPI() throws Exception {
+        final String testName = "testJPA22TimeAPI";
+        System.out.println("STARTING " + testName + " ...");
+
+        try {
+            java.time.LocalDate localDate = LocalDate.now();
+            java.time.LocalDateTime localDateTime = LocalDateTime.now();
+            java.time.LocalTime localTime = LocalTime.now();
+            java.time.OffsetTime offsetTime = OffsetTime.now();
+            java.time.OffsetDateTime offsetDateTime = OffsetDateTime.now();
+
+            TimeAPIEntity timeEntity = new TimeAPIEntity();
+            timeEntity.setLocalDate(localDate);
+            timeEntity.setLocalDateTime(localDateTime);
+            timeEntity.setLocalTime(localTime);
+            timeEntity.setOffsetDateTime(offsetDateTime);
+            timeEntity.setOffsetTime(offsetTime);
+
+            tx.begin();
+            em.persist(timeEntity);
+            tx.commit();
+
+            em.clear();
+
+            TimeAPIEntity findEntity = em.find(TimeAPIEntity.class, timeEntity.getId());
+            Assert.assertNotNull(findEntity);
+
+            Assert.assertEquals(localDate, findEntity.getLocalDate());
+            Assert.assertEquals(localDateTime, findEntity.getLocalDateTime());
+            Assert.assertEquals(localTime, findEntity.getLocalTime());
+            Assert.assertEquals(offsetTime, findEntity.getOffsetTime());
+            Assert.assertEquals(offsetDateTime, findEntity.getOffsetDateTime());
+        } finally {
+            System.out.println("ENDING " + testName);
+        }
+    }
 }


### PR DESCRIPTION
Added some basic tests for the new capabilities introduced with JPA 2.2: CDI injection into Attribute Converters, @Repeatable annotations (@PersistenceContext and @PersistenceUnit since those are the only two the JPA Runtime is responsible for processing), JPA Query Stream, Java Time API.