### PR TITLE
invokeAll or invokeAny across multiple executors

### DIFF
--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -17,7 +17,7 @@
 # configuration elements
 
 concurrencyPolicy=Concurrency Policy
-concurrencyPolicy.desc=Concurrency policy, including constraints such as maximum concurrency and maximum queue size, for tasks that are capable of asynchronous execution
+concurrencyPolicy.desc=A set of behaviors and constraints to be applied for tasks that are capable of asynchronous execution. For example maximum concurrency and maximum queue size.
 
 # attributes
 
@@ -42,4 +42,4 @@ runIfQueueFull=Run if queue full
 runIfQueueFull.desc=Applies when using the execute or submit methods. Indicates whether or not to run the task on the submitter's thread when the queue is full and the maximum wait for enqueue has been exceeded. When configured to false, the task submission is rejected after the maximum wait for enqueue elapses instead of running on the submitter's thread.
 
 startTimeout=Start timeout
-startTimeout.desc=Specifies a duration of time, beginning at task submit, after which a task should not start. By default, tasks do not time out. If both a maximum wait for enqueue and a start timeout are enabled, the start timeout should be configured larger than the maximum wait for enqueue such that remains possible to start tasks after they have waited for a queue position. When the start timeout is updated while in use, the new start timeout value applies to tasks submitted after the update occurs.
+startTimeout.desc=Specifies the maximum amount of time that may elapse between task submission and task starting. By default, tasks do not time out. If both a maximum wait for enqueue and a start timeout are enabled, the start timeout should be configured larger than the maximum wait for enqueue such that remains possible to start tasks after they have waited for a queue position. When the start timeout is updated while in use, the new start timeout value applies to tasks submitted after the update occurs.

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -16,6 +16,30 @@
 
 # configuration elements
 
+concurrencyPolicy=Concurrency Policy
+concurrencyPolicy.desc=Concurrency policy, including constraints such as maximum concurrency and maximum queue size, for tasks that are capable of asynchronous execution
 
 # attributes
 
+expedite=Expedite
+expedite.desc=Specifies a core number of tasks to aim to run concurrently by expediting requests to the global thread pool. This provides no guarantee that this many tasks will run concurrently. If the expedite value is updated while in use, the update goes into effect gradually as previous expedited and non-expedited requests complete.
+
+max=Maximum concurrency
+max.desc=Specifies the maximum number of tasks that can be running at any given point in time. The default is unbounded, up to Integer.MAX_VALUE. Maximum concurrency can be updated while tasks are in progress. If the maximum concurrency is reduced below the number of concurrently executing tasks, the update goes into effect gradually as in-progress tasks complete rather than causing them to be canceled.
+
+maxPolicy=Maximum policy
+maxPolicy.desc=Indicates whether to loosely or strictly enforce maximum concurrency for tasks that run on the task submitter's thread. Tasks can run on the task submitter's thread when using the untimed invokeAll method, or, if only invoking a single task, the untimed invokeAny method. If the run-if-queue-full attribute is configured, it is also possible for tasks to run the task submitter's thread when using the execute and submit methods. In all of these cases, this attribute determines whether or not running on the submitter's thread counts against the maximum concurrency.
+maxPolicy.loose.desc=Maximum concurrency is loosely enforced, in that tasks are allowed to run on the task submitter's thread without counting against maximum concurrency.
+maxPolicy.strict.desc=Maximum concurrency is strictly enforced, in that tasks that run on the task submitter's thread count towards maximum concurrency. This policy does not allow running on the task submitter's thread when already at maximum concurrency.
+
+maxQueueSize=Maximum queue size
+maxQueueSize.desc=Specifies the maximum number of tasks that can be queued for execution at any given point in time. As tasks are started, canceled, or aborted, they are removed from the queue. When the queue is at capacity and another task is submitted, the behavior is determined by the maximum wait for enqueue and run-if-queue-full attributes. To ensure that a specific number of tasks can be queued within a short interval of time, use a maximum queue size that is at least as large as that amount. The default maximum queue size is unbounded, up to Integer.MAX_VALUE. Maximum queue size can be updated while tasks are in progress and/or queued for execution. If the maximum queue size is reduced below the current number of queued tasks, the update goes into effect gradually, as queued tasks execute naturally or are canceled by the user, rather than automatically canceling the excess queued tasks.
+
+maxWaitForEnqueue=Maximum wait for enqueue
+maxWaitForEnqueue.desc=Specifies the maximum duration of time to wait for enqueuing a task. If unable to enqueue the task within this interval, the task submission is subject to the run-if-queue-full policy. When the maximum wait for enqueue is updated, the update applies only to tasks submitted after that point. Tasks submissions that were already waiting for a queue position continue to wait per the previously configured value.
+
+runIfQueueFull=Run if queue full
+runIfQueueFull.desc=Applies when using the execute or submit methods. Indicates whether or not to run the task on the submitter's thread when the queue is full and the maximum wait for enqueue has been exceeded. When configured to false, the task submission is rejected after the maximum wait for enqueue elapses instead of running on the submitter's thread.
+
+startTimeout=Start timeout
+startTimeout.desc=Specifies a duration of time, beginning at task submit, after which a task should not start. By default, tasks do not time out. If both a maximum wait for enqueue and a start timeout are enabled, the start timeout should be configured larger than the maximum wait for enqueue such that remains possible to start tasks after they have waited for a queue position. When the start timeout is updated while in use, the new start timeout value applies to tasks submitted after the update occurs.

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -22,7 +22,7 @@ concurrencyPolicy.desc=A set of behaviors and constraints that are applied to ta
 # attributes
 
 expedite=Expedite
