### PR TITLE
update main concurrency bucket to run with policy executor

### DIFF
--- a/dev/com.ibm.ws.concurrent/.classpath
+++ b/dev/com.ibm.ws.concurrent/.classpath
@@ -4,5 +4,6 @@
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="src" path="/com.ibm.ws.threading"/>
+	<classpathentry kind="src" path="/com.ibm.ws.logging.core"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -24,6 +24,7 @@ import javax.enterprise.concurrent.ManagedTaskListener;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.threading.PolicyTaskCallback;
 import com.ibm.ws.threading.PolicyTaskFuture;
 import com.ibm.wsspi.threadcontext.ThreadContext;
@@ -73,6 +74,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
         return taskName == null ? task.toString() : taskName;
     }
 
+    @FFDCIgnore({ Error.class, RuntimeException.class }) // No need for FFDC, error is logged instead
     @Override
     public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {
         // Tasks that are canceled while running have the taskAborted notification sent on the thread of execution instead.
@@ -92,10 +94,12 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
                         Tr.event(this, tc, "taskAborted", managedExecutor, task, x);
                     listener.taskAborted(future, managedExecutor, task, x);
-                } catch (RuntimeException x) {
+                } catch (Error x) {
+                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
                     failure = x;
                     throw x;
-                } catch (Error x) {
+                } catch (RuntimeException x) {
+                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
                     failure = x;
                     throw x;
                 } finally {
@@ -103,6 +107,12 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
                             Tr.event(this, tc, "taskDone", managedExecutor, task, failure);
                         listener.taskDone(future, managedExecutor, task, failure);
+                    } catch (Error x) {
+                        Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                        throw x;
+                    } catch (RuntimeException x) {
+                        Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                        throw x;
                     } finally {
                         if (suspendTranContext != null)
                             suspendTranContext.taskStopping();
@@ -112,6 +122,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
         }
     }
 
+    @FFDCIgnore(Throwable.class) // No need for FFDC given that an error is already logged
     @Override
     public void onEnd(Object task, PolicyTaskFuture<?> future, Object startObj, boolean aborted, int pending, Throwable failure) {
         if (pending >= 0 && task instanceof ManagedTask) {
@@ -159,6 +170,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
         }
     }
 
+    @FFDCIgnore({ Error.class, RuntimeException.class }) // No need for FFDC, error is logged instead
     @Override
     public Object onStart(Object task, PolicyTaskFuture<?> future) {
         // EE Concurrency 3.1.6.1: No task submitted to an executor can run if task's component is not started.
@@ -174,9 +186,11 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
                         Tr.event(this, tc, "taskStarting", managedExecutor, task);
                     listener.taskStarting(future, managedExecutor, task);
                 } catch (Error x) {
+                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
                     threadContextDescriptor.taskStopping(contextAppliedToThread);
                     throw x;
                 } catch (RuntimeException x) {
+                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
                     threadContextDescriptor.taskStopping(contextAppliedToThread);
                     throw x;
                 }

--- a/dev/com.ibm.ws.concurrent_fat/publish/servers/concurrent.spec.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent_fat/publish/servers/concurrent.spec.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info=enabled:concurrent=all:context=all:test.concurrent.*=all
+com.ibm.ws.logging.trace.specification=*=info=enabled:concurrent=all:context=all:test.concurrent.*=all:com.ibm.ws.threading.Policy*=all:com.ibm.ws.threading.internal.Policy*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 #websphere.java.security=true

--- a/dev/com.ibm.ws.concurrent_fat/publish/servers/concurrent.spec.fat/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat/publish/servers/concurrent.spec.fat/server.xml
@@ -10,17 +10,21 @@
   <include location="../fatTestPorts.xml"/>
   <variable name="onError" value="FAIL"/>
 
-  <managedExecutorService jndiName="concurrent/jeeMetadataContextSvc">
+  <!-- TODO remove the internal attribute (and overrides of default instances) once managed executors are switched over to using policy executor -->
+  <managedExecutorService id="DefaultManagedExecutorService" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"/>
+  <managedScheduledExecutorService id="DefaultManagedScheduledExecutorService" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"/>
+
+  <managedExecutorService jndiName="concurrent/jeeMetadataContextSvc" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only">
     <contextService>
       <jeeMetadataContext/>
     </contextService>
   </managedExecutorService>
 
-  <managedExecutorService jndiName="concurrent/xsvc-empty-context">
+  <managedExecutorService jndiName="concurrent/xsvc-empty-context" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only">
     <contextService/>
   </managedExecutorService>
 
-  <managedScheduledExecutorService jndiName="concurrent/schedxsvc-classloader-context">
+  <managedScheduledExecutorService jndiName="concurrent/schedxsvc-classloader-context" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only">
     <contextService>
       <classloaderContext/>
     </contextService>

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -279,6 +279,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
         }
     }
 
+    @FFDCIgnore(RejectedExecutionException.class)
     PolicyTaskFutureImpl(PolicyExecutorImpl executor, Callable<T> task, PolicyTaskCallback callback) {
         if (task == null)
             throw new NullPointerException();
@@ -296,12 +297,16 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             } catch (Error x) {
                 abort(x);
                 throw x;
+            } catch (RejectedExecutionException x) { // same as RuntimeException, but ignore FFDC
+                abort(x);
+                throw x;
             } catch (RuntimeException x) {
                 abort(x);
                 throw x;
             }
     }
 
+    @FFDCIgnore(RejectedExecutionException.class)
     PolicyTaskFutureImpl(PolicyExecutorImpl executor, Callable<T> task, PolicyTaskCallback callback, InvokeAnyLatch latch) {
         if (task == null)
             throw new NullPointerException();
@@ -319,12 +324,16 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             } catch (Error x) {
                 abort(x);
                 throw x;
+            } catch (RejectedExecutionException x) { // same as RuntimeException, but ignore FFDC
+                abort(x);
+                throw x;
             } catch (RuntimeException x) {
                 abort(x);
                 throw x;
             }
     }
 
+    @FFDCIgnore(RejectedExecutionException.class)
     PolicyTaskFutureImpl(PolicyExecutorImpl executor, Runnable task, T predefinedResult, PolicyTaskCallback callback) {
         if (task == null)
             throw new NullPointerException();
@@ -340,6 +349,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             try {
                 callback.onSubmit(task, this, 0);
             } catch (Error x) {
+                abort(x);
+                throw x;
+            } catch (RejectedExecutionException x) { // same as RuntimeException, but ignore FFDC
                 abort(x);
                 throw x;
             } catch (RuntimeException x) {


### PR DESCRIPTION
Updates to the main EE Concurrency bucket (some temporary) to have it run with managed executors that are backed by unconstrained policy executors.  Although we haven't switched over managed executor yet, this will help us in advance catch potential intermittent issues that might arise, given that this bucket which provides excellent coverage of the Liberty implementation of the EE Concurrency spec will be running in every build.  The updates needed in the tests themselves were to exception paths, where the current implementation had a bug in reporting ExecutionException despite the task being canceled and never starting.  The policy executor based implementation correctly reports CancellationException for this case, and tests are updated to match the proper expectation.