### PR TITLE
remove redundant tracking of Futures for submitted tasks

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.internal;
 
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -21,8 +22,10 @@ import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.enterprise.concurrent.Trigger;
 
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
@@ -49,6 +52,13 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
      */
     @Reference(target = "(deferrable=false)")
     ScheduledExecutorService scheduledExecSvc;
+
+    @Override
+    @Modified
+    @Trivial
+    protected void modified(ComponentContext context, Map<String, Object> properties) {
+        super.modified(context, properties);
+    }
 
     /**
      * @see java.util.concurrent.ScheduledExecutorService#schedule(java.util.concurrent.Callable, long, java.util.concurrent.TimeUnit)

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -92,7 +92,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
     @Override
     @Trivial
     public String getIdentifier(String identifier) {
-        return identifier.startsWith("managed") ? identifier : managedExecutor.name.get() + " (" + identifier + ')';
+        return managedExecutor.getIdentifier(identifier);
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -90,6 +90,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
      * @return identifier to use in messages.
      */
     @Override
+    @Trivial
     public String getIdentifier(String identifier) {
         return identifier.startsWith("managed") ? identifier : managedExecutor.name.get() + " (" + identifier + ')';
     }

--- a/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
@@ -188,7 +188,7 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
             assertNull(listener.exception[ABORTED].getCause());
         else {
             Throwable cause = listener.exception[ABORTED].getCause();
-            if (cause == null || !causeClass.equals(cause.getClass()) ||
+            if (cause == null || !causeClass.isAssignableFrom(cause.getClass()) ||
                 causeMessagePrefix != null && (cause.getMessage() == null || !cause.getMessage().startsWith(causeMessagePrefix)))
                 throw new Exception("Unexpected or missing cause of AbortedException. See chained exceptions", listener.exception[ABORTED]);
         }
@@ -200,7 +200,7 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
             if (!(failure instanceof AbortedException))
                 throw new Exception("Unexpected or missing failure. See chained exceptions", failure);
             Throwable cause = failure.getCause();
-            if (cause == null || !causeClass.equals(cause.getClass()) ||
+            if (cause == null || !causeClass.isAssignableFrom(cause.getClass()) ||
                 causeMessagePrefix != null && (cause.getMessage() == null || !cause.getMessage().startsWith(causeMessagePrefix)))
                 throw new Exception("Unexpected or missing cause of AbortedException. See chained exceptions", failure);
         } else {
@@ -223,7 +223,7 @@ public class ConcurrentPolicyFATServlet extends FATServlet {
             if (!(failure instanceof AbortedException))
                 throw new Exception("Unexpected or missing failure. See chained exceptions", failure);
             Throwable cause = failure.getCause();
-            if (cause == null || !causeClass.equals(cause.getClass()) ||
+            if (cause == null || !causeClass.isAssignableFrom(cause.getClass()) ||
                 causeMessagePrefix != null && (cause.getMessage() == null || !cause.getMessage().startsWith(causeMessagePrefix)))
                 throw new Exception("Unexpected or missing cause of AbortedException. See chained exceptions", failure);
         } else {

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -49,6 +49,19 @@ public interface PolicyExecutor extends ExecutorService {
     }
 
     /**
+     * Attempts to cancel all tasks (both in the queue and running) where the identifier of the task submitter matches the specified identifier.
+     * If PolicyTaskCallback is used when submitting a task, the identifier of the task submitter is obtained via PolicyTaskCallback.getIdentifier.
+     * Otherwise, the identifier is the identifier computed by the PolicyExecutorProvider.create method when the PolicyExecutor was created.
+     * Canceled tasks which have already started might still be in progress when this method returns. How the tasks responds to the interrupt/cancel
+     * signal depends on the task implementation.
+     *
+     * @param identifier the identifier to match
+     * @param interruptIfRunning indicates whether or not to allow interrupt on cancel
+     * @return count of task Futures that were successfully put into the canceled state.
+     */
+    int cancel(String identifier, boolean interruptIfRunning);
+
+    /**
      * Specifies a core number of tasks to aim to run concurrently
      * by expediting requests to the global thread pool. This provides no guarantee
      * that this many tasks will run concurrently. The default value is 0.
@@ -61,6 +74,13 @@ public interface PolicyExecutor extends ExecutorService {
      * @throws IllegalStateException if the executor has been shut down.
      */
     PolicyExecutor expedite(int num);
+
+    /**
+     * Returns the unique identifier for this policy executor.
+     *
+     * @return the unique identifier for this policy executor.
+     */
+    String getIdentifier();
 
     /**
      * Returns the number of tasks from this PolicyExecutor currently running on the global executor.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/StartTimeoutException.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/StartTimeoutException.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.threading;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Exception that indicates a task was rejected or aborted due to exceeding its start timeout.
+ */
+public class StartTimeoutException extends IllegalStateException {
+    private static final long serialVersionUID = 1L;
+    private static final TraceComponent tc = Tr.register(StartTimeoutException.class, "concurrencyPolicy", "com.ibm.ws.threading.internal.resources.ThreadingMessages");
+
+    public StartTimeoutException(String executorId, String taskName, long elapsedNS, long startTimeoutNS) {
+        super(Tr.formatMessage(tc, "CWWKE1205.start.timeout", executorId, taskName, elapsedNS, startTimeoutNS));
+    }
+}

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -333,6 +333,23 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     }
 
     @Override
+    public int cancel(String identifier, boolean interruptIfRunning) {
+        int count = 0;
+
+        // Remove and cancel all queued tasks.
+        for (PolicyTaskFutureImpl<?> f = queue.poll(); f != null; f = queue.poll())
+            if (f.cancel(false))
+                count++;
+
+        // Cancel tasks that are running
+        for (Iterator<PolicyTaskFutureImpl<?>> it = running.iterator(); it.hasNext();)
+            if (it.next().cancel(interruptIfRunning))
+                count++;
+
+        return count;
+    }
+
+    @Override
     public PolicyExecutor expedite(int num) {
         if (num == -1)
             num = Integer.MAX_VALUE;
@@ -571,6 +588,12 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                     Tr.debug(this, tc, "expedites/maxConcurrency available", cca, maxConcurrencyConstraint.availablePermits());
             }
         }
+    }
+
+    @Override
+    @Trivial
+    public String getIdentifier() {
+        return identifier;
     }
 
     @Override

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -28,6 +28,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.threading.PolicyTaskCallback;
 import com.ibm.ws.threading.PolicyTaskFuture;
+import com.ibm.ws.threading.StartTimeoutException;
 
 /**
  * Allows the policy executor to tie into internal state and other details of a Future implementation.
@@ -429,9 +430,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 state.tryAcquireSharedNanos(1, nsStartBy - nsGetBegin);
                 s = state.get();
                 if (s == SUBMITTED) { // attempt to abort the task
-                    abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout", getIdentifier(), getTaskName(),
-                                                                           System.nanoTime() - nsAcceptBegin,
-                                                                           nsStartBy - nsAcceptBegin)));
+                    abort(true, new StartTimeoutException(getIdentifier(), getTaskName(), //
+                                    System.nanoTime() - nsAcceptBegin, //
+                                    nsStartBy - nsAcceptBegin));
                     s = state.get();
                 }
                 if (s == RUNNING) { // continue waiting
@@ -467,9 +468,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                 state.tryAcquireSharedNanos(1, nsStartBy - nsGetBegin);
                 s = state.get();
                 if (s == SUBMITTED) { // attempt to abort the task
-                    abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout", getIdentifier(), getTaskName(),
-                                                                           System.nanoTime() - nsAcceptBegin,
-                                                                           nsStartBy - nsAcceptBegin)));
+                    abort(true, new StartTimeoutException(getIdentifier(), getTaskName(), //
+                                    System.nanoTime() - nsAcceptBegin, //
+                                    nsStartBy - nsAcceptBegin));
                     s = state.get();
                 }
                 if (s == RUNNING) { // wait for the remainder of the timeout supplied to get
@@ -490,11 +491,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
         if (nsStartBy != nsAcceptBegin - 1 // has a start timeout
             && state.get() < RUNNING // not started yet
             && System.nanoTime() - nsStartBy > 0) // start timeout has elapsed
-            abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout",
-                                                                   getIdentifier(),
-                                                                   getTaskName(),
-                                                                   System.nanoTime() - nsAcceptBegin,
-                                                                   nsStartBy - nsAcceptBegin)));
+            abort(true, new StartTimeoutException(getIdentifier(), getTaskName(), //
+                            System.nanoTime() - nsAcceptBegin, //
+                            nsStartBy - nsAcceptBegin));
 
         if (result.compareAndSet(state, CANCELED))
             try {
@@ -637,11 +636,9 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                || nsStartBy != nsAcceptBegin - 1 // has a start timeout
                   && s < RUNNING // not started yet
                   && System.nanoTime() - nsStartBy > 0 // start timeout has elapsed
-                  && (abort(true, new IllegalStateException(Tr.formatMessage(tc, "CWWKE1205.start.timeout",
-                                                                             getIdentifier(),
-                                                                             getTaskName(),
-                                                                             System.nanoTime() - nsAcceptBegin,
-                                                                             nsStartBy - nsAcceptBegin)))
+                  && (abort(true, new StartTimeoutException(getIdentifier(), getTaskName(), //
+                                  System.nanoTime() - nsAcceptBegin, //
+                                  nsStartBy - nsAcceptBegin))
                       || state.get() > RUNNING);
     }
 

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -57,6 +57,7 @@ import com.ibm.ws.threading.PolicyExecutor.MaxPolicy;
 import com.ibm.ws.threading.PolicyExecutorProvider;
 import com.ibm.ws.threading.PolicyTaskCallback;
 import com.ibm.ws.threading.PolicyTaskFuture;
+import com.ibm.ws.threading.StartTimeoutException;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.app.FATServlet;
@@ -4499,7 +4500,9 @@ public class PolicyExecutorServlet extends FATServlet {
             Integer result = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
             fail("Task should be been aborted, instead result is: " + result);
         } catch (RejectedExecutionException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("CWWKE1205E"))
+            if (!(x.getCause() instanceof StartTimeoutException)
+                || x.getCause().getMessage() == null
+                || !x.getCause().getMessage().contains("CWWKE1205E"))
                 throw x;
             // else pass - aborted due to timeout
         }
@@ -4585,7 +4588,9 @@ public class PolicyExecutorServlet extends FATServlet {
             Integer result = future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
             fail("Task 2 should be been aborted, instead result is: " + result);
         } catch (RejectedExecutionException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("CWWKE1205E"))
+            if (!(x.getCause() instanceof StartTimeoutException)
+                || x.getCause().getMessage() == null
+                || !x.getCause().getMessage().contains("CWWKE1205E"))
                 throw x;
             // else pass - aborted due to timeout
         }
@@ -4594,7 +4599,9 @@ public class PolicyExecutorServlet extends FATServlet {
             Integer result = future3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
             fail("Task 3 should be been aborted, instead result is: " + result);
         } catch (RejectedExecutionException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("CWWKE1205E"))
+            if (!(x.getCause() instanceof StartTimeoutException)
+                || x.getCause().getMessage() == null
+                || !x.getCause().getMessage().contains("CWWKE1205E"))
                 throw x;
             // else pass - aborted due to timeout
         }
@@ -4663,7 +4670,9 @@ public class PolicyExecutorServlet extends FATServlet {
             Integer result = future1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
             fail("Task 1 should be been aborted, instead result is: " + result);
         } catch (RejectedExecutionException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("CWWKE1205E"))
+            if (!(x.getCause() instanceof StartTimeoutException)
+                || x.getCause().getMessage() == null
+                || !x.getCause().getMessage().contains("CWWKE1205E"))
                 throw x;
             // else pass - aborted due to timeout
         }


### PR DESCRIPTION
ManagedExecutorServiceImpl does not need to track Futures of submitted/running tasks because the policy executors already do that.  The only place where it is absent is from tasks that are scheduled for the future, in which case we can move the logic to the ManagedScheduledExecutorServiceImpl and completely remove it from ManagedExecutorServiceImpl, instead relying on the policy executor(s) to do the tracking.