### PR TITLE
Apply 'bulidfat' task to all projects

### DIFF
--- a/dev/cnf/gradle/scripts/fat.gradle
+++ b/dev/cnf/gradle/scripts/fat.gradle
@@ -317,14 +317,14 @@ assemble {
 }
 
 build {
-  // Skip out on 'assemble' unless top-level gradle invocation contains "fat"
+  // Skip out on 'build' unless top-level gradle invocation contains "fat"
   if(!buildFatEnabled) {
     enabled = false;
     dependsOn = [];
   }
 }
 
-task buildfat {
+buildfat {
   dependsOn build
 }
 

--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -431,6 +431,10 @@ subprojects {
       }
     }
   }
+  
+  task buildfat {
+	  // A no-op task for regular projects which FATs will override
+  }
 
   sourceSets {
     main {


### PR DESCRIPTION
Unless the `buildfat` task is applied to all subprojects, it won't be able to invoke the `buildfat` task at top level for all projects (i.e. `./gradlew buildfat`)