### PR TITLE
restore lost CWWKC1120 message

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -92,7 +92,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
     @Override
     @Trivial
     public String getIdentifier(String identifier) {
-        return identifier.startsWith("managed") ? identifier : managedExecutor.name.get() + " (" + identifier + ')';
+        return managedExecutor.getIdentifier(identifier);
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -126,7 +126,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
 
     @FFDCIgnore({ Error.class, RuntimeException.class }) // No need for FFDC, error is logged instead
     @Override
-    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {
+    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean whileRunning) {
         // Tasks that are canceled while running have the taskAborted notification sent on the thread of execution instead.
 
         // notify listener: taskAborted (if task was canceled before it started)

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -281,4 +281,9 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
     public void raiseAbortedException(Throwable x) throws ExecutionException {
         throw new AbortedException(x);
     }
+
+    @Override
+    public void resolveDeadlockOnFutureGet() throws InterruptedException {
+        throw new InterruptedException(Tr.formatMessage(tc, "CWWKC1120.future.get.rejected"));
+    }
 }

--- a/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyTestServlet.java
@@ -6161,7 +6161,8 @@ public class EEConcurrencyTestServlet extends FATServlet {
             throw new Exception("taskSubmitted: future from " + event + " doesn't match " + future);
         if (event.uowType != UOWManager.UOW_TYPE_LOCAL_TRANSACTION)
             throw new Exception("taskSubmitted: should not be running in a transaction: " + event);
-        if (!(event.failureFromFutureGet instanceof InterruptedException))
+        if (!(event.failureFromFutureGet instanceof InterruptedException)
+            || !event.failureFromFutureGet.getMessage().startsWith("CWWKC1120E"))
             throw new Exception("taskSubmitted: missing or unexpected failure for Future.get during " + event, event.failureFromFutureGet);
 
         // taskStarting
@@ -6176,7 +6177,8 @@ public class EEConcurrencyTestServlet extends FATServlet {
             throw new Exception("taskStarting: future from " + event + " doesn't match " + future);
         if (event.uowType != UOWManager.UOW_TYPE_LOCAL_TRANSACTION)
             throw new Exception("taskStarting: should not be running in a transaction: " + event);
-        if (!(event.failureFromFutureGet instanceof InterruptedException))
+        if (!(event.failureFromFutureGet instanceof InterruptedException)
+            || !event.failureFromFutureGet.getMessage().startsWith("CWWKC1120E"))
             throw new Exception("taskStarting: missing or unexpected failure for Future.get during " + event, event.failureFromFutureGet);
 
         // taskDone

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -49,6 +49,19 @@ public interface PolicyExecutor extends ExecutorService {
     }
 
     /**
+     * Attempts to cancel all tasks (both in the queue and running) where the identifier of the task submitter matches the specified identifier.
+     * If PolicyTaskCallback is used when submitting a task, the identifier of the task submitter is obtained via PolicyTaskCallback.getIdentifier.
+     * Otherwise, the identifier is the identifier computed by the PolicyExecutorProvider.create method when the PolicyExecutor was created.
+     * Canceled tasks which have already started might still be in progress when this method returns. How the tasks responds to the interrupt/cancel
+     * signal depends on the task implementation.
+     *
+     * @param identifier the identifier to match
+     * @param interruptIfRunning indicates whether or not to allow interrupt on cancel
+     * @return count of task Futures that were successfully put into the canceled state.
+     */
+    int cancel(String identifier, boolean interruptIfRunning);
+
+    /**
      * Specifies a core number of tasks to aim to run concurrently
      * by expediting requests to the global thread pool. This provides no guarantee
      * that this many tasks will run concurrently. The default value is 0.
@@ -61,6 +74,13 @@ public interface PolicyExecutor extends ExecutorService {
      * @throws IllegalStateException if the executor has been shut down.
      */
     PolicyExecutor expedite(int num);
+
+    /**
+     * Returns the unique identifier for this policy executor.
+     *
+     * @return the unique identifier for this policy executor.
+     */
+    String getIdentifier();
 
     /**
      * Returns the number of tasks from this PolicyExecutor currently running on the global executor.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
@@ -124,4 +124,15 @@ public abstract class PolicyTaskCallback {
      * @throws ExecutionException
      */
     public void raiseAbortedException(Throwable x) throws ExecutionException {}
+
+    /**
+     * Allows for raising a more meaningful exception when the Future.get is attempted from the same
+     * thread that is preparing to submit or start the task. This is essentially a deadlock where the
+     * task will never be able to start. The deadlock must be broken by raising an exception.
+     * The default implementation does nothing, in response to which the policy executor raises a generic
+     * InterruptedException without any message or cause exception.
+     *
+     * @throws InterruptedException if the callback provider wishes to replace the generic InterruptedException that is raised for this condition.
+     */
+    public void resolveDeadlockOnFutureGet() throws InterruptedException {}
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
@@ -69,10 +69,9 @@ public abstract class PolicyTaskCallback {
      *
      * @param task the Callable or Runnable task.
      * @param future the future for the task that was canceled.
-     * @param timedOut indicates if the start timeout elapsed and caused cancellation.
      * @param whileRunning indicates if the task was canceled while running (as opposed to while still queued for execution or just before it started).
      */
-    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {}
+    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean whileRunning) {}
 
     /**
      * Invoked on the thread of execution of a task after it completes, which could be successfully, exceptionally, or due to cancellation/interrupt.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -333,6 +333,23 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     }
 
     @Override
+    public int cancel(String identifier, boolean interruptIfRunning) {
+        int count = 0;
+
+        // Remove and cancel all queued tasks.
+        for (PolicyTaskFutureImpl<?> f = queue.poll(); f != null; f = queue.poll())
+            if (f.cancel(false))
+                count++;
+
+        // Cancel tasks that are running
+        for (Iterator<PolicyTaskFutureImpl<?>> it = running.iterator(); it.hasNext();)
+            if (it.next().cancel(interruptIfRunning))
+                count++;
+
+        return count;
+    }
+
+    @Override
     public PolicyExecutor expedite(int num) {
         if (num == -1)
             num = Integer.MAX_VALUE;
@@ -571,6 +588,12 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                     Tr.debug(this, tc, "expedites/maxConcurrency available", cca, maxConcurrencyConstraint.availablePermits());
             }
         }
+    }
+
+    @Override
+    @Trivial
+    public String getIdentifier() {
+        return identifier;
     }
 
     @Override

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -561,8 +561,10 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             case CANCELING:
                 throw new CancellationException();
             case RUNNING: // only possible when get() is invoked from thread of execution and therefore blocks completion
-            case PRESUBMIT: // only possible when get() is invoke from onStart, which runs on the submitter's thread and therefore blocks completion
-                throw new InterruptedException(); // TODO message
+            case PRESUBMIT: // only possible when get() is invoked from onStart, which runs on the submitter's thread and therefore blocks completion
+                if (callback != null)
+                    callback.resolveDeadlockOnFutureGet();
+                throw new InterruptedException();
             default: // should be unreachable
                 throw new IllegalStateException(Integer.toString(state.get()));
         }
@@ -586,8 +588,10 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             case TIMEOUT:
                 throw new TimeoutException();
             case RUNNING: // only possible when get() is invoked from thread of execution and therefore blocks completion
-            case PRESUBMIT: // only possible when get() is invoke from onStart, which runs on the submitter's thread and therefore blocks completion
-                throw new InterruptedException(); // TODO message
+            case PRESUBMIT: // only possible when get() is invoked from onStart, which runs on the submitter's thread and therefore blocks completion
+                if (callback != null)
+                    callback.resolveDeadlockOnFutureGet();
+                throw new InterruptedException();
             default: // should be unreachable
                 throw new IllegalStateException(Integer.toString(state.get()));
         }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -504,14 +504,14 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(this, tc, "canceled from queue");
                     if (callback != null)
-                        callback.onCancel(task, this, false, false);
+                        callback.onCancel(task, this, false);
                 } else if (state.get() == PRESUBMIT) {
                     nsRunEnd = nsQueueEnd = nsAcceptEnd = System.nanoTime();
                     state.releaseShared(CANCELED);
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(this, tc, "canceled during pre-submit");
                     if (callback != null)
-                        callback.onCancel(task, this, false, false);
+                        callback.onCancel(task, this, false);
                 } else if (interruptIfRunning) {
                     state.releaseShared(CANCELING);
                     Thread t = thread;
@@ -524,12 +524,12 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                     } finally {
                         state.releaseShared(CANCELED);
                         if (callback != null)
-                            callback.onCancel(task, this, false, true);
+                            callback.onCancel(task, this, true);
                     }
                 } else {
                     state.releaseShared(CANCELED);
                     if (callback != null)
-                        callback.onCancel(task, this, false, true);
+                        callback.onCancel(task, this, true);
                 }
 
                 return true;

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/FailingCallback.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/FailingCallback.java
@@ -29,8 +29,8 @@ public class FailingCallback extends ParameterInfoCallback {
     }
 
     @Override
-    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {
-        super.onCancel(task, future, timedOut, whileRunning);
+    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean whileRunning) {
+        super.onCancel(task, future, whileRunning);
         if (failureClass[CANCEL] != null)
             throw newRuntimeException(failureClass[CANCEL]);
     }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ParameterInfoCallback.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ParameterInfoCallback.java
@@ -38,7 +38,7 @@ public class ParameterInfoCallback extends PolicyTaskCallback {
     }
 
     @Override
-    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {
+    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean whileRunning) {
         nsAccept[CANCEL] = future.getElapsedAcceptTime(TimeUnit.NANOSECONDS);
         nsQueue[CANCEL] = future.getElapsedQueueTime(TimeUnit.NANOSECONDS);
         nsRun[CANCEL] = future.getElapsedRunTime(TimeUnit.NANOSECONDS);


### PR DESCRIPTION
The message that is raised on the InterruptedException that is used to resolve the deadlock on Future.get from taskSubmitted/taskStarting was lost in the switch to policy executor.  Need to restore it.