### PR TITLE
Adding InvokeDynamic as an option to be able to compile lambda expressions.

### DIFF
--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/utils/SDEInstaller.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/utils/SDEInstaller.java
@@ -8,6 +8,9 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+//APARS:
+//PI89577    hmpadill    11/16/17    JSPs containg Java 8 specific syntaxes might fail to compile 
+
 package com.ibm.ws.jsp.translator.utils;
 
 import java.io.File;
@@ -252,6 +255,7 @@ public class SDEInstaller {
                 case 3 : // Integer
                 case 4 : // Float
                 case 12 : // NameAndType
+                case 18 : // InvokeDynamic PI89577
                     if (verbose) {
                         System.out.println(i + " copying 4 bytes");
                     }


### PR DESCRIPTION
JSP pages containing some Java 8 lambda expressions may result in a compilation error reported with an exception similar to the following:

java.io.IOException: unexpected tag: 18
    at com.ibm.ws.jsp.translator.utils.SDEInstaller.copyConstantPool(SDEInstaller.java:278)

An example scriptlet producing such error is:

<%@ page import="java.util.Arrays" %>
<%@ page import="java.util.stream.Collectors" %>
<%= Arrays.asList(1,2,3).stream().map(i -> "A" + i * i).collect(Collectors.toList()) %>