### PR TITLE
Re-enable com.ibm.ws.microprofile.config unit tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.config/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config/bnd.bnd
@@ -19,7 +19,7 @@ Bundle-SymbolicName: com.ibm.ws.microprofile.config
 
 Bundle-Description:MicroProfile Configuration Implementation, version ${bVersion}
 
-testsrc: test/src, test/resources
+testsrc: test/src
 
 -dsannotations-inherit: true
 -dsannotations: com.ibm.ws.microprofile.config.archaius.impl.ArchaiusConfigProviderResolverImpl


### PR DESCRIPTION
It appears if you have two directories in testsrc there are issues.