### PR TITLE
Beta the beanValidation-2.0 feature and related auto-features

### DIFF
--- a/dev/com.ibm.websphere.appserver.beanValidation-2.0/com.ibm.websphere.appserver.beanValidation-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.beanValidation-2.0/com.ibm.websphere.appserver.beanValidation-2.0.feature
@@ -26,5 +26,5 @@ Subsystem-Name: Bean Validation 2.0
 -bundles=com.ibm.ws.org.apache.commons.weaver.1.1, \
  com.ibm.ws.beanvalidation.v11, \
  com.ibm.ws.org.apache.bval.1.1.0
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.javax.validation-2.0/com.ibm.websphere.appserver.javax.validation-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.javax.validation-2.0/com.ibm.websphere.appserver.javax.validation-2.0.feature
@@ -2,5 +2,5 @@
 symbolicName=com.ibm.websphere.appserver.javax.validation-2.0
 singleton=true
 -bundles=com.ibm.websphere.javaee.validation.2.0; location:="dev/api/spec/,lib/"
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.jsf.beanValidation-2.3/com.ibm.websphere.appserver.jsf.beanValidation-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.jsf.beanValidation-2.3/com.ibm.websphere.appserver.jsf.beanValidation-2.3.feature
@@ -6,5 +6,5 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.beanValidation-2.0))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.jsf.beanvalidation
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.javaee.validation.2.0/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.validation.2.0/bnd.bnd
@@ -24,6 +24,8 @@ Import-Package: !org.apache.geronimo.osgi.registry.api, \
 
 Private-Package: org.apache.geronimo.osgi.locator
 
+# NOTE: We are intentionally including javax.validation 1.1 API for now
+#       until we get a 2.0 provider in a workable state
 Include-Resource: \
   @${repo;org.apache.geronimo.specs.geronimo-validation_1.1_spec;1.0.0.SNAPSHOT}!/META-INF/NOTICE
 


### PR DESCRIPTION
We are going to push out `beanValidation-2.0` into beta form so that other features such as `jaxrs-2.1` and `cdi-2.0` can work with some level of bean validation.

Note that the `beanValidation-2.0` feature still provides BVAL 2.0 API and impl, so we will have to upgrade this at a later time.