### PR TITLE
977 use unique ID for WSPrincipal

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/BasicHttpAuthenticationMechanism.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/BasicHttpAuthenticationMechanism.java
@@ -10,28 +10,18 @@
  *******************************************************************************/
 package com.ibm.ws.security.javaeesec.cdi.beans;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.Properties;
-import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.message.callback.PasswordValidationCallback;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
 import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
 import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
 import javax.security.enterprise.credential.BasicAuthenticationCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -39,7 +29,6 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.common.internal.encoder.Base64Coder;
-import com.ibm.ws.security.authentication.AuthenticationConstants;
 import com.ibm.ws.security.javaeesec.properties.ModulePropertiesProvider;
 import com.ibm.ws.security.javaeesec.JavaEESecConstants;
 import com.ibm.wsspi.security.token.AttributeNameConstants;
@@ -121,7 +110,7 @@ public class BasicHttpAuthenticationMechanism implements HttpAuthenticationMecha
 
             if (isAuthorizationHeaderValid(basicAuthHeader)) { // BasicAuthenticationCredential.isValid does not work
                 BasicAuthenticationCredential basicAuthCredential = new BasicAuthenticationCredential(encodedHeader);
-                status = validateUserAndPassword(clientSubject, basicAuthCredential, httpMessageContext);
+                status = Utils.getInstance().validateUserAndPassword(getCDI(), realmName, clientSubject, basicAuthCredential, httpMessageContext);
                 if (status == AuthenticationStatus.SUCCESS) {
                     httpMessageContext.getMessageInfo().getMap().put("javax.servlet.http.authType", "JASPI_AUTH");
                     rspStatus = HttpServletResponse.SC_OK;
@@ -147,149 +136,9 @@ public class BasicHttpAuthenticationMechanism implements HttpAuthenticationMecha
         return !isNotValid;
     }
 
-    private AuthenticationStatus validateUserAndPassword(Subject clientSubject, @Sensitive BasicAuthenticationCredential credential,
-                                                         HttpMessageContext httpMessageContext) throws AuthenticationException {
-        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
-        IdentityStoreHandler identityStoreHandler = getIdentityStoreHandler();
-        if (identityStoreHandler != null) {
-            status = validateWithIdentityStore(clientSubject, credential, identityStoreHandler, httpMessageContext);
-        }
-        if (identityStoreHandler == null || status == AuthenticationStatus.NOT_DONE) {
-            // If an identity store is not available, fall back to the original user registry.
-            status = validateWithUserRegistry(clientSubject, credential, httpMessageContext.getHandler());
-        }
-        return status;
-    }
-
-    @SuppressWarnings("unchecked")
-    private IdentityStoreHandler getIdentityStoreHandler() {
-        IdentityStoreHandler identityStoreHandler = null;
-        Instance<IdentityStoreHandler> storeHandlerInstance = getCDI().select(IdentityStoreHandler.class);
-        if (storeHandlerInstance.isUnsatisfied() == false && storeHandlerInstance.isAmbiguous() == false) {
-            identityStoreHandler = storeHandlerInstance.get();
-        }
-        return identityStoreHandler;
-    }
-
     @SuppressWarnings("rawtypes")
     protected CDI getCDI() {
         return CDI.current();
-    }
-
-    private AuthenticationStatus validateWithIdentityStore(Subject clientSubject, @Sensitive BasicAuthenticationCredential credential, IdentityStoreHandler identityStoreHandler,
-                                                           HttpMessageContext httpMessageContext) {
-        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
-        CredentialValidationResult result = identityStoreHandler.validate(credential);
-        if (result.getStatus() == CredentialValidationResult.Status.VALID) {
-            setLoginHashtable(clientSubject, result);
-            status = AuthenticationStatus.SUCCESS;
-        } else if (result.getStatus() == CredentialValidationResult.Status.NOT_VALIDATED) {
-            status = AuthenticationStatus.NOT_DONE;
-        }
-        return status;
-    }
-
-    private void setLoginHashtable(Subject clientSubject, CredentialValidationResult result) {
-        Hashtable<String, Object> subjectHashtable = getSubjectHashtable(clientSubject);
-        String callerPrincipalName = result.getCallerPrincipal().getName();
-        String callerUniqueId = result.getCallerUniqueId();
-        String realm = result.getIdentityStoreId();
-        realm = realm != null ? realm : realmName;
-        String uniqueId = callerUniqueId != null ? callerUniqueId : callerPrincipalName;
-
-        setCommonAttributes(subjectHashtable, realm, callerPrincipalName);
-        setUniqueId(subjectHashtable, realm, uniqueId);
-        setGroups(subjectHashtable, result.getCallerGroups());
-    }
-
-    private void setCommonAttributes(Hashtable<String, Object> subjectHashtable, String realm, String callerPrincipalName) {
-        subjectHashtable.put(AuthenticationConstants.INTERNAL_ASSERTION_KEY, Boolean.TRUE);
-        subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_REALM, realm);
-        subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_USERID, callerPrincipalName);
-        subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_SECURITYNAME, callerPrincipalName);
-    }
-
-    private void setUniqueId(Hashtable<String, Object> subjectHashtable, String realm, String uniqueId) {
-        subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_UNIQUEID, "user:" + realm + "/" + uniqueId);
-    }
-
-    private void setGroups(Hashtable<String, Object> subjectHashtable, Set<String> groups) {
-        if (groups != null && !groups.isEmpty()) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Adding groups found in an identitystore", groups);
-            }
-            subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_GROUPS, new ArrayList<String>(groups));
-        } else {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "No group  found in an identitystore");
-            }
-            subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_GROUPS, new ArrayList<String>());
-        }
-    }
-
-    private Hashtable<String, Object> getSubjectHashtable(final Subject clientSubject) {
-        Hashtable<String, Object> subjectHashtable = getSubjectExistingHashtable(clientSubject);
-        if (subjectHashtable == null) {
-            subjectHashtable = createNewSubjectHashtable(clientSubject);
-        }
-        return subjectHashtable;
-    }
-
-    private Hashtable<String, Object> getSubjectExistingHashtable(final Subject clientSubject) {
-        if (clientSubject == null) {
-            return null;
-        }
-
-        PrivilegedAction<Hashtable<String, Object>> action = new PrivilegedAction<Hashtable<String, Object>>() {
-
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            @Override
-            public Hashtable<String, Object> run() {
-                Set hashtables = clientSubject.getPrivateCredentials(Hashtable.class);
-                if (hashtables == null || hashtables.isEmpty()) {
-                    if (tc.isDebugEnabled()) {
-                        Tr.debug(tc, "Subject has no Hashtable with custom credentials, return null.");
-                    }
-                    return null;
-                } else {
-                    Hashtable hashtable = (Hashtable) hashtables.iterator().next();
-                    return hashtable;
-                }
-            }
-        };
-        Hashtable<String, Object> cred = AccessController.doPrivileged(action);
-        return cred;
-    }
-
-    private Hashtable<String, Object> createNewSubjectHashtable(final Subject clientSubject) {
-        PrivilegedAction<Hashtable<String, Object>> action = new PrivilegedAction<Hashtable<String, Object>>() {
-
-            @Override
-            public Hashtable<String, Object> run() {
-                Hashtable<String, Object> newCred = new Hashtable<String, Object>();
-                clientSubject.getPrivateCredentials().add(newCred);
-                return newCred;
-            }
-        };
-        return AccessController.doPrivileged(action);
-    }
-
-    private AuthenticationStatus validateWithUserRegistry(Subject clientSubject, @Sensitive BasicAuthenticationCredential credential,
-                                                          CallbackHandler handler) throws AuthenticationException {
-        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
-        if (handler != null) {
-            PasswordValidationCallback pwcb = new PasswordValidationCallback(clientSubject, credential.getCaller(), credential.getPassword().getValue());
-            try {
-                handler.handle(new Callback[] { pwcb });
-                boolean isValidPassword = pwcb.getResult();
-                if (isValidPassword) {
-                    status = AuthenticationStatus.SUCCESS;
-                }
-            } catch (Exception e) {
-                throw new AuthenticationException(e.toString());
-            }
-        }
-        return status;
     }
 
     protected ModulePropertiesProvider getModulePropertiesProvider() {

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/CustomFormAuthenticationMechanism.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/CustomFormAuthenticationMechanism.java
@@ -10,44 +10,24 @@
  *******************************************************************************/
 package com.ibm.ws.security.javaeesec.cdi.beans;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Hashtable;
-import java.util.Map;
-import java.util.Set;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.message.callback.PasswordValidationCallback;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
 import javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters;
 import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
 import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
 import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
-import javax.security.enterprise.credential.BasicAuthenticationCredential;
 import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
-import com.ibm.ws.security.authentication.AuthenticationConstants;
-import com.ibm.wsspi.security.token.AttributeNameConstants;
-
-// TODO: investigate whether HttpMessageContext.isAuthenticationRequest() needs to be implemented.
-// The current code assumes that all of the call to validateRequest with credential is made programmatically,
-// thus there is no consideration for isAuthenticationRequest, but need to make sure whether that's the case.
 
 @Default
 @ApplicationScoped
@@ -64,8 +44,6 @@ public class CustomFormAuthenticationMechanism implements HttpAuthenticationMech
 
         Subject clientSubject = httpMessageContext.getClientSubject();
         @SuppressWarnings("unchecked")
-        Map<String, String> msgMap = httpMessageContext.getMessageInfo().getMap();
-        CallbackHandler handler = httpMessageContext.getHandler();
         HttpServletRequest req = httpMessageContext.getRequest();
         HttpServletResponse rsp = httpMessageContext.getResponse();
         AuthenticationParameters authParams = httpMessageContext.getAuthParameters();
@@ -92,7 +70,7 @@ public class CustomFormAuthenticationMechanism implements HttpAuthenticationMech
                     status = AuthenticationStatus.SEND_CONTINUE;
                 }
             } else {
-                status = handleFormLogin(cred, rsp, msgMap, clientSubject, handler);
+                status = handleFormLogin(cred, rsp, clientSubject, httpMessageContext);
             }
         }
         return status;
