### PR TITLE
Allow usage of server and client side debugging in FATs

### DIFF
--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -233,7 +233,7 @@
 
 		<echo>Running ${test.bucket.name}</echo>
 		<echo>Timeout: ${fattest.timeout}</echo>
-		<iff if="debug.framework">
+		<iff if="env.debug.framework">
 			<then>
 				<!-- if we are debugging then set these values to be passed to the JVM -->
 				<property name="framework.debug.jvmarg1" value="-Xdebug" />
@@ -246,7 +246,7 @@
 				<property name="framework.debug.jvmarg2" value="-Dignore=ignore" />
 			</else>
 		</iff>
-		<iff if="debug.server">
+		<iff if="env.debug.server">
 			<then>
 				<!-- this is the debugging port for the liberty server that will be launched by the tests -->
 				<property name="server.debug.sysprop.value" value="7777" />


### PR DESCRIPTION
Update FAT launch script to look for debug properties.

To debug the client (junit) side of a FAT, you can launch a FAT with the following command and listen on port 7777:
`$ ./gradlew :build.example_fat:buildandrun -Ddebug.framework=true`

To debug the server-side of a FAT, you can launch a FAT with the following command and listen on port 6666:
`$ ./gradlew :build.example_fat:buildandrun -Ddebug.server=true`