### PR TITLE
thenAcceptBoth for managed completable future

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
@@ -1378,6 +1378,111 @@ public class ConcurrentRxTestServlet extends FATServlet {
     }
 
     /**
+     * Verify thenCombine and both forms of thenCombineAsync.
+     */
+    @Test
+    public void testThenCombine() throws Exception {
+        LinkedBlockingQueue<Object> results = new LinkedBlockingQueue<Object>();
+        String currentThreadName = Thread.currentThread().getName();
+
+        BiFunction<Integer, Integer, Integer> sum = (a, b) -> {
+            System.out.println("> sum " + a + "+" + b + " from testThenCombine");
+            results.add(Thread.currentThread().getName());
+            try {
+                results.add(InitialContext.doLookup("java:comp/env/executorRef"));
+            } catch (NamingException x) {
+                results.add(x);
+            }
+            System.out.println("< sum: " + (a + b));
+            return a + b;
+        };
+
+        // The test logic requires that all of these completable futures run in order.
+        // To guarantee this, ensure that at least one of the completable futures supplied to thenCombine* is the previous one.
+
+        CompletableFuture<Integer> cf1 = ManagedCompletableFuture.supplyAsync(() -> 1, defaultManagedExecutor);
+
+        CompletableFuture<Integer> cf2 = ManagedCompletableFuture.supplyAsync(() -> 2, noContextExecutor);
+
+        CompletableFuture<Integer> cf3 = cf1.thenCombineAsync(cf2, sum);
+
+        CompletableFuture<Integer> cf4 = cf1.thenCombineAsync(cf3, sum, testThreads);
+
+        CompletableFuture<Integer> cf5 = cf4.thenCombine(cf1, sum);
+
+        CompletableFuture<Integer> cf6 = cf5.thenCombineAsync(cf1, sum);
+
+        // Submit from thread that lacks context
+        CompletableFuture<CompletableFuture<Integer>> cfcf12 = CompletableFuture.supplyAsync(() -> cf6.thenCombineAsync(cf6, sum));
+
+        String threadName;
+        Object lookupResult;
+
+        assertTrue(cf1.toString(), cf1 instanceof ManagedCompletableFuture);
+        assertTrue(cf2.toString(), cf2 instanceof ManagedCompletableFuture);
+        assertTrue(cf3.toString(), cf3 instanceof ManagedCompletableFuture);
+        assertTrue(cf4.toString(), cf4 instanceof ManagedCompletableFuture);
+        assertTrue(cf5.toString(), cf5 instanceof ManagedCompletableFuture);
+        assertTrue(cf6.toString(), cf6 instanceof ManagedCompletableFuture);
+
+        // thenCombineAsync on default execution facility
+        assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
+        assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // must run on Liberty global thread pool
+        assertNotSame(currentThreadName, threadName); // cannot be the servlet thread because operation is async
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        if (lookupResult instanceof Throwable)
+            throw new Exception((Throwable) lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
+        assertEquals(Integer.valueOf(3), cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // thenCombineAsync on unmanaged executor
+        assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
+        assertFalse(threadName, threadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        if (lookupResult instanceof NamingException)
+            ; // pass
+        else if (lookupResult instanceof Throwable)
+            throw new Exception((Throwable) lookupResult);
+        else
+            fail("Unexpected result of lookup: " + lookupResult);
+        assertEquals(Integer.valueOf(4), cf4.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // thenCombine on unmanaged thread or servlet thread (context should be applied from stage creation time)
+        assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
+        assertTrue(threadName, threadName.equals(currentThreadName) || !threadName.startsWith("Default Executor-thread-")); // could run on current thread if previous stage is complete, otherwise must run on unmanaged thread
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        if (lookupResult instanceof Throwable)
+            throw new Exception((Throwable) lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
+        assertEquals(Integer.valueOf(5), cf5.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // thenCombineAsync (second occurrence) on default execution facility
+        assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
+        assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // must run on Liberty global thread pool
+        assertNotSame(currentThreadName, threadName); // cannot be the servlet thread because operation is async
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        if (lookupResult instanceof Throwable)
+            throw new Exception((Throwable) lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
+        assertEquals(Integer.valueOf(6), cf6.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // thenCombineAsync requested from unmanaged thread
+        assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
+        assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // must run on Liberty global thread pool
+        assertNotSame(currentThreadName, threadName); // cannot be the servlet thread because operation is async
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        if (lookupResult instanceof NamingException)
+            ; // pass
+        else if (lookupResult instanceof Throwable)
+            throw new Exception((Throwable) lookupResult);
+        else
+            fail("Unexpected result of lookup: " + lookupResult);
+
+        CompletableFuture<Integer> cf12 = cfcf12.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals(Integer.valueOf(12), cf12.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
      * Verify thenCompose and both forms of thenComposeAsync.
      */
     @Test

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -1290,6 +1291,94 @@ public class ConcurrentRxTestServlet extends FATServlet {
     }
 
     /**
+     * Verify thenAcceptBoth and both forms of thenAcceptBothAsync.
+     */
+    @Test
+    public void testThenAcceptBoth() throws Exception {
+        LinkedBlockingQueue<Object> results = new LinkedBlockingQueue<Object>();
+        String currentThreadName = Thread.currentThread().getName();
+
+        BiConsumer<Integer, Integer> action = (a, b) -> {
+            System.out.println("> sum " + a + "+" + b + " from testThenAcceptBoth");
+            results.add(a + b);
+            results.add(Thread.currentThread().getName());
+            try {
+                results.add(InitialContext.doLookup("java:comp/env/executorRef"));
+            } catch (NamingException x) {
+                results.add(x);
+            }
+            System.out.println("< sum");
+        };
+
+        // The test logic requires that all of these completable futures run in order.
+        // To guarantee this, ensure that at least one of the completable futures supplied to thenAcceptBoth* is the previous one.
+
+        CompletableFuture<Integer> cf1 = ManagedCompletableFuture.supplyAsync(() -> 1, defaultManagedExecutor);
+
+        CompletableFuture<Integer> cf2 = ManagedCompletableFuture.supplyAsync(() -> 2, noContextExecutor);
+
+        CompletableFuture<Integer> cf5 = cf1
+                        .thenAcceptBothAsync(cf2, action)
+                        .thenApply((unused) -> 3)
+                        .thenAcceptBothAsync(cf1, action, testThreads)
+                        .thenApply((unused) -> 4)
+                        .thenAcceptBoth(cf1, action)
+                        .thenApply((unused) -> 5);
+
+        CompletableFuture<Void> cf7 = cf2.thenAcceptBothAsync(cf5, action);
+
+        String threadName;
+        Object lookupResult;
+
+        // thenAcceptBothAsync on default execution facility
+        assertEquals(Integer.valueOf(3), results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
+        assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // must run on Liberty global thread pool
+        assertNotSame(currentThreadName, threadName); // cannot be the servlet thread because operation is async
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        if (lookupResult instanceof Throwable)
+            throw new Exception((Throwable) lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
+
+        // thenAcceptBothAsync on unmanaged executor
+        assertEquals(Integer.valueOf(4), results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
+        assertFalse(threadName, threadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        if (lookupResult instanceof NamingException)
+            ; // pass
+        else if (lookupResult instanceof Throwable)
+            throw new Exception((Throwable) lookupResult);
+        else
+            fail("Unexpected result of lookup: " + lookupResult);
+
+        // thenAcceptBoth on unmanaged thread or servlet thread (context should be applied from stage creation time)
+        assertEquals(Integer.valueOf(5), results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
+        assertTrue(threadName, threadName.equals(currentThreadName) || !threadName.startsWith("Default Executor-thread-")); // could run on current thread if previous stage is complete, otherwise must run on unmanaged thread
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        if (lookupResult instanceof Throwable)
+            throw new Exception((Throwable) lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
+
+        // thenAcceptBothAsync (second occurrence) on default execution facility
+        assertEquals(Integer.valueOf(7), results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
+        assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // must run on Liberty global thread pool
+        assertNotSame(currentThreadName, threadName); // cannot be the servlet thread because operation is async
+        assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        if (lookupResult instanceof NamingException)
+            ; // pass
+        else if (lookupResult instanceof Throwable)
+            throw new Exception((Throwable) lookupResult);
+        else
+            fail("Unexpected result of lookup: " + lookupResult);
+
+        assertTrue(cf7.toString(), cf7 instanceof ManagedCompletableFuture);
+        assertNull(cf7.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
      * Verify thenApply and both forms of thenApplyAsync.
      */
     @Test
@@ -1729,6 +1818,57 @@ public class ConcurrentRxTestServlet extends FATServlet {
         assertNotNull(results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 
         assertNull(cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Supply unmanaged CompletableFuture as a parameter to thenCombineAsync and thenAcceptBothAsync of ManagedCompletableFuture.
+     */
+    @Test
+    public void testUnmanagedThenCombineThenAcceptBoth() {
+        LinkedList<String> results = new LinkedList<String>();
+        BiFunction<String, String, List<String>> fn = (item1, item2) -> {
+            results.add(item1);
+            results.add(item2);
+            return results;
+        };
+        CompletableFuture<String> cf1 = ManagedCompletableFuture.supplyAsync(() -> "param1", noContextExecutor);
+        CompletableFuture<String> cf2 = CompletableFuture.supplyAsync(() -> "param2");
+        CompletableFuture<String> cf3 = CompletableFuture.supplyAsync(() -> "param3");
+        CompletableFuture<Void> cf = cf1
+                        .thenCombineAsync(cf2, (a, b) -> {
+                            results.add(Thread.currentThread().getName());
+                            results.add(a);
+                            results.add(b);
+                            return results;
+                        })
+                        .thenAcceptBothAsync(cf3, (a, b) -> {
+                            a.add(Thread.currentThread().getName());
+                            a.add(b);
+                        });
+
+        assertTrue(cf.toString(), cf instanceof ManagedCompletableFuture);
+
+        cf.join();
+
+        assertTrue(cf.isDone());
+        assertFalse(cf.isCompletedExceptionally());
+        assertFalse(cf.isCancelled());
+
+        String servletThreadName = Thread.currentThread().getName();
+        String threadName;
+
+        assertNotNull(threadName = results.poll());
+        assertTrue(threadName, threadName.startsWith("Default Executor-thread-"));
+        assertNotSame(servletThreadName, threadName);
+
+        assertEquals("param1", results.poll());
+        assertEquals("param2", results.poll());
+
+        assertNotNull(threadName = results.poll());
+        assertTrue(threadName, threadName.startsWith("Default Executor-thread-"));
+        assertNotSame(servletThreadName, threadName);
+
+        assertEquals("param3", results.poll());
     }
 
     /**


### PR DESCRIPTION
Implement and test thenAcceptBoth and thenAcceptBothAsync methods for managed completable future.