### PR TITLE
Future.isDone/cancel should reflect start timeout

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -304,13 +304,13 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             try {
                 callback.onSubmit(task, this, 0);
             } catch (Error x) {
-                abort(x);
+                abort(false, x);
                 throw x;
             } catch (RejectedExecutionException x) { // same as RuntimeException, but ignore FFDC
-                abort(x);
+                abort(false, x);
                 throw x;
             } catch (RuntimeException x) {
-                abort(x);
+                abort(false, x);
                 throw x;
             }
     }
@@ -332,13 +332,13 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             try {
                 callback.onSubmit(task, this, latch.getCount());
             } catch (Error x) {
-                abort(x);
+                abort(false, x);
                 throw x;
             } catch (RejectedExecutionException x) { // same as RuntimeException, but ignore FFDC
-                abort(x);
+                abort(false, x);
                 throw x;
             } catch (RuntimeException x) {
-                abort(x);
+                abort(false, x);
                 throw x;
             }
     }
@@ -360,13 +360,13 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             try {
                 callback.onSubmit(task, this, 0);
             } catch (Error x) {
-                abort(x);
+                abort(false, x);
                 throw x;
             } catch (RejectedExecutionException x) { // same as RuntimeException, but ignore FFDC
-                abort(x);
+                abort(false, x);
                 throw x;
             } catch (RuntimeException x) {
-                abort(x);
+                abort(false, x);
                 throw x;
             }
     }
@@ -374,10 +374,13 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
     /**
      * Invoked to abort a task.
      *
+     * @param removeFromQueue indicates whether we should first remove the task from the executor's queue.
      * @param cause the cause of the abort.
      * @return true if the future transitioned to ABORTED state.
      */
-    final boolean abort(Throwable cause) {
+    final boolean abort(boolean removeFromQueue, Throwable cause) {
+        if (removeFromQueue && executor.queue.remove(this))
+            executor.maxQueueSizeConstraint.release();
         if (nsAcceptEnd == nsAcceptBegin - 1) // currently unset
             nsRunEnd = nsQueueEnd = nsAcceptEnd = System.nanoTime();
         boolean aborted = result.compareAndSet(state, cause) && state.releaseShared(ABORTED);
@@ -427,9 +430,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 state.tryAcquireSharedNanos(1, nsStartBy - nsGetBegin);
                 s = state.get();
                 if (s == SUBMITTED) { // attempt to abort the task
-                    abort(new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout", executor.identifier, getTaskName(),
-                                                                     System.nanoTime() - nsAcceptBegin,
-                                                                     nsStartBy - nsAcceptBegin)));
+                    abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout", executor.identifier, getTaskName(),
+                                                                           System.nanoTime() - nsAcceptBegin,
+                                                                           nsStartBy - nsAcceptBegin)));
                     s = state.get();
                 }
                 if (s == RUNNING) { // continue waiting
@@ -465,9 +468,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 state.tryAcquireSharedNanos(1, nsStartBy - nsGetBegin);
                 s = state.get();
                 if (s == SUBMITTED) { // attempt to abort the task
-                    abort(new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout", executor.identifier, getTaskName(),
-                                                                     System.nanoTime() - nsAcceptBegin,
-                                                                     nsStartBy - nsAcceptBegin)));
+                    abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout", executor.identifier, getTaskName(),
+                                                                           System.nanoTime() - nsAcceptBegin,
+                                                                           nsStartBy - nsAcceptBegin)));
                     s = state.get();
                 }
                 if (s == RUNNING) { // wait for the remainder of the timeout supplied to get
@@ -488,11 +491,11 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
         if (nsStartBy != nsAcceptBegin - 1 // has a start timeout
             && state.get() < RUNNING // not started yet
             && System.nanoTime() - nsStartBy > 0) // start timeout has elapsed
-            abort(new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout",
-                                                             executor.identifier,
-                                                             getTaskName(),
-                                                             System.nanoTime() - nsAcceptBegin,
-                                                             nsStartBy - nsAcceptBegin)));
+            abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout",
+                                                                   executor.identifier,
+                                                                   getTaskName(),
+                                                                   System.nanoTime() - nsAcceptBegin,
+                                                                   nsStartBy - nsAcceptBegin)));
 
         if (result.compareAndSet(state, CANCELED))
             try {
@@ -630,11 +633,11 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                || nsStartBy != nsAcceptBegin - 1 // has a start timeout
                   && s < RUNNING // not started yet
                   && System.nanoTime() - nsStartBy > 0 // start timeout has elapsed
-                  && (abort(new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout",
-                                                                       executor.identifier,
-                                                                       getTaskName(),
-                                                                       System.nanoTime() - nsAcceptBegin,
-                                                                       nsStartBy - nsAcceptBegin)))
+                  && (abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout",
+                                                                             executor.identifier,
+                                                                             getTaskName(),
+                                                                             System.nanoTime() - nsAcceptBegin,
+                                                                             nsStartBy - nsAcceptBegin)))
                       || state.get() > RUNNING);
     }
 

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -4342,7 +4342,7 @@ public class PolicyExecutorServlet extends FATServlet {
         // Additional testing for the measured run time of the blocker task
         assertTrue(blockerFuture.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
         long runTimeMS = blockerFuture.getElapsedRunTime(TimeUnit.MILLISECONDS);
-        assertTrue(runTimeMS + "ms, " + delayMS + "ms", runTimeMS >= delayMS);
+        assertTrue(runTimeMS + "ms, " + delayMS + "ms", runTimeMS >= delayMS - 100); // tolerate lack of millisecond precision
         assertEquals(runTimeMS, blockerFuture.getElapsedRunTime(TimeUnit.MILLISECONDS));
 
         assertEquals(Collections.EMPTY_LIST, executor.shutdownNow());


### PR DESCRIPTION
After the start timeout has elapsed, if you invoke isDone on a Future for a task that hasn't yet started, isDone must return true.  If you invoke cancel, it must return false.  Also, we will more aggressively purge timed out tasks from the queue at these and other points where aborts occur, which is more efficient than having to scan for & remove timed out tasks at submit time.