### PR TITLE
automated test for XA recovery of JCA connection factory

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -72,7 +72,9 @@ public class DerbyResourceAdapterTest extends FATServletClient {
     public static void tearDown() throws Exception {
         server.stopServer("SRVE9967W", // The manifest class path derbyLocale_cs.jar can not be found in jar file wsjar:file:/C:/Users/IBM_ADMIN/Documents/workspace/build.image/wlp/usr/servers/com.ibm.ws.jca.fat.derbyra/connectors/DerbyRA.rar!/derby.jar or its parent.
                           // This may just be because we don't care about including manifest files in our test buckets, if that's the case, we can ignore this.
-                          "J2CA0081E"); //Expected due to simulated exception in testConnPoolStatsExceptionDestroy
+                          "J2CA0027E: .*eis/ds3", // Intentionally caused failure on XA.commit in order to cause in-doubt transaction
+                          "J2CA0081E", //Expected due to simulated exception in testConnPoolStatsExceptionDestroy
+                          "WTRN0048W: .*XAER_RMFAIL"); // Intentionally caused failure on XA.commit in order to cause in-doubt transaction
     }
 
     private void runTest(String servlet) throws Exception {
@@ -141,6 +143,12 @@ public class DerbyResourceAdapterTest extends FATServletClient {
 
     @Test
     public void testTransactionSynchronizationRegistry() throws Exception {
+        runTest(DerbyRAAnnoServlet);
+    }
+
+    @ExpectedFFDC("javax.transaction.xa.XAException") // intentionally caused failure to make the transaction in-doubt
+    @Test
+    public void testXARecovery() throws Exception {
         runTest(DerbyRAAnnoServlet);
     }
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=event=enabled:logservice=all:rarInstall=all:WAS.j2c=all:test=all:web.*=all:app.manager=all:com.ibm.ws.config.xml.internal.MetaTypeRegistry=all:com.ibm.ws.connectionpool.monitor.*=all
+com.ibm.ws.logging.trace.specification=*=info:logservice=all:rarInstall=all:WAS.j2c=all:test=all:web.*=all:com.ibm.ws.config.xml.internal.MetaTypeRegistry=all:com.ibm.ws.connectionpool.monitor.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -19,12 +19,17 @@
       <connectionManager maxPoolSize="2" connectionTimeout="0"/>
       <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
       <properties.DerbyRA/>
-    </connectionFactory>    
+    </connectionFactory>
     
     <connectionFactory jndiName="eis/ds2">
       <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
       <properties.DerbyRA exceptionOnDestroy="true"/>
-    </connectionFactory>   
+    </connectionFactory>
+
+    <connectionFactory jndiName="eis/ds3">
+      <connectionManager maxPoolSize="1"/>
+      <properties.DerbyRA userName="DS1USER" password="{xor}GwxuDwgb" xaSuccessLimit="0"/>
+    </connectionFactory>
 
     <adminObject jndiName="eis/bootstrapContext">
       <properties.DerbyRA.BootstrapContext/>
@@ -38,6 +43,9 @@
     <authData id="APP" user="APP" password="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX"/>
 
     <application type="ear" id="derbyRAApp" name="${id}Name" location="derbyRAApp.ear"/>
+
+    <transaction heuristicRetryInterval="2s"/>
+
     <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
     <javaPermission codebase="${server.config.dir}/connectors/DerbyRA.rar" className="java.security.AllPermission"/>
     <javaPermission className="javax.security.auth.PrivateCredentialPermission" signedBy="javax.resource.spi.security.PasswordCredential" principalType="*" principalName="*" actions="read"/>

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAAnnoServlet.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAAnnoServlet.java
@@ -11,8 +11,11 @@
 package web;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.LinkedList;
@@ -26,12 +29,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.annotation.Resource;
+import javax.naming.InitialContext;
 import javax.resource.spi.BootstrapContext;
 import javax.resource.spi.XATerminator;
 import javax.resource.spi.work.ExecutionContext;
 import javax.resource.spi.work.WorkManager;
 import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
+import javax.transaction.HeuristicMixedException;
 import javax.transaction.Status;
 import javax.transaction.Synchronization;
 import javax.transaction.TransactionSynchronizationRegistry;
@@ -271,6 +276,82 @@ public class DerbyRAAnnoServlet extends FATServlet {
 
         if (list.size() != 2)
             throw new Exception("Missing beforeCompletion, afterCompletion, or both from: " + list);
+    }
+
+    /**
+     * Intentionally cause an in-doubt transaction and verify that the transaction manager successfully recovers it
+     * by committing the updates to the database.
+     */
+    public void testXARecovery() throws Exception {
+        Connection con = ds1.getConnection();
+        try {
+            // create table
+            Statement stmt = con.createStatement();
+            stmt.executeUpdate("create table TestXARecoveryTBL (id int not null primary key, value varchar(30))");
+            stmt.close();
+        } finally {
+            con.close();
+        }
+
+        DataSource ds3 = InitialContext.doLookup("eis/ds3");
+
+        boolean commitAttempted = false;
+        tran.begin();
+        try {
+            Connection con1 = ds1.getConnection();
+            try {
+                Statement s1 = con1.createStatement();
+                s1.executeUpdate("insert into TestXARecoveryTBL values (1, 'VALUE FROM DS1')");
+                s1.close();
+            } finally {
+                con1.close();
+            }
+
+            Connection con2 = ds3.getConnection();
+            try {
+                Statement s2 = con2.createStatement();
+                s2.executeUpdate("insert into TestXARecoveryTBL values (2, 'VALUE FROM DS3')");
+                s2.close();
+            } finally {
+                con2.close();
+            }
+
+            try {
+                commitAttempted = true;
+                tran.commit();
+                fail("Commit should not have succeeded because the test infrastructure is supposed to cause an in-doubt transaction.");
+            } catch (HeuristicMixedException x) {
+                // Adjust the XA success limit, so as to allow XA recovery to commit the in-doubt transaction
+                ds3.unwrap(AtomicInteger.class).set(1);
+                System.out.println("Caught expected exception: " + x);
+            }
+        } finally {
+            if (!commitAttempted)
+                tran.rollback();
+        }
+
+        System.out.println("--- attempting to access data (only possible after recovery) ---");
+
+        con = ds1.getConnection();
+        try {
+            PreparedStatement ps = con.prepareStatement("select value from TestXARecoveryTBL where id=?");
+
+            ps.setInt(1, 2);
+            ResultSet result = ps.executeQuery();
+            assertTrue(result.next());
+            assertEquals("VALUE FROM DS3", result.getString(1));
+            result.close();
+
+            ps.setInt(1, 1);
+            result = ps.executeQuery();
+            assertTrue(result.next());
+            assertEquals("VALUE FROM DS1", result.getString(1));
+            result.close();
+
+            ps.close();
+        } finally {
+            con.close();
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml
@@ -51,6 +51,12 @@
      	  <config-property-type>java.lang.Boolean</config-property-type>
      	  <config-property-value>false</config-property-value> 
     	</config-property>
+        <config-property>
+    	  <description>Enforce a success limit on XA resource commits and rollbacks (-1 means no limit)</description>
+     	  <config-property-name>xaSuccessLimit</config-property-name> 
+     	  <config-property-type>java.lang.Integer</config-property-type>
+     	  <config-property-value>-1</config-property-value>  
+    	</config-property>
         <connectionfactory-interface>javax.sql.DataSource</connectionfactory-interface> 
         <connectionfactory-impl-class>fat.derbyra.resourceadapter.DerbyConnectionFactory</connectionfactory-impl-class> 
         <connection-interface>java.sql.Connection</connection-interface> 

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyConnectionFactory.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyConnectionFactory.java
@@ -14,6 +14,7 @@ import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 import javax.resource.ResourceException;
@@ -58,7 +59,7 @@ public class DerbyConnectionFactory implements DataSource {
 
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        return false;
+        return AtomicInteger.class.equals(iface);
     }
 
     @Override
@@ -73,7 +74,11 @@ public class DerbyConnectionFactory implements DataSource {
 
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        throw new UnsupportedOperationException();
+        // convenient way of exposing the XA success limit to the application
+        if (AtomicInteger.class.equals(iface))
+            return iface.cast(mcf.xaSuccessLimitCountDown);
+        else
+            throw new UnsupportedOperationException();
     }
 
     //@Override // Java 7

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnectionFactory.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnectionFactory.java
@@ -13,6 +13,7 @@ package fat.derbyra.resourceadapter;
 import java.io.PrintWriter;
 import java.sql.SQLException;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.resource.NotSupportedException;
 import javax.resource.ResourceException;
@@ -30,9 +31,11 @@ public class DerbyManagedConnectionFactory implements ManagedConnectionFactory, 
 
     transient DerbyResourceAdapter adapter;
     private transient boolean dissociatable;
-    private transient String password; // confidential config-property
-    private transient String userName; // config-property
+    transient String password; // confidential config-property
+    transient String userName; // config-property
     private transient boolean exceptionOnDestroy; // config-property
+    private transient int xaSuccessLimit; // config-property
+    transient AtomicInteger xaSuccessLimitCountDown;
 
     /** {@inheritDoc} */
     @Override
@@ -85,6 +88,10 @@ public class DerbyManagedConnectionFactory implements ManagedConnectionFactory, 
 
     String getUserName() {
         return userName;
+    }
+
+    public int getXaSuccessLimit() {
+        return xaSuccessLimit;
     }
 
     public boolean isDissociatable() {
@@ -141,5 +148,10 @@ public class DerbyManagedConnectionFactory implements ManagedConnectionFactory, 
 
     public void setUserName(String userName) {
         this.userName = userName;
+    }
+
+    public void setXaSuccessLimit(int xaSuccessLimit) {
+        this.xaSuccessLimit = xaSuccessLimit;
+        xaSuccessLimitCountDown = xaSuccessLimit >= 0 ? new AtomicInteger(xaSuccessLimit) : null;
     }
 }

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyXAResource.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyXAResource.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package fat.derbyra.resourceadapter;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+/**
+ * Wrapper for XAResource that allows us to simulate errors on XAResource.commit/rollback after
+ * these methods have been invoked a specified number of times. We use this to cause in-doubt
+ * transactions that require recovery.
+ *
+ * For example, if we have 3 resources participating in a transaction, we can wrap each of them
+ * with TestXAResource and set the commit/rollback limit to 2. When the test case does
+ * transaction.commit, the transaction manager will prepare all 3 resources, and then it will
+ * attempt to commit them. The first two will commit successfully (because they are within the
+ * limit) but the third will fail, leaving the transaction in an in-doubt state.
+ */
+public class DerbyXAResource implements XAResource {
+    /**
+     * Number of commits or rollbacks allowed before we simulate errors.
+     */
+    private AtomicInteger successLimit;
+
+    /**
+     * The real XAResource.
+     */
+    private final XAResource xaRes;
+
+    /**
+     * Construct a wrapper for the specified XA resource.
+     *
+     * @param xaRes XA resource to wrap.
+     * @param successLimit limit of commits/rollbacks that should succeed for the group of
+     *            XA resources before raising errors.
+     */
+    DerbyXAResource(XAResource xaRes, AtomicInteger successLimit) {
+        this.xaRes = xaRes;
+        this.successLimit = successLimit;
+    }
+
+    /**
+     * Allow the commit (delegate to the real XA resource) if we haven't exceeded the limit
+     * of commit/rollback attempts. If the limit is exceeded, then raise an error.
+     */
+    @Override
+    public void commit(Xid xid, boolean onePhase) throws XAException {
+        if (successLimit == null || successLimit.getAndDecrement() > 0)
+            xaRes.commit(xid, onePhase);
+        else {
+            XAException x = new XAException("Simulating an error for commit.");
+            x.errorCode = XAException.XAER_RMFAIL;
+            throw x;
+        }
+    }
+
+    @Override
+    public void end(Xid xid, int flags) throws XAException {
+        xaRes.end(xid, flags);
+    }
+
+    @Override
+    public void forget(Xid xid) throws XAException {
+        xaRes.forget(xid);
+    }
+
+    @Override
+    public int getTransactionTimeout() throws XAException {
+        return xaRes.getTransactionTimeout();
+    }
+
+    @Override
+    public boolean isSameRM(XAResource r) throws XAException {
+        return xaRes.isSameRM(r);
+    }
+
+    @Override
+    public int prepare(Xid xid) throws XAException {
+        return xaRes.prepare(xid);
+    }
+
+    @Override
+    public Xid[] recover(int flag) throws XAException {
+        return xaRes.recover(flag);
+    }
+
+    /**
+     * Allow the rollback (delegate to the real XA resource) if we haven't exceeded the limit
+     * of commit/rollback attempts. If the limit is exceeded, then raise an error.
+     */
+    @Override
+    public void rollback(Xid xid) throws XAException {
+        if (successLimit == null || successLimit.getAndDecrement() > 0)
+            xaRes.rollback(xid);
+        else {
+            successLimit = null; // TODO remove this when
+            XAException x = new XAException("Simulating an error for rollback.");
+            x.errorCode = XAException.XAER_RMFAIL;
+            throw x;
+        }
+    }
+
+    @Override
+    public boolean setTransactionTimeout(int s) throws XAException {
+        return xaRes.setTransactionTimeout(s);
+    }
+
+    @Override
+    public void start(Xid xid, int flags) throws XAException {
+        xaRes.start(xid, flags);
+    }
+}


### PR DESCRIPTION
Update the Derby-backed test resource adapter (including fixes) and write a test that uses it to put a transaction in-doubt and verify that the WAS transaction manager recovers it.