### PR TITLE
Add a test case which verifies JPA Provider managed @Repeatable annot…

### DIFF
--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22/jpa22injection/src/jpa22injection/entity/InjectEntityA.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa22/jpa22injection/src/jpa22injection/entity/InjectEntityA.java
@@ -4,10 +4,13 @@ import javax.persistence.Basic;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 
 @Entity
 @Table(name = "Inject_Ent_A")
+@NamedQuery(name = "findAllEntityA", query = "SELECT a FROM InjectEntityA a")
+@NamedQuery(name = "findEntityAById", query = "SELECT a FROM InjectEntityA a WHERE a.id = :id")
 public class InjectEntityA {
     @Id
     @GeneratedValue


### PR DESCRIPTION
Simple added test case to verify that @NamedQuery is a @Repeatable annotation that is processed by the JPA 2.2 complaint Provider Implementation.