### PR TITLE
per-task override of startTimeout and test via invokeAny

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -67,11 +67,27 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
      * @param task the task.
      * @return the task name.
      */
+    @Override
     @Trivial
-    final String getName(Object task) {
+    public final String getName(Object task) {
         Map<String, String> execProps = threadContextDescriptor.getExecutionProperties();
         String taskName = execProps == null ? null : execProps.get(ManagedTask.IDENTITY_NAME);
         return taskName == null ? task.toString() : taskName;
+    }
+
+    @Override
+    @Trivial
+    public final long getStartTimeout(long defaultStartTimeoutNS) {
+        Map<String, String> execProps = threadContextDescriptor.getExecutionProperties();
+        String value = execProps == null ? null : execProps.get("com.ibm.ws.concurrent.START_TIMEOUT_NANOS");
+        try {
+            long ns = value == null ? defaultStartTimeoutNS : Long.parseLong(value);
+            if (ns < -1)
+                throw new IllegalArgumentException("com.ibm.ws.concurrent.START_TIMEOUT_NANOS: " + value);
+            return ns;
+        } catch (NumberFormatException x) {
+            throw new IllegalArgumentException("com.ibm.ws.concurrent.START_TIMEOUT_NANOS: " + value);
+        }
     }
 
     @FFDCIgnore({ Error.class, RuntimeException.class }) // No need for FFDC, error is logged instead

--- a/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
@@ -33,7 +33,7 @@
    maxConcurrency="1" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" maxWaitForEnqueue="0" runIfQueueFull="false"/>
 
   <managedScheduledExecutorService jndiName="concurrent/scheduledExecutor2" contextServiceRef="jeeMetadataOnly" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   coreConcurrency="1" maxConcurency="2" maxConcurrencyAppliesToCallerThread="false" maxQueueSize="2" runIfQueueFull="false"/>
+   coreConcurrency="1" maxConcurrency="2" maxConcurrencyAppliesToCallerThread="false" maxQueueSize="2" runIfQueueFull="false"/>
 
   <contextService id="jeeMetadataOnly">
     <jeeMetadataContext/>

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
@@ -20,6 +20,26 @@ import com.ibm.websphere.ras.annotation.Trivial;
 @Trivial
 public abstract class PolicyTaskCallback {
     /**
+     * Returns the name of the task, which, for example, might be reported in exception messages or messages that are logged.
+     *
+     * @param task the Callable or Runnable task.
+     * @return the default implementation invokes toString on the task object.
+     */
+    public String getName(Object task) {
+        return task.toString();
+    }
+
+    /**
+     * Allows for an override of the default start timeout, which is provided as a parameter.
+     *
+     * @param defaultStartTimeoutNS the default start timeout (in nanoseconds) that is configured on the policy executor. -1 indicates no timeout.
+     * @return the default implementation returns the default start timeout in nanoseconds.
+     */
+    public long getStartTimeout(long defaultStartTimeoutNS) {
+        return defaultStartTimeoutNS;
+    }
+
+    /**
      * Invoked when a task's future is canceled.
      * This callback is invoked synchronously on the thread that cancels the task.
      *

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -176,9 +176,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                 Tr.debug(PolicyExecutorImpl.this, tc, "core/maxConcurrency available", coreConcurrencyAvailable, maxConcurrencyConstraint.availablePermits(), canRun);
 
             // Avoid reschedule if we are in a state that disallows starting tasks or if no withheld tasks remain
-            if (canRun && withheldConcurrency.get() > 0 && maxConcurrencyConstraint.tryAcquire())
-
-            {
+            if (canRun && withheldConcurrency.get() > 0 && maxConcurrencyConstraint.tryAcquire()) {
                 decrementWithheldConcurrency();
                 if (acquireCoreConcurrency() > 0)
                     expediteGlobal(GlobalPoolTask.this);
@@ -543,8 +541,11 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         try {
             // create futures in advance, which gives the callback an opportunity to reject
             int t = 0;
-            for (Callable<T> task : tasks)
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callbacks == null ? null : callbacks[t++], startTimeout));
+            for (Callable<T> task : tasks) {
+                PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS));
+            }
 
             // enqueue tasks (except the last if we are able to run tasks on the current thread)
             int numToSubmitAsync = useCurrentThread ? taskCount - 1 : taskCount;
@@ -636,8 +637,11 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         try {
             // create futures in advance, which gives the callback an opportunity to reject
             int t = 0;
-            for (Callable<T> task : tasks)
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callbacks == null ? null : callbacks[t++], startTimeout));
+            for (Callable<T> task : tasks) {
+                PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS));
+            }
 
             // enqueue all tasks
             for (PolicyTaskFutureImpl<T> taskFuture : futures) {
@@ -723,8 +727,11 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         try {
             // create futures in advance, which gives the callback an opportunity to reject
             int t = 0;
-            for (Callable<T> task : tasks)
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callbacks == null ? null : callbacks[t++], startTimeout, latch));
+            for (Callable<T> task : tasks) {
+                PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS, latch));
+            }
 
             // enqueue all tasks
             for (PolicyTaskFutureImpl<T> taskFuture : futures) {
@@ -770,7 +777,9 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             int t = 0;
             for (Callable<T> task : tasks) {
                 remaining = stop - System.nanoTime();
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callbacks == null ? null : callbacks[t++], startTimeout, latch));
+                PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS, latch));
                 if (remaining <= 0)
                     throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1204.unable.to.invoke", identifier, taskCount - futures.size(), taskCount, timeout, unit));
             }
@@ -1071,7 +1080,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
     @Override
     public <T> PolicyTaskFuture<T> submit(Callable<T> task, PolicyTaskCallback callback) {
-        PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task, callback, startTimeout);
+        long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+        PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS);
         enqueue(policyTaskFuture, maxWaitForEnqueueNS.get(), null);
         return policyTaskFuture;
     }
@@ -1092,7 +1102,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
     @Override
     public <T> PolicyTaskFuture<T> submit(Runnable task, T result, PolicyTaskCallback callback) {
-        PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task, result, callback, startTimeout);
+        long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+        PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task, result, callback, startTimeoutNS);
         enqueue(policyTaskFuture, maxWaitForEnqueueNS.get(), null);
         return policyTaskFuture;
     }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -3516,7 +3516,8 @@ public class PolicyExecutorServlet extends FATServlet {
     // Verify that invokeAny returns the result of one of the successful tasks.
     @Test
     public void testInvokeAnyTimedAllSuccessful() throws Exception {
-        PolicyExecutor executor = provider.create("testInvokeAnyTimedAllSuccessful");
+        PolicyExecutor executor = provider.create("testInvokeAnyTimedAllSuccessful")
+                        .startTimeout(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS));
 
         final int numTasks = 3;
         AtomicInteger counter = new AtomicInteger();


### PR DESCRIPTION
Make it possible to override startTimeout per task.
Add a test case where all tasks submitted to invokeAny time out per their respective startTimeout override