### PR TITLE
Update policy executor introspector and add testing

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -1286,6 +1286,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         out.println(INDENT + "maxQueueSize = " + maxQueueSize);
         out.println(INDENT + "maxWaitForEnqueue = " + TimeUnit.NANOSECONDS.toMillis(maxWaitForEnqueueNS.get()) + " ms");
         out.println(INDENT + "runIfQueueFull = " + runIfQueueFull);
+        out.println(INDENT + "startTimeout = " + (startTimeout == -1 ? "None" : TimeUnit.NANOSECONDS.toMillis(startTimeout) + " ms"));
         int numRunningThreads, numRunningPrioritizedThreads;
         synchronized (configLock) {
             numRunningThreads = maxConcurrency - maxConcurrencyConstraint.availablePermits();
@@ -1294,9 +1295,8 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         out.println(INDENT + "Total Enqueued to Global Executor = " + numRunningThreads + " (" + numRunningPrioritizedThreads + " expedited)");
         out.println(INDENT + "withheldConcurrency = " + withheldConcurrency.get());
         out.println(INDENT + "Remaining Queue Capacity = " + maxQueueSizeConstraint.availablePermits());
-        out.println(INDENT + "Created by PolicyExecutorProvider = " + (providerCreated != null));
         out.println(INDENT + "state = " + state.toString());
-        out.println(INDENT + "Running Task Futures: ");
+        out.println(INDENT + "Running Task Futures:");
         if (running.isEmpty()) {
             out.println(DOUBLEINDENT + "None");
         } else {

--- a/dev/com.ibm.ws.threading/test/com/ibm/ws/threading/internal/PolicyExecutorTest.java
+++ b/dev/com.ibm.ws.threading/test/com/ibm/ws/threading/internal/PolicyExecutorTest.java
@@ -10,8 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.threading.internal;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -167,4 +170,38 @@ public class PolicyExecutorTest {
         } catch (IllegalStateException x) {
         } // pass
     }
+
+    /**
+     * Test introspector for policy executors
+     */
+    @Test
+    public void testIntrospector() {
+
+        PolicyExecutorImpl exec = (PolicyExecutorImpl) provider.create("testIntrospector").expedite(5).maxConcurrency(10).maxQueueSize(3).maxWaitForEnqueue(30).startTimeout(10).runIfQueueFull(true);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintWriter pw = new PrintWriter(out);
+        exec.introspect(pw);
+        pw.flush();
+        String output = new String(out.toByteArray());
+
+        String expectedoutput = "PolicyExecutorProvider-testIntrospector\n"
+                                + "  expedite = 5\n"
+                                + "  maxConcurrency = 10 (loose)\n"
+                                + "  maxQueueSize = 3\n"
+                                + "  maxWaitForEnqueue = 30 ms\n"
+                                + "  runIfQueueFull = true\n"
+                                + "  startTimeout = 10 ms\n"
+                                + "  Total Enqueued to Global Executor = 0 (0 expedited)\n"
+                                + "  withheldConcurrency = 0\n"
+                                + "  Remaining Queue Capacity = 3\n"
+                                + "  state = ACTIVE\n"
+                                + "  Running Task Futures:\n"
+                                + "    None\n"
+                                + "  Queued Task Futures (up to first 50):\n"
+                                + "    None\n\n";
+
+        assertEquals("The policy executor introspector output did not match the expected output.", expectedoutput, output);
+    }
+
 }


### PR DESCRIPTION
Update the policy executor introspector to:
1. Include start timeout value
2. Remove mention of whether the policy executor was created by the
PolicyExecutorProvider

Adds a unit test to ensure the output of the introspector matches what is
expected.