### PR TITLE
Enhance Derby-based test resource adapter to support MDBs and add a test case

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_derbyra/bnd.bnd
@@ -28,6 +28,7 @@ fat.project: true
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.websphere.javaee.connector.1.6;version=latest,\
+	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.ws.security.jaas.common;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -48,6 +48,7 @@ public class DerbyResourceAdapterTest extends FATServletClient {
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, WAR_NAME + ".war");
         war.addPackage("web");
+        war.addPackage("web.mdb");
         war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/ibm-web-bnd.xml"));
         war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/web.xml"));
 
@@ -79,6 +80,11 @@ public class DerbyResourceAdapterTest extends FATServletClient {
 
     private void runTest(String servlet) throws Exception {
         FATServletClient.runTest(server, servlet, testName.getMethodName());
+    }
+
+    @Test
+    public void testActivationSpec() throws Exception {
+        runTest(DerbyRAAnnoServlet);
     }
 
     @Test

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -5,6 +5,7 @@
       <feature>jca-1.7</feature>
       <feature>jndi-1.0</feature>
       <feature>localConnector-1.0</feature>
+      <feature>mdb-3.2</feature>
       <feature>servlet-3.1</feature>
       <feature>monitor-1.0</feature>
     </featureManager>
@@ -31,11 +32,15 @@
       <properties.DerbyRA userName="DS1USER" password="{xor}GwxuDwgb" xaSuccessLimit="0"/>
     </connectionFactory>
 
+    <activationSpec id="derbyRAApp/fvtweb/DerbyRAMessageDrivenBean">
+      <properties.DerbyRA destinationRef="map1" keyPrefix="mdbtest"/>
+    </activationSpec>
+
     <adminObject jndiName="eis/bootstrapContext">
       <properties.DerbyRA.BootstrapContext/>
     </adminObject>
 
-    <adminObject jndiName="eis/map1">
+    <adminObject id="map1" jndiName="eis/map1">
       <properties.DerbyRA.Map tableName="MAP1"/>
     </adminObject>
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -33,14 +33,14 @@
     </connectionFactory>
 
     <activationSpec id="derbyRAApp/fvtweb/DerbyRAMessageDrivenBean">
-      <properties.DerbyRA destinationRef="map1" keyPrefix="mdbtest"/>
+      <properties.DerbyRA keyPrefix="mdbtest"/>
     </activationSpec>
 
     <adminObject jndiName="eis/bootstrapContext">
       <properties.DerbyRA.BootstrapContext/>
     </adminObject>
 
-    <adminObject id="map1" jndiName="eis/map1">
+    <adminObject jndiName="eis/map1">
       <properties.DerbyRA.Map tableName="MAP1"/>
     </adminObject>
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/mdb/DerbyRAMessageDrivenBean.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/mdb/DerbyRAMessageDrivenBean.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web.mdb;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.Statement;
+
+import javax.annotation.Resource;
+import javax.ejb.MessageDriven;
+import javax.resource.ResourceException;
+import javax.resource.cci.MappedRecord;
+import javax.resource.cci.MessageListener;
+import javax.resource.cci.Record;
+import javax.sql.DataSource;
+
+@MessageDriven
+public class DerbyRAMessageDrivenBean implements MessageListener {
+    @Resource(lookup = "eis/ds1")
+    private DataSource ds1;
+
+    @Override
+    public Record onMessage(Record record) throws ResourceException {
+        System.out.println("onMessage for " + record);
+
+        MappedRecord m = (MappedRecord) record;
+        Object key = m.get("key");
+        Object newValue = m.get("newValue");
+        Object oldValue = m.get("previousValue");
+        // Write the previous value to a database table
+        try {
+            Connection con = ds1.getConnection();
+            try {
+                Statement stmt = con.createStatement();
+                try {
+                    stmt.executeUpdate("insert into TestActivationSpecTBL values ('" + key + "', '" + oldValue + "')");
+                } catch (SQLIntegrityConstraintViolationException x) {
+                    stmt.executeUpdate("update TestActivationSpecTBL set oldValue='" + oldValue + "' where id='" + key + "'");
+                }
+                stmt.close();
+            } finally {
+                con.close();
+            }
+        } catch (SQLException x) {
+            throw new ResourceException(x);
+        }
+        m.clear();
+        m.setRecordShortDescription(key + ": " + oldValue + " --> " + newValue);
+        return m;
+    }
+}

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml
@@ -76,10 +76,6 @@
           <activationspec>
             <activationspec-class>fat.derbyra.resourceadapter.DerbyActivationSpec</activationspec-class>
             <config-property>
-              <description>Destination</description>
-              <config-property-name>destination</config-property-name>
-            </config-property>
-            <config-property>
               <description>Key prefix for which to send a message when its value is replaced in any DerbyMap admin object that is associated with the resource adapter.</description>
               <config-property-name>keyPrefix</config-property-name>
               <config-property-type>java.lang.String</config-property-type>

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml
@@ -69,6 +69,25 @@
       </connection-definition>
       <reauthentication-support>false</reauthentication-support> 
     </outbound-resourceadapter>
+    <inbound-resourceadapter>
+      <messageadapter>
+        <messagelistener>
+          <messagelistener-type>javax.resource.cci.MessageListener</messagelistener-type>
+          <activationspec>
+            <activationspec-class>fat.derbyra.resourceadapter.DerbyActivationSpec</activationspec-class>
+            <config-property>
+              <description>Destination</description>
+              <config-property-name>destination</config-property-name>
+            </config-property>
+            <config-property>
+              <description>Key prefix for which to send a message when its value is replaced in any DerbyMap admin object that is associated with the resource adapter.</description>
+              <config-property-name>keyPrefix</config-property-name>
+              <config-property-type>java.lang.String</config-property-type>
+            </config-property>
+          </activationspec>
+        </messagelistener>
+      </messageadapter>
+    </inbound-resourceadapter>
     <adminobject>
       <adminobject-interface>java.util.Map</adminobject-interface>
       <adminobject-class>fat.derbyra.resourceadapter.DerbyMap</adminobject-class>

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyActivationSpec.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyActivationSpec.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package fat.derbyra.resourceadapter;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import javax.resource.ResourceException;
@@ -25,13 +24,8 @@ import javax.resource.spi.endpoint.MessageEndpointFactory;
  */
 public class DerbyActivationSpec implements ActivationSpec {
     private ResourceAdapter adapter;
-    DerbyMap<?, ?> destination;
     String keyPrefix;
     final ConcurrentLinkedQueue<MessageEndpointFactory> messageEndpointFactories = new ConcurrentLinkedQueue<MessageEndpointFactory>();
-
-    public Map<?, ?> getDestination() {
-        return destination;
-    }
 
     public String getKeyPrefix() {
         return keyPrefix;
@@ -40,10 +34,6 @@ public class DerbyActivationSpec implements ActivationSpec {
     @Override
     public ResourceAdapter getResourceAdapter() {
         return adapter;
-    }
-
-    public void setDestination(Map<?, ?> destination) {
-        this.destination = (DerbyMap<?, ?>) destination;
     }
 
     public void setKeyPrefix(String keyPrefix) {
@@ -57,8 +47,6 @@ public class DerbyActivationSpec implements ActivationSpec {
 
     @Override
     public void validate() throws InvalidPropertyException {
-        System.out.println("Validating ActivationSpec with keyPrefix " + keyPrefix + " for destination " + destination + " and resource adapter " + adapter);
-        if (destination == null)
-            throw new InvalidPropertyException("Destination: " + destination);
+        System.out.println("Validated ActivationSpec with keyPrefix " + keyPrefix + " and resource adapter " + adapter);
     }
 }

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyActivationSpec.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyActivationSpec.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package fat.derbyra.resourceadapter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.InvalidPropertyException;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+
+/**
+ * Activation spec, which, for any Map admin object, whenever a value is replaced
+ * for a key that matches the specified key prefix, notifies a message driven bean.
+ */
+public class DerbyActivationSpec implements ActivationSpec {
+    private ResourceAdapter adapter;
+    DerbyMap<?, ?> destination;
+    String keyPrefix;
+    final ConcurrentLinkedQueue<MessageEndpointFactory> messageEndpointFactories = new ConcurrentLinkedQueue<MessageEndpointFactory>();
+
+    public Map<?, ?> getDestination() {
+        return destination;
+    }
+
+    public String getKeyPrefix() {
+        return keyPrefix;
+    }
+
+    @Override
+    public ResourceAdapter getResourceAdapter() {
+        return adapter;
+    }
+
+    public void setDestination(Map<?, ?> destination) {
+        this.destination = (DerbyMap<?, ?>) destination;
+    }
+
+    public void setKeyPrefix(String keyPrefix) {
+        this.keyPrefix = keyPrefix;
+    }
+
+    @Override
+    public void setResourceAdapter(ResourceAdapter adapter) throws ResourceException {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public void validate() throws InvalidPropertyException {
+        System.out.println("Validating ActivationSpec with keyPrefix " + keyPrefix + " for destination " + destination + " and resource adapter " + adapter);
+        if (destination == null)
+            throw new InvalidPropertyException("Destination: " + destination);
+    }
+}

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyMappedRecord.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyMappedRecord.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package fat.derbyra.resourceadapter;
+
+import java.util.TreeMap;
+
+import javax.resource.cci.MappedRecord;
+
+@SuppressWarnings("rawtypes")
+public class DerbyMappedRecord extends TreeMap implements MappedRecord {
+    private static final long serialVersionUID = 1L;
+
+    private String desc;
+    private String name;
+
+    @Override
+    public String getRecordName() {
+        return name;
+    }
+
+    @Override
+    public String getRecordShortDescription() {
+        return desc;
+    }
+
+    @Override
+    public void setRecordName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void setRecordShortDescription(String desc) {
+        this.desc = desc;
+    }
+}

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyMessageWork.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyMessageWork.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package fat.derbyra.resourceadapter;
+
+import java.lang.reflect.Method;
+
+import javax.resource.ResourceException;
+import javax.resource.cci.MappedRecord;
+import javax.resource.cci.MessageListener;
+import javax.resource.cci.Record;
+import javax.resource.spi.endpoint.MessageEndpoint;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.resource.spi.work.Work;
+
+/**
+ * Notifies message driven beans that a value in a DerbyMap was replaced.
+ */
+public class DerbyMessageWork implements Work {
+    private final DerbyActivationSpec activationSpec;
+    private final Object key, value, previous;
+
+    DerbyMessageWork(DerbyActivationSpec activationSpec, Object key, Object value, Object previous) {
+        this.activationSpec = activationSpec;
+        this.key = key;
+        this.value = value;
+        this.previous = previous;
+    }
+
+    @Override
+    public void release() {}
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void run() {
+        System.out.println("Work impl will notify MDB for " + key + ", value " + previous + " updated to " + value);
+
+        for (MessageEndpointFactory mef : activationSpec.messageEndpointFactories)
+            try {
+                MappedRecord record = new DerbyMappedRecord();
+                record.setRecordName("MapValueReplaced");
+                record.setRecordShortDescription("A value in DerbyMap was replaced with a new value.");
+                record.put("key", key);
+                record.put("newValue", value);
+                record.put("previousValue", previous);
+
+                MessageEndpoint endpoint = mef.createEndpoint(null);
+                MessageListener listener = (MessageListener) endpoint;
+                Method onMessage = MessageListener.class.getMethod("onMessage", Record.class);
+                endpoint.beforeDelivery(onMessage);
+                record = (MappedRecord) listener.onMessage(record);
+                endpoint.afterDelivery();
+                endpoint.release();
+
+                System.out.println("Response from MDB has record name " + record.getRecordName() +
+                                   " and description: " + record.getRecordShortDescription() +
+                                   ". Content is " + record);
+            } catch (ResourceException x) {
+                x.printStackTrace();
+            } catch (NoSuchMethodException x) {
+                x.printStackTrace();
+            } finally {
+            }
+    }
+}


### PR DESCRIPTION
In order for subsequent development of a test that covers XA recovery for activation specs, we first need the Derby-backed test resource adapter to support activation specs and a message driven bean needs to be added to the test bucket.  This pull will accomplish those preliminary steps, resulting in a working MDB test for the Derby-backed test resource adapter.