### PR TITLE
Allow global java 2 security enablement in FATs

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -32,9 +32,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.Charset;
-import java.security.AccessController;
 import java.security.KeyStore;
-import java.security.PrivilegedAction;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -93,6 +91,7 @@ import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyFileManager.LogSearchResult;
 import componenttest.topology.utils.FileUtils;
 import componenttest.topology.utils.LibertyServerUtils;
+import componenttest.topology.utils.PrivHelper;
 
 public class LibertyServer implements LogMonitorClient {
 
@@ -105,152 +104,24 @@ public class LibertyServer implements LogMonitorClient {
 
     boolean runAsAWindowService = false;
 
-    protected static final String DEBUGGING_PORT = AccessController.doPrivileged(new PrivilegedAction<String>() {
-        @Override
-        public String run() {
-            return System.getProperty("debugging.port");
-        }
-    });
-
+    protected static final String MAC_RUN = PrivHelper.getProperty("fat.on.mac");
+    protected static final String DEBUGGING_PORT = PrivHelper.getProperty("debugging.port");
     protected static final boolean DEFAULT_PRE_CLEAN = true;
-
-    protected static final boolean DEFAULT_CLEANSTART = Boolean.parseBoolean(AccessController.doPrivileged(new PrivilegedAction<String>() {
-        @Override
-        public String run() {
-            // Default is true if not set.
-            return System.getProperty("default.clean.start", "true");
-        }
-    }));
-
+    protected static final boolean DEFAULT_CLEANSTART = Boolean.parseBoolean(PrivHelper.getProperty("default.clean.start", "true"));
     protected static final boolean DEFAULT_VALIDATE_APPS = true;
+    protected static final String RELEASE_MICRO_VERSION = PrivHelper.getProperty("micro.version");
+    protected static final String TMP_DIR = PrivHelper.getProperty("java.io.tmpdir");
     public static boolean validateApps = DEFAULT_VALIDATE_APPS;
 
-    protected static final String JAVA_VERSION = AccessController.doPrivileged(new PrivilegedAction<String>() {
-        @Override
-        public String run() {
-            return System.getProperty("java.version");
-        }
-    });
-
     protected static final JavaInfo javaInfo = JavaInfo.forCurrentVM();
-    protected static final boolean JAVA_VERSION_6 = javaInfo.majorVersion() == 6;
-    protected static final boolean JAVA_VERSION_8 = javaInfo.majorVersion() == 8;
-    protected static final boolean J9_JVM_RUN = javaInfo.vendor() == Vendor.IBM;
-    protected static final boolean HOTSPOT_JVM_RUN = javaInfo.vendor() == Vendor.SUN_ORACLE;
 
-    protected static final String MAC_RUN = AccessController.doPrivileged(new PrivilegedAction<String>() {
-        @Override
-        public String run() {
-            return System.getProperty("fat.on.mac");
-        }
-    });
+    protected static final boolean GLOBAL_JAVA2SECURITY = PrivHelper.getBoolean("global.java2.sec");
+    protected static final boolean GLOBAL_DEBUG_JAVA2SECURITY = PrivHelper.getBoolean("global.debug.java2.sec");
+    protected static final String GLOBAL_TRACE = PrivHelper.getProperty("global.trace.spec", "").trim();
+    protected static final String GLOBAL_JVM_ARGS = PrivHelper.getProperty("global.jvm.args", "").trim();
 
-    protected static final boolean IBM_JVM = javaInfo.vendor() == Vendor.IBM;
-
-    protected static final boolean ORACLE_JVM = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-        @Override
-        public Boolean run() {
-            String vendor = System.getProperty("java.vendor");
-
-            if (vendor != null) {
-                return vendor.toLowerCase().contains("oracle");
-            }
-            return true;
-        }
-    });
-
-    protected static final boolean SUN_JVM = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-        @Override
-        public Boolean run() {
-            String vendor = System.getProperty("java.vendor");
-
-            if (vendor != null) {
-                return vendor.toLowerCase().contains("sun");
-            }
-            return true;
-        }
-    });
-
-    protected static final String GLOBAL_TRACE = AccessController.doPrivileged(new PrivilegedAction<String>() {
-        @Override
-        public String run() {
-            String prop = System.getProperty("global.trace.spec");
-            return prop == null ? "" : prop.trim();
-        }
-    });
-
-    protected static final boolean GLOBAL_JAVA2SECURITY = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-        @Override
-        public Boolean run() {
-            String prop = System.getProperty("global.java2.sec");
-            boolean java2security = false;
-            if (prop != null) {
-                Log.info(c, "<clinit>", "global.java2.sec=" + prop);
-                java2security = Boolean.parseBoolean(prop);
-            }
-            Log.info(c, "<clinit>", "GLOBAL_JAVA2SECURITY=" + java2security);
-            return java2security;
-        }
-    });
-
-    protected static final boolean GLOBAL_DEBUG_JAVA2SECURITY = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-        @Override
-        public Boolean run() {
-            String prop = System.getProperty("global.debug.java2.sec");
-            boolean java2security = false;
-            if (prop != null) {
-                Log.info(c, "<clinit>", "global.debug.java2.sec=" + prop);
-                java2security = Boolean.parseBoolean(prop);
-            }
-            return java2security;
-        }
-    });
-
-    protected static final String GLOBAL_JVM_ARGS = AccessController.doPrivileged(new PrivilegedAction<String>() {
-        @Override
-        public String run() {
-            String prop = System.getProperty("global.jvm.args");
-            return prop == null ? "" : prop.trim();
-        }
-    });
-    protected static final String TMP_DIR = AccessController.doPrivileged(new PrivilegedAction<String>() {
-        @Override
-        public String run() {
-            return System.getProperty("java.io.tmpdir");
-        }
-    });
-
-    protected static final boolean DO_COVERAGE = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-        @Override
-        public Boolean run() {
-            String fatCoverageString = System.getProperty("test.coverage");
-            boolean fatcoverage = false;
-            if (fatCoverageString != null) {
-                Log.info(c, "<clinit>", "test.coverage=" + fatCoverageString);
-                fatcoverage = Boolean.parseBoolean(fatCoverageString);
-            }
-            Log.info(c, "<clinit>", "DO_COVERAGE=" + fatcoverage);
-            return fatcoverage;
-        }
-    });
-
-    protected static final String JAVA_AGENT_FOR_JACOCO = AccessController.doPrivileged(new PrivilegedAction<String>() {
-        @Override
-        public String run() {
-            String agent = System.getProperty("javaagent.for.jacoco");
-            Log.info(c, "<clinit>", "JAVA_AGENT_FOR_JACOCO=" + agent);
-            return agent;
-        }
-    });
-
-    protected static final String RELEASE_MICRO_VERSION = AccessController.doPrivileged(new PrivilegedAction<String>() {
-        @Override
-        public String run() {
-            String micro = System.getProperty("micro.version");
-            Log.info(c, "<clinit>", "RELEASE_MICRO_VERSION=" + micro);
-            return micro;
-        }
-    });
+    protected static final boolean DO_COVERAGE = PrivHelper.getBoolean("test.coverage");
+    protected static final String JAVA_AGENT_FOR_JACOCO = PrivHelper.getProperty("javaagent.for.jacoco");
 
     protected static final int SERVER_START_TIMEOUT = 30 * 1000;
     protected static final int SERVER_STOP_TIMEOUT = 30 * 1000;
