### PR TITLE
ProviderFactory.isReadable() and ProviderFactory.isWritable() will

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -981,6 +981,7 @@ public abstract class ProviderFactory {
         MessageBodyReader<?> ep = pi.getProvider();
         if (m.get(ACTIVE_JAXRS_PROVIDER_KEY) != ep) {
             injectContextValues(pi, m);
+            ep = pi.getProvider(); // now that CDI or EJB may have changed the provider impl
         }
         return ep.isReadable(type, genericType, annotations, mediaType);
     }
@@ -1025,6 +1026,7 @@ public abstract class ProviderFactory {
         MessageBodyWriter<?> ep = pi.getProvider();
         if (m.get(ACTIVE_JAXRS_PROVIDER_KEY) != ep) {
             injectContextValues(pi, m);
+            ep = pi.getProvider(); // now that CDI or EJB may have changed the provider impl
         }
         return ep.isWriteable(type, genericType, annotations, mediaType);
     }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
@@ -4,6 +4,7 @@
 	<classpathentry kind="src" path="test-applications/patchapp/src"/>
 	<classpathentry kind="src" path="test-applications/providerPriorityApp/src"/>
 	<classpathentry kind="src" path="test-applications/classSubResApp/src"/>
+	<classpathentry kind="src" path="test-applications/cdiApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
@@ -15,7 +15,8 @@ src: \
   fat/src,\
   test-applications/patchapp/src,\
   test-applications/providerPriorityApp/src,\
-  test-applications/classSubResApp/src
+  test-applications/classSubResApp/src,\
+  test-applications/cdiApp/src
 
 fat.project: true
 
@@ -24,5 +25,8 @@ javac.target: 1.8
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+  com.ibm.websphere.javaee.cdi.2.0;version=latest,\
   com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
