### PR TITLE
Revert "Remove com.ibm.ws.security.javaeesec.cdi.beans.hash package as IBM-API"

### DIFF
--- a/dev/com.ibm.websphere.appserver.appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
@@ -4,7 +4,8 @@ visibility=public
 IBM-API-Package: javax.security.enterprise; type="spec", \
  javax.security.enterprise.authentication.mechanism.http; type="spec", \
  javax.security.enterprise.credential; type="spec", \
- javax.security.enterprise.identitystore; type="spec"
+ javax.security.enterprise.identitystore; type="spec", \
+ com.ibm.ws.security.javaeesec.cdi.beans.hash; type="spec"
 
 IBM-ShortName: appSecurity-3.0
 #IBM-SPI-Package:


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#1121 because this PR conflicts with PR979.
