### PR TITLE
Add basic security config to javaee.8.0_fat so servers start up without errors.

### DIFF
--- a/dev/com.ibm.ws.javaee.8.0_fat/publish/servers/javaee8.fat.webProfile/server.xml
+++ b/dev/com.ibm.ws.javaee.8.0_fat/publish/servers/javaee8.fat.webProfile/server.xml
@@ -24,6 +24,9 @@
     <library id="DerbyLib">
     	<fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
     </library>
+    
+    <keyStore id="defaultKeyStore" password="openliberty"/>
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
 
     <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.javaee.8.0_fat/publish/servers/javaee8.fat/server.xml
+++ b/dev/com.ibm.ws.javaee.8.0_fat/publish/servers/javaee8.fat/server.xml
@@ -24,6 +24,9 @@
     <library id="DerbyLib">
     	<fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
     </library>
+    
+    <keyStore id="defaultKeyStore" password="openliberty"/>
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
 
     <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>


### PR DESCRIPTION
Sometimes running the com.ibm.ws.javaee.8.0_fat fails because the following message is generated in logs after server start:

```
java.lang.Exception: Errors/warnings were found in server javaee8.fat logs:
 <br>[11/17/17 4:11:19:552 UTC] 0000003a ibm.ws.transport.iiop.security.AbstractCsiv2SubsystemFactory E CWWKS9582E: The [defaultSSLConfig] sslRef attributes required by the orb element with the defaultOrb id have not been resolved within 10 seconds. As a result, the applications will not start. Ensure that you have included a keyStore element and that Secure Sockets Layer (SSL) is configured correctly. If the sslRef is defaultSSLConfig, then add a keyStore element with the id defaultKeyStore and a password.
 <br>[11/17/17 4:11:19:556 UTC] 0000003a .ibm.ws.transport.iiop.server.security.CSIv2SubsystemFactory E CWWKS9660E: The orb element with the defaultOrb id attribute requires a user registry but no user registry became available within 10 seconds.   As a result, no application will start. Ensure that you have configured an appropriate user registry in the server.xml file.
	at componenttest.topology.impl.LibertyServer.checkLogsForErrorsAndWarnings(LibertyServer.java:2348)
	at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:2236)
	at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:2130)
	at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:2099)
	at com.ibm.ws.javaee.v80.fat.FullProfileTest.tearDown(FullProfileTest.java:43)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:316)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:152)
```