### PR TITLE
serviceability review comments

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -92,7 +92,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
     @Override
     @Trivial
     public String getIdentifier(String identifier) {
-        return identifier.startsWith("managed") ? identifier : managedExecutor.name.get() + " (" + identifier + ')';
+        return managedExecutor.getIdentifier(identifier);
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -126,7 +126,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
 
     @FFDCIgnore({ Error.class, RuntimeException.class }) // No need for FFDC, error is logged instead
     @Override
-    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {
+    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean whileRunning) {
         // Tasks that are canceled while running have the taskAborted notification sent on the thread of execution instead.
 
         // notify listener: taskAborted (if task was canceled before it started)

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -281,4 +281,9 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
     public void raiseAbortedException(Throwable x) throws ExecutionException {
         throw new AbortedException(x);
     }
+
+    @Override
+    public void resolveDeadlockOnFutureGet() throws InterruptedException {
+        throw new InterruptedException(Tr.formatMessage(tc, "CWWKC1120.future.get.rejected"));
+    }
 }

--- a/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyTestServlet.java
@@ -6161,7 +6161,8 @@ public class EEConcurrencyTestServlet extends FATServlet {
             throw new Exception("taskSubmitted: future from " + event + " doesn't match " + future);
         if (event.uowType != UOWManager.UOW_TYPE_LOCAL_TRANSACTION)
             throw new Exception("taskSubmitted: should not be running in a transaction: " + event);
-        if (!(event.failureFromFutureGet instanceof InterruptedException))
+        if (!(event.failureFromFutureGet instanceof InterruptedException)
+            || !event.failureFromFutureGet.getMessage().startsWith("CWWKC1120E"))
             throw new Exception("taskSubmitted: missing or unexpected failure for Future.get during " + event, event.failureFromFutureGet);
 
         // taskStarting
@@ -6176,7 +6177,8 @@ public class EEConcurrencyTestServlet extends FATServlet {
             throw new Exception("taskStarting: future from " + event + " doesn't match " + future);
         if (event.uowType != UOWManager.UOW_TYPE_LOCAL_TRANSACTION)
             throw new Exception("taskStarting: should not be running in a transaction: " + event);
-        if (!(event.failureFromFutureGet instanceof InterruptedException))
+        if (!(event.failureFromFutureGet instanceof InterruptedException)
+            || !event.failureFromFutureGet.getMessage().startsWith("CWWKC1120E"))
             throw new Exception("taskStarting: missing or unexpected failure for Future.get during " + event, event.failureFromFutureGet);
 
         // taskDone

--- a/dev/com.ibm.ws.concurrent_fat_policy/fat/src/com/ibm/ws/concurrent/policy/fat/ConcurrentPolicyExecutorTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/fat/src/com/ibm/ws/concurrent/policy/fat/ConcurrentPolicyExecutorTest.java
@@ -48,6 +48,6 @@ public class ConcurrentPolicyExecutorTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKE1205E:"); // several tests intentionally exceed the startTimeout
     }
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -49,6 +49,19 @@ public interface PolicyExecutor extends ExecutorService {
     }
 
     /**
+     * Attempts to cancel all tasks (both in the queue and running) where the identifier of the task submitter matches the specified identifier.
+     * If PolicyTaskCallback is used when submitting a task, the identifier of the task submitter is obtained via PolicyTaskCallback.getIdentifier.
+     * Otherwise, the identifier is the identifier computed by the PolicyExecutorProvider.create method when the PolicyExecutor was created.
+     * Canceled tasks which have already started might still be in progress when this method returns. How the tasks responds to the interrupt/cancel
+     * signal depends on the task implementation.
+     *
+     * @param identifier the identifier to match
+     * @param interruptIfRunning indicates whether or not to allow interrupt on cancel
+     * @return count of task Futures that were successfully put into the canceled state.
+     */
+    int cancel(String identifier, boolean interruptIfRunning);
+
+    /**
      * Specifies a core number of tasks to aim to run concurrently
      * by expediting requests to the global thread pool. This provides no guarantee
      * that this many tasks will run concurrently. The default value is 0.
@@ -61,6 +74,13 @@ public interface PolicyExecutor extends ExecutorService {
      * @throws IllegalStateException if the executor has been shut down.
      */
     PolicyExecutor expedite(int num);
+
+    /**
+     * Returns the unique identifier for this policy executor.
+     *
+     * @return the unique identifier for this policy executor.
+     */
+    String getIdentifier();
 
     /**
      * Returns the number of tasks from this PolicyExecutor currently running on the global executor.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
@@ -124,4 +124,15 @@ public abstract class PolicyTaskCallback {
      * @throws ExecutionException
      */
     public void raiseAbortedException(Throwable x) throws ExecutionException {}
+
+    /**
+     * Allows for raising a more meaningful exception when the Future.get is attempted from the same
+     * thread that is preparing to submit or start the task. This is essentially a deadlock where the
+     * task will never be able to start. The deadlock must be broken by raising an exception.
+     * The default implementation does nothing, in response to which the policy executor raises a generic
+     * InterruptedException without any message or cause exception.
+     *
+     * @throws InterruptedException if the callback provider wishes to replace the generic InterruptedException that is raised for this condition.
+     */
+    public void resolveDeadlockOnFutureGet() throws InterruptedException {}
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyTaskCallback.java
@@ -69,10 +69,9 @@ public abstract class PolicyTaskCallback {
      *
      * @param task the Callable or Runnable task.
      * @param future the future for the task that was canceled.
-     * @param timedOut indicates if the start timeout elapsed and caused cancellation.
      * @param whileRunning indicates if the task was canceled while running (as opposed to while still queued for execution or just before it started).
      */
-    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {}
+    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean whileRunning) {}
 
     /**
      * Invoked on the thread of execution of a task after it completes, which could be successfully, exceptionally, or due to cancellation/interrupt.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/StartTimeoutException.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/StartTimeoutException.java
@@ -22,5 +22,6 @@ public class StartTimeoutException extends IllegalStateException {
 
     public StartTimeoutException(String executorId, String taskName, long elapsedNS, long startTimeoutNS) {
         super(Tr.formatMessage(tc, "CWWKE1205.start.timeout", executorId, taskName, elapsedNS, startTimeoutNS));
+        Tr.error(tc, "CWWKE1205.start.timeout", executorId, taskName, elapsedNS, startTimeoutNS);
     }
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -359,7 +359,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         int a;
         synchronized (configLock) {
             if (num > maxConcurrency)
-                throw new IllegalArgumentException(Integer.toString(num));
+                throw new IllegalArgumentException("expedite: " + num + " > maxConcurrency: " + maxConcurrency);
 
             if (state.get() != State.ACTIVE)
                 throw new IllegalStateException(Tr.formatMessage(tc, "CWWKE1203.config.update.after.shutdown", "expedite", identifier));
@@ -950,7 +950,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
         synchronized (configLock) {
             if (max < expedite)
-                throw new IllegalArgumentException(Integer.toString(max));
+                throw new IllegalArgumentException("maxConcurrency: " + max + " < expedite: " + expedite);
 
             if (state.get() != State.ACTIVE)
                 throw new IllegalStateException(Tr.formatMessage(tc, "CWWKE1203.config.update.after.shutdown", "maxConcurrency", identifier));
@@ -1311,13 +1311,13 @@ public class PolicyExecutorImpl implements PolicyExecutor {
 
         // Validation that cannot be performed by metatype:
         if (u_expedite > u_max)
-            throw new IllegalArgumentException(u_expedite + " > " + u_max);
+            throw new IllegalArgumentException("expedite: " + u_expedite + " > max: " + u_max);
 
         if (u_maxWaitForEnqueue < 0 || u_maxWaitForEnqueue > maxMS)
-            throw new IllegalArgumentException(Long.toString(u_maxWaitForEnqueue));
+            throw new IllegalArgumentException("maxWaitForEnqueue: " + u_maxWaitForEnqueue);
 
         if (u_startTimeout < -1 || u_startTimeout > maxMS)
-            throw new IllegalArgumentException(Long.toString(u_startTimeout));
+            throw new IllegalArgumentException("startTimeout: " + u_startTimeout);
 
         for (long current = maxWaitForEnqueueNS.get(); current != -1; current = maxWaitForEnqueueNS.get())
             if (maxWaitForEnqueueNS.compareAndSet(current, TimeUnit.MILLISECONDS.toNanos(u_maxWaitForEnqueue)))

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -333,6 +333,23 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     }
 
     @Override
+    public int cancel(String identifier, boolean interruptIfRunning) {
+        int count = 0;
+
+        // Remove and cancel all queued tasks.
+        for (PolicyTaskFutureImpl<?> f = queue.poll(); f != null; f = queue.poll())
+            if (f.cancel(false))
+                count++;
+
+        // Cancel tasks that are running
+        for (Iterator<PolicyTaskFutureImpl<?>> it = running.iterator(); it.hasNext();)
+            if (it.next().cancel(interruptIfRunning))
+                count++;
+
+        return count;
+    }
+
+    @Override
     public PolicyExecutor expedite(int num) {
         if (num == -1)
             num = Integer.MAX_VALUE;
@@ -571,6 +588,12 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                     Tr.debug(this, tc, "expedites/maxConcurrency available", cca, maxConcurrencyConstraint.availablePermits());
             }
         }
+    }
+
+    @Override
+    @Trivial
+    public String getIdentifier() {
+        return identifier;
     }
 
     @Override

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -561,8 +561,10 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             case CANCELING:
                 throw new CancellationException();
             case RUNNING: // only possible when get() is invoked from thread of execution and therefore blocks completion
-            case PRESUBMIT: // only possible when get() is invoke from onStart, which runs on the submitter's thread and therefore blocks completion
-                throw new InterruptedException(); // TODO message
+            case PRESUBMIT: // only possible when get() is invoked from onStart, which runs on the submitter's thread and therefore blocks completion
+                if (callback != null)
+                    callback.resolveDeadlockOnFutureGet();
+                throw new InterruptedException();
             default: // should be unreachable
                 throw new IllegalStateException(Integer.toString(state.get()));
         }
@@ -586,8 +588,10 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
             case TIMEOUT:
                 throw new TimeoutException();
             case RUNNING: // only possible when get() is invoked from thread of execution and therefore blocks completion
-            case PRESUBMIT: // only possible when get() is invoke from onStart, which runs on the submitter's thread and therefore blocks completion
-                throw new InterruptedException(); // TODO message
+            case PRESUBMIT: // only possible when get() is invoked from onStart, which runs on the submitter's thread and therefore blocks completion
+                if (callback != null)
+                    callback.resolveDeadlockOnFutureGet();
+                throw new InterruptedException();
             default: // should be unreachable
                 throw new IllegalStateException(Integer.toString(state.get()));
         }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyTaskFutureImpl.java
@@ -504,14 +504,14 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(this, tc, "canceled from queue");
                     if (callback != null)
-                        callback.onCancel(task, this, false, false);
+                        callback.onCancel(task, this, false);
                 } else if (state.get() == PRESUBMIT) {
                     nsRunEnd = nsQueueEnd = nsAcceptEnd = System.nanoTime();
                     state.releaseShared(CANCELED);
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(this, tc, "canceled during pre-submit");
                     if (callback != null)
-                        callback.onCancel(task, this, false, false);
+                        callback.onCancel(task, this, false);
                 } else if (interruptIfRunning) {
                     state.releaseShared(CANCELING);
                     Thread t = thread;
@@ -524,12 +524,12 @@ public class PolicyTaskFutureImpl<T> implements PolicyTaskFuture<T> {
                     } finally {
                         state.releaseShared(CANCELED);
                         if (callback != null)
-                            callback.onCancel(task, this, false, true);
+                            callback.onCancel(task, this, true);
                     }
                 } else {
                     state.releaseShared(CANCELED);
                     if (callback != null)
-                        callback.onCancel(task, this, false, true);
+                        callback.onCancel(task, this, true);
                 }
 
                 return true;

--- a/dev/com.ibm.ws.threading_policy_fat/fat/src/com/ibm/ws/threading/policy/PolicyExecutorTest.java
+++ b/dev/com.ibm.ws.threading_policy_fat/fat/src/com/ibm/ws/threading/policy/PolicyExecutorTest.java
@@ -49,7 +49,7 @@ public class PolicyExecutorTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.stopServer();
+        server1.stopServer("CWWKE1205E:.*PolicyExecutorProvider-testStartTimeout.*"); // some tests intentionally exceed the startTimeout
         server1.deleteFileFromLibertyInstallRoot("lib/features/policyExecutorUser-1.0.mf");
         server1.deleteFileFromLibertyInstallRoot("lib/test.policyexecutor.bundle_fat.jar");
     }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/FailingCallback.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/FailingCallback.java
@@ -29,8 +29,8 @@ public class FailingCallback extends ParameterInfoCallback {
     }
 
     @Override
-    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {
-        super.onCancel(task, future, timedOut, whileRunning);
+    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean whileRunning) {
+        super.onCancel(task, future, whileRunning);
         if (failureClass[CANCEL] != null)
             throw newRuntimeException(failureClass[CANCEL]);
     }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ParameterInfoCallback.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ParameterInfoCallback.java
@@ -38,7 +38,7 @@ public class ParameterInfoCallback extends PolicyTaskCallback {
     }
 
     @Override
-    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean timedOut, boolean whileRunning) {
+    public void onCancel(Object task, PolicyTaskFuture<?> future, boolean whileRunning) {
         nsAccept[CANCEL] = future.getElapsedAcceptTime(TimeUnit.NANOSECONDS);
         nsQueue[CANCEL] = future.getElapsedQueueTime(TimeUnit.NANOSECONDS);
         nsRun[CANCEL] = future.getElapsedRunTime(TimeUnit.NANOSECONDS);


### PR DESCRIPTION
Address a couple of comments from the serviceability review:
Should log errors for tasks that are aborted due to startTimeout.
Need to report more detail on the error that is raised for user configuring expedite larger than max, to at least identify which values pertain to which attributes.