### PR TITLE
Opentracing support for excluding/including spans by URI.

### DIFF
--- a/dev/com.ibm.ws.opentracing/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing/bnd.bnd
@@ -21,14 +21,17 @@ Bundle-Description:Opentracing 1.0, version ${bVersion}
 WS-TraceGroup: OPENTRACING
 
 -dsannotations: com.ibm.ws.opentracing.OpentracingUserFeatureAccessService, \
-                com.ibm.ws.opentracing.OpentracingJaxRsProviderRegister
+                com.ibm.ws.opentracing.OpentracingJaxRsProviderRegister, \
+                com.ibm.ws.opentracing.OpentracingService
                 
 -includeresource: \
+   OSGI-INF=resources/OSGI-INF, \
    @${repo;io.opentracing:opentracing-api;0.30.0}!/!(OSGI-OPT/src|META-INF/maven)/*
 
 Import-Package: *
 
 Export-Package:  com.ibm.ws.opentracing, \
+                 com.ibm.ws.opentracing.filters, \
                  com.ibm.ws.opentracing.tracer;provide=true, \
                  io.opentracing;version=0.30.0, \
                  io.opentracing.propagation;version=0.30.0, \
@@ -46,6 +49,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
         com.ibm.ws.jaxrs.2.0.common;version=latest, \
         com.ibm.wsspi.org.osgi.service.component;version=latest, \
         com.ibm.wsspi.org.osgi.core;version=latest, \
-        com.ibm.wsspi.org.osgi.service.component.annotations;version=latest
+        com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
+        com.ibm.websphere.org.osgi.service.cm;version=latest
 
 

--- a/dev/com.ibm.ws.opentracing/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.opentracing/resources/OSGI-INF/l10n/metatype.properties
@@ -1,0 +1,34 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation
+###############################################################################
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+opentracing.name=Opentracing
+opentracing.desc=Optional. Configuration for the opentracing feature.
+
+excludeSpans.name=Exclude
+excludeSpans.desc=Optional. Configuration to exclude inbound and/or outbound spans. By default, nothing is excluded.
+
+includeSpans.name=Include
+includeSpans.desc=Optional. Configuration to override excludeSpans. By default, anything that is not excluded is included.
+
+pattern.name=URL pattern
+pattern.desc=Required. The URL pattern for which this filter applies.
+
+type.name=Filter type
+type.desc=Optional. Whether to apply this filter to INCOMING requests, OUTGOING requests, or BOTH. Default BOTH.
+
+ignoreCase.name=Ignore case
+ignoreCase.desc=Optional. Whether to ignore case when comparing URIs. Default true.
+
+regex.name=Use a regular expression
+regex.desc=Optional. Whether to interpret the pattern as a regular expression. Default false. Discouraged due to the performance overhead of applying to every request.

--- a/dev/com.ibm.ws.opentracing/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.opentracing/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2011 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0"
+	xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
+	localization="OSGI-INF/l10n/metatype">
+
+	<OCD name="%opentracing.name" description="%opentracing.desc" id="com.ibm.ws.opentracing"
+		ibm:alias="opentracing">
+
+		<AD id="excludeSpans" name="%excludeSpans.name" description="%excludeSpans.desc"
+			ibm:reference="com.ibm.ws.opentracing.excludeSpans" ibm:type="pid"
+			type="String" required="false" cardinality="2147483647" />
+
+		<AD id="includeSpans" name="%includeSpans.name" description="%includeSpans.desc"
+			ibm:reference="com.ibm.ws.opentracing.includeSpans" ibm:type="pid"
+			type="String" required="false" cardinality="2147483647" />
+
+	</OCD>
+
+	<Designate pid="com.ibm.ws.opentracing">
+		<Object ocdref="com.ibm.ws.opentracing" />
+	</Designate>
+
+	<OCD name="%excludeSpans.name" description="%excludeSpans.desc"
+		id="com.ibm.ws.opentracing.excludeSpans.metatype" ibm:alias="excludeSpans">
+
+		<AD name="%pattern.name" description="%pattern.desc"
+			id="pattern" required="true" type="String" default="" />
+
+		<AD name="%type.name" description="%type.desc"
+			id="type" required="false" type="String" default="BOTH" />
+
+		<AD name="%ignoreCase.name" description="%ignoreCase.desc"
+			id="ignoreCase" required="false" type="Boolean" default="true" />
+
+		<AD name="%regex.name" description="%regex.desc"
+			id="regex" required="false" type="Boolean" default="false" />
+
+	</OCD>
+
+	<Designate factoryPid="com.ibm.ws.opentracing.excludeSpans">
+		<Object ocdref="com.ibm.ws.opentracing.excludeSpans.metatype" />
+	</Designate>
+
+	<OCD name="%includeSpans.name" description="%includeSpans.desc"
+		id="com.ibm.ws.opentracing.includeSpans.metatype" ibm:alias="includeSpans">
+
+		<AD name="%pattern.name" description="%pattern.desc"
+			id="pattern" required="true" type="String" default="" />
+
+		<AD name="%type.name" description="%type.desc"
+			id="type" required="false" type="String" default="BOTH" />
+
+		<AD name="%ignoreCase.name" description="%ignoreCase.desc"
+			id="ignoreCase" required="false" type="Boolean" default="true" />
+
+		<AD name="%regex.name" description="%regex.desc"
+			id="regex" required="false" type="Boolean" default="false" />
+
+	</OCD>
+
+	<Designate factoryPid="com.ibm.ws.opentracing.includeSpans">
+		<Object ocdref="com.ibm.ws.opentracing.includeSpans.metatype" />
+	</Designate>
+
+</metatype:MetaData>

--- a/dev/com.ibm.ws.opentracing/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -87,12 +87,12 @@ OPENTRACING_TRACERFACTORY_RETURNED_NULL.explanation=The feature constructs Trace
 OPENTRACING_TRACERFACTORY_RETURNED_NULL.useraction=Determine why the user supplied OpentracingTracerFactory newInstance method returned null.
 
 OPENTRACING_FILTER_PATTERN_BLANK=CWMOT0007E: The pattern attribute of an opentracing excludeSpans or includeSpans configuration element is blank.
-OPENTRACING_FILTER_PATTERN_BLANK.explanation=A valid URI pattern must be specified.
+OPENTRACING_FILTER_PATTERN_BLANK.explanation=A valid URI pattern must be specified and cannot be blank.
 OPENTRACING_FILTER_PATTERN_BLANK.useraction=Consult the documentation on valid patterns.
 
 OPENTRACING_FILTER_PATTERN_INVALID=CWMOT0008E: The pattern attribute {0} of an opentracing excludeSpans or includeSpans configuration element is an invalid URI (RFC 2396).
-OPENTRACING_FILTER_PATTERN_INVALID.explanation=A valid URI pattern must be specified.
-OPENTRACING_FILTER_PATTERN_INVALID.useraction=Consult RFC 2396. The most common problem is not properly % URL-encoding invalid characters.
+OPENTRACING_FILTER_PATTERN_INVALID.explanation=A valid URI pattern must be specified. The most common problem is not properly % URL-encoding invalid characters.
+OPENTRACING_FILTER_PATTERN_INVALID.useraction=Consult RFC 2396 and ensure that you have correctly % URL-encoding invalid characters.
 
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message

--- a/dev/com.ibm.ws.opentracing/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -86,6 +86,14 @@ OPENTRACING_TRACERFACTORY_RETURNED_NULL=CWMOT0006E: Invocation of user supplied 
 OPENTRACING_TRACERFACTORY_RETURNED_NULL.explanation=The feature constructs Tracer implementations with a user provided OpentracingTracerFactory. The OpentracingTracerFactory.newInstance method returned null.
 OPENTRACING_TRACERFACTORY_RETURNED_NULL.useraction=Determine why the user supplied OpentracingTracerFactory newInstance method returned null.
 
+OPENTRACING_FILTER_PATTERN_BLANK=CWMOT0007E: The pattern attribute of an opentracing excludeSpans or includeSpans configuration element is blank.
+OPENTRACING_FILTER_PATTERN_BLANK.explanation=A valid URI pattern must be specified.
+OPENTRACING_FILTER_PATTERN_BLANK.useraction=Consult the documentation on valid patterns.
+
+OPENTRACING_FILTER_PATTERN_INVALID=CWMOT0008E: The pattern attribute {0} of an opentracing excludeSpans or includeSpans configuration element is an invalid URI (RFC 2396).
+OPENTRACING_FILTER_PATTERN_INVALID.explanation=A valid URI pattern must be specified.
+OPENTRACING_FILTER_PATTERN_INVALID.useraction=Consult RFC 2396. The most common problem is not properly % URL-encoding invalid characters.
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingClientFilter.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingClientFilter.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.opentracing;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -25,9 +26,11 @@ import org.osgi.service.component.annotations.Component;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.opentracing.filters.SpanFilterType;
 
 import io.opentracing.ActiveSpan;
 import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
@@ -40,7 +43,7 @@ import io.opentracing.tag.Tags;
  *
  * <p>Implements both {@link ClientRequestFilter} and {@link ClientResponseFilter}.</p>
  *
- * <p>This implementation is stateless.  A single client filter is used by all clients.</p>
+ * <p>This implementation is stateless. A single client filter is used by all clients.</p>
  */
 @Component
 public class OpentracingClientFilter implements ClientRequestFilter, ClientResponseFilter {
@@ -54,6 +57,8 @@ public class OpentracingClientFilter implements ClientRequestFilter, ClientRespo
      * <p>See {@link OpentracingContainerFilter#SERVER_SPAN_PROP_ID} for more information.</p>
      */
     public static final String CLIENT_SPAN_PROP_ID = OpentracingClientFilter.class.getName() + ".Span";
+
+    public static final String CLIENT_SPAN_SKIPPED_ID = OpentracingClientFilter.class.getName() + ".Skipped";
 
     /**
      * <p>Handle an outgoing request.</p>
@@ -74,56 +79,70 @@ public class OpentracingClientFilter implements ClientRequestFilter, ClientRespo
         String methodName = "filter(outgoing)";
 
         Tracer tracer = OpentracingTracerManager.getTracer();
-        if ( tracer == null ) {
+        if (tracer == null) {
             Tr.error(tc, "OPENTRACING_NO_TRACER_FOR_OUTBOUND_REQUEST");
             return;
         } else {
-            if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, methodName, OpentracingUtils.getTracerText(tracer));
             }
         }
 
-        String outgoingURL = clientRequestContext.getUri().toURL().toString();
+        URI outgoingUri = clientRequestContext.getUri();
+        String outgoingURL = outgoingUri.toURL().toString();
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, methodName + " outgoing URL", outgoingURL);
         }
 
-        Tracer.SpanBuilder spanBuilder = tracer.buildSpan(outgoingURL);
-
-        spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT);
-        spanBuilder.withTag(Tags.HTTP_URL.getKey(), outgoingURL);
-        spanBuilder.withTag(Tags.HTTP_METHOD.getKey(), clientRequestContext.getMethod());
-
         ActiveSpan priorIncomingSpan = tracer.activeSpan();
-        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, methodName + " parent", priorIncomingSpan);
         }
-        if ( priorIncomingSpan != null ) {
-            spanBuilder.asChildOf(priorIncomingSpan.context());
-        } else {
-            // spanBuilder.ignoreActiveSpan();
-            //
-            // TODO:
-            // The work-around, which is a call 'spanBuilder.ignoreActiveSpan()',
-            // and which is used in the container filter, is not needed here.
-            //
-            // The code is a bit muddled, though, as the mock span defaults to
-            // look for and use the active span as the parent span, which means
-            // the call 'spanBuilder.asChildOf' may not be necessary.
-        }
 
-        Span newOutoingSpan = spanBuilder.startManual();
-        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-            Tr.debug(tc, methodName + " outgoingSpan", newOutoingSpan);
+        boolean process = OpentracingService.process(outgoingUri, SpanFilterType.OUTGOING);
+
+        SpanContext nextContext;
+
+        if (process) {
+            Tracer.SpanBuilder spanBuilder = tracer.buildSpan(outgoingURL);
+
+            spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT);
+            spanBuilder.withTag(Tags.HTTP_URL.getKey(), outgoingURL);
+            spanBuilder.withTag(Tags.HTTP_METHOD.getKey(), clientRequestContext.getMethod());
+
+            if (priorIncomingSpan != null) {
+                spanBuilder.asChildOf(priorIncomingSpan.context());
+            } else {
+                // spanBuilder.ignoreActiveSpan();
+                //
+                // TODO:
+                // The work-around, which is a call 'spanBuilder.ignoreActiveSpan()',
+                // and which is used in the container filter, is not needed here.
+                //
+                // The code is a bit muddled, though, as the mock span defaults to
+                // look for and use the active span as the parent span, which means
+                // the call 'spanBuilder.asChildOf' may not be necessary.
+            }
+
+            Span newOutoingSpan = spanBuilder.startManual();
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, methodName + " outgoingSpan", newOutoingSpan);
+            }
+
+            nextContext = newOutoingSpan.context();
+
+            // Note the use of the span stored under the client property: This is to
+            // create the association of the outgoing request to the incoming response.
+            clientRequestContext.setProperty(CLIENT_SPAN_PROP_ID, newOutoingSpan);
+        } else {
+            nextContext = priorIncomingSpan.context();
         }
 
         tracer.inject(
-            newOutoingSpan.context(),
-            Format.Builtin.HTTP_HEADERS, new MultivaluedMapToTextMap(clientRequestContext.getHeaders()));
+                      nextContext,
+                      Format.Builtin.HTTP_HEADERS, new MultivaluedMapToTextMap(clientRequestContext.getHeaders()));
 
-        // Note the use of the span stored under the client property: This is to
-        // create the association of the outgoing request to the incoming response.
-        clientRequestContext.setProperty(CLIENT_SPAN_PROP_ID, newOutoingSpan);
+        clientRequestContext.setProperty(CLIENT_SPAN_SKIPPED_ID, !process);
     }
 
     /**
@@ -142,26 +161,34 @@ public class OpentracingClientFilter implements ClientRequestFilter, ClientRespo
                        ClientResponseContext clientResponseContext) throws IOException {
         String methodName = "filter(incoming)";
 
+        if ((Boolean) clientRequestContext.getProperty(CLIENT_SPAN_SKIPPED_ID)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, methodName, "skipped");
+            }
+            clientRequestContext.removeProperty(CLIENT_SPAN_SKIPPED_ID);
+            return;
+        }
+
         Span priorOutgoingSpan = (Span) clientRequestContext.getProperty(CLIENT_SPAN_PROP_ID);
-        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, methodName, priorOutgoingSpan);
         }
 
-        if ( priorOutgoingSpan == null ) {
+        if (priorOutgoingSpan == null) {
             Tr.error(tc, "OPENTRACING_NO_SPAN_FOR_RESPONSE_TO_OUTBOUND_REQUEST");
             return;
         }
 
         try {
             Integer httpStatus = Integer.valueOf(clientResponseContext.getStatus());
-            if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, methodName + " httpStatus", httpStatus);
             }
 
             priorOutgoingSpan.setTag(Tags.HTTP_STATUS.getKey(), httpStatus);
-            if ( clientResponseContext.getStatus() >= 400 ) {
+            if (clientResponseContext.getStatus() >= 400) {
                 priorOutgoingSpan.setTag(Tags.ERROR.getKey(), true);
-                if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, methodName + " error", Boolean.TRUE);
                 }
             }

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingService.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingService.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.opentracing;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.opentracing.filters.ExcludeFilter;
+import com.ibm.ws.opentracing.filters.IncludeFilter;
+import com.ibm.ws.opentracing.filters.SpanFilter;
+import com.ibm.ws.opentracing.filters.SpanFilterType;
+
+/**
+ * Opentracing configuration and static utilities such as running filters on a URI.
+ */
+@Component(configurationPid = "com.ibm.ws.opentracing", configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true, property = { "service.vendor=IBM" })
+public class OpentracingService {
+
+    private static final TraceComponent tc = Tr.register(OpentracingService.class);
+
+    /**
+     * List of all active span filters.
+     */
+    private static volatile SpanFilter[] allFilters = new SpanFilter[0];
+
+    /**
+     * First configuration loaded.
+     *
+     * @param map Configuration properties.
+     */
+    @Activate
+    protected void activate(Map<String, Object> map) {
+        modified(map);
+    }
+
+    /**
+     * Configuration dynamically updated.
+     *
+     * @param map Configuration properties.
+     */
+    @Modified
+    protected void modified(Map<String, Object> map) {
+
+        // https://www.ibm.com/support/knowledgecenter/SSAW57_8.5.5/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/twlp_nest_config_elem.html
+        BundleContext bundleContext = FrameworkUtil.getBundle(getClass()).getBundleContext();
+        ServiceReference<?> configurationAdminReference = bundleContext.getServiceReference(ConfigurationAdmin.class.getName());
+        ConfigurationAdmin configAdmin = (ConfigurationAdmin) bundleContext.getService(configurationAdminReference);
+
+        // Build up the list of filters in a local list, then convert that to an array
+        // and assign to the static reference. This is done to avoid creating an iterator
+        // in the main path in `process`.
+        List<SpanFilter> filters = new ArrayList<SpanFilter>();
+
+        processFilters(filters, map, configAdmin, "excludeSpans", ExcludeFilter.class);
+        processFilters(filters, map, configAdmin, "includeSpans", IncludeFilter.class);
+
+        SpanFilter[] finalFilters = new SpanFilter[filters.size()];
+        filters.toArray(finalFilters);
+
+        allFilters = finalFilters;
+    }
+
+    /**
+     * Check the configuration for filters of a particular type.
+     *
+     * @param filters The resulting list of filters.
+     * @param map Configuration properties.
+     * @param configAdmin Service to get child configurations.
+     * @param childNames The name of the configuration element to check for.
+     * @param impl The filter class to instantiate if an element is found.
+     */
+    private void processFilters(List<SpanFilter> filters, Map<String, Object> map, ConfigurationAdmin configAdmin, String childNames, Class<? extends SpanFilter> impl) {
+
+        final String methodName = "processFilters";
+
+        String[] children = (String[]) map.get(childNames);
+        if (children != null) {
+            for (String child : children) {
+                try {
+                    Configuration config = configAdmin.getConfiguration(child, null);
+                    Dictionary<String, Object> childProperties = config.getProperties();
+
+                    String pattern = (String) childProperties.get("pattern");
+                    SpanFilterType type = SpanFilterType.valueOf(((String) childProperties.get("type")).trim());
+                    boolean ignoreCase = (Boolean) childProperties.get("ignoreCase");
+                    boolean regex = (Boolean) childProperties.get("regex");
+
+                    SpanFilter filter = (SpanFilter) Class.forName(impl.getName()).getConstructor(String.class, SpanFilterType.class, boolean.class,
+                                                                                                  boolean.class).newInstance(pattern, type,
+                                                                                                                             ignoreCase, regex);
+
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, methodName, "filter " + filter);
+                    }
+
+                    filters.add(filter);
+                } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | SecurityException | IllegalArgumentException
+                                | InvocationTargetException | IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Return true if a span for the specified URI and type should be included.
+     *
+     * @param uri The URI of the request.
+     * @param type The type of the request.
+     * @return true if a span for the specified URI and type should be included.
+     */
+    public static boolean process(final URI uri, final SpanFilterType type) {
+        final String methodName = "process";
+
+        boolean result = true;
+
+        // Copy the static reference locally so that it doesn't matter if the static list
+        // is updated while we're processing since that will just overwrite the reference
+        final SpanFilter[] filters = allFilters;
+
+        for (int i = 0; i < filters.length; i++) {
+            result = filters[i].process(result, uri, type);
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, methodName, "filter " + filters[i] + " set result to " + result);
+            }
+        }
+
+        return result;
+    }
+}

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/ExcludeFilter.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/ExcludeFilter.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.opentracing.filters;
+
+import java.net.URI;
+
+/**
+ * If the URI and type match, then exclude the request.
+ */
+public class ExcludeFilter extends SpanFilterBase {
+    /**
+     * Create a new filter with a pattern, filter type, and whether to ignore case on the pattern match.
+     * If the URI and type match, then exclude the request.
+     *
+     * @param pattern The pattern for which this filter matches.
+     * @param type The filter types for which this filter matches.
+     * @param ignoreCase Whether to ignore case on the pattern match.
+     * @param regex If true, pattern is treated as a regular expression.
+     */
+    public ExcludeFilter(String pattern, SpanFilterType type, boolean ignoreCase, boolean regex) {
+        super(pattern, type, ignoreCase, regex);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected final boolean matchAction(final boolean previousState, final URI uri, final SpanFilterType contextType) {
+        return false;
+    }
+}

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/IncludeFilter.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/IncludeFilter.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.opentracing.filters;
+
+import java.net.URI;
+
+/**
+ * If the URI and type match, then include the request.
+ */
+public class IncludeFilter extends SpanFilterBase {
+    /**
+     * Create a new filter with a pattern, filter type, and whether to ignore case on the pattern match.
+     * If the URI and type match, then include the request.
+     *
+     * @param pattern The pattern for which this filter matches.
+     * @param type The filter types for which this filter matches.
+     * @param ignoreCase Whether to ignore case on the pattern match.
+     * @param regex If true, pattern is treated as a regular expression.
+     */
+    public IncludeFilter(String pattern, SpanFilterType type, boolean ignoreCase, boolean regex) {
+        super(pattern, type, ignoreCase, regex);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected final boolean matchAction(final boolean previousState, final URI uri, final SpanFilterType contextType) {
+        return true;
+    }
+}

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/SpanFilter.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/SpanFilter.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.opentracing.filters;
+
+import java.net.URI;
+
+/**
+ * There are two types of configuration elements: excludeSpans and includeSpans.
+ *
+ * <code>
+ * &lt;opentracing&gt;
+ * &lt;excludeSpans pattern="URI" type="INCOMING|OUTGOING|BOTH" ignoreCase="true|false" regex="true|false" /&gt;
+ * &lt;includeSpans pattern="URI" type="INCOMING|OUTGOING|BOTH" ignoreCase="true|false" regex="true|false" /&gt;
+ * &lt;/opentracing&gt;
+ * </code>
+ *
+ * These are called filters. Each filter may be specified 0 or more times.
+ *
+ * When a request comes in to the container, all INCOMING or BOTH filters are checked with
+ * the incoming URI. If all checks return true, then a new span is created for the incoming
+ * request; otherwise, no new span is created, but any incoming spans are passed through.
+ *
+ * When a request is sent from the container, all OUTGOING or BOTH filters are checked with
+ * the outgoing URI. If all checks return true, then a new span is created for the outgoing
+ * request; otherwise, no new span is created, but any incoming spans are passed through.
+ *
+ * The default type of a filter is BOTH.
+ *
+ * All filters have a pattern attribute which is the URI pattern to match the filter. If
+ * the pattern starts with http(s)://, then the filter will compare to the absolute URI;
+ * otherwise, the filter will compare to the URI starting with the path. In both cases, the
+ * filter will compare with query and fragment, if available, for both the pattern and the
+ * URI.
+ *
+ * If regex is false (the default) and pattern ends with '*', then the filter will check if
+ * the URI starts with the pattern; otherwise, the filter will do an exact match. In both
+ * cases, the comparison will be done in a case sensitive or insensitive way depending on
+ * the value of ignoreCase. The default of ignoreCase is true.
+ *
+ * If regex is true, pattern is compiled into a {@see java.util.regex.Pattern} and
+ * the URI is matched interpreting the pattern as a regular expression. The comparison will
+ * be done in a case sensitive or insensitive way depending on the value of ignoreCase.
+ * Regular expressions are discouraged because they are resource intensive. One common
+ * mistake when using regular expressions is that some URL components such as the query
+ * separator (?) have special meaning in regular expressions and must be escaped with '\'.
+ *
+ * If no filters match the URI, then the default is that the span is created.
+ *
+ * The filters are processed in the order in which they appear in the configuration. For
+ * example, if we want to only process URIs that start with /api, then we can use an
+ * excludeSpans first with a pattern of '*' to exclude all URIs (this is needed since,
+ * by default, spans are created), and then we can use an includeSpans with a pattern of
+ * '/api*'.
+ *
+ * Both the pattern and URI are compared with RFC 2396-compliant % URI-encoding, when
+ * needed.
+ */
+public interface SpanFilter {
+
+    /**
+     * Bit flag representing an incoming request.
+     */
+    public static final int SPAN_TYPE_INCOMING = 1 << 0;
+
+    /**
+     * Bit flag representing an outgoing request.
+     */
+    public static final int SPAN_TYPE_OUTGOING = 1 << 1;
+
+    /**
+     * Returns the pattern for this filter.
+     *
+     * @return Pattern for this filter.
+     */
+    String getPattern();
+
+    /**
+     * Returns the type(s) this filter supports.
+     *
+     * @return type(s) this filter supports.
+     */
+    SpanFilterType getType();
+
+    /**
+     * Process a filter in sequence and return true if a span should be created for this request.
+     *
+     * @param previousState It is expected that filters are called in sequence, so this is the result of the previous filter, or a default.
+     * @param uri The full URI of this request.
+     * @param contextType The type of request.
+     * @return True if a span should be created for this request; otherwise, false.
+     */
+    boolean process(final boolean previousState, final URI uri, final SpanFilterType contextType);
+}

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/SpanFilterBase.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/SpanFilterBase.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.opentracing.filters;
+
+import java.net.URI;
+import java.util.regex.Pattern;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Base class for filters that does the matching on the pattern and other helper methods.
+ */
+public abstract class SpanFilterBase implements SpanFilter {
+
+    private static final TraceComponent tc = Tr.register(SpanFilterBase.class);
+
+    protected final String pattern;
+    protected final SpanFilterType type;
+    protected final boolean ignoreCase;
+    protected final boolean compareRelative;
+    protected final boolean wildcard;
+    protected final boolean regex;
+    protected final Pattern matcher;
+
+    /**
+     * Create a new filter with a pattern, filter type, and whether to ignore case on the pattern match.
+     *
+     * @param pattern The pattern for which this filter matches.
+     * @param type The filter types for which this filter matches.
+     * @param ignoreCase Whether to ignore case on the pattern match.
+     * @param regex If true, pattern is treated as a regular expression.
+     */
+    public SpanFilterBase(String pattern, SpanFilterType type, boolean ignoreCase, boolean regex) {
+
+        this.type = type;
+        this.ignoreCase = ignoreCase;
+        this.regex = regex;
+
+        if (this.regex) {
+            this.matcher = Pattern.compile(pattern, this.ignoreCase ? Pattern.CASE_INSENSITIVE : 0);
+        } else {
+            this.matcher = null;
+        }
+
+        String processedPattern = pattern.trim();
+        if (ignoreCase) {
+            processedPattern = processedPattern.toLowerCase();
+        }
+
+        this.wildcard = processedPattern.endsWith("*");
+
+        if (wildcard) {
+            processedPattern = processedPattern.substring(0, processedPattern.length() - 2);
+        }
+
+        this.pattern = processedPattern;
+
+        this.compareRelative = !pattern.startsWith("http://") && !pattern.startsWith("https://");
+
+        validatePattern();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Trivial
+    public String getPattern() {
+        return pattern;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Trivial
+    public SpanFilterType getType() {
+        return type;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    public String toString() {
+        return super.toString() + " { pattern: \"" + pattern + "\", type: \"" + type + "\", regex: \"" + this.matcher + "\" }";
+    }
+
+    /**
+     * Throw exceptions if the pattern is invalid.
+     *
+     * @throws IllegalArgumentException Pattern is blank or non-conformant to RFC 2396.
+     */
+    protected void validatePattern() {
+        if (pattern.length() == 0) {
+            throw new IllegalArgumentException(Tr.formatMessage(tc, "OPENTRACING_FILTER_PATTERN_BLANK"));
+        }
+
+        if (!regex) {
+            try {
+                URI.create(pattern);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(Tr.formatMessage(tc, "OPENTRACING_FILTER_PATTERN_INVALID", pattern), e);
+            }
+        }
+    }
+
+    /**
+     * Check if the URI matches the pattern.
+     *
+     * @param uri The URI to check against our pattern.
+     * @return Whether or not the URI matches our pattern.
+     */
+    protected boolean match(final URI uri) {
+
+        final String methodName = "match";
+        final String uriStr = prepareUri(uri);
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, methodName, this, uriStr, ignoreCase, wildcard);
+        }
+
+        if (this.matcher == null) {
+            if (ignoreCase) {
+                if (pattern.equalsIgnoreCase(uriStr)) {
+                    return true;
+                }
+                if (wildcard && uriStr.toLowerCase().startsWith(pattern)) {
+                    return true;
+                }
+            } else {
+                if (pattern.equals(uriStr)) {
+                    return true;
+                }
+                if (wildcard && uriStr.startsWith(pattern)) {
+                    return true;
+                }
+            }
+        } else {
+            return this.matcher.matcher(uriStr).matches();
+        }
+
+        return false;
+    }
+
+    /**
+     * Prepare the URI for matching.
+     *
+     * @param uri The URI.
+     * @return A String version of the URI to compare to the pattern.
+     */
+    protected final String prepareUri(final URI uri) {
+        if (compareRelative) {
+            final String path = uri.getRawPath();
+            final String query = uri.getRawQuery();
+            final String fragment = uri.getRawFragment();
+            if (query != null && fragment != null) {
+                return path + "?" + query + "#" + fragment;
+            } else if (query != null) {
+                return path + "?" + query;
+            } else if (fragment != null) {
+                return path + "#" + fragment;
+            } else {
+                return path;
+            }
+        } else {
+            return uri.toString();
+        }
+    }
+
+    /**
+     * Check if the request context type matches this filter's context type(s).
+     *
+     * @param contextType The request context type.
+     * @return True if this filter matches the context type.
+     */
+    protected final boolean contextApplies(final SpanFilterType contextType) {
+        return (this.type.getValue() & contextType.getValue()) != 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean process(final boolean previousState, final URI uri, final SpanFilterType contextType) {
+
+        if (contextApplies(contextType) && match(uri)) {
+            return matchAction(previousState, uri, contextType);
+        }
+
+        return previousState;
+    }
+
+    /**
+     * This method will be called when the URI matches this filter's pattern and the type of the request matches this filter's type. Return true to include the request or false to
+     * exclude the request (contingent on subsequent filters).
+     *
+     * @param previousState It is expected that filters are called in sequence, so this is the result of the previous filter, or a default.
+     * @param uri The full URI of this request.
+     * @param contextType The type of request.
+     * @return True to include or false to exclude.
+     */
+    protected abstract boolean matchAction(final boolean previousState, final URI uri, final SpanFilterType contextType);
+}

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/SpanFilterType.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/SpanFilterType.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.opentracing.filters;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Bit flags representing types of requests that filters apply to.
+ */
+public enum SpanFilterType {
+    /**
+     * Filter applies to incoming requests.
+     */
+    INCOMING(SpanFilter.SPAN_TYPE_INCOMING),
+
+    /**
+     * Filter applies to outgoing requests.
+     */
+    OUTGOING(SpanFilter.SPAN_TYPE_OUTGOING),
+
+    /**
+     * Filter applies to incoming or outgoing requests.
+     */
+    BOTH(SpanFilter.SPAN_TYPE_INCOMING | SpanFilter.SPAN_TYPE_OUTGOING);
+
+    private final int value;
+
+    /**
+     * Create a filter type.
+     *
+     * @param value Bit flags of this type.
+     */
+    SpanFilterType(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Return the bit flags of this type.
+     *
+     * @return Bit flags of this type.
+     */
+    @Trivial
+    public int getValue() {
+        return value;
+    }
+}

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/package-info.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/filters/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "OPENTRACING", messageBundle = "com.ibm.ws.opentracing.resources.Opentracing")
+package com.ibm.ws.opentracing.filters;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracing.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracing.java
@@ -173,6 +173,7 @@ public class FATOpentracing implements FATOpentracingConstants {
 
     public static final String[] GET_MANUAL_CONDITION = new String[] { GET_MANUAL_PATH };
     public static final String[] MANUAL_CONDITION = new String[] { "manualSpan" };
+    public static final String[] GET_EXCLUDE_TEST_CONDITION = new String[] { GET_EXCLUDE_TEST_PATH };
 
     /**
      * <p>Answer the condition for a delayed get.</p>
@@ -309,6 +310,12 @@ public class FATOpentracing implements FATOpentracingConstants {
 
         return null;
     }
+    
+    public void verifyContiguousSpans(
+                                      List<FATUtilsSpans.CompletedSpan> completedSpans,
+                                      int expectedSpanCount) {
+        verifyContiguousSpans(completedSpans, expectedSpanCount, 1);
+    }
 
     /**
      * <p>Verify that a contiguous collection of spans is present as the tail
@@ -330,7 +337,7 @@ public class FATOpentracing implements FATOpentracingConstants {
      */
     public void verifyContiguousSpans(
         List<FATUtilsSpans.CompletedSpan> completedSpans,
-        int expectedSpanCount) {
+        int expectedSpanCount, int expectedRootSpanCount) {
 
         String methodName = "verifyContiguousSpans";
 
@@ -378,7 +385,7 @@ public class FATOpentracing implements FATOpentracingConstants {
 
         // *** Exactly one root span must be present. ***
 
-        assertEq("Root spans", Integer.valueOf(1), Integer.valueOf(rootCount));
+        assertEq("Root spans", Integer.valueOf(expectedRootSpanCount), Integer.valueOf(rootCount));
     }
 
     public static final boolean IS_CONTAINER = true;
@@ -516,7 +523,7 @@ public class FATOpentracing implements FATOpentracingConstants {
 
     /**
      * <p>Retrieve the completed span state by making a service call to the
-     * opening tracing FAT service.</p>
+     * open tracing FAT service.</p>
      *
      * @param priorRequestPath The immediately preceding request made to the
      *     open tracing FAT service.  Used for to match this request within
@@ -1500,5 +1507,173 @@ public class FATOpentracing implements FATOpentracingConstants {
             useServer.getHostname(),
             useServer.getHttpDefaultPort(),
             requestPath );
+    }
+
+    @Test
+    public void testExcludes() throws Exception {
+        testExcludedPath("simple");
+        testExcludedPath("wildcardTest");
+        testExcludedPath("absoluteUri");
+        testExcludedPath("regexTest123");
+        testIncludedPath("wildcardInclude");
+        testNestedExcludePath("nestedSuccess", 1, false);
+        testNestedExcludePath("nestedExcludeTest1", 1, true);
+        testExcludedPath("incomingExcluded");
+        testIncludedPath("incomingIncluded");
+    }
+
+    /**
+     * @throws Exception
+     * @throws UnsupportedEncodingException
+     */
+    private void testExcludedPath(String param) throws Exception, UnsupportedEncodingException {
+        int initialCompletedSpansSize = getCompletedSpans(GET_EXCLUDE_TEST_PATH).size();
+
+        sendRequest(GET_EXCLUDE_TEST_PATH, param);
+        
+        int newCompletedSpansCount = getCompletedSpans(GET_EXCLUDE_TEST_PATH).size();
+        
+        // Subtract one because getCompletedSpans itself creates another span for /serviceApp/rest/testService/getTracerState
+        assertEq("Completed Spans Count", initialCompletedSpansSize, newCompletedSpansCount - 1);
+    }
+
+    private void testIncludedPath(String param) throws Exception, UnsupportedEncodingException {
+        sendRequest(GET_EXCLUDE_TEST_PATH, param);
+        
+        List<FATUtilsSpans.CompletedSpan> completedSpans = getCompletedSpans(GET_EXCLUDE_TEST_PATH);
+
+        int tailSize = 1;
+
+        // *** The included request is expected to generate exactly one completed span. ***
+
+        verifyContiguousSpans(completedSpans, tailSize);
+
+        // *** The single completed span must be a root span, and must be for the get. ***
+
+        ParentCondition getExcludeTestCondition = new ParentCondition(
+                FATUtilsSpans.SpanKind.SERVER, null,
+                FATUtilsSpans.SpanKind.SERVER, GET_EXCLUDE_TEST_CONDITION);
+        verifyParents(completedSpans, tailSize, getExcludeTestCondition);
+        
+        completedSpans = getCompletedSpans(GET_IMMEDIATE_PATH);
+        
+        verifyTracerStateEvent(completedSpans);
+
+        verifyContiguousSpans(completedSpans, 1);
+    }
+
+    /**
+     * @throws UnsupportedEncodingException
+     * @throws Exception
+     */
+    private void sendRequest(String path, String responseText) throws UnsupportedEncodingException, Exception {
+        String methodName = "sendRequest";
+        Map<String, Object> requestParms = new HashMap<String, Object>();
+        requestParms.put(RESPONSE_PARAM_NAME, responseText);
+
+        String requestUrl = getRequestUrl(path, requestParms);
+
+        info(methodName, "Request URL", requestUrl);
+        info(methodName, "Expected Response", responseText);
+
+        List<String> actualResponseLines =
+            FATUtilsServer.gatherHttpRequest(FATUtilsServer.HttpRequestMethod.GET, requestUrl);
+        // throws Exception
+        info(methodName, "Actual Response", actualResponseLines);
+
+        // *** The excludeBoth request is expected to have exactly one line of text. ***
+
+        assertEq("Line count",
+                 Integer.valueOf(1), Integer.valueOf(actualResponseLines.size()));
+
+        // *** And is expected to have the response text as specified through the request parameter. ***
+
+        assertEq("Reponse text",
+                 responseText, actualResponseLines.get(0));
+    }
+    
+    private void testNestedExcludePath(String param, int nestDepth, boolean excludingDelay4) throws Exception {
+        String methodName = "testNestedExcludePath";
+
+        String responseText = param + " nested [ " + Integer.toString(nestDepth) + " ]";
+
+        Map<String, Object> requestParms = getNestedParms(nestDepth, false, responseText);
+
+        String requestUrl = getRequestUrl(GET_NESTED_PATH, requestParms);
+
+        info(methodName, "Request URL", requestUrl);
+        info(methodName, "Expected Response", responseText);
+
+        List<String> actualResponseLines =
+            FATUtilsServer.gatherHttpRequest(FATUtilsServer.HttpRequestMethod.GET, requestUrl);
+        info(methodName, "Actual Response", actualResponseLines);
+
+        List<FATUtilsSpans.CompletedSpan> completedSpans = getCompletedSpans(GET_NESTED_PATH);
+
+        int tailSize = excludingDelay4 ? 5 : 7;
+
+        verifyContiguousSpans(completedSpans, tailSize);
+
+        // *** A root span for the initial get nested request. ***
+
+        String[] getNested1Text = getNestedCondition(1);
+        ParentCondition getNested1Condition = new ParentCondition(
+                FATUtilsSpans.SpanKind.SERVER, null,
+                FATUtilsSpans.SpanKind.SERVER, getNested1Text);
+
+        String[] getDelayed2Text = getDelayedCondition(2);
+        String[] getDelayed4Text = getDelayedCondition(4);
+        String[] getDelayed6Text = getDelayedCondition(6);
+
+        // *** A pair of completed spans for the call from root get nested ***
+        // *** request to the two second delay request. ***
+
+        ParentCondition getDelay2ClientCondition = new ParentCondition(
+                FATUtilsSpans.SpanKind.SERVER, getNested1Text,
+                FATUtilsSpans.SpanKind.CLIENT, getDelayed2Text);
+        ParentCondition getDelay2ContainerCondition = new ParentCondition(
+                FATUtilsSpans.SpanKind.CLIENT, getDelayed2Text,
+                FATUtilsSpans.SpanKind.SERVER, getDelayed2Text);
+
+        // *** A pair of completed spans for the call from root get nested ***
+        // *** request to the four second delay request. ***
+
+        ParentCondition getDelay4ClientCondition = new ParentCondition(
+                FATUtilsSpans.SpanKind.SERVER, getNested1Text,
+                FATUtilsSpans.SpanKind.CLIENT, getDelayed4Text);
+        ParentCondition getDelay4ContainerCondition = new ParentCondition(
+                FATUtilsSpans.SpanKind.CLIENT, getDelayed4Text,
+                FATUtilsSpans.SpanKind.SERVER, getDelayed4Text);
+
+        // *** A pair of completed spans for the call from root get nested ***
+        // *** request to the six second delay request. ***
+
+        ParentCondition getDelay6ClientCondition = new ParentCondition(
+                FATUtilsSpans.SpanKind.SERVER, getNested1Text,
+                FATUtilsSpans.SpanKind.CLIENT, getDelayed6Text);
+        ParentCondition getDelay6ContainerCondition = new ParentCondition(
+                FATUtilsSpans.SpanKind.CLIENT, getDelayed6Text,
+                FATUtilsSpans.SpanKind.SERVER, getDelayed6Text);
+
+        if (excludingDelay4) {
+            verifyParents(
+                          completedSpans, tailSize,
+                          getNested1Condition,
+                          getDelay2ClientCondition, getDelay2ContainerCondition,
+                          getDelay6ClientCondition, getDelay6ContainerCondition);
+        } else {
+            verifyParents(
+                          completedSpans, tailSize,
+                          getNested1Condition,
+                          getDelay2ClientCondition, getDelay2ContainerCondition,
+                          getDelay4ClientCondition, getDelay4ContainerCondition,
+                          getDelay6ClientCondition, getDelay6ContainerCondition);
+        }
+        
+        completedSpans = getCompletedSpans(GET_IMMEDIATE_PATH);
+
+        verifyTracerStateEvent(completedSpans);
+
+        verifyContiguousSpans(completedSpans, 1);
     }
 }

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracingConstants.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracingConstants.java
@@ -51,4 +51,7 @@ public interface FATOpentracingConstants {
 
     // Introspection service API ...
     String GET_TRACER_STATE_PATH = "getTracerState";
+    
+    // 'excludeTest' API
+    String GET_EXCLUDE_TEST_PATH = "excludeTest";
 }

--- a/dev/com.ibm.ws.opentracing_fat/publish/servers/opentracingFATServer1/server.xml
+++ b/dev/com.ibm.ws.opentracing_fat/publish/servers/opentracingFATServer1/server.xml
@@ -19,7 +19,7 @@
   <opentracing>
   	<!-- Test excluding exact relative and absolute URIs -->
   	<excludeSpans pattern="/serviceApp/rest/testService/excludeTest?response=simple" />
-  	<excludeSpans pattern="http://localhost:8010/serviceApp/rest/testService/excludeTest?response=absoluteUri" />
+  	<excludeSpans pattern="http://localhost:${bvt.prop.HTTP_default}/serviceApp/rest/testService/excludeTest?response=absoluteUri" />
   	<excludeSpans pattern="/serviceApp/rest/testService/excludeTest\?response=regexTest[0-9]+" regex="true" />
 
 	<!-- Test excluding wildcard URIs -->

--- a/dev/com.ibm.ws.opentracing_fat/publish/servers/opentracingFATServer1/server.xml
+++ b/dev/com.ibm.ws.opentracing_fat/publish/servers/opentracingFATServer1/server.xml
@@ -15,5 +15,25 @@
   <!-- Turn this on for the FAT: That provides good diagnostics in case -->
   <!-- of a failure, and means that trace code is tested. -->
   <logging traceSpecification="*=audit:com.ibm.ws.opentracing.*=all"/>
+  
+  <opentracing>
+  	<!-- Test excluding exact relative and absolute URIs -->
+  	<excludeSpans pattern="/serviceApp/rest/testService/excludeTest?response=simple" />
+  	<excludeSpans pattern="http://localhost:8010/serviceApp/rest/testService/excludeTest?response=absoluteUri" />
+  	<excludeSpans pattern="/serviceApp/rest/testService/excludeTest\?response=regexTest[0-9]+" regex="true" />
+
+	<!-- Test excluding wildcard URIs -->
+  	<excludeSpans pattern="/serviceApp/rest/testService/excludeTest?response=wildcard*" />
+  	
+  	<!-- Test including a subset of requests that would otherwise be excluded by the above wildcard -->
+  	<includeSpans pattern="/serviceApp/rest/testService/excludeTest?response=wildcardInclude*" />
+
+	<!-- Test excluding nested paths -->
+  	<excludeSpans pattern="/serviceApp/rest/testService/getDelayed?delay=4&amp;response=nestedExcludeTest1*" />
+  	
+  	<!-- Test exclude types -->
+  	<excludeSpans pattern="/serviceApp/rest/testService/excludeTest?response=incomingExcluded" type="INCOMING" />
+  	<excludeSpans pattern="/serviceApp/rest/testService/excludeTest?response=incomingIncluded" type="OUTGOING" />
+  </opentracing>
 
 </server>

--- a/dev/com.ibm.ws.opentracing_fat/test-applications/serviceApp/src/com/ibm/ws/testing/opentracing/service/FATOpentracingConstants.java
+++ b/dev/com.ibm.ws.opentracing_fat/test-applications/serviceApp/src/com/ibm/ws/testing/opentracing/service/FATOpentracingConstants.java
@@ -39,4 +39,7 @@ public interface FATOpentracingConstants {
 
     // Introspection service API ...
     String GET_TRACER_STATE_PATH = "getTracerState";
+    
+    // 'excludeTest' API
+    String GET_EXCLUDE_TEST_PATH = "excludeTest";
 }

--- a/dev/com.ibm.ws.opentracing_fat/test-applications/serviceApp/src/com/ibm/ws/testing/opentracing/service/FATOpentracingService.java
+++ b/dev/com.ibm.ws.opentracing_fat/test-applications/serviceApp/src/com/ibm/ws/testing/opentracing/service/FATOpentracingService.java
@@ -117,8 +117,11 @@ public class FATOpentracingService extends Application implements FATOpentracing
     /**
      * <p>Start a new child span of the active span.</p>
      *
-     * <p>The child span must be finish using {@link #finishChildSpan}
+     * <p>The child span must be finished using {@link #finishChildSpan}
      * before completing the service request which created the span.</p>
+     * 
+     * If there is no active span, the newly created span is made the
+     * active span.
      *
      * @param spanName The name to give the new child span.
      *
@@ -137,8 +140,13 @@ public class FATOpentracingService extends Application implements FATOpentracing
         } else {
             ActiveSpan activeSpan = useTracer.activeSpan();
             Tracer.SpanBuilder spanBuilder = useTracer.buildSpan(spanName);
-            spanBuilder.asChildOf( activeSpan.context() );
+            if (activeSpan != null) {
+                spanBuilder.asChildOf( activeSpan.context() );
+            }
             childSpan = spanBuilder.startManual();
+            if (activeSpan == null) {
+                useTracer.makeActive(childSpan);
+            }
         }
 
         traceReturn(methodName, "ChildSpan", childSpan);
@@ -450,5 +458,14 @@ public class FATOpentracingService extends Application implements FATOpentracing
 
         traceReturn(methodName, "FinalResponse", finalResponse);
         return finalResponse;
+    }
+
+    @GET
+    @Path(GET_EXCLUDE_TEST_PATH)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String excludeTest(@QueryParam(RESPONSE_PARAM_NAME) String responseText) {
+        String methodName = "excludeTest";
+        traceEnterReturn(methodName, "ResponseText", responseText);
+        return responseText;
     }
 }


### PR DESCRIPTION
Add support for excluding and including opentracing spans by URI (see `com.ibm.ws.opentracing.filters.SpanFilter` for the algorithm).