### PR TITLE
Read kernel defaults from a file instead of the kernel boot jar manifest.

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapDefaults.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapDefaults.java
@@ -21,13 +21,13 @@ import com.ibm.ws.kernel.boot.BootstrapConfig;
  * Wrapper around the Liberty defaults file (in wlp/lib/platform/defaults).
  */
 public class BootstrapDefaults {
-    /** Manifest header for the default kernel version */
+    /** Property key in the defaults file, for the default kernel version */
     static final String MANIFEST_KERNEL = "WebSphere-DefaultKernel";
 
-    /** Manifest header for the default log provider */
+    /** Property key in the defaults file, for the default log provider */
     static final String MANIFEST_LOG_PROVIDER = "WebSphere-DefaultLogProvider";
 
-    /** Manifest header for the default OS Extensions */
+    /** Property key in the defaults file, for the default OS Extensions */
     static final String MANIFEST_OS_EXTENSION = "WebSphere-DefaultExtension-";
 
     /** bootstrap property to override kernel version */

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapDefaults.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapDefaults.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.boot.internal;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Locale;
+import java.util.Properties;
+
+import com.ibm.ws.kernel.boot.BootstrapConfig;
+
+/**
+ * Wrapper around the Liberty defaults file (in wlp/lib/platform/defaults).
+ */
+public class BootstrapDefaults {
+    /** Manifest header for the default kernel version */
+    static final String MANIFEST_KERNEL = "WebSphere-DefaultKernel";
+
+    /** Manifest header for the default log provider */
+    static final String MANIFEST_LOG_PROVIDER = "WebSphere-DefaultLogProvider";
+
+    /** Manifest header for the default OS Extensions */
+    static final String MANIFEST_OS_EXTENSION = "WebSphere-DefaultExtension-";
+
+    /** bootstrap property to override kernel version */
+    static final String BOOTPROP_KERNEL = "websphere.kernel";
+
+    /** bootstrap property to override log provider */
+    static final String BOOTPROP_LOG_PROVIDER = "websphere.log.provider";
+
+    /** bootstrap property to override os extension */
+    static final String BOOTPROP_OS_EXTENSIONS = "websphere.os.extension";
+
+    /** The properties that we read from the defaults file. */
+    private final Properties defaults;
+
+    /**
+     * Read the defaults from the file
+     */
+    BootstrapDefaults(BootstrapConfig bootConfig) throws java.io.IOException {
+        // Read the default values
+        FileInputStream fis = new FileInputStream(new File(bootConfig.getInstallRoot(), "lib/platform/defaults"));
+        Properties defaultProps = null;
+        try {
+            defaultProps = new Properties();
+            defaultProps.load(fis);
+        } finally {
+            fis.close();
+        }
+
+        // Read platform-specific default values, if they exist.
+        String normalizedOsName = getNormalizedOperatingSystemName(bootConfig.get("os.name"));
+        File osDefaults = new File(bootConfig.getInstallRoot(), "lib/platform/defaults-" + normalizedOsName);
+        if ((osDefaults.exists()) && (osDefaults.isFile())) {
+            fis = new FileInputStream(osDefaults);
+            try {
+                defaults = new Properties(defaultProps);
+                defaults.load(fis);
+            } finally {
+                fis.close();
+            }
+        } else {
+            defaults = defaultProps;
+        }
+    }
+
+    /**
+     * Find and return the name of the core/kernel feature. Look in
+     * bootstrap properties first, if not explicitly defined there, get
+     * the default from the manifest.
+     *
+     * @return the selected kernel version
+     */
+    public String getKernelDefinition(BootstrapConfig bootProps) {
+        String kernelDef = bootProps.get(BOOTPROP_KERNEL);
+
+        if (kernelDef == null)
+            kernelDef = defaults.getProperty(MANIFEST_KERNEL);
+
+        if (kernelDef != null)
+            bootProps.put(BOOTPROP_KERNEL, kernelDef);
+
+        return kernelDef;
+    }
+
+    /**
+     * Find and return the name of the log provider. Look in
+     * bootstrap properties first, if not explicitly defined there, get
+     * the default from the manifest.
+     *
+     * @return the selected log provider
+     */
+    public String getLogProviderDefinition(BootstrapConfig bootProps) {
+        String logProvider = bootProps.get(BOOTPROP_LOG_PROVIDER);
+
+        if (logProvider == null)
+            logProvider = defaults.getProperty(MANIFEST_LOG_PROVIDER);
+
+        if (logProvider != null)
+            bootProps.put(BOOTPROP_LOG_PROVIDER, logProvider);
+
+        return logProvider;
+    }
+
+    /**
+     * Find and return the name of the os extension. Look in
+     * bootstrap properties first, if not explicitly defined there, get
+     * the default from the manifest.
+     *
+     * @return the selected log provider
+     */
+    public String getOSExtensionDefinition(BootstrapConfig bootProps) {
+        String osExtension = bootProps.get(BOOTPROP_OS_EXTENSIONS);
+
+        if (osExtension == null) {
+            String normalizedName = getNormalizedOperatingSystemName(bootProps.get("os.name"));
+            osExtension = defaults.getProperty(MANIFEST_OS_EXTENSION + normalizedName);
+        }
+
+        if (osExtension != null)
+            bootProps.put(BOOTPROP_OS_EXTENSIONS, osExtension);
+
+        return osExtension;
+    }
+
+    /**
+     * Normalize the value associated with the &quot;os.name&quot; system
+     * property by putting it in lower case and removing characters that
+     * cannot be used with {@link java.util.jar.Attributes.Name}.
+     *
+     * @return the normalized OS name
+     */
+    static String getNormalizedOperatingSystemName(final String osName) {
+        String name = osName.toLowerCase(Locale.ENGLISH);
+        name = name.replaceAll("[^0-9a-zA-Z_-]", "");
+        return name;
+    }
+}

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapManifest.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapManifest.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Locale;
 import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
@@ -43,24 +42,6 @@ public class BootstrapManifest {
 
     static final String BUNDLE_VERSION = "Bundle-Version";
     static final String JAR_PROTOCOL = "jar";
-
-    /** Manifest header for the default kernel version */
-    static final String MANIFEST_KERNEL = "WebSphere-DefaultKernel";
-
-    /** Manifest header for the default log provider */
-    static final String MANIFEST_LOG_PROVIDER = "WebSphere-DefaultLogProvider";
-
-    /** Manifest header for the default OS Extensions */
-    static final String MANIFEST_OS_EXTENSION = "WebSphere-DefaultExtension-";
-
-    /** bootstrap property to override kernel version */
-    static final String BOOTPROP_KERNEL = "websphere.kernel";
-
-    /** bootstrap property to override log provider */
-    static final String BOOTPROP_LOG_PROVIDER = "websphere.log.provider";
-
-    /** bootstrap property to override os extension */
-    static final String BOOTPROP_OS_EXTENSIONS = "websphere.os.extension";
 
     /** prefix for system-package files */
     static final String SYSTEM_PKG_PREFIX = "OSGI-OPT/websphere/system-packages_";
@@ -160,65 +141,6 @@ public class BootstrapManifest {
     private JarFile getBootJar() throws IOException {
         // For liberty boot don't try to find the bootstrap jar.
         return libertyBoot ? getLibertBootJarFile() : new JarFile(KernelUtils.getBootstrapJar());
-    }
-
-    /**
-     * Find and return the name of the core/kernel feature. Look in
-     * bootstrap properties first, if not explicitly defined there, get
-     * the default from the manifest.
-     *
-     * @return the selected kernel version
-     */
-    public String getKernelDefinition(BootstrapConfig bootProps) {
-        String kernelDef = bootProps.get(BOOTPROP_KERNEL);
-
-        if (kernelDef == null)
-            kernelDef = manifestAttributes.getValue(MANIFEST_KERNEL);
-
-        if (kernelDef != null)
-            bootProps.put(BOOTPROP_KERNEL, kernelDef);
-
-        return kernelDef;
-    }
-
-    /**
-     * Find and return the name of the log provider. Look in
-     * bootstrap properties first, if not explicitly defined there, get
-     * the default from the manifest.
-     *
-     * @return the selected log provider
-     */
-    public String getLogProviderDefinition(BootstrapConfig bootProps) {
-        String logProvider = bootProps.get(BOOTPROP_LOG_PROVIDER);
-
-        if (logProvider == null)
-            logProvider = manifestAttributes.getValue(MANIFEST_LOG_PROVIDER);
-
-        if (logProvider != null)
-            bootProps.put(BOOTPROP_LOG_PROVIDER, logProvider);
-
-        return logProvider;
-    }
-
-    /**
-     * Find and return the name of the os extension. Look in
-     * bootstrap properties first, if not explicitly defined there, get
-     * the default from the manifest.
-     *
-     * @return the selected log provider
-     */
-    public String getOSExtensionDefinition(BootstrapConfig bootProps) {
-        String osExtension = bootProps.get(BOOTPROP_OS_EXTENSIONS);
-
-        if (osExtension == null) {
-            String normalizedName = getNormalizedOperatingSystemName(bootProps.get("os.name"));
-            osExtension = manifestAttributes.getValue(MANIFEST_OS_EXTENSION + normalizedName);
-        }
-
-        if (osExtension != null)
-            bootProps.put(BOOTPROP_OS_EXTENSIONS, osExtension);
-
-        return osExtension;
     }
 
     /**
@@ -324,9 +246,8 @@ public class BootstrapManifest {
                     bootProps.put(BootstrapConstants.INITPROP_OSGI_SYSTEM_PACKAGES, syspackages);
 
             } catch (IOException ioe) {
-                throw new LaunchException("Unable to find or read specified properties file; " + pkgListFileName,
-                                    MessageFormat.format(BootstrapConstants.messages.getString("error.unknownException"), ioe.toString()),
-                                    ioe);
+                throw new LaunchException("Unable to find or read specified properties file; "
+                                          + pkgListFileName, MessageFormat.format(BootstrapConstants.messages.getString("error.unknownException"), ioe.toString()), ioe);
             } finally {
                 Utils.tryToClose(jarFile);
             }
@@ -355,18 +276,5 @@ public class BootstrapManifest {
             }
         }
         return packages;
-    }
-
-    /**
-     * Normalize the value associated with the &quot;os.name&quot; system
-     * property by putting it in lower case and removing characters that
-     * cannot be used with {@link java.util.jar.Attributes.Name}.
-     *
-     * @return the normalized OS name
-     */
-    static String getNormalizedOperatingSystemName(final String osName) {
-        String name = osName.toLowerCase(Locale.ENGLISH);
-        name = name.replaceAll("[^0-9a-zA-Z_-]", "");
-        return name;
     }
 }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/KernelBootstrap.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/KernelBootstrap.java
@@ -142,7 +142,12 @@ public class KernelBootstrap {
 
             // Find the bootstrap resources we need to launch the nested framework.
             // MAY THROW if these resources can not be found or read
-            KernelResolver resolver = new KernelResolver(bootProps.getInstallRoot(), bootProps.getWorkareaFile(KernelResolver.CACHE_FILE), bootDefaults.getKernelDefinition(bootProps), bootDefaults.getLogProviderDefinition(bootProps), bootDefaults.getOSExtensionDefinition(bootProps), libertyBoot);
+            KernelResolver resolver = new KernelResolver(bootProps.getInstallRoot(),
+                            bootProps.getWorkareaFile(KernelResolver.CACHE_FILE),
+                            bootDefaults.getKernelDefinition(bootProps),
+                            bootDefaults.getLogProviderDefinition(bootProps),
+                            bootDefaults.getOSExtensionDefinition(bootProps),
+                            libertyBoot);
 
             // ISSUE LAUNCH FEEDBACK TO THE CONSOLE -- we've done the cursory validation at least.
             String logLevel = bootProps.get("com.ibm.ws.logging.console.log.level");

--- a/dev/com.ibm.ws.kernel.boot/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.boot/bnd.bnd
@@ -12,7 +12,7 @@
 # The kernel boot bundle has an extra include: it brings in the default
 # values for the kernel/os extensions/log provider versions.
 #
--include= ~../cnf/resources/bnd/bundle.props, publish/platform/defaults
+-include= ~../cnf/resources/bnd/bundle.props
 -nouses=true
 bVersion=1.0
 

--- a/dev/com.ibm.ws.kernel.boot/publish/platform/defaults
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/defaults
@@ -1,8 +1,6 @@
-# These defaults are present in (and read from) the jar manifest. 
 # Use the following properties (in the System or bootstrap.properties) to
 # override the values:
 #   websphere.kernel
 #   websphere.log.provider
 WebSphere-DefaultKernel: kernelCore-1.0
 WebSphere-DefaultLogProvider: defaultLogging-1.0
-WebSphere-DefaultExtension-zos: zosExtensions-1.0

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/SharedBootstrapConfig.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/SharedBootstrapConfig.java
@@ -65,6 +65,10 @@ public class SharedBootstrapConfig extends BootstrapConfig {
         this.initProps = initProps;
     }
 
+    public void setInstallRoot(File installRoot) {
+        this.installRoot = installRoot;
+    }
+
     public void cleanServerDir() {
         FileUtils.recursiveClean(getConfigFile(null));
     }

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/internal/BootstrapDefaultsTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/internal/BootstrapDefaultsTest.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.boot.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.kernel.boot.SharedBootstrapConfig;
+
+import test.common.SharedOutputManager;
+import test.shared.TestUtils;
+
+/**
+ *
+ */
+public class BootstrapDefaultsTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Rule
+    public TestRule outputRule = outputMgr;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        TestUtils.cleanTempFiles();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        TestUtils.cleanTempFiles();
+    }
+
+    @After
+    public void tearDown() throws Exception {}
+
+    @Test
+    public void testGetDefaults() throws Exception {
+        String testClassesDir = System.getProperty("test.classesDir", "bin_test");
+        final File installDir = new File(testClassesDir, "test data/default-files/default");
+
+        // Trick the bootstrap config into pointing to our copy of the defaults file
+        SharedBootstrapConfig config = SharedBootstrapConfig.createSharedConfig(outputMgr);
+        config.setInstallRoot(installDir);
+
+        BootstrapDefaults defaults = new BootstrapDefaults(config);
+        assertEquals("Kernel definition should be set to the name of the default", "kernelCore-1.0", defaults.getKernelDefinition(config));
+        assertEquals("Log provider definition should be set to the name of the default", "defaultLogging-1.0", defaults.getLogProviderDefinition(config));
+    }
+
+    @Test
+    public void testGetDefaultsOverride() throws Exception {
+        String testClassesDir = System.getProperty("test.classesDir", "bin_test");
+        final File installDir = new File(testClassesDir, "test data/default-files/extension");
+
+        // Trick the bootstrap config into pointing to our copy of the defaults file
+        SharedBootstrapConfig config = SharedBootstrapConfig.createSharedConfig(outputMgr);
+
+        // Trick the bootstrap config into thinking our os name is 'aaa'.
+        Map<String, String> initProps = new HashMap<String, String>();
+        initProps.put("os.name", "aaa");
+        config.setInitProps(initProps);
+        config.setInstallRoot(installDir);
+
+        // Try to read the bootstrap defaults from our own internal directory.
+        BootstrapDefaults defaults = new BootstrapDefaults(config);
+        assertEquals("Kernel definition should be set to the test value", "kernelCoreTestA-1.0", defaults.getKernelDefinition(config));
+        assertEquals("Log provider definition should be set to the name of the default", "defaultLoggingTest-1.0", defaults.getLogProviderDefinition(config));
+        assertEquals("Kernel extension definition should be set to the test value", "aaaExtensions-1.0", defaults.getOSExtensionDefinition(config));
+    }
+
+    @Test
+    public void testMissingKernelDefinition() throws Exception {
+        String testClassesDir = System.getProperty("test.classesDir", "bin_test");
+        final File installDir = new File(testClassesDir, "test data/default-files/missing");
+
+        // Trick the bootstrap config into pointing to our copy of the defaults file
+        SharedBootstrapConfig config = SharedBootstrapConfig.createSharedConfig(outputMgr);
+        config.setInstallRoot(installDir);
+
+        // Try to read the bootstrap defaults from our own internal directory.
+        BootstrapDefaults defaults = new BootstrapDefaults(config);
+        assertNull("No value should have been found for kernel version", defaults.getKernelDefinition(config)); // this will throw
+        assertNull("No value should have been found for log provider", defaults.getLogProviderDefinition(config));
+    }
+
+    @Test
+    public void testMissingKernelDefinitionOverrideProperty() throws Exception {
+        String testClassesDir = System.getProperty("test.classesDir", "bin_test");
+        final File installDir = new File(testClassesDir, "test data/default-files/missing");
+
+        // Trick the bootstrap config into pointing to our copy of the defaults file
+        SharedBootstrapConfig config = SharedBootstrapConfig.createSharedConfig(outputMgr);
+        config.setInstallRoot(installDir);
+
+        // Set the kernel etc using properties
+        String kernelDef = "kernel_1.x";
+        String operatingSystemExtensionsDef = "extension_1.x";
+        String logProviderDef = "logging_1.x";
+
+        Map<String, String> initProps = new HashMap<String, String>();
+        initProps.put(BootstrapDefaults.BOOTPROP_KERNEL, kernelDef);
+        initProps.put(BootstrapDefaults.BOOTPROP_OS_EXTENSIONS, operatingSystemExtensionsDef);
+        initProps.put(BootstrapDefaults.BOOTPROP_LOG_PROVIDER, logProviderDef);
+        config.setInitProps(initProps);
+
+        // Try to read the bootstrap defaults from our own internal directory.
+        BootstrapDefaults defaults = new BootstrapDefaults(config);
+
+        assertEquals("Property was set: Kernel definition should equal provided property value",
+                     kernelDef, defaults.getKernelDefinition(config));
+        assertEquals("Property was set: OS extensions definition should equal provided property value",
+                     operatingSystemExtensionsDef, defaults.getOSExtensionDefinition(config));
+        assertEquals("Property was set: Log provider definition should equal provided property value",
+                     logProviderDef, defaults.getLogProviderDefinition(config));
+    }
+
+    @Test
+    public void testGetNormalizedOperatingSystemName() throws Exception {
+        Map<String, String> names = new HashMap<String, String>();
+        names.put("AIX", "aix");
+        names.put("Digital Unix", "digitalunix");
+        names.put("FreeBSD", "freebsd");
+        names.put("HP UX", "hpux");
+        names.put("Irix", "irix");
+        names.put("Linux", "linux");
+        names.put("Mac OS", "macos");
+        names.put("Mac OS X", "macosx");
+        names.put("MPE/iX", "mpeix");
+        names.put("Netware 4.11", "netware411");
+        names.put("OS/2", "os2");
+        names.put("OS/390", "os390");
+        names.put("Solaris", "solaris");
+        names.put("Windows 2000", "windows2000");
+        names.put("Windows 7", "windows7");
+        names.put("Windows 8", "windows8");
+        names.put("Windows 95", "windows95");
+        names.put("Windows 98", "windows98");
+        names.put("Windows NT", "windowsnt");
+        names.put("Windows NT (unknown)", "windowsntunknown");
+        names.put("Windows Server 2012", "windowsserver2012");
+        names.put("Windows Vista", "windowsvista");
+        names.put("Windows XP", "windowsxp");
+        names.put("z/OS", "zos");
+
+        for (String osName : names.keySet()) {
+            assertEquals(names.get(osName), BootstrapDefaults.getNormalizedOperatingSystemName(osName));
+        }
+    }
+}

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/internal/BootstrapManifestTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/internal/BootstrapManifestTest.java
@@ -72,43 +72,6 @@ public class BootstrapManifestTest {
         setBootstrapJar(0); // use a real built jar
         BootstrapManifest m = new BootstrapManifest();
         assertNotNull("Bundle version should be set for the kernel.boot jar/bundle", m.getBundleVersion());
-        assertEquals("Kernel definition should be set to the name of the default", "kernelCore-1.0", m.getKernelDefinition(config));
-        assertEquals("Log provider definition should be set to the name of the default", "defaultLogging-1.0", m.getLogProviderDefinition(config));
-    }
-
-    @Test
-    public void testMissingKernelDefinition() throws Exception {
-        BootstrapConfig config = new BootstrapConfig();
-
-        setBootstrapJar(1); // use a jar with a missing kernel definition
-        BootstrapManifest m = new BootstrapManifest();
-        assertNull("No value should have been found for kernel version", m.getKernelDefinition(config)); // this will throw
-        assertNull("No value should have been found for log provider", m.getLogProviderDefinition(config));
-    }
-
-    @Test
-    public void testMissingAttributesWithProperties() throws Exception {
-        SharedBootstrapConfig config = SharedBootstrapConfig.createSharedConfig(outputMgr);
-
-        setBootstrapJar(1); // use a jar with a missing kernel definition and log provider
-
-        String kernelDef = "kernel_1.x";
-        String operatingSystemExtensionsDef = "extension_1.x";
-        String logProviderDef = "logging_1.x";
-
-        Map<String, String> initProps = new HashMap<String, String>();
-        initProps.put(BootstrapManifest.BOOTPROP_KERNEL, kernelDef);
-        initProps.put(BootstrapManifest.BOOTPROP_OS_EXTENSIONS, operatingSystemExtensionsDef);
-        initProps.put(BootstrapManifest.BOOTPROP_LOG_PROVIDER, logProviderDef);
-        config.setInitProps(initProps);
-
-        BootstrapManifest m = new BootstrapManifest();
-        assertEquals("Property was set: Kernel definition should equal provided property value",
-                     kernelDef, m.getKernelDefinition(config));
-        assertEquals("Property was set: OS extensions definition should equal provided property value",
-                     operatingSystemExtensionsDef, m.getOSExtensionDefinition(config));
-        assertEquals("Property was set: Log provider definition should equal provided property value",
-                     logProviderDef, m.getLogProviderDefinition(config));
     }
 
     @Test(expected = com.ibm.ws.kernel.boot.LaunchException.class)
@@ -205,39 +168,6 @@ public class BootstrapManifestTest {
         m.prepSystemPackages(config);
         assertNull(initProps.get(BootstrapConstants.INITPROP_OSGI_EXTRA_PACKAGE));
         assertNull(initProps.get(BootstrapConstants.INITPROP_OSGI_SYSTEM_PACKAGES));
-    }
-
-    @Test
-    public void testGetNormalizedOperatingSystemName() throws Exception {
-        Map<String, String> names = new HashMap<String, String>();
-        names.put("AIX", "aix");
-        names.put("Digital Unix", "digitalunix");
-        names.put("FreeBSD", "freebsd");
-        names.put("HP UX", "hpux");
-        names.put("Irix", "irix");
-        names.put("Linux", "linux");
-        names.put("Mac OS", "macos");
-        names.put("Mac OS X", "macosx");
-        names.put("MPE/iX", "mpeix");
-        names.put("Netware 4.11", "netware411");
-        names.put("OS/2", "os2");
-        names.put("OS/390", "os390");
-        names.put("Solaris", "solaris");
-        names.put("Windows 2000", "windows2000");
-        names.put("Windows 7", "windows7");
-        names.put("Windows 8", "windows8");
-        names.put("Windows 95", "windows95");
-        names.put("Windows 98", "windows98");
-        names.put("Windows NT", "windowsnt");
-        names.put("Windows NT (unknown)", "windowsntunknown");
-        names.put("Windows Server 2012", "windowsserver2012");
-        names.put("Windows Vista", "windowsvista");
-        names.put("Windows XP", "windowsxp");
-        names.put("z/OS", "zos");
-
-        for (String osName : names.keySet()) {
-            assertEquals(names.get(osName), BootstrapManifest.getNormalizedOperatingSystemName(osName));
-        }
     }
 
     protected static void setBootstrapJar(int jarTestCase) throws Exception {

--- a/dev/com.ibm.ws.kernel.boot_test/test/test data/default-files/default/lib/platform/defaults
+++ b/dev/com.ibm.ws.kernel.boot_test/test/test data/default-files/default/lib/platform/defaults
@@ -1,0 +1,6 @@
+# Use the following properties (in the System or bootstrap.properties) to
+# override the values:
+#   websphere.kernel
+#   websphere.log.provider
+WebSphere-DefaultKernel: kernelCore-1.0
+WebSphere-DefaultLogProvider: defaultLogging-1.0

--- a/dev/com.ibm.ws.kernel.boot_test/test/test data/default-files/extension/lib/platform/defaults
+++ b/dev/com.ibm.ws.kernel.boot_test/test/test data/default-files/extension/lib/platform/defaults
@@ -1,0 +1,3 @@
+# These defaults are used by the test bucket only.
+WebSphere-DefaultKernel: kernelCoreTest-1.0
+WebSphere-DefaultLogProvider: defaultLoggingTest-1.0

--- a/dev/com.ibm.ws.kernel.boot_test/test/test data/default-files/extension/lib/platform/defaults-aaa
+++ b/dev/com.ibm.ws.kernel.boot_test/test/test data/default-files/extension/lib/platform/defaults-aaa
@@ -1,0 +1,3 @@
+# These defaults are used by the test bucket only.
+WebSphere-DefaultKernel: kernelCoreTestA-1.0
+WebSphere-DefaultExtension-aaa: aaaExtensions-1.0

--- a/dev/com.ibm.ws.kernel.boot_test/test/test data/default-files/missing/lib/platform/defaults
+++ b/dev/com.ibm.ws.kernel.boot_test/test/test data/default-files/missing/lib/platform/defaults
@@ -1,0 +1,1 @@
+# These defaults are used by the test bucket only and are intentionally blank.


### PR DESCRIPTION
Currently, the only way for a product that extends Liberty to over-ride the default kernel or kernel extension, is for it to specify that kernel or extension as a system property.  It would be convenient to be able to specify extensions in a file instead, since that would eliminate the need to set the system property on every server instance.  Since to date all kernel extensions are platform-specific, we are introducing a platform-specific defaults over-ride file.  The file name is "lib/platform/defaults-*" where the asterisk is replaced by the os.name returned by the JVM.  If that file exists, we will read it, and it will over-ride what is specified in "lib/platform/defaults".

We also discovered that we were reading the defaults from the kernel boot jar manifest, instead of from the defaults file.  While this is fine, it makes more sense to read from the file since that can be updated more easily than changing the jar manifest.  We've changed how that works.

Resolves issue #425 
#build 
