### PR TITLE
switch expedite attribute of concurrencyPolicy back to beta

### DIFF
--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/metatype/metatype.xml
@@ -18,7 +18,7 @@
  </Designate>
 
  <OCD id="com.ibm.ws.concurrency.policy.concurrencyPolicy" ibm:alias="concurrencyPolicy" name="%concurrencyPolicy" description="%concurrencyPolicy.desc">
-  <AD id="expedite"          type="Integer" default="0" min="0" name="%expedite" description="%expedite.desc"/>
+  <AD id="expedite"          type="Integer" default="0" min="0" ibm:beta="true" name="%expedite" description="%expedite.desc"/>
   <AD id="max"               type="Integer" required="false" min="1" name="%max" description="%max.desc"/>
   <AD id="maxPolicy"         type="String"  default="loose" name="%maxPolicy" description="%maxPolicy.desc">
    <Option value="loose"        label="%maxPolicy.loose.desc"/>


### PR DESCRIPTION
Switch the expedite attribute of concurrencyPolicy back to beta so that we have the opportunity to give it a better name.