### PR TITLE
Issue #785 separate exception for startTimeout

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -90,6 +90,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
      * @return identifier to use in messages.
      */
     @Override
+    @Trivial
     public String getIdentifier(String identifier) {
         return identifier.startsWith("managed") ? identifier : managedExecutor.name.get() + " (" + identifier + ')';
     }

--- a/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
@@ -188,7 +188,7 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
             assertNull(listener.exception[ABORTED].getCause());
         else {
             Throwable cause = listener.exception[ABORTED].getCause();
-            if (cause == null || !causeClass.equals(cause.getClass()) ||
+            if (cause == null || !causeClass.isAssignableFrom(cause.getClass()) ||
                 causeMessagePrefix != null && (cause.getMessage() == null || !cause.getMessage().startsWith(causeMessagePrefix)))
                 throw new Exception("Unexpected or missing cause of AbortedException. See chained exceptions", listener.exception[ABORTED]);
         }
@@ -200,7 +200,7 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
             if (!(failure instanceof AbortedException))
                 throw new Exception("Unexpected or missing failure. See chained exceptions", failure);
             Throwable cause = failure.getCause();
-            if (cause == null || !causeClass.equals(cause.getClass()) ||
+            if (cause == null || !causeClass.isAssignableFrom(cause.getClass()) ||
                 causeMessagePrefix != null && (cause.getMessage() == null || !cause.getMessage().startsWith(causeMessagePrefix)))
                 throw new Exception("Unexpected or missing cause of AbortedException. See chained exceptions", failure);
         } else {
@@ -223,7 +223,7 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
             if (!(failure instanceof AbortedException))
                 throw new Exception("Unexpected or missing failure. See chained exceptions", failure);
             Throwable cause = failure.getCause();
-            if (cause == null || !causeClass.equals(cause.getClass()) ||
+            if (cause == null || !causeClass.isAssignableFrom(cause.getClass()) ||
                 causeMessagePrefix != null && (cause.getMessage() == null || !cause.getMessage().startsWith(causeMessagePrefix)))
                 throw new Exception("Unexpected or missing cause of AbortedException. See chained exceptions", failure);
         } else {

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/StartTimeoutException.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/StartTimeoutException.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.threading;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Exception that indicates a task was rejected or aborted due to exceeding its start timeout.
+ */
+public class StartTimeoutException extends IllegalStateException {
+    private static final long serialVersionUID = 1L;
+    private static final TraceComponent tc = Tr.register(StartTimeoutException.class, "concurrencyPolicy", "com.ibm.ws.threading.internal.resources.ThreadingMessages");
+
+    public StartTimeoutException(String executorId, String taskName, long elapsedNS, long startTimeoutNS) {
+        super(Tr.formatMessage(tc, "CWWKE1205.start.timeout", executorId, taskName, elapsedNS, startTimeoutNS));
+    }
+}

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -28,6 +28,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.threading.PolicyTaskCallback;
 import com.ibm.ws.threading.PolicyTaskFuture;
+import com.ibm.ws.threading.StartTimeoutException;
 
 /**
  * Allows the policy executor to tie into internal state and other details of a Future implementation.
@@ -429,9 +430,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 state.tryAcquireSharedNanos(1, nsStartBy - nsGetBegin);
                 s = state.get();
                 if (s == SUBMITTED) { // attempt to abort the task
-                    abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout", getIdentifier(), getTaskName(),
-                                                                           System.nanoTime() - nsAcceptBegin,
-                                                                           nsStartBy - nsAcceptBegin)));
+                    abort(true, new StartTimeoutException(getIdentifier(), getTaskName(), //
+                                    System.nanoTime() - nsAcceptBegin, //
+                                    nsStartBy - nsAcceptBegin));
                     s = state.get();
                 }
                 if (s == RUNNING) { // continue waiting
@@ -467,9 +468,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 state.tryAcquireSharedNanos(1, nsStartBy - nsGetBegin);
                 s = state.get();
                 if (s == SUBMITTED) { // attempt to abort the task
-                    abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout", getIdentifier(), getTaskName(),
-                                                                           System.nanoTime() - nsAcceptBegin,
-                                                                           nsStartBy - nsAcceptBegin)));
+                    abort(true, new StartTimeoutException(getIdentifier(), getTaskName(), //
+                                    System.nanoTime() - nsAcceptBegin, //
+                                    nsStartBy - nsAcceptBegin));
                     s = state.get();
                 }
                 if (s == RUNNING) { // wait for the remainder of the timeout supplied to get
@@ -490,11 +491,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
         if (nsStartBy != nsAcceptBegin - 1 // has a start timeout
             && state.get() < RUNNING // not started yet
             && System.nanoTime() - nsStartBy > 0) // start timeout has elapsed
-            abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout",
-                                                                   getIdentifier(),
-                                                                   getTaskName(),
-                                                                   System.nanoTime() - nsAcceptBegin,
-                                                                   nsStartBy - nsAcceptBegin)));
+            abort(true, new StartTimeoutException(getIdentifier(), getTaskName(), //
+                            System.nanoTime() - nsAcceptBegin, //
+                            nsStartBy - nsAcceptBegin));
 
         if (result.compareAndSet(state, CANCELED))
             try {
@@ -637,11 +636,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                || nsStartBy != nsAcceptBegin - 1 // has a start timeout
                   && s < RUNNING // not started yet
                   && System.nanoTime() - nsStartBy > 0 // start timeout has elapsed
-                  && (abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout",
-                                                                             getIdentifier(),
-                                                                             getTaskName(),
-                                                                             System.nanoTime() - nsAcceptBegin,
-                                                                             nsStartBy - nsAcceptBegin)))
+                  && (abort(true, new StartTimeoutException(getIdentifier(), getTaskName(), //
+                                  System.nanoTime() - nsAcceptBegin, //
+                                  nsStartBy - nsAcceptBegin))
                       || state.get() > RUNNING);
     }
 

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -57,6 +57,7 @@ import com.ibm.ws.threading.PolicyExecutor.MaxPolicy;
 import com.ibm.ws.threading.PolicyExecutorProvider;
 import com.ibm.ws.threading.PolicyTaskCallback;
 import com.ibm.ws.threading.PolicyTaskFuture;
+import com.ibm.ws.threading.StartTimeoutException;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.app.FATServlet;
@@ -4499,7 +4500,9 @@ public class PolicyExecutorServlet extends FATServlet {
             Integer result = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
             fail("Task should be been aborted, instead result is: " + result);
         } catch (RejectedExecutionException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("CWWKE1205E"))
+            if (!(x.getCause() instanceof StartTimeoutException)
+                || x.getCause().getMessage() == null
+                || !x.getCause().getMessage().contains("CWWKE1205E"))
                 throw x;
             // else pass - aborted due to timeout
         }
@@ -4585,7 +4588,9 @@ public class PolicyExecutorServlet extends FATServlet {
             Integer result = future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
             fail("Task 2 should be been aborted, instead result is: " + result);
         } catch (RejectedExecutionException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("CWWKE1205E"))
+            if (!(x.getCause() instanceof StartTimeoutException)
+                || x.getCause().getMessage() == null
+                || !x.getCause().getMessage().contains("CWWKE1205E"))
                 throw x;
             // else pass - aborted due to timeout
         }
@@ -4594,7 +4599,9 @@ public class PolicyExecutorServlet extends FATServlet {
             Integer result = future3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
             fail("Task 3 should be been aborted, instead result is: " + result);
         } catch (RejectedExecutionException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("CWWKE1205E"))
+            if (!(x.getCause() instanceof StartTimeoutException)
+                || x.getCause().getMessage() == null
+                || !x.getCause().getMessage().contains("CWWKE1205E"))
                 throw x;
             // else pass - aborted due to timeout
         }
@@ -4663,7 +4670,9 @@ public class PolicyExecutorServlet extends FATServlet {
             Integer result = future1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
             fail("Task 1 should be been aborted, instead result is: " + result);
         } catch (RejectedExecutionException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("CWWKE1205E"))
+            if (!(x.getCause() instanceof StartTimeoutException)
+                || x.getCause().getMessage() == null
+                || !x.getCause().getMessage().contains("CWWKE1205E"))
                 throw x;
             // else pass - aborted due to timeout
         }


### PR DESCRIPTION
When a task aborts or is rejected due to having exceeded the startTimeout, use a chained exception, StartTimeoutException, to more clearly identify the cause.