### PR TITLE
Update java permissions for context_fat bucket

### DIFF
--- a/dev/com.ibm.ws.context_fat/publish/servers/com.ibm.ws.context.fat/server.xml
+++ b/dev/com.ibm.ws.context_fat/publish/servers/com.ibm.ws.context.fat/server.xml
@@ -13,5 +13,7 @@
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
     <javaPermission className="java.lang.RuntimePermission" name="createSecurityManager"/>
     <javaPermission className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission className="org.osgi.framework.AdminPermission" name="*" actions="*"/>
+    <javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="register,get"/>
     <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
 </server>


### PR DESCRIPTION
PR for issue #1237 - update java permissions for the context_fat bucket so that it can be run with Java 2 Security enabled.