### PR TITLE
runAfterEither for managed completable future

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_rx/publish/servers/com.ibm.ws.concurrent.fat.rx/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_rx/publish/servers/com.ibm.ws.concurrent.fat.rx/server.xml
@@ -21,7 +21,12 @@
     <include location="../fatTestPorts.xml"/>
     
     <application location="concurrentrxfat.war" />
-    
+
+    <managedScheduledExecutorService jndiName="concurrent/noContextExecutor">
+        <concurrencyPolicy max="2" maxQueueSize="2" runIfQueueFull="false"/>
+        <contextService/>
+    </managedScheduledExecutorService>
+
     <!-- Needed for application to shutdown the ExecutorService testThreads -->
     <javaPermission codebase="${server.config.dir}/apps/concurrentrxfat.war" className="java.lang.RuntimePermission" name="modifyThread"/>
     


### PR DESCRIPTION
Implement and test the runAfterEither/runAfterEitherAsync methods for managed completable future.  Also, added some additional replacements of static methods from CompletableFuture.