-expedite.desc=Specifies a core number of tasks to aim to run concurrently by expediting requests to the global thread pool. This provides no guarantee that this many tasks will run concurrently. If the expedite value is updated while in use, the update goes into effect gradually as previous expedited and non-expedited requests complete.
+expedite.desc=Specifies a target minimum number of tasks to run concurrently by expediting requests to the global thread pool. The actual number of tasks that run concurrently might be fewer than the target number you define. If the expedite value is updated while in use, the update goes into effect gradually, as previous expedited and non-expedited requests complete.
 
 max=Maximum concurrency
 max.desc=Specifies the maximum number of tasks that can run simultaneously. The default is Integer.MAX_VALUE. Maximum concurrency can be updated while tasks are in progress. If the maximum concurrency is reduced below the number of concurrently running tasks, the update goes into effect gradually as in-progress tasks complete, rather than canceling them.

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -17,7 +17,7 @@
 # configuration elements
 
 concurrencyPolicy=Concurrency Policy
-concurrencyPolicy.desc=A set of behaviors and constraints to be applied for tasks that are capable of asynchronous execution. For example maximum concurrency and maximum queue size.
+concurrencyPolicy.desc=A set of behaviors and constraints that are applied to tasks that are capable of asynchronous execution, such as maximum concurrency and maximum queue size.
 
 # attributes
 
@@ -25,15 +25,15 @@ expedite=Expedite
 expedite.desc=Specifies a core number of tasks to aim to run concurrently by expediting requests to the global thread pool. This provides no guarantee that this many tasks will run concurrently. If the expedite value is updated while in use, the update goes into effect gradually as previous expedited and non-expedited requests complete.
 
 max=Maximum concurrency
-max.desc=Specifies the maximum number of tasks that can be running at any given point in time. The default is unbounded, up to Integer.MAX_VALUE. Maximum concurrency can be updated while tasks are in progress. If the maximum concurrency is reduced below the number of concurrently executing tasks, the update goes into effect gradually as in-progress tasks complete rather than causing them to be canceled.
+max.desc=Specifies the maximum number of tasks that can run simultaneously. The default is Integer.MAX_VALUE. Maximum concurrency can be updated while tasks are in progress. If the maximum concurrency is reduced below the number of concurrently running tasks, the update goes into effect gradually as in-progress tasks complete, rather than canceling them.
 
 maxPolicy=Maximum policy
 maxPolicy.desc=Indicates whether to loosely or strictly enforce maximum concurrency for tasks that run on the task submitter's thread. Tasks can run on the task submitter's thread when using the untimed invokeAll method, or, if only invoking a single task, the untimed invokeAny method. If the run-if-queue-full attribute is configured, it is also possible for tasks to run the task submitter's thread when using the execute and submit methods. In all of these cases, this attribute determines whether or not running on the submitter's thread counts against the maximum concurrency.
-maxPolicy.loose.desc=Maximum concurrency is loosely enforced, in that tasks are allowed to run on the task submitter's thread without counting against maximum concurrency.
-maxPolicy.strict.desc=Maximum concurrency is strictly enforced, in that tasks that run on the task submitter's thread count towards maximum concurrency. This policy does not allow running on the task submitter's thread when already at maximum concurrency.
+maxPolicy.loose.desc=Maximum concurrency is loosely enforced. Tasks are allowed to run on the task submitter's thread without counting against maximum concurrency.
+maxPolicy.strict.desc=Maximum concurrency is strictly enforced. Tasks that run on the task submitter's thread count towards maximum concurrency. This policy does not allow tasks to run on the task submitter's thread when already at maximum concurrency.
 
 maxQueueSize=Maximum queue size
-maxQueueSize.desc=Specifies the maximum number of tasks that can be queued for execution at any given point in time. As tasks are started, canceled, or aborted, they are removed from the queue. When the queue is at capacity and another task is submitted, the behavior is determined by the maximum wait for enqueue and run-if-queue-full attributes. To ensure that a specific number of tasks can be queued within a short interval of time, use a maximum queue size that is at least as large as that amount. The default maximum queue size is unbounded, up to Integer.MAX_VALUE. Maximum queue size can be updated while tasks are in progress and/or queued for execution. If the maximum queue size is reduced below the current number of queued tasks, the update goes into effect gradually, as queued tasks execute naturally or are canceled by the user, rather than automatically canceling the excess queued tasks.
+maxQueueSize.desc=Specifies the maximum number of tasks that can be in the queue waiting for execution. As tasks are started, canceled, or aborted, they are removed from the queue. When the queue is at capacity and another task is submitted, the behavior is determined by the maximum wait for enqueue and run-if-queue-full attributes. To ensure that a specific number of tasks can be queued within a short interval of time, use a maximum queue size that is at least as large as that amount. The default maximum queue size is Integer.MAX_VALUE. Maximum queue size can be updated while tasks are both in progress or queued for execution. If the maximum queue size is reduced below the current number of queued tasks, the update goes into effect gradually rather than automatically canceling the excess queued tasks.
 
 maxWaitForEnqueue=Maximum wait for enqueue
 maxWaitForEnqueue.desc=Specifies the maximum duration of time to wait for enqueuing a task. If unable to enqueue the task within this interval, the task submission is subject to the run-if-queue-full policy. When the maximum wait for enqueue is updated, the update applies only to tasks submitted after that point. Tasks submissions that were already waiting for a queue position continue to wait per the previously configured value.
@@ -42,4 +42,4 @@ runIfQueueFull=Run if queue full
 runIfQueueFull.desc=Applies when using the execute or submit methods. Indicates whether or not to run the task on the submitter's thread when the queue is full and the maximum wait for enqueue has been exceeded. When configured to false, the task submission is rejected after the maximum wait for enqueue elapses instead of running on the submitter's thread.
 
 startTimeout=Start timeout
