### PR TITLE
XA recovery test for activation spec

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -87,6 +87,15 @@ public class DerbyResourceAdapterTest extends FATServletClient {
         runTest(DerbyRAAnnoServlet);
     }
 
+    @ExpectedFFDC({ "javax.ejb.EJBException",
+                    "javax.transaction.HeuristicMixedException",
+                    "javax.transaction.xa.XAException",
+                    "com.ibm.websphere.csi.CSITransactionRolledbackException" })
+    @Test
+    public void testActivationSpecXARecovery() throws Exception {
+        runTest(DerbyRAAnnoServlet);
+    }
+
     @Test
     public void testAdminObjectDirectLookup() throws Exception {
         runTest(DerbyRAServlet);

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyActivationSpec.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyActivationSpec.java
@@ -23,9 +23,20 @@ import javax.resource.spi.endpoint.MessageEndpointFactory;
  * for a key that matches the specified key prefix, notifies a message driven bean.
  */
 public class DerbyActivationSpec implements ActivationSpec {
-    private ResourceAdapter adapter;
+    private DerbyResourceAdapter adapter;
     String keyPrefix;
     final ConcurrentLinkedQueue<MessageEndpointFactory> messageEndpointFactories = new ConcurrentLinkedQueue<MessageEndpointFactory>();
+
+    /**
+     * Track an XA resource for recovery
+     *
+     * @param xaRes XA resource instance in need of recovery
+     */
+    void addRecoverableResource(DerbyXAResource xaRes) {
+        ConcurrentLinkedQueue<DerbyXAResource> newList = new ConcurrentLinkedQueue<DerbyXAResource>();
+        ConcurrentLinkedQueue<DerbyXAResource> oldList = adapter.recoverableXAResources.putIfAbsent(keyPrefix, newList);
+        (oldList == null ? newList : oldList).add(xaRes);
+    }
 
     public String getKeyPrefix() {
         return keyPrefix;
@@ -42,11 +53,11 @@ public class DerbyActivationSpec implements ActivationSpec {
 
     @Override
     public void setResourceAdapter(ResourceAdapter adapter) throws ResourceException {
-        this.adapter = adapter;
+        this.adapter = (DerbyResourceAdapter) adapter;
     }
 
     @Override
     public void validate() throws InvalidPropertyException {
-        System.out.println("Validated ActivationSpec with keyPrefix " + keyPrefix + " and resource adapter " + adapter);
+        System.out.println("Validated " + this + " with keyPrefix " + keyPrefix + " and resource adapter " + adapter);
     }
 }

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnection.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnection.java
@@ -31,7 +31,6 @@ import javax.sql.XAConnection;
 import javax.transaction.xa.XAResource;
 
 public class DerbyManagedConnection implements LocalTransaction, ManagedConnection {
-
     Connection con;
     final DerbyConnectionRequestInfo cri;
     final ConcurrentLinkedQueue<DerbyConnection> handles = new ConcurrentLinkedQueue<DerbyConnection>();
@@ -71,7 +70,7 @@ public class DerbyManagedConnection implements LocalTransaction, ManagedConnecti
                                             ? mcf.adapter.xaDataSource.getXAConnection() //
                                             : mcf.adapter.xaDataSource.getXAConnection(mcf.userName, mcf.password)) //
                             : mcf.adapter.xaDataSource.getXAConnection(userPwd[0], userPwd[1]);
-            this.xares = new DerbyXAResource(this, xacon.getXAResource(), mcf.xaSuccessLimitCountDown);
+            this.xares = new DerbyXAResource(xacon.getXAResource(), DerbyXAResource.XA_RECOVERY_QMID.equals(mcf.qmid) ? null : mcf.xaSuccessLimitCountDown);
             this.con = xacon.getConnection();
         } catch (SQLException x) {
             throw new ResourceAllocationException(x);


### PR DESCRIPTION
To prepare for testing the scenario where an activation spec's qmid is required for XA recovery, we first need an automated test of XA recovery for activation spec.  This pull updates the Derby-backed test resource adapter to support XA recovery for activation specs and then adds an automated test to verify.