### PR TITLE
Provide an option to set a 400 status code instead of 500 if the request

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
@@ -303,7 +303,7 @@ public class WCCustomProperties {
     
     //start 17.0.0.4
     public static boolean USE_ORIGINAL_QS_IN_FORWARD_IF_NULL; //PI81569
-
+    public static boolean SET_400_SC_ON_TOO_MANY_PARENT_DIRS;//PI80786
     static {
         setCustomPropertyVariables(); //initilizes all the variables
     }
@@ -393,6 +393,7 @@ public class WCCustomProperties {
         WCCustomProperties.FullyQualifiedPropertiesMap.put("usemaxrequestsizeformultipart", "com.ibm.ws.webcontainer.usemaxrequestsizeformultipart"); //PI75528
         WCCustomProperties.FullyQualifiedPropertiesMap.put("enablemultireadofpostdata", "com.ibm.ws.webcontainer.enablemultireadofpostdata");
         WCCustomProperties.FullyQualifiedPropertiesMap.put("useoriginalqsinforwardifnull", "com.ibm.ws.webcontainer.useoriginalqsinforwardifnull"); //PI81569
+        WCCustomProperties.FullyQualifiedPropertiesMap.put("set400scontoomanyparentdirs", "com.ibm.ws.webcontainer.set400scontoomanyparentdirs"); //PI80786
     }
 
     //some properties require "com.ibm.ws.webcontainer." on the front
@@ -769,7 +770,9 @@ public class WCCustomProperties {
 
         //Start 17.0.0.4
         USE_ORIGINAL_QS_IN_FORWARD_IF_NULL = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.useoriginalqsinforwardifnull")).booleanValue(); //PI81569
+        SET_400_SC_ON_TOO_MANY_PARENT_DIRS = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.set400scontoomanyparentdirs")).booleanValue(); //PI80786
 
+        
     }
 
 }


### PR DESCRIPTION
URL contains more ../ than allowed. A new WebContainer custom property
will need to be set to enable this behavior. Setting this property will
check if there are more ../ than allowed early on in the request
processing if security is enabled or if we cannot match the request to 
a Servlet wrapper.

The new WebContainer custom property needed is as follows:

Name: com.ibm.ws.webcontainer.set400SCOnTooManyParentDirs
values: true/false (default)

When set to true the new behavior will be enabled.