### PR TITLE
Tests for returning Class as a subresource locator

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/patchapp/src"/>
 	<classpathentry kind="src" path="test-applications/providerPriorityApp/src"/>
+	<classpathentry kind="src" path="test-applications/classSubResApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
@@ -14,7 +14,8 @@ bVersion=1.0
 src: \
   fat/src,\
   test-applications/patchapp/src,\
-  test-applications/providerPriorityApp/src
+  test-applications/providerPriorityApp/src,\
+  test-applications/classSubResApp/src
 
 test.project: true
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/ClassSubResTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/ClassSubResTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs21.fat.extended;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import jaxrs21.fat.classSubRes.ClassSubResTestServlet;
+
+@RunWith(FATRunner.class)
+public class ClassSubResTest extends FATServletClient {
+
+    private static final String appName = "classSubResApp";
+
+    @Server("jaxrs21.fat.classSubRes")
+    @TestServlet(servlet = ClassSubResTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, appName, "jaxrs21.fat.classSubRes", "jaxrs21.fat.classSubRes.sub");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.classSubRes/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.classSubRes/bootstrap.properties
@@ -1,0 +1,8 @@
+com.ibm.ws.logging.trace.specification=*=info:\
+com.ibm.ws.jaxrs20.*=all:\
+com.ibm.websphere.jaxrs20.*=all:\
+org.apache.cxf.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.classSubRes/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.classSubRes/server.xml
@@ -1,0 +1,8 @@
+<server>
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>    
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/ClassSubResTestApp.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/ClassSubResTestApp.java
@@ -8,16 +8,19 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs21.fat.extended;
+package jaxrs21.fat.classSubRes;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Application;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                PatchTest.class,
-                ProviderPriorityTest.class,
-                ClassSubResTest.class
-})
-public class FATSuite {}
+@ApplicationPath("/rest")
+@Path("/test")
+public class ClassSubResTestApp extends Application {
+
+    @Path("/sub/{subType}")
+    public Class<?> page(@PathParam("subType") String subType) throws ClassNotFoundException {
+        return Class.forName("jaxrs21.fat.classSubRes.sub." + subType);
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/ClassSubResTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/ClassSubResTestServlet.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.classSubRes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/ClassSubResTestServlet")
+public class ClassSubResTestServlet extends FATServlet {
+
+    private Client client;
+
+    @Override
+    public void init() throws ServletException {
+        client = ClientBuilder.newBuilder().build();
+    }
+
+    @Override
+    public void destroy() {
+        client.close();
+    }
+
+    @Test
+    public void testNoArgPublicConstructor(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        Response response = target(req, "NoArgCtor").request().get();
+        assertEquals(200, response.getStatus());
+        assertEquals("NoArgCtor", response.readEntity(String.class));
+
+        response = target(req, "NoArgCtor").request().post(Entity.text("POST"));
+        assertEquals(200, response.getStatus());
+        assertEquals("NoArgCtor POST", response.readEntity(String.class));
+
+        response = target(req, "NoArgCtor").request().method("PATCH", Entity.text("PATCH"));
+        assertEquals(200, response.getStatus());
+        assertEquals("NoArgCtor PATCH", response.readEntity(String.class));
+
+        response = target(req, "NoArgCtor").request().options();
+        assertEquals(200, response.getStatus());
+        assertTrue(response.getHeaderString("Allow").contains("GET"));
+        assertTrue(response.getHeaderString("Allow").contains("POST"));
+        assertTrue(response.getHeaderString("Allow").contains("PATCH"));
+    }
+
+    @Test
+    public void testMultipleMultiArgConstructors(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        Response response = target(req, "MultiMultiArgCtor").queryParam("a", "b").request().get();
+        assertEquals(200, response.getStatus());
+        assertEquals("MultiMultiArgCtor 3", response.readEntity(String.class));
+
+        response = target(req, "MultiMultiArgCtor").queryParam("a", "c").request().post(Entity.text("POST"));
+        assertEquals(200, response.getStatus());
+        assertEquals("MultiMultiArgCtor POST 3", response.readEntity(String.class));
+
+        response = target(req, "MultiMultiArgCtor").queryParam("a", "d").request().method("PATCH", Entity.text("PATCH"));
+        assertEquals(200, response.getStatus());
+        assertEquals("MultiMultiArgCtor PATCH 3", response.readEntity(String.class));
+
+        response = target(req, "MultiMultiArgCtor").request().options();
+        assertEquals(200, response.getStatus());
+        assertTrue(response.getHeaderString("Allow").contains("GET"));
+        assertTrue(response.getHeaderString("Allow").contains("POST"));
+        assertTrue(response.getHeaderString("Allow").contains("PATCH"));
+    }
+
+    @Test
+    public void testUnsuitableConstructors(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+
+        Response response = target(req, "DefaultVisCtor").request().get();
+        assertEquals(500, response.getStatus());
+
+        response = target(req, "PrivateCtor").request().get();
+        assertEquals(500, response.getStatus());
+
+        response = target(req, "ProtectedCtor").request().get();
+        assertEquals(500, response.getStatus());
+
+        response = target(req, "UnknownParmCtor").request().get();
+        assertEquals(500, response.getStatus());
+    }
+
+    private WebTarget target(HttpServletRequest request, String path) {
+        String base = "http://" + request.getServerName() + ':' + request.getServerPort() + "/classSubResApp/rest/test/sub/";
+        return client.target(base + path);
+    }
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/AbstractSubResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/AbstractSubResource.java
@@ -1,0 +1,31 @@
+/**
+ *
+ */
+package jaxrs21.fat.classSubRes.sub;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
+import javax.ws.rs.POST;
+import javax.ws.rs.core.Response;
+
+public class AbstractSubResource {
+
+    @GET
+    public Response get() {
+        return Response.ok(returnString("")).build();
+    }
+
+    @POST
+    public Response post(String postData) {
+        return Response.ok(returnString(" " + postData)).build();
+    }
+
+    @PATCH
+    public Response patch(String patchData) {
+        return Response.ok(returnString(" " + patchData)).build();
+    }
+
+    String returnString(String suffix) {
+        return this.getClass().getSimpleName() + suffix;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/DefaultVisCtor.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/DefaultVisCtor.java
@@ -1,0 +1,11 @@
+/**
+ *
+ */
+package jaxrs21.fat.classSubRes.sub;
+
+public class DefaultVisCtor extends AbstractSubResource {
+
+    DefaultVisCtor() {
+        System.out.println(this.getClass().getSimpleName());
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/MultiMultiArgCtor.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/MultiMultiArgCtor.java
@@ -1,0 +1,34 @@
+/**
+ *
+ */
+package jaxrs21.fat.classSubRes.sub;
+
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.UriInfo;
+
+public class MultiMultiArgCtor extends AbstractSubResource {
+
+    private final String ctor;
+
+    public MultiMultiArgCtor(@Context HttpHeaders headers) {
+        ctor = " 1";
+        System.out.println(this.getClass().getSimpleName() + " 1");
+    }
+
+    public MultiMultiArgCtor(@Context HttpHeaders headers, @Context UriInfo uriInfo) {
+        ctor = " 2";
+        System.out.println(this.getClass().getSimpleName() + " 2");
+    }
+
+    public MultiMultiArgCtor(@QueryParam("a") String a, @Context HttpHeaders headers, @Context UriInfo uriInfo) {
+        ctor = " 3";
+        System.out.println(this.getClass().getSimpleName() + " 3 " + a);
+    }
+
+    @Override
+    String returnString(String suffix) {
+        return super.returnString(suffix) + ctor;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/NoArgCtor.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/NoArgCtor.java
@@ -1,0 +1,11 @@
+/**
+ *
+ */
+package jaxrs21.fat.classSubRes.sub;
+
+public class NoArgCtor extends AbstractSubResource {
+
+    public NoArgCtor() {
+        System.out.println(this.getClass().getSimpleName());
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/PrivateCtor.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/PrivateCtor.java
@@ -1,0 +1,11 @@
+/**
+ *
+ */
+package jaxrs21.fat.classSubRes.sub;
+
+public class PrivateCtor extends AbstractSubResource {
+
+    private PrivateCtor() {
+        System.out.println(this.getClass().getSimpleName());
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/ProtectedCtor.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/ProtectedCtor.java
@@ -1,0 +1,11 @@
+/**
+ *
+ */
+package jaxrs21.fat.classSubRes.sub;
+
+public class ProtectedCtor extends AbstractSubResource {
+
+    protected ProtectedCtor() {
+        System.out.println(this.getClass().getSimpleName());
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/UnknownParmCtor.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/classSubResApp/src/jaxrs21/fat/classSubRes/sub/UnknownParmCtor.java
@@ -1,0 +1,11 @@
+/**
+ *
+ */
+package jaxrs21.fat.classSubRes.sub;
+
+public class UnknownParmCtor extends AbstractSubResource {
+
+    public UnknownParmCtor(PrivateCtor unknownParm) {
+        System.out.println(this.getClass().getSimpleName());
+    }
+}


### PR DESCRIPTION
New in the JAX-RS 2.1 spec (section 3.4.1) is the ability for sub
resource locator methods to return a Class type.  According to the spec
the JAX-RS implementation must create a new instance of that class via
a suitable constructor (section 3.1.2 defines what a suitable ctor is),
and then invoke that instance as it would for any other type returned
from the sub resource locator method.