-startTimeout.desc=Specifies the maximum amount of time that may elapse between task submission and task starting. By default, tasks do not time out. If both a maximum wait for enqueue and a start timeout are enabled, the start timeout should be configured larger than the maximum wait for enqueue such that remains possible to start tasks after they have waited for a queue position. When the start timeout is updated while in use, the new start timeout value applies to tasks submitted after the update occurs.
+startTimeout.desc=Specifies the maximum amount of time that may elapse between the task submission and the task start. By default, tasks do not time out. If both a maximum wait for enqueue and a start timeout are enabled, configure the start timeout to be larger than the maximum wait for enqueue. When the start timeout is updated while in use, the new start timeout value applies to tasks submitted after the update occurs.

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/metatype/metatype.xml
@@ -17,18 +17,17 @@
   <Object ocdref="com.ibm.ws.concurrency.policy.concurrencyPolicy"/>
  </Designate>
 
- <!-- TODO switch from internal to beta, and have translatable names/descriptions -->
- <OCD id="com.ibm.ws.concurrency.policy.concurrencyPolicy" ibm:alias="concurrencyPolicy" name="internal" description="internal use only">
-  <AD id="expedite"          type="Integer" default="0" min="0" name="internal" description="internal use only"/>
-  <AD id="max"               type="Integer" required="false" min="1" name="internal" description="internal use only"/>
-  <AD id="maxPolicy"         type="String"  default="loose" name="internal" description="internal use only">
-   <Option value="loose"        label="internal"/>
-   <Option value="strict"       label="internal"/>
+ <OCD id="com.ibm.ws.concurrency.policy.concurrencyPolicy" ibm:alias="concurrencyPolicy" ibm:beta="true" name="%concurrencyPolicy" description="%concurrencyPolicy.desc">
+  <AD id="expedite"          type="Integer" default="0" min="0" name="%expedite" description="%expedite.desc"/>
+  <AD id="max"               type="Integer" required="false" min="1" name="%max" description="%max.desc"/>
+  <AD id="maxPolicy"         type="String"  default="loose" name="%maxPolicy" description="%maxPolicy.desc">
+   <Option value="loose"        label="%maxPolicy.loose.desc"/>
+   <Option value="strict"       label="%maxPolicy.strict.desc"/>
   </AD>
-  <AD id="maxQueueSize"      type="Integer" required="false" min="1" name="internal" description="internal use only"/>
-  <AD id="maxWaitForEnqueue" type="String"  ibm:type="duration" default="0" name="internal" description="internal use only"/>
-  <AD id="runIfQueueFull"    type="Boolean" default="false" name="internal" description="internal use only"/>
-  <AD id="startTimeout"      type="String"  ibm:type="duration" required="false" name="internal" description="internal use only"/>
+  <AD id="maxQueueSize"      type="Integer" required="false" min="1" name="%maxQueueSize" description="%maxQueueSize.desc"/>
+  <AD id="maxWaitForEnqueue" type="String"  ibm:type="duration" default="0" name="%maxWaitForEnqueue" description="%maxWaitForEnqueue.desc"/>
+  <AD id="runIfQueueFull"    type="Boolean" default="false" name="%runIfQueueFull" description="%runIfQueueFull.desc"/>
+  <AD id="startTimeout"      type="String"  ibm:type="duration" required="false" name="%startTimeout" description="%startTimeout.desc"/>
  </OCD>
 
 </metatype:MetaData>

--- a/dev/com.ibm.ws.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent/bnd.bnd
@@ -55,12 +55,6 @@ Service-Component:\
   com.ibm.ws.concurrent.internal.ManagedExecutorServiceImpl,\
   com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl
 
--dsannotations-options:inherit,felixExtensions
-
--metatypeannotations: \
-  com.ibm.ws.concurrent.internal.ManagedExecutorServiceConfig,\
-  com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceConfig
-
 instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 
 -buildpath: \
@@ -74,7 +68,6 @@ instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 	com.ibm.ws.concurrency.policy;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.context;version=latest,\
-	com.ibm.ws.org.apache.felix.scr;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.resource;version=latest,\
 	com.ibm.ws.threading;version=latest,\

--- a/dev/com.ibm.ws.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent/bnd.bnd
@@ -64,18 +64,19 @@ Service-Component:\
 instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 
 -buildpath: \
+	com.ibm.websphere.appserver.spi.kernel.service,\
 	com.ibm.websphere.appserver.spi.logging,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
-	com.ibm.ws.context;version=latest,\
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.component,\
-	com.ibm.wsspi.org.osgi.service.component.annotations,\
-	com.ibm.websphere.appserver.spi.kernel.service,\
 	com.ibm.ws.app.manager.lifecycle;version=latest,\
-	com.ibm.ws.container.service;version=latest,\
-	com.ibm.ws.resource;version=latest,\
-	com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest,\
-	com.ibm.ws.org.apache.felix.scr;version=latest,\
 	com.ibm.ws.bnd.annotations;version=latest, \
+	com.ibm.ws.concurrency.policy;version=latest,\
+	com.ibm.ws.container.service;version=latest,\
+	com.ibm.ws.context;version=latest,\
+	com.ibm.ws.org.apache.felix.scr;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.threading;version=latest
+	com.ibm.ws.resource;version=latest,\
+	com.ibm.ws.threading;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations,\
+	com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest

--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/l10n/metatype.properties
@@ -41,7 +41,7 @@ baseContextRef.desc=Specifies a base context service from which to inherit conte
 
 concurrencyPolicy=Concurrency Policy
 concurrencyPolicy$Ref=Concurrency policy