@@ -1070,13 +941,6 @@ public class LibertyServer implements LogMonitorClient {
         // from Java 9 onwards, IBM JDKs will also exhibit the same behaviour as it will start to use /dev/random by default.
         // The fix is thus to ensure we use the pseudorandom entropy pool (/dev/urandom) (which is also valid for Windows/zOS).
         JVM_ARGS += " -Djava.security.egd=file:///dev/urandom";
-
-        // Avoid ClassLoader deadlocks on HotSpot Java 6.
-        if (HOTSPOT_JVM_RUN && JAVA_VERSION_6) {
-            JVM_ARGS += " -XX:+UnlockDiagnosticVMOptions" +
-                        " -XX:+UnsyncloadClass" +
-                        " -Dosgi.classloader.lock=classname";
-        }
 
         JavaInfo info = JavaInfo.forServer(this);
         // Debug for a highly intermittent problem on IBM JVMs.
@@ -5661,19 +5525,19 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     public boolean isJavaVersion6() {
-        return JAVA_VERSION_6;
+        return javaInfo.majorVersion() == 6;
     }
 
     public boolean isJavaVersion8() {
-        return JAVA_VERSION_8;
+        return javaInfo.majorVersion() == 8;
     }
 
     public boolean isIBMJVM() {
-        return IBM_JVM;
+        return javaInfo.vendor() == JavaInfo.Vendor.IBM;
     }
 
     public boolean isOracleJVM() {
-        return ORACLE_JVM;
+        return javaInfo.vendor() == JavaInfo.Vendor.SUN_ORACLE;
     }
 
     public void useSecondaryHTTPPort() {

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServerFactory.java
@@ -13,8 +13,6 @@ package componenttest.topology.impl;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -29,8 +27,10 @@ import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.log.Log;
+
 import componenttest.common.apiservices.Bootstrap;
 import componenttest.exception.TopologyException;
+import componenttest.topology.utils.PrivHelper;
 
 public class LibertyServerFactory {
     //track the known Liberty servers by test class name, so that suites don't clean up servers from other test classes in the suite
@@ -44,20 +44,11 @@ public class LibertyServerFactory {
         OFF
     }
 
-    private static final boolean DELETE_RUN_FATS =
-                    Boolean.parseBoolean(AccessController.doPrivileged(new PrivilegedAction<String>() {
-                        @Override
-                        public String run() {
-                            // Default is false if not set
-                            //nb the default passed in is ${delete.run.fats} but
-                            //parseBoolean does default that to false.
-                            return System.getProperty("delete.run.fats", "false");
-                        }
-                    }));
+    private static final boolean DELETE_RUN_FATS = PrivHelper.getBoolean("delete.run.fats");
 
     /**
      * This method will return a newly created LibertyServer instance with the specified server name
-     * 
+     *
      * @return A stopped Liberty Server instance
      * @throws Exception
      */
@@ -67,7 +58,7 @@ public class LibertyServerFactory {
 
     /**
      * This method will return a newly created LibertyServer instance with the specified server name
-     * 
+     *
      * @param serverName The name of the server
      * @param testClassName The name of the class to associate with the server.
      * @return A stopped Liberty Server instance
@@ -80,7 +71,7 @@ public class LibertyServerFactory {
      * This method will return a newly created LibertyServer instance with the specified server name.
      * Note if the ignoreCache parameter is set to false, then the returned LibertyServer instance may
      * not be newly-created.
-     * 
+     *
      * @return A stopped Liberty Server instance
      * @throws Exception
      */
@@ -168,8 +159,7 @@ public class LibertyServerFactory {
                     }
                     ls = new LibertyServer(serverName, bootstrap, ignoreCache, usePreviouslyConfigured, windowsServiceOption);
 
-                    if (!usePreviouslyConfigured)
-                    {
+                    if (!usePreviouslyConfigured) {
                         if (installServerFromSampleJar) {
                             if (!LibertyFileManager.libertyFileExists(ls.getMachine(), ls.getServerRoot())) {
                                 //Samples don't overwrite, so only bother running it if the server directory isn't already there
@@ -272,7 +262,7 @@ public class LibertyServerFactory {
 
     /**
      * This method will return a newly created LibertyServer instance with the specified server name
-     * 
+     *
      * @return A started Liberty Server instance
      * @throws Exception
      */
@@ -291,13 +281,13 @@ public class LibertyServerFactory {
      * This method will install a sample server and download any external dependencies defined in it. Once the server is installed the server.xml will be exchanged with a default
      * server XML, that includes fatTestPorts.xml and the sample server.xml. The bootstrap.properties will be exchanged with a default properties file that includes the
      * "../testports.properties" file and the sample properties file. The server will then be added to the list of known servers and returned.
-     * 
+     *
      * @param serverName The name of the server to install, must be matched by a local file named serverName.jar in the lib/LibertyFATTestFiles folder (populated from publish/files
      *            in a FAT test project)
      * @param bootstrap The bootstrap to use on the server
      * @param ignoreCache <code>false</code> if we should load a cached server if available
      * @return The server
-     * 
+     *
      */
     public static LibertyServer installSampleServer(String serverName, Bootstrap bootstrap, boolean ignoreCache) {
         return getLibertyServer(serverName, bootstrap, ignoreCache, true, false, null);
@@ -311,12 +301,12 @@ public class LibertyServerFactory {
      * This method should not be ran by the user, it is ran by the JUnit
      * runner at the end of each test to ensure that post test tidying is
      * done.
-     * 
+     *
      * Once a server has under gone the tidy action, it needs to be removed
      * from the list of known servers, or subsequent cleanups will fail.
      * This will happen in the case of FATSuite being the entry point with
      * multiple test classes.
-     * 
+     *
      * @param testClassName, the name of the test class for which servers should be tidied
      * @throws Exception
      */
@@ -352,7 +342,7 @@ public class LibertyServerFactory {
     /**
      * This method should not be ran by the user, it is ran by the JUnit runner at the end of each test
      * to recover the servers.
-     * 
+     *
      * @param testClassName the name of the FAT test class to recover known servers for
      * @throws Exception
      */
@@ -647,7 +637,7 @@ public class LibertyServerFactory {
 
     /**
      * Hack to get the calling test class name from the stack.
-     * 
+     *
      * @param methodName the name of the method that is being called
      */
     private static String getCallerClassNameFromStack() {

--- a/dev/fattest.simplicity/src/componenttest/topology/ldap/LocalLdapServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/ldap/LocalLdapServer.java
@@ -13,12 +13,12 @@ package componenttest.topology.ldap;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.List;
 
 import com.ibm.websphere.simplicity.log.Log;
+
 import componenttest.common.apiservices.Bootstrap;
+import componenttest.topology.utils.PrivHelper;
 
 /**
  *
@@ -30,21 +30,8 @@ public class LocalLdapServer {
     private BufferedReader in;
 
     private static final Class<?> c = LocalLdapServer.class;
-    private static final String APACHE_DS_HOME =
-                    AccessController.doPrivileged(new PrivilegedAction<String>() {
-                        @Override
-                        public String run() {
-                            return System.getProperty("apache.ds.home");
-                        }
-                    });
-
-    private static final String OS_NAME =
-                    AccessController.doPrivileged(new PrivilegedAction<String>() {
-                        @Override
-                        public String run() {
-                            return System.getProperty("os.name");
-                        }
-                    });
+    private static final String APACHE_DS_HOME = PrivHelper.getProperty("apache.ds.home");
+    private static final String OS_NAME = PrivHelper.getProperty("os.name");
 
     /**
      * Sets the name of the instance
@@ -108,8 +95,7 @@ public class LocalLdapServer {
             }
         }
 
-        in = new BufferedReader(
-                        new InputStreamReader(localLdapInstance.getInputStream()));
+        in = new BufferedReader(new InputStreamReader(localLdapInstance.getInputStream()));
 
         try {
             String line = null;
@@ -123,14 +109,12 @@ public class LocalLdapServer {
                     if (line.trim().equals("|_|")) {
                         //started, break the loop
                         break;
-                    }
-                    else {
+                    } else {
                         //wasn't the output we expected, but wasn't end of stream
                         //so just continue
                         continue;
                     }
-                }
-                else {
+                } else {
                     //reached the end of the stream, wait 1 second before trying again
                     try {
                         Thread.sleep(1000);

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/PrivHelper.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/PrivHelper.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.topology.utils;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+public class PrivHelper {
+
+    public static String getProperty(final String prop) {
+        return AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return System.getProperty(prop);
+            }
+        });
+    }
+
+    public static String getProperty(final String prop, final String defaultValue) {
+        return AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return System.getProperty(prop, defaultValue);
+            }
+        });
+    }
+
+    public static boolean getBoolean(final String prop) {
+        return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+            @Override
+            public Boolean run() {
+                return Boolean.getBoolean(prop);
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
In order to test all FATs with java 2 security enabled, we would like to be able to specify a property `global.java2.sec=true` which will programatically add `websphere.java.security` to the bootstrap.properties file of all servers (thus enabling java 2 security).