### PR TITLE
Modify AppSecurityClient-1.0 to tolerate Servlet-4.0 for Java EE 8 compatibility

### DIFF
--- a/dev/com.ibm.websphere.appserver.appSecurityClient-1.0/com.ibm.websphere.appserver.appSecurityClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.appSecurityClient-1.0/com.ibm.websphere.appserver.appSecurityClient-1.0.feature
@@ -6,7 +6,7 @@ IBM-API-Package: com.ibm.wsspi.security.auth.callback; type="ibm-api", \
  com.ibm.websphere.security; type="ibm-api"
 IBM-ShortName: appSecurityClient-1.0
 Subsystem-Name: Application Security for Client 1.0
--features=com.ibm.websphere.appserver.javax.servlet-3.0; ibm.tolerates:=3.1; apiJar=false, \
+-features=com.ibm.websphere.appserver.javax.servlet-3.0; ibm.tolerates:="3.1,4.0"; apiJar=false, \
  com.ibm.websphere.appserver.ssl-1.0, \
  com.ibm.websphere.appserver.csiv2Client-1.0
 -bundles=com.ibm.ws.security.authentication, \


### PR DESCRIPTION
Modify the `com.ibm.websphere.appserver.appSecurityClient-1.0.feature` to tolerate `Servlet-4.0` to be compatible with Java EE 8. Otherwise, starting this feature alongside `CDI 2.0` will cause this feature to not load properly due to a missing dependency on `Servlet-4.0`

Fixes #776 
#build