-concurrencyPolicy.desc=Concurrency policy for tasks submitted to this executor. If multiple executors specify the same concurrency policy then the policy's constraints are enforced across tasks submitted by the whole the collection of executors that specify the policy.
+concurrencyPolicy.desc=Concurrency policy for tasks that are submitted to this executor. If multiple executors specify the same concurrency policy, then the policy's constraints are enforced across tasks that are submitted by the collection of executors that specify the policy.
 
 contextServiceRef=Thread Context Propagation
 contextServiceRef$Ref=Context propagation reference
@@ -58,7 +58,7 @@ jndiName.desc=JNDI name
 
 longRunningPolicy=Long Running Policy
 longRunningPolicy$Ref=Long running policy
-longRunningPolicy.desc=Concurrency policy for tasks that specify the LONGRUNNING_HINT execution property with value of 'true'. If multiple executors specify the same concurrency policy then the policy's constraints are enforced across tasks submitted by the whole the collection of executors that specify the policy. If unspecified, the long running concurrency policy defaults to the executor's general concurrency policy. 
+longRunningPolicy.desc=Concurrency policy for tasks that specify the LONGRUNNING_HINT execution property with value of 'true'. If multiple executors specify the same concurrency policy, then the policy's constraints are enforced across tasks that are submitted by the whole the collection of executors that specify the policy. If unspecified, the long running concurrency policy defaults to the executor's general concurrency policy.
 
 maxPriority=Maximum thread priority
 maxPriority.desc=Maximum priority for threads created by the managed thread factory.

--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/l10n/metatype.properties
@@ -58,7 +58,7 @@ jndiName.desc=JNDI name
 
 longRunningPolicy=Long Running Policy
 longRunningPolicy$Ref=Long running policy
-longRunningPolicy.desc=Concurrency policy for tasks that specify the LONGRUNNING_HINT execution property with value of true. If multiple executors specify the same concurrency policy then the policy's constraints are enforced across tasks submitted by the whole the collection of executors that specify the policy. If unspecified, the long running concurrency policy defaults to the concurrency policy for normal duration tasks. 
+longRunningPolicy.desc=Concurrency policy for tasks that specify the LONGRUNNING_HINT execution property with value of 'true'. If multiple executors specify the same concurrency policy then the policy's constraints are enforced across tasks submitted by the whole the collection of executors that specify the policy. If unspecified, the long running concurrency policy defaults to the executor's general concurrency policy. 
 
 maxPriority=Maximum thread priority
 maxPriority.desc=Maximum priority for threads created by the managed thread factory.

--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/l10n/metatype.properties
@@ -39,6 +39,10 @@ baseContextRef=Base Context
 baseContextRef$Ref=Base instance from which to inherit context
 baseContextRef.desc=Specifies a base context service from which to inherit context that is not already defined on this context service.
 
+concurrencyPolicy=Concurrency Policy
+concurrencyPolicy$Ref=Concurrency policy
+concurrencyPolicy.desc=Concurrency policy for tasks submitted to this executor. If multiple executors specify the same concurrency policy then the policy's constraints are enforced across tasks submitted by the whole the collection of executors that specify the policy.
+
 contextServiceRef=Thread Context Propagation
 contextServiceRef$Ref=Context propagation reference
 contextServiceRef.desc=Configures how context is propagated to threads
@@ -51,6 +55,10 @@ defaultPriority.desc=Default priority for threads created by the managed thread 
 
 jndiName=JNDI name
 jndiName.desc=JNDI name
+
+longRunningPolicy=Long Running Policy
+longRunningPolicy$Ref=Long running policy
+longRunningPolicy.desc=Concurrency policy for tasks that specify the LONGRUNNING_HINT execution property with value of true. If multiple executors specify the same concurrency policy then the policy's constraints are enforced across tasks submitted by the whole the collection of executors that specify the policy. If unspecified, the long running concurrency policy defaults to the concurrency policy for normal duration tasks. 
 
 maxPriority=Maximum thread priority
 maxPriority.desc=Maximum priority for threads created by the managed thread factory.

--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
@@ -35,8 +35,45 @@
   <AD id="javaCompDefaultName"               type="String"  required="false" name="internal" description="internal use only" /> 
  </OCD>
 
