### PR TITLE
Add appclient test cases to JPA FVT bucket.

### DIFF
--- a/dev/com.ibm.ws.jpa_22_fat/.classpath
+++ b/dev/com.ibm.ws.jpa_22_fat/.classpath
@@ -6,6 +6,7 @@
 	<classpathentry kind="src" path="test-applications/jpa22/jpa22query/src"/>
 	<classpathentry kind="src" path="test-applications/jpa22/jpa22timeapi/src"/>
 	<classpathentry kind="src" path="test-applications/jpa22/jpa22injection/src"/>
+	<classpathentry kind="src" path="test-applications/appclient/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
@@ -16,6 +16,7 @@ javac.source: 1.8
 
 src: \
 	fat/src,\
+	test-applications/appclient/src,\
 	test-applications/jpabootstrap/src,\
 	test-applications/jpa22/cdi/src,\
 	test-applications/jpa22/jpa22injection/src,\

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPAAppClientTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPAAppClientTest.java
@@ -1,0 +1,222 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa;
+
+import java.io.File;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.Application;
+import com.ibm.websphere.simplicity.config.ClientConfiguration;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyClient;
+import componenttest.topology.impl.LibertyClientFactory;
+
+@RunWith(FATRunner.class)
+public class JPAAppClientTest {
+    private static final String APPCLIENT_ROOT = "test-applications/appclient";
+    private final static String CLIENT_NAME = "JPAAppClient";
+    private final static String PKG_ROOT = "jpaappcli";
+
+    protected static LibertyClient client = LibertyClientFactory.getLibertyClient(CLIENT_NAME);
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+
+    }
+
+    @Test
+    public void testAppClientFieldInjection() throws Exception {
+        final String appName = "AppCliJPAFieldInj";
+        final String resRoot = APPCLIENT_ROOT + "/" + appName + ".ear";
+
+        final JavaArchive appCliJar = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
+        appCliJar.addPackage(PKG_ROOT + ".client.fieldinjection");
+        appCliJar.addPackage(PKG_ROOT + ".entity");
+        ShrinkHelper.addDirectory(appCliJar, resRoot + "/" + appName + ".jar");
+
+        final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appName + ".ear");
+        app.addAsModule(appCliJar);
+        app.setApplicationXML(new File(resRoot + "/META-INF/application.xml"));
+
+        ShrinkHelper.exportToClient(client, "apps", app);
+        client.addInstalledAppForValidation(appName);
+
+        Application appRecord = new Application();
+        appRecord.setLocation(appName + ".ear");
+        appRecord.setName(appName);
+
+        ClientConfiguration cc = client.getClientConfiguration();
+        cc.getApplications().add(appRecord);
+        client.updateClientConfiguration(cc);
+        client.saveClientConfiguration();
+
+        client.startClient();
+        client.waitForStringInCopiedLog("CWWKE0908I");
+        List<String> jpaCliStrings = client.findStringsInCopiedLogs("JPACLI");
+        boolean foundPass = false;
+        boolean foundFail = false;
+        if (jpaCliStrings != null && jpaCliStrings.size() > 0) {
+            for (String s : jpaCliStrings) {
+                if (s.indexOf("JPACLI: PASSED:") > -1) {
+                    foundPass = true;
+                }
+                if (s.indexOf("JPACLI: FAILED:") > -1) {
+                    foundFail = true;
+                }
+            }
+        }
+
+        cc = client.getClientConfiguration();
+        cc.getApplications().clear();;
+        client.updateClientConfiguration(cc);
+        client.saveClientConfiguration();
+
+        if (foundFail) {
+            Assert.fail("Observed failure messages in the client log.");
+        }
+        if (foundPass) {
+            System.out.println("Found PASS eyecatcher in the client log.");
+        } else {
+            Assert.fail("Observed no PASS messages in the client log.");
+        }
+    }
+
+    @Test
+    public void testAppClientMethodInjection() throws Exception {
+        final String appName = "AppCliJPAMethodInj";
+        final String resRoot = APPCLIENT_ROOT + "/" + appName + ".ear";
+
+        final JavaArchive appCliJar = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
+        appCliJar.addPackage(PKG_ROOT + ".client.methodinjection");
+        appCliJar.addPackage(PKG_ROOT + ".entity");
+        ShrinkHelper.addDirectory(appCliJar, resRoot + "/" + appName + ".jar");
+
+        final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appName + ".ear");
+        app.addAsModule(appCliJar);
+        app.setApplicationXML(new File(resRoot + "/META-INF/application.xml"));
+
+        ShrinkHelper.exportToClient(client, "apps", app);
+        client.addInstalledAppForValidation(appName);
+
+        Application appRecord = new Application();
+        appRecord.setLocation(appName + ".ear");
+        appRecord.setName(appName);
+
+        ClientConfiguration cc = client.getClientConfiguration();
+        cc.getApplications().add(appRecord);
+        client.updateClientConfiguration(cc);
+        client.saveClientConfiguration();
+
+        client.startClient();
+        client.waitForStringInCopiedLog("CWWKE0908I");
+        List<String> jpaCliStrings = client.findStringsInCopiedLogs("JPACLI");
+        boolean foundPass = false;
+        boolean foundFail = false;
+        if (jpaCliStrings != null && jpaCliStrings.size() > 0) {
+            for (String s : jpaCliStrings) {
+                if (s.indexOf("JPACLI: PASSED:") > -1) {
+                    foundPass = true;
+                }
+                if (s.indexOf("JPACLI: FAILED:") > -1) {
+                    foundFail = true;
+                }
+            }
+        }
+
+        cc = client.getClientConfiguration();
+        cc.getApplications().clear();;
+        client.updateClientConfiguration(cc);
+        client.saveClientConfiguration();
+
+        if (foundFail) {
+            Assert.fail("Observed failure messages in the client log.");
+        }
+        if (foundPass) {
+            System.out.println("Found PASS eyecatcher in the client log.");
+        } else {
+            Assert.fail("Observed no PASS messages in the client log.");
+        }
+    }
+
+    @Test
+    public void testAppClientMethodJNDI() throws Exception {
+        final String appName = "AppCliJPAJNDIInj";
+        final String resRoot = APPCLIENT_ROOT + "/" + appName + ".ear";
+
+        final JavaArchive appCliJar = ShrinkWrap.create(JavaArchive.class, appName + ".jar");
+        appCliJar.addPackage(PKG_ROOT + ".client.jndiinjection");
+        appCliJar.addPackage(PKG_ROOT + ".entity");
+        ShrinkHelper.addDirectory(appCliJar, resRoot + "/" + appName + ".jar");
+
+        final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, appName + ".ear");
+        app.addAsModule(appCliJar);
+        app.setApplicationXML(new File(resRoot + "/META-INF/application.xml"));
+
+        ShrinkHelper.exportToClient(client, "apps", app);
+        client.addInstalledAppForValidation(appName);
+
+        Application appRecord = new Application();
+        appRecord.setLocation(appName + ".ear");
+        appRecord.setName(appName);
+
+        ClientConfiguration cc = client.getClientConfiguration();
+        cc.getApplications().add(appRecord);
+        client.updateClientConfiguration(cc);
+        client.saveClientConfiguration();
+
+        client.startClient();
+        client.waitForStringInCopiedLog("CWWKE0908I");
+        List<String> jpaCliStrings = client.findStringsInCopiedLogs("JPACLI");
+        boolean foundPass = false;
+        boolean foundFail = false;
+        if (jpaCliStrings != null && jpaCliStrings.size() > 0) {
+            for (String s : jpaCliStrings) {
+                if (s.indexOf("JPACLI: PASSED:") > -1) {
+                    foundPass = true;
+                }
+                if (s.indexOf("JPACLI: FAILED:") > -1) {
+                    foundFail = true;
+                }
+            }
+        }
+
+        cc = client.getClientConfiguration();
+        cc.getApplications().clear();;
+        client.updateClientConfiguration(cc);
+        client.saveClientConfiguration();
+
+        if (foundFail) {
+            Assert.fail("Observed failure messages in the client log.");
+        }
+        if (foundPass) {
+            System.out.println("Found PASS eyecatcher in the client log.");
+        } else {
+            Assert.fail("Observed no PASS messages in the client log.");
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/publish/clients/JPAAppClient/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/clients/JPAAppClient/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.timedexit.timetolive=120000

--- a/dev/com.ibm.ws.jpa_22_fat/publish/clients/JPAAppClient/client.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/clients/JPAAppClient/client.xml
@@ -1,0 +1,33 @@
+<!--
+    Copyright (c) 2015, 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<client>
+    <include location="../fatTestPorts.xml"/>
+    <featureManager>
+        <feature>javaeeClient-8.0</feature>
+    </featureManager>
+    
+    <dataSource id="jdbc/JPA_DS" jndiName="jdbc/JPA_DS" fat.modify="true">
+        <jdbcDriver libraryRef="DerbyLib"/>
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />   
+    </dataSource>
+    <dataSource id="jdbc/JPA_NJTADS" jndiName="jdbc/JPA_NJTADS" fat.modify="true" transactional="false">
+        <jdbcDriver libraryRef="DerbyLib"/>
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />   
+    </dataSource>
+    
+    <library id="DerbyLib" fat.modify="true">
+        <fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
+    </library>
+    
+   <!--  <application id="JPAAppClient" name="JPAAppClient" type="ear" location="JPAAppClient.ear"/> -->
+   
+   <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+</client>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAFieldInj.ear/AppCliJPAFieldInj.jar/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAFieldInj.ear/AppCliJPAFieldInj.jar/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: jpaappcli.client.fieldinjection.JPAApplicationFieldInjectClient
+Class-Path: 

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAFieldInj.ear/AppCliJPAFieldInj.jar/META-INF/application-client.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAFieldInj.ear/AppCliJPAFieldInj.jar/META-INF/application-client.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application-client xmlns="http://java.sun.com/xml/ns/javaee"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application-client_6.xsd"
+     version="6">
+      <display-name>JPAApplicationFieldInjectClient</display-name>
+      
+      <resource-ref>
+         <res-ref-name>java:app/env/jdbc/JPA_NJTADS</res-ref-name>
+         <res-type>javax.sql.DataSource</res-type>
+         <res-auth>Container</res-auth>
+         <res-sharing-scope>Shareable</res-sharing-scope>
+      </resource-ref>
+      
+      <persistence-unit-ref>
+         <persistence-unit-ref-name>AppCliPU_DD_EMF</persistence-unit-ref-name>
+         <persistence-unit-name>AppCliPU</persistence-unit-name>
+         <injection-target>
+            <injection-target-class>jpaappcli.client.fieldinjection.JPAApplicationFieldInjectClient</injection-target-class>
+            <injection-target-name>emfDD</injection-target-name>
+         </injection-target>
+      </persistence-unit-ref>
+      <persistence-unit-ref>
+         <persistence-unit-ref-name>AppCliPU_DDOVRD_EMF</persistence-unit-ref-name>
+         <persistence-unit-name>AppCliPU_2</persistence-unit-name>
+         <injection-target>
+            <injection-target-class>jpaappcli.client.fieldinjection.JPAApplicationFieldInjectClient</injection-target-class>
+            <injection-target-name>emfMerge</injection-target-name>
+         </injection-target>
+      </persistence-unit-ref>
+</application-client>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAFieldInj.ear/AppCliJPAFieldInj.jar/META-INF/ibm-application-client-bnd.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAFieldInj.ear/AppCliJPAFieldInj.jar/META-INF/ibm-application-client-bnd.xml
@@ -1,0 +1,8 @@
+<application-client-bnd
+   xmlns="http://websphere.ibm.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-application-client-bnd_1_2.xsd"
+   version="1.2">
+
+   <resource-ref name="java:app/env/jdbc/JPA_NJTADS" binding-name="jdbc/JPA_NJTADS"/>   
+</application-client-bnd>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAFieldInj.ear/AppCliJPAFieldInj.jar/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAFieldInj.ear/AppCliJPAFieldInj.jar/META-INF/persistence.xml
@@ -1,0 +1,33 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" 
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence persistence_1_0.xsd" 
+             version="1.0">
+    <persistence-unit name="AppCliPU">
+        <non-jta-data-source>jdbc/JPA_NJTADS</non-jta-data-source>
+        <class>jpaappcli.entity.AppClientEntity</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+    
+    <persistence-unit name="AppCliPU_2">       
+        <non-jta-data-source>jdbc/JPA_NJTADS</non-jta-data-source>
+        <class>jpaappcli.entity.AnotherAppClientEntity</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+    
+    <persistence-unit name="AppCliPU_RESREF">
+        <non-jta-data-source>java:app/env/jdbc/JPA_NJTADS</non-jta-data-source>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAFieldInj.ear/META-INF/application.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAFieldInj.ear/META-INF/application.xml
@@ -1,0 +1,8 @@
+<application xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd"
+             version="7">
+   <module>
+       <java>AppCliJPAFieldInj.jar</java>
+   </module>
+</application>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAJNDIInj.ear/AppCliJPAJNDIInj.jar/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAJNDIInj.ear/AppCliJPAJNDIInj.jar/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: jpaappcli.client.jndiinjection.JPAApplicationJNDIInjectClient
+Class-Path: 

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAJNDIInj.ear/AppCliJPAJNDIInj.jar/META-INF/application-client.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAJNDIInj.ear/AppCliJPAJNDIInj.jar/META-INF/application-client.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application-client xmlns="http://java.sun.com/xml/ns/javaee"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application-client_6.xsd"
+     version="6">
+      <display-name>JPAApplicationJNDIInjectClient</display-name>
+      
+      <resource-ref>
+         <res-ref-name>java:app/env/jdbc/JPA_NJTADS</res-ref-name>
+         <res-type>javax.sql.DataSource</res-type>
+         <res-auth>Container</res-auth>
+         <res-sharing-scope>Shareable</res-sharing-scope>
+      </resource-ref>
+      
+      <persistence-unit-ref>
+         <persistence-unit-ref-name>java:app/env/emfDD</persistence-unit-ref-name>
+         <persistence-unit-name>AppCliPU</persistence-unit-name>
+      </persistence-unit-ref>
+      <persistence-unit-ref>
+         <persistence-unit-ref-name>java:app/env/AppCliPU_DDOVRD_EMF</persistence-unit-ref-name>
+         <persistence-unit-name>AppCliPU_2</persistence-unit-name>
+      </persistence-unit-ref>
+</application-client>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAJNDIInj.ear/AppCliJPAJNDIInj.jar/META-INF/ibm-application-client-bnd.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAJNDIInj.ear/AppCliJPAJNDIInj.jar/META-INF/ibm-application-client-bnd.xml
@@ -1,0 +1,8 @@
+<application-client-bnd
+   xmlns="http://websphere.ibm.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-application-client-bnd_1_2.xsd"
+   version="1.2">
+
+   <resource-ref name="java:app/env/jdbc/JPA_NJTADS" binding-name="jdbc/JPA_NJTADS"/>   
+</application-client-bnd>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAJNDIInj.ear/AppCliJPAJNDIInj.jar/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAJNDIInj.ear/AppCliJPAJNDIInj.jar/META-INF/persistence.xml
@@ -1,0 +1,33 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" 
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence persistence_1_0.xsd" 
+             version="1.0">
+    <persistence-unit name="AppCliPU">
+        <non-jta-data-source>jdbc/JPA_NJTADS</non-jta-data-source>
+        <class>jpaappcli.entity.AppClientEntity</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+    
+    <persistence-unit name="AppCliPU_2">       
+        <non-jta-data-source>jdbc/JPA_NJTADS</non-jta-data-source>
+        <class>jpaappcli.entity.AnotherAppClientEntity</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+    
+    <persistence-unit name="AppCliPU_RESREF">
+        <non-jta-data-source>java:app/env/jdbc/JPA_NJTADS</non-jta-data-source>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAJNDIInj.ear/META-INF/application.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAJNDIInj.ear/META-INF/application.xml
@@ -1,0 +1,8 @@
+<application xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd"
+             version="7">
+   <module>
+       <java>AppCliJPAJNDIInj.jar</java>
+   </module>
+</application>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAMethodInj.ear/AppCliJPAMethodInj.jar/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAMethodInj.ear/AppCliJPAMethodInj.jar/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: jpaappcli.client.methodinjection.JPAApplicationMethodInjectClient
+Class-Path: 

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAMethodInj.ear/AppCliJPAMethodInj.jar/META-INF/application-client.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAMethodInj.ear/AppCliJPAMethodInj.jar/META-INF/application-client.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application-client xmlns="http://java.sun.com/xml/ns/javaee"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application-client_6.xsd"
+     version="6">
+      <display-name>JPAApplicationMethodInjectClient</display-name>
+      
+      <resource-ref>
+         <res-ref-name>java:app/env/jdbc/JPA_NJTADS</res-ref-name>
+         <res-type>javax.sql.DataSource</res-type>
+         <res-auth>Container</res-auth>
+         <res-sharing-scope>Shareable</res-sharing-scope>
+      </resource-ref>
+      
+      <persistence-unit-ref>
+         <persistence-unit-ref-name>AppCliPU_DD_EMF</persistence-unit-ref-name>
+         <persistence-unit-name>AppCliPU</persistence-unit-name>
+         <injection-target>
+            <injection-target-class>jpaappcli.client.methodinjection.JPAApplicationMethodInjectClient</injection-target-class>
+            <injection-target-name>emfDD</injection-target-name>
+         </injection-target>
+      </persistence-unit-ref>
+      <persistence-unit-ref>
+         <persistence-unit-ref-name>AppCliPU_DDOVRD_EMF</persistence-unit-ref-name>
+         <persistence-unit-name>AppCliPU_2</persistence-unit-name>
+         <injection-target>
+            <injection-target-class>jpaappcli.client.methodinjection.JPAApplicationMethodInjectClient</injection-target-class>
+            <injection-target-name>emfMerge</injection-target-name>
+         </injection-target>
+      </persistence-unit-ref>
+</application-client>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAMethodInj.ear/AppCliJPAMethodInj.jar/META-INF/ibm-application-client-bnd.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAMethodInj.ear/AppCliJPAMethodInj.jar/META-INF/ibm-application-client-bnd.xml
@@ -1,0 +1,8 @@
+<application-client-bnd
+   xmlns="http://websphere.ibm.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-application-client-bnd_1_2.xsd"
+   version="1.2">
+
+   <resource-ref name="java:app/env/jdbc/JPA_NJTADS" binding-name="jdbc/JPA_NJTADS"/>   
+</application-client-bnd>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAMethodInj.ear/AppCliJPAMethodInj.jar/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAMethodInj.ear/AppCliJPAMethodInj.jar/META-INF/persistence.xml
@@ -1,0 +1,33 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" 
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence persistence_1_0.xsd" 
+             version="1.0">
+    <persistence-unit name="AppCliPU">
+        <non-jta-data-source>jdbc/JPA_NJTADS</non-jta-data-source>
+        <class>jpaappcli.entity.AppClientEntity</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+    
+    <persistence-unit name="AppCliPU_2">       
+        <non-jta-data-source>jdbc/JPA_NJTADS</non-jta-data-source>
+        <class>jpaappcli.entity.AnotherAppClientEntity</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+    
+    <persistence-unit name="AppCliPU_RESREF">
+        <non-jta-data-source>java:app/env/jdbc/JPA_NJTADS</non-jta-data-source>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAMethodInj.ear/META-INF/application.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/AppCliJPAMethodInj.ear/META-INF/application.xml
@@ -1,0 +1,8 @@
+<application xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd"
+             version="7">
+   <module>
+       <java>AppCliJPAMethodInj.jar</java>
+   </module>
+</application>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/simpleappclient/resources/JPAAppClient.ear/META-INF/application.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/simpleappclient/resources/JPAAppClient.ear/META-INF/application.xml
@@ -1,0 +1,8 @@
+<application xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd"
+             version="7">
+   <module>
+       <java>JPAAppClient.jar</java>
+   </module>
+</application>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/simpleappclient/resources/JPAAppClient.jar/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/simpleappclient/resources/JPAAppClient.jar/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: jpaappcli.client.JPAApplicationClient
+Class-Path: 

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/simpleappclient/resources/JPAAppClient.jar/META-INF/application-client.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/simpleappclient/resources/JPAAppClient.jar/META-INF/application-client.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE application-client PUBLIC "-//Sun Microsystems, Inc.//DTD J2EE Application Client 1.2//EN"  "http://java.sun.com/j2ee/dtds/application-client_1_2.dtd">
+<application-client id="Application-client_ID">
+      <display-name>JPAAppClient</display-name>
+</application-client>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/simpleappclient/resources/JPAAppClient.jar/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/simpleappclient/resources/JPAAppClient.jar/META-INF/persistence.xml
@@ -1,0 +1,12 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" 
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence persistence_1_0.xsd" 
+             version="1.0">
+    <persistence-unit name="JPAPU_RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>jdbc/JPA_NJTADS</non-jta-data-source>
+        <properties>
+            <!-- EclipseLink should create the database schema automatically -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/client/JPAApplicationClient.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/client/JPAApplicationClient.java
@@ -9,20 +9,17 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa;
+package jpaappcli.client;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
 
-import com.ibm.ws.jpa.jpa22.JPA22FATSuite;
+public class JPAApplicationClient {
+    @PersistenceUnit(unitName = "JPAPU_RL")
+    private static EntityManagerFactory emf;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                JPABootstrapTest.class,
-                JPA22FATSuite.class,
-                JPAAppClientTest.class
-})
-public class FATSuite {
+    public static void main(String[] args) {
 
+        System.out.println("emf=" + emf);
+    }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/client/fieldinjection/JPAApplicationFieldInjectClient.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/client/fieldinjection/JPAApplicationFieldInjectClient.java
@@ -1,0 +1,229 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpaappcli.client.fieldinjection;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
+
+import jpaappcli.entity.AnotherAppClientEntity;
+import jpaappcli.entity.AppClientEntity;
+
+public class JPAApplicationFieldInjectClient {
+    private static final String EYECATCHER = "JPACLI: ";
+    private static final String FAIL_EYECATCHER = EYECATCHER + "FAILED: ";
+    private static final String PASS_EYECATCHER = EYECATCHER + "PASSED: ";
+
+    @PersistenceUnit(unitName = "AppCliPU")
+    private static EntityManagerFactory emf;
+
+    @PersistenceUnit(unitName = "AppCliPU_RESREF")
+    private static EntityManagerFactory emfRR;
+
+    private static EntityManagerFactory emfDD;
+
+    @PersistenceUnit(name = "AppCliPU_DDOVRD_EMF", unitName = "AppCliPU")
+    private static EntityManagerFactory emfMerge;
+
+    private static boolean passed = true;
+
+    static {
+        System.out.println(EYECATCHER + JPAApplicationFieldInjectClient.class.getName() + " has initialized.");
+    }
+
+    public static void main(String[] args) throws Throwable {
+        System.out.println(EYECATCHER + JPAApplicationFieldInjectClient.class.getName() + ": hello");
+
+        // Verify injection was successful
+        System.out.println(EYECATCHER + "emf=" + emf);
+        if (emf == null) {
+            // Injection has failed.
+            fail(" emf is null");
+        }
+
+        System.out.println(EYECATCHER + "emfDD=" + emfDD);
+        if (emfDD == null) {
+            // Injection has failed.
+            fail(" emfDD is null");
+        }
+
+        System.out.println(EYECATCHER + "emfRR=" + emfRR);
+        if (emfRR == null) {
+            // Injection has failed.
+            fail(" emfRR is null");
+        }
+
+        System.out.println(EYECATCHER + "emfMerge=" + emfMerge);
+        if (emfMerge == null) {
+            // Injection has failed.
+            fail(" emfMerge is null");
+        }
+
+        // Run Tests
+        System.out.println(EYECATCHER + " Running Tests");
+        testAnnotationInjectedEMF(emf, "Basic_Field_Inject");
+        testAnnotationInjectedEMF(emfRR, "Basic_Field_ResourceRefDS_Inject");
+        testAnnotationInjectedEMF(emfDD, "Basic_Field_DD_Inject");
+        testAnnotationInjectedEMFOverride(emfMerge, "Basic_Field_DDOverride_Inject");
+
+        if (passed)
+            System.out.println(PASS_EYECATCHER + JPAApplicationFieldInjectClient.class.getName() + ": test ended successfully");
+        else
+            System.out.println(FAIL_EYECATCHER + JPAApplicationFieldInjectClient.class.getName() + ": test ended unsuccessfully");
+    }
+
+    private static void testAnnotationInjectedEMF(final EntityManagerFactory emf, final String testqualifier) throws Throwable {
+        System.out.println(EYECATCHER + " Starting testAnnotationInjectedEMF_" + testqualifier + "...");
+
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+            System.out.println(EYECATCHER + "em=" + em);
+            if (em == null) {
+                fail(" em is null");
+            }
+
+            System.out.println(EYECATCHER + " Beginning transaction ...");
+            em.getTransaction().begin();
+
+            System.out.println(EYECATCHER + " Creating new AppClientEntity ...");
+            final AppClientEntity newEntity = new AppClientEntity();
+            newEntity.setStrData("Simple String");
+            em.persist(newEntity);
+
+            System.out.println(EYECATCHER + " Commmitting transaction ...");
+            em.getTransaction().commit();
+
+            em.clear();
+
+            final AppClientEntity findEntity = em.find(AppClientEntity.class, newEntity.getId());
+            if (findEntity == null) {
+                fail(" em.find() returned null.");
+            }
+
+            boolean entityIsEnhanced = verifyClassEnhancement(findEntity);
+            if (entityIsEnhanced) {
+                System.out.println(EYECATCHER + " Entity AppClientEntity is enhanced.");
+            } else {
+                fail(" Entity AppClientEntity is not enhanced.");
+            }
+
+        } catch (Throwable t) {
+            System.out.println(FAIL_EYECATCHER + " Caught unexpected Exception " + t.toString());
+            t.printStackTrace();
+            throw t;
+        } finally {
+            System.out.println(EYECATCHER + " Exiting testAnnotationInjectedEMF_" + testqualifier + " ...");
+
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+
+    private static void testAnnotationInjectedEMFOverride(final EntityManagerFactory emf, final String testqualifier) throws Throwable {
+        System.out.println(EYECATCHER + " Starting testAnnotationInjectedEMFOverride_" + testqualifier + "...");
+
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+            System.out.println(EYECATCHER + "em=" + em);
+            if (em == null) {
+                fail("em is null.");
+            }
+
+            System.out.println(EYECATCHER + " Beginning transaction ...");
+            em.getTransaction().begin();
+
+            System.out.println(EYECATCHER + " Creating new AppClientEntity ...");
+            final AppClientEntity newEntity = new AppClientEntity();
+            newEntity.setStrData("Simple String");
+            try {
+                em.persist(newEntity);
+                fail("The persist operation did not throw an Exception.");
+            } catch (IllegalArgumentException iae) {
+                // Expected
+            }
+
+            System.out.println(EYECATCHER + " Rolling back transaction ...");
+            em.getTransaction().rollback();
+
+            System.out.println(EYECATCHER + " Beginning transaction ...");
+            em.getTransaction().begin();
+
+            System.out.println(EYECATCHER + " Creating new AnotherAppClientEntity ...");
+            final AnotherAppClientEntity newEntity2 = new AnotherAppClientEntity();
+            newEntity2.setStrData("Simple String");
+            em.persist(newEntity2);
+
+            System.out.println(EYECATCHER + " Commmitting transaction ...");
+            em.getTransaction().commit();
+
+            em.clear();
+
+            final AnotherAppClientEntity findEntity = em.find(AnotherAppClientEntity.class, newEntity2.getId());
+            if (findEntity == null) {
+                fail(" em.find() returned null.");
+            }
+
+            boolean entityIsEnhanced = verifyClassEnhancement(findEntity);
+            if (entityIsEnhanced) {
+                System.out.println(EYECATCHER + " Entity AppClientEntity is enhanced.");
+            } else {
+                fail(" Entity AppClientEntity is not enhanced.");
+            }
+
+        } catch (Throwable t) {
+            System.out.println(FAIL_EYECATCHER + " Caught unexpected Exception " + t.toString());
+            t.printStackTrace();
+            throw t;
+        } finally {
+            System.out.println(EYECATCHER + " Exiting testAnnotationInjectedEMF_" + testqualifier + " ...");
+
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+
+    private final static void fail(String message) {
+        passed = false;
+        System.out.println(FAIL_EYECATCHER + message);
+        throw new RuntimeException("Test has failed.");
+    }
+
+    private final static String[] providerEnhancementSignatures = {
+                                                                    "org.eclipse.persistence.internal.descriptors.PersistenceEntity",
+                                                                    "org.apache.openjpa.enhance.PersistenceCapable"
+    };
+
+    @SuppressWarnings("rawtypes")
+    private static boolean verifyClassEnhancement(Object o) {
+        boolean retVal = false;
+        Class cls = o.getClass();
+        Class[] interfaces = cls.getInterfaces();
+
+        if (interfaces != null && interfaces.length > 0) {
+            out: for (Class iFaceClass : interfaces) {
+                String clsName = iFaceClass.getName();
+                for (String enhSig : providerEnhancementSignatures) {
+                    if (enhSig.equals(clsName)) {
+                        retVal = true;
+                        break out;
+                    }
+                }
+            }
+        }
+
+        return retVal;
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/client/jndiinjection/JPAApplicationJNDIInjectClient.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/client/jndiinjection/JPAApplicationJNDIInjectClient.java
@@ -1,0 +1,239 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpaappcli.client.jndiinjection;
+
+import javax.naming.InitialContext;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
+
+import jpaappcli.entity.AnotherAppClientEntity;
+import jpaappcli.entity.AppClientEntity;
+
+@PersistenceUnit(unitName = "AppCliPU", name = "java:app/env/emf") // emf
+@PersistenceUnit(unitName = "AppCliPU_RESREF", name = "java:app/env/emfRR") // emfRR
+// @PersistenceUnit(unitName = "AppCliPU", name = "java:app/env/emfDD") // emfDD -- declared in DD only
+@PersistenceUnit(unitName = "AppCliPU", name = "java:app/env/AppCliPU_DDOVRD_EMF") // emfMerge -- DD override
+public class JPAApplicationJNDIInjectClient {
+    private static final String EYECATCHER = "JPACLI: ";
+    private static final String FAIL_EYECATCHER = EYECATCHER + "FAILED: ";
+    private static final String PASS_EYECATCHER = EYECATCHER + "PASSED: ";
+
+    private static EntityManagerFactory emf;
+    private static EntityManagerFactory emfRR;
+    private static EntityManagerFactory emfDD;
+    private static EntityManagerFactory emfMerge;
+
+    private static boolean passed = true;
+
+    static {
+        System.out.println(EYECATCHER + JPAApplicationJNDIInjectClient.class.getName() + " has initialized.");
+    }
+
+    public static void main(String[] args) throws Throwable {
+        System.out.println(EYECATCHER + JPAApplicationJNDIInjectClient.class.getName() + ": hello");
+
+        InitialContext ic = new InitialContext();
+        System.out.println(EYECATCHER + "ic=" + ic);
+        if (ic == null) {
+            // Injection has failed.
+            fail(" ic is null");
+        }
+        emf = (EntityManagerFactory) ic.lookup("java:app/env/emf");
+        emfRR = (EntityManagerFactory) ic.lookup("java:app/env/emfRR");
+        emfDD = (EntityManagerFactory) ic.lookup("java:app/env/emfDD");
+        emfMerge = (EntityManagerFactory) ic.lookup("java:app/env/AppCliPU_DDOVRD_EMF");
+
+        // Verify injection was successful
+        System.out.println(EYECATCHER + "emf=" + emf);
+        if (emf == null) {
+            // Injection has failed.
+            fail(" emf is null");
+        }
+
+        System.out.println(EYECATCHER + "emfDD=" + emfDD);
+        if (emfDD == null) {
+            // Injection has failed.
+            fail(" emfDD is null");
+        }
+
+        System.out.println(EYECATCHER + "emfRR=" + emfRR);
+        if (emfRR == null) {
+            // Injection has failed.
+            fail(" emfRR is null");
+        }
+
+        System.out.println(EYECATCHER + "emfMerge=" + emfMerge);
+        if (emfMerge == null) {
+            // Injection has failed.
+            fail(" emfMerge is null");
+        }
+
+        // Run Tests
+        System.out.println(EYECATCHER + " Running Tests");
+        testAnnotationInjectedEMF(emf, "Basic_Field_Inject");
+        testAnnotationInjectedEMF(emfRR, "Basic_Field_ResourceRefDS_Inject");
+        testAnnotationInjectedEMF(emfDD, "Basic_Field_DD_Inject");
+        testAnnotationInjectedEMFOverride(emfMerge, "Basic_Field_DDOverride_Inject");
+
+        if (passed)
+            System.out.println(PASS_EYECATCHER + JPAApplicationJNDIInjectClient.class.getName() + ": test ended successfully");
+        else
+            System.out.println(FAIL_EYECATCHER + JPAApplicationJNDIInjectClient.class.getName() + ": test ended unsuccessfully");
+    }
+
+    private static void testAnnotationInjectedEMF(final EntityManagerFactory emf, final String testqualifier) throws Throwable {
+        System.out.println(EYECATCHER + " Starting testAnnotationInjectedEMF_" + testqualifier + "...");
+
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+            System.out.println(EYECATCHER + "em=" + em);
+            if (em == null) {
+                fail(" em is null");
+            }
+
+            System.out.println(EYECATCHER + " Beginning transaction ...");
+            em.getTransaction().begin();
+
+            System.out.println(EYECATCHER + " Creating new AppClientEntity ...");
+            final AppClientEntity newEntity = new AppClientEntity();
+            newEntity.setStrData("Simple String");
+            em.persist(newEntity);
+
+            System.out.println(EYECATCHER + " Commmitting transaction ...");
+            em.getTransaction().commit();
+
+            em.clear();
+
+            final AppClientEntity findEntity = em.find(AppClientEntity.class, newEntity.getId());
+            if (findEntity == null) {
+                fail(" em.find() returned null.");
+            }
+
+            boolean entityIsEnhanced = verifyClassEnhancement(findEntity);
+            if (entityIsEnhanced) {
+                System.out.println(EYECATCHER + " Entity AppClientEntity is enhanced.");
+            } else {
+                fail(" Entity AppClientEntity is not enhanced.");
+            }
+
+        } catch (Throwable t) {
+            System.out.println(FAIL_EYECATCHER + " Caught unexpected Exception " + t.toString());
+            t.printStackTrace();
+            throw t;
+        } finally {
+            System.out.println(EYECATCHER + " Exiting testAnnotationInjectedEMF_" + testqualifier + " ...");
+
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+
+    private static void testAnnotationInjectedEMFOverride(final EntityManagerFactory emf, final String testqualifier) throws Throwable {
+        System.out.println(EYECATCHER + " Starting testAnnotationInjectedEMFOverride_" + testqualifier + "...");
+
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+            System.out.println(EYECATCHER + "em=" + em);
+            if (em == null) {
+                fail("em is null.");
+            }
+
+            System.out.println(EYECATCHER + " Beginning transaction ...");
+            em.getTransaction().begin();
+
+            System.out.println(EYECATCHER + " Creating new AppClientEntity ...");
+            final AppClientEntity newEntity = new AppClientEntity();
+            newEntity.setStrData("Simple String");
+            try {
+                em.persist(newEntity);
+                fail("The persist operation did not throw an Exception.");
+            } catch (IllegalArgumentException iae) {
+                // Expected
+            }
+
+            System.out.println(EYECATCHER + " Rolling back transaction ...");
+            em.getTransaction().rollback();
+
+            System.out.println(EYECATCHER + " Beginning transaction ...");
+            em.getTransaction().begin();
+
+            System.out.println(EYECATCHER + " Creating new AnotherAppClientEntity ...");
+            final AnotherAppClientEntity newEntity2 = new AnotherAppClientEntity();
+            newEntity2.setStrData("Simple String");
+            em.persist(newEntity2);
+
+            System.out.println(EYECATCHER + " Commmitting transaction ...");
+            em.getTransaction().commit();
+
+            em.clear();
+
+            final AnotherAppClientEntity findEntity = em.find(AnotherAppClientEntity.class, newEntity2.getId());
+            if (findEntity == null) {
+                fail(" em.find() returned null.");
+            }
+
+            boolean entityIsEnhanced = verifyClassEnhancement(findEntity);
+            if (entityIsEnhanced) {
+                System.out.println(EYECATCHER + " Entity AppClientEntity is enhanced.");
+            } else {
+                fail(" Entity AppClientEntity is not enhanced.");
+            }
+
+        } catch (Throwable t) {
+            System.out.println(FAIL_EYECATCHER + " Caught unexpected Exception " + t.toString());
+            t.printStackTrace();
+            throw t;
+        } finally {
+            System.out.println(EYECATCHER + " Exiting testAnnotationInjectedEMF_" + testqualifier + " ...");
+
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+
+    private final static void fail(String message) {
+        passed = false;
+        System.out.println(FAIL_EYECATCHER + message);
+        throw new RuntimeException("Test has failed.");
+    }
+
+    private final static String[] providerEnhancementSignatures = {
+                                                                    "org.eclipse.persistence.internal.descriptors.PersistenceEntity",
+                                                                    "org.apache.openjpa.enhance.PersistenceCapable"
+    };
+
+    @SuppressWarnings("rawtypes")
+    private static boolean verifyClassEnhancement(Object o) {
+        boolean retVal = false;
+        Class cls = o.getClass();
+        Class[] interfaces = cls.getInterfaces();
+
+        if (interfaces != null && interfaces.length > 0) {
+            out: for (Class iFaceClass : interfaces) {
+                String clsName = iFaceClass.getName();
+                for (String enhSig : providerEnhancementSignatures) {
+                    if (enhSig.equals(clsName)) {
+                        retVal = true;
+                        break out;
+                    }
+                }
+            }
+        }
+
+        return retVal;
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/client/methodinjection/JPAApplicationMethodInjectClient.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/client/methodinjection/JPAApplicationMethodInjectClient.java
@@ -1,0 +1,262 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpaappcli.client.methodinjection;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
+
+import jpaappcli.entity.AnotherAppClientEntity;
+import jpaappcli.entity.AppClientEntity;
+
+public class JPAApplicationMethodInjectClient {
+    private static final String EYECATCHER = "JPACLI: ";
+    private static final String FAIL_EYECATCHER = EYECATCHER + "FAILED: ";
+    private static final String PASS_EYECATCHER = EYECATCHER + "PASSED: ";
+
+    private static EntityManagerFactory emf;
+    private static EntityManagerFactory emfRR;
+    private static EntityManagerFactory emfDD;
+    private static EntityManagerFactory emfMerge;
+
+    private static boolean passed = true;
+
+    static {
+        System.out.println(EYECATCHER + JPAApplicationMethodInjectClient.class.getName() + " has initialized.");
+    }
+
+    // Inject: emf
+    @PersistenceUnit(unitName = "AppCliPU")
+    public static void setEmf(EntityManagerFactory emf) {
+        JPAApplicationMethodInjectClient.emf = emf;
+    }
+
+    public static EntityManagerFactory getEmf() {
+        return JPAApplicationMethodInjectClient.emf;
+    }
+
+    // Inject: emfRR
+    @PersistenceUnit(unitName = "AppCliPU_RESREF")
+    public static void setEmfRR(EntityManagerFactory emf) {
+        JPAApplicationMethodInjectClient.emfRR = emf;
+    }
+
+    public static EntityManagerFactory getEmfRR() {
+        return JPAApplicationMethodInjectClient.emfRR;
+    }
+
+    // Inject: emfDD
+    public static void setEmfDD(EntityManagerFactory emf) {
+        JPAApplicationMethodInjectClient.emfDD = emf;
+    }
+
+    public static EntityManagerFactory getEmfDD() {
+        return JPAApplicationMethodInjectClient.emfDD;
+    }
+
+    // Inject: emfMerge
+    @PersistenceUnit(name = "AppCliPU_DDOVRD_EMF", unitName = "AppCliPU")
+    public static void setEmfMerge(EntityManagerFactory emf) {
+        JPAApplicationMethodInjectClient.emfMerge = emf;
+    }
+
+    public static EntityManagerFactory getEmfMerge() {
+        return JPAApplicationMethodInjectClient.emfMerge;
+    }
+
+    public static void main(String[] args) throws Throwable {
+        System.out.println(EYECATCHER + JPAApplicationMethodInjectClient.class.getName() + ": hello");
+
+        // Verify injection was successful
+        System.out.println(EYECATCHER + "emf=" + emf);
+        if (emf == null) {
+            // Injection has failed.
+            fail(" emf is null");
+        }
+
+        System.out.println(EYECATCHER + "emfDD=" + emfDD);
+        if (emfDD == null) {
+            // Injection has failed.
+            fail(" emfDD is null");
+        }
+
+        System.out.println(EYECATCHER + "emfRR=" + emfRR);
+        if (emfRR == null) {
+            // Injection has failed.
+            fail(" emfRR is null");
+        }
+
+        System.out.println(EYECATCHER + "emfMerge=" + emfMerge);
+        if (emfMerge == null) {
+            // Injection has failed.
+            fail(" emfMerge is null");
+        }
+
+        // Run Tests
+        System.out.println(EYECATCHER + " Running Tests");
+        testAnnotationInjectedEMF(emf, "Basic_Field_Inject");
+        testAnnotationInjectedEMF(emfRR, "Basic_Field_ResourceRefDS_Inject");
+        testAnnotationInjectedEMF(emfDD, "Basic_Field_DD_Inject");
+        testAnnotationInjectedEMFOverride(emfMerge, "Basic_Field_DDOverride_Inject");
+
+        if (passed)
+            System.out.println(PASS_EYECATCHER + JPAApplicationMethodInjectClient.class.getName() + ": test ended successfully");
+        else
+            System.out.println(FAIL_EYECATCHER + JPAApplicationMethodInjectClient.class.getName() + ": test ended unsuccessfully");
+    }
+
+    private static void testAnnotationInjectedEMF(final EntityManagerFactory emf, final String testqualifier) throws Throwable {
+        System.out.println(EYECATCHER + " Starting testAnnotationInjectedEMF_" + testqualifier + "...");
+
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+            System.out.println(EYECATCHER + "em=" + em);
+            if (em == null) {
+                fail(" em is null");
+            }
+
+            System.out.println(EYECATCHER + " Beginning transaction ...");
+            em.getTransaction().begin();
+
+            System.out.println(EYECATCHER + " Creating new AppClientEntity ...");
+            final AppClientEntity newEntity = new AppClientEntity();
+            newEntity.setStrData("Simple String");
+            em.persist(newEntity);
+
+            System.out.println(EYECATCHER + " Commmitting transaction ...");
+            em.getTransaction().commit();
+
+            em.clear();
+
+            final AppClientEntity findEntity = em.find(AppClientEntity.class, newEntity.getId());
+            if (findEntity == null) {
+                fail(" em.find() returned null.");
+            }
+
+            boolean entityIsEnhanced = verifyClassEnhancement(findEntity);
+            if (entityIsEnhanced) {
+                System.out.println(EYECATCHER + " Entity AppClientEntity is enhanced.");
+            } else {
+                fail(" Entity AppClientEntity is not enhanced.");
+            }
+
+        } catch (Throwable t) {
+            System.out.println(FAIL_EYECATCHER + " Caught unexpected Exception " + t.toString());
+            t.printStackTrace();
+            throw t;
+        } finally {
+            System.out.println(EYECATCHER + " Exiting testAnnotationInjectedEMF_" + testqualifier + " ...");
+
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+
+    private static void testAnnotationInjectedEMFOverride(final EntityManagerFactory emf, final String testqualifier) throws Throwable {
+        System.out.println(EYECATCHER + " Starting testAnnotationInjectedEMFOverride_" + testqualifier + "...");
+
+        EntityManager em = null;
+        try {
+            em = emf.createEntityManager();
+            System.out.println(EYECATCHER + "em=" + em);
+            if (em == null) {
+                fail("em is null.");
+            }
+
+            System.out.println(EYECATCHER + " Beginning transaction ...");
+            em.getTransaction().begin();
+
+            System.out.println(EYECATCHER + " Creating new AppClientEntity ...");
+            final AppClientEntity newEntity = new AppClientEntity();
+            newEntity.setStrData("Simple String");
+            try {
+                em.persist(newEntity);
+                fail("The persist operation did not throw an Exception.");
+            } catch (IllegalArgumentException iae) {
+                // Expected
+            }
+
+            System.out.println(EYECATCHER + " Rolling back transaction ...");
+            em.getTransaction().rollback();
+
+            System.out.println(EYECATCHER + " Beginning transaction ...");
+            em.getTransaction().begin();
+
+            System.out.println(EYECATCHER + " Creating new AnotherAppClientEntity ...");
+            final AnotherAppClientEntity newEntity2 = new AnotherAppClientEntity();
+            newEntity2.setStrData("Simple String");
+            em.persist(newEntity2);
+
+            System.out.println(EYECATCHER + " Commmitting transaction ...");
+            em.getTransaction().commit();
+
+            em.clear();
+
+            final AnotherAppClientEntity findEntity = em.find(AnotherAppClientEntity.class, newEntity2.getId());
+            if (findEntity == null) {
+                fail(" em.find() returned null.");
+            }
+
+            boolean entityIsEnhanced = verifyClassEnhancement(findEntity);
+            if (entityIsEnhanced) {
+                System.out.println(EYECATCHER + " Entity AppClientEntity is enhanced.");
+            } else {
+                fail(" Entity AppClientEntity is not enhanced.");
+            }
+
+        } catch (Throwable t) {
+            System.out.println(FAIL_EYECATCHER + " Caught unexpected Exception " + t.toString());
+            t.printStackTrace();
+            throw t;
+        } finally {
+            System.out.println(EYECATCHER + " Exiting testAnnotationInjectedEMF_" + testqualifier + " ...");
+
+            if (em != null) {
+                em.close();
+            }
+        }
+    }
+
+    private final static void fail(String message) {
+        passed = false;
+        System.out.println(FAIL_EYECATCHER + message);
+        throw new RuntimeException("Test has failed.");
+    }
+
+    private final static String[] providerEnhancementSignatures = {
+                                                                    "org.eclipse.persistence.internal.descriptors.PersistenceEntity",
+                                                                    "org.apache.openjpa.enhance.PersistenceCapable"
+    };
+
+    @SuppressWarnings("rawtypes")
+    private static boolean verifyClassEnhancement(Object o) {
+        boolean retVal = false;
+        Class cls = o.getClass();
+        Class[] interfaces = cls.getInterfaces();
+
+        if (interfaces != null && interfaces.length > 0) {
+            out: for (Class iFaceClass : interfaces) {
+                String clsName = iFaceClass.getName();
+                for (String enhSig : providerEnhancementSignatures) {
+                    if (enhSig.equals(clsName)) {
+                        retVal = true;
+                        break out;
+                    }
+                }
+            }
+        }
+
+        return retVal;
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/entity/AnotherAppClientEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/entity/AnotherAppClientEntity.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpaappcli.entity;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class AnotherAppClientEntity {
+    @Id
+    @GeneratedValue
+    private long id;
+
+    @Basic
+    private String strData;
+
+    public AnotherAppClientEntity() {
+
+    }
+
+    /**
+     * @return the id
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the strData
+     */
+    public String getStrData() {
+        return strData;
+    }
+
+    /**
+     * @param strData the strData to set
+     */
+    public void setStrData(String strData) {
+        this.strData = strData;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "AnotherAppClientEntity [id=" + id + ", strData=" + strData + "]";
+    }
+
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/entity/AppClientEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/appclient/src/jpaappcli/entity/AppClientEntity.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpaappcli.entity;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class AppClientEntity {
+    @Id
+    @GeneratedValue
+    private long id;
+
+    @Basic
+    private String strData;
+
+    public AppClientEntity() {
+
+    }
+
+    /**
+     * @return the id
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the strData
+     */
+    public String getStrData() {
+        return strData;
+    }
+
+    /**
+     * @param strData the strData to set
+     */
+    public void setStrData(String strData) {
+        this.strData = strData;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "AppClientEntity [id=" + id + ", strData=" + strData + "]";
+    }
+
+}


### PR DESCRIPTION
Add JPA application client tests to com.ibm.ws.jpa_22_fat, tests appclient @PersistenceUnit injection into classes, fields, and methods.

Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>