@@ -112,161 +90,19 @@ public class CustomFormAuthenticationMechanism implements HttpAuthenticationMech
 
     }
 
-    private AuthenticationStatus handleFormLogin(@Sensitive Credential cred, HttpServletResponse rsp, Map<String, String> msgMap, Subject clientSubject,
-                                                 CallbackHandler handler) throws AuthenticationException {
+    private AuthenticationStatus handleFormLogin(@Sensitive Credential credential, HttpServletResponse rsp, Subject clientSubject,
+                                                 HttpMessageContext httpMessageContext) throws AuthenticationException {
         AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
         int rspStatus = HttpServletResponse.SC_FORBIDDEN;
-        status = validateUserAndPassword(clientSubject, cred, handler);
+        status = Utils.getInstance().validateCredential(getCDI(), "defaultRealm", clientSubject, credential, httpMessageContext);
         if (status == AuthenticationStatus.SUCCESS) {
-            msgMap.put("javax.servlet.http.authType", "JASPI_AUTH");
+            httpMessageContext.getMessageInfo().getMap().put("javax.servlet.http.authType", "JASPI_AUTH");
             rspStatus = HttpServletResponse.SC_OK;
         } else {
             // TODO: Audit invalid user or password
         }
         rsp.setStatus(rspStatus);
         return status;
-    }
-
-    private AuthenticationStatus validateUserAndPassword(Subject clientSubject, @Sensitive Credential credential,
-                                                         CallbackHandler handler) throws AuthenticationException {
-        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
-        IdentityStoreHandler identityStoreHandler = getIdentityStoreHandler();
-        if (identityStoreHandler != null) {
-            status = validateWithIdentityStore(clientSubject, credential, identityStoreHandler, handler);
-        } else {
-            Tr.warning(tc, "JAVAEESEC_CDI_WARNING_NO_IDENTITY_STORE_HANDLER");
-        }
-        if (identityStoreHandler == null || status == AuthenticationStatus.NOT_DONE) {
-            // If an identity store is not available, fall back to the original user registry.
-            status = validateWithUserRegistry(clientSubject, credential, handler);
-        }
-        return status;
-    }
-
-    private AuthenticationStatus validateWithUserRegistry(Subject clientSubject, @Sensitive Credential credential,
-                                                          CallbackHandler handler) throws AuthenticationException {
-        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
-        if (handler != null) {
-            if (isSupportedCredential(credential)) {
-                PasswordValidationCallback pwcb = new PasswordValidationCallback(clientSubject, ((UsernamePasswordCredential) credential).getCaller(), ((UsernamePasswordCredential) credential).getPassword().getValue());
-                try {
-                    handler.handle(new Callback[] { pwcb });
-                    boolean isValidPassword = pwcb.getResult();
-                    if (isValidPassword) {
-                        status = AuthenticationStatus.SUCCESS;
-                    }
-                } catch (Exception e) {
-                    throw new AuthenticationException(e.toString());
-                }
-            } else {
-                // This is an error condition.
-                Tr.error(tc, "JAVAEESEC_CDI_ERROR_UNSUPPORTED_CRED", credential.getClass().getName());
-                String msg = Tr.formatMessage(tc, "JAVAEESEC_CDI_ERROR_UNSUPPORTED_CRED", credential.getClass().getName());
-                throw new AuthenticationException(msg);
-            }
-        }
-        return status;
-    }
-
-    private AuthenticationStatus validateWithIdentityStore(Subject clientSubject, @Sensitive Credential credential, IdentityStoreHandler identityStoreHandler,
-                                                           CallbackHandler handler) throws AuthenticationException {
-        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
-        CredentialValidationResult result = identityStoreHandler.validate(credential);
-        if (result.getStatus() == CredentialValidationResult.Status.VALID) {
-            createLoginHashMap(clientSubject, result);
-            status = AuthenticationStatus.SUCCESS;
-        } else if (result.getStatus() == CredentialValidationResult.Status.NOT_VALIDATED) {
-            // TODO: error message. no identitystore.
-            status = AuthenticationStatus.NOT_DONE;
-        } else {
-            // TODO: Audit invalid user or password
-        }
-        return status;
-    }
-
-    protected void createLoginHashMap(Subject clientSubject, CredentialValidationResult result) throws AuthenticationException {
-        Utils.validateResult(result);
-        Hashtable<String, Object> credData = getSubjectCustomData(clientSubject);
-        Set<String> groups = result.getCallerGroups();
-        String realm = result.getIdentityStoreId();
-        if (realm == null) {
-            realm = "default";
-        }
-        credData.put(AttributeNameConstants.WSCREDENTIAL_REALM, realm);
-        credData.put(AttributeNameConstants.WSCREDENTIAL_USERID, result.getCallerPrincipal().getName());
-        credData.put(AttributeNameConstants.WSCREDENTIAL_SECURITYNAME, result.getCallerUniqueId());
-        credData.put(AttributeNameConstants.WSCREDENTIAL_UNIQUEID, "user:" + realm + "/" + result.getCallerUniqueId());
-
-        credData.put(AuthenticationConstants.INTERNAL_ASSERTION_KEY, Boolean.TRUE);
-        if (groups != null && !groups.isEmpty()) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Adding groups found in an identitystore", groups);
-            }
-            credData.put(AttributeNameConstants.WSCREDENTIAL_GROUPS, new ArrayList<String>(groups));
-        } else {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "No group  found in an identitystore");
-            }
-            credData.put(AttributeNameConstants.WSCREDENTIAL_GROUPS, new ArrayList<String>());
-        }
-        return;
-    }
-
-    protected Hashtable<String, Object> getSubjectCustomData(final Subject clientSubject) {
-        Hashtable<String, Object> cred = getCustomCredentials(clientSubject);
-        if (cred == null) {
-            PrivilegedAction<Hashtable<String, Object>> action = new PrivilegedAction<Hashtable<String, Object>>() {
-
-                @Override
-                public Hashtable<String, Object> run() {
-                    Hashtable<String, Object> newCred = new Hashtable<String, Object>();
-                    clientSubject.getPrivateCredentials().add(newCred);
-                    return newCred;
-                }
-            };
-            cred = AccessController.doPrivileged(action);
-        }
-        return cred;
-    }
-
-    protected Hashtable<String, Object> getCustomCredentials(final Subject clientSubject) {
-        if (clientSubject == null)
-            return null;
-        PrivilegedAction<Hashtable<String, Object>> action = new PrivilegedAction<Hashtable<String, Object>>() {
-
-            @SuppressWarnings("unchecked")
-            @Override
-            public Hashtable<String, Object> run() {
-                Set s = clientSubject.getPrivateCredentials(Hashtable.class);
-                if (s == null || s.isEmpty()) {
-                    if (tc.isDebugEnabled())
-                        Tr.debug(tc, "Subject has no Hashtable with custom credentials, return null.");
-                    return null;
-                } else {
-                    Hashtable t = (Hashtable) s.iterator().next();
-                    return t;
-                }
-            }
-        };
-        Hashtable<String, Object> cred = AccessController.doPrivileged(action);
-        return cred;
-    }
-
-    private IdentityStoreHandler getIdentityStoreHandler() {
-        IdentityStoreHandler identityStoreHandler = null;
-        Instance<IdentityStoreHandler> storeHandlerInstance = getCDI().select(IdentityStoreHandler.class);
-        if (storeHandlerInstance.isUnsatisfied() == false && storeHandlerInstance.isAmbiguous() == false) {
-            identityStoreHandler = storeHandlerInstance.get();
-        }
-        return identityStoreHandler;
-    }
-
-    private boolean isSupportedCredential(@Sensitive Credential cred) {
-        if (cred != null && (cred instanceof UsernamePasswordCredential || cred instanceof BasicAuthenticationCredential)) {
-            return true;
-        } else {
-            return false;
-        }
     }
 
     protected CDI getCDI() {

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/FormAuthenticationMechanism.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/FormAuthenticationMechanism.java
@@ -10,37 +10,24 @@
  *******************************************************************************/
 package com.ibm.ws.security.javaeesec.cdi.beans;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.Map;
-import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
-import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.message.callback.PasswordValidationCallback;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
 import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
 import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
 import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
-import com.ibm.ws.security.authentication.AuthenticationConstants;
-import com.ibm.wsspi.security.token.AttributeNameConstants;
 
 @Default
 @ApplicationScoped
@@ -57,8 +44,6 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
 
         Subject clientSubject = httpMessageContext.getClientSubject();
         @SuppressWarnings("unchecked")
-        Map<String, String> msgMap = httpMessageContext.getMessageInfo().getMap();
-        CallbackHandler handler = httpMessageContext.getHandler();
         HttpServletRequest req = httpMessageContext.getRequest();
         HttpServletResponse rsp = httpMessageContext.getResponse();
         String username = null;
@@ -80,7 +65,7 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
 
         if (httpMessageContext.isAuthenticationRequest()) {
             if (username != null && password != null) {
-                status = handleFormLogin(username, password, rsp, msgMap, clientSubject, handler);
+                status = handleFormLogin(username, password, rsp, clientSubject, httpMessageContext);
             } else {
                 status = AuthenticationStatus.SEND_CONTINUE;
             }
@@ -95,7 +80,7 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
                     status = AuthenticationStatus.SEND_CONTINUE;
                 }
             } else {
-                status = handleFormLogin(username, password, rsp, msgMap, clientSubject, handler);
+                status = handleFormLogin(username, password, rsp, clientSubject, httpMessageContext);
             }
         }
 
