### PR TITLE
Mechanism to repeat FATs for different feature combinations

### DIFF
--- a/dev/build.example_fat/bnd.bnd
+++ b/dev/build.example_fat/bnd.bnd
@@ -17,6 +17,11 @@ src: \
 
 test.project: true
 
+# Define additional tested features that are NOT present any any XML files in this bucket.
+# In this case, servlet-4.0 is added programatically at runtime by the RepeatTests rule.
+tested.features:\
+	servlet-4.0
+
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
 # runtime.minimum.java.level: 1.8

--- a/dev/build.example_fat/fat/src/com/ibm/ws/example/FATSuite.java
+++ b/dev/build.example_fat/fat/src/com/ibm/ws/example/FATSuite.java
@@ -10,14 +10,25 @@
  *******************************************************************************/
 package com.ibm.ws.example;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.rules.FeatureReplacementAction;
+import componenttest.rules.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
                 SimpleTest.class,
 })
 public class FATSuite {
+
+    // Using the RepeatTests @ClassRule will cause all tests to be run twice.
+    // First without any modifications, then again with all features upgraded to their EE8 equivalents.
+    @ClassRule
+    public static RepeatTests r = new RepeatTests()
+                    .withoutModification()
+                    .with(FeatureReplacementAction.EE8_FEATURES);
 
 }

