### PR TITLE
QMID getter belongs on ManagedConnection, not ManagedConnectionFactory

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnection.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnection.java
@@ -178,6 +178,10 @@ public class DerbyManagedConnection implements LocalTransaction, ManagedConnecti
         return null;
     }
 
+    public String getQmid() {
+        return DerbyXAResource.XA_RECOVERY_QMID;
+    }
+
     /** {@inheritDoc} */
     @Override
     public XAResource getXAResource() throws ResourceException {

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnectionFactory.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyManagedConnectionFactory.java
@@ -73,10 +73,6 @@ public class DerbyManagedConnectionFactory implements ManagedConnectionFactory, 
         return password;
     }
 
-    public String getQmid() {
-        return qmid == null ? DerbyXAResource.XA_RECOVERY_QMID : qmid;
-    }
-
     /** {@inheritDoc} */
     @Override
     public ResourceAdapter getResourceAdapter() {


### PR DESCRIPTION
WMQ resource adapter places the QMID getter on ManagedConnection, not ManagedConnectionFactory.  Update the test resource adapter to match.