### PR TITLE
Modify jaxwclient-2.2 feature to tolerate JavaMail-1.6 feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.jaxwsClient-2.2/com.ibm.websphere.appserver.jaxwsClient-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.jaxwsClient-2.2/com.ibm.websphere.appserver.jaxwsClient-2.2.feature
@@ -7,7 +7,7 @@ IBM-Process-Types: client
 -features=com.ibm.websphere.appserver.injection-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.classloading-1.0, \
- com.ibm.websphere.appserver.javax.mail-1.5, \
+ com.ibm.websphere.appserver.javax.mail-1.5; ibm.tolerates:="1.6", \
  com.ibm.websphere.appserver.jaxb-2.2
 -bundles=com.ibm.ws.org.apache.cxf-rt-transports-http.2.6.2, \
  com.ibm.ws.org.apache.cxf-rt-core.2.6.2, \


### PR DESCRIPTION
Modify the feature file of com.ibm.websphere.appserver.jaxwsClient-2.2 to tolerate JavaMail-1.6 for Java EE 8 compatibility

Fixes #773 