### PR TITLE
Test JSF Container for WAR in EAR application

### DIFF
--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfo.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfo.java
@@ -1006,7 +1006,8 @@ public class EARDeployedAppInfo extends DeployedAppInfoBase {
         ClassLoaderConfiguration clCfg = classLoadingService.createClassLoaderConfiguration()
                         .setId(moduleClassLoaderId)
                         .setParentId(parentId)
-                        .setDelegateToParentAfterCheckingLocalClasspath(isDelegateLast);
+                        .setDelegateToParentAfterCheckingLocalClasspath(isDelegateLast)
+			.setIncludeAppExtensions(true);
 
         clCfg.setProtectionDomain(protectionDomain);
 

--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/war/internal/WARDeployedAppInfo.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/war/internal/WARDeployedAppInfo.java
@@ -101,7 +101,8 @@ class WARDeployedAppInfo extends DeployedAppInfoBase {
 
             ClassLoaderConfiguration clCfg = cls.createClassLoaderConfiguration()
                             .setId(cls.createIdentity("WebModule", j2eeAppName + "#" + j2eeModuleName))
-                            .setProtectionDomain(protectionDomain);
+                            .setProtectionDomain(protectionDomain)
+			    .setIncludeAppExtensions(true);
 
             return createTopLevelClassLoader(containers, gwCfg, clCfg);
         } else {

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderConfigurationImpl.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderConfigurationImpl.java
@@ -14,6 +14,7 @@ import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -26,9 +27,10 @@ import com.ibm.wsspi.classloading.ClassLoaderIdentity;
 class ClassLoaderConfigurationImpl implements ClassLoaderConfiguration {
     private final static ProtectionDomain DEFAULT_PROTECTION_DOMAIN = new ProtectionDomain(new CodeSource((URL) null, (Certificate[]) null), null);
     private boolean delegateLast;
+    private boolean includeAppExtensions;
     private ClassLoaderIdentity id;
     private ClassLoaderIdentity parentId;
-    private List<String> sharedLibraries = Collections.emptyList();
+    private List<String> sharedLibraries = new ArrayList<String>();
     private List<String> commonLibraries = Collections.emptyList();
     private List<String> providers = Collections.emptyList();
     private List<Container> nativeLibraryContainers = Collections.emptyList();
@@ -61,6 +63,19 @@ class ClassLoaderConfigurationImpl implements ClassLoaderConfiguration {
     @Override
     public ClassLoaderConfiguration setSharedLibraries(String... libs) {
         return setSharedLibraries(libs == null ? null : Arrays.asList(libs));
+    }
+
+    @Override
+    public ClassLoaderConfiguration addSharedLibraries(List<String> libs) {
+        for (String lib : libs)
+            if (!this.sharedLibraries.contains(lib))
+                this.sharedLibraries.add(lib);
+        return this;
+    }
+
+    @Override
+    public ClassLoaderConfiguration addSharedLibraries(String... libs) {
+        return libs == null ? this : this.addSharedLibraries(Arrays.asList(libs));
     }
 
     @Override
@@ -141,17 +156,17 @@ class ClassLoaderConfigurationImpl implements ClassLoaderConfiguration {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append(id)
-                        .append(" [child of ").append(parentId).append("]")
-                        .append(" privateLibraries = ").append(sharedLibraries)
-                        .append(" commonLibraries = ").append(commonLibraries)
-                        .append(" providers = ").append(providers)
-                        .append(" nativeLibraries = ").append(nativeLibraryContainers);
+          .append(" [child of ").append(parentId).append("]")
+          .append(" privateLibraries = ").append(sharedLibraries)
+          .append(" commonLibraries = ").append(commonLibraries)
+          .append(" providers = ").append(providers)
+          .append(" nativeLibraries = ").append(nativeLibraryContainers);
         return sb.toString();
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.classloading.ClassLoaderConfiguration#setProtectionDomain(java.security.ProtectionDomain)
      */
     @Override
@@ -162,11 +177,22 @@ class ClassLoaderConfigurationImpl implements ClassLoaderConfiguration {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.classloading.ClassLoaderConfiguration#getProtectionDomain()
      */
     @Override
     public ProtectionDomain getProtectionDomain() {
         return protectionDomain;
+    }
+
+    @Override
+    public ClassLoaderConfiguration setIncludeAppExtensions(boolean include) {
+        includeAppExtensions = include;
+        return this;
+    }
+
+    @Override
+    public boolean getIncludeAppExtensions() {
+        return includeAppExtensions;
     }
 }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ClassLoaderConfiguration.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ClassLoaderConfiguration.java
@@ -42,6 +42,12 @@ public interface ClassLoaderConfiguration {
     /** @see #setSharedLibraries(List) */
     ClassLoaderConfiguration setSharedLibraries(String... libs);
 
+    /** @param libs the names of shared libraries that should be associated with this classloader */
+    ClassLoaderConfiguration addSharedLibraries(List<String> libs);
+
+    /** @see #addSharedLibraries(List) */
+    ClassLoaderConfiguration addSharedLibraries(String... libs);
+
     List<String> getSharedLibraries();
 
     /** @param libs the names of common shared libraries that should be associated with this classloader */
@@ -73,4 +79,9 @@ public interface ClassLoaderConfiguration {
     ClassLoaderConfiguration setProtectionDomain(ProtectionDomain domain);
 
     ProtectionDomain getProtectionDomain();
+
+    /** @param include Whether or not to include ApplicationExtensionLibrary instances to this classloader */
+    ClassLoaderConfiguration setIncludeAppExtensions(boolean include);
+
+    boolean getIncludeAppExtensions();
 }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ClassLoadingService.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ClassLoadingService.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.ibm.wsspi.adaptable.module.Container;
-import com.ibm.wsspi.library.ApplicationExtensionLibrary;
 import com.ibm.wsspi.library.Library;
 
 /**
@@ -199,10 +198,4 @@ public interface ClassLoadingService {
      * @param protectionDomainMap
      */
     void setSharedLibraryProtectionDomains(Map<String, ProtectionDomain> protectionDomainMap);
-
-    /**
-     * Returns a list of Libraries that are attached to application classloaders
-     * without configuration, for the purposes of providing application extensions
-     */
-    List<ApplicationExtensionLibrary> getAppExtLibs();
 }

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
@@ -25,7 +25,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 JSF22StatelessViewTests.class,
                 JSF22BeanValidationTests.class,
                 ErrorPathsTest.class,
-                ConfigTest.class
+                ClassloadingTest.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/files/server_testCommonLib.xml
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/files/server_testCommonLib.xml
@@ -25,6 +25,10 @@
     <application location="noJsfApp.war">
     	<classloader commonLibraryRef="somelib"/>
     </application>
+    
+    <enterpriseApplication location="jsfEarApp.ear">
+    	<classloader commonLibraryRef="somelib"/>
+    </enterpriseApplication>
 
     <library id="somelib">
        <fileset dir="${server.config.dir}/lib" includes="someLib.jar"/>

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/files/server_testGlobalLib.xml
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/files/server_testGlobalLib.xml
@@ -21,6 +21,8 @@
     <application location="jsfApp.war"/>
 
     <application location="noJsfApp.war"/>
+    
+    <enterpriseApplication location="jsfEarApp.ear"/>
 
     <library id="global">
        <fileset dir="${server.config.dir}/lib" includes="someLib.jar"/>

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/files/server_testPrivateLib.xml
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/files/server_testPrivateLib.xml
@@ -25,6 +25,10 @@
     <application location="noJsfApp.war">
     	<classloader privateLibraryRef="somelib"/>
     </application>
+    
+    <enterpriseApplication location="jsfEarApp.ear">
+    	<classloader privateLibraryRef="somelib"/>
+    </enterpriseApplication>
 
     <library id="somelib">
        <fileset dir="${server.config.dir}/lib" includes="someLib.jar"/>

--- a/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/servers/jsf.container.2.2_fat.config/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer.2.2_fat/publish/servers/jsf.container.2.2_fat.config/bootstrap.properties
@@ -9,3 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all:\
+com.ibm.ws.classloading.internal.ClassLoadingServiceImpl=all:\
+com.ibm.ws.classloading.ClassLoaderConfigHelper=all


### PR DESCRIPTION
When using jsfContainer in an EAR application, it is not sufficient to
apply AppExtLibs to the top level classloader.  Instead, we need to apply
AppExtLibs to the module classloaders.

As a result of this change, we now apply AppExtLibs to the top level
classloader for WAR applications (single module, single classloader) and
for EAR applications we apply them to each individual child module.