### PR TITLE
Add Reader Writer Reentrant lock to avoid CMException  in BufferManagerImpl

### DIFF
--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/collector/manager/buffer/BufferManagerImpl.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/collector/manager/buffer/BufferManagerImpl.java
@@ -117,20 +117,22 @@ public class BufferManagerImpl extends BufferManager {
 	}
 
 	public void addSyncHandler(SynchronousHandler syncHandler) {
-        /* There can be many Reader locks, but only one writer lock.
-        *  This ReaderWriter lock is needed to avoid CMException when the add() method is forwarding log events
-        *  to synchronized handlers and an addSyncHandler or removeSyncHandler is called
-        */
+		/*
+		 * There can be many Reader locks, but only one writer lock. This
+		 * ReaderWriter lock is needed to avoid CMException when the add()
+		 * method is forwarding log events to synchronized handlers and an
+		 * addSyncHandler or removeSyncHandler is called
+		 */
 		RERWLOCK.writeLock().lock();
-		try{
+		try {
 			synchronizedHandlerSet.add(syncHandler);
 		} finally {
-        RERWLOCK.writeLock().unlock();
-    	}
+			RERWLOCK.writeLock().unlock();
+		}
 	}
-	
+
 	public void removeSyncHandler(SynchronousHandler syncHandler) {
-        /*
+		/*
 		 * There can be many Reader locks, but only one writer lock. This
 		 * ReaderWriter lock is needed to avoid CMException when the add()
 		 * method is forwarding log events to synchronized handlers and an


### PR DESCRIPTION
Add Reader Writer Re-entrant lock to avoid CMException when accessing/modifying synchronized handler set.

Fixes #1418