### PR TITLE
HTTP2 - Fixing a deadlock when processing a read (slice buffer) frames

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/FrameReadProcessor.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/FrameReadProcessor.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.http.channel.h2internal;
 
+import java.util.Arrays;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
@@ -20,11 +22,13 @@ import com.ibm.ws.http.channel.h2internal.exceptions.ProtocolException;
 import com.ibm.ws.http.channel.h2internal.frames.Frame;
 import com.ibm.ws.http.channel.h2internal.frames.FrameFactory;
 import com.ibm.ws.http.channel.h2internal.frames.FrameRstStream;
+import com.ibm.ws.http.channel.internal.HttpMessages;
 import com.ibm.wsspi.bytebuffer.WsByteBuffer;
 
 public class FrameReadProcessor {
 
-    private static final TraceComponent tc = Tr.register(FrameReadProcessor.class);
+    /** RAS tracing variable */
+    private static final TraceComponent tc = Tr.register(FrameReadProcessor.class, HttpMessages.HTTP_TRACE_NAME, HttpMessages.HTTP_BUNDLE);
 
     /** starting size of the pending buffer array */
     private static final int BUFFER_ARRAY_INITIAL_SIZE = 10;
@@ -382,6 +386,16 @@ public class FrameReadProcessor {
     public boolean checkConnectionPreface() throws FrameSizeException {
         byte[] value = grabNextBytes(24);
         String valueString = new String(value);
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "checkConnectionPreface: processNextFrame-:  stream: 0 frame type: Magic Preface  direction: "
+                         + Direction.READ_IN
+                         + " H2InboundLink hc: " + muxLink.hashCode());
+            if (value != null) {
+                Tr.debug(tc, "checkConnectionPreface: Preface String: " + Arrays.toString(valueString.getBytes()));
+            }
+        }
+
         return valueString.equals("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
     }
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/frames/Frame.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/frames/Frame.java
@@ -260,7 +260,7 @@ public abstract class Frame {
     public String toString() {
         StringBuilder frameToString = new StringBuilder();
 
-        frameToString.append("FrameType: " + this.getFrameType() + "\n");
+        frameToString.append("\nFrameType: " + this.getFrameType() + "\n");
 
         frameToString.append("FrameFlags:\n");
         frameToString.append(" FlagAckSet: ").append(this.flagAckSet()).append("\n");


### PR DESCRIPTION
and write frames
Timing issue where a thread processing a read of a sliced buffer can
deadlock with another thread that is writing a frame on the same HTTP/2
connection.