### PR TITLE
Make javaMail-1.6 include javaeeCompatible-8.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.javaMail-1.6/com.ibm.websphere.appserver.javaMail-1.6.feature
+++ b/dev/com.ibm.websphere.appserver.javaMail-1.6/com.ibm.websphere.appserver.javaMail-1.6.feature
@@ -2,28 +2,30 @@
 symbolicName=com.ibm.websphere.appserver.javaMail-1.6
 visibility=public
 singleton=true
-IBM-API-Package: javax.mail;  type="spec", \
- javax.mail.internet;  type="spec", \
- javax.mail.util;  type="spec", \
- javax.mail.search;  type="spec", \
- javax.mail.event;  type="spec", \
- com.sun.mail;  type="third-party", \
- com.sun.mail.auth;  type="third-party", \
- com.sun.mail.imap;  type="third-party", \
- com.sun.mail.imap.protocol;  type="third-party", \
- com.sun.mail.iap;  type="third-party", \
- com.sun.mail.pop3;  type="third-party", \
- com.sun.mail.smtp;  type="third-party", \
- com.sun.mail.util;  type="third-party", \
- com.sun.mail.util.logging;  type="third-party", \
- com.sun.mail.handlers;  type="third-party"
 IBM-ShortName: javaMail-1.6
 Subsystem-Version: 1.6
 Subsystem-Name: JavaMail 1.6
+IBM-API-Package: \
+ javax.mail; type="spec", \
+ javax.mail.internet; type="spec", \
+ javax.mail.util; type="spec", \
+ javax.mail.search; type="spec", \
+ javax.mail.event; type="spec", \
+ com.sun.mail; type="third-party", \
+ com.sun.mail.auth; type="third-party", \
+ com.sun.mail.imap; type="third-party", \
+ com.sun.mail.imap.protocol; type="third-party", \
+ com.sun.mail.iap; type="third-party", \
+ com.sun.mail.pop3; type="third-party", \
+ com.sun.mail.smtp; type="third-party", \
+ com.sun.mail.util; type="third-party", \
+ com.sun.mail.util.logging; type="third-party", \
+ com.sun.mail.handlers; type="third-party"
 -features=\
   com.ibm.websphere.appserver.classloading-1.0,\
   com.ibm.websphere.appserver.injection-1.0,\
-  com.ibm.websphere.appserver.javax.mail-1.6
+  com.ibm.websphere.appserver.javax.mail-1.6,\
+  com.ibm.websphere.appserver.javaeeCompatible-8.0
 -bundles=\
   com.ibm.ws.javamail.1.6,\
   com.ibm.ws.javamail.config

--- a/dev/com.ibm.websphere.appserver.javaee-7.0/com.ibm.websphere.appserver.javaee-7.0.feature
+++ b/dev/com.ibm.websphere.appserver.javaee-7.0/com.ibm.websphere.appserver.javaee-7.0.feature
@@ -27,5 +27,3 @@ Subsystem-Name: Java EE Full Platform 7.0
  com.ibm.websphere.appserver.appClientSupport-1.0
 kind=ga
 edition=base
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
-

--- a/dev/com.ibm.websphere.appserver.javaee-8.0/com.ibm.websphere.appserver.javaee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.javaee-8.0/com.ibm.websphere.appserver.javaee-8.0.feature
@@ -27,4 +27,3 @@ Subsystem-Name: Java EE Full Platform 8.0
   com.ibm.websphere.appserver.webProfile-8.0
 kind=beta
 edition=base
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"

--- a/dev/com.ibm.websphere.appserver.mpJwt-1.0/com.ibm.websphere.appserver.mpJwt-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.mpJwt-1.0/com.ibm.websphere.appserver.mpJwt-1.0.feature
@@ -18,4 +18,3 @@ Subsystem-Name: Micro Profile Json Web Token 1.0
   com.ibm.ws.org.apache.commons.logging.1.0.3
 kind=ga
 edition=core
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"

--- a/dev/com.ibm.websphere.appserver.webProfile-7.0/com.ibm.websphere.appserver.webProfile-7.0.feature
+++ b/dev/com.ibm.websphere.appserver.webProfile-7.0/com.ibm.websphere.appserver.webProfile-7.0.feature
@@ -24,4 +24,3 @@ Subsystem-Name: Java EE Web Profile 7.0
  com.ibm.websphere.appserver.managedBeans-1.0
 kind=ga
 edition=core
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"

--- a/dev/com.ibm.websphere.appserver.webProfile-8.0/com.ibm.websphere.appserver.webProfile-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.webProfile-8.0/com.ibm.websphere.appserver.webProfile-8.0.feature
@@ -26,4 +26,3 @@ Subsystem-Name: Java EE Web Profile 8.0
   com.ibm.websphere.appserver.websocket-1.1
 kind=beta
 edition=core
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"


### PR DESCRIPTION
For issue #1221 

This will enforce that javaMail-1.6 can only be used with EE8 features (or EE6/7 features that do not have newer equivalents), and is consistent with our design for the rest of the EE feature sets.