### PR TITLE
callback when queue capacity drops below specified value

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -166,6 +166,25 @@ public interface PolicyExecutor extends ExecutorService {
     PolicyExecutor maxWaitForEnqueue(long ms);
 
     /**
+     * Registers a one-time callback to be invoked asynchronously
+     * when the available remaining capacity of the task queue
+     * drops below the specified minimum.
+     * If a queue size callback is already registered, this replaces
+     * the previous registration.
+     * To unregister an existing callback without replacing,
+     * specify a null value for the callback.
+     * The callback is not guaranteed to be invoked in the case of
+     * available queue capacity being taken away due to shutdown.
+     *
+     * @param minAvailable threshold for minimum available queue capacity
+     *            below which the callback should be notified.
+     * @param callback the callback, or null to unregister.
+     * @return callback that was replaced or removed by the new registration.
+     *         null if no previous callback was in place.
+     */
+    Runnable registerQueueSizeCallback(int minAvailable, Runnable callback);
+
+    /**
      * Applies when using the <code>execute</code> or <code>submit</code> methods. Indicates whether or not to run the task on the
      * caller's thread when the queue is full and the <code>maxWaitForEnqueue</code> has been exceeded.
      * The default value is false, in which case the task submission is rejected after the <code>maxWaitForEnqueue</code> elapses

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -49,6 +49,19 @@ import com.ibm.ws.threading.internal.PolicyTaskFutureImpl.InvokeAnyLatch;
 public class PolicyExecutorImpl implements PolicyExecutor {
     private static final TraceComponent tc = Tr.register(PolicyExecutorImpl.class, "concurrencyPolicy", "com.ibm.ws.threading.internal.resources.ThreadingMessages");
 
+    @Trivial
+    private static class Callback {
+        private final Runnable runnable;
+        private final long threshold;
+
+        private Callback(long threshold, Runnable runnable) {
+            this.runnable = runnable;
+            this.threshold = threshold;
+        }
+    }
+
+    private final AtomicReference<Callback> cbQueueSize = new AtomicReference<Callback>();
+
     /**
      * Use this lock to make a consistent update to both expedite and expeditesAvailable,
      * maxConcurrency and maxConcurrencyConstraint, and to maxQueueSize and maxQueueSizeConstraint.
@@ -428,6 +441,15 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             }
 
             if (haveQueuePermit) {
+                Callback callback = cbQueueSize.get();
+                if (callback != null
+                    && maxQueueSizeConstraint.availablePermits() < callback.threshold
+                    && cbQueueSize.compareAndSet(callback, null)) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "callback: queue capacity < " + callback.threshold, callback.runnable);
+                    globalExecutor.submit(callback.runnable);
+                }
+
                 policyTaskFuture.accept(false);
                 enqueued = queue.offer(policyTaskFuture);
 
@@ -939,16 +961,28 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         else if (max < 1)
             throw new IllegalArgumentException(Integer.toString(max));
 
+        int increase;
         synchronized (configLock) {
             if (state.get() != State.ACTIVE)
                 throw new IllegalStateException(Tr.formatMessage(tc, "CWWKE1203.config.update.after.shutdown", "maxQueueSize", identifier));
 
-            int increase = max - maxQueueSize;
+            increase = max - maxQueueSize;
             if (increase > 0)
                 maxQueueSizeConstraint.release(increase);
             else if (increase < 0)
                 maxQueueSizeConstraint.reducePermits(-increase);
             maxQueueSize = max;
+        }
+
+        if (increase < 0) {
+            Callback callback = cbQueueSize.get();
+            if (callback != null
+                && maxQueueSizeConstraint.availablePermits() < callback.threshold
+                && cbQueueSize.compareAndSet(callback, null)) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "callback: queue capacity < " + callback.threshold, callback.runnable);
+                globalExecutor.submit(callback.runnable);
+            }
         }
 
         return this;
@@ -964,6 +998,20 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                 return this;
 
         throw new IllegalStateException(Tr.formatMessage(tc, "CWWKE1203.config.update.after.shutdown", "maxWaitForEnqueue", identifier));
+    }
+
+    @Override
+    public Runnable registerQueueSizeCallback(int minAvailable, Runnable runnable) {
+        Callback callback = new Callback(minAvailable, runnable);
+        Callback previous = cbQueueSize.getAndSet(callback);
+        if (runnable != null
+            && maxQueueSizeConstraint.availablePermits() < minAvailable
+            && cbQueueSize.compareAndSet(callback, null)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "callback: queue capacity < " + minAvailable, runnable);
+            globalExecutor.submit(runnable);
+        }
+        return previous == null ? null : previous.runnable;
     }
 
     @Override
@@ -1185,7 +1233,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         runIfQueueFull = u_runIfQueueFull;
         startTimeout = u_startTimeout == -1 ? -1 : TimeUnit.MILLISECONDS.toNanos(u_startTimeout);
 
-        int a;
+        int a, queueCapacityAdded;
         synchronized (configLock) {
             a = expeditesAvailable.addAndGet(u_expedite - expedite);
             expedite = u_expedite;
@@ -1197,12 +1245,23 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                 maxConcurrencyConstraint.reducePermits(-increase);
             maxConcurrency = u_max;
 
-            increase = u_maxQueueSize - maxQueueSize;
-            if (increase > 0)
-                maxQueueSizeConstraint.release(increase);
-            else if (increase < 0)
-                maxQueueSizeConstraint.reducePermits(-increase);
+            queueCapacityAdded = u_maxQueueSize - maxQueueSize;
+            if (queueCapacityAdded > 0)
+                maxQueueSizeConstraint.release(queueCapacityAdded);
+            else if (queueCapacityAdded < 0)
+                maxQueueSizeConstraint.reducePermits(-queueCapacityAdded);
             maxQueueSize = u_max;
+        }
+
+        if (queueCapacityAdded < 0) {
+            Callback callback = cbQueueSize.get();
+            if (callback != null
+                && maxQueueSizeConstraint.availablePermits() < callback.threshold
+                && cbQueueSize.compareAndSet(callback, null)) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "callback: queue capacity < " + callback.threshold, callback.runnable);
+                globalExecutor.submit(callback.runnable);
+            }
         }
 
         // Expedite as many of the remaining tasks as the available maxConcurrency permits and increased expedites

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/CountDownCallback.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/CountDownCallback.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * A callback that decrements a latch when it runs.
+ */
+public class CountDownCallback implements Runnable {
+    private final CountDownLatch beginLatch;
+
+    public CountDownCallback(CountDownLatch beginLatch) {
+        this.beginLatch = beginLatch;
+    }
+
+    @Override
+    public void run() {
+        System.out.println("run " + toString());
+        beginLatch.countDown();
+    }
+}

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,7 +42,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -3295,18 +3293,8 @@ public class PolicyExecutorServlet extends FATServlet {
         Future<Boolean> blockerFuture = executor.submit(new CountDownTask(beginLatch, noQueueCapacityRemains, TIMEOUT_NS));
         assertTrue(beginLatch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 
-        // TODO Update in future user story. Temporarily use internals while lacking the callback to decrement the above latch once queue capacity is used up.
-        Field f = executor.getClass().getDeclaredField("maxQueueSizeConstraint");
-        f.setAccessible(true);
-        final Semaphore q = (Semaphore) f.get(executor);
-        testThreads.submit(new Callable<Void>() {
-            @Override
-            public Void call() throws InterruptedException {
-                for (long start = System.nanoTime(); q.availablePermits() > 0 && System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(100));
-                noQueueCapacityRemains.countDown();
-                return null;
-            }
-        });
+        // Register callback to decrement the above latch once queue capacity is used up.
+        assertNull(executor.registerQueueSizeCallback(1, new CountDownCallback(noQueueCapacityRemains)));
 
         // Permit is required and unavailable. Task should be run on global thread pool.
         assertNotSame(curThreadId, executor.invokeAny(oneTask));
@@ -3374,18 +3362,8 @@ public class PolicyExecutorServlet extends FATServlet {
         List<Callable<Integer>> tasks = Arrays.<Callable<Integer>> asList(new SharedIncrementTask(counter), new SharedIncrementTask(counter));
 
         final CountDownLatch noQueueCapacityRemains = new CountDownLatch(1);
-        // TODO Update in future user story. Temporarily use internals while lacking the callback to decrement the above latch once queue capacity is used up.
-        Field f = executor.getClass().getDeclaredField("maxQueueSizeConstraint");
-        f.setAccessible(true);
-        final Semaphore q = (Semaphore) f.get(executor);
-        testThreads.submit(new Callable<Void>() {
-            @Override
-            public Void call() throws InterruptedException {
-                for (long start = System.nanoTime(); q.availablePermits() > 0 && System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(100));
-                noQueueCapacityRemains.countDown();
-                return null;
-            }
-        });
+        // Register a callback to decrement the above latch once queue capacity is used up.
+        assertNull(executor.registerQueueSizeCallback(1, new CountDownCallback(noQueueCapacityRemains)));
 
         Future<List<Runnable>> shutdownFuture = testThreads.submit(new ShutdownTask(executor, true, new CountDownLatch(0), noQueueCapacityRemains, TIMEOUT_NS));
 
@@ -3679,18 +3657,8 @@ public class PolicyExecutorServlet extends FATServlet {
         List<Callable<Integer>> tasks = Arrays.<Callable<Integer>> asList(new SharedIncrementTask(counter), new SharedIncrementTask(counter));
 
         final CountDownLatch noQueueCapacityRemains = new CountDownLatch(1);
-        // TODO Update in future user story. Temporarily use internals while lacking the callback to decrement the above latch once queue capacity is used up.
-        Field f = executor.getClass().getDeclaredField("maxQueueSizeConstraint");
-        f.setAccessible(true);
-        final Semaphore q = (Semaphore) f.get(executor);
-        testThreads.submit(new Callable<Void>() {
-            @Override
-            public Void call() throws InterruptedException {
-                for (long start = System.nanoTime(); q.availablePermits() > 0 && System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(100));
-                noQueueCapacityRemains.countDown();
-                return null;
-            }
-        });
+        // Register a callback to decrement the above latch once queue capacity is used up.
+        assertNull(executor.registerQueueSizeCallback(1, new CountDownCallback(noQueueCapacityRemains)));
 
         Future<List<Runnable>> shutdownFuture = testThreads.submit(new ShutdownTask(executor, true, new CountDownLatch(0), noQueueCapacityRemains, TIMEOUT_NS));
 
@@ -3905,6 +3873,68 @@ public class PolicyExecutorServlet extends FATServlet {
 
         executor.shutdown();
         assertTrue(executor.awaitTermination(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    // Register queue size callbacks with a policy executor. Verify that at most one can be registered,
+    // that the most recently registered replaces any previous ones, and that the queue size callback
+    // can be unregistered by supplying null. Verify that the queue size callback is notified when the
+    // queue size drops below the threshold.
+    @Test
+    public void testQueueSizeCallback() throws Exception {
+        PolicyExecutor executor = provider.create("testQueueSizeCallback")
+                        .maxConcurrency(1)
+                        .maxQueueSize(5);
+
+        CountDownLatch under5Latch = new CountDownLatch(1);
+        Runnable callbackUnder5 = new CountDownCallback(under5Latch);
+        assertNull(executor.registerQueueSizeCallback(5, callbackUnder5));
+        assertEquals(1, under5Latch.getCount());
+
+        // new registration replaces previous
+        CountDownLatch under4Latch = new CountDownLatch(1);
+        Runnable callbackUnder4 = new CountDownCallback(under4Latch);
+        assertEquals(callbackUnder5, executor.registerQueueSizeCallback(4, callbackUnder4));
+        assertEquals(1, under4Latch.getCount());
+
+        // previously registered callback is not invoked
+        CountDownLatch blockerStartedLatch = new CountDownLatch(1);
+        CountDownLatch blockerContinueLatch = new CountDownLatch(1);
+        CountDownTask blockerTask = new CountDownTask(blockerStartedLatch, blockerContinueLatch, TimeUnit.MINUTES.toNanos(8));
+        Future<Boolean> blockerFuture = executor.submit(blockerTask);
+        assertTrue(blockerStartedLatch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(1, under5Latch.getCount());
+        assertEquals(1, under4Latch.getCount());
+
+        // add a task to the queue (will be stuck until blocker completes), such that capacity of 4 remains
+        Future<Integer> queuedFuture1 = executor.submit((Callable<Integer>) new SharedIncrementTask());
+        assertEquals(1, under4Latch.getCount());
+        assertEquals(1, under5Latch.getCount());
+
+        // trigger the active callback (under4Latch) by adding another task to the queue
+        Future<Integer> queuedFuture2 = executor.submit((Callable<Integer>) new SharedIncrementTask());
+        assertTrue(under4Latch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(1, under5Latch.getCount());
+
+        // register another callback
+        CountDownLatch under3Latch = new CountDownLatch(1);
+        Runnable callbackUnder3 = new CountDownCallback(under3Latch);
+        assertNull(executor.registerQueueSizeCallback(3, callbackUnder3));
+        assertEquals(1, under3Latch.getCount());
+
+        // trigger the active callback (under3Latch) by shrinking the queue
+        executor.maxQueueSize(4);
+        assertTrue(under3Latch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(1, under5Latch.getCount());
+
+        // register a callback for a threshold that has already been reached
+        CountDownLatch under6Latch = new CountDownLatch(1);
+        Runnable callbackUnder6 = new CountDownCallback(under6Latch);
+        assertNull(executor.registerQueueSizeCallback(6, callbackUnder6));
+        assertTrue(under6Latch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        List<Runnable> canceledFromQueue = executor.shutdownNow();
+        assertEquals(2, canceledFromQueue.size());
+        assertTrue(blockerFuture.isCancelled());
     }
 
     // Use a policy executor to submit tasks that resubmit themselves to perform a recursive computation.


### PR DESCRIPTION
Allow microprofile to supply a callback to be invoked when remaining queue capacity drops below a specified a value.