### PR TITLE
Fix and test issue where a connection error occurs on a free connection

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
@@ -2193,7 +2193,15 @@ public final class MCWrapper implements com.ibm.ws.j2c.MCWrapper, JCAPMIHelper {
 
                 this.clearHandleList();
                 try {
-                    this.releaseToPoolManager();
+                    if (state != STATE_INACTIVE) { // If this MCWrapper is inactive then it has already been destroyed, likely because
+                        //a connection error occurred event was called on this connection while it was in the free pool.  Skipping a second
+                        //cleanup and destroy so the connection count is not double decremented and we don't get an IllegalStateException.
+                        this.releaseToPoolManager();
+                    } else {
+                        if (isTracingEnabled && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Skipping release since the MCWrapper state was already STATE_INACTIVE");
+                        }
+                    }
                 } catch (Exception ex) {
                     // Nothing to do here. PoolManager has already logged it.
                     // Since we are in cleanup mode, we will not surface a Runtime exception to the ResourceAdapter

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -162,4 +162,9 @@ public class DerbyResourceAdapterTest extends FATServletClient {
     public void testConnPoolStatsExceptionInDestroy() throws Exception {
         runTest(DerbyRAServlet);
     }
+
+    @Test
+    public void testErrorInFreeConn() throws Exception {
+        runTest(DerbyRAServlet);
+    }
 }

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -30,6 +30,11 @@
       <connectionManager maxPoolSize="1"/>
       <properties.DerbyRA userName="DS1USER" password="{xor}GwxuDwgb" xaSuccessLimit="0"/>
     </connectionFactory>
+    
+    <connectionFactory jndiName="eis/ds4">
+      <connectionManager enableSharingForDirectLookups="false"/>
+      <properties.DerbyRA user="DS1USER" password="{xor}GwxuDwgb"/>
+    </connectionFactory>
 
     <adminObject jndiName="eis/bootstrapContext">
       <properties.DerbyRA.BootstrapContext/>

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -33,7 +33,8 @@
     
     <connectionFactory jndiName="eis/ds4">
       <connectionManager enableSharingForDirectLookups="false"/>
-      <properties.DerbyRA user="DS1USER" password="{xor}GwxuDwgb"/>
+      <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
+      <properties.DerbyRA/>
     </connectionFactory>
 
     <adminObject jndiName="eis/bootstrapContext">

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAServlet.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAServlet.java
@@ -435,7 +435,7 @@ public class DerbyRAServlet extends FATServlet {
     }
 
     public void testErrorInFreeConn() throws Exception {
-        DataSource ds = (DataSource) new InitialContext().lookup("eis/ds3");
+        DataSource ds = (DataSource) new InitialContext().lookup("eis/ds4");
         Object managedConn = null;
         Connection con = null;
         Class<?> derbyConnClass = null;
@@ -456,7 +456,7 @@ public class DerbyRAServlet extends FATServlet {
         Method m = c.getMethod("notify", int.class, derbyConnClass, Exception.class);
         m.invoke(managedConn, 5, con, sqe); //5 indicates connection error
 
-        String contents = (String) mbeanServer.invoke(getMBeanObjectInstance("eis/ds3").getObjectName(), "showPoolContents", null, null);
+        String contents = (String) mbeanServer.invoke(getMBeanObjectInstance("eis/ds4").getObjectName(), "showPoolContents", null, null);
         int begin = contents.indexOf("size=");
         int end = contents.indexOf(System.lineSeparator(), begin);
         int poolSizeAfterError = Integer.parseInt(contents.substring(begin + 5, end).trim());

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyConnection.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyConnection.java
@@ -40,7 +40,7 @@ public class DerbyConnection implements Connection {
     ConnectionManager cm;
     DerbyConnectionRequestInfo cri;
     boolean isClosed;
-    DerbyManagedConnection mc;
+    public DerbyManagedConnection mc;
     DerbyManagedConnectionFactory mcf;
 
     DerbyConnection(DerbyManagedConnection mc) {
@@ -387,6 +387,6 @@ public class DerbyConnection implements Connection {
 
     @Override
     public String toString() {
-        return super.toString() + "[Subject=" + mc.subject + "]";
+        return mc == null ? super.toString() : super.toString() + "[Subject=" + mc.subject + "]";
     }
 }

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnection.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnection.java
@@ -185,7 +185,7 @@ public class DerbyManagedConnection implements LocalTransaction, ManagedConnecti
         return xares;
     }
 
-    void notify(int eventType, DerbyConnection conHandle, Exception failure) {
+    public void notify(int eventType, DerbyConnection conHandle, Exception failure) {
         ConnectionEvent event = new ConnectionEvent(this, eventType, failure);
         event.setConnectionHandle(conHandle);
         for (ConnectionEventListener listener : listeners)


### PR DESCRIPTION
Currently, when a connection error occurs on a free connection the connection count is double decremented and an illegal state exception is thrown.  This PR allows our code to correctly handle a connection error occurring on a connection in the free pool and adds a test to cover this scenario.

#999