### PR TITLE
Add appmanager-1.0 dependency to persistentExecutor-1.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.persistentExecutor-1.0/com.ibm.websphere.appserver.persistentExecutor-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.persistentExecutor-1.0/com.ibm.websphere.appserver.persistentExecutor-1.0.feature
@@ -1,13 +1,16 @@
 -include= ~../cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.persistentExecutor-1.0
-visibility=public
-IBM-API-Package: com.ibm.websphere.concurrent.persistent; type="ibm-api", \
- com.ibm.websphere.concurrent.persistent.mbean; type="ibm-api"
 IBM-ShortName: persistentExecutor-1.0
 Subsystem-Name: Persistent Scheduled Executor
--features=com.ibm.websphere.appserver.concurrent-1.0, \
- com.ibm.websphere.appserver.persistentExecutorSubset-1.0, \
- com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.2", \
- com.ibm.websphere.appserver.transaction-1.2
+symbolicName=com.ibm.websphere.appserver.persistentExecutor-1.0
+visibility=public
+IBM-API-Package: \
+  com.ibm.websphere.concurrent.persistent; type="ibm-api", \
+  com.ibm.websphere.concurrent.persistent.mbean; type="ibm-api"
+-features=\
+  com.ibm.websphere.appserver.appmanager-1.0, \
+  com.ibm.websphere.appserver.concurrent-1.0, \
+  com.ibm.websphere.appserver.persistentExecutorSubset-1.0, \
+  com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.2", \
+  com.ibm.websphere.appserver.transaction-1.2
 kind=noship
 edition=full


### PR DESCRIPTION
If the `persistentExecutor-1.0` feature is enabled by itself in a server.xml the following error show up in logs:
```
[ERROR   ] CWWKF0029E: Could not resolve module: com.ibm.ws.concurrent.persistent [117]
  Unresolved requirement: Import-Package: com.ibm.wsspi.application; version="[1.1.0,2.0.0)"
```
