### PR TITLE
remove timed out tasks if unable to enqueue

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -67,11 +67,27 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
      * @param task the task.
      * @return the task name.
      */
+    @Override
     @Trivial
-    final String getName(Object task) {
+    public final String getName(Object task) {
         Map<String, String> execProps = threadContextDescriptor.getExecutionProperties();
         String taskName = execProps == null ? null : execProps.get(ManagedTask.IDENTITY_NAME);
         return taskName == null ? task.toString() : taskName;
+    }
+
+    @Override
+    @Trivial
+    public final long getStartTimeout(long defaultStartTimeoutNS) {
+        Map<String, String> execProps = threadContextDescriptor.getExecutionProperties();
+        String value = execProps == null ? null : execProps.get("com.ibm.ws.concurrent.START_TIMEOUT_NANOS");
+        try {
+            long ns = value == null ? defaultStartTimeoutNS : Long.parseLong(value);
+            if (ns < -1)
+                throw new IllegalArgumentException("com.ibm.ws.concurrent.START_TIMEOUT_NANOS: " + value);
+            return ns;
+        } catch (NumberFormatException x) {
+            throw new IllegalArgumentException("com.ibm.ws.concurrent.START_TIMEOUT_NANOS: " + value);
+        }
     }
 
     @FFDCIgnore({ Error.class, RuntimeException.class }) // No need for FFDC, error is logged instead

--- a/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
@@ -33,7 +33,7 @@
    maxConcurrency="1" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" maxWaitForEnqueue="0" runIfQueueFull="false"/>
 
   <managedScheduledExecutorService jndiName="concurrent/scheduledExecutor2" contextServiceRef="jeeMetadataOnly" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   coreConcurrency="1" maxConcurency="2" maxConcurrencyAppliesToCallerThread="false" maxQueueSize="2" runIfQueueFull="false"/>
+   coreConcurrency="1" maxConcurrency="2" maxConcurrencyAppliesToCallerThread="false" maxQueueSize="2" runIfQueueFull="false"/>
 
   <contextService id="jeeMetadataOnly">
     <jeeMetadataContext/>

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
@@ -20,6 +20,26 @@ import com.ibm.websphere.ras.annotation.Trivial;
 @Trivial
 public abstract class PolicyTaskCallback {
     /**
+     * Returns the name of the task, which, for example, might be reported in exception messages or messages that are logged.
+     *
+     * @param task the Callable or Runnable task.
+     * @return the default implementation invokes toString on the task object.
+     */
+    public String getName(Object task) {
+        return task.toString();
+    }
+
+    /**
+     * Allows for an override of the default start timeout, which is provided as a parameter.
+     *
+     * @param defaultStartTimeoutNS the default start timeout (in nanoseconds) that is configured on the policy executor. -1 indicates no timeout.
+     * @return the default implementation returns the default start timeout in nanoseconds.
+     */
+    public long getStartTimeout(long defaultStartTimeoutNS) {
+        return defaultStartTimeoutNS;
+    }
+
+    /**
      * Invoked when a task's future is canceled.
      * This callback is invoked synchronously on the thread that cancels the task.
      *

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -394,8 +394,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         try {
             // TODO purge timed out tasks and retry if we cannot immediately acquire a permit
             if (wait <= 0 ? maxQueueSizeConstraint.tryAcquire() : maxQueueSizeConstraint.tryAcquire(wait, TimeUnit.NANOSECONDS)) {
-                enqueued = queue.offer(policyTaskFuture);
                 policyTaskFuture.accept(false);
+                enqueued = queue.offer(policyTaskFuture);
 
                 int w = withheldConcurrency.incrementAndGet();
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -176,9 +176,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                 Tr.debug(PolicyExecutorImpl.this, tc, "core/maxConcurrency available", coreConcurrencyAvailable, maxConcurrencyConstraint.availablePermits(), canRun);
 
             // Avoid reschedule if we are in a state that disallows starting tasks or if no withheld tasks remain
-            if (canRun && withheldConcurrency.get() > 0 && maxConcurrencyConstraint.tryAcquire())
-
-            {
+            if (canRun && withheldConcurrency.get() > 0 && maxConcurrencyConstraint.tryAcquire()) {
                 decrementWithheldConcurrency();
                 if (acquireCoreConcurrency() > 0)
                     expediteGlobal(GlobalPoolTask.this);
@@ -543,8 +541,11 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         try {
             // create futures in advance, which gives the callback an opportunity to reject
             int t = 0;
-            for (Callable<T> task : tasks)
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callbacks == null ? null : callbacks[t++], startTimeout));
+            for (Callable<T> task : tasks) {
+                PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS));
+            }
 
             // enqueue tasks (except the last if we are able to run tasks on the current thread)
             int numToSubmitAsync = useCurrentThread ? taskCount - 1 : taskCount;
@@ -636,8 +637,11 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         try {
             // create futures in advance, which gives the callback an opportunity to reject
             int t = 0;
-            for (Callable<T> task : tasks)
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callbacks == null ? null : callbacks[t++], startTimeout));
+            for (Callable<T> task : tasks) {
+                PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS));
+            }
 
             // enqueue all tasks
             for (PolicyTaskFutureImpl<T> taskFuture : futures) {
@@ -723,8 +727,11 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         try {
             // create futures in advance, which gives the callback an opportunity to reject
             int t = 0;
-            for (Callable<T> task : tasks)
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callbacks == null ? null : callbacks[t++], startTimeout, latch));
+            for (Callable<T> task : tasks) {
+                PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS, latch));
+            }
 
             // enqueue all tasks
             for (PolicyTaskFutureImpl<T> taskFuture : futures) {
@@ -770,7 +777,9 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             int t = 0;
             for (Callable<T> task : tasks) {
                 remaining = stop - System.nanoTime();
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callbacks == null ? null : callbacks[t++], startTimeout, latch));
+                PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS, latch));
                 if (remaining <= 0)
                     throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1204.unable.to.invoke", identifier, taskCount - futures.size(), taskCount, timeout, unit));
             }
@@ -1071,7 +1080,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
     @Override
     public <T> PolicyTaskFuture<T> submit(Callable<T> task, PolicyTaskCallback callback) {
-        PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task, callback, startTimeout);
+        long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+        PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS);
         enqueue(policyTaskFuture, maxWaitForEnqueueNS.get(), null);
         return policyTaskFuture;
     }
@@ -1092,7 +1102,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
     @Override
     public <T> PolicyTaskFuture<T> submit(Runnable task, T result, PolicyTaskCallback callback) {
-        PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task, result, callback, startTimeout);
+        long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
+        PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task, result, callback, startTimeoutNS);
         enqueue(policyTaskFuture, maxWaitForEnqueueNS.get(), null);
         return policyTaskFuture;
     }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -3516,7 +3516,8 @@ public class PolicyExecutorServlet extends FATServlet {
     // Verify that invokeAny returns the result of one of the successful tasks.
     @Test
     public void testInvokeAnyTimedAllSuccessful() throws Exception {
-        PolicyExecutor executor = provider.create("testInvokeAnyTimedAllSuccessful");
+        PolicyExecutor executor = provider.create("testInvokeAnyTimedAllSuccessful")
+                        .startTimeout(TimeUnit.NANOSECONDS.toMillis(TIMEOUT_NS));
 
         final int numTasks = 3;
         AtomicInteger counter = new AtomicInteger();

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -4302,23 +4302,18 @@ public class PolicyExecutorServlet extends FATServlet {
     @Test
     public void testStartTimeout() throws Exception {
         PolicyExecutor executor = provider.create("testStartTimeout")
-                        .maxConcurrency(1)
-                        .startTimeout(300);
+                        .maxConcurrency(1);
         // Use up maxConcurrency so that no other tasks can start
         CountDownLatch blocker = new CountDownLatch(1);
         CountDownLatch unused = new CountDownLatch(0);
         CountDownTask blockerTask = new CountDownTask(unused, blocker, TIMEOUT_NS * 2);
         PolicyTaskFuture<Boolean> blockerFuture = (PolicyTaskFuture<Boolean>) executor.submit(blockerTask);
 
-        // Assume that we can get a task to submit in under 300ms if we try enough times, even if test infrastructure that we are running on is very slow and suffers delays
+        // startTimeout is applied after submitting the blocker so that it doesn't ever stop the blocker task from starting
+        executor.startTimeout(300);
+
         AtomicInteger counter = new AtomicInteger();
-        PolicyTaskFuture<Integer> future = null;
-        for (int i = 0; i < 20 && future == null; i++)
-            try {
-                future = (PolicyTaskFuture<Integer>) executor.submit(new SharedIncrementTask(counter), 1);
-            } catch (RejectedExecutionException x) {
-            } // pass - timed out too soon TODO check exception message to confirm
-        assertNotNull(future);
+        PolicyTaskFuture<Integer> future = (PolicyTaskFuture<Integer>) executor.submit(new SharedIncrementTask(counter), 1);
 
         // Wait just long enough to time out the queued task
         long delayMS = 300 - future.getElapsedAcceptTime(TimeUnit.MILLISECONDS) - future.getElapsedQueueTime(TimeUnit.MILLISECONDS) + 2;
@@ -4328,7 +4323,7 @@ public class PolicyExecutorServlet extends FATServlet {
         // Let the blocking task finish so that the queued task can attempt to run
         blocker.countDown();
 
-        // Task must aborted due to start timeout
+        // Task must be aborted due to start timeout
         try {
             Integer result = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
             fail("Task should be been aborted, instead result is: " + result);
@@ -4348,6 +4343,101 @@ public class PolicyExecutorServlet extends FATServlet {
         long runTimeMS = blockerFuture.getElapsedRunTime(TimeUnit.MILLISECONDS);
         assertTrue(runTimeMS + "ms, " + delayMS + "ms", runTimeMS >= delayMS);
         assertEquals(runTimeMS, blockerFuture.getElapsedRunTime(TimeUnit.MILLISECONDS));
+
+        assertEquals(Collections.EMPTY_LIST, executor.shutdownNow());
+    }
+
+    // Submit tasks that get queued, but time out (due to startTimeout) while in the queue due to other
+    // submits needing their queue positions.
+    @Test
+    public void testStartTimeoutFromQueue() throws Exception {
+        PolicyExecutor executor = provider.create("testStartTimeoutFromQueue")
+                        .maxConcurrency(1)
+                        .maxQueueSize(3);
+        // Use up maxConcurrency so that no other tasks can start
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch unused = new CountDownLatch(0);
+        CountDownTask blockerTask = new CountDownTask(unused, blocker, TIMEOUT_NS * 2);
+        PolicyTaskFuture<Boolean> blockerFuture = (PolicyTaskFuture<Boolean>) executor.submit(blockerTask);
+
+        AtomicInteger counter145 = new AtomicInteger();
+        AtomicInteger counter23 = new AtomicInteger();
+
+        // Use up the first queue position for a task that doesn't time out
+        Future<Integer> future1 = executor.submit((Callable<Integer>) new SharedIncrementTask(counter145));
+
+        // startTimeout is applied after submitting the blocker and first task,
+        // so that it doesn't ever stop them from starting
+        executor.startTimeout(200);
+
+        // Submit 2 tasks that can time out
+        Callable<Integer> task2 = new SharedIncrementTask(counter23);
+        PolicyTaskFuture<Integer> future2 = (PolicyTaskFuture<Integer>) executor.submit(task2);
+        Callable<Integer> task3 = new SharedIncrementTask(counter23);
+        PolicyTaskFuture<Integer> future3 = (PolicyTaskFuture<Integer>) executor.submit(task3);
+
+        // Let the tasks time out, but they remain in the queue
+        TimeUnit.MILLISECONDS.sleep(200);
+
+        // ensure that tasks submitted after this point do not time out
+        executor.startTimeout(-1);
+
+        // Submit 2 more tasks that should take over the queue positions of the previous 2 tasks
+        Callable<Integer> task4 = new SharedIncrementTask(counter145);
+        PolicyTaskFuture<Integer> future4 = (PolicyTaskFuture<Integer>) executor.submit(task4);
+        Callable<Integer> task5 = new SharedIncrementTask(counter145);
+        PolicyTaskFuture<Integer> future5 = (PolicyTaskFuture<Integer>) executor.submit(task5);
+
+        // Tasks 2 and 3 must be aborted due to start timeout
+        long acceptTime2 = future2.getElapsedAcceptTime(TimeUnit.NANOSECONDS);
+        long acceptTime3 = future3.getElapsedAcceptTime(TimeUnit.NANOSECONDS);
+        long queueTime2 = future2.getElapsedQueueTime(TimeUnit.NANOSECONDS);
+        long queueTime3 = future3.getElapsedQueueTime(TimeUnit.NANOSECONDS);
+        assertTrue(future2.isDone());
+        assertTrue(future3.isDone());
+        assertFalse(future2.isCancelled());
+        assertFalse(future3.isCancelled());
+        assertTrue(acceptTime2 >= 0);
+        assertTrue(acceptTime3 >= 0);
+        assertTrue(queueTime2 >= 0);
+        assertTrue(queueTime3 >= 0);
+
+        try {
+            Integer result = future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+            fail("Task 2 should be been aborted, instead result is: " + result);
+        } catch (RejectedExecutionException x) {
+            // TODO check the message of the cause exception once we add it
+        } // pass - aborted due to timeout
+
+        try {
+            Integer result = future3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+            fail("Task 3 should be been aborted, instead result is: " + result);
+        } catch (RejectedExecutionException x) {
+            // TODO check the message of the cause exception once we add it
+        } // pass - aborted due to timeout
+
+        assertEquals(0, future2.getElapsedRunTime(TimeUnit.NANOSECONDS));
+        assertEquals(0, future3.getElapsedRunTime(TimeUnit.NANOSECONDS));
+
+        assertEquals(acceptTime2, future2.getElapsedAcceptTime(TimeUnit.NANOSECONDS));
+        assertEquals(acceptTime3, future3.getElapsedAcceptTime(TimeUnit.NANOSECONDS));
+        assertEquals(queueTime2, future2.getElapsedQueueTime(TimeUnit.NANOSECONDS));
+        assertEquals(queueTime3, future3.getElapsedQueueTime(TimeUnit.NANOSECONDS));
+
+        assertFalse(future1.isDone());
+        assertFalse(future4.isDone());
+        assertFalse(future5.isDone());
+
+        // Let the blocking task finish so that the queued task can attempt to run
+        blocker.countDown();
+
+        // other tasks can run now, and should be successful
+        assertEquals(Integer.valueOf(1), future1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(Integer.valueOf(2), future4.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(Integer.valueOf(3), future5.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        assertEquals(0, counter23.get());
+        assertEquals(3, counter145.get());
 
         assertEquals(Collections.EMPTY_LIST, executor.shutdownNow());
     }


### PR DESCRIPTION
When the policy executor is unable to enqueue a task, look through the task queue for timed-out tasks that can be removed to make room.  There are a number of potential optimizations that could be made, such as limiting how often we attempt to purge the queue of timed out tasks, or having some awareness of whether or not a start timeout was set, but to start out we will take the simplest approach of looking until we find an item to remove or find that there is nothing to remove.