### PR TITLE
Add and test queueCapacityRemaining and getRunningTaskCount methods

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -63,6 +63,13 @@ public interface PolicyExecutor extends ExecutorService {
     PolicyExecutor expedite(int num);
 
     /**
+     * Returns the number of tasks from this PolicyExecutor currently running on the global executor.
+     *
+     * @return the number of running tasks
+     */
+    int getRunningTaskCount();
+
+    /**
      * Submits and invokes a group of tasks with a callback per task to be invoked at various points in the task's life cycle.
      * The first task is paired with the first callback. The second task is paired with the second callback. An so forth.
      * It is okay to include the same callback at multiple positions or to include null callbacks at some positions.
@@ -164,6 +171,13 @@ public interface PolicyExecutor extends ExecutorService {
      * @throws IllegalStateException if the executor has been shut down.
      */
     PolicyExecutor maxWaitForEnqueue(long ms);
+
+    /**
+     * Returns the number of additional tasks that can be enqueued without exceeding the maximum queue size.
+     *
+     * @return remaining capacity in queue
+     */
+    int queueCapacityRemaining();
 
     /**
      * Registers a one-time callback to be invoked asynchronously

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -573,6 +573,11 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     }
 
     @Override
+    public int getRunningTaskCount() {
+        return runningCount.get();
+    }
+
+    @Override
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Trivial
     public final <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
@@ -999,6 +1004,12 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                 return this;
 
         throw new IllegalStateException(Tr.formatMessage(tc, "CWWKE1203.config.update.after.shutdown", "maxWaitForEnqueue", identifier));
+    }
+
+    @Override
+    public int queueCapacityRemaining() {
+        int capacity = maxQueueSizeConstraint.availablePermits();
+        return capacity < 0 ? 0 : capacity;
     }
 
     @Override

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -5682,6 +5682,7 @@ public class PolicyExecutorServlet extends FATServlet {
 
         continueLatch1.countDown(); //allow task1 to complete
         assertTrue(future1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        for (long start = System.nanoTime(); executor.getRunningTaskCount() != 1 && System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(200));
         assertEquals(1, executor.getRunningTaskCount()); //task2 is running
 
         executor.shutdown();
@@ -5689,6 +5690,7 @@ public class PolicyExecutorServlet extends FATServlet {
 
         continueLatch2.countDown(); //allow task2 to complete
         assertTrue(future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        for (long start = System.nanoTime(); executor.getRunningTaskCount() != 0 && System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(200));
         assertEquals(0, executor.getRunningTaskCount()); //no tasks running
     }
 

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -5656,4 +5656,85 @@ public class PolicyExecutorServlet extends FATServlet {
         executor.shutdownNow();
     }
 
+    //Test the getRunningTaskCount method
+    @Test
+    public void testGetRunningTaskCount() throws Exception {
+        PolicyExecutor executor = provider.create("testgetRunningTaskCount").maxConcurrency(2);
+
+        CountDownLatch beginLatch1 = new CountDownLatch(1);
+        CountDownLatch continueLatch1 = new CountDownLatch(1);
+        CountDownLatch beginLatch2 = new CountDownLatch(1);
+        CountDownLatch continueLatch2 = new CountDownLatch(1);
+
+        assertEquals(0, executor.getRunningTaskCount()); //no tasks running
+
+        CountDownTask task1 = new CountDownTask(beginLatch1, continueLatch1, TimeUnit.HOURS.toNanos(1));
+        Future<Boolean> future1 = executor.submit(task1); //task1 will begin running and block on continueLatch1
+        assertTrue(beginLatch1.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        assertEquals(1, executor.getRunningTaskCount()); //task1 is running
+
+        CountDownTask task2 = new CountDownTask(beginLatch2, continueLatch2, TimeUnit.HOURS.toNanos(1));
+        Future<Boolean> future2 = executor.submit(task2); //task2 will begin running and block on continueLatch2
+        assertTrue(beginLatch2.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        assertEquals(2, executor.getRunningTaskCount()); //task1 and task2 are running
+
+        continueLatch1.countDown(); //allow task1 to complete
+        assertTrue(future1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(1, executor.getRunningTaskCount()); //task2 is running
+
+        executor.shutdown();
+        assertEquals(1, executor.getRunningTaskCount()); //task2 is running
+
+        continueLatch2.countDown(); //allow task2 to complete
+        assertTrue(future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(0, executor.getRunningTaskCount()); //no tasks running
+    }
+
+    //Test that testqueueCapacityRemaining is correct as tasks are queued, run, and the maxQueueSize value is changed.
+    @Test
+    public void testQueueCapacityRemaining() throws Exception {
+        PolicyExecutor executor = provider.create("testqueueCapacityRemaining").maxConcurrency(1).maxQueueSize(5);
+
+        CountDownLatch blockingBeginLatch = new CountDownLatch(1);
+        CountDownLatch blockingContinueLatch = new CountDownLatch(1);
+        CountDownLatch beginLatch = new CountDownLatch(1);
+        CountDownLatch continueLatch = new CountDownLatch(1);
+
+        assertEquals(5, executor.queueCapacityRemaining()); //no tasks in queue
+        CountDownTask blockingTask = new CountDownTask(blockingBeginLatch, blockingContinueLatch, TimeUnit.HOURS.toNanos(1));
+        Future<Boolean> blockingFuture = executor.submit(blockingTask); //blockingTask should start and block on continueLatch
+        assertTrue(blockingBeginLatch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(5, executor.queueCapacityRemaining()); //no tasks in queue, maxQueueSize=5
+
+        CountDownTask task1 = new CountDownTask(beginLatch, continueLatch, TimeUnit.HOURS.toNanos(1));
+        Future<Boolean> future1 = executor.submit(task1); // should queue
+        assertEquals(4, executor.queueCapacityRemaining()); //task1 in queue, maxQueueSize=5
+
+        executor.maxQueueSize(6);
+        assertEquals(5, executor.queueCapacityRemaining()); //task 1 in queue, maxQueueSize=6
+
+        executor.maxQueueSize(4);
+        assertEquals(3, executor.queueCapacityRemaining()); //task1 in queue, maxQueueSize=4
+
+        CountDownTask task2 = new CountDownTask(new CountDownLatch(1), new CountDownLatch(0), TimeUnit.HOURS.toNanos(1));
+        Future<Boolean> future2 = executor.submit(task2); // should queue
+        assertEquals(2, executor.queueCapacityRemaining()); //task1 and task2 in queue, maxQueueSize=4
+
+        blockingContinueLatch.countDown(); //allow blockingTask to complete
+        assertTrue(beginLatch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS)); //wait for task1 to begin running
+
+        assertEquals(3, executor.queueCapacityRemaining()); //task2 in queue, maxQueueSize=4
+        continueLatch.countDown(); //allow task1 and task2 to complete
+
+        assertTrue(blockingFuture.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertTrue(future1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertTrue(future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        assertEquals(4, executor.queueCapacityRemaining()); //no tasks in queue, maxQueueSize=4
+
+        executor.shutdown();
+        assertEquals(0, executor.queueCapacityRemaining()); //should return 0 after shutdown
+    }
 }


### PR DESCRIPTION
Implements the queueCapacityRemaining and getRunningTaskCount methods on the PolicyExecutor.  Adds a basic test for each to ensure the correct values are returned.