### PR TITLE
Revert "Fix api/spi versioning"

### DIFF
--- a/dev/com.ibm.websphere.appserver.classloading-1.0/com.ibm.websphere.appserver.classloading-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.classloading-1.0/com.ibm.websphere.appserver.classloading-1.0.feature
@@ -10,6 +10,6 @@ IBM-Process-Types: server, \
  com.ibm.websphere.appserver.dynamicBundle-1.0
 -bundles=com.ibm.ws.classloading
 -jars=com.ibm.websphere.appserver.spi.classloading; location:=dev/spi/ibm/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.classloading_1.4-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.classloading_1.3-javadoc.zip
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.httptransport-1.0/com.ibm.websphere.appserver.httptransport-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.httptransport-1.0/com.ibm.websphere.appserver.httptransport-1.0.feature
@@ -6,6 +6,6 @@ Subsystem-Version: 1.0
 -features=com.ibm.websphere.appserver.channelfw-1.0
 -bundles=com.ibm.ws.transport.http
 -jars=com.ibm.websphere.appserver.spi.httptransport; location:=dev/spi/ibm/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.httptransport_2.0-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.httptransport_1.2-javadoc.zip
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.javaeedd-1.0/com.ibm.websphere.appserver.javaeedd-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.javaeedd-1.0/com.ibm.websphere.appserver.javaeedd-1.0.feature
@@ -18,6 +18,6 @@ IBM-Process-Types: server, \
  com.ibm.ws.javaee.dd.common, \
  com.ibm.ws.javaee.dd.ejb
 -jars=com.ibm.websphere.appserver.spi.javaeedd; location:=dev/spi/ibm/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.javaeedd_1.3-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.javaeedd_1.2-javadoc.zip
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.spi.classloading/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.classloading/bnd.bnd
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion: 1.4
+bVersion: 1.3
 
 Bundle-Name: WebSphere Classloading SPI
 Bundle-Description: WebSphere Classloading SPI, version ${bVersion}

--- a/dev/com.ibm.websphere.appserver.spi.classloading/com.ibm.websphere.appserver.spi.classloading.pom
+++ b/dev/com.ibm.websphere.appserver.spi.classloading/com.ibm.websphere.appserver.spi.classloading.pom
@@ -25,5 +25,5 @@
   <artifactId>com.ibm.websphere.appserver.spi.classloading</artifactId>
   <version>${bFullVersion}</version>
   <name>WebSphere Classloading SPI</name>
-  <description>WebSphere Classloading SPI, version 1.4</description>
+  <description>WebSphere Classloading SPI, version 1.2</description>
 </project>

--- a/dev/com.ibm.websphere.appserver.spi.httptransport/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.httptransport/bnd.bnd
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion: 2.0
+bVersion: 1.2
 
 Bundle-Name: WebSphere HTTP Transport SPI
 Bundle-Description: WebSphere HTTP Transport SPI, version ${bVersion}

--- a/dev/com.ibm.websphere.appserver.spi.httptransport/com.ibm.websphere.appserver.spi.httptransport.pom
+++ b/dev/com.ibm.websphere.appserver.spi.httptransport/com.ibm.websphere.appserver.spi.httptransport.pom
@@ -26,5 +26,5 @@
   <artifactId>com.ibm.websphere.appserver.spi.httptransport</artifactId>
   <version>${bFullVersion}</version>
   <name>WebSphere HTTP Transport SPI</name>
-  <description>WebSphere HTTP Transport SPI, version 2.0</description>
+  <description>WebSphere HTTP Transport SPI, version 1.1</description>
 </project>

--- a/dev/com.ibm.websphere.appserver.spi.javaeedd/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.javaeedd/bnd.bnd
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion: 1.3
+bVersion: 1.2
 
 Bundle-Name: WebSphere Bindings and Extensions SPI
 Bundle-Description: WebSphere Bindings and Extensions SPI, version ${bVersion}

--- a/dev/com.ibm.websphere.appserver.spi.javaeedd/com.ibm.websphere.appserver.spi.javaeedd.pom
+++ b/dev/com.ibm.websphere.appserver.spi.javaeedd/com.ibm.websphere.appserver.spi.javaeedd.pom
@@ -25,5 +25,5 @@
   <artifactId>com.ibm.websphere.appserver.spi.javaeedd</artifactId>
   <version>${bFullVersion}</version>
   <name>WebSphere Bindings and Extensions SPI</name>
-  <description>WebSphere Bindings and Extensions SPI, version 1.3</description>
+  <description>WebSphere Bindings and Extensions SPI, version 1.2</description>
 </project>

--- a/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/package-info.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/package-info.java
@@ -9,9 +9,9 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
- * @version 1.5.0
+ * @version 1.4.0
  */
-@org.osgi.annotation.versioning.Version("1.5.0")
+@org.osgi.annotation.versioning.Version("1.4.0")
 @TraceOptions(traceGroup = "ClassLoadingService", messageBundle = "com.ibm.ws.classloading.internal.resources.ClassLoadingServiceMessages")
 package com.ibm.wsspi.classloading;
 

--- a/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/common/package-info.java
+++ b/dev/com.ibm.ws.javaee.dd/src/com/ibm/ws/javaee/dd/web/common/package-info.java
@@ -9,8 +9,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
- * @version 1.3
+ * @version 1.2
  */
-@org.osgi.annotation.versioning.Version("1.3")
+@org.osgi.annotation.versioning.Version("1.2")
 package com.ibm.ws.javaee.dd.web.common;
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/ee8/package-info.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/ee8/package-info.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
- * @version 2.0.16
+ * @version 1.0.16
  */
-@org.osgi.annotation.versioning.Version("2.0.16")
+@org.osgi.annotation.versioning.Version("1.0.16")
 package com.ibm.wsspi.http.ee8;

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/package-info.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/package-info.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
- * @version 1.3
+ * @version 1.2
  */
-@org.osgi.annotation.versioning.Version("1.3")
+@org.osgi.annotation.versioning.Version("1.2")
 package com.ibm.wsspi.http;


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#1051

Failure was:
ERROR: com.ibm.websphere.appserver.httptransport-1.0
[BAD_PACKAGE_VERSION com.ibm.wsspi.http@1.3.0]
Changes were detected in package com.ibm.wsspi.http@1.3.0 which mean the package version is now incorrect. The baseline knows the package at version 1.1.0 Change the version of the package from its current version 1.3.0 to 1.2.0
For More Information, visit http://was.pok.ibm.com/xwiki/bin/view/Build/FeatureChecker

I believe this has caused a hard build break failure since Build LAOS Continuous build 20171122-2142
https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.build.viewResult&id=_soeDgM_CEeeDVI_EqAFnyg