- <!-- managedExecutorService generated-->
- <!-- managedScheduledExecutorService generated-->
+ <!-- managedExecutorService -->
+
+ <Designate factoryPid="com.ibm.ws.concurrent.managedExecutorService">
+  <Object ocdref="com.ibm.ws.concurrent.managedExecutorService"/>
+ </Designate>
+
+ <OCD id="com.ibm.ws.concurrent.managedExecutorService" ibm:alias="managedExecutorService" ibm:supportExtensions="true" ibmui:localization="OSGI-INF/l10n/metatype" name="%managedExecutorService" description="%managedExecutorService.desc">
+  <AD id="concurrencyPolicyRef"               type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" default="defaultConcurrencyPolicy" ibm:beta="true" cardinality="1" name="%concurrencyPolicy" description="%concurrencyPolicy.desc"/>
+  <AD id="ConcurrencyPolicy.target"           type="String"  ibm:final="true" default="(service.pid=${concurrencyPolicyRef})" name="internal" description="internal use only"/>
+  <AD id="contextServiceRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" cardinality="1" name="%contextServiceRef" description="%contextServiceRef.desc"/>
+  <AD id="ContextService.target"              type="String"  ibm:final="true" default="(service.pid=${contextServiceRef})" name="internal" description="internal use only"/>
+  <AD id="executorService.target"             type="String"  ibm:final="true" default="(service.pid=com.ibm.ws.threading)" name="internal" description="internal use only"/>
+  <AD id="javaCompDefaultName"                type="String"  required="false" name="internal" description="internal use only" />
+  <AD id="jndiName"                           type="String"  required="false" ibm:unique="jndiName" name="%jndiName" description="%jndiName.desc"/>
+  <!-- TODO to switch longRunningPolicyRef's default to be the concurrencyPolicyRef, will need to make optional, taking advantage of reference minimum cardinality, and have no value by default -->
+  <AD id="longRunningPolicyRef"               type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" default="defaultConcurrencyPolicy" ibm:beta="true" cardinality="1" name="%longRunningPolicy" description="%longRunningPolicy.desc"/>
+  <AD id="LongRunningPolicy.target"           type="String"  ibm:final="true" default="(service.pid=${longRunningPolicyRef})" name="internal" description="internal use only"/>
+  <AD id="service.ranking"                    type="Integer" default="-1000" name="internal" description="internal use only"/>
+ </OCD>
+
+ <!-- managedScheduledExecutorService -->
+
+ <Designate factoryPid="com.ibm.ws.concurrent.managedScheduledExecutorService">
+  <Object ocdref="com.ibm.ws.concurrent.managedScheduledExecutorService"/>
+ </Designate>
+
+ <OCD id="com.ibm.ws.concurrent.managedScheduledExecutorService" ibm:alias="managedScheduledExecutorService" ibm:supportExtensions="true" ibmui:localization="OSGI-INF/l10n/metatype" name="%managedScheduledExecutorService" description="%managedScheduledExecutorService.desc">
+  <AD id="concurrencyPolicyRef"               type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" default="defaultConcurrencyPolicy" ibm:beta="true" cardinality="1" name="%concurrencyPolicy" description="%concurrencyPolicy.desc"/>
+  <AD id="ConcurrencyPolicy.target"           type="String"  ibm:final="true" default="(service.pid=${concurrencyPolicyRef})" name="internal" description="internal use only"/>
+  <AD id="contextServiceRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" cardinality="1" name="%contextServiceRef" description="%contextServiceRef.desc"/>
+  <AD id="ContextService.target"              type="String"  ibm:final="true" default="(service.pid=${contextServiceRef})" name="internal" description="internal use only"/>
+  <AD id="executorService.target"             type="String"  ibm:final="true" default="(service.pid=com.ibm.ws.threading)" name="internal" description="internal use only"/>
+  <AD id="javaCompDefaultName"                type="String"  required="false" name="internal" description="internal use only" />
+  <AD id="jndiName"                           type="String"  required="false" ibm:unique="jndiName" name="%jndiName" description="%jndiName.desc"/>
+  <!-- TODO to switch longRunningPolicyRef's default to be the concurrencyPolicyRef, will need to make optional, taking advantage of reference minimum cardinality, and have no value by default -->
+  <AD id="longRunningPolicyRef"               type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" default="defaultConcurrencyPolicy" ibm:beta="true" cardinality="1" name="%longRunningPolicy" description="%longRunningPolicy.desc"/>
+  <AD id="LongRunningPolicy.target"           type="String"  ibm:final="true" default="(service.pid=${longRunningPolicyRef})" name="internal" description="internal use only"/>
+  <AD id="service.ranking"                    type="Integer" default="-1000" name="internal" description="internal use only"/>
+ </OCD>
 
  <!-- managedThreadFactory -->
 

--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
@@ -46,7 +46,6 @@
   <AD id="ConcurrencyPolicy.target"           type="String"  ibm:final="true" default="(service.pid=${concurrencyPolicyRef})" name="internal" description="internal use only"/>
   <AD id="contextServiceRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" cardinality="1" name="%contextServiceRef" description="%contextServiceRef.desc"/>
   <AD id="ContextService.target"              type="String"  ibm:final="true" default="(service.pid=${contextServiceRef})" name="internal" description="internal use only"/>
-  <AD id="executorService.target"             type="String"  ibm:final="true" default="(service.pid=com.ibm.ws.threading)" name="internal" description="internal use only"/>
   <AD id="javaCompDefaultName"                type="String"  required="false" name="internal" description="internal use only" />
   <AD id="jndiName"                           type="String"  required="false" ibm:unique="jndiName" name="%jndiName" description="%jndiName.desc"/>
   <!-- TODO to switch longRunningPolicyRef's default to be the concurrencyPolicyRef, will need to make optional, taking advantage of reference minimum cardinality, and have no value by default -->
@@ -66,7 +65,6 @@
   <AD id="ConcurrencyPolicy.target"           type="String"  ibm:final="true" default="(service.pid=${concurrencyPolicyRef})" name="internal" description="internal use only"/>
   <AD id="contextServiceRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" cardinality="1" name="%contextServiceRef" description="%contextServiceRef.desc"/>
   <AD id="ContextService.target"              type="String"  ibm:final="true" default="(service.pid=${contextServiceRef})" name="internal" description="internal use only"/>
-  <AD id="executorService.target"             type="String"  ibm:final="true" default="(service.pid=com.ibm.ws.threading)" name="internal" description="internal use only"/>
   <AD id="javaCompDefaultName"                type="String"  required="false" name="internal" description="internal use only" />
   <AD id="jndiName"                           type="String"  required="false" ibm:unique="jndiName" name="%jndiName" description="%jndiName.desc"/>
   <!-- TODO to switch longRunningPolicyRef's default to be the concurrencyPolicyRef, will need to make optional, taking advantage of reference minimum cardinality, and have no value by default -->

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -121,7 +121,6 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
     /**
      * Reference to the (unmanaged) executor service for this managed executor service.
      */
