### PR TITLE
Update local maven publish with license and scm info plus pom files for ivy download

### DIFF
--- a/dev/cnf/build.bnd
+++ b/dev/cnf/build.bnd
@@ -66,6 +66,15 @@ javac.encoding: UTF-8
 
 buildEngineName: defaultEngine
 
+Bundle-License: \
+  Eclipse Public License; \
+  url=https://www.eclipse.org/legal/epl-v10.html
+
+Bundle-SCM: \
+  connection=scm:git:https://github.com/OpenLiberty/open-liberty.git, \
+  developerConnection=scm:git:https://github.com:OpenLiberty/open-liberty.git, \
+  url=https://github.com/OpenLiberty/open-liberty/tree/master
+
 # This is the version of JUnit that will be used at build time and run time
 junit: org.apache.servicemix.bundles.junit;version="[4.11,5)"
 

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -45,8 +45,14 @@ task createIvyXml {
                         } else {
                             (org, name) = ['dev', bsn]
                         }
-                        depsList = depsList + '        <dependency org="' + org + '" name="' + name + '" rev="' + bndProject.getVersion(bsn) + '"/>\n'
-                        depsListLatest = depsListLatest + '        <dependency org="' + org + '" name="' + name + '" rev="latest.integration"/>\n'
+                        depsList = depsList + '        <dependency org="' + org + '" name="' + name + '" rev="' + bndProject.getVersion(bsn) + '">\n'
+                        depsList = depsList + '          <artifact name="' + name + '" type="jar"/>\n'
+                        depsList = depsList + '          <artifact name="' + name + '" type="pom"/>\n'
+                        depsList = depsList + '        </dependency>\n'
+                        depsListLatest = depsListLatest + '        <dependency org="' + org + '" name="' + name + '" rev="latest.integration">\n'
+                        depsListLatest = depsListLatest + '          <artifact name="' + name + '" type="jar"/>\n'
+                        depsListLatest = depsListLatest + '          <artifact name="' + name + '" type="pom"/>\n'
+                        depsListLatest = depsListLatest + '        </dependency>\n'
                     }
                 }
             }


### PR DESCRIPTION
Add the pom files to the ivy list of artifacts from the Open Liberty build, so they are downloaded with the jar files in dependent ivy builds.

Add the EPL and scm information to the bundles output by the build.