### PR TITLE
Generate api/spi javadocs

### DIFF
--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -47,19 +47,56 @@ task publishWLPJars(type: Copy) {
   }
 }
 
-task publishDevApiIBMJavadoc(type: Copy) {
+task apiSpiJavadoc(type: Javadoc) {
   dependsOn jar
-  from project.projectDir
-  into buildImage.file('wlp/dev/api/ibm/javadoc')
-  include 'com.ibm.websphere.appserver.api.*.javadoc.zip'
-  rename '.javadoc.zip', "_${bnd.bVersion}-javadoc.zip"
+  def publishSuffix = bnd('publish.wlp.jar.suffix', 'lib')
+  enabled publishSuffix.contains('api/ibm') || publishSuffix.contains('spi/ibm')
+
+  onlyIf {
+    !new File(buildDir, "javadoc").exists()
+  }
+
+  def sp = files()
+  def cp = files()
+  bndWorkspace.getProject(bnd('Bundle-SymbolicName', project.name))?.getBuildpath()*.getProject().each {
+    sp += files(it.getSourcePath())
+    cp += files(it.getBuildpath()*.getFile())
+  }
+
+  destinationDir = file("$buildDir/javadoc")
+  classpath += cp
+  source = sp
+
+  include bnd('Export-Package', '').split(',').collect {
+    def pkg = it
+    int index = pkg.indexOf(";")
+    if (index != -1) {
+      pkg = pkg.substring(0, index)
+    }
+    pkg = pkg.trim().replaceAll("\\.", "/") + "/*.java"
+    return pkg
+  }
+  exclude "**/internal/**"
+  title = bnd('Bundle-Name')
+  options.source '1.6'
+  options.memberLevel = 'PUBLIC'
+  options.noIndex true
+  options.use true
+  if (JavaVersion.current().isJava8Compatible()) {
+    options.addStringOption('Xdoclint:none', '-quiet')
+  }
 }
 
-task publishDevSpiIBMJavadoc(type: Copy) {
-  dependsOn jar
-  from project.projectDir
-  into buildImage.file('wlp/dev/spi/ibm/javadoc')
-  include 'com.ibm.websphere.appserver.spi.*.javadoc.zip'
+task zipJavadoc(type: Zip) {
+  dependsOn apiSpiJavadoc
+  archiveName bnd('Bundle-SymbolicName', project.name) + '.javadoc.zip'
+  from new File(project.buildDir, "javadoc")
+}
+
+task publishJavadoc(type: Copy) {
+  dependsOn zipJavadoc
+  from zipJavadoc
+  into rootProject.file("build.image/wlp/" + bnd('publish.wlp.jar.suffix', 'lib') + "/javadoc")
   rename '.javadoc.zip', "_${bnd.bVersion}-javadoc.zip"
 }
 
@@ -270,8 +307,7 @@ task publishLibNative(type: Copy) {
 assemble {
   dependsOn ':cnf:copyMavenLibs'
   dependsOn publishWLPJars
-  dependsOn publishDevApiIBMJavadoc
-  dependsOn publishDevSpiIBMJavadoc
+  dependsOn publishJavadoc
   dependsOn publishToolJars
   dependsOn publishSchemaResources
   dependsOn publishFeatureResources

--- a/dev/com.ibm.websphere.appserver.spi.kernel.embeddable/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.kernel.embeddable/bnd.bnd
@@ -24,4 +24,6 @@ Export-Package: com.ibm.wsspi.kernel.embeddable,com.ibm.wsspi.kernel.security.th
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \
-	com.ibm.ws.kernel.boot;version=latest
+	com.ibm.ws.kernel.boot;version=latest,\
+	com.ibm.ws.kernel.boot.core;version=latest,\
+	com.ibm.ws.kernel.security.thread;version=latest

--- a/dev/com.ibm.websphere.appserver.spi.logging/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.logging/bnd.bnd
@@ -24,4 +24,5 @@ Export-Package: com.ibm.websphere.ras,com.ibm.websphere.ras.annotation,com.ibm.w
 publish.wlp.jar.suffix: dev/spi/ibm
 
 -buildpath: \
-	com.ibm.ws.logging;version=latest
+	com.ibm.ws.logging;version=latest,\
+	com.ibm.ws.logging.core;version=latest

--- a/dev/com.ibm.ws.org.apache.cxf.jaxws/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.jaxws/bnd.bnd
@@ -10,6 +10,9 @@
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/liberty-release.props
 
+bVersion=1.0
+bFullVersion=${version;==;${bVersion}}.${libertyBundleMicroVersion}
+
 -sub: *.bnd
 
 globalize: false


### PR DESCRIPTION
For 17.0.0.3 we relied on javadoc generated internally from our Ant scripting. Release 17.0.0.4 and future versions will be using Gradle.