### PR TITLE
Issue 891: Fix ClassCast in SecurityNameBridge

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
@@ -103,6 +103,7 @@ autoFVT.doLast {
     'com.ibm.ws.security.wim.adapter.ldap.fat.context.pool.on.ldap.fail',
     'com.ibm.ws.security.wim.adapter.ldap.fat.context.pool.timeout',
     'com.ibm.ws.security.wim.adapter.ldap.fat.custom',
+    'com.ibm.ws.security.wim.adapter.ldap.fat.custom.getname',
     'com.ibm.ws.security.wim.adapter.ldap.fat.dynamic',
     'com.ibm.ws.security.wim.adapter.ldap.fat.ETSFforGroupM',
     'com.ibm.ws.security.wim.adapter.ldap.fat.federation',

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATSuite.java
@@ -69,7 +69,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 VMMAPIs_TDSLDAPTest.class,
                 OutboundSSLLDAPTest.class,
                 URAPIs_PropertiesNotSupportedTest.class,
-                SearchPagingTest.class
+                SearchPagingTest.class,
+                GetUserSecurityCustomLDAP.class
 })
 public class FATSuite extends CommonLocalLDAPServerSuite {
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/GetUserSecurityCustomLDAP.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/GetUserSecurityCustomLDAP.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.wim.adapter.ldap.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.registry.test.UserRegistryServletConnection;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.LDAPUtils;
+import componenttest.vulnerability.LeakedPasswordChecker;
+
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class GetUserSecurityCustomLDAP {
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.adapter.ldap.fat.custom.getname");
+    private static final Class<?> c = GetUserSecurityCustomLDAP.class;
+    private static UserRegistryServletConnection servlet;
+    private final LeakedPasswordChecker passwordChecker = new LeakedPasswordChecker(server);
+
+    /**
+     * Updates the sample, which is expected to be at the hard-coded path.
+     * If this test is failing, check this path is correct.
+     */
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Add LDAP variables to bootstrap properties file
+        LDAPUtils.addLDAPVariables(server);
+        Log.info(c, "setUp", "Starting the server... (will wait for userRegistry servlet to start)");
+        server.copyFileToLibertyInstallRoot("lib/features", "internalfeatures/securitylibertyinternals-1.0.mf");
+        server.addInstalledAppForValidation("userRegistry");
+        server.startServer(c.getName() + ".log");
+
+        //Make sure the application has come up before proceeding
+        assertNotNull("Application userRegistry does not appear to have started.",
+                      server.waitForStringInLog("CWWKZ0001I:.*userRegistry"));
+        assertNotNull("Security service did not report it was ready",
+                      server.waitForStringInLog("CWWKS0008I"));
+        assertNotNull("Server did not came up",
+                      server.waitForStringInLog("CWWKF0011I"));
+
+        Log.info(c, "setUp", "Creating servlet connection the server");
+        servlet = new UserRegistryServletConnection(server.getHostname(), server.getHttpDefaultPort());
+
+        if (servlet.getRealm() == null) {
+            Thread.sleep(5000);
+            servlet.getRealm();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        Log.info(c, "tearDown", "Stopping the server...");
+        try {
+            server.stopServer();
+        } finally {
+            server.deleteFileFromLibertyInstallRoot("lib/features/internalfeatures/securitylibertyinternals-1.0.mf");
+        }
+    }
+
+    /**
+     * Hit the test servlet to see if getRealm works.
+     * This verifies the various required bundles got installed and are working.
+     */
+    @Test
+    public void getRealm() throws Exception {
+        Log.info(c, "getRealm", "Checking expected realm");
+        assertEquals("SampleLdapCustomRealm", servlet.getRealm());
+    }
+
+    /**
+     * Hit the test servlet to see if getUserSecurityName works when supplied with a valid user
+     *
+     * With the configured server.xml, make sure we don't get a ClassCastException.
+     * See Issue 981.
+     */
+    @Test
+    public void getUserSecurityName() throws Exception {
+        String user = "vmmtestuser";
+        String securityName = "cn=vmmtestuser,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com";
+
+        Log.info(c, "getUserSecurityName", "Checking with a valid user.");
+        assertEquals(securityName, servlet.getUserSecurityName(user));
+    }
+
+}

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.custom.getname/bootstrap.properties
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.custom.getname/bootstrap.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.wsspi.security.wim.model.*=all=enabled:com.ibm.ws.security.*=all=enabled
+com.ibm.ws.logging.max.file.size=0
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.custom.getname/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.custom.getname/server.xml
@@ -1,0 +1,36 @@
+<!--
+    Copyright (c) 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="new server">
+	<include location="../fatTestPorts.xml"/>
+    <!-- Enable features -->
+    <featureManager>
+        <feature>appSecurity-2.0</feature>
+        <feature>servlet-3.1</feature>
+        <feature>securitylibertyinternals-1.0</feature>
+		<feature>ldapRegistry-3.0</feature>
+    </featureManager>
+
+		<ldapRegistry id="LDAP" realm="SampleLdapCustomRealm" host="${ldap.server.2.name}" port="${ldap.server.2.port}" ignoreCase="true"  baseDN="cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com"
+		bindDN="cn=testuser,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com"
+		bindPassword="testuserpwd"
+		ldapType="Custom"
+		searchTimeout="8m"
+		>
+		<failoverServers name="failoverLdapServers">
+		   <server host="${ldap.server.6.name}" port="${ldap.server.6.port}"/>
+        </failoverServers>		
+        <customFilters id='customFilters' userFilter='(&amp;(cn=%v)(objectClass=User))' groupFilter='(&amp;(cn=%v)(objectClass=group))' userIdMap='*:cn' groupIdMap='*:cn' groupMemberIdMap='group:member' />
+	</ldapRegistry>
+	
+	
+	<include location="../fatTestPorts.xml"/>
+    
+</server>

--- a/dev/com.ibm.ws.security.wim.registry/src/com/ibm/ws/security/wim/registry/util/SecurityNameBridge.java
+++ b/dev/com.ibm.ws.security.wim.registry/src/com/ibm/ws/security/wim/registry/util/SecurityNameBridge.java
@@ -200,13 +200,11 @@ public class SecurityNameBridge {
             else {
                 Entity entity = returnList.get(0);
                 if (entity != null) {
-                    LoginAccount loginAct = (LoginAccount) entity;
-
                     // d115256
                     if (!this.mappingUtils.isIdentifierTypeProperty(outputAttrName)) {
-                        returnValue = (String) loginAct.get(outputAttrName);
+                        returnValue = (String) entity.get(outputAttrName);
                     } else {
-                        returnValue = (String) loginAct.getIdentifier().get(outputAttrName);
+                        returnValue = (String) entity.getIdentifier().get(outputAttrName);
                     }
                 }
             }


### PR DESCRIPTION
Fix ClassCastException and add a fat test for getDisplayName with the correct filter/LDAPtype that caused the ClassCastException.