### PR TITLE
update security permission entry to align with changed Derby location

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_demo/publish/servers/com.ibm.ws.concurrent.fat.demo/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_demo/publish/servers/com.ibm.ws.concurrent.fat.demo/server.xml
@@ -25,7 +25,7 @@
     <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
   </library>
 
-  <javaPermission codebase="${server.config.dir}derby/derby-10.11.1.1.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 
   <include location="../fatTestPorts.xml"/>
 </server>


### PR DESCRIPTION
This broke again after the Derby jar location for this bucket was changed, without having updated the permissions.  The pull updates the security permission to align with the new location.

Pull fixes #1167