### PR TITLE
copy kernel messages to all kernel nlsprops files

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.cmdline/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.cmdline/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -662,6 +662,14 @@ warning.variable.invalid=CWWKE0941W: The variable declaration {0} specified in s
 warning.variable.invalid.explanation=Only alphanumeric characters are allowed in variable names specified in the server.env file.
 warning.variable.invalid.useraction=Either modify the variable name to only use alphanumeric characters or move the definition of the variable to the bootstrap.properties file.
 
+error.zosProcStart.procedure.invalid=CWWKE0942E: The z/OS STC procedure {0} failed to start. The procedure name is not valid. Ensure that the procedure name is no longer than eight characters and does not contain a comma.
+error.zosProcStart.procedure.invalid.explanation=The STC procedure name specified by the WLP_ZOS_PROCEDURE property in the server.env file is not valid. The procedure name must be no longer than 8 characters and must not contain a comma.
+error.zosProcStart.procedure.invalid.useraction=Verify that the procedure name is no longer than eight characters and that it does not contain a comma.
+
+error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed to start. The {1} job name is not valid. Ensure that the job name is no longer than eight characters and does not contain a comma.
+error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
+error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot.core/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.core/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -655,6 +655,14 @@ info.envProductExtension=CWWKE0940I: The {0} product extension has a product ide
 info.envProductExtension.explanation= The WLP_PRODUCT_EXT_DIR environment variable points to the location of the product extension. The server found and is using the product extension.
 info.envProductExtension.useraction=No action is required.
 
+error.zosProcStart.procedure.invalid=CWWKE0942E: The z/OS STC procedure {0} failed to start. The procedure name is not valid. Ensure that the procedure name is no longer than eight characters and does not contain a comma.
+error.zosProcStart.procedure.invalid.explanation=The STC procedure name specified by the WLP_ZOS_PROCEDURE property in the server.env file is not valid. The procedure name must be no longer than 8 characters and must not contain a comma.
+error.zosProcStart.procedure.invalid.useraction=Verify that the procedure name is no longer than eight characters and that it does not contain a comma.
+
+error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed to start. The {1} job name is not valid. Ensure that the job name is no longer than eight characters and does not contain a comma.
+error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
+error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot.nested/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.nested/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -654,6 +654,14 @@ info.envProductExtension=CWWKE0940I: The {0} product extension has a product ide
 info.envProductExtension.explanation= The WLP_PRODUCT_EXT_DIR environment variable points to the location of the product extension. The server found and is using the product extension.
 info.envProductExtension.useraction=No action is required.
 
+error.zosProcStart.procedure.invalid=CWWKE0942E: The z/OS STC procedure {0} failed to start. The procedure name is not valid. Ensure that the procedure name is no longer than eight characters and does not contain a comma.
+error.zosProcStart.procedure.invalid.explanation=The STC procedure name specified by the WLP_ZOS_PROCEDURE property in the server.env file is not valid. The procedure name must be no longer than 8 characters and must not contain a comma.
+error.zosProcStart.procedure.invalid.useraction=Verify that the procedure name is no longer than eight characters and that it does not contain a comma.
+
+error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed to start. The {1} job name is not valid. Ensure that the job name is no longer than eight characters and does not contain a comma.
+error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
+error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.


### PR DESCRIPTION
These messages have already been approved by ID and delivered. This PR is just to make sure they are consistent across all LauncherMesages.nlsprops files. 