### PR TITLE
add doPriv for beanval 2.0 code

### DIFF
--- a/dev/com.ibm.ws.org.hibernate.validator.cdi/.classpath
+++ b/dev/com.ibm.ws.org.hibernate.validator.cdi/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="src" path="/com.ibm.ws.kernel.service"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.org.hibernate.validator.cdi/.classpath
+++ b/dev/com.ibm.ws.org.hibernate.validator.cdi/.classpath
@@ -3,6 +3,5 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="src" path="/com.ibm.ws.kernel.service"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.org.hibernate.validator.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.org.hibernate.validator.cdi/bnd.bnd
@@ -25,5 +25,6 @@ instrument.disabled: true
   org.hibernate.validator:hibernate-validator-cdi;version=6.0.4.Final,\
   com.ibm.ws.beanvalidation;version=latest,\
   com.ibm.ws.container.service;version=latest,\
-  com.ibm.ws.classloading;version=latest
+  com.ibm.ws.classloading;version=latest,\
+  com.ibm.ws.kernel.service;version=latest
 

--- a/dev/com.ibm.ws.org.hibernate.validator.cdi/src/com/ibm/ws/beanvalidation/v20/cdi/internal/LibertyHibernateValidatorExtension.java
+++ b/dev/com.ibm.ws.org.hibernate.validator.cdi/src/com/ibm/ws/beanvalidation/v20/cdi/internal/LibertyHibernateValidatorExtension.java
@@ -36,6 +36,7 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.ws.beanvalidation.service.BeanValidation;
 import com.ibm.ws.cdi.extension.WebSphereCDIExtension;
+import com.ibm.ws.kernel.service.util.PrivHelper;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
@@ -62,8 +63,8 @@ public class LibertyHibernateValidatorExtension implements Extension, WebSphereC
     BeanValidation beanValidation;
 
     public static BeanValidation getBeanVal() {
-        BundleContext bctx = FrameworkUtil.getBundle(LibertyHibernateValidatorExtension.class).getBundleContext();
-        return bctx.getService(bctx.getServiceReference(BeanValidation.class));
+        BundleContext bctx = PrivHelper.getBundleContext(FrameworkUtil.getBundle(LibertyHibernateValidatorExtension.class));
+        return PrivHelper.getService(bctx, BeanValidation.class);
     }
 
     public static Validator getDefaultValidator() {


### PR DESCRIPTION
Add doPriv blocks to resolve a number of Java 2 security exceptions for bean validation 2.0 code.

After these changes, the beanval 2.0 FAT bucket only reports Java 2 security exceptions for the following, which needs to be addressed separately:
java.security.AccessControlException: access denied ("org.hibernate.validator.HibernateValidatorPermission" "accessPrivateMembers")