### PR TITLE
Pause resume command port failure

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.cmdline/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.cmdline/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -670,13 +670,13 @@ error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed
 error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
 error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
 
-error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
-error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the pause request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
-error.server.pause.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. Enable the command port, and try again.
+error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the pause request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.pause.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this pause can alternatively be requested from the operator console.
 
-error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
-error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the resume request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
-error.server.resume.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. Enable the command port, and try again.
+error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the resume request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.resume.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this resume can alternatively be requested from the operator console.
 
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.

--- a/dev/com.ibm.ws.kernel.boot.cmdline/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.cmdline/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -670,6 +670,14 @@ error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed
 error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
 error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
 
+error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
+error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the pause request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.pause.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+
+error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
+error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the resume request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.resume.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot.core/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.core/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -663,13 +663,13 @@ error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed
 error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
 error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
 
-error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
-error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the pause request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
-error.server.pause.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. Enable the command port, and try again.
+error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the pause request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.pause.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this pause can alternatively be requested from the operator console.
 
-error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
-error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the resume request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
-error.server.resume.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. Enable the command port, and try again.
+error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the resume request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.resume.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this resume can alternatively be requested from the operator console.
 
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.

--- a/dev/com.ibm.ws.kernel.boot.core/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.core/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -663,6 +663,14 @@ error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed
 error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
 error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
 
+error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
+error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the pause request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.pause.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+
+error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
+error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the resume request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.resume.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
@@ -526,6 +526,8 @@ public class ProcessControlHelper {
             }
         } else if (pauseRc == ReturnCode.SERVER_UNKNOWN_STATUS) {
             System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("info.serverNotRunning"), serverName));
+        } else if (pauseRc == ReturnCode.SERVER_COMMAND_PORT_DISABLED_STATUS) {
+            System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("error.server.pause.command.port.disabled"), serverName));
         } else {
             if (targetParm != null) {
                 System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("info.pauseFailedException.target"), serverName));
@@ -591,6 +593,8 @@ public class ProcessControlHelper {
             }
         } else if (resumeRc == ReturnCode.SERVER_UNKNOWN_STATUS) {
             System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("info.serverNotRunning"), serverName));
+        } else if (resumeRc == ReturnCode.SERVER_COMMAND_PORT_DISABLED_STATUS) {
+            System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("error.server.resume.command.port.disabled"), serverName));
         } else {
             if (targetParm != null) {
                 System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("info.resumeFailedException.target"), serverName));

--- a/dev/com.ibm.ws.kernel.boot.nested/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.nested/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -662,6 +662,14 @@ error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed
 error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
 error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
 
+error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
+error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the pause request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.pause.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+
+error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
+error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the resume request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.resume.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot.nested/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.nested/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -662,13 +662,13 @@ error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed
 error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
 error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
 
-error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
-error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the pause request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
-error.server.pause.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. Enable the command port, and try again.
+error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the pause request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.pause.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this pause can alternatively be requested from the operator console.
 
-error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
-error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the resume request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
-error.server.resume.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. Enable the command port, and try again.
+error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the resume request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.resume.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this resume can alternatively be requested from the operator console.
 
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -672,6 +672,14 @@ error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed
 error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
 error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
 
+error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
+error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the pause request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.pause.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+
+error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
+error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the resume request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.resume.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -672,13 +672,13 @@ error.zosProcStart.jobname.invalid=CWWKE0943E: The z/OS STC procedure {0} failed
 error.zosProcStart.jobname.invalid.explanation=The STC job name specified by the WLP_ZOS_JOBNAME property in the server.env file is not valid. The job name must be no longer than 8 characters and must not contain a comma.
 error.zosProcStart.jobname.invalid.useraction=Verify that the job name is no longer than eight characters and that it does not contain a comma.
 
-error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
-error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the pause request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
-error.server.pause.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+error.server.pause.command.port.disabled=CWWKE0944E: A pause request was received for server {0}, but the server command port is disabled. The request cannot be processed. Enable the command port, and try again.
+error.server.pause.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the pause request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.pause.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this pause can alternatively be requested from the operator console.
 
-error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. 
-error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server.  The command port is disabled for this server, therefore the resume request could not be processed.  Note that the command port is disabled by default when a server is started as a started task on z/OS.
-error.server.resume.command.port.disabled.useraction=If the server is running as a started task on z/OS, this dump can be requested from the operator console.  See the information center for details.
+error.server.resume.command.port.disabled=CWWKE0945E: A resume request was received for server {0}, but the server command port is disabled. The request cannot be processed. Enable the command port, and try again.
+error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the resume request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
+error.server.resume.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this resume can alternatively be requested from the operator console.
 
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandport/ServerCommandPortTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandport/ServerCommandPortTest.java
@@ -99,6 +99,12 @@ public class ServerCommandPortTest {
             assertTrue(output.contains("CWWKE0090W"));
             validateDumpFile(output, server, COMMAND_PORT_DISABLED_SERVER_NAME);
 
+            output = server.executeServerScript("pause", null).getStdout();
+            assertTrue(output.contains("CWWKE0944E"));
+
+            output = server.executeServerScript("resume", null).getStdout();
+            assertTrue(output.contains("CWWKE0945E"));
+
             // stopping the server should produce an error
             output = server.executeServerScript("stop", null).getStdout();
             assertTrue(output.contains("CWWKE0089E"));


### PR DESCRIPTION
If the command port is disabled when issuing a pause or resume request from the server script, issue a message saying so. 