-    @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
     volatile ExecutorService executorService;
 
     /**
@@ -529,6 +528,11 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
         contextSvcRef.setReference(ref);
     }
 
+    @Reference(policy = ReferencePolicy.DYNAMIC, target = "(service.pid=com.ibm.ws.threading)")
+    protected void setExecutorService(ExecutorService svc) {
+        executorService = svc;
+    }
+
     /**
      * Declarative Services method for setting the transaction context provider service reference
      *
@@ -635,6 +639,8 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
     protected void unsetContextService(ServiceReference<WSContextService> ref) {
         contextSvcRef.unsetReference(ref);
     }
+
+    protected void unsetExecutorService(ExecutorService svc) {}
 
     /**
      * Declarative Services method for unsetting the transaction context provider service reference

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,36 +20,33 @@ import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.enterprise.concurrent.Trigger;
 
-import org.apache.felix.scr.ext.annotation.DSExt;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
-import com.ibm.ws.bnd.metatype.annotation.Ext;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrency.policy.ConcurrencyPolicy;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleCoordinator;
 import com.ibm.wsspi.resource.ResourceFactory;
-
-@ObjectClassDefinition(factoryPid = "com.ibm.ws.concurrent.managedScheduledExecutorService", name = "%managedScheduledExecutorService",
-                       description = "%managedScheduledExecutorService.desc",
-                       localization = Ext.LOCALIZATION)
-@Ext.Alias("managedScheduledExecutorService")
-@Ext.SupportExtensions
-interface ManagedScheduledExecutorServiceConfig extends FullManagedExecutorServiceConfig {
-
-}
+import com.ibm.wsspi.threadcontext.ThreadContextProvider;
+import com.ibm.wsspi.threadcontext.WSContextService;
 
 @Component(configurationPid = "com.ibm.ws.concurrent.managedScheduledExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
            service = { ExecutorService.class, ManagedExecutorService.class, ResourceFactory.class, ApplicationRecycleComponent.class, ScheduledExecutorService.class,
                        ManagedScheduledExecutorService.class },
-           reference = @Reference(name = ManagedExecutorServiceImpl.APP_RECYCLE_SERVICE, service = ApplicationRecycleCoordinator.class) ,
+           reference = @Reference(name = ManagedExecutorServiceImpl.APP_RECYCLE_SERVICE, service = ApplicationRecycleCoordinator.class),
            property = { "creates.objectClass=java.util.concurrent.ExecutorService",
                         "creates.objectClass=java.util.concurrent.ScheduledExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedScheduledExecutorService" })
-@DSExt.ConfigureWithInterfaces
 public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceImpl implements ManagedScheduledExecutorService {
+    @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
+    volatile ExecutorService executorService;
+
     /**
      * Reference to the (unmanaged) scheduled executor service for this managed scheduled executor service.
      */
@@ -138,4 +135,42 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
         return scheduledTask.future;
     }
 
+    @Override
+    @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
+    @Trivial
+    protected void setConcurrencyPolicy(ConcurrencyPolicy svc) {
+        super.setConcurrencyPolicy(svc);
+    }
+
+    @Override
+    @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
+    @Trivial
+    protected void setContextService(ServiceReference<WSContextService> ref) {
+        super.setContextService(ref);
+    }
+
+    @Override
+    @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(component.name=com.ibm.ws.transaction.context.provider)")
+    @Trivial
+    protected void setTransactionContextProvider(ServiceReference<ThreadContextProvider> ref) {
+        super.setTransactionContextProvider(ref);
+    }
+
+    @Override
+    @Trivial
+    protected void unsetConcurrencyPolicy(ConcurrencyPolicy svc) {
+        super.unsetConcurrencyPolicy(svc);
+    }
+
+    @Override
+    @Trivial
+    protected void unsetContextService(ServiceReference<WSContextService> ref) {
+        super.unsetContextService(ref);
+    }
+
+    @Override
+    @Trivial
+    protected void unsetTransactionContextProvider(ServiceReference<ThreadContextProvider> ref) {
+        super.unsetTransactionContextProvider(ref);
+    }
 }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
@@ -44,9 +44,6 @@ import com.ibm.wsspi.threadcontext.WSContextService;
                         "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedScheduledExecutorService" })
 public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceImpl implements ManagedScheduledExecutorService {
-    @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
-    volatile ExecutorService executorService;
-
     /**
      * Reference to the (unmanaged) scheduled executor service for this managed scheduled executor service.
      */
@@ -150,6 +147,13 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     }
 
     @Override
