### PR TITLE
Add CA 1.2 to FAT buildpath

### DIFF
--- a/dev/com.ibm.ws.persistence_fat/bnd.bnd
+++ b/dev/com.ibm.ws.persistence_fat/bnd.bnd
@@ -20,16 +20,11 @@ src: \
 
 test.project: true
 
-# To define a global minimum java level for the FAT, use the following property.
-# If unspecified, the default value is ${javac.source}
-#runtime.minimum.java.level: 1.7
-
-# Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
-#      or binaries from Artifactory (e.g. org.apache.derby:derbynet)
 -buildpath: \
     com.ibm.websphere.appserver.api.persistence;version=latest,\
     com.ibm.ws.persistence;version=latest,\
     com.ibm.ws.persistence.mbean;version=latest,\
+    com.ibm.websphere.javaee.annotation.1.2;version=latest,\
     com.ibm.websphere.javaee.ejb.3.2;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.persistence.2.1;version=latest,\


### PR DESCRIPTION
Needed in order to compile on java 9