### PR TITLE
Update concurrent_fat & threading_policy_fat to work with java2security

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat/publish/servers/concurrent.spec.fat/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat/publish/servers/concurrent.spec.fat/server.xml
@@ -33,8 +33,9 @@
   </managedThreadFactory>
 
   <!-- Test application needs these permissions to help verify thread context -->
-  <javaPermission codebase="${server.config.dir}/dropins/war/concurrentbvt" className="java.lang.RuntimePermission" name="getClassLoader"/>
-  <javaPermission codebase="${server.config.dir}/dropins/war/concurrentbvt" className="java.lang.RuntimePermission" name="getContextClassLoader"/>
-  <javaPermission codebase="${server.config.dir}/dropins/war/concurrentbvt" className="java.lang.RuntimePermission" name="modifyThread"/>
-  <javaPermission codebase="${server.config.dir}/dropins/war/concurrentbvt" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+  <javaPermission codebase="${server.config.dir}/dropins/concurrentSpec.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+  <javaPermission codebase="${server.config.dir}/dropins/concurrentSpec.war" className="java.lang.RuntimePermission" name="getContextClassLoader"/>
+  <javaPermission codebase="${server.config.dir}/dropins/concurrentSpec.war" className="java.lang.RuntimePermission" name="modifyThread"/>
+  <javaPermission codebase="${server.config.dir}/dropins/concurrentSpec.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+  
 </server>

--- a/dev/com.ibm.ws.threading_policy_fat/publish/servers/PolicyExecutorServer/server.xml
+++ b/dev/com.ibm.ws.threading_policy_fat/publish/servers/PolicyExecutorServer/server.xml
@@ -20,4 +20,7 @@
     
     <application location="basicfat.war" />
     
+    <!-- Needed for application to shutdown the ExecutorService testThreads -->
+    <javaPermission codebase="${server.config.dir}/apps/basicfat.war" className="java.lang.RuntimePermission" name="modifyThread"/>
+    
 </server>


### PR DESCRIPTION
PR for issue #1049.  Fix issues with application permissions causing java 2 security failures for the following tests: 

com.ibm.ws.concurrent_fat:
- testDefaultThreadFactory
- testJavaSEExecutorUsingManagedThreadFactory

com.ibm.ws.threading_policy_fat:
- (error) com.ibm.ws.threading.policy.PolicyExecutorTest