--- a/dev/build.example_fat/fat/src/com/ibm/ws/example/FATSuite.java
+++ b/dev/build.example_fat/fat/src/com/ibm/ws/example/FATSuite.java
@@ -27,8 +27,7 @@ public class FATSuite {
     // Using the RepeatTests @ClassRule will cause all tests to be run twice.
     // First without any modifications, then again with all features upgraded to their EE8 equivalents.
     @ClassRule
-    public static RepeatTests r = new RepeatTests()
-                    .withoutModification()
-                    .with(FeatureReplacementAction.EE8_FEATURES);
+    public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(FeatureReplacementAction.EE8_FEATURES);
 
 }

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
@@ -499,8 +499,6 @@ public class FATRunner extends BlockJUnit4ClassRunner {
                             }
                         }
                     } catch (TopologyException e) {
-                        //ignore the exception as log directory doesn't exist and no FFDC log
-                        Log.info(c, "retrieveFFDCCounts", "Ignoring exception: " + e);
                         retry = false;
                     } catch (Exception e) {
                         Log.info(c, "retrieveFFDCCounts", "Exception parsing FFDC summary");

--- a/dev/fattest.simplicity/src/componenttest/rules/FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/FeatureReplacementAction.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.rules;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Scanner;
+import java.util.Set;
+
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.ServerConfigurationFactory;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.topology.impl.JavaInfo;
+
+/**
+ * Test repeat action that removes and adds features during setup.
+ */
+public class FeatureReplacementAction implements RepeatTestAction {
+
+    private static final Class<?> c = FeatureReplacementAction.class;
+
+    static final String ALL_SERVERS = "ALL_SERVERS";
+
+    private static final String[] EE7_FEATURES_ARRAY = { "javaee-7.0", "webProfile-7.0", "servlet-3.1", "jdbc-4.1", "javaMail-1.5", "cdi-1.2", "jpa-2.1", "beanValidation-1.1",
+                                                         "jaxrs-2.0", "jsf-2.2", "appSecurity-2.0", "jsonp-1.0" };
+    private static final String[] EE8_FEATURES_ARRAY = { "javaee-8.0", "webProfile-8.0", "servlet-4.0", "jdbc-4.2", "javaMail-1.6", "cdi-2.0", "jpa-2.2", "beanValidation-2.0",
+                                                         "jaxrs-2.1", "jsf-2.3", "appSecurity-3.0", "jsonp-1.1", "jsonb-1.0", };
+
+    private static final Set<String> EE7_FEATURE_SET = new HashSet<>(Arrays.asList(EE7_FEATURES_ARRAY));
+    private static final Set<String> EE8_FEATURE_SET = new HashSet<>(Arrays.asList(EE8_FEATURES_ARRAY));
+
+    /**
+     * Replaces any Java EE 8 features with the Java EE 7 equivalent feature.
+     */
+    public static final FeatureReplacementAction EE7_FEATURES = new FeatureReplacementAction(EE8_FEATURE_SET, EE7_FEATURE_SET).forceAddFeatures(false);
+    /**
+     * Replaces any Java EE 7 features with the Java EE 8 equivalent feature.
+     * Will automatically skip if running below Java 8.
+     */
+    public static final FeatureReplacementAction EE8_FEATURES = new FeatureReplacementAction(EE7_FEATURE_SET, EE8_FEATURE_SET).withMinJavaLevel(8).forceAddFeatures(false);
+
+    private boolean forceAddFeatures = true;
+    private int minJavaLevel = 7;
+    private final Set<String> servers = new HashSet<>(Arrays.asList(ALL_SERVERS));
+    private final Set<String> removeFeatures = new HashSet<>();
+    private final Set<String> addFeatures = new HashSet<>();
+
+    public FeatureReplacementAction(String removeFeature, String addFeature) {
+        this(Collections.singleton(removeFeature), Collections.singleton(addFeature));
+        forceAddFeatures = true;
+    }
+
+    public FeatureReplacementAction(Set<String> removeFeatures, Set<String> addFeatures) {
+        this.removeFeatures.addAll(removeFeatures);
+        this.addFeatures.addAll(addFeatures);
+    }
+
+    /**
+     * Defines a minimum java level in order for this RepeatTestAction to be enabled
+     */
+    public FeatureReplacementAction withMinJavaLevel(int javaLevel) {
+        this.minJavaLevel = javaLevel;
+        return this;
+    }
+
+    /**
+     * Specify a list of server names to include in the feature replace action and any server configuration
+     * files under "publish/servers/SERVER_NAME/" will be scanned.
+     * By default, all server config files in publish/servers/ and publish/files/ will be scanned for updates.
+     */
+    public FeatureReplacementAction forServers(String... serverNames) {
+        servers.remove(ALL_SERVERS);
+        servers.addAll(Arrays.asList(serverNames));
+        return this;
+    }
+
+    /**
+     * Set to true in order to force the addition of all features in the 'addFeature' list.
+     * Set to false to "smart upgrade", where features in the 'addFeatures' list are only added if
+     * a different version of the corresponding feature is present in the server configuration and the
+     * 'removeFeatures' list.
+     */
+    public FeatureReplacementAction forceAddFeatures(boolean force) {
+        this.forceAddFeatures = force;
+        return this;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        boolean enabled = JavaInfo.forCurrentVM().majorVersion() >= minJavaLevel;
+        if (!enabled)
+            Log.info(c, "isEnabled", "Skipping action '" + toString() + "' because the java level is too low.");
+        return enabled;
+    }
+
+    @Override
+    public void setup() throws Exception {
+        final String m = "setup";
+        final String pathToAutoFVTTestFiles = "lib/LibertyFATTestFiles/";
+        final String pathToAutoFVTTestServers = "publish/servers/";
+
+        // Find all of the server configurations to replace features in
+        Set<File> serverConfigs = new HashSet<>();
+        File serverFolder = new File(pathToAutoFVTTestServers);
+        File filesFolder = new File(pathToAutoFVTTestFiles);
+        if (servers.contains(ALL_SERVERS)) {
+            // Find all *.xml in this test project
+            serverConfigs.addAll(findFile(serverFolder, ".xml"));
+            serverConfigs.addAll(findFile(filesFolder, ".xml"));
+        } else {
+            for (String serverName : servers)
+                serverConfigs.add(new File(pathToAutoFVTTestServers + serverName));
+        }
+
+        // Make sure that XML file we find is a server config file, by checking if it contains the <server> tag
+        Log.info(c, m, "Got files: " + serverConfigs.toString());
+
+        // change all the server.xml files
+        assertTrue("There were no servers (*.xml) in " + serverFolder.getAbsolutePath() + " and in " + filesFolder.getAbsolutePath()
+                   + ". If you see this failure, what you need to do is add a simple server to publish/servers which includes the feature you're trying to test.",
+                   serverConfigs.size() > 0);
+
+        for (File serverConfig : serverConfigs) {
+            if (!serverConfig.exists() || !serverConfig.canRead() || !serverConfig.canWrite()) {
+                Log.info(c, m, "File did not exist or was not readable: " + serverConfig.getAbsolutePath());
+                continue;
+            }
+
+            // Before we try to unmarshal the file, be sure it's a valid <server> config file
+            boolean isServerConfig = false;
+            try (Scanner s = new Scanner(serverConfig)) {
+                while (!isServerConfig && s.hasNextLine())
+                    isServerConfig = s.nextLine().contains("<server");
+            }
+            if (!isServerConfig) {
+                Log.info(c, m, "File did not contain <server> so assuming it is not a valid server.xml" + serverConfig.getAbsolutePath());
+                continue;
+            }
+
+            ServerConfiguration config = ServerConfigurationFactory.fromFile(serverConfig);
+            Set<String> features = config.getFeatureManager().getFeatures();
+
+            Log.info(c, m, "Original features:  " + features);
+            if (forceAddFeatures) {
+                features.removeAll(removeFeatures);
+                features.addAll(addFeatures);
+            } else {
+                for (String removeFeature : removeFeatures)
+                    if (features.remove(removeFeature)) {
+                        // If we found a feature to remove that is actually present in server.xml, then
+                        // remove it and replace it with the corresponding feature
+                        String toAdd = getReplacementFeature(removeFeature, addFeatures);
+                        if (toAdd != null)
+                            features.add(toAdd);
+                    }
+            }
+            Log.info(c, m, "Resulting features: " + features);
+
+            ServerConfigurationFactory.toFile(serverConfig, config);
+        }
+    }
+
+    private static String getReplacementFeature(String originalFeature, Set<String> featuresToAdd) {
+        // Example: servlet-3.1 --> servlet-4.0
+        String featureBasename = originalFeature.substring(0, originalFeature.indexOf('-') + 1); // "servlet-"
+        for (String featureToAdd : featuresToAdd)
+            if (featureToAdd.contains(featureBasename)) // "servlet-4.0".contains("servlet-")
+                return featureToAdd;
+        // We may need to remove a feature without adding any replacement
+        // (e.g. jsonb-1.0 is EE8 only) so in this case return null
+        return null;
+    }
+
+    private static Set<File> findFile(File dir, String suffix) {
+        HashSet<File> set = new HashSet<File>();
+        File[] list = dir.listFiles();
+        if (list != null) {
+            for (File file : list) {
+                if (file.isDirectory()) {
+                    set.addAll(findFile(file, suffix));
+                } else if (file.getName().endsWith(suffix)) {
+                    set.add(file);
+                }
+            }
+        }
+        return set;
+    }
+
+    @Override
+    public String toString() {
+        if (this == EE7_FEATURES)
+            return "Set all features to EE7 compatibility";
+        if (this == EE8_FEATURES)
+            return "Set all features to EE8 compatibility";
+        return getClass().getSimpleName() + "  REMOVE " + removeFeatures + "  ADD " + addFeatures;
+    }
+}

--- a/dev/fattest.simplicity/src/componenttest/rules/RepeatTestAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/RepeatTestAction.java
@@ -14,6 +14,7 @@ public interface RepeatTestAction {
 
     /**
      * Invoked by the FAT framework to test if the action should be applied or not.
+     * If a RepeatTestAction is disabled, it ought to log a message indicating why.
      */
     public boolean isEnabled();
 

--- a/dev/fattest.simplicity/src/componenttest/rules/RepeatTestAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/RepeatTestAction.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.rules;
+
+public interface RepeatTestAction {
+
+    /**
+     * Invoked by the FAT framework to test if the action should be applied or not.
+     */
+    public boolean isEnabled();
+
+    /**
+     * Invoked by the FAT framework to perform setup steps before repeating the tests.
+     */
+    public void setup() throws Exception;
+
+}

--- a/dev/fattest.simplicity/src/componenttest/rules/RepeatTests.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/RepeatTests.java
@@ -30,11 +30,25 @@ import com.ibm.websphere.simplicity.log.Log;
  * <pre>
  * <code>@ClassRule
  * public static RepeatTests r = new RepeatTests().withoutModification()
- *                                                .with(FeatureReplacementAction.EE8);
+ *                                                .andWith(FeatureReplacementAction.EE8);
  * </code>
  * </pre>
  */
 public class RepeatTests extends ExternalResource {
+
+    /**
+     * Adds an iteration of test execution without making any modifications
+     */
+    public static RepeatTests withoutModification() {
+        return new RepeatTests().andWithoutModification();
+    }
+
+    /**
+     * Adds an iteration of test execution, where the action.setup() is called before repeating the tests.
+     */
+    public static RepeatTests with(RepeatTestAction action) {
+        return new RepeatTests().andWith(action);
+    }
 
     private static final RepeatTestAction NO_MODIFICATION_ACTION = new RepeatTestAction() {
         @Override
@@ -53,12 +67,14 @@ public class RepeatTests extends ExternalResource {
 
     private final List<RepeatTestAction> actions = new ArrayList<>();
 
-    public RepeatTests() {}
+    private RepeatTests() {
+        // private ctor, require static entry point
+    }
 
     /**
      * Adds an iteration of test execution without making any modifications
      */
-    public RepeatTests withoutModification() {
+    public RepeatTests andWithoutModification() {
         actions.add(NO_MODIFICATION_ACTION);
         return this;
     }
@@ -66,7 +82,7 @@ public class RepeatTests extends ExternalResource {
     /**
      * Adds an iteration of test execution, where the action.setup() is called before repeating the tests.
      */
-    public RepeatTests with(RepeatTestAction action) {
+    public RepeatTests andWith(RepeatTestAction action) {
         actions.add(action);
         return this;
     }

--- a/dev/fattest.simplicity/src/componenttest/rules/RepeatTests.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/RepeatTests.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+/**
+ * Used as a JUnit <code>@ClassRule</code> to repeat all tests with the specified actions.
+ * <br>
+ * <b>NOTE: Order is significant when building the object! Tests will be run in the order of the builder methods.</b>
+ * <br>
+ * For example, if a FAT was written with Java EE 7 features initially, and we want to repeat
+ * the tests with Java EE 8 equivalent features, do the following:
+ *
+ * <pre>
+ * <code>@ClassRule
+ * public static RepeatTests r = new RepeatTests().withoutModification()
+ *                                                .with(FeatureReplacementAction.EE8);
+ * </code>
+ * </pre>
+ */
+public class RepeatTests extends ExternalResource {
+
+    private static final RepeatTestAction NO_MODIFICATION_ACTION = new RepeatTestAction() {
+        @Override
+        public void setup() {}
+
+        @Override
+        public boolean isEnabled() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "No modifications";
+        }
+    };
+
+    private final List<RepeatTestAction> actions = new ArrayList<>();
+
+    public RepeatTests() {}
+
+    /**
+     * Adds an iteration of test execution without making any modifications
+     */
+    public RepeatTests withoutModification() {
+        actions.add(NO_MODIFICATION_ACTION);
+        return this;
+    }
+
+    /**
+     * Adds an iteration of test execution, where the action.setup() is called before repeating the tests.
+     */
+    public RepeatTests with(RepeatTestAction action) {
+        actions.add(action);
+        return this;
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        return new CompositeRepeatTestActionStatement(actions, statement);
+    }
+
+    private static class CompositeRepeatTestActionStatement extends Statement {
+        private static Class<?> c = CompositeRepeatTestActionStatement.class;
+
+        private final Statement statement;
+        private final List<RepeatTestAction> actions;
+
+        private CompositeRepeatTestActionStatement(List<RepeatTestAction> actions, Statement statement) {
+            this.statement = statement;
+            this.actions = actions;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            final String m = "evaluate";
+            for (RepeatTestAction action : actions) {
+                if (action.isEnabled()) {
+                    Log.info(c, m, "===================================");
+                    Log.info(c, m, "");
+                    Log.info(c, m, "Running tests with action: " + action);
+                    Log.info(c, m, "");
+                    Log.info(c, m, "===================================");
+                    action.setup();
+                    statement.evaluate();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Provide a simple way to FATs to re-run tests with different feature sets.

Current draft looks like this:
```java
public class FATSuite {

    // Using the RepeatTests @ClassRule will cause all tests to be run twice.
    // First without any modifications, then again with all features upgraded to their EE8 equivalents.
    @ClassRule
    public static RepeatTests r = RepeatTests.withoutModification()
                    .andWith(FeatureReplacementAction.EE8_FEATURES);

}
```