### PR TITLE
thenCompose and acceptEither for managed completable future

### DIFF
--- a/dev/com.ibm.ws.concurrent.rx/src/com/ibm/websphere/concurrent/rx/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent.rx/src/com/ibm/websphere/concurrent/rx/ManagedCompletableFuture.java
@@ -223,7 +223,21 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Override
     public ManagedCompletableFuture<Void> acceptEither(CompletionStage<? extends T> other, Consumer<? super T> action) {
-        throw new UnsupportedOperationException();
+        if (other instanceof ManagedCompletableFuture)
+            other = ((ManagedCompletableFuture<? extends T>) other).completableFuture;
+
+        // Reject ManagedTask so that we have the flexibility to decide later how to handle ManagedTaskListener and execution properties
+        if (action instanceof ManagedTask)
+            throw new IllegalArgumentException(ManagedTask.class.getName());
+
+        WSContextService contextSvc = defaultExecutor.getContextService();
+
+        @SuppressWarnings("unchecked")
+        ThreadContextDescriptor contextDescriptor = contextSvc.captureThreadContext(XPROPS_SUSPEND_TRAN);
+        action = new ContextualConsumer<>(contextDescriptor, action);
+
+        CompletableFuture<Void> dependentStage = completableFuture.acceptEither(other, action);
+        return new ManagedCompletableFuture<Void>(dependentStage, defaultExecutor);
     }
 
     /**
@@ -231,7 +245,22 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Override
     public ManagedCompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other, Consumer<? super T> action) {
-        throw new UnsupportedOperationException();
+        if (other instanceof ManagedCompletableFuture)
+            other = ((ManagedCompletableFuture<? extends T>) other).completableFuture;
+
+        // Reject ManagedTask so that we have the flexibility to decide later how to handle ManagedTaskListener and execution properties
+        if (action instanceof ManagedTask)
+            throw new IllegalArgumentException(ManagedTask.class.getName());
+
+        PolicyExecutor policyExecutor = defaultExecutor.getNormalPolicyExecutor(); // TODO choose based on LONGRUNNING_HINT execution property
+        WSContextService contextSvc = defaultExecutor.getContextService();
+
+        @SuppressWarnings("unchecked")
+        ThreadContextDescriptor contextDescriptor = contextSvc.captureThreadContext(XPROPS_SUSPEND_TRAN);
+        action = new ContextualConsumer<>(contextDescriptor, action);
+
+        CompletableFuture<Void> dependentStage = completableFuture.acceptEitherAsync(other, action, policyExecutor);
+        return new ManagedCompletableFuture<Void>(dependentStage, defaultExecutor);
     }
 
     /**
@@ -239,7 +268,28 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Override
     public ManagedCompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other, Consumer<? super T> action, Executor executor) {
-        throw new UnsupportedOperationException();
+        if (other instanceof ManagedCompletableFuture)
+            other = ((ManagedCompletableFuture<? extends T>) other).completableFuture;
+
+        CompletableFuture<Void> dependentStage;
+        if (executor instanceof ManagedExecutorService) { // the only type of managed executor implementation allowed here is the built-in one
+            // Reject ManagedTask so that we have the flexibility to decide later how to handle ManagedTaskListener and execution properties
+            if (action instanceof ManagedTask)
+                throw new IllegalArgumentException(ManagedTask.class.getName());
+
+            WSManagedExecutorService managedExecutor = (WSManagedExecutorService) executor;
+            PolicyExecutor policyExecutor = managedExecutor.getNormalPolicyExecutor(); // TODO choose based on LONGRUNNING_HINT execution property
+            WSContextService contextSvc = managedExecutor.getContextService();
+
+            @SuppressWarnings("unchecked")
+            ThreadContextDescriptor contextDescriptor = contextSvc.captureThreadContext(XPROPS_SUSPEND_TRAN);
+            action = new ContextualConsumer<>(contextDescriptor, action);
+
+            dependentStage = completableFuture.acceptEitherAsync(other, action, policyExecutor);
+        } else {
+            dependentStage = completableFuture.acceptEitherAsync(other, action, executor);
+        }
+        return new ManagedCompletableFuture<Void>(dependentStage, defaultExecutor);
     }
 
     /**
@@ -372,12 +422,6 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         // TODO contextualize fn and other steps
         Executor policyExecutor = executor; // TODO get policy executor from the supplied executor, if a managed executor
         return new ManagedCompletableFuture<U>(completableFuture.handleAsync(fn, policyExecutor), defaultExecutor);
-    }
-
-    @Override
-    @Trivial
-    public int hashCode() {
-        return completableFuture.hashCode();
     }
 
     /**
@@ -892,7 +936,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         return this;
     }
 
-    /*
+    /**
      * @see java.util.concurrent.CompletableFuture#toString()
      */
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -62,7 +63,7 @@ public class ConcurrentRxTestServlet extends FATServlet {
     @Resource(name = "java:comp/env/executorRef")
     private ManagedExecutorService defaultManagedExecutor;
 
-    @Resource(name = "java:comp/module/noContextExecutorRef", lookup = "concurrent/noContextExecutor")
+    @Resource(name = "java:module/noContextExecutorRef", lookup = "concurrent/noContextExecutor")
     private ManagedScheduledExecutorService noContextExecutor;
 
     // Executor that can be used when tests don't want to tie up threads from the Liberty global thread pool to perform concurrent test logic
@@ -76,6 +77,253 @@ public class ConcurrentRxTestServlet extends FATServlet {
     @Override
     public void init(ServletConfig config) {
         testThreads = Executors.newFixedThreadPool(20);
+    }
+
+    /**
+     * Verify that acceptEither only requires one of the stages to complete, and that it runs with the context of the thread that
+     * creates the stage.
+     */
+    @Test
+    public void testAcceptEither() throws Exception {
+        CountDownLatch blocker1 = new CountDownLatch(1);
+        ManagedCompletableFuture<Boolean> cf1 = ManagedCompletableFuture.supplyAsync(() -> {
+            System.out.println("> supplyAsync[1] from testAcceptEither");
+            try {
+                boolean result = blocker1.await(TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                System.out.println("< supplyAsync[1] " + result);
+                return result;
+            } catch (InterruptedException x) {
+                System.out.println("< supplyAsync[1] " + x);
+                throw new CompletionException(x);
+            }
+        });
+
+        CountDownLatch blocker2 = new CountDownLatch(1);
+        CompletableFuture<Boolean> cf2 = CompletableFuture.supplyAsync(() -> {
+            System.out.println("> supplyAsync[2] from testAcceptEither");
+            try {
+                boolean result = blocker2.await(TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                System.out.println("< supplyAsync[2] " + result);
+                return result;
+            } catch (InterruptedException x) {
+                System.out.println("< supplyAsync[2] " + x);
+                throw new CompletionException(x);
+            }
+        });
+
+        LinkedBlockingQueue<Object> results = new LinkedBlockingQueue<Object>();
+        ManagedCompletableFuture<Void> cf3 = cf1.acceptEither(cf2, (b) -> {
+            System.out.println("> lookup from testAcceptEither");
+            results.add(b);
+            results.add(Thread.currentThread().getName());
+            try {
+                ManagedExecutorService result = InitialContext.doLookup("java:module/noContextExecutorRef");
+                results.add(result);
+                System.out.println("< lookup: " + result);
+            } catch (NamingException x) {
+                System.out.println("< lookup failed");
+                x.printStackTrace(System.out);
+                throw new CompletionException(x);
+            }
+        });
+
+        assertFalse(cf3.isDone());
+        try {
+            Object result = cf3.get(100, TimeUnit.MILLISECONDS);
+            fail("Dependent completion stage must not complete first");
+        } catch (TimeoutException x) {
+        }
+
+        // Allow cf2 to complete
+        blocker2.countDown();
+
+        // Dependent stage must be able to complete now
+        assertNull(cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertTrue(cf3.isDone());
+        assertFalse(cf3.isCancelled());
+        assertFalse(cf3.isCompletedExceptionally());
+
+        // Verify the parameter that is supplied to acceptEither's consumer
+        assertEquals(Boolean.TRUE, results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // acceptEither runs on the unmanaged thread of the stage that completed
+        String threadName;
+        assertNotNull(threadName = (String) results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertTrue(threadName, !threadName.startsWith(("Default Executor-thread-")));
+
+        // thread context is made available to acceptEither's consumer per the managed executor which is the default asynchronous execution facility,
+        // enabling java:module lookup to succeed from the unmanaged thread.
+        Object lookupResult;
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(noContextExecutor, lookupResult);
+
+        // allow cf1 to complete
+        blocker1.countDown();
+        assertEquals(Boolean.TRUE, cf1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Verify that acceptEitherAsync only requires one of the stages to complete, and that it runs with the context of the thread that
+     * creates the stage, as captured and propagated by the default asynchronous execution facility.
+     */
+    @Test
+    public void testAcceptEitherAsync() throws Exception {
+        CountDownLatch blocker1 = new CountDownLatch(1);
+        CompletableFuture<Boolean> cf1 = ManagedCompletableFuture.supplyAsync(() -> {
+            System.out.println("> supplyAsync[1] from testAcceptEitherAsync");
+            try {
+                boolean result = blocker1.await(TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                System.out.println("< supplyAsync[1] " + result);
+                return result;
+            } catch (InterruptedException x) {
+                System.out.println("< supplyAsync[1] " + x);
+                throw new CompletionException(x);
+            }
+        });
+
+        CountDownLatch blocker2 = new CountDownLatch(1);
+        CompletableFuture<Boolean> cf2 = CompletableFuture.supplyAsync(() -> {
+            System.out.println("> supplyAsync[2] from testAcceptEitherAsync");
+            try {
+                boolean result = blocker2.await(TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                System.out.println("< supplyAsync[2] " + result);
+                return result;
+            } catch (InterruptedException x) {
+                System.out.println("< supplyAsync[2] " + x);
+                throw new CompletionException(x);
+            }
+        });
+
+        LinkedBlockingQueue<Object> results = new LinkedBlockingQueue<Object>();
+        CompletableFuture<Void> cf3 = cf1.acceptEitherAsync(cf2, (b) -> {
+            System.out.println("> lookup from testAcceptEitherAsyncOnExecutor");
+            results.add(b);
+            results.add(Thread.currentThread().getName());
+            try {
+                ManagedExecutorService result = InitialContext.doLookup("java:module/noContextExecutorRef");
+                results.add(result);
+                System.out.println("< lookup: " + result);
+            } catch (NamingException x) {
+                System.out.println("< lookup failed");
+                x.printStackTrace(System.out);
+                throw new CompletionException(x);
+            }
+        });
+
+        assertFalse(cf3.isDone());
+        try {
+            Object result = cf3.get(100, TimeUnit.MILLISECONDS);
+            fail("Dependent completion stage must not complete first");
+        } catch (TimeoutException x) {
+        }
+
+        // Allow cf1 to complete
+        blocker1.countDown();
+
+        // Dependent stage must be able to complete now
+        assertNull(cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertTrue(cf3.isDone());
+        assertFalse(cf3.isCancelled());
+        assertFalse(cf3.isCompletedExceptionally());
+
+        // Verify the parameter that is supplied to acceptEither's consumer
+        assertEquals(Boolean.TRUE, results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // acceptEither runs on the Liberty global thread pool
+        String threadName;
+        assertNotNull(threadName = (String) results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertTrue(threadName, threadName.startsWith(("Default Executor-thread-")));
+
+        // thread context is made available to acceptEither's consumer per the supplied managed executor, enabling java:module lookup to succeed
+        Object lookupResult;
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(noContextExecutor, lookupResult);
+
+        // allow cf2 to complete
+        blocker2.countDown();
+        assertEquals(Boolean.TRUE, cf2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Verify that acceptEitherAsync only requires one of the stages to complete, and that it runs with the context of the thread that
+     * creates the stage, as captured and propagated by the specified executor.
+     */
+    @Test
+    public void testAcceptEitherAsyncOnExecutor() throws Exception {
+        CountDownLatch blocker1 = new CountDownLatch(1);
+        CompletableFuture<Boolean> cf1 = ManagedCompletableFuture.supplyAsync(() -> {
+            System.out.println("> supplyAsync[1] from testAcceptEitherAsyncOnExecutor");
+            try {
+                boolean result = blocker1.await(TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                System.out.println("< supplyAsync[1] " + result);
+                return result;
+            } catch (InterruptedException x) {
+                System.out.println("< supplyAsync[1] " + x);
+                throw new CompletionException(x);
+            }
+        }, noContextExecutor);
+
+        CountDownLatch blocker2 = new CountDownLatch(1);
+        CompletableFuture<Boolean> cf2 = CompletableFuture.supplyAsync(() -> {
+            System.out.println("> supplyAsync[2] from testAcceptEitherAsyncOnExecutor");
+            try {
+                boolean result = blocker2.await(TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                System.out.println("< supplyAsync[2] " + result);
+                return result;
+            } catch (InterruptedException x) {
+                System.out.println("< supplyAsync[2] " + x);
+                throw new CompletionException(x);
+            }
+        });
+
+        LinkedBlockingQueue<Object> results = new LinkedBlockingQueue<Object>();
+        CompletableFuture<Void> cf3 = cf1.acceptEitherAsync(cf2, (b) -> {
+            System.out.println("> lookup from testAcceptEitherAsyncOnExecutor");
+            results.add(b);
+            results.add(Thread.currentThread().getName());
+            try {
+                ManagedExecutorService result = InitialContext.doLookup("java:module/noContextExecutorRef");
+                results.add(result);
+                System.out.println("< lookup: " + result);
+            } catch (NamingException x) {
+                System.out.println("< lookup failed");
+                x.printStackTrace(System.out);
+                throw new CompletionException(x);
+            }
+        }, defaultManagedExecutor);
+
+        assertFalse(cf3.isDone());
+        try {
+            Object result = cf3.get(100, TimeUnit.MILLISECONDS);
+            fail("Dependent completion stage must not complete first");
+        } catch (TimeoutException x) {
+        }
+
+        // Allow cf2 to complete
+        blocker2.countDown();
+
+        // Dependent stage must be able to complete now
+        assertNull(cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertTrue(cf3.isDone());
+        assertFalse(cf3.isCancelled());
+        assertFalse(cf3.isCompletedExceptionally());
+
+        // Verify the parameter that is supplied to acceptEither's consumer
+        assertEquals(Boolean.TRUE, results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // acceptEither runs on the Liberty global thread pool
+        String threadName;
+        assertNotNull(threadName = (String) results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertTrue(threadName, threadName.startsWith(("Default Executor-thread-")));
+
+        // thread context is made available to acceptEither's consumer per the supplied managed executor, enabling java:module lookup to succeed
+        Object lookupResult;
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals(noContextExecutor, lookupResult);
+
+        // allow cf1 to complete
+        blocker1.countDown();
+        assertEquals(Boolean.TRUE, cf1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
     }
 
     /**


### PR DESCRIPTION
Implement thenCompose and thenComposeAsync methods, and acceptEither and acceptEitherAsync methods for managed completable future, and test them.
This also includes a more meaningful toString operation, which shows the state of the underlying CompletableFuture