@@ -120,151 +105,20 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
      * note that both username and password should not be null.
      */
 
-    private AuthenticationStatus handleFormLogin(String username, @Sensitive String password, HttpServletResponse rsp, Map<String, String> msgMap, Subject clientSubject,
-                                                 CallbackHandler handler) throws AuthenticationException {
+    private AuthenticationStatus handleFormLogin(String username, @Sensitive String password, HttpServletResponse rsp, Subject clientSubject,
+                                                 HttpMessageContext httpMessageContext) throws AuthenticationException {
         AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
         int rspStatus = HttpServletResponse.SC_FORBIDDEN;
         UsernamePasswordCredential credential = new UsernamePasswordCredential(username, password);
-        status = validateUserAndPassword(clientSubject, credential, handler);
+        status = Utils.getInstance().validateUserAndPassword(getCDI(), "defaultRealm", clientSubject, credential, httpMessageContext);
         if (status == AuthenticationStatus.SUCCESS) {
-            msgMap.put("javax.servlet.http.authType", "JASPI_AUTH");
+            httpMessageContext.getMessageInfo().getMap().put("javax.servlet.http.authType", "JASPI_AUTH");
             rspStatus = HttpServletResponse.SC_OK;
         } else {
             // TODO: Audit invalid user or password
         }
         rsp.setStatus(rspStatus);
         return status;
-    }
-
-    private AuthenticationStatus validateUserAndPassword(Subject clientSubject, @Sensitive UsernamePasswordCredential credential,
-                                                         CallbackHandler handler) throws AuthenticationException {
-        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
-        IdentityStoreHandler identityStoreHandler = getIdentityStoreHandler();
-        if (identityStoreHandler != null) {
-            status = validateWithIdentityStore(clientSubject, credential, identityStoreHandler);
-        } else {
-            Tr.warning(tc, "JAVAEESEC_CDI_WARNING_NO_IDENTITY_STORE_HANDLER");
-        }
-        if (identityStoreHandler == null || status == AuthenticationStatus.NOT_DONE) {
-            // If an identity store is not available, fall back to the original user registry.
-            status = validateWithUserRegistry(clientSubject, credential, handler);
-        }
-        return status;
-    }
-
-    private AuthenticationStatus validateWithUserRegistry(Subject clientSubject, @Sensitive UsernamePasswordCredential credential,
-                                                          CallbackHandler handler) throws AuthenticationException {
-        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
-        if (handler != null) {
-            PasswordValidationCallback pwcb = new PasswordValidationCallback(clientSubject, credential.getCaller(), credential.getPassword().getValue());
-            try {
-                handler.handle(new Callback[] { pwcb });
-                boolean isValidPassword = pwcb.getResult();
-                if (isValidPassword) {
-                    status = AuthenticationStatus.SUCCESS;
-                }
-            } catch (Exception e) {
-                throw new AuthenticationException(e.toString());
-            }
-        } else {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "A CallbackHandler object, which is required for validating user id and password, is null.");
-            }
-        }
-        return status;
-    }
-
-    private AuthenticationStatus validateWithIdentityStore(Subject clientSubject, @Sensitive UsernamePasswordCredential credential,
-                                                           IdentityStoreHandler identityStoreHandler) throws AuthenticationException {
-        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
-        CredentialValidationResult result = identityStoreHandler.validate(credential);
-        if (result.getStatus() == CredentialValidationResult.Status.VALID) {
-            createLoginHashMap(clientSubject, result);
-            status = AuthenticationStatus.SUCCESS;
-        } else if (result.getStatus() == CredentialValidationResult.Status.NOT_VALIDATED) {
-            // TODO: error message. no identitystore.
-            status = AuthenticationStatus.NOT_DONE;
-        } else {
-            // TODO: Audit invalid user or password
-        }
-        return status;
-    }
-
-    protected void createLoginHashMap(Subject clientSubject, CredentialValidationResult result) throws AuthenticationException {
-        Utils.validateResult(result);
-        Hashtable<String, Object> credData = getSubjectCustomData(clientSubject);
-        Set<String> groups = result.getCallerGroups();
-        String realm = result.getIdentityStoreId();
-        if (realm == null) {
-            realm = "default";
-        }
-        credData.put(AttributeNameConstants.WSCREDENTIAL_REALM, realm);
-        credData.put(AttributeNameConstants.WSCREDENTIAL_USERID, result.getCallerPrincipal().getName());
-        credData.put(AttributeNameConstants.WSCREDENTIAL_SECURITYNAME, result.getCallerUniqueId());
-        credData.put(AttributeNameConstants.WSCREDENTIAL_UNIQUEID, "user:" + realm + "/" + result.getCallerUniqueId());
-
-        credData.put(AuthenticationConstants.INTERNAL_ASSERTION_KEY, Boolean.TRUE);
-        if (groups != null && !groups.isEmpty()) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Adding groups found in an identitystore", groups);
-            }
-            credData.put(AttributeNameConstants.WSCREDENTIAL_GROUPS, new ArrayList<String>(groups));
-        } else {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "No group  found in an identitystore");
-            }
-            credData.put(AttributeNameConstants.WSCREDENTIAL_GROUPS, new ArrayList<String>());
-        }
-        return;
-    }
-
-    protected Hashtable<String, Object> getSubjectCustomData(final Subject clientSubject) {
-        Hashtable<String, Object> cred = getCustomCredentials(clientSubject);
-        if (cred == null) {
-            PrivilegedAction<Hashtable<String, Object>> action = new PrivilegedAction<Hashtable<String, Object>>() {
-
-                @Override
-                public Hashtable<String, Object> run() {
-                    Hashtable<String, Object> newCred = new Hashtable<String, Object>();
-                    clientSubject.getPrivateCredentials().add(newCred);
-                    return newCred;
-                }
-            };
-            cred = AccessController.doPrivileged(action);
-        }
-        return cred;
-    }
-
-    protected Hashtable<String, Object> getCustomCredentials(final Subject clientSubject) {
-        if (clientSubject == null)
-            return null;
-        PrivilegedAction<Hashtable<String, Object>> action = new PrivilegedAction<Hashtable<String, Object>>() {
-
-            @SuppressWarnings("unchecked")
-            @Override
-            public Hashtable<String, Object> run() {
-                Set s = clientSubject.getPrivateCredentials(Hashtable.class);
-                if (s == null || s.isEmpty()) {
-                    if (tc.isDebugEnabled())
-                        Tr.debug(tc, "Subject has no Hashtable with custom credentials, return null.");
-                    return null;
-                } else {
-                    Hashtable t = (Hashtable) s.iterator().next();
-                    return t;
-                }
-            }
-        };
-        Hashtable<String, Object> cred = AccessController.doPrivileged(action);
-        return cred;
-    }
-
-    private IdentityStoreHandler getIdentityStoreHandler() {
-        IdentityStoreHandler identityStoreHandler = null;
-        Instance<IdentityStoreHandler> storeHandlerInstance = getCDI().select(IdentityStoreHandler.class);
-        if (storeHandlerInstance != null && storeHandlerInstance.isUnsatisfied() == false && storeHandlerInstance.isAmbiguous() == false) {
-            identityStoreHandler = storeHandlerInstance.get();
-        }
-        return identityStoreHandler;
     }
 
     protected CDI getCDI() {

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/Utils.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/Utils.java
@@ -10,19 +10,48 @@
  *******************************************************************************/
 package com.ibm.ws.security.javaeesec.cdi.beans;
 
+import java.security.AccessController;
 import java.security.Principal;
+import java.security.PrivilegedAction;
 
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.Set;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.Subject;
+import javax.security.auth.message.callback.PasswordValidationCallback;
 import javax.security.enterprise.AuthenticationException;
+import javax.security.enterprise.AuthenticationStatus;
+import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import javax.security.enterprise.credential.BasicAuthenticationCredential;
+import javax.security.enterprise.credential.Credential;
+import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
+import javax.security.enterprise.identitystore.IdentityStoreHandler;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.ws.security.authentication.AuthenticationConstants;
+import com.ibm.ws.security.javaeesec.JavaEESecConstants;
+import com.ibm.wsspi.security.token.AttributeNameConstants;
 
 public class Utils {
 
     private static final TraceComponent tc = Tr.register(Utils.class);
+    private static Utils self = new Utils();
 
-    public static boolean validateResult(CredentialValidationResult result) throws AuthenticationException {
+    protected Utils() {}
+
+    public static Utils getInstance() {
+        return self;
+    }
+
+    protected boolean validateResult(CredentialValidationResult result) throws AuthenticationException {
         Principal principal = result.getCallerPrincipal();
         String username = null;
         if (principal != null) {
@@ -39,5 +68,167 @@ public class Utils {
             throw new AuthenticationException(msg);
         }
         return true;
+    }
+
+    protected AuthenticationStatus validateUserAndPassword(CDI cdi, String realmName, Subject clientSubject, @Sensitive UsernamePasswordCredential credential,
+                                                         HttpMessageContext httpMessageContext) throws AuthenticationException {
+        return validateCredential(cdi, realmName, clientSubject, credential, httpMessageContext);
+    }
+
+    protected AuthenticationStatus validateCredential(CDI cdi, String realmName, Subject clientSubject, @Sensitive Credential credential,
+                                                         HttpMessageContext httpMessageContext) throws AuthenticationException {
+        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
+        IdentityStoreHandler identityStoreHandler = getIdentityStoreHandler(cdi);
+        if (identityStoreHandler != null) {
+            status = validateWithIdentityStore(realmName, clientSubject, credential, identityStoreHandler, httpMessageContext);
+        } else {
+            Tr.warning(tc, "JAVAEESEC_CDI_WARNING_NO_IDENTITY_STORE_HANDLER");
+        }
+        if (identityStoreHandler == null || status == AuthenticationStatus.NOT_DONE) {
+            // If an identity store is not available, fall back to the original user registry.
+            status = Utils.getInstance().validateWithUserRegistry(clientSubject, credential, httpMessageContext.getHandler());
+        }
+        return status;
+    }
+
+    private AuthenticationStatus validateWithIdentityStore(String realmName, Subject clientSubject, @Sensitive Credential credential, IdentityStoreHandler identityStoreHandler,
+                                                           HttpMessageContext httpMessageContext) {
+        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
+        CredentialValidationResult result = identityStoreHandler.validate(credential);
+        if (result.getStatus() == CredentialValidationResult.Status.VALID) {
+            setLoginHashtable(realmName, clientSubject, result);
+            status = AuthenticationStatus.SUCCESS;
+        } else if (result.getStatus() == CredentialValidationResult.Status.NOT_VALIDATED) {
+            status = AuthenticationStatus.NOT_DONE;
+        }
+        return status;
+    }
+    private AuthenticationStatus validateWithUserRegistry(Subject clientSubject, @Sensitive Credential credential,
+                                                          CallbackHandler handler) throws AuthenticationException {
+        AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
+        if (handler != null) {
+            if (isSupportedCredential(credential)) {
+                PasswordValidationCallback pwcb = new PasswordValidationCallback(clientSubject, ((UsernamePasswordCredential) credential).getCaller(), ((UsernamePasswordCredential) credential).getPassword().getValue());
+                try {
+                    handler.handle(new Callback[] { pwcb });
+                    boolean isValidPassword = pwcb.getResult();
+                    if (isValidPassword) {
+                        status = AuthenticationStatus.SUCCESS;
+                    }
+                } catch (Exception e) {
+                    throw new AuthenticationException(e.toString());
+                }
+            } else {
+                // This is an error condition.
+                Tr.error(tc, "JAVAEESEC_CDI_ERROR_UNSUPPORTED_CRED", credential.getClass().getName());
+                String msg = Tr.formatMessage(tc, "JAVAEESEC_CDI_ERROR_UNSUPPORTED_CRED", credential.getClass().getName());
+                throw new AuthenticationException(msg);
+            }
+        }
+        return status;
+    }
+
+    private void setLoginHashtable(String realmName, Subject clientSubject, CredentialValidationResult result) {
+        Hashtable<String, Object> subjectHashtable = getSubjectHashtable(clientSubject);
+        String callerPrincipalName = result.getCallerPrincipal().getName();
+        String callerUniqueId = result.getCallerUniqueId();
+        String realm = result.getIdentityStoreId();
+        realm = realm != null ? realm : realmName;
+        String uniqueId = callerUniqueId != null ? callerUniqueId : callerPrincipalName;
+
+        setCommonAttributes(subjectHashtable, realm, callerPrincipalName);
+        setUniqueId(subjectHashtable, realm, uniqueId);
+        setGroups(subjectHashtable, result.getCallerGroups());
+    }
+
+    private void setCommonAttributes(Hashtable<String, Object> subjectHashtable, String realm, String callerPrincipalName) {
+        subjectHashtable.put(AuthenticationConstants.INTERNAL_ASSERTION_KEY, Boolean.TRUE);
+        subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_REALM, realm);
+        subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_USERID, callerPrincipalName);
+        subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_SECURITYNAME, callerPrincipalName);
+    }
+
+    private void setUniqueId(Hashtable<String, Object> subjectHashtable, String realm, String uniqueId) {
+        subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_UNIQUEID, "user:" + realm + "/" + uniqueId);
+    }
+
+    private void setGroups(Hashtable<String, Object> subjectHashtable, Set<String> groups) {
+        if (groups != null && !groups.isEmpty()) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Adding groups found in an identitystore", groups);
+            }
+            subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_GROUPS, new ArrayList<String>(groups));
+        } else {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "No group  found in an identitystore");
+            }
+            subjectHashtable.put(AttributeNameConstants.WSCREDENTIAL_GROUPS, new ArrayList<String>());
+        }
+    }
+
+
+    private Hashtable<String, Object> getSubjectHashtable(final Subject clientSubject) {
+        Hashtable<String, Object> subjectHashtable = getSubjectExistingHashtable(clientSubject);
+        if (subjectHashtable == null) {
+            subjectHashtable = createNewSubjectHashtable(clientSubject);
+        }
+        return subjectHashtable;
+    }
+
+    private Hashtable<String, Object> getSubjectExistingHashtable(final Subject clientSubject) {
+        if (clientSubject == null) {
+            return null;
+        }
+
+        PrivilegedAction<Hashtable<String, Object>> action = new PrivilegedAction<Hashtable<String, Object>>() {
+
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            @Override
+            public Hashtable<String, Object> run() {
+                Set hashtables = clientSubject.getPrivateCredentials(Hashtable.class);
+                if (hashtables == null || hashtables.isEmpty()) {
+                    if (tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Subject has no Hashtable with custom credentials, return null.");
+                    }
+                    return null;
+                } else {
+                    Hashtable hashtable = (Hashtable) hashtables.iterator().next();
+                    return hashtable;
+                }
+            }
+        };
+        Hashtable<String, Object> cred = AccessController.doPrivileged(action);
+        return cred;
+    }
+
+    private Hashtable<String, Object> createNewSubjectHashtable(final Subject clientSubject) {
+        PrivilegedAction<Hashtable<String, Object>> action = new PrivilegedAction<Hashtable<String, Object>>() {
+
+            @Override
+            public Hashtable<String, Object> run() {
+                Hashtable<String, Object> newCred = new Hashtable<String, Object>();
+                clientSubject.getPrivateCredentials().add(newCred);
+                return newCred;
+            }
+        };
+        return AccessController.doPrivileged(action);
+    }
+
+    @SuppressWarnings("unchecked")
+    private IdentityStoreHandler getIdentityStoreHandler(CDI cdi) {
+        IdentityStoreHandler identityStoreHandler = null;
+        Instance<IdentityStoreHandler> storeHandlerInstance = cdi.select(IdentityStoreHandler.class);
+        if (storeHandlerInstance.isUnsatisfied() == false && storeHandlerInstance.isAmbiguous() == false) {
+            identityStoreHandler = storeHandlerInstance.get();
+        }
+        return identityStoreHandler;
+    }
+
+    private boolean isSupportedCredential(@Sensitive Credential cred) {
+        if (cred != null && (cred instanceof UsernamePasswordCredential || cred instanceof BasicAuthenticationCredential)) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/beans/FormAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/beans/FormAuthenticationMechanismTest.java
@@ -135,7 +135,7 @@ public class FormAuthenticationMechanismTest {
     @Test
     public void testValidateRequestAuthReqFalseValidIdAndPWIdentityStoreHandler() throws Exception {
         IdentityStoreHandler mish = new MyIdentityStoreHandler();
-        withMessageContext(ch).withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(false).withBeanInstance(mish).withSetStatusToResponse(HttpServletResponse.SC_OK);
+        withMessageContext().withMessageInfo().withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(false).withBeanInstance(mish).withSetStatusToResponse(HttpServletResponse.SC_OK);
 
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be SUCCESS", AuthenticationStatus.SUCCESS, status);
@@ -147,7 +147,7 @@ public class FormAuthenticationMechanismTest {
     @Test
     public void testValidateRequestAuthReqFalseInvalidIdAndPWIdentityStoreHandler() throws Exception {
         IdentityStoreHandler mish = new MyIdentityStoreHandler();
-        withMessageContext(ch).withUsernamePassword(USER1, "invalid").withAuthenticationRequest(false).withBeanInstance(mish).withSetStatusToResponse(HttpServletResponse.SC_FORBIDDEN);
+        withMessageContext().withUsernamePassword(USER1, "invalid").withAuthenticationRequest(false).withBeanInstance(mish).withSetStatusToResponse(HttpServletResponse.SC_FORBIDDEN);
 
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be SEND_FAILURE", AuthenticationStatus.SEND_FAILURE, status);
@@ -160,7 +160,7 @@ public class FormAuthenticationMechanismTest {
     @Test
     public void testValidateRequestAuthReqFalseValidIdAndPWNoIdentityStoreHandlerCallbackHandler() throws Exception {
         final MyCallbackHandler mch = new MyCallbackHandler();
-        withMessageContext(mch).withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(false).withBeanInstance(null).withSetStatusToResponse(HttpServletResponse.SC_OK);
+        withMessageContext().withHandler(mch).withMessageInfo().withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(false).withBeanInstance(null).withSetStatusToResponse(HttpServletResponse.SC_OK);
 
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be SUCCESS", AuthenticationStatus.SUCCESS, status);
@@ -172,7 +172,7 @@ public class FormAuthenticationMechanismTest {
     @Test
     public void testValidateRequestAuthReqFalseInvalidIdAndPWNoIdentityStoreHandlerCallbackHandler() throws Exception {
         final MyCallbackHandler mch = new MyCallbackHandler();
-        withMessageContext(mch).withUsernamePassword(USER1, "invalid").withAuthenticationRequest(false).withBeanInstance(null).withSetStatusToResponse(HttpServletResponse.SC_FORBIDDEN);
+        withMessageContext().withHandler(mch).withUsernamePassword(USER1, "invalid").withAuthenticationRequest(false).withBeanInstance(null).withSetStatusToResponse(HttpServletResponse.SC_FORBIDDEN);
 
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be SEND_FAILURE", AuthenticationStatus.SEND_FAILURE, status);
@@ -184,7 +184,7 @@ public class FormAuthenticationMechanismTest {
     @Test
     public void testValidateRequestAuthReqTrueValidIdAndPWIdentityStoreHandler() throws Exception {
         IdentityStoreHandler mish = new MyIdentityStoreHandler();
-        withMessageContext(ch).withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(true).withBeanInstance(mish).withSetStatusToResponse(HttpServletResponse.SC_OK);
+        withMessageContext().withMessageInfo().withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(true).withBeanInstance(mish).withSetStatusToResponse(HttpServletResponse.SC_OK);
 
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be SUCCESS", AuthenticationStatus.SUCCESS, status);
@@ -196,7 +196,7 @@ public class FormAuthenticationMechanismTest {
     @Test
     public void testValidateRequestAuthReqTrueInvalidIdAndPWIdentityStoreHandler() throws Exception {
         IdentityStoreHandler mish = new MyIdentityStoreHandler();
-        withMessageContext(ch).withUsernamePassword(USER1, "invalid").withAuthenticationRequest(true).withBeanInstance(mish).withSetStatusToResponse(HttpServletResponse.SC_FORBIDDEN);
+        withMessageContext().withUsernamePassword(USER1, "invalid").withAuthenticationRequest(true).withBeanInstance(mish).withSetStatusToResponse(HttpServletResponse.SC_FORBIDDEN);
 
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be SEND_FAILURE", AuthenticationStatus.SEND_FAILURE, status);
@@ -209,7 +209,7 @@ public class FormAuthenticationMechanismTest {
     @Test
     public void testValidateRequestAuthReqTrueValidIdAndPWNoIdentityStoreHandlerCallbackHandler() throws Exception {
         final MyCallbackHandler mch = new MyCallbackHandler();
-        withMessageContext(mch).withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(true).withBeanInstance(null).withSetStatusToResponse(HttpServletResponse.SC_OK);
+        withMessageContext().withMessageInfo().withHandler(mch).withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(true).withBeanInstance(null).withSetStatusToResponse(HttpServletResponse.SC_OK);
 
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be SUCCESS", AuthenticationStatus.SUCCESS, status);
@@ -221,7 +221,7 @@ public class FormAuthenticationMechanismTest {
     @Test
     public void testValidateRequestAuthReqTrueInvalidIdAndPWNoIdentityStoreHandlerCallbackHandler() throws Exception {
         final MyCallbackHandler mch = new MyCallbackHandler();
-        withMessageContext(mch).withUsernamePassword(USER1, "invalid").withAuthenticationRequest(true).withBeanInstance(null).withSetStatusToResponse(HttpServletResponse.SC_FORBIDDEN);
+        withMessageContext().withHandler(mch).withUsernamePassword(USER1, "invalid").withAuthenticationRequest(true).withBeanInstance(null).withSetStatusToResponse(HttpServletResponse.SC_FORBIDDEN);
 
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be SEND_FAILURE", AuthenticationStatus.SEND_FAILURE, status);
@@ -234,7 +234,7 @@ public class FormAuthenticationMechanismTest {
     public void testValidateRequestAuthReqTrueValidIdAndPWNoIdentityStoreHandlerCallbackHandlerException() throws Exception {
         final String msg = "An Exception by CallbackHandler";
         IOException ex = new IOException(msg);
-        withMessageContext(ch).withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(true).withBeanInstance(null).withCallbackHandlerException(ex);
+        withMessageContext().withHandler(ch).withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(true).withBeanInstance(null).withCallbackHandlerException(ex);
 
         try {
             AuthenticationStatus status = fam.validateRequest(req, res, hmc);
@@ -250,7 +250,7 @@ public class FormAuthenticationMechanismTest {
      */
     @Test
     public void testValidateRequestAuthReqTrueValidIdAndPWNoIdentityStoreHandlerNoCallbackHandler() throws Exception {
-        withMessageContext(null).withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(true).withBeanInstance(null).withSetStatusToResponse(HttpServletResponse.SC_FORBIDDEN);
+        withMessageContext().withHandler(null).withUsernamePassword(USER1, PASSWORD1).withAuthenticationRequest(true).withBeanInstance(null).withSetStatusToResponse(HttpServletResponse.SC_FORBIDDEN);
 
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
     }
@@ -260,7 +260,7 @@ public class FormAuthenticationMechanismTest {
      */
     @Test
     public void testValidateRequestAuthReqFalseNoIdAndPWProtectedTrue() throws Exception {
-        withMessageContext(ch).withUsernamePassword(null, null).withAuthenticationRequest(false).withProtected(true);
+        withMessageContext().withUsernamePassword(null, null).withAuthenticationRequest(false).withProtected(true);
  
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be SEND_CONTINUE", AuthenticationStatus.SEND_CONTINUE, status);
@@ -271,7 +271,7 @@ public class FormAuthenticationMechanismTest {
      */
     @Test
     public void testValidateRequestAuthReqFalseNoIdAndPWProtectedFalse() throws Exception {
-        withMessageContext(ch).withUsernamePassword(null, null).withAuthenticationRequest(false).withProtected(false);
+        withMessageContext().withUsernamePassword(null, null).withAuthenticationRequest(false).withProtected(false);
  
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be NOT_DONE", AuthenticationStatus.NOT_DONE, status);
@@ -282,7 +282,7 @@ public class FormAuthenticationMechanismTest {
      */
     @Test
     public void testValidateRequestAuthReqTrueNoIdAndPW() throws Exception {
-        withMessageContext(ch).withUsernamePassword(null, null).withAuthenticationRequest(true);
+        withMessageContext().withUsernamePassword(null, null).withAuthenticationRequest(true);
  
         AuthenticationStatus status = fam.validateRequest(req, res, hmc);
         assertEquals("The result should be SEND_CONTINUE", AuthenticationStatus.SEND_CONTINUE, status);
@@ -309,7 +309,23 @@ public class FormAuthenticationMechanismTest {
     }
 
     @SuppressWarnings("unchecked")
-    private FormAuthenticationMechanismTest withMessageContext(final CallbackHandler handler) throws Exception {
+    private FormAuthenticationMechanismTest withMessageContext() throws Exception {
+        
+        mockery.checking(new Expectations() {
+            {
+                one(hmc).getClientSubject();
+                will(returnValue(cs));
+                one(hmc).getRequest();
+                will(returnValue(req));
+                one(hmc).getResponse();
+                will(returnValue(res));
+            }
+        });
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    private FormAuthenticationMechanismTest withMessageInfo() throws Exception {
         
         mockery.checking(new Expectations() {
             {
@@ -317,14 +333,18 @@ public class FormAuthenticationMechanismTest {
                 will(returnValue(mi));
                 one(mi).getMap();
                 will(returnValue(mm));
-                one(hmc).getClientSubject();
-                will(returnValue(cs));
+            }
+        });
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    private FormAuthenticationMechanismTest withHandler(final CallbackHandler handler) throws Exception {
+        
+        mockery.checking(new Expectations() {
+            {
                 one(hmc).getHandler();
                 will(returnValue(handler));
-                one(hmc).getRequest();
-                will(returnValue(req));
-                one(hmc).getResponse();
-                will(returnValue(res));
             }
         });
         return this;


### PR DESCRIPTION
Based on the specification, WSPrincipal needs to be the same as CallerPrincipal.getName(). Although this will introduce an inconsistency with the original Liberty behavior, the only way to preserve the original ID (short ID, or callerPrincipal) is to set this value as a WSPrincipal. 
So, both Custom and Form HAMs are modified to do the same as BasicAuth HAM, along with refactoring the way to authenticate the user. Now all container provided HAMs are using the same logic for constructing Subject.
