### PR TITLE
Try to remove an existing SAF map before adding one.

### DIFF
--- a/dev/com.ibm.ws.junit.extensions/src/test/common/zos/SAFConfigHelper.java
+++ b/dev/com.ibm.ws.junit.extensions/src/test/common/zos/SAFConfigHelper.java
@@ -704,6 +704,10 @@ public class SAFConfigHelper {
      *
      */
     public static void addMap(String user, String userIdFilter, String filterLabel, String registry, Cleanup c, boolean ignoreCleanupError) throws Exception {
+        // Attempt to remove the mapping first
+        new CleanupMap(user, filterLabel, true).call();
+
+        // Now add the mapping
         String safClass = "IDIDMAP";
         runTsoCmd("RACMAP MAP ID(" + user + ") USERDIDFILTER(NAME('" + userIdFilter + "')) WITHLABEL('" + filterLabel + "') REGISTRY(NAME('" + registry + "'))");
         c.addCleanup(new CleanupMap(user, filterLabel, ignoreCleanupError));


### PR DESCRIPTION
Occasionally the test system where the FAT tests buckets get run already has the SAF MAP defined, and SAF will get upset if you try to re-define it.  We'll try to delete it first, and ignore the error if it didn't already exist.

Personal build:
https://wasrtc.hursley.ibm.com:9443/jazz/resource/itemOid/com.ibm.team.build.BuildResult/_NRWoIOEEEeeJvLD-oValiA