+    @Reference(policy = ReferencePolicy.DYNAMIC, target = "(service.pid=com.ibm.ws.threading)")
+    @Trivial
+    protected void setExecutorService(ExecutorService svc) {
+        super.setExecutorService(svc);
+    }
+
+    @Override
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(component.name=com.ibm.ws.transaction.context.provider)")
     @Trivial
     protected void setTransactionContextProvider(ServiceReference<ThreadContextProvider> ref) {
@@ -166,6 +170,12 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     @Trivial
     protected void unsetContextService(ServiceReference<WSContextService> ref) {
         super.unsetContextService(ref);
+    }
+
+    @Override
+    @Trivial
+    protected void unsetExecutorService(ExecutorService svc) {
+        super.unsetExecutorService(svc);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
@@ -21,32 +21,30 @@
 
   <variable name="onError" value="FAIL"/>
 
-  <!-- TODO remove the internal attribute once managed executors are switched over to using policy executor -->
+  <concurrencyPolicy id="defaultConcurrencyPolicy" max="1" maxQueueSize="1" maxWaitForEnqueue="2m"/>
 
-  <managedExecutorService id="DefaultManagedExecutorService" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   maxConcurrency="1" maxQueueSize="1" maxWaitForEnqueue="120000"/>
+  <concurrencyPolicy id="longrunning" max="1" maxPolicy="strict" maxQueueSize="1" maxWaitForEnqueue="20s" startTimeout="1m"/>
 
-  <managedScheduledExecutorService id="DefaultManagedScheduledExecutorService" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   coreConcurrency="0" maxConcurrency="4" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" runIfQueueFull="true"/>
-
-  <managedExecutorService id="executor1" jndiName="concurrent/executor1" contextServiceRef="jeeMetadataOnly" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   maxConcurrency="1" maxConcurrencyAppliesToCallerThread="true" maxQueueSize="1" maxWaitForEnqueue="0" runIfQueueFull="false"/>
-
-  <!-- TODO switch to concurrencyPolicyRef="normal" once managed executor supports the concurrencyPolicyRefs -->
-  <managedScheduledExecutorService jndiName="concurrent/scheduledExecutor2" contextServiceRef="jeeMetadataOnly" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"
-   coreConcurrency="1" maxConcurrency="2" maxConcurrencyAppliesToCallerThread="false" maxQueueSize="2" runIfQueueFull="false"/>
-
-  <managedExecutorService id="executor2" jndiName="concurrent/executor2"
-   concurrencyPolicyRef="normal" longRunningPolicyRef="longrunning"/>
-
-  <concurrencyPolicy id="longrunning"
-   max="1" maxPolicy="strict" maxQueueSize="1" maxWaitForEnqueue="20s" startTimeout="1m"/>
-
-  <concurrencyPolicy id="normal"
-   expedite="1" max="2" maxPolicy="loose" maxQueueSize="2" runIfQueueFull="false"/>
+  <concurrencyPolicy id="normal" expedite="1" max="2" maxPolicy="loose" maxQueueSize="2" runIfQueueFull="false"/>
 
   <contextService id="jeeMetadataOnly">
     <jeeMetadataContext/>
   </contextService>
+
+  <!-- TODO remove the internal attribute once managed executors are switched over to using policy executor -->
+
+  <managedExecutorService id="DefaultManagedExecutorService" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"/>
+
+  <managedScheduledExecutorService id="DefaultManagedScheduledExecutorService" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only">
+   <concurrencyPolicy expedite="0" max="4" maxPolicy="strict" maxQueueSize="1" runIfQueueFull="true"/>
+  </managedScheduledExecutorService>
+
+  <managedExecutorService id="executor1" jndiName="concurrent/executor1" contextServiceRef="jeeMetadataOnly" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only">
+   <concurrencyPolicy max="1" maxPolicy="strict" maxQueueSize="1" maxWaitForEnqueue="0" runIfQueueFull="false"/>
+  </managedExecutorService>
+
+  <managedScheduledExecutorService jndiName="concurrent/scheduledExecutor2" concurrencyPolicyRef="normal" contextServiceRef="jeeMetadataOnly" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"/>
+
+  <managedExecutorService id="executor2" jndiName="concurrent/executor2" concurrencyPolicyRef="normal" longRunningPolicyRef="longrunning" policyExecutor.internal.prototype.do.not.use="enabled-for-internal-testing-only"/>
 
 </server>

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
@@ -20,6 +20,17 @@ import com.ibm.websphere.ras.annotation.Trivial;
 @Trivial
 public abstract class PolicyTaskCallback {
     /**
+     * Allows for replacing the policy executor to which the task was submitted with another when the invokeAll/invokeAny methods are used to submit multiple tasks.
+     *
+     * @param executor policy executor to which the task was submitted.
+     * @return the default implementation returns the policy executor to which the task was submitted, such that invokeAll/invokeAny
+     *         always run tasks according the policy executor upon which the invokeAll/invokeAny operation was invoked.
+     */
+    public PolicyExecutor getExecutor(PolicyExecutor executor) {
+        return executor;
+    }
+
+    /**
      * Returns the name of the task, which, for example, might be reported in exception messages or messages that are logged.
      *
      * @param task the Callable or Runnable task.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -586,20 +586,21 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             int t = 0;
             for (Callable<T> task : tasks) {
                 PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
-                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS));
+                PolicyExecutorImpl executor = callback == null ? this : (PolicyExecutorImpl) callback.getExecutor(this);
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(executor.startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(executor, task, callback, startTimeoutNS));
             }
 
             // enqueue tasks (except the last if we are able to run tasks on the current thread)
             int numToSubmitAsync = useCurrentThread ? taskCount - 1 : taskCount;
             t = 0;
             for (PolicyTaskFutureImpl<T> taskFuture : futures)
-                if (t++ < numToSubmitAsync) {
+                if (t++ < numToSubmitAsync || taskFuture.executor != this) {
                     boolean enqueued;
-                    if (useCurrentThread)
-                        enqueued = enqueue(taskFuture, 0, true);
+                    if (useCurrentThread && taskFuture.executor == this)
+                        enqueued = taskFuture.executor.enqueue(taskFuture, 0, true);
                     else
-                        enqueued = enqueue(taskFuture, maxWaitForEnqueueNS.get(), null);
+                        enqueued = taskFuture.executor.enqueue(taskFuture, taskFuture.executor.maxWaitForEnqueueNS.get(), null);
 
                     if (!enqueued) // must immediately return if ran on current thread and was interrupted
                         taskFuture.throwIfInterrupted();
@@ -607,20 +608,20 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                     taskFuture.accept(true);
                 }
 
-            // run on current thread if possible
+            // run on current thread (by current executor) if possible
             if (useCurrentThread)
                 for (t = numToSubmitAsync; t >= 0; t--) {
                     PolicyTaskFutureImpl<T> taskFuture = futures.get(t);
-                    State currentState = state.get();
-                    if (t == numToSubmitAsync) { // we intentionally avoided submitting the last task
+                    State currentState = taskFuture.executor.state.get();
+                    if (taskFuture.executor == this && t == numToSubmitAsync) { // we intentionally avoided submitting the last task
                         if (currentState != State.ACTIVE)
                             throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1202.submit.after.shutdown", identifier));
-                    } else if (!taskFuture.isDone() && currentState.canStartTask && queue.remove(taskFuture)) {
+                    } else if (taskFuture.executor == this && !taskFuture.isDone() && currentState.canStartTask && queue.remove(taskFuture)) {
                         maxQueueSizeConstraint.release();
                         taskFuture.nsQueueEnd = System.nanoTime();
                     } else {
                         if (trace && tc.isDebugEnabled())
-                            Tr.debug(this, tc, "no longer in queue", taskFuture);
+                            Tr.debug(this, tc, "no longer in queue, or this executor is unable to run it", taskFuture);
                         continue; // other thread could already be processing the task, or it could be cancelled
                     }
 
@@ -684,20 +685,21 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             int t = 0;
             for (Callable<T> task : tasks) {
                 PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
-                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS));
+                PolicyExecutorImpl executor = callback == null ? this : (PolicyExecutorImpl) callback.getExecutor(this);
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(executor.startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(executor, task, callback, startTimeoutNS));
             }
 
             // enqueue all tasks
             for (PolicyTaskFutureImpl<T> taskFuture : futures) {
                 remaining = stop - System.nanoTime();
                 if (remaining <= 0)
-                    throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1204.unable.to.invoke", identifier, taskCount - futures.indexOf(taskFuture) + 1, taskCount,
-                                                                          timeout, unit));
-                qWait = maxWaitForEnqueueNS.get();
-                enqueue(taskFuture,
-                        qWait < remaining ? qWait : remaining, // limit waiting to lesser of maxWaitForEnqueue and remaining time
-                        false); // never run on the current thread because it would prevent timeout
+                    throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1204.unable.to.invoke", taskFuture.executor.identifier,
+                                                                          taskCount - futures.indexOf(taskFuture) + 1, taskCount, timeout, unit));
+                qWait = taskFuture.executor.maxWaitForEnqueueNS.get();
+                taskFuture.executor.enqueue(taskFuture,
+                                            qWait < remaining ? qWait : remaining, // limit waiting to lesser of maxWaitForEnqueue and remaining time
+                                            false); // never run on the current thread because it would prevent timeout
             }
 
             // wait for completion
@@ -774,8 +776,9 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             int t = 0;
             for (Callable<T> task : tasks) {
                 PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
-                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS, latch));
+                PolicyExecutorImpl executor = callback == null ? this : (PolicyExecutorImpl) callback.getExecutor(this);
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(executor.startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(executor, task, callback, startTimeoutNS, latch));
             }
 
             // enqueue all tasks
@@ -784,7 +787,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                 if (latch.getCount() == 0)
                     break;
 
-                enqueue(taskFuture, maxWaitForEnqueueNS.get(), false); // never run on the current thread because it would prevent timeout
+                taskFuture.executor.enqueue(taskFuture, taskFuture.executor.maxWaitForEnqueueNS.get(), false); // never run on the current thread because it would prevent timeout
             }
 
             // wait for completion
@@ -823,10 +826,12 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             for (Callable<T> task : tasks) {
                 remaining = stop - System.nanoTime();
                 PolicyTaskCallback callback = callbacks == null ? null : callbacks[t++];
-                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(startTimeout);
-                futures.add(new PolicyTaskFutureImpl<T>(this, task, callback, startTimeoutNS, latch));
+                PolicyExecutorImpl executor = callback == null ? this : (PolicyExecutorImpl) callback.getExecutor(this);
+                long startTimeoutNS = callback == null ? startTimeout : callback.getStartTimeout(executor.startTimeout);
+                futures.add(new PolicyTaskFutureImpl<T>(executor, task, callback, startTimeoutNS, latch));
                 if (remaining <= 0)
-                    throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1204.unable.to.invoke", identifier, taskCount - futures.size(), taskCount, timeout, unit));
+                    throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1204.unable.to.invoke", executor.identifier,
+                                                                          taskCount - futures.size(), taskCount, timeout, unit));
             }
 
             // enqueue all tasks
@@ -838,11 +843,12 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                     break;
 
                 if (remaining <= 0)
-                    throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1204.unable.to.invoke", identifier, taskCount - futures.size(), taskCount, timeout, unit));
-                qWait = maxWaitForEnqueueNS.get();
-                enqueue(taskFuture,
-                        qWait < remaining ? qWait : remaining, // limit waiting to lesser of maxWaitForEnqueue and remaining time
-                        false); // never run on the current thread because it would prevent timeout
+                    throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKE1204.unable.to.invoke", taskFuture.executor.identifier,
+                                                                          taskCount - futures.size(), taskCount, timeout, unit));
+                qWait = taskFuture.executor.maxWaitForEnqueueNS.get();
+                taskFuture.executor.enqueue(taskFuture,
+                                            qWait < remaining ? qWait : remaining, // limit waiting to lesser of maxWaitForEnqueue and remaining time
+                                            false); // never run on the current thread because it would prevent timeout
             }
 
             // wait for completion

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -1207,7 +1207,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
         maxPolicy = u_maxPolicy;
         runIfQueueFull = u_runIfQueueFull;
-        startTimeout = TimeUnit.MILLISECONDS.toNanos(u_startTimeout);
+        startTimeout = u_startTimeout == -1 ? -1 : TimeUnit.MILLISECONDS.toNanos(u_startTimeout);
 
         int a;
         synchronized (configLock) {

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -57,7 +57,7 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
     /**
      * The policy executor instance.
      */
-    private final PolicyExecutorImpl executor;
+    final PolicyExecutorImpl executor;
 
     /**
      * Latch for invokeAny futures. Otherwise null.


### PR DESCRIPTION
Update policy executor to allow invokeAll and invokeAny to optionally invoke tasks across multiple executors.  This will be needed if we are to allow different policies for tasks marked with LONGRUNNING_HINT=true vs normal tasks