### PR TITLE
use build label for release type builds

### DIFF
--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -103,6 +103,7 @@ def loadBuildProps() {
   props.setProperty('javac.bootclasspath.1.7', jdkLibString)
   props.setProperty('javac.bootclasspath.1.8', jdkLibString)
  
+ 
   if (usrHomeProps.exists() && !props.getProperty('artifactory.force.external.repo')) {
     //Some functionality is added if we are able to access particular internal systems.
     //This is to support more controlled dependency management, and multiple JDK paths for cross-compilation
@@ -136,7 +137,13 @@ def loadBuildProps() {
 
   // Must be run after isRelease is set
   def (qualifier, timestamp) = getVersionQualifier(isRelease)
-
+  
+  //For release builds we can use a consistent qualifier of the build label.
+  //This comes from the RTC build engines
+  if (isRelease && (props.getProperty('buildLabel') != null)) {
+    qualifier = props.getProperty('buildLabel')
+  }
+  
   props.setProperty('version.qualifier', qualifier)
   props.setProperty('buildLabel', timestamp)
   props.setProperty('artifactory.matrix.parameters', matrixParams)
@@ -183,7 +190,7 @@ def loadBuildProps() {
 
 def getVersionQualifier(boolean isRelease) {
   //ex: 201708101600
-  def timestamp = new SimpleDateFormat("yyyyMMddHHmm").format(new java.util.Date())
+  def timestamp = new SimpleDateFormat("yyyyMMdd-HHmm").format(new java.util.Date())
   if (isRelease) {
     return [timestamp, timestamp]
   }


### PR DESCRIPTION
For consistency, we should use the buildLabel for our release type builds for easier matching between the bundle versions and the build version.