### PR TITLE
add qmid attribute to activation spec of Derby-backed test resource adapter

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -87,6 +87,15 @@ public class DerbyResourceAdapterTest extends FATServletClient {
         runTest(DerbyRAAnnoServlet);
     }
 
+    @ExpectedFFDC({ "javax.ejb.EJBException",
+                    "javax.transaction.HeuristicMixedException",
+                    "javax.transaction.xa.XAException",
+                    "com.ibm.websphere.csi.CSITransactionRolledbackException" })
+    @Test
+    public void testActivationSpecXARecovery() throws Exception {
+        runTest(DerbyRAAnnoServlet);
+    }
+
     @Test
     public void testAdminObjectDirectLookup() throws Exception {
         runTest(DerbyRAServlet);

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -33,7 +33,9 @@
     </connectionFactory>
 
     <activationSpec id="derbyRAApp/fvtweb/DerbyRAMessageDrivenBean">
-      <properties.DerbyRA keyPrefix="mdbtest"/>
+      <recoveryAuthData userName="ActvSpecUser" password="ActvSpecPwd"/> <!-- convenient place to test recoveryAuthData for activation specs -->
+      <!-- TODO remove configuration of qmid once application server starts setting the value on XA recovery path -->
+      <properties.DerbyRA keyPrefix="mdbtest" qmid="This-QMID-Is-Required-For-XA-Recovery"/>
     </activationSpec>
 
     <adminObject jndiName="eis/bootstrapContext">

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAAnnoServlet.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAAnnoServlet.java
@@ -141,8 +141,8 @@ public class DerbyRAAnnoServlet extends FATServlet {
 
             // Database entry inserted by message driven bean should show up in a reasonable amount of time
             String oldValueFromDB = null;
-            DataSource ds = InitialContext.doLookup("java:global/env/eis/ds1ref");
-            Connection con = ds.getConnection();
+            DataSource ds = InitialContext.doLookup("eis/ds1");
+            Connection con = ds.getConnection("ActvSpecUser", "ActvSpecPwd");
             try {
                 PreparedStatement pstmt = con.prepareStatement("select description from TestActivationSpecRecoveryTBL where id=?");
                 pstmt.setString(1, "mdbtestRecovery");

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml
@@ -80,6 +80,11 @@
               <config-property-name>keyPrefix</config-property-name>
               <config-property-type>java.lang.String</config-property-type>
             </config-property>
+            <config-property>
+    	      <description>This property added to test WMQ XA recovery path. Value should not be configured because it will be supplied by the application server.</description>
+     	      <config-property-name>qmid</config-property-name> 
+     	      <config-property-type>java.lang.String</config-property-type> 
+    	    </config-property>
           </activationspec>
         </messagelistener>
       </messageadapter>

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyActivationSpec.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyActivationSpec.java
@@ -24,8 +24,9 @@ import javax.resource.spi.endpoint.MessageEndpointFactory;
  */
 public class DerbyActivationSpec implements ActivationSpec {
     private DerbyResourceAdapter adapter;
-    String keyPrefix;
+    String keyPrefix; // config-property
     final ConcurrentLinkedQueue<MessageEndpointFactory> messageEndpointFactories = new ConcurrentLinkedQueue<MessageEndpointFactory>();
+    String qmid; // config-property
 
     /**
      * Track an XA resource for recovery
@@ -42,6 +43,10 @@ public class DerbyActivationSpec implements ActivationSpec {
         return keyPrefix;
     }
 
+    public String getQmid() {
+        return qmid == null ? DerbyXAResource.XA_RECOVERY_QMID : qmid;
+    }
+
     @Override
     public ResourceAdapter getResourceAdapter() {
         return adapter;
@@ -49,6 +54,10 @@ public class DerbyActivationSpec implements ActivationSpec {
 
     public void setKeyPrefix(String keyPrefix) {
         this.keyPrefix = keyPrefix;
+    }
+
+    public void setQmid(String qmid) {
+        this.qmid = qmid;
     }
 
     @Override

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyActivationSpec.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyActivationSpec.java
@@ -23,9 +23,20 @@ import javax.resource.spi.endpoint.MessageEndpointFactory;
  * for a key that matches the specified key prefix, notifies a message driven bean.
  */
 public class DerbyActivationSpec implements ActivationSpec {
-    private ResourceAdapter adapter;
+    private DerbyResourceAdapter adapter;
     String keyPrefix;
     final ConcurrentLinkedQueue<MessageEndpointFactory> messageEndpointFactories = new ConcurrentLinkedQueue<MessageEndpointFactory>();
+
+    /**
+     * Track an XA resource for recovery
+     *
+     * @param xaRes XA resource instance in need of recovery
+     */
+    void addRecoverableResource(DerbyXAResource xaRes) {
+        ConcurrentLinkedQueue<DerbyXAResource> newList = new ConcurrentLinkedQueue<DerbyXAResource>();
+        ConcurrentLinkedQueue<DerbyXAResource> oldList = adapter.recoverableXAResources.putIfAbsent(keyPrefix, newList);
+        (oldList == null ? newList : oldList).add(xaRes);
+    }
 
     public String getKeyPrefix() {
         return keyPrefix;
@@ -42,11 +53,11 @@ public class DerbyActivationSpec implements ActivationSpec {
 
     @Override
     public void setResourceAdapter(ResourceAdapter adapter) throws ResourceException {
-        this.adapter = adapter;
+        this.adapter = (DerbyResourceAdapter) adapter;
     }
 
     @Override
     public void validate() throws InvalidPropertyException {
-        System.out.println("Validated ActivationSpec with keyPrefix " + keyPrefix + " and resource adapter " + adapter);
+        System.out.println("Validated " + this + " with keyPrefix " + keyPrefix + " and resource adapter " + adapter);
     }
 }

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnection.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnection.java
@@ -31,7 +31,6 @@ import javax.sql.XAConnection;
 import javax.transaction.xa.XAResource;
 
 public class DerbyManagedConnection implements LocalTransaction, ManagedConnection {
-
     Connection con;
     final DerbyConnectionRequestInfo cri;
     final ConcurrentLinkedQueue<DerbyConnection> handles = new ConcurrentLinkedQueue<DerbyConnection>();
@@ -71,7 +70,7 @@ public class DerbyManagedConnection implements LocalTransaction, ManagedConnecti
                                             ? mcf.adapter.xaDataSource.getXAConnection() //
                                             : mcf.adapter.xaDataSource.getXAConnection(mcf.userName, mcf.password)) //
                             : mcf.adapter.xaDataSource.getXAConnection(userPwd[0], userPwd[1]);
-            this.xares = new DerbyXAResource(this, xacon.getXAResource(), mcf.xaSuccessLimitCountDown);
+            this.xares = new DerbyXAResource(xacon.getXAResource(), DerbyXAResource.XA_RECOVERY_QMID.equals(mcf.qmid) ? null : mcf.xaSuccessLimitCountDown);
             this.con = xacon.getConnection();
         } catch (SQLException x) {
             throw new ResourceAllocationException(x);


### PR DESCRIPTION
Add a QMID attribute to the test resource adapter's activation spec, and require it in order for XA recovery to succeed.  For now, the test case will specify it in server config in order for it to run successfully.   The line where it is doing this is marked so that it can be removed in order to add test coverage for the scenario where the application server must supply the QMID to the activation spec.

Also, this test case looked like a convenient place to cover recoveryAuthData for activationSpec, which I don't think we test anywhere else, so I've included some updates to cover that as well.