### PR TITLE
Fix static values

### DIFF
--- a/dev/com.ibm.ws.appclient.boot/test/com/ibm/ws/kernel/boot/internal/commands/FrameworkManagerTest.java
+++ b/dev/com.ibm.ws.appclient.boot/test/com/ibm/ws/kernel/boot/internal/commands/FrameworkManagerTest.java
@@ -11,7 +11,6 @@
 package com.ibm.ws.kernel.boot.internal.commands;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
@@ -64,17 +63,13 @@ public class FrameworkManagerTest {
             }
         });
 
-        Field f = Utils.class.getDeclaredField("installDir");
-        f.setAccessible(true);
-        installDirBefore = (File) f.get(null);
-        f.set(null, new File("test", "test data"));
+        installDirBefore = Utils.getInstallDir();
+        Utils.setInstallDir(new File("test", "test data"));
     }
 
     @After
     public void after() throws Exception {
-        Field f = Utils.class.getDeclaredField("installDir");
-        f.setAccessible(true);
-        f.set(null, installDirBefore);
+        Utils.setInstallDir(installDirBefore);
 
         // Previous these tests were using @RunWith(JMock) to check expectations. I switched to asserting
         // expectations here because the TimeoutRule will not be called when using @RunWith(JMock)

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/websphere/channelfw/osgi/CHFWBundle.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/websphere/channelfw/osgi/CHFWBundle.java
@@ -13,6 +13,7 @@ package com.ibm.websphere.channelfw.osgi;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
@@ -44,6 +45,7 @@ import com.ibm.ws.channelfw.internal.ChannelFrameworkImpl;
 import com.ibm.ws.channelfw.internal.chains.EndPointMgrImpl;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.feature.ServerStarted;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.ws.tcpchannel.internal.TCPChannelFactory;
 import com.ibm.ws.udpchannel.internal.UDPChannelFactory;
 import com.ibm.wsspi.bytebuffer.WsByteBufferPoolManager;
@@ -67,16 +69,20 @@ import com.ibm.wsspi.timer.QuickApproxTime;
 public class CHFWBundle implements ServerQuiesceListener {
 
     /** Trace service */
-    private static final TraceComponent tc =
-                    Tr.register(CHFWBundle.class,
-                                ChannelFrameworkConstants.BASE_TRACE_NAME,
-                                ChannelFrameworkConstants.BASE_BUNDLE);
+    private static final TraceComponent tc = Tr.register(CHFWBundle.class,
+                                                         ChannelFrameworkConstants.BASE_TRACE_NAME,
+                                                         ChannelFrameworkConstants.BASE_BUNDLE);
 
     /**
      * Active HttpDispatcher instance. May be null between deactivate and activate
      * calls.
      */
-    private static final AtomicReference<CHFWBundle> instance = new AtomicReference<CHFWBundle>();
+    private static final StaticValue<AtomicReference<CHFWBundle>> instance = StaticValue.createStaticValue(new Callable<AtomicReference<CHFWBundle>>() {
+        @Override
+        public AtomicReference<CHFWBundle> call() {
+            return new AtomicReference<CHFWBundle>();
+        }
+    });;
 
     /** Reference to the channel framework */
     private ChannelFrameworkImpl chfw = null;
@@ -103,7 +109,7 @@ public class CHFWBundle implements ServerQuiesceListener {
 
     /**
      * DS method for activating this component.
-     * 
+     *
      * @param context
      */
     @Activate
@@ -112,7 +118,7 @@ public class CHFWBundle implements ServerQuiesceListener {
             Tr.event(this, tc, "Activating ", config);
         }
 
-        // handle config (such as TCP factory info) before registering 
+        // handle config (such as TCP factory info) before registering
         // factories, as the register will trigger an automatic load of any
         // delayed configuration, and we need the config before that happens
         modified(config);
@@ -120,12 +126,12 @@ public class CHFWBundle implements ServerQuiesceListener {
         this.chfw.registerFactory("TCPChannel", TCPChannelFactory.class);
         this.chfw.registerFactory("UDPChannel", UDPChannelFactory.class);
 
-        instance.set(this); // required components have been activated
+        instance.get().set(this); // required components have been activated
     }
 
     /**
      * DS method for deactivating this component.
-     * 
+     *
      * @param context
      */
     @Deactivate
@@ -133,7 +139,7 @@ public class CHFWBundle implements ServerQuiesceListener {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(this, tc, "Deactivating");
         }
-        instance.compareAndSet(this, null);
+        instance.get().compareAndSet(this, null);
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(this, tc, "Destroying all endpoints");
@@ -156,7 +162,7 @@ public class CHFWBundle implements ServerQuiesceListener {
      * Modified method. This method is called when the
      * service properties associated with the service are updated through a
      * configuration change.
-     * 
+     *
      * @param cfwConfiguration
      *            the configuration data
      */
@@ -186,12 +192,12 @@ public class CHFWBundle implements ServerQuiesceListener {
     /**
      * When notified that the server is going to stop, pre-quiesce all chains in the runtime.
      * This will be called before services start getting torn down..
-     * 
+     *
      * @see com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener#serverStopping()
      */
     @Override
     public void serverStopping() {
-        // If the system is configured to quiesce connections.. 
+        // If the system is configured to quiesce connections..
         long timeout = chfw.getDefaultChainQuiesceTimeout();
         if (timeout > 0) {
             ChainData[] runningChains = chfw.getRunningChains();
@@ -214,7 +220,7 @@ public class CHFWBundle implements ServerQuiesceListener {
      * Declarative services method that is invoked once the server is started.
      * Only after this method is invoked is the initial polling for
      * persistent tasks performed.
-     * 
+     *
      * @param ref reference to the ServerStarted service
      */
     @Reference(service = ServerStarted.class,
@@ -238,7 +244,7 @@ public class CHFWBundle implements ServerQuiesceListener {
 
     /**
      * Declarative Services method for unsetting the ServerStarted service
-     * 
+     *
      * @param ref reference to the service
      */
     protected synchronized void unsetServerStarted(ServiceReference<ServerStarted> ref) {
@@ -282,18 +288,18 @@ public class CHFWBundle implements ServerQuiesceListener {
     /**
      * DS method for removing the ByteBufferConfiguration.
      * This is a required reference, will be called after deactivate.
-     * 
+     *
      * @param service
      */
     protected void unsetByteBufferConfig(ByteBufferConfiguration bbConfig) {}
 
     /**
      * Access the event service.
-     * 
+     *
      * @return EventEngine - null if not found
      */
     public static EventEngine getEventService() {
-        CHFWBundle c = instance.get();
+        CHFWBundle c = instance.get().get();
         if (null != c) {
             return c.eventService;
         }
@@ -302,7 +308,7 @@ public class CHFWBundle implements ServerQuiesceListener {
 
     /**
      * DS method for setting the event reference.
-     * 
+     *
      * @param service
      */
     @Reference(service = EventEngine.class,
@@ -314,7 +320,7 @@ public class CHFWBundle implements ServerQuiesceListener {
     /**
      * DS method for removing the event reference.
      * This is a required reference, will be called after deactivate.
-     * 
+     *
      * @param service
      */
     protected void unsetEventService(EventEngine service) {}
@@ -322,11 +328,11 @@ public class CHFWBundle implements ServerQuiesceListener {
     /**
      * Access the channel framework's {@link java.util.concurrent.ExecutorService} to
      * use for work dispatch.
-     * 
+     *
      * @return the executor service instance to use within the channel framework
      */
     public static ExecutorService getExecutorService() {
-        CHFWBundle c = instance.get();
+        CHFWBundle c = instance.get().get();
         if (null != c) {
             return c.executorService;
         }
@@ -335,7 +341,7 @@ public class CHFWBundle implements ServerQuiesceListener {
 
     /**
      * DS method for setting the executor service reference.
-     * 
+     *
      * @param executorService the {@link java.util.concurrent.ExecutorService} to
      *            queue work to.
      */
@@ -348,18 +354,18 @@ public class CHFWBundle implements ServerQuiesceListener {
     /**
      * DS method for clearing the executor service reference.
      * This is a required reference, will be called after deactivate.
-     * 
+     *
      * @param executorService the service instance to clear
      */
     protected void unsetExecutorService(ExecutorService executorService) {}
 
     /**
      * Access the scheduled event service.
-     * 
+     *
      * @return ScheduledEventService - null if not found
      */
     public static ScheduledEventService getScheduleService() {
-        CHFWBundle c = instance.get();
+        CHFWBundle c = instance.get().get();
         if (null != c) {
             return c.scheduler;
         }
@@ -391,7 +397,7 @@ public class CHFWBundle implements ServerQuiesceListener {
      * @return ScheduledEventService - null if not found
      */
     public static ScheduledExecutorService getScheduledExecutorService() {
-        CHFWBundle c = instance.get();
+        CHFWBundle c = instance.get().get();
         if (null != c) {
             return c.scheduledExecutor;
         }
@@ -400,7 +406,7 @@ public class CHFWBundle implements ServerQuiesceListener {
 
     /**
      * DS method for setting the scheduled event service reference.
-     * 
+     *
      * @param ref
      */
     @Reference(service = ScheduledEventService.class,
@@ -412,14 +418,14 @@ public class CHFWBundle implements ServerQuiesceListener {
     /**
      * DS method for removing the scheduled event service reference.
      * This is a required reference, will be called after deactivate.
-     * 
+     *
      * @param ref
      */
     protected void unsetScheduledEventService(ScheduledEventService ref) {}
 
     /**
      * DS method to set a factory provider.
-     * 
+     *
      * @param provider
      */
     @Reference(service = ChannelFactoryProvider.class,
@@ -436,7 +442,7 @@ public class CHFWBundle implements ServerQuiesceListener {
 
     /**
      * DS method to remove a factory provider.
-     * 
+     *
      * @param provider
      */
     protected void unsetFactoryProvider(ChannelFactoryProvider provider) {
@@ -449,7 +455,7 @@ public class CHFWBundle implements ServerQuiesceListener {
 
     /**
      * Access the channel framework's {@link ApproximateTime} service.
-     * 
+     *
      * @return the approximate time service instance to use within the channel framework
      */
     public static long getApproxTime() {
@@ -459,7 +465,7 @@ public class CHFWBundle implements ServerQuiesceListener {
     /**
      * Set the approximate time service reference.
      * This is a required reference: will be called before activation.
-     * 
+     *
      * @param ref new ApproximateTime service instance/provider
      */
     @Reference(service = ApproximateTime.class,
@@ -471,7 +477,7 @@ public class CHFWBundle implements ServerQuiesceListener {
     /**
      * Remove the reference to the approximate time service.
      * This is a required reference, will be called after deactivate.
-     * 
+     *
      * @param ref ApproximateTime service instance/provider to remove
      */
     protected void unsetApproxTimeService(ApproximateTime ref) {
@@ -480,7 +486,7 @@ public class CHFWBundle implements ServerQuiesceListener {
 
     /**
      * Query the reference to the channel framework.
-     * 
+     *
      * @return ChannelFramework
      */
     public ChannelFramework getFramework() {
@@ -490,9 +496,9 @@ public class CHFWBundle implements ServerQuiesceListener {
     /**
      * Access the reference to the bytebuffer pool manager created by this
      * bundle, or the default/fallback pool.
-     * 
+     *
      * This method should never return null
-     * 
+     *
      * @return WsByteBufferPoolManager
      */
     public WsByteBufferPoolManager getBufferManager() {
@@ -501,7 +507,7 @@ public class CHFWBundle implements ServerQuiesceListener {
         // Get the byte buffer manager-- bbMgr could return null
         WsByteBufferPoolManager result = (bbMgr == null) ? null : bbMgr.getBufferManager();
 
-        // Fall back to a default if bbMgr was null or null was returned 
+        // Fall back to a default if bbMgr was null or null was returned
         return result != null ? result : ChannelFrameworkFactory.getBufferManager();
     }
 

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/tcpchannel/internal/NioTCPChannel.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/tcpchannel/internal/NioTCPChannel.java
@@ -24,7 +24,7 @@ import com.ibm.wsspi.channelfw.exception.ChannelException;
  */
 public class NioTCPChannel extends TCPChannel {
 
-    private static WorkQueueManager workQueueManager = null;
+    private WorkQueueManager workQueueManager;
 
     private static final TraceComponent tc = Tr.register(NioTCPChannel.class, TCPChannelMessageConstants.TCP_TRACE_NAME, TCPChannelMessageConstants.TCP_BUNDLE);
 
@@ -42,13 +42,12 @@ public class NioTCPChannel extends TCPChannel {
         }
 
         super.setup(runtimeConfig, tcpConfig, factory);
+        
         // create WorkQueueMgr if this is the first NonBlocking Channel that
         // is being created.
-
         if (workQueueManager == null) {
             workQueueManager = new WorkQueueManager();
         }
-
         if (!config.isInbound()) {
             connectionManager = new ConnectionManager(this, workQueueManager);
         }
@@ -63,7 +62,7 @@ public class NioTCPChannel extends TCPChannel {
 
     /**
      * Returns the WorkQueueManager reference.
-     * 
+     *
      * @return WorkQueueManager
      */
     protected WorkQueueManager getWorkQueueManager() {

--- a/dev/com.ibm.ws.config.schemagen/test/com/ibm/ws/config/schemagen/internal/GeneratorTestBase.java
+++ b/dev/com.ibm.ws.config.schemagen/test/com/ibm/ws/config/schemagen/internal/GeneratorTestBase.java
@@ -139,10 +139,8 @@ public abstract class GeneratorTestBase {
 
   protected static void setInstallDir(File file) throws SecurityException,
       NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
-        Field installDirField = Utils.class.getDeclaredField("installDir");
-        installDirField.setAccessible(true);
-        installDirField.set(null, file);
-        installDirField = SchemaWriter.class.getDeclaredField("installDir");
+        Utils.setInstallDir(file);
+        Field installDirField = SchemaWriter.class.getDeclaredField("installDir");
         installDirField.setAccessible(true);
         installDirField.set(null, file);
         System.setProperty("wlp.install.dir", file.getAbsolutePath());

--- a/dev/com.ibm.ws.event/bnd.bnd
+++ b/dev/com.ibm.ws.event/bnd.bnd
@@ -46,7 +46,8 @@ Import-Package: \
 	com.ibm.wsspi.org.osgi.service.event;version=latest,\
 	com.ibm.wsspi.org.osgi.service.log;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+	com.ibm.ws.logging.core;version=latest
 
 -testpath: \
 	org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/com.ibm.ws.event/src/com/ibm/websphere/event/Topic.java
+++ b/dev/com.ibm.ws.event/src/com/ibm/websphere/event/Topic.java
@@ -11,10 +11,12 @@
 
 package com.ibm.websphere.event;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import com.ibm.ws.event.internal.TopicData;
+import com.ibm.ws.staticvalue.StaticValue;
 
 /**
  * Representation of a topic to be used by event sources.
@@ -30,7 +32,12 @@ public final class Topic {
 
     // Double nesting of the atomic reference since we're forced to expose the
     // reference itself - and that needs memory model compliance too
-    final AtomicReference<AtomicReference<TopicData>> topicDataReference = new AtomicReference<AtomicReference<TopicData>>(new AtomicReference<TopicData>());
+    final StaticValue<AtomicReference<AtomicReference<TopicData>>> topicDataReference = StaticValue.createStaticValue(new Callable<AtomicReference<AtomicReference<TopicData>>>() {
+        @Override
+        public AtomicReference<AtomicReference<TopicData>> call() throws Exception {
+            return new AtomicReference<AtomicReference<TopicData>>(new AtomicReference<TopicData>());
+        }
+    });
 
     public Topic(String name) {
         validateTopic(name);
@@ -53,22 +60,25 @@ public final class Topic {
 
     // TODO: Hide the topicData from code outside the bundle
     public TopicData getTopicData() {
-        return topicDataReference.get().get();
+        return topicDataReference.get().get().get();
     }
 
     // TODO: Hide the topicData from code outside the bundle
     public void setTopicDataReference(AtomicReference<TopicData> topicDataReference) {
-        this.topicDataReference.set(topicDataReference);
+        this.topicDataReference.get().set(topicDataReference);
     }
 
+    @Override
     public String toString() {
         return name;
     }
 
+    @Override
     public int hashCode() {
         return name.hashCode();
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof Topic) {
             Topic that = (Topic) o;

--- a/dev/com.ibm.ws.junit.extensions/src/com/ibm/websphere/ras/TrConfigZapper.java
+++ b/dev/com.ibm.ws.junit.extensions/src/com/ibm/websphere/ras/TrConfigZapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,8 +17,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.concurrent.Callable;
 
 import com.ibm.ws.logging.internal.impl.LogProviderConfigImpl;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
 import com.ibm.wsspi.logprovider.TrService;
 
@@ -94,16 +96,22 @@ public class TrConfigZapper extends TrConfigurator {
      */
     public static void revert() {
         stop();
-        delegate = null;
-        loggingConfig.set(null);
+        delegate = StaticValue.mutateStaticValue(delegate, null);
+        loggingConfig.get().set(null);
     }
 
     public TrService getTrDelegate() {
-        return delegate;
+        return delegate.get();
     }
 
-    public void setTrDelegate(TrService newDelegate) {
-        delegate = newDelegate;
+    public void setTrDelegate(final TrService newDelegate) {
+        Callable<TrService> c = new Callable<TrService>() {
+            @Override
+            public TrService call() throws Exception {
+                return newDelegate;
+            }
+        };
+        delegate = StaticValue.mutateStaticValue(delegate, c);
     }
 
 }

--- a/dev/com.ibm.ws.junit.extensions/src/test/common/SharedLocationManager.java
+++ b/dev/com.ibm.ws.junit.extensions/src/test/common/SharedLocationManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,24 +17,26 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.ibm.ws.staticvalue.StaticValue;
+
 /**
  * The SharedLocationManager primes the configured locations used by
  * the WsLocationAdmin service and the WsLocationAdminManager. When used in
  * unit test, it allows your test code to drive methods that rely on
  * a configured WsLocationAdmin service or the static WsLocationAdminManager.
- * 
+ *
  * <h2>Unit Testing</h2>
  * <p>
  * Our unit test cases need to check for the presence of files, etc. in known
  * locations. There is one set of methods providing an abbreviated tree, and
  * another that replicates the default server tree structure, both starting at
  * specified root directoy
- * 
+ *
  * <h2>Component Testing</h2>
  * <p>
  * The JUnit drivers for our component tests need to check for the presence of
  * files, etc. in the relevant server directory in the target image.
- * 
+ *
  */
 public class SharedLocationManager {
     /**
@@ -44,7 +46,7 @@ public class SharedLocationManager {
      * underneath the provided root directory (instead of wlp/).
      * <p>
      * Directories will not be accessed/created until requested.
-     * 
+     *
      * @param rootDirStr
      *            Root directory for structure shown above
      * @param serverName
@@ -54,7 +56,7 @@ public class SharedLocationManager {
      *            be passed to the location service. The following properties are
      *            set by this method (and will be overwritten): wlp.install.dir,
      *            wlp.user.dir, wlp.lib.dir, wlp.server.name
-     * 
+     *
      * @return the configured WsLocationAdmin instance.
      */
     public static Object createDefaultLocations(String rootDirStr, String serverName, Map<String, Object> map) {
@@ -68,7 +70,7 @@ public class SharedLocationManager {
      * underneath the provided root directory (instead of wlp/).
      * <p>
      * Directories will not be accessed/created until requested.
-     * 
+     *
      * @param rootDirStr
      *            Root directory for structure shown above
      * @param serverName
@@ -80,7 +82,7 @@ public class SharedLocationManager {
      *            wlp.user.dir, wlp.lib.dir, wlp.server.name
      * @param isClient
      *            boolean value to determine whether this call is used for client or server.
-     * 
+     *
      * @return the configured WsLocationAdmin instance.
      */
     public static Object createDefaultLocations(String rootDirStr, String serverName, Map<String, Object> map, boolean isClient) {
@@ -106,7 +108,7 @@ public class SharedLocationManager {
         map.put("wlp.lib.dir", lib.getAbsolutePath() + '/');
         map.put("wlp.server.name", serverName);
 
-        // Defined in BootstrapConstants.PROCESS_TYPE_CLIENT 
+        // Defined in BootstrapConstants.PROCESS_TYPE_CLIENT
         // Defined in BootstrapConstants.PROCESS_TYPE_SERVER
         map.put("wlp.process.type", isClient ? "client" : "server");
 
@@ -139,12 +141,12 @@ public class SharedLocationManager {
      * document
      * will be the default "rootDir/usr/servers/serverName/server.xml" (does not
      * need to exist).
-     * 
+     *
      * @param rootDirStr
      *            Root directory for structure shown above
      * @param serverName
      *            Name of server
-     * 
+     *
      * @return the configured WsLocationAdmin instance.
      * @see #createDefaultLocations(String, String, Map)
      */
@@ -158,10 +160,10 @@ public class SharedLocationManager {
      * server directory name will be "defaultServer". The config root document
      * will be the default "rootDir/usr/servers/defaultServer/server.xml" (does
      * not need to exist).
-     * 
+     *
      * @param rootDirStr
      *            Root directory for structure shown above
-     * 
+     *
      * @return the configured WsLocationAdmin instance.
      * @see #createDefaultLocations(String, String, Map)
      */
@@ -173,7 +175,7 @@ public class SharedLocationManager {
      * Used in test: construct and replace the singleton instance of the
      * WsLocationAdmin service/manager based on the provided root directory. This
      * will create/look for the following directory structure:
-     * 
+     *
      * <pre>
      * rootDir/
      * applications/ (shared.app.dir)
@@ -190,9 +192,9 @@ public class SharedLocationManager {
      * workarea/
      * getServerWorkareaFile()
      * </pre>
-     * 
+     *
      * Directories will not be accessed/created until requested.
-     * 
+     *
      * @param rootDirStr
      *            Root directory for structure shown above
      * @param serverName
@@ -249,7 +251,7 @@ public class SharedLocationManager {
      * WsLocationAdmin service/manager based on the provided root directory. The
      * config root document will be the default "rootDir/serverName/server.xml"
      * (does not need to exist).
-     * 
+     *
      * @param rootDirStr
      *            Root directory for structure shown above
      * @param serverName
@@ -267,7 +269,7 @@ public class SharedLocationManager {
      * directory. The server directory name will be "defaultServer".
      * The config root document will be the default
      * "rootDir/defaultServer/server.xml" (does not need to exist).
-     * 
+     *
      * @param rootDirStr
      *            Root directory for structure shown above
      * @see #createLocations(String, String, Map)
@@ -280,7 +282,7 @@ public class SharedLocationManager {
      * For use with component tests: Populate an WsLocationAdmin instance with
      * paths pointing to the install image directory using the "image.dir" system
      * property so that the test clients can check for the presence of files, etc.
-     * 
+     *
      * @param serverName
      *            Name of server
      * @param map
@@ -343,14 +345,14 @@ public class SharedLocationManager {
      * WsLocationAdmin service/manager with the location of the build
      * image and the provided server name (e.g.
      * build.image/wlp/usr/servers/serverName).
-     * 
+     *
      * Will use the default configuration file(s) contained in the server
      * directory (if present, both are optional):
      * <ul>
      * <li>build.image/wlp/usr/servers/serverName/server.xml,</li>
      * <li>build.image/wlp/usr/servers/serverName/bootstrap.properties</li>
      * </ul>
-     * 
+     *
      * @param serverName
      *            Name of server
      * @return the configured WsLocationAdmin instance.
@@ -370,7 +372,7 @@ public class SharedLocationManager {
         try {
             f = impl.getDeclaredField("instance");
             f.setAccessible(true);
-            f.set(null, null);
+            f.set(null, StaticValue.mutateStaticValue((StaticValue<?>) f.get(null), null));
         } catch (Exception e) {
             System.err.println("Woops! Something is amiss; could not reset test locations");
             e.printStackTrace();
@@ -381,33 +383,38 @@ public class SharedLocationManager {
     /**
      * Return the instance of the WsLocationAdminManager for use with jmock
      * objects:
-     * 
+     *
      * <pre>
      * final ServiceReference mockServiceRef = context.mock(ServiceReference.class);
      * final BundleContext mockBundleContext = context.mock(BundleContext.class);
      * final WsLocationAdmin location = (WsLocationAdmin) SharedLocationManager.getLocationInstance();
-     * 
-     * context.checking(new Expectations()
-     * {
-     * {
-     * one(mockBundleContext).getServiceReference(with(WsLocationAdmin.class.getName()));
-     * will(returnValue(mockServiceRef));
-     * one(mockBundleContext).getService(mockServiceRef);
-     * will(returnValue(location));
-     * }
+     *
+     * context.checking(new Expectations() {
+     *     {
+     *         one(mockBundleContext).getServiceReference(with(WsLocationAdmin.class.getName()));
+     *         will(returnValue(mockServiceRef));
+     *         one(mockBundleContext).getService(mockServiceRef);
+     *         will(returnValue(location));
+     *     }
      * });
      * </pre>
-     * 
+     *
      * @return the configured WsLocationAdmin instance.
      */
     public static Object getLocationInstance() {
         Class<?> impl = getLocServiceImpl();
 
-        Field f;
+        Method m;
         try {
-            f = impl.getDeclaredField("instance");
-            f.setAccessible(true);
-            return f.get(null);
+            m = impl.getDeclaredMethod("getInstance");
+            return m.invoke(null);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof IllegalStateException) {
+                return null;
+            }
+            System.err.println("Woops! Something is amiss; could not get WsLocationAdmin instance");
+            e.printStackTrace();
+            throw new java.lang.InstantiationError("Unable to get test WsLocationAdmin instance");
         } catch (Exception e) {
             System.err.println("Woops! Something is amiss; could not get WsLocationAdmin instance");
             e.printStackTrace();
@@ -417,7 +424,7 @@ public class SharedLocationManager {
 
     /**
      * Print out configured locations
-     * 
+     *
      * @return Formatted string describing configured locations
      */
     public static String debugConfiguredLocations() {

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/cmdline/Utils.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/cmdline/Utils.java
@@ -18,24 +18,40 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.AccessController;
 import java.util.ResourceBundle;
+import java.util.concurrent.Callable;
 import java.util.zip.ZipFile;
 
 import com.ibm.ws.kernel.boot.internal.BootstrapConstants;
+import com.ibm.ws.staticvalue.StaticValue;
 
 public class Utils {
-    private static File installDir;
-    private static File userDir;
-    private static File outputDir;
-    private static File logDir;
+    private static StaticValue<File> installDir = StaticValue.createStaticValue(null);
+    private static StaticValue<File> userDir = StaticValue.createStaticValue(null);
+    private static StaticValue<File> outputDir = StaticValue.createStaticValue(null);
+    private static StaticValue<File> logDir = StaticValue.createStaticValue(null);
     private static ResourceBundle cmdlineResourceBundle;
 
-    public static File getInstallDir() {
-        if (installDir == null) {
-            URL url = UtilityMain.class.getProtectionDomain().getCodeSource().getLocation();
-            installDir = getFile(url).getParentFile().getParentFile();
+    public static class FileInitializer implements Callable<File> {
+        final File file;
+
+        public FileInitializer(File file) {
+            this.file = file;
         }
 
-        return installDir;
+        @Override
+        public File call() throws Exception {
+            return file;
+        }
+    }
+
+    public static File getInstallDir() {
+        if (installDir.get() == null) {
+            URL url = UtilityMain.class.getProtectionDomain().getCodeSource().getLocation();
+            File file = getFile(url).getParentFile().getParentFile();
+            installDir = StaticValue.mutateStaticValue(installDir, new FileInitializer(file));
+        }
+
+        return installDir.get();
     }
 
     public static File getUserDir() {
@@ -44,26 +60,28 @@ public class Utils {
 
         // 1st check in environment variable is set.  This is the normal case
         // when the server is started from the command line.
-        if (userDir == null) {
+        if (userDir.get() == null) {
+            File resultDir = null;
             userDirLoc = System.getenv(BootstrapConstants.ENV_WLP_USER_DIR);
             if (userDirLoc != null) {
-                userDir = new File(userDirLoc);
+                resultDir = new File(userDirLoc);
             } else {
 
                 // PI20344: Check if the Java property is set, which is the normal case when
                 // the server is embedded; i.e. they didn't launch it from the command line.
                 userDirLoc = System.getProperty(BootstrapConstants.ENV_WLP_USER_DIR);
                 if (userDirLoc != null) {
-                    userDir = new File(userDirLoc);
+                    resultDir = new File(userDirLoc);
                 } else {
                     File installDir = Utils.getInstallDir();
                     if (installDir != null) {
-                        userDir = new File(installDir, "usr");
+                        resultDir = new File(installDir, "usr");
                     }
                 }
             }
+            userDir = StaticValue.mutateStaticValue(userDir, new FileInitializer(resultDir));
         }
-        return userDir;
+        return userDir.get();
     }
 
     /**
@@ -88,8 +106,8 @@ public class Utils {
 
         // 1st check in environment variable is set.  This is the normal case
         // when the server is started from the command line.
-        if (logDir == null) {
-
+        if (logDir.get() == null) {
+            File resultDir = null;
             try {
                 logDirLoc = AccessController.doPrivileged(new java.security.PrivilegedExceptionAction<String>() {
                     @Override
@@ -102,17 +120,19 @@ public class Utils {
 
             //outputDirLoc = System.getenv(BootstrapConstants.ENV_WLP_OUTPUT_DIR);
             if (logDirLoc != null) {
-                logDir = new File(logDirLoc);
+                resultDir = new File(logDirLoc);
             } else {
                 // PI20344: Check if the Java property is set, which is the normal case when
                 // the server is embedded; i.e. they didn't launch it from the command line.
                 logDirLoc = System.getProperty(BootstrapConstants.ENV_LOG_DIR);
                 if (logDirLoc != null) {
-                    logDir = new File(logDirLoc);
+                    resultDir = new File(logDirLoc);
                 }
             }
+            logDir = StaticValue.mutateStaticValue(logDir, new FileInitializer(resultDir));
         }
-        return logDir;
+
+        return logDir.get();
     }
 
     /**
@@ -128,7 +148,7 @@ public class Utils {
 
         // 1st check in environment variable is set.  This is the normal case
         // when the server is started from the command line.
-        if (outputDir == null) {
+        if (outputDir.get() == null) {
 
             try {
                 outputDirLoc = AccessController.doPrivileged(new java.security.PrivilegedExceptionAction<String>() {
@@ -141,27 +161,29 @@ public class Utils {
             }
 
             //outputDirLoc = System.getenv(BootstrapConstants.ENV_WLP_OUTPUT_DIR);
+            File resultDir = null;
             if (outputDirLoc != null) {
-                outputDir = new File(outputDirLoc);
+                resultDir = new File(outputDirLoc);
             } else {
                 // PI20344: Check if the Java property is set, which is the normal case when
                 // the server is embedded; i.e. they didn't launch it from the command line.
                 outputDirLoc = System.getProperty(BootstrapConstants.ENV_WLP_OUTPUT_DIR);
                 if (outputDirLoc != null) {
-                    outputDir = new File(outputDirLoc);
+                    resultDir = new File(outputDirLoc);
                 } else {
                     File userDir = Utils.getUserDir();
                     if (userDir != null) {
                         if (isClient) {
-                            outputDir = new File(userDir, "clients");
+                            resultDir = new File(userDir, "clients");
                         } else {
-                            outputDir = new File(userDir, "servers");
+                            resultDir = new File(userDir, "servers");
                         }
                     }
                 }
             }
+            outputDir = StaticValue.mutateStaticValue(outputDir, new FileInitializer(resultDir));
         }
-        return outputDir;
+        return outputDir.get();
     }
 
     /**
@@ -314,16 +336,16 @@ public class Utils {
      * @param installDir
      */
     public static void setInstallDir(File installDir) {
-        Utils.installDir = installDir;
+        Utils.installDir = StaticValue.mutateStaticValue(Utils.installDir, new FileInitializer(installDir));
     }
 
     /**
      * This method should be called by common install kernel only.
      *
-     * @param installDir
+     * @param userDir
      */
     public static void setUserDir(File userDir) {
-        Utils.userDir = userDir;
+        Utils.userDir = StaticValue.mutateStaticValue(Utils.userDir, new FileInitializer(userDir));
     }
 
     /**

--- a/dev/com.ibm.ws.kernel.boot/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.boot/bnd.bnd
@@ -69,7 +69,8 @@ Private-Package: \
  com.ibm.ws.kernel.boot.*, \
  com.ibm.ws.kernel.launch.*, \
  com.ibm.ws.kernel.internal.*, \
- com.ibm.wsspi.kernel.embeddable.*
+ com.ibm.wsspi.kernel.embeddable.*, \
+ com.ibm.ws.staticvalue
 
 # security.policy file is pre-processed: the ${osgi-jar} variable in it will be replaced
 # with the name of the osgi jar specified above.

--- a/dev/com.ibm.ws.kernel.boot_bvt/bvt/src/test/client/EmbeddedServerTest.java
+++ b/dev/com.ibm.ws.kernel.boot_bvt/bvt/src/test/client/EmbeddedServerTest.java
@@ -21,14 +21,14 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Assert;
-import junit.framework.AssertionFailedError;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.ibm.ws.kernel.boot.cmdline.Utils;
 import com.ibm.ws.kernel.boot.internal.KernelUtils;
+
+import junit.framework.Assert;
+import junit.framework.AssertionFailedError;
 
 /**
  *
@@ -61,8 +61,7 @@ public class EmbeddedServerTest {
         // We're going to start by making a nested classloader with limited delegation back
         // to this classloader.. a pain, but ..
         URLClassLoader classloader = new URLClassLoader(new URL[] { bvtImageKernelBundle.toURI().toURL(),
-                                                                   testServerClasses.toURI().toURL() },
-                                                        this.getClass().getClassLoader()) {
+                                                                    testServerClasses.toURI().toURL() }, this.getClass().getClassLoader()) {
             @Override
             protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
                 Class<?> result = null;
@@ -132,8 +131,7 @@ public class EmbeddedServerTest {
 
         // We're going to start by making a nested classloader with limited delegation back
         // to this classloader.. a pain, but ..
-        URLClassLoader classloader = new URLClassLoader(jarURLs.toArray(new URL[0]),
-                                                        null) {
+        URLClassLoader classloader = new URLClassLoader(jarURLs.toArray(new URL[0]), null) {
             @Override
             protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
                 Class<?> result = null;
@@ -204,18 +202,10 @@ public class EmbeddedServerTest {
     }
 
     public static void setKernelUtilsBootstrapLibDir(File bootLibDir) throws Exception {
-        if (bootLibDirField == null) {
-            bootLibDirField = KernelUtils.class.getDeclaredField("libDir");
-            bootLibDirField.setAccessible(true);
-        }
-        bootLibDirField.set(null, bootLibDir);
+        KernelUtils.setBootStrapLibDir(bootLibDir);
     }
 
     public static void setUtilsInstallDir(File installDir) throws Exception {
-        if (utilsInstallDirField == null) {
-            utilsInstallDirField = Utils.class.getDeclaredField("installDir");
-            utilsInstallDirField.setAccessible(true);
-        }
-        utilsInstallDirField.set(null, installDir);
+        Utils.setInstallDir(installDir);
     }
 }

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
@@ -43,6 +43,7 @@ public class ServerClasspathTest {
                                                         "org.omg.CORBA", "com.sun", "org.xml.sax", "com.ibm.jit",
                                                         "com.ibm.jsse2", "com.ibm.lang.management", "com.ibm.tools.attach",
                                                         "com.ibm.virtualization.management", "com.ibm.wsspi.kernel",
+                                                        "com.ibm.ws.staticvalue",
                                                         "jdk." // Java 9
     };
 

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/internal/FrameworkManagerTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/internal/FrameworkManagerTest.java
@@ -11,7 +11,6 @@
 package com.ibm.ws.kernel.boot.internal;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
@@ -66,18 +65,14 @@ public class FrameworkManagerTest {
             }
         });
 
-        Field f = Utils.class.getDeclaredField("installDir");
-        f.setAccessible(true);
-        installDirBefore = (File) f.get(null);
+        installDirBefore = Utils.getInstallDir();
         String testClassesDir = System.getProperty("test.classesDir", "bin_test");
-        f.set(null, new File(testClassesDir, "test data"));
+        Utils.setInstallDir(new File(testClassesDir, "test data"));
     }
 
     @After
     public void after() throws Exception {
-        Field f = Utils.class.getDeclaredField("installDir");
-        f.setAccessible(true);
-        f.set(null, installDirBefore);
+        Utils.setInstallDir(installDirBefore);
 
         // Previous these tests were using @RunWith(JMock) to check expectations. I switched to asserting
         // expectations here because the TimeoutRule will not be called when using @RunWith(JMock)

--- a/dev/com.ibm.ws.kernel.boot_test/test/test/shared/TestUtils.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/test/shared/TestUtils.java
@@ -26,8 +26,6 @@ import com.ibm.ws.kernel.boot.internal.KernelUtils;
 public class TestUtils {
     private static AtomicInteger count = new AtomicInteger(0);
     static Field bootJarField = null;
-    static Field bootLibDirField = null;
-    static Field utilsInstallDirField = null;
 
     public static File findBuiltKernelBundle() {
         File root = new File(Constants.BOOTSTRAP_LIB_DIR);
@@ -54,19 +52,11 @@ public class TestUtils {
     }
 
     public static void setKernelUtilsBootstrapLibDir(File bootLibDir) throws Exception {
-        if (bootLibDirField == null) {
-            bootLibDirField = KernelUtils.class.getDeclaredField("libDir");
-            bootLibDirField.setAccessible(true);
-        }
-        bootLibDirField.set(null, bootLibDir);
+        KernelUtils.setBootStrapLibDir(bootLibDir);
     }
 
     public static void setUtilsInstallDir(File installDir) throws Exception {
-        if (utilsInstallDirField == null) {
-            utilsInstallDirField = Utils.class.getDeclaredField("installDir");
-            utilsInstallDirField.setAccessible(true);
-        }
-        utilsInstallDirField.set(null, installDir);
+        Utils.setInstallDir(installDir);
     }
 
     public static File createTempFile(String name, String suffix) throws IOException {

--- a/dev/com.ibm.ws.kernel.cmdline/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.cmdline/bnd.bnd
@@ -23,7 +23,8 @@ Bundle-Description: WebSphere Liberty kernel command line, version ${bVersion}
 Private-Package: com.ibm.ws.kernel.boot.cmdline;-split-package:=merge-last, \
  com.ibm.ws.kernel.boot.cmdline.resources, \
  com.ibm.ws.kernel.provisioning, \
- com.ibm.ws.kernel.boot.resources.*
+ com.ibm.ws.kernel.boot.resources.*,\
+ com.ibm.ws.staticvalue
 
 -includeresource: \
  @${repo;com.ibm.websphere.org.osgi.core}!/org/osgi/framework/Version*.class
@@ -32,7 +33,8 @@ instrument.disabled: true
 
 -buildpath: \
 	com.ibm.websphere.org.osgi.core;version=latest, \
-	com.ibm.ws.kernel.boot;version=latest
+	com.ibm.ws.kernel.boot;version=latest, \
+	com.ibm.ws.logging.core;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.kernel.feature/test/test/utils/TestUtils.java
+++ b/dev/com.ibm.ws.kernel.feature/test/test/utils/TestUtils.java
@@ -41,8 +41,6 @@ import com.ibm.wsspi.kernel.service.location.WsResource;
  */
 public class TestUtils {
 
-    static Field bootLibDirField = null;
-    static Field utilsInstallDirField = null;
     static Field bundleRepository = null;
 
     public static void clearBundleRepositoryRegistry() throws Exception {
@@ -55,25 +53,17 @@ public class TestUtils {
 
     /** Replace the location of the kernel lib directory (usually calculated) */
     public static void setKernelUtilsBootstrapLibDir(File bootLibDir) throws Exception {
-        if (bootLibDirField == null) {
-            bootLibDirField = KernelUtils.class.getDeclaredField("libDir");
-            bootLibDirField.setAccessible(true);
-        }
-        bootLibDirField.set(null, bootLibDir);
+        KernelUtils.setBootStrapLibDir(bootLibDir);
     }
 
     /** Replace the location of the utils install directory (usually calculated) */
     public static void setUtilsInstallDir(File installDir) throws Exception {
-        if (utilsInstallDirField == null) {
-            utilsInstallDirField = Utils.class.getDeclaredField("installDir");
-            utilsInstallDirField.setAccessible(true);
-        }
-        utilsInstallDirField.set(null, installDir);
+        Utils.setInstallDir(installDir);
     }
 
     /**
      * Return an input stream containing a valid feature manifest
-     * 
+     *
      * @param symbolicNameString flattened symbolic name string. e.g. com.ibm.websphere.dummy;visibility:=protected
      * @param subsystemContentString flattened subsystem content string (including leading whitespace and
      *            middle line endings if wrapped): notexist1;location:="lib/notexist1"
@@ -85,7 +75,7 @@ public class TestUtils {
 
     /**
      * Return an input stream containing a valid feature manifest
-     * 
+     *
      * @param shortName - the short name for the feature.
      * @param symbolicNameString flattened symbolic name string. e.g. com.ibm.websphere.dummy;visibility:=protected
      * @param subsystemContentString flattened subsystem content string (including leading whitespace and
@@ -191,7 +181,7 @@ public class TestUtils {
 
         /*
          * (non-Javadoc)
-         * 
+         *
          * @see org.osgi.framework.wiring.FrameworkWiring#findProviders(org.osgi.resource.Requirement)
          */
         @Override

--- a/dev/com.ibm.ws.kernel.service.location/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.service.location/bnd.bnd
@@ -28,6 +28,7 @@ Private-Package: \
 instrument.classesExcludes: com/ibm/ws/kernel/**/internal/resources/*.class
 
 -buildpath: \
+	com.ibm.ws.logging.core;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
 	com.ibm.websphere.appserver.spi.logging;version=latest, \

--- a/dev/com.ibm.ws.kernel.service.location/src/com/ibm/ws/kernel/service/location/internal/SymbolRegistry.java
+++ b/dev/com.ibm.ws.kernel.service.location/src/com/ibm/ws/kernel/service/location/internal/SymbolRegistry.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.kernel.service.location.internal;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.regex.Matcher;
@@ -18,6 +19,7 @@ import java.util.regex.Pattern;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.wsspi.kernel.service.location.MalformedLocationException;
 import com.ibm.wsspi.kernel.service.location.WsLocationConstants;
 import com.ibm.wsspi.kernel.service.location.WsResource;
@@ -34,7 +36,11 @@ public class SymbolRegistry {
     final static Pattern SYMBOL_DEF = Pattern.compile("\\$\\{([^\\$\\(\\)]*?)\\}");
 
     /** Singleton instance */
-    private final static SymbolRegistry instance = new SymbolRegistry();
+    private final static StaticValue<SymbolRegistry> instance = StaticValue.createStaticValue(new Callable<SymbolRegistry>() {
+        public SymbolRegistry call() {
+            return new SymbolRegistry();
+        }
+    });
 
     final static int RECURSE_LIMIT = 10;
 
@@ -48,7 +54,7 @@ public class SymbolRegistry {
      */
     @Trivial
     public static SymbolRegistry getRegistry() {
-        return instance;
+        return instance.get();
     }
 
     /**
@@ -117,7 +123,7 @@ public class SymbolRegistry {
         SymRegEntry entry = new SymRegEntry(EntryType.RESOURCE, symbol, value);
         SymRegEntry prev = stringToEntry.putIfAbsent(symbol, entry);
         if (prev == null && TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
-            Tr.event(instance, tc, EVENT_ADDED + symbol + EVENT_ADDED_MIDDLE + value);
+            Tr.event(instance.get(), tc, EVENT_ADDED + symbol + EVENT_ADDED_MIDDLE + value);
 
         return prev == null;
     }
@@ -131,7 +137,7 @@ public class SymbolRegistry {
                 rootPaths.add(entry);
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
-                Tr.event(instance, tc, EVENT_ADDED + symbol + EVENT_ADDED_MIDDLE + value);
+                Tr.event(instance.get(), tc, EVENT_ADDED + symbol + EVENT_ADDED_MIDDLE + value);
 
             return true;
         }
@@ -142,7 +148,7 @@ public class SymbolRegistry {
         SymRegEntry entry = new SymRegEntry(EntryType.STRING, symbol, value);
         SymRegEntry prev = stringToEntry.putIfAbsent(symbol, entry);
         if (prev == null && TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
-            Tr.event(instance, tc, EVENT_ADDED + symbol + EVENT_ADDED_MIDDLE + value);
+            Tr.event(instance.get(), tc, EVENT_ADDED + symbol + EVENT_ADDED_MIDDLE + value);
 
         return prev == null;
     }
@@ -152,9 +158,9 @@ public class SymbolRegistry {
         SymRegEntry prev = stringToEntry.put(symbol, entry);
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             if (prev == null) {
-                Tr.event(instance, tc, EVENT_ADDED + symbol + EVENT_ADDED_MIDDLE + value);
+                Tr.event(instance.get(), tc, EVENT_ADDED + symbol + EVENT_ADDED_MIDDLE + value);
             } else {
-                Tr.event(instance, tc, EVENT_REPLACED + symbol + EVENT_ADDED_MIDDLE + value);
+                Tr.event(instance.get(), tc, EVENT_REPLACED + symbol + EVENT_ADDED_MIDDLE + value);
             }
         }
     }
@@ -169,7 +175,7 @@ public class SymbolRegistry {
         stringToEntry.clear();
         rootPaths.clear();
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
-            Tr.event(instance, tc, "Symbol registry cleared");
+            Tr.event(instance.get(), tc, "Symbol registry cleared");
     }
 
     /**

--- a/dev/com.ibm.ws.kernel.service.location/src/com/ibm/ws/kernel/service/location/internal/WsLocationAdminImpl.java
+++ b/dev/com.ibm.ws.kernel.service.location/src/com/ibm/ws/kernel/service/location/internal/WsLocationAdminImpl.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -42,6 +43,7 @@ import org.osgi.framework.FrameworkUtil;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.wsspi.kernel.service.location.MalformedLocationException;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.location.WsLocationConstants;
@@ -66,7 +68,7 @@ public class WsLocationAdminImpl implements WsLocationAdmin {
                     LOC_AREA_NAME_WORKING = "workarea/",
                     LOC_AREA_NAME_EXTENSION = "extension/";
 
-    private static WsLocationAdminImpl instance;
+    private volatile static StaticValue<WsLocationAdminImpl> instance = StaticValue.createStaticValue(null);
 
     /**
      * Construct the WsLocationAdminService singleton based on a set of initial
@@ -76,13 +78,19 @@ public class WsLocationAdminImpl implements WsLocationAdmin {
      * @param initProps
      * @return WsLocationAdmin
      */
-    public static WsLocationAdminImpl createLocations(Map<String, Object> initProps) {
-        if (instance == null) {
+    public static WsLocationAdminImpl createLocations(final Map<String, Object> initProps) {
+        if (instance.get() == null) {
             SymbolRegistry.getRegistry().clear();
-            instance = new WsLocationAdminImpl(initProps);
+            Callable<WsLocationAdminImpl> initializer = new Callable<WsLocationAdminImpl>() {
+                @Override
+                public WsLocationAdminImpl call() throws Exception {
+                    return new WsLocationAdminImpl(initProps);
+                }
+            };
+            instance = StaticValue.mutateStaticValue(instance, initializer);
         }
 
-        return instance;
+        return instance.get();
     }
 
     /**
@@ -93,23 +101,30 @@ public class WsLocationAdminImpl implements WsLocationAdmin {
      * @param initProps
      * @return WsLocationAdmin
      */
-    public static WsLocationAdminImpl createLocations(BundleContext ctx) {
-        if (instance == null) {
+    public static WsLocationAdminImpl createLocations(final BundleContext ctx) {
+        if (instance.get() == null) {
             SymbolRegistry.getRegistry().clear();
-            instance = new WsLocationAdminImpl(new BundleContextMap(ctx));
+            Callable<WsLocationAdminImpl> initializer = new Callable<WsLocationAdminImpl>() {
+                @Override
+                public WsLocationAdminImpl call() throws Exception {
+                    return new WsLocationAdminImpl(new BundleContextMap(ctx));
+                }
+            };
+            instance = StaticValue.mutateStaticValue(instance,initializer);
         }
 
-        return instance;
+        return instance.get();
     }
 
     /**
      * @return
      */
     public static WsLocationAdminImpl getInstance() {
-        if (instance == null)
+        WsLocationAdminImpl result  = instance.get();
+        if (result == null)
             throw new IllegalStateException("Location manager not initialized");
 
-        return instance;
+        return result;
     }
 
     /**

--- a/dev/com.ibm.ws.logging.core/bnd.bnd
+++ b/dev/com.ibm.ws.logging.core/bnd.bnd
@@ -20,6 +20,7 @@ Export-Package: \
 	com.ibm.ws.ffdc,\
 	com.ibm.ws.ffdc.annotation,\
 	com.ibm.ws.kernel.provisioning.packages,\
+	com.ibm.ws.staticvalue,\
 	com.ibm.ws.logging,\
 	com.ibm.ws.logging.internal,\
 	com.ibm.wsspi.logging,\

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/TrConfigurator.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/TrConfigurator.java
@@ -12,6 +12,7 @@ package com.ibm.websphere.ras;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -22,6 +23,7 @@ import com.ibm.ws.logging.internal.DisabledTraceService;
 import com.ibm.ws.logging.internal.SafeTraceLevelIndexFactory;
 import com.ibm.ws.logging.internal.TraceSpecification;
 import com.ibm.ws.logging.internal.TraceSpecification.TraceSpecificationException;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.wsspi.logging.MessageRouter;
 import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
 import com.ibm.wsspi.logprovider.LogProviderConfig;
@@ -38,13 +40,23 @@ public class TrConfigurator {
     }
 
     /** Mark the initialization of the Tr */
-    static final AtomicReference<LogProviderConfig> loggingConfig = new AtomicReference<LogProviderConfig>(null);
+    static final StaticValue<AtomicReference<LogProviderConfig>> loggingConfig = StaticValue.createStaticValue(new Callable<AtomicReference<LogProviderConfig>>() {
+        @Override
+        public AtomicReference<LogProviderConfig> call() throws Exception {
+            return new AtomicReference<LogProviderConfig>(null);
+        }
+    });
 
     /** Active configuration */
-    static TrService delegate = null;
+    static StaticValue<TrService> delegate = StaticValue.createStaticValue(null);
 
     /** List of registered trace component change listeners */
-    static Set<TraceComponentChangeListener> registeredListeners = new CopyOnWriteArraySet<TraceComponentChangeListener>();
+    final static StaticValue<Set<TraceComponentChangeListener>> registeredListeners = StaticValue.createStaticValue(new Callable<Set<TraceComponentChangeListener>>() {
+        @Override
+        public Set<TraceComponentChangeListener> call() throws Exception {
+            return new CopyOnWriteArraySet<TraceComponentChangeListener>();
+        }
+    });
 
     private static boolean instrumentationAvailable;
 
@@ -73,7 +85,7 @@ public class TrConfigurator {
         if (config == null)
             throw new NullPointerException("LogProviderConfig must not be null");
 
-        if (loggingConfig.compareAndSet(null, config)) {
+        if (loggingConfig.get().compareAndSet(null, config)) {
             // Only initialize Tr once -- all subsequent changes go through update
             // The synchronization of this method is gratuitous (just makes us feel better), 
             // it is called while the system is single threaded at startup. 
@@ -81,11 +93,17 @@ public class TrConfigurator {
             // config.getTrDelegate() must not return null -- it should either
             // return a dummy/disabled delegate, or throw an exception so that startup
             // does not proceed.
-            delegate = config.getTrDelegate();
-            if (delegate == null)
+            final TrService tr = config.getTrDelegate();
+            if (tr == null)
                 throw new NullPointerException("LogProviderConfig must provide a TrService delegate");
-
-            delegate.init(config);
+            Callable<TrService> result = new Callable<TrService>() {
+                @Override
+                public TrService call() throws Exception {
+                    return tr;
+                }
+            };
+            delegate = StaticValue.mutateStaticValue(delegate, result);
+            delegate.get().init(config);
 
             // Validate and propagate the initial trace specification 
             setTraceSpec(config.getTraceString());
@@ -111,7 +129,7 @@ public class TrConfigurator {
         boolean traceWasDisabled = !TraceComponent.isAnyTracingEnabled();
 
         // Update the logging configuration
-        LogProviderConfig config = loggingConfig.get();
+        LogProviderConfig config = loggingConfig.get().get();
         if (config != null) {
             config.update(newConfig);
 
@@ -186,16 +204,24 @@ public class TrConfigurator {
      * @return active delegate
      */
     static TrService getDelegate() {
-        TrService trDelegate = delegate;
-        if (trDelegate != null)
-            return trDelegate;
+        TrService result = delegate.get();
+        if (result != null) {
+            return result;
+        }
 
-        LogProviderConfig config = loggingConfig.get();
+        LogProviderConfig config = loggingConfig.get().get();
         if (config != null) {
-            trDelegate = config.getTrDelegate();
-            if (trDelegate != null) {
-                delegate = trDelegate;
-                return trDelegate;
+            final TrService tr = config.getTrDelegate();
+            if (tr != null) {
+                Callable<TrService> initializer = new Callable<TrService>() {
+                    @Override
+                    public TrService call() throws Exception {
+                        return tr;
+                    }
+                };
+                delegate = StaticValue.mutateStaticValue(delegate, initializer);
+                delegate.get().init(config);
+                return delegate.get();
             }
         }
 
@@ -210,7 +236,7 @@ public class TrConfigurator {
      *            the {@link TraceComponent} that was registered
      */
     static void traceComponentRegistered(TraceComponent tc) {
-        for (TraceComponentChangeListener listener : registeredListeners) {
+        for (TraceComponentChangeListener listener : registeredListeners.get()) {
             listener.traceComponentRegistered(tc);
         }
     }
@@ -223,17 +249,17 @@ public class TrConfigurator {
      *            the {@link TraceComponent} that was updated
      */
     static void traceComponentUpdated(TraceComponent tc) {
-        for (TraceComponentChangeListener listener : registeredListeners) {
+        for (TraceComponentChangeListener listener : registeredListeners.get()) {
             listener.traceComponentUpdated(tc);
         }
     }
 
     public static void addTraceComponentListener(TraceComponentChangeListener tcl) {
-        registeredListeners.add(tcl);
+        registeredListeners.get().add(tcl);
     }
 
     public static void removeTraceComponentListener(TraceComponentChangeListener tcl) {
-        registeredListeners.remove(tcl);
+        registeredListeners.get().remove(tcl);
     }
 
     /**
@@ -293,7 +319,7 @@ public class TrConfigurator {
      * @return
      */
     public static String getLogLocation() {
-        LogProviderConfig cfg = loggingConfig.get();
+        LogProviderConfig cfg = loggingConfig.get().get();
         if (cfg == null)
             throw new IllegalStateException("Tr not initialized");
 
@@ -362,7 +388,7 @@ public class TrConfigurator {
      * @return
      */
     public static TextFileOutputStreamFactory getFileOutputStreamFactory() {
-        LogProviderConfig cfg = loggingConfig.get();
+        LogProviderConfig cfg = loggingConfig.get().get();
         if (cfg == null)
             throw new IllegalStateException("Tr not initialized");
 

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/staticvalue/StaticValue.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/staticvalue/StaticValue.java
@@ -214,4 +214,8 @@ public abstract class StaticValue<T> {
     T initialize(ThreadGroup g, Callable<T> initializer) {
         return null;
     }
+
+    public String toString() {
+        return "StaticValue[" + get() + "]";
+    }
 }

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/staticvalue/StaticValue.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/staticvalue/StaticValue.java
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.staticvalue;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.Callable;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+/**
+ * A StaticValue object is intended to be used for static field values
+ * which hold state for a specific group of threads when multiplexing
+ * is enabled.  When multiplexing is not enabled accessing the value
+ * with {@link #get()} should be a simple read on a final field which
+ * requires no additional locks to read.
+ * <p>
+ * If a static field is final then you can use the {@link #createStaticValue(Callable)}
+ * with a callable which will assign the final value value for the
+ * StaticValue.  If a static field is not final then you should
+ * use the {@link #createStaticValue(Callable)} method with a
+ * {@code null} callable. If the
+ * static field needs updated with a new value then the method
+ * {@link #mutateStaticValue(StaticValue, Callable)}
+ * is called with the callable to initialize the value.
+ * 
+ *
+ * @param <T> the type of value
+ */
+public abstract class StaticValue<T> {
+    /**
+     * Indicates if values are multiplexed according to thread group.
+     * Note that to enable this a resource is searched for called
+     * <q>com.ibm.ws.staticvalue.multiplex</q>.  This is to ensure
+     * the multiplex flag is set appropriately as soon as possible.
+     */
+    private static final boolean multiplex = StaticValue.class.getResource("/com.ibm.ws.staticvalue.multiplex") != null;
+
+    /**
+     * Creates a new StaticValue and uses the initializer callable to obtain the
+     * initial value when {@link #get()} is called.  Note that when not multiplexing
+     * the initializer is called immediately.
+     * @param initializer the callable to obtain the initial value.  A {@code null} value
+     * is used to indicate no initial value.  In this case the {@link #mutateStaticValue(StaticValue, Callable)}
+     * method can be used to set the static value later.
+     * @return the new static value
+     */
+    @FFDCIgnore(Exception.class)
+    public static <T> StaticValue<T> createStaticValue(Callable<T> initializer) {
+        if (multiplex) {
+            return new Multiplexed<T>(initializer);
+        }
+        try {
+            return new FinalSingleton<T>(initializer == null ? null : initializer.call());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Mutates a static value.  Note that if not multiplexing then this method returns a
+     * new StaticValue object with the value as obtained by the initializer.
+     * @param staticValue the mutated static value using the specified initializer
+     * @param initializer the initializer to use to get the new value for the static value
+     * @return the static value.  This may be a new static value or the one passed in depending on
+     * if the static value can be mutated.
+     */
+    public static <T> StaticValue<T> mutateStaticValue(StaticValue<T> staticValue, Callable<T> initializer) {
+        if (multiplex) {
+            // Multiplexing case; must check for existing StaticValue
+            if (staticValue == null) {
+                // no existing value; create new one with no constructor initializer
+                staticValue = StaticValue.createStaticValue(null);
+            }
+            // initialize this thread only with the initializer
+            staticValue.initialize(getThreadGroup(), initializer);
+            return staticValue;
+        }
+        // Final singleton case; just create a new StaticValue
+        return StaticValue.createStaticValue(initializer);
+    }
+
+    static class Multiplexed<T> extends StaticValue<T> {
+        static class GroupHolder<T> {
+            final T t;
+            final Callable<T> initializer;
+
+            GroupHolder(T t, Callable<T> initializer) {
+                this.t = t;
+                this.initializer = initializer;
+            }
+        }
+
+        private final Map<ThreadGroup, GroupHolder<T>> threadGroups = new WeakHashMap<>();
+        private final Callable<T> constructorInitializer;
+        private GroupHolder<T> singleton;
+
+        Multiplexed(Callable<T> initializer) {
+            this.constructorInitializer = initializer;
+        }
+
+        @Override
+        T initialize(ThreadGroup g, Callable<T> initializer) {
+            if (g == null) {
+                return getOrInitSingleton(initializer);
+            }
+            return getOrInitGroup(g, initializer);
+        }
+
+        @Override
+        public T get() {
+            ThreadGroup g = getThreadGroup();
+            GroupHolder<T> result;
+            boolean initialize = false;
+            synchronized (this) {
+                result = g == null ? singleton : threadGroups.get(g);
+                if (result == null) {
+                    if (constructorInitializer != null) {
+                        initialize = true;
+                    } else {
+                        return null;
+                    }
+                }
+            }
+            return initialize ? initialize(g, constructorInitializer) : result.t;
+        }
+
+        @FFDCIgnore(Exception.class)
+        private T getOrInitSingleton(Callable<T> initializer) {
+            // Note that we simply override the singleton each time to get the latest
+            try {
+                synchronized (this) {
+                    if (singleton != null && singleton.initializer == initializer) {
+                        return singleton.t;
+                    }
+                }
+                T val = initializer == null ? null : initializer.call();
+                synchronized (this) {
+                    // check to make sure this initializer was not used by another thread
+                    if (singleton != null && singleton.initializer == initializer) {
+                        // another thread won with the same initializer
+                        return singleton.t;
+                    }
+                    singleton = new GroupHolder<>(val, initializer);
+                    return singleton.t;
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @FFDCIgnore(Exception.class)
+        private T getOrInitGroup(ThreadGroup g, Callable<T> initializer) {
+            synchronized (this) {
+                GroupHolder<T> result = threadGroups.get(g);
+                if (result != null && result.initializer == initializer) {
+                    return result.t;
+                }
+            }
+
+            try {
+                T val = initializer == null ? null : initializer.call();
+                synchronized (this) {
+                    // check to make sure this initializer was not used by another thread
+                    GroupHolder<T> result = threadGroups.get(g);
+                    if (result != null && result.initializer == initializer) {
+                        // another thread won with the same initializer
+                        return result.t;
+                    }
+                    // note the last initializer called wins
+                    result = new GroupHolder<>(val, initializer);
+                    threadGroups.put(g, result);
+                    // note that we overide singleton each time to keep it the latest
+                    singleton = result;
+                    return result.t;
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    static class FinalSingleton<T> extends StaticValue<T> {
+        private final T singleton;
+
+        FinalSingleton(T initial) {
+            this.singleton = initial;
+        }
+
+        @Override
+        public T get() {
+            return singleton;
+        }
+    }
+
+    static ThreadGroup getThreadGroup() {
+        ThreadGroup g = Thread.currentThread().getThreadGroup();
+        while (g != null && (g.getName() == null || !g.getName().startsWith("osgi-boot-"))) {
+            g = g.getParent();
+        }
+        return g;
+    }
+
+    public abstract T get();
+
+    T initialize(ThreadGroup g, Callable<T> initializer) {
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/staticvalue/package-info.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/staticvalue/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = com.ibm.ws.logging.internal.NLSConstants.GROUP, messageBundle = com.ibm.ws.logging.internal.NLSConstants.LOGGING_NLS)
+package com.ibm.ws.staticvalue;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/hpel/viewer/BinaryLogTest.java
+++ b/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/hpel/viewer/BinaryLogTest.java
@@ -548,7 +548,7 @@ public class BinaryLogTest {
 
         int exitValue = p.exitValue();
         if (exitValue != 0) {
-            throw new IOException(command.get(0) + " failed (" + exitValue + "): " + output);
+            throw new IOException(command.get(0) + " failed (" + exitValue + "): " + output + " ERROR: " + error);
         }
 
         List[] returnList = new List[2];

--- a/dev/com.ibm.ws.logging.osgi/test/com/ibm/websphere/ras/SharedTr.java
+++ b/dev/com.ibm.ws.logging.osgi/test/com/ibm/websphere/ras/SharedTr.java
@@ -21,6 +21,7 @@ import test.TestConstants;
 
 import com.ibm.ws.logging.internal.impl.LogProviderConfigImpl;
 import com.ibm.ws.logging.internal.impl.LoggingConstants;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
 import com.ibm.wsspi.logprovider.LogProviderConfig;
 import com.ibm.wsspi.logprovider.TrService;
@@ -60,8 +61,8 @@ public class SharedTr extends Tr {
     }
 
     public static void clearConfig() {
-        TrConfigurator.loggingConfig.set(null);
-        TrConfigurator.delegate = null;
+        TrConfigurator.loggingConfig.get().set(null);
+        TrConfigurator.delegate = StaticValue.mutateStaticValue(TrConfigurator.delegate, null);
     }
 
     public static TrService getDelegate() {

--- a/dev/com.ibm.ws.logging/bnd.bnd
+++ b/dev/com.ibm.ws.logging/bnd.bnd
@@ -32,6 +32,7 @@ Export-Package: \
  com.ibm.websphere.ras.annotation;provide:=true, \
  com.ibm.ws.ffdc;provide:=true, \
  com.ibm.ws.ffdc.annotation;provide:=true, \
+ com.ibm.ws.staticvalue;provide:=true, \
  com.ibm.ws.logging;provide:=true, \
  com.ibm.ws.ras.instrument.annotation, \
  com.ibm.ws.logging.internal, \

--- a/dev/com.ibm.ws.logging_test/test/com/ibm/websphere/ras/SharedTr.java
+++ b/dev/com.ibm.ws.logging_test/test/com/ibm/websphere/ras/SharedTr.java
@@ -21,6 +21,7 @@ import test.TestConstants;
 
 import com.ibm.ws.logging.internal.impl.LogProviderConfigImpl;
 import com.ibm.ws.logging.internal.impl.LoggingConstants;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
 import com.ibm.wsspi.logprovider.LogProviderConfig;
 import com.ibm.wsspi.logprovider.TrService;
@@ -60,8 +61,8 @@ public class SharedTr extends Tr {
     }
 
     public static void clearConfig() {
-        TrConfigurator.loggingConfig.set(null);
-        TrConfigurator.delegate = null;
+        TrConfigurator.loggingConfig.get().set(null);
+        TrConfigurator.delegate = StaticValue.mutateStaticValue(TrConfigurator.delegate, null);
     }
 
     public static TrService getDelegate() {

--- a/dev/com.ibm.ws.product.utility/test/com/ibm/ws/product/utility/extension/IFixUtilsTest.java
+++ b/dev/com.ibm.ws.product.utility/test/com/ibm/ws/product/utility/extension/IFixUtilsTest.java
@@ -124,14 +124,7 @@ public class IFixUtilsTest {
         platformDir.mkdirs();
         toolsDir.mkdirs();
 
-        // Reflectively amend the Utils class to set the current WLP dir as the installDir field. 
-        try {
-            Field getInstallField = Utils.class.getDeclaredField("installDir");
-            getInstallField.setAccessible(true);
-            getInstallField.set(null, wlpDir);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        Utils.setInstallDir(wlpDir);
     }
 
     @After

--- a/dev/com.ibm.ws.product.utility/test/com/ibm/ws/product/utility/extension/ValidateCommandTest.java
+++ b/dev/com.ibm.ws.product.utility/test/com/ibm/ws/product/utility/extension/ValidateCommandTest.java
@@ -13,7 +13,6 @@ package com.ibm.ws.product.utility.extension;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -97,14 +96,7 @@ public class ValidateCommandTest {
         wlpDir = new File(uniqueTestDir, "wlp");
         setupMocking();
 
-        // Reflectively amend the Utils class to set the current WLP dir as the installDir field.
-        try {
-            Field getInstallField = Utils.class.getDeclaredField("installDir");
-            getInstallField.setAccessible(true);
-            getInstallField.set(null, wlpDir);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        Utils.setInstallDir(wlpDir);
 
         libDir = new File(wlpDir, "lib");
         binDir = new File(wlpDir, "bin");

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionInvalidatorWithThreadPool.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionInvalidatorWithThreadPool.java
@@ -34,7 +34,7 @@ public class SessionInvalidatorWithThreadPool implements ITimer{
         _invalInterval = interval;
         
         /*Get reference to ScheduledExecutorService from SessionMgrComponentImpl*/
-        _scheduler = SessionMgrComponentImpl.INSTANCE.get().getScheduledExecutorService();
+        _scheduler = SessionMgrComponentImpl.INSTANCE.get().get().getScheduledExecutorService();
         
         _invalTask = new InvalidationTask(store);
         

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/webcontainer/httpsession/SessionMgrComponentImpl.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/webcontainer/httpsession/SessionMgrComponentImpl.java
@@ -16,6 +16,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
@@ -27,6 +28,7 @@ import com.ibm.ws.session.SessionProperties;
 import com.ibm.ws.session.SessionStoreService;
 import com.ibm.ws.session.utils.EncodeCloneID;
 import com.ibm.ws.session.utils.LoggingUtil;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 
 /*
@@ -36,7 +38,11 @@ import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 public class SessionMgrComponentImpl implements SessionManager {
     
     /** Only used by WXS. Should be removed as soon as SPI is defined. */
-    public static final AtomicReference<SessionMgrComponentImpl> INSTANCE = new AtomicReference<SessionMgrComponentImpl>();
+    public static final StaticValue<AtomicReference<SessionMgrComponentImpl>> INSTANCE = StaticValue.createStaticValue(new Callable<AtomicReference<SessionMgrComponentImpl>>() {
+        @Override
+        public AtomicReference<SessionMgrComponentImpl> call() throws Exception {
+            return new AtomicReference<SessionMgrComponentImpl>();
+        }});
 
     private final SessionManagerConfig serverLevelSessionManagerConfig = new SessionManagerConfig();
     private final WsLocationAdmin wsLocationAdmin;
@@ -54,7 +60,7 @@ public class SessionMgrComponentImpl implements SessionManager {
      * @return the configuration of the currently active SessionManager instance
      */
     public static SessionManagerConfig getServerSessionManagerConfig() {
-        SessionMgrComponentImpl service = INSTANCE.get();
+        SessionMgrComponentImpl service = INSTANCE.get().get();
         if (service == null) {
             // no session manager service is available
             return null; 

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/webcontainer/httpsession/SessionMgrCoordinator.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/webcontainer/httpsession/SessionMgrCoordinator.java
@@ -139,7 +139,7 @@ public class SessionMgrCoordinator {
             }
             this.smgrRegistration.unregister();
             this.smgrRegistration = null;
-            SessionMgrComponentImpl.INSTANCE.compareAndSet(this.smgr, null);
+            SessionMgrComponentImpl.INSTANCE.get().compareAndSet(this.smgr, null);
             this.smgr = null;
         } else {
             if (TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
@@ -214,7 +214,7 @@ public class SessionMgrCoordinator {
         }
         this.smgrRegistration = newSmgrRegistration;
         this.smgr = newSmgr;
-        SessionMgrComponentImpl.INSTANCE.set(this.smgr);
+        SessionMgrComponentImpl.INSTANCE.get().set(this.smgr);
         if (TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINER)) {
             LoggingUtil.SESSION_LOGGER_CORE.exiting(CLASS_NAME, "registerSessionManager");
         }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/HttpDispatcher.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/HttpDispatcher.java
@@ -10,16 +10,15 @@
  *******************************************************************************/
 package com.ibm.ws.http.dispatcher.internal;
 
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.osgi.framework.ServiceReference;
-import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.ComponentConstants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -37,13 +36,13 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.http.internal.EncodingUtilsImpl;
 import com.ibm.ws.http.internal.HttpDateFormatImpl;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.wsspi.bytebuffer.WsByteBufferPoolManager;
 import com.ibm.wsspi.channelfw.ChannelFramework;
 import com.ibm.wsspi.channelfw.ChannelFrameworkFactory;
 import com.ibm.wsspi.http.EncodingUtils;
 import com.ibm.wsspi.http.HttpDateFormat;
 import com.ibm.wsspi.http.VirtualHostListener;
-import com.ibm.wsspi.http.WelcomePage;
 import com.ibm.wsspi.http.WorkClassifier;
 import com.ibm.wsspi.http.ee7.HttpTransportBehavior;
 import com.ibm.wsspi.kernel.service.utils.MetatypeUtils;
@@ -104,7 +103,12 @@ public class HttpDispatcher {
      * Active HttpDispatcher instance. May be null between deactivate and activate
      * calls.
      */
-    private static final AtomicReference<HttpDispatcher> instance = new AtomicReference<HttpDispatcher>();
+    private static final StaticValue<AtomicReference<HttpDispatcher>> instance = StaticValue.createStaticValue(new Callable<AtomicReference<HttpDispatcher>>() {
+        @Override
+        public AtomicReference<HttpDispatcher> call() throws Exception {
+            return new AtomicReference<HttpDispatcher>();
+        }
+    });
 
     /** appOrContextRootMissingMessage custom property */
     private volatile String appOrContextRootNotFound = null;
@@ -124,7 +128,12 @@ public class HttpDispatcher {
     /** PM97514 - webcontainer trusted attribute */
     private volatile boolean wcTrusted = true;
 
-    private static final AtomicInteger updateCount = new AtomicInteger(0);
+    private static final StaticValue<AtomicInteger> updateCount = StaticValue.createStaticValue(new Callable<AtomicInteger>() {
+        @Override
+        public AtomicInteger call() throws Exception {
+            return new AtomicInteger();
+        }
+    });;
 
     /**
      * Constructor.
@@ -141,7 +150,7 @@ public class HttpDispatcher {
         modified(properties);
 
         // Set this as the active HttpDispatcher instance
-        instance.set(this);
+        instance.get().set(this);
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(this, tc, "HttpDispatcher activated, id=" + properties.get(ComponentConstants.COMPONENT_ID));
@@ -160,7 +169,7 @@ public class HttpDispatcher {
         }
 
         // Clear this as the active HttpDispatcher instance (unless another has already replaced)
-        instance.compareAndSet(this, null);
+        instance.get().compareAndSet(this, null);
     }
 
     /**
@@ -199,7 +208,7 @@ public class HttpDispatcher {
     }
 
     public static Boolean isWelcomePageEnabled() {
-        HttpDispatcher f = instance.get();
+        HttpDispatcher f = instance.get().get();
         if (f != null)
             return f.enableWelcomePage;
 
@@ -221,7 +230,7 @@ public class HttpDispatcher {
         // this does not return a default string, since the caller may (and does in our case) choose to build a runtime
         // dependent string.
 
-        HttpDispatcher f = instance.get();
+        HttpDispatcher f = instance.get().get();
         if (f != null)
             return f.appOrContextRootNotFound;
 
@@ -242,7 +251,7 @@ public class HttpDispatcher {
     }
 
     public static boolean padContextRootNotFoundMessage() {
-        HttpDispatcher f = instance.get();
+        HttpDispatcher f = instance.get().get();
         if (f != null)
             return f.padAppOrContextRootNotFoundMessage;
 
@@ -260,7 +269,7 @@ public class HttpDispatcher {
      */
     private synchronized void parseTrustedPrivateHeaderOrigin(String[] value) {
         // bump the updated count every time we call this.
-        updateCount.incrementAndGet();
+        updateCount.get().incrementAndGet();
 
         // PM97514 - allow restricting the use of private headers to requests coming from specific IP addresses
         List<String> addrs = new ArrayList<String>();
@@ -304,7 +313,7 @@ public class HttpDispatcher {
      * @return true if private headers should be used (the default is true)
      */
     public static boolean usePrivateHeaders(String hostAddr) {
-        HttpDispatcher f = instance.get();
+        HttpDispatcher f = instance.get().get();
         if (f != null) {
             return f.originIsTrusted(hostAddr);
         }
@@ -375,7 +384,7 @@ public class HttpDispatcher {
      * @return EncodingUtils
      */
     public static EncodingUtils getEncodingUtils() {
-        HttpDispatcher f = instance.get();
+        HttpDispatcher f = instance.get().get();
         EncodingUtils svc = null;
         if (f != null) {
             svc = f.encodingSvc;
@@ -413,7 +422,7 @@ public class HttpDispatcher {
      * @return EventEngine - null if not found
      */
     public static EventEngine getEventService() {
-        HttpDispatcher f = instance.get();
+        HttpDispatcher f = instance.get().get();
         if (f != null)
             return f.eventSvc;
 
@@ -446,7 +455,7 @@ public class HttpDispatcher {
      * @return CollaborationEngine - null if not found
      */
     public static ExecutorService getExecutorService() {
-        HttpDispatcher f = instance.get();
+        HttpDispatcher f = instance.get().get();
         if (f == null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
                 Tr.event(tc, "HttpDispatcher instance not found");
@@ -519,7 +528,7 @@ public class HttpDispatcher {
      * @return CHFWBundle
      */
     public static CHFWBundle getCHFWBundle() {
-        HttpDispatcher f = instance.get();
+        HttpDispatcher f = instance.get().get();
         if (f != null)
             return f.chfw;
 
@@ -607,7 +616,7 @@ public class HttpDispatcher {
      * @return WorkClassifier - null if not found
      */
     public static WorkClassifier getWorkClassifier() {
-        HttpDispatcher f = instance.get();
+        HttpDispatcher f = instance.get().get();
         if (f != null)
             return f.workClassifier;
 
@@ -618,7 +627,7 @@ public class HttpDispatcher {
      * @return
      */
     public static int getConfigUpdate() {
-        return updateCount.get();
+        return updateCount.get().get();
     }
 
     @Reference(service = HttpTransportBehavior.class, cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpEndpointList.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpEndpointList.java
@@ -11,44 +11,49 @@
 package com.ibm.ws.http.internal;
 
 import java.util.Iterator;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.staticvalue.StaticValue;
 
 /**
  *
  */
 public class HttpEndpointList implements Iterable<HttpEndpointImpl> {
 
-    static final class Singleton {
-        private static final HttpEndpointList instance = new HttpEndpointList();
-    }
+    private final static StaticValue<HttpEndpointList> instance = StaticValue.createStaticValue(new Callable<HttpEndpointList>() {
+        @Override
+        public HttpEndpointList call() {
+            return new HttpEndpointList();
+        }
+    });
 
     /**
      * @return the singleton HttpEndpointMap instance.
      */
     @Trivial
     public static HttpEndpointList getInstance() {
-        return Singleton.instance;
+        return instance.get();
     }
 
     public static void registerEndpoint(HttpEndpointImpl h) {
-        Singleton.instance.add(h);
+        instance.get().add(h);
     }
 
     public static void unregisterEndpoint(HttpEndpointImpl h) {
-        Singleton.instance.remove(h);
+        instance.get().remove(h);
     }
 
     /**
      * Return the endpoint for the given id.
-     * 
+     *
      * @param endpointId
-     * 
+     *
      * @return The endpoint associated with the id, or null.
      */
     public static HttpEndpointImpl findEndpoint(String endpointId) {
-        for (HttpEndpointImpl i : Singleton.instance) {
+        for (HttpEndpointImpl i : instance.get()) {
             if (i.getName().equals(endpointId))
                 return i;
         }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/VirtualHostMap.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/VirtualHostMap.java
@@ -91,7 +91,7 @@ public class VirtualHostMap {
      */
     public synchronized static void addVirtualHost(final VirtualHostConfig oldConfig, final VirtualHostConfig newConfig) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Add virtual host: " + newConfig.getVirtualHost(), oldConfig, newConfig, defaultHost.get(), alternateHostSelector);
+            Tr.event(tc, "Add virtual host: " + newConfig.getVirtualHost(), oldConfig, newConfig, defaultHost.get(), alternateHostSelector.get());
         }
 
         // If the "default/catch-all-ness" of the host was modified,
@@ -841,9 +841,9 @@ public class VirtualHostMap {
      */
     protected synchronized static void dump(PrintStream ps) {
         ps.println("Default host: " + defaultHost.get());
-        ps.println("Alternate hosts: " + (alternateHostSelector != null));
-        if (alternateHostSelector != null)
-            ps.println(alternateHostSelector);
+        ps.println("Alternate hosts: " + (alternateHostSelector.get() != null));
+        if (alternateHostSelector.get() != null)
+            ps.println(alternateHostSelector.get());
     }
 
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/VirtualHostMap.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/VirtualHostMap.java
@@ -19,10 +19,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.staticvalue.StaticValue;
 
 /**
  * This map bridges between independent dynamic components: HttpEndpoints (with their Chains), and
@@ -63,8 +65,8 @@ import com.ibm.websphere.ras.annotation.Trivial;
 public class VirtualHostMap {
     static final TraceComponent tc = Tr.register(VirtualHostMap.class);
 
-    private static volatile VirtualHostConfig defaultHost = null;
-    private static volatile AlternateHostSelector alternateHostSelector = null;
+    private static volatile StaticValue<VirtualHostConfig> defaultHost = StaticValue.createStaticValue(null);
+    private static volatile StaticValue<AlternateHostSelector> alternateHostSelector = StaticValue.createStaticValue(null);
 
     /**
      * Simple interface to allow deferred retrieval of host/port information
@@ -87,42 +89,58 @@ public class VirtualHostMap {
      *
      * @see VirtualHostImpl#modified
      */
-    public synchronized static void addVirtualHost(VirtualHostConfig oldConfig, VirtualHostConfig newConfig) {
+    public synchronized static void addVirtualHost(final VirtualHostConfig oldConfig, final VirtualHostConfig newConfig) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Add virtual host: " + newConfig.getVirtualHost(), oldConfig, newConfig, defaultHost, alternateHostSelector);
+            Tr.event(tc, "Add virtual host: " + newConfig.getVirtualHost(), oldConfig, newConfig, defaultHost.get(), alternateHostSelector);
         }
 
         // If the "default/catch-all-ness" of the host was modified,
         // the virtual host was removed before calling this method.
         if (newConfig.isDefaultHost()) {
-            defaultHost = newConfig;
-            if (alternateHostSelector != null) {
-                alternateHostSelector.alternateAddDefaultHost(newConfig);
+            defaultHost = StaticValue.mutateStaticValue(defaultHost, new Callable<VirtualHostConfig>() {
+                @Override
+                public VirtualHostConfig call() {
+                    return newConfig;
+                }
+            });
+
+            if (alternateHostSelector.get() != null) {
+                alternateHostSelector.get().alternateAddDefaultHost(newConfig);
             } else {
                 // notify default host of  active listeners
                 for (HttpEndpointImpl e : HttpEndpointList.getInstance()) {
                     int ePort = e.getListeningHttpPort();
-                    if (ePort > 0)
-                        defaultHost.listenerStarted(e, e.getResolvedHostName(), ePort, false);
+                    if (ePort > 0) {
+                        defaultHost.get().listenerStarted(e, e.getResolvedHostName(), ePort, false);
+                    }
+
                     ePort = e.getListeningSecureHttpPort();
-                    if (ePort > 0)
-                        defaultHost.listenerStarted(e, e.getResolvedHostName(), ePort, true);
+                    if (ePort > 0) {
+                        defaultHost.get().listenerStarted(e, e.getResolvedHostName(), ePort, true);
+                    }
+
                 }
             }
         } else {
-            if (alternateHostSelector == null) {
-                alternateHostSelector = new AlternateHostSelector();
-            }
+            if (alternateHostSelector.get() == null) {
+                alternateHostSelector = StaticValue.mutateStaticValue(alternateHostSelector, new Callable<AlternateHostSelector>() {
+                    @Override
+                    public AlternateHostSelector call() throws Exception {
+                        return new AlternateHostSelector();
+                    }
 
+                });
+            }
+            AlternateHostSelector current = alternateHostSelector.get();
             // Figure out which host aliases should be removed
             List<HostAlias> toRemove = new ArrayList<HostAlias>(oldConfig.getHostAliases());
             toRemove.removeAll(newConfig.getHostAliases());
 
             if (!toRemove.isEmpty()) {
-                alternateHostSelector.alternateRemoveVirtualHost(oldConfig, toRemove);
+                current.alternateRemoveVirtualHost(oldConfig, toRemove);
             }
 
-            alternateHostSelector.alternateAddVirtualHost(newConfig);
+            current.alternateAddVirtualHost(newConfig);
         }
     }
 
@@ -136,26 +154,35 @@ public class VirtualHostMap {
      */
     public synchronized static void removeVirtualHost(VirtualHostConfig config) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Remove virtual host: " + config.getVirtualHost(), config, defaultHost, alternateHostSelector);
+            Tr.event(tc, "Remove virtual host: " + config.getVirtualHost(), config, defaultHost.get(), alternateHostSelector);
         }
         if (config.isDefaultHost()) {
-            defaultHost = null;
-            if (alternateHostSelector != null) {
-                alternateHostSelector.alternateRemoveDefaultHost(config);
+            defaultHost = StaticValue.mutateStaticValue(defaultHost, new Callable<VirtualHostConfig>() {
+                @Override
+                public VirtualHostConfig call() {
+                    return null;
+                }
+            });
+            if (alternateHostSelector.get() != null) {
+                alternateHostSelector.get().alternateRemoveDefaultHost(config);
             } else {
                 // notify default host of  active listeners
                 for (HttpEndpointImpl e : HttpEndpointList.getInstance()) {
                     int ePort = e.getListeningHttpPort();
-                    if (ePort > 0)
+                    if (ePort > 0) {
                         config.listenerStopped(e, e.getResolvedHostName(), ePort, false);
+                    }
+
                     ePort = e.getListeningSecureHttpPort();
-                    if (ePort > 0)
+                    if (ePort > 0) {
                         config.listenerStopped(e, e.getResolvedHostName(), ePort, true);
+                    }
+
                 }
             }
-        } else if (alternateHostSelector != null) {
+        } else if (alternateHostSelector.get() != null) {
             // remove all configured host aliases.
-            alternateHostSelector.alternateRemoveVirtualHost(config, config.getHostAliases());
+            alternateHostSelector.get().alternateRemoveVirtualHost(config, config.getHostAliases());
         }
     }
 
@@ -170,13 +197,15 @@ public class VirtualHostMap {
      */
     public static synchronized void notifyStarted(HttpEndpointImpl endpoint, String resolvedHostName, int port, boolean isHttps) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Notify endpoint started: " + endpoint, resolvedHostName, port, isHttps, defaultHost, alternateHostSelector);
+            Tr.event(tc, "Notify endpoint started: " + endpoint, resolvedHostName, port, isHttps, defaultHost.get(), alternateHostSelector);
         }
-        if (alternateHostSelector == null) {
-            if (defaultHost != null)
-                defaultHost.listenerStarted(endpoint, resolvedHostName, port, isHttps);
+        if (alternateHostSelector.get() == null) {
+            if (defaultHost.get() != null) {
+                defaultHost.get().listenerStarted(endpoint, resolvedHostName, port, isHttps);
+            }
+
         } else {
-            alternateHostSelector.alternateNotifyStarted(endpoint, resolvedHostName, port, isHttps);
+            alternateHostSelector.get().alternateNotifyStarted(endpoint, resolvedHostName, port, isHttps);
         }
     }
 
@@ -193,13 +222,15 @@ public class VirtualHostMap {
      */
     public static synchronized void notifyStopped(HttpEndpointImpl endpoint, String resolvedHostName, int port, boolean isHttps) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Notify endpoint stopped: " + endpoint, resolvedHostName, port, isHttps, defaultHost, alternateHostSelector);
+            Tr.event(tc, "Notify endpoint stopped: " + endpoint, resolvedHostName, port, isHttps, defaultHost.get(), alternateHostSelector);
         }
-        if (alternateHostSelector == null) {
-            if (defaultHost != null)
-                defaultHost.listenerStopped(endpoint, resolvedHostName, port, isHttps);
+        if (alternateHostSelector.get() == null) {
+            if (defaultHost.get() != null) {
+                defaultHost.get().listenerStopped(endpoint, resolvedHostName, port, isHttps);
+            }
+
         } else {
-            alternateHostSelector.alternateNotifyStopped(endpoint, resolvedHostName, port, isHttps);
+            alternateHostSelector.get().alternateNotifyStopped(endpoint, resolvedHostName, port, isHttps);
         }
     }
 
@@ -216,11 +247,13 @@ public class VirtualHostMap {
         // defer retrieval of headers until we need them:
         // if we don't have virtual hosts to select from, we don't care what the
         // headers are, there is only one answer.
-        AlternateHostSelector selector = alternateHostSelector;
+        AlternateHostSelector selector = alternateHostSelector.get();
         if (selector == null) {
-            VirtualHostConfig defHostCfg = defaultHost;
-            if (defHostCfg != null)
+            VirtualHostConfig defHostCfg = defaultHost.get();
+            if (defHostCfg != null) {
                 return defHostCfg.getVirtualHost();
+            }
+
             return null;
         }
 
@@ -278,7 +311,7 @@ public class VirtualHostMap {
             if (d != null) {
                 target = d.selectVirtualHost(hostName.toLowerCase(Locale.ENGLISH));
             } else {
-                target = defaultHost;
+                target = defaultHost.get();
             }
 
             // Make sure the target is ready to accept request from the selected endpoint..
@@ -476,7 +509,7 @@ public class VirtualHostMap {
          *
          * @see #selectVirtualHost(String)
          */
-        volatile HostTuple currentHosts = new HostTuple(null, defaultHost);
+        volatile HostTuple currentHosts = new HostTuple(null, defaultHost.get());
 
         VirtualHostDiscriminator(int port) {
             this.port = port;
@@ -577,8 +610,8 @@ public class VirtualHostMap {
 
                     // if we're removing a non-default host, and there is a default host around.. add the default host
                     // as the catch-all for this alias
-                    if (!config.isDefaultHost() && defaultHost != null) {
-                        addVirtualHost(hostName, defaultHost);
+                    if (!config.isDefaultHost() && defaultHost.get() != null) {
+                        addVirtualHost(hostName, defaultHost.get());
                     }
                 }
             } else {
@@ -742,7 +775,7 @@ public class VirtualHostMap {
          * @return true if this element should be cleaned up.
          */
         boolean cleanup() {
-            if ((currentHosts.wildcardHost == null || currentHosts.wildcardHost == defaultHost)
+            if ((currentHosts.wildcardHost == null || currentHosts.wildcardHost == defaultHost.get())
                 && currentHosts.otherHosts == null && endpoints.isEmpty()) {
                 return true;
             }
@@ -788,7 +821,7 @@ public class VirtualHostMap {
             }
 
             // no dice. Return the default host if we have one.
-            return defaultHost;
+            return defaultHost.get();
         }
 
         @Override
@@ -807,7 +840,7 @@ public class VirtualHostMap {
      *
      */
     protected synchronized static void dump(PrintStream ps) {
-        ps.println("Default host: " + defaultHost);
+        ps.println("Default host: " + defaultHost.get());
         ps.println("Alternate hosts: " + (alternateHostSelector != null));
         if (alternateHostSelector != null)
             ps.println(alternateHostSelector);

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/dispatcher/internal/HttpDispatcherTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/dispatcher/internal/HttpDispatcherTest.java
@@ -5,8 +5,8 @@
  *
  * WLP Copyright IBM Corp. 2014, 2017
  *
- * The source code for this program is not published or otherwise divested 
- * of its trade secrets, irrespective of what has been deposited with the 
+ * The source code for this program is not published or otherwise divested
+ * of its trade secrets, irrespective of what has been deposited with the
  * U.S. Copyright Office.
  */
 package com.ibm.ws.http.dispatcher.internal;
@@ -15,8 +15,6 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-
-import junit.framework.Assert;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -31,12 +29,14 @@ import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.osgi.framework.ServiceReference;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink;
 import com.ibm.ws.http.dispatcher.internal.channel.HttpRequestImpl;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.wsspi.http.VirtualHostListener;
 import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
+
+import junit.framework.Assert;
+import test.common.SharedOutputManager;
 
 /**
  *
@@ -71,11 +71,11 @@ public class HttpDispatcherTest {
     }
 
     private static void clearDispatcher() throws Exception {
-        ((AtomicReference<HttpDispatcher>) dispatcherInstance.get(null)).set(null);
+        ((StaticValue<AtomicReference<HttpDispatcher>>) dispatcherInstance.get(null)).get().set(null);
     }
 
     private static HttpDispatcher getDispatcher() throws Exception {
-        return ((AtomicReference<HttpDispatcher>) dispatcherInstance.get(null)).get();
+        return ((StaticValue<AtomicReference<HttpDispatcher>>) dispatcherInstance.get(null)).get().get();
     }
 
     @Rule
@@ -86,7 +86,7 @@ public class HttpDispatcherTest {
 
     @Before
     public void setUp() throws Exception {
-        // make sure the default instance is clear before we start anything.. 
+        // make sure the default instance is clear before we start anything..
         clearDispatcher();
     }
 
@@ -152,7 +152,7 @@ public class HttpDispatcherTest {
         // the static instance value should be set to the newly activated dispatcher instance.
         Assert.assertNull("Dispatcher d1 should be removed as active instance", getDispatcher());
 
-        // Now that there is no instance, there should be some default behavior for shutdown: 
+        // Now that there is no instance, there should be some default behavior for shutdown:
         Assert.assertNull("No default missing-context message", HttpDispatcher.getContextRootNotFoundMessage());
         Assert.assertFalse("Do not show welcome page when there is no dispatcher", HttpDispatcher.isWelcomePageEnabled());
         Assert.assertTrue("Trust private headers by default", HttpDispatcher.usePrivateHeaders("a.b.c"));
@@ -174,7 +174,7 @@ public class HttpDispatcherTest {
         Assert.assertFalse("Private headers should be disabled for a.b.c", HttpDispatcher.usePrivateHeaders("a.b.c"));
         Assert.assertTrue("Private headers should be enabled for d.e.f", HttpDispatcher.usePrivateHeaders("d.e.f"));
 
-        // Set webcontainer ref w/ setting to disable headers.. 
+        // Set webcontainer ref w/ setting to disable headers..
         // since there is a value for trusted header origin, this should be ignored
         context.checking(new Expectations() {
             {
@@ -191,7 +191,7 @@ public class HttpDispatcherTest {
             context.assertIsSatisfied();
         }
 
-        // Set the trustedHeaderOrigin back to the default, which should then use the 
+        // Set the trustedHeaderOrigin back to the default, which should then use the
         // blanket-off setting from the webcontainer.
         context.checking(new Expectations() {
             {
@@ -293,7 +293,7 @@ public class HttpDispatcherTest {
             context.assertIsSatisfied();
         }
 
-        // Registered dispatcher, trust header from matching source 
+        // Registered dispatcher, trust header from matching source
         d.modified(buildMap(true, null, new String[] { "1.2.3.4" }));
 
         // reset the cached value of use private headers for the connection

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/internal/VirtualHostMapTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/internal/VirtualHostMapTest.java
@@ -5,8 +5,8 @@
  *
  * WLP Copyright IBM Corp. 2013, 2017
  *
- * The source code for this program is not published or otherwise divested 
- * of its trade secrets, irrespective of what has been deposited with the 
+ * The source code for this program is not published or otherwise divested
+ * of its trade secrets, irrespective of what has been deposited with the
  * U.S. Copyright Office.
  */
 package com.ibm.ws.http.internal;
@@ -40,12 +40,13 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.http.internal.VirtualHostMap.RequestHelper;
+import com.ibm.ws.staticvalue.StaticValue;
 import com.ibm.wsspi.http.HttpContainer;
 import com.ibm.wsspi.http.VirtualHost;
 import com.ibm.wsspi.http.VirtualHostListener;
+
+import test.common.SharedOutputManager;
 
 /**
  *
@@ -97,11 +98,11 @@ public class VirtualHostMapTest {
         // Clear the alternateHostSelector and defaultHost
         Field f = VirtualHostMap.class.getDeclaredField("alternateHostSelector");
         f.setAccessible(true);
-        f.set(null, null);
+        f.set(null, StaticValue.createStaticValue(null));
 
         f = VirtualHostMap.class.getDeclaredField("defaultHost");
         f.setAccessible(true);
-        f.set(null, null);
+        f.set(null, StaticValue.createStaticValue(null));
     }
 
     @After
@@ -129,9 +130,9 @@ public class VirtualHostMapTest {
         setUpOneActivation();
         VirtualHostImpl vhost = new VirtualHostImpl();
 
-        // If there are aliases defined for the default virtual host, 
-        // it stops acting like the "catch-all" host, and starts acting 
-        // like any other virtual host.. 
+        // If there are aliases defined for the default virtual host,
+        // it stops acting like the "catch-all" host, and starts acting
+        // like any other virtual host..
         vhost.activate(mockComponentContext, buildMap("default_host", Arrays.asList(new String[] { "*" })));
         Assert.assertFalse("isDefaultHost should return false (hostAlias defined)", vhost.getActiveConfig().isDefaultHost());
 
@@ -156,7 +157,7 @@ public class VirtualHostMapTest {
                 one(mockVHostReg).setProperties(with(any(Dictionary.class)));
             }
         });
-        // Now, modify the default host configuration to remove the host alias, 
+        // Now, modify the default host configuration to remove the host alias,
         // and try to disable it. Should get a warning that you can't.
         Map<String, Object> map = buildMap("default_host", null);
         map.put("enabled", false);
@@ -174,8 +175,8 @@ public class VirtualHostMapTest {
         setUpOneActivation();
         VirtualHostImpl vhost = new VirtualHostImpl();
 
-        // pass through: should give a warning. 
-        // There are no aliases defined at all, and this is not the default host.. 
+        // pass through: should give a warning.
+        // There are no aliases defined at all, and this is not the default host..
         vhost.activate(mockComponentContext, buildMap("vhost1", null));
         Assert.assertTrue("Should see a warning about missing hostAliases", outputMgr.checkForMessages("CWWKT0025W"));
         vhost.deactivate(mockComponentContext, 0);
@@ -186,8 +187,8 @@ public class VirtualHostMapTest {
         setUpOneActivation();
         VirtualHostImpl vhost = new VirtualHostImpl();
 
-        // activate with a bad alias, that one bad alias should be removed, 
-        // so we should end up with no aliases and another warning.. 
+        // activate with a bad alias, that one bad alias should be removed,
+        // so we should end up with no aliases and another warning..
         vhost.activate(mockComponentContext, buildMap("vhost1", Arrays.asList(new String[] { "*bad" })));
         Assert.assertTrue("Should see a warning about bad use of wildcard", outputMgr.checkForMessages("CWWKT0026W"));
         Assert.assertTrue("Should see a warning about missing hostAliases", outputMgr.checkForMessages("CWWKT0025W"));
@@ -203,8 +204,8 @@ public class VirtualHostMapTest {
         VirtualHostImpl vhost2 = new VirtualHostImpl();
         VirtualHostImpl vhost3 = new VirtualHostImpl();
 
-        // activate with a bad alias, that one bad alias should be removed, 
-        // so we should end up with no aliases and another warning.. 
+        // activate with a bad alias, that one bad alias should be removed,
+        // so we should end up with no aliases and another warning..
         vhost.activate(mockComponentContext, buildMap("vhost1", Arrays.asList(new String[] { "*:80" })));
         vhost2.activate(mockComponentContext, buildMap("vhost2", Arrays.asList(new String[] { "myhost:80" })));
         vhost3.activate(mockComponentContext, buildMap("vhost2", Arrays.asList(new String[] { "other:80" })));
@@ -222,8 +223,8 @@ public class VirtualHostMapTest {
         VirtualHostImpl vhost = new VirtualHostImpl();
         VirtualHostImpl vhost2 = new VirtualHostImpl();
 
-        // activate with a bad alias, that one bad alias should be removed, 
-        // so we should end up with no aliases and another warning.. 
+        // activate with a bad alias, that one bad alias should be removed,
+        // so we should end up with no aliases and another warning..
         vhost.activate(mockComponentContext, buildMap("vhost1", Arrays.asList(new String[] { "myhost:80" })));
         vhost2.activate(mockComponentContext, buildMap("vhost2", Arrays.asList(new String[] { "myhost:80" })));
         Assert.assertTrue("Should see a warning about duplicate aliases", outputMgr.checkForMessages("CWWKT0027W"));
@@ -238,8 +239,8 @@ public class VirtualHostMapTest {
         VirtualHostImpl vhost = new VirtualHostImpl();
         VirtualHostImpl vhost2 = new VirtualHostImpl();
 
-        // activate with a bad alias, that one bad alias should be removed, 
-        // so we should end up with no aliases and another warning.. 
+        // activate with a bad alias, that one bad alias should be removed,
+        // so we should end up with no aliases and another warning..
         vhost.activate(mockComponentContext, buildMap("vhost1", Arrays.asList(new String[] { "*:80" })));
         vhost2.activate(mockComponentContext, buildMap("vhost2", Arrays.asList(new String[] { "*:80" })));
         Assert.assertTrue("Should see a warning about duplicate aliases", outputMgr.checkForMessages("CWWKT0027W"));
@@ -252,7 +253,7 @@ public class VirtualHostMapTest {
         setUpOneActivation();
         VirtualHostImpl vhost = new VirtualHostImpl();
 
-        // add the wildcard alias for the vhost.. 
+        // add the wildcard alias for the vhost..
         vhost.activate(mockComponentContext, buildMap("vhost1", Arrays.asList(new String[] { "*" })));
 
         context.checking(new Expectations() {
@@ -270,9 +271,9 @@ public class VirtualHostMapTest {
             }
         });
 
-        // update the vhost configuration: should remove the good alias, 
-        // and then define a bad alias, that one bad alias should be removed, 
-        // so we should end up with no aliases and another warning.. 
+        // update the vhost configuration: should remove the good alias,
+        // and then define a bad alias, that one bad alias should be removed,
+        // so we should end up with no aliases and another warning..
         vhost.modified(buildMap("vhost1", Arrays.asList(new String[] { "*bad" })));
         Assert.assertTrue("Should see a warning about bad use of wildcard", outputMgr.checkForMessages("CWWKT0026W"));
         Assert.assertTrue("Should see a warning about missing hostAliases", outputMgr.checkForMessages("CWWKT0025W"));
@@ -286,7 +287,7 @@ public class VirtualHostMapTest {
         final HttpEndpointImpl mockEP1 = context.mock(HttpEndpointImpl.class, "allowEP1");
         final HttpEndpointImpl mockEP2 = context.mock(HttpEndpointImpl.class, "allowEP2");
 
-        // define two allowFromEndpoints 
+        // define two allowFromEndpoints
         final ArrayList<String> ep = new ArrayList<String>();
         ep.add("allowEP1");
         ep.add("allowEP2");
@@ -308,7 +309,7 @@ public class VirtualHostMapTest {
             }
         });
 
-        // update the vhost configuration: should remove one allowFromEndpoint, 
+        // update the vhost configuration: should remove one allowFromEndpoint,
         // so we should end up with only one allowFromEndpoint
         ep.remove("allowEP2");
         vhost.modified(buildMapWithEndpoint("vhost1", Arrays.asList(new String[] { "*" }), ep));
@@ -341,7 +342,7 @@ public class VirtualHostMapTest {
             }
         });
         // update the vhost configuration with the identical alias list. This should
-        // not result in a call to update the service properties.. 
+        // not result in a call to update the service properties..
         vhost.modified(buildMap("vhost1", Arrays.asList(new String[] { "*" })));
         vhost.deactivate(mockComponentContext, 0);
     }
@@ -354,8 +355,8 @@ public class VirtualHostMapTest {
         // register the vhost with an alias
         vhost.activate(mockComponentContext, buildMap("vhost1", Arrays.asList(new String[] { "*" })));
 
-        // update the vhost configuration with the identical configuration, 
-        // but toggle the enabled flag.. 
+        // update the vhost configuration with the identical configuration,
+        // but toggle the enabled flag..
         Map<String, Object> newMap = buildMap("vhost1", Arrays.asList(new String[] { "*" }));
         newMap.put(HttpServiceConstants.ENABLED, false);
         vhost.modified(newMap);
@@ -426,11 +427,11 @@ public class VirtualHostMapTest {
         defaulthost.deactivate(mockComponentContext, 0);
         Assert.assertNull("VirtualHost should not be retrieved by port.. (no default virtual host)", VirtualHostMap.findVirtualHost("endpoint", wildcard8080));
 
-        // Stop the endpoint before deactivate: the virtual host will still be in the map.. 
+        // Stop the endpoint before deactivate: the virtual host will still be in the map..
         VirtualHostMap.notifyStopped(mockEndpoint, "*", 8080, false);
         Assert.assertNotNull("VirtualHost is still associated with the port.. (listener stopped)", VirtualHostMap.findVirtualHost("endpoint", helper8080));
 
-        // now deactivate.. 
+        // now deactivate..
         vhost.deactivate(mockComponentContext, 0);
         Assert.assertNull("VirtualHost should not be retrieved by port.. (no virtual hosts)", VirtualHostMap.findVirtualHost("endpoint", helper8080));
         HttpEndpointList.unregisterEndpoint(mockEndpoint);
@@ -505,7 +506,7 @@ public class VirtualHostMapTest {
         // This puts the default_host in as a regular virtual host, not as the default/catch-all.
         defaulthost.activate(mockComponentContext, buildMap("default_host", Arrays.asList(new String[] { "*:8443" })));
 
-        // This endpoint is in the list of registered endpoints already.. 
+        // This endpoint is in the list of registered endpoints already..
         VirtualHostMap.notifyStarted(mockEndpointABC, "a.b.c", 8443, true);
         Assert.assertSame("VirtualHost should be retrieved by port.. ", vhost, VirtualHostMap.findVirtualHost("endpoint", helper8443));
 
@@ -556,10 +557,10 @@ public class VirtualHostMapTest {
         TestRequestHelper helper8080 = new TestRequestHelper("a.b.c", 8080);
         TestRequestHelper helper8443 = new TestRequestHelper("a.b.c", 8443);
 
-        // Clear the alternateHostSelector.. 
+        // Clear the alternateHostSelector..
         Field f = VirtualHostMap.class.getDeclaredField("alternateHostSelector");
         f.setAccessible(true);
-        f.set(null, null);
+        f.set(null, StaticValue.createStaticValue(null));
 
         HttpEndpointList.registerEndpoint(mockEndpoint);
         VirtualHostImpl vhost = new VirtualHostImpl();
@@ -673,7 +674,7 @@ public class VirtualHostMapTest {
         Assert.assertSame("Should retrieve default_host for port ", vhost1, vh);
 
         System.out.println("## 6");
-        // activate of wildcard vhost means removal of port from default host: there is only one endpoint, 
+        // activate of wildcard vhost means removal of port from default host: there is only one endpoint,
         // which means we see a notification of removal of context x
         vhost2.activate(mockComponentContext, buildMap("vhost2", Arrays.asList(new String[] { "*:8443" })));
         VirtualHostMap.dump(System.out);
@@ -789,8 +790,8 @@ public class VirtualHostMapTest {
                 allowing(mockVHostReg).setProperties(with(any(Dictionary.class)));
 
                 // The x context root is added to the default host.
-                // There may be more messages about this context being added or removed 
-                // depending on when vhost2 (*:8443) is added/removed relative to 
+                // There may be more messages about this context being added or removed
+                // depending on when vhost2 (*:8443) is added/removed relative to
                 // the other port (*:8080).
                 atLeast(1).of(mockListener).contextRootAdded("/x", vhost1);
                 atLeast(1).of(mockListener).contextRootRemoved("/x", vhost1);
@@ -803,10 +804,10 @@ public class VirtualHostMapTest {
             }
         });
 
-        // Clear the alternateHostSelector.. 
+        // Clear the alternateHostSelector..
         Field f = VirtualHostMap.class.getDeclaredField("alternateHostSelector");
         f.setAccessible(true);
-        f.set(null, null);
+        f.set(null, StaticValue.createStaticValue(null));
 
         final Runnable r1 = new Runnable() {
             @Override
@@ -817,7 +818,7 @@ public class VirtualHostMapTest {
 
                     waitFor(start);
 
-                    // Addition/removal of VirtualHosts 
+                    // Addition/removal of VirtualHosts
                     vhost1.activate(mockComponentContext, buildMap("default_host", null));
                     sleep(5);
 
@@ -857,14 +858,14 @@ public class VirtualHostMapTest {
         };
 
         Thread t1 = new Thread(r1, "t1");
-        t1.setDaemon(true); // allow JVM to exit if we deadlock... 
+        t1.setDaemon(true); // allow JVM to exit if we deadlock...
         t1.start();
 
         final Runnable r2 = new Runnable() {
             @Override
             public void run() {
                 try {
-                    // Addition/removal of HttpEndpoint ports.. 
+                    // Addition/removal of HttpEndpoint ports..
                     waitFor(start);
 
                     HttpEndpointList.registerEndpoint(mockEndpoint);
@@ -881,7 +882,7 @@ public class VirtualHostMapTest {
 
                     waitFor(middle);
                     // want to be stable when looking up virtual hosts just so we can make sure
-                    // that we can assert a definite answer.. 
+                    // that we can assert a definite answer..
                     VirtualHostImpl result = VirtualHostMap.findVirtualHost("endpoint", new TestRequestHelper("e.f", 8443));
                     Assert.assertSame("VirtualHost 2 should be retrieved with wildcard host", vhost2, result);
 
@@ -908,7 +909,7 @@ public class VirtualHostMapTest {
         };
 
         Thread t2 = new Thread(r2, "t2");
-        t2.setDaemon(true); // allow JVM to exit if we deadlock...  
+        t2.setDaemon(true); // allow JVM to exit if we deadlock...
         t2.start();
 
         // Wait at most 10 minutes for the above to sort itself out (which is a ridiculous amount of time)


### PR DESCRIPTION
This pull request fixes several places (not all) in open-liberty where state is held by a static variable.  This pattern causes issues when trying to embed multiple Liberty Server instances using the same class loader.

The approach taken to solve this assumes that each embedded instance of Liberty can be started within its own thread group.  And every executor used in liberty to do work inherits that thread group as a parent thread group for the executor.  This allows for multiplexing of the static value to be done depending on which thread group a thread is in which is accessing the static.

A new class com.ibm.ws.staticvalue.StaticValue<T> is introduced which holds the logic for multiplexing based on thread groups.  By default no multiplexing is done.  In this case a FinalSingleton value is created which has a final slot for accessing the static variable.  This should provide for no additional overhead for accessing the static value by default.  The StaticValue class can be put in a mode to do multiplexing, but it involves having a resource on the classpath of the embedded application which is looked up in the StaticValue<clinit> this means the StaticValue class is either always multiplexing or always singleton for the lifetime of the class.  There is no chance to dynamically enable/disable this behavior.  Note that it must be configured in <clinit> because of how low-level the StaticValue class is used by the boot strap code (including the logging code).

If a static field is final then you can use the createStaticValue(Callable) with a callable which will assign the final value for the StaticValue. If a static field is not final then you should use the createStaticValue(Callable) method but the callable should return null for the initial value or the callable can be null itself. If the static field needs updated with a new value then the method mutateStaticValue(StaticValue, Callable) is called with the callable to initialize/change the value.

When multiplexing the callable is NOT called during createStaticValue, instead it is deferred until the get() method is called in the context of a thread group.  when not multiplexing the callable is invoked immediately to initialize the FinalSingleton.  For the mutateStaticValue(StaticValue, Callable) this method will always be called in the context of a thread group and the callable is always called immediately for both the multplex and singleton cases.