### PR TITLE
grant Hibernate validator accessPrivateMembers permission by default

### DIFF
--- a/dev/com.ibm.ws.beanvalidation.v20/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.beanvalidation.v20/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -13,4 +13,5 @@
   <com.ibm.ws.beanvalidation.service.ValidatorFactoryBuilder type="ValidatorFactoryBuilderV20"/>
   <com.ibm.ws.beanvalidation.OSGiBeanValidationImpl />
 
+  <javaPermission id="org.hibernate.validator.HibernateValidatorPermission" className="org.hibernate.validator.HibernateValidatorPermission" name="accessPrivateMembers"/>
 </server>


### PR DESCRIPTION
grant the accessPrivateMembers permission for Hibernate validator by default