### PR TITLE
create new accessor class for timed operations to obtain information for JDBC wrappers

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/timedoperations/TimedOpsAccessor.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/timedoperations/TimedOpsAccessor.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jdbc.timedoperations;
+
+import com.ibm.ws.rsadapter.jdbc.WSJdbcUtil;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcWrapper;
+
+/**
+ * This class provides externalizes to other bundles various information that is useful for recording timed JDBC operations.
+ * This includes the SQL command, if any, and the identifier of the data source with which a JDBC resource is associated.
+ */
+public class TimedOpsAccessor {
+    /**
+     * Obtains the unique identifier of the data source associated with a JDBC wrapper.
+     * 
+     * @param jdbcWrapper proxy for a JDBC resource.
+     * @return JNDI name of the data source if it has one, otherwise the config.displayId of the data source.
+     */
+    public static final String getDataSourceIdentifier(Object jdbcWrapper) {
+        return WSJdbcUtil.getDataSourceIdentifier((WSJdbcWrapper) jdbcWrapper);
+    }
+
+    /**
+     * Obtain the SQL command, if any, that is associated with a JDBC resource.
+     * 
+     * @param jdbcWrapper proxy for a JDBC resource.
+     * @return SQL command associated with the JDBC resource. Null if not a wrapper for a PreparedStatement, CallableStatement, or ResultSet.
+     */
+    public static final String getSql(Object jdbcWrapper) {
+        return WSJdbcUtil.getSql(jdbcWrapper);
+    }
+}

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcPreparedStatement.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcPreparedStatement.java
@@ -545,6 +545,7 @@ public class WSJdbcPreparedStatement extends WSJdbcStatement implements Prepared
         return numUpdates;
     }
 
+    // TODO remove once WSJdbcObjectHelper has been fully replaced with TimedOpsAccessor
     public String getSql(){
         return sql;         
     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcResultSet.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcResultSet.java
@@ -1105,7 +1105,8 @@ public class WSJdbcResultSet extends WSJdbcObject implements ResultSet, WSJdbcOb
     {
         return rsetImpl;
     }
-    
+
+    // TODO remove once WSJdbcObjectHelper has been fully replaced with TimedOpsAccessor
     /**
      * @see com.ibm.ws.jdbc.timedoperations.WSJdbcObjectHelper#getUniqueIdentifier()
      * 
@@ -1116,7 +1117,7 @@ public class WSJdbcResultSet extends WSJdbcObject implements ResultSet, WSJdbcOb
         return config.jndiName == null ? config.id : config.jndiName;
     }
     
-    
+    // TODO remove once WSJdbcObjectHelper has been fully replaced with TimedOpsAccessor
     public String getSql(){
         return sql;  
     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcStatement.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcStatement.java
@@ -675,7 +675,7 @@ public class WSJdbcStatement extends WSJdbcObject implements Statement, WSJdbcOb
         return stmtImpl;
     }
 
-
+    // TODO remove once WSJdbcObjectHelper has been fully replaced with TimedOpsAccessor
     /**
      * @see com.ibm.ws.jdbc.timedoperations.WSJdbcObjectHelper#getUniqueIdentifier()
      * 
@@ -685,7 +685,8 @@ public class WSJdbcStatement extends WSJdbcObject implements Statement, WSJdbcOb
         DSConfig config = dsConfig.get();
         return config.jndiName == null ? config.id : config.jndiName;
     }    
-    
+
+    //TODO remove once WSJdbcObjectHelper has been fully replaced with TimedOpsAccessor
     public String getSql(){
         return null; //dummy method, not used 
         

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcUtil.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcUtil.java
@@ -15,6 +15,7 @@ import java.sql.SQLException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.rsadapter.AdapterUtil;
+import com.ibm.ws.rsadapter.DSConfig;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 
 /**
@@ -23,6 +24,32 @@ import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 public class WSJdbcUtil
 {
     private static final TraceComponent tc = Tr.register(WSJdbcUtil.class, AdapterUtil.TRACE_GROUP, AdapterUtil.NLS_FILE);
+
+    /**
+     * Utility method to obtain the unique identifier of the data source associated with a JDBC wrapper.
+     * 
+     * @param jdbcWrapper proxy for a JDBC resource.
+     * @return JNDI name of the data source if it has one, otherwise the config.displayId of the data source.
+     */
+    public static String getDataSourceIdentifier(WSJdbcWrapper jdbcWrapper) {
+        DSConfig config = jdbcWrapper.dsConfig.get();
+        return config.jndiName == null ? config.id : config.jndiName;
+    }
+
+    /**
+     * Utility method to obtain the SQL command associated with a JDBC resource.
+     * 
+     * @param jdbcWrapper proxy for a JDBC resource.
+     * @return SQL command associated with the JDBC resource. Null if not a PreparedStatement, CallableStatement, or ResultSet.
+     */
+    public static String getSql(Object jdbcWrapper) {
+        if (jdbcWrapper instanceof WSJdbcPreparedStatement) // also includes WSJdbcCallableStatement
+            return ((WSJdbcPreparedStatement) jdbcWrapper).sql;
+        else if (jdbcWrapper instanceof WSJdbcResultSet)
+            return ((WSJdbcResultSet) jdbcWrapper).sql;
+        else
+            return null;
+    }
 
     /**
      * Performs special handling for stale statements, such as clearing the statement cache


### PR DESCRIPTION
Create a new class in the timedoperations package that will be exported from the jdbc bundle for use by other bundles.  Static methods on this class will replace WSJdbcObjectHelper, making it possible to remove WSJdbcObjectHelper once code has switched over.  The removal will occur in a second pull once ready. 