### PR TITLE
Do not call Apache specific cleanup for beanVal-2.0

### DIFF
--- a/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/OSGiBeanValidationImpl.java
+++ b/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/OSGiBeanValidationImpl.java
@@ -62,11 +62,10 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
  * service. <p>
  */
 @Component(service = { ModuleMetaDataListener.class,
-                      BeanValidationUsingClassLoader.class,
-                      BeanValidation.class },
+                       BeanValidationUsingClassLoader.class,
+                       BeanValidation.class },
            immediate = true)
-public class OSGiBeanValidationImpl extends AbstractBeanValidation
-                implements ModuleMetaDataListener, BeanValidationUsingClassLoader {
+public class OSGiBeanValidationImpl extends AbstractBeanValidation implements ModuleMetaDataListener, BeanValidationUsingClassLoader {
     private static final TraceComponent tc = Tr.register(OSGiBeanValidationImpl.class);
 
     private static final String REFERENCE_VALIDATION_CONFIG_FACTORY = "validationConfigFactory";
@@ -74,22 +73,19 @@ public class OSGiBeanValidationImpl extends AbstractBeanValidation
 
     private MetaDataSlot ivModuleMetaDataSlot;
 
-    private final AtomicServiceReference<ValidationConfigurationFactory> validationConfigFactorySR =
-                    new AtomicServiceReference<ValidationConfigurationFactory>(REFERENCE_VALIDATION_CONFIG_FACTORY);
+    private final AtomicServiceReference<ValidationConfigurationFactory> validationConfigFactorySR = new AtomicServiceReference<ValidationConfigurationFactory>(REFERENCE_VALIDATION_CONFIG_FACTORY);
 
-    private final AtomicServiceReference<ClassLoadingService> classLoadingServiceSR =
-                    new AtomicServiceReference<ClassLoadingService>(REFERENCE_CLASSLOADING_SERVICE);
+    private final AtomicServiceReference<ClassLoadingService> classLoadingServiceSR = new AtomicServiceReference<ClassLoadingService>(REFERENCE_CLASSLOADING_SERVICE);
 
     private static final Version DEFAULT_VERSION = BeanValidationRuntimeVersion.VERSION_1_0;
     private Version runtimeVersion = DEFAULT_VERSION;
 
-    private static final PrivilegedAction<ThreadContextAccessor> getThreadContextAccessorAction =
-                    new PrivilegedAction<ThreadContextAccessor>() {
-                        @Override
-                        public ThreadContextAccessor run() {
-                            return ThreadContextAccessor.getThreadContextAccessor();
-                        }
-                    };
+    private static final PrivilegedAction<ThreadContextAccessor> getThreadContextAccessorAction = new PrivilegedAction<ThreadContextAccessor>() {
+        @Override
+        public ThreadContextAccessor run() {
+            return ThreadContextAccessor.getThreadContextAccessor();
+        }
+    };
 
     @Override
     public void registerValidatorFactory(ModuleMetaData mmd, ClassLoader cl, ValidatorFactory validatorFactory) {
@@ -132,7 +128,7 @@ public class OSGiBeanValidationImpl extends AbstractBeanValidation
             synchronized (scopeData) {
                 vf = scopeData.ivValidatorFactory;
                 if (vf == null) {
-                    // It's possible that the requesting component is doing so after the app 
+                    // It's possible that the requesting component is doing so after the app
                     // has been destroyed (i.e. moduleMetaDataDestroyed already called). If so,
                     // indicate by throwing an exception if the version>=11. For compatibility,
                     // leave the v10 case as is.
@@ -394,7 +390,11 @@ public class OSGiBeanValidationImpl extends AbstractBeanValidation
     }
 
     private boolean isBeanValidationVersion11OrGreater() {
-        return runtimeVersion.compareTo(BeanValidationRuntimeVersion.VERSION_1_1) >= 0 ? true : false;
+        return runtimeVersion.compareTo(BeanValidationRuntimeVersion.VERSION_1_1) >= 0;
+    }
+
+    private boolean isBeanValidationVersion11() {
+        return runtimeVersion.compareTo(BeanValidationRuntimeVersion.VERSION_1_1) == 0;
     }
 
     @Override
@@ -418,7 +418,7 @@ public class OSGiBeanValidationImpl extends AbstractBeanValidation
      * configuration updates.
      */
     private void cleanBvalCache() {
-        if (isBeanValidationVersion11OrGreater()) {
+        if (isBeanValidationVersion11()) {
             ClassLoader classLoader = null;
             SetContextClassLoaderPrivileged setClassLoader = null;
             ClassLoader oldClassLoader = null;
@@ -432,9 +432,7 @@ public class OSGiBeanValidationImpl extends AbstractBeanValidation
                     wasTcclCreated = true;
                 }
 
-                ThreadContextAccessor tca = System.getSecurityManager() == null ?
-                                ThreadContextAccessor.getThreadContextAccessor() :
-                                AccessController.doPrivileged(getThreadContextAccessorAction);
+                ThreadContextAccessor tca = System.getSecurityManager() == null ? ThreadContextAccessor.getThreadContextAccessor() : AccessController.doPrivileged(getThreadContextAccessorAction);
 
                 // set the thread context class loader to be used, must be reset in finally block
                 setClassLoader = new SetContextClassLoaderPrivileged(tca);


### PR DESCRIPTION
On server shutdown, the following FFDC may be emitted when using `beanValidation-2.0`:

```
Exception = java.lang.ClassNotFoundException 
Source = com.ibm.ws.beanvalidation.OSGiBeanValidationImpl 
probeid = 464 
Stack Dump = java.lang.ClassNotFoundException: org.apache.bval.jsr.ConstraintAnnotationAttributes 
at com.ibm.ws.classloading.internal.UnifiedClassLoader.findClass(UnifiedClassLoader.java:119) 
at com.ibm.ws.classloading.internal.ThreadContextClassLoader.findClass(ThreadContextClassLoader.java:120) 
at java.lang.ClassLoader.loadClassHelper(ClassLoader.java:846) 
at java.lang.ClassLoader.loadClass(ClassLoader.java:825) 
at com.ibm.ws.classloading.internal.UnifiedClassLoader.loadClass0(UnifiedClassLoader.java:107) 
at com.ibm.ws.classloading.internal.UnifiedClassLoader$Delegation.loadClass(UnifiedClassLoader.java:78) 
at com.ibm.ws.classloading.internal.UnifiedClassLoader.loadClass(UnifiedClassLoader.java:102) 
at com.ibm.ws.classloading.internal.ThreadContextClassLoader.loadClass(ThreadContextClassLoader.java:136) 
at com.ibm.ws.classloading.internal.ThreadContextClassLoaderForBundles.loadClass(ThreadContextClassLoaderForBundles.java:44) > 
at java.lang.ClassLoader.loadClass(ClassLoader.java:805) > 
at com.ibm.ws.beanvalidation.OSGiBeanValidationImpl.cleanBvalCache(OSGiBeanValidationImpl.java:447) > 
at com.ibm.ws.beanvalidation.OSGiBeanValidationImpl.moduleMetaDataDestroyed(OSGiBeanValidationImpl.java:333)
at com.ibm.ws.container.service.metadata.internal.ModuleMetaDataManager.fireMetaDataDestroyed(ModuleMetaDataManager.java:35) 
at com.ibm.ws.container.service.metadata.internal.ModuleMetaDataManager.fireMetaDataDestroyed(ModuleMetaDataManager.java:18) 
at com.ibm.ws.container.service.metadata.internal.MetaDataManager.fireMetaDataDestroyedImpl(MetaDataManager.java:148) 
at com.ibm.ws.container.service.metadata.internal.MetaDataManager.fireMetaDataDestroyed(MetaDataManager.java:128) 
at com.ibm.ws.container.service.metadata.internal.MetaDataServiceImpl.fireModuleMetaDataDestroyed(MetaDataServiceImpl.java:137) 
at com.ibm.ws.app.manager.module.internal.ModuleHandlerBase.undeployModule(ModuleHandlerBase.java:152) 
at com.ibm.ws.app.manager.module.internal.DeployedModuleInfoImpl.uninstallModule(DeployedModuleInfoImpl.java:64) 
at com.ibm.ws.app.manager.module.internal.SimpleDeployedAppInfoBase.uninstallApp(SimpleDeployedAppInfoBase.java:497) 
at com.ibm.ws.app.manager.ear.internal.EARApplicationHandlerImpl.uninstall(EARApplicationHandlerImpl.java:97) 
at com.ibm.ws.app.manager.internal.statemachine.StopAction.execute(StopAction.java:83) 
at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.enterState(ApplicationStateMachineImpl.java:1283) 
at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.performAction(ApplicationStateMachineImpl.java:1126) 
at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.run(ApplicationStateMachineImpl.java:881) 
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1153) 
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) 
at java.lang.Thread.run(Thread.java:785)
```