-  com.ibm.websphere.javaee.servlet.3.1;version=latest
+  com.ibm.websphere.javaee.jsonb.1.0,\
+  com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+  com.ibm.ws.cdi.interfaces;version=latest

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/CDITest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/CDITest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs21.fat.extended;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import jaxrs21.fat.cdi.CDITestServlet;
+
+@RunWith(FATRunner.class)
+public class CDITest extends FATServletClient {
+
+    private static final String appName = "cdiapp";
+
+    @Server("jaxrs21.fat.cdi")
+    @TestServlet(servlet = CDITestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive app = ShrinkHelper.buildDefaultApp(appName, "jaxrs21.fat.cdi");
+        ShrinkHelper.exportDropinAppToServer(server, app);
+        server.addInstalledAppForValidation(appName);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer("CWWKW1001W|CWWKW1002W");
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.cdi/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.cdi/bootstrap.properties
@@ -1,0 +1,8 @@
+com.ibm.ws.logging.trace.specification=*=info:\
+com.ibm.ws.jaxrs20.*=all:\
+com.ibm.websphere.jaxrs20.*=all:\
+org.apache.cxf.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.cdi/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.cdi/server.xml
@@ -1,0 +1,10 @@
+<server>
+	<featureManager>
+		<feature>cdi-2.0</feature>
+		<feature>componenttest-1.0</feature>
+		<feature>jaxrs-2.1</feature>
+		<feature>jsonb-1.0</feature>
+	</featureManager>
+
+	<include location="../fatTestPorts.xml"/>
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/CDIApplication.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/CDIApplication.java
@@ -8,17 +8,24 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs21.fat.extended;
+package jaxrs21.fat.cdi;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import java.util.HashSet;
+import java.util.Set;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                PatchTest.class,
-                ProviderPriorityTest.class,
-                ClassSubResTest.class,
-                CDITest.class
-})
-public class FATSuite {}
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/rest")
+public class CDIApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> classes = new HashSet<Class<?>>();
+        classes.add(CDIResource.class);
+        classes.add(CDIObject.class);
+        classes.add(MyCar.class);
+        classes.add(MyCDIProvider.class);
+        return classes;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/CDIObject.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/CDIObject.java
@@ -8,17 +8,16 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs21.fat.extended;
+package jaxrs21.fat.cdi;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import javax.enterprise.context.ApplicationScoped;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                PatchTest.class,
-                ProviderPriorityTest.class,
-                ClassSubResTest.class,
-                CDITest.class
-})
-public class FATSuite {}
+@ApplicationScoped
+public class CDIObject {
+
+    private String car = "Corvette";
+
+    public String getCar() {
+        return car;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/CDIResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/CDIResource.java
@@ -8,17 +8,20 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs21.fat.extended;
+package jaxrs21.fat.cdi;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                PatchTest.class,
-                ProviderPriorityTest.class,
-                ClassSubResTest.class,
-                CDITest.class
-})
-public class FATSuite {}
+@Path("/cdi")
+public class CDIResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/car")
+    public MyCar getCar() {
+        return new MyCar();
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/CDITestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/CDITestServlet.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.cdi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/CDITestServlet")
+public class CDITestServlet extends FATServlet {
+
+    private Client client;
+
+    @Override
+    public void init() throws ServletException {
+        client = ClientBuilder.newBuilder().build();
+    }
+
+    @Override
+    public void destroy() {
+        client.close();
+    }
+
+    @Test
+    public void testCDIisWritable(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        Response response = target(req, "car").request(MediaType.APPLICATION_JSON).get();
+        assertEquals(200, response.getStatus());
+        MyCar myCar = response.readEntity(MyCar.class);
+        assertTrue("This " + myCar.getModel() + " isn't my Corvette!", myCar.getModel().equals("Corvette"));
+    }
+
+    private WebTarget target(HttpServletRequest request, String path) {
+        String base = "http://" + request.getServerName() + ':' + request.getServerPort() + "/cdiapp/rest/cdi/";
+        return client.target(base + path);
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/MyCDIProvider.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/MyCDIProvider.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.cdi;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+@ApplicationScoped
+@Produces({ MediaType.MEDIA_TYPE_WILDCARD })
+@Consumes({ MediaType.MEDIA_TYPE_WILDCARD })
+@Provider
+public class MyCDIProvider implements MessageBodyWriter<MyCar>, MessageBodyReader<MyCar> {
+
+    @Inject
+    private CDIObject cdiObject;
+
+    private final Jsonb jsonb;
+
+    public MyCDIProvider() {
+        JsonbBuilder builder = JsonbBuilder.newBuilder();
+        jsonb = builder.build();
+    }
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        boolean readable = true;
+        if (cdiObject != null) {
+//            javax.enterprise.inject.spi.CDI.current().select(CDIObject.class).get();
+            readable = true;
+        }
+        return readable;
+    }
+
+    @Override
+    public MyCar readFrom(Class<MyCar> clazz, Type genericType, Annotation[] annotations,
+                          MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        return jsonb.fromJson(entityStream, genericType);
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        boolean writeable = true;
+        if (cdiObject != null) {
+//            javax.enterprise.inject.spi.CDI.current().select(CDIObject.class).get();
+            writeable = true;
+        }
+        return writeable;
+    }
+
+    @Override
+    public void writeTo(MyCar car, Class<?> type, Type genericType, Annotation[] annotations,
+                        MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        car.setModel(cdiObject.getCar());
+        this.jsonb.toJson(car, entityStream);
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/MyCar.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/cdiApp/src/jaxrs21/fat/cdi/MyCar.java
@@ -8,17 +8,24 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs21.fat.extended;
+package jaxrs21.fat.cdi;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+public class MyCar {
+    private String car;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                PatchTest.class,
-                ProviderPriorityTest.class,
-                ClassSubResTest.class,
-                CDITest.class
-})
-public class FATSuite {}
+    public MyCar() {
+        car = "Pinto";
+    }
+
+    public MyCar(String model) {
+        car = model;
+    }
+
+    public String getModel() {
+        return car;
+    }
+
+    public void setModel(String model) {
+        car = model;
+    }
+}


### PR DESCRIPTION
create a new provider instance and do the CDI injection and readFrom() and
writeTo() will use the new instance. However, isReadable/Writable do not
get the new instance themselves, so if a customer uses a CDI injected
field in the isReadable/Writable methods of their
MessageBodyReader/Writer their first request will fail and subsequent
requests will work. This commit fixes that and gets the new instance in
the isReadable/Writable methods.

#1228 