### PR TITLE
Issue 1457: Move LDAPFatUtils and swap equalsDns in VMM fats

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.file_fat/fat/src/com/ibm/ws/security/wim/adapter/file/fat/BasicTests.java
+++ b/dev/com.ibm.ws.security.wim.adapter.file_fat/fat/src/com/ibm/ws/security/wim/adapter/file/fat/BasicTests.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.file.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -18,9 +19,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -248,7 +246,7 @@ public class BasicTests {
         String user = "admin";
         String uniqueUserId = "uid=admin,o=defaultWIMFileBasedRealm";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
-        equalDNs("", uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("UniqueUserId is incorrect", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -454,7 +452,7 @@ public class BasicTests {
         String group = "group1";
         String uniqueGroupId = "cn=group1,o=defaultWIMFileBasedRealm";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupID is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -680,9 +678,4 @@ public class BasicTests {
         }
     }
 
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.file_fat/fat/src/com/ibm/ws/security/wim/adapter/file/fat/MultipleReposTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.file_fat/fat/src/com/ibm/ws/security/wim/adapter/file/fat/MultipleReposTest.java
@@ -11,15 +11,13 @@
 
 package com.ibm.ws.security.wim.adapter.file.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -181,10 +179,7 @@ public class MultipleReposTest {
         String uniqueUserId = "uid=admin,o=defaultWIMFileBasedRealm";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
         try {
-            equalDNs("", uniqueUserId, servlet.getUniqueUserId(user));
-        } catch (InvalidNameException e) {
-            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
-            e.printStackTrace();
+            assertDNsEqual("UniqueUserId is incorrect", uniqueUserId, servlet.getUniqueUserId(user));
         } catch (EntryNotFoundException e) {
             // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
             e.printStackTrace();
@@ -278,10 +273,7 @@ public class MultipleReposTest {
         String uniqueGroupId = "cn=group1,o=defaultWIMFileBasedRealm";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
         try {
-            equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
-        } catch (InvalidNameException e) {
-            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
-            e.printStackTrace();
+            assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
         } catch (EntryNotFoundException e) {
             // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
             e.printStackTrace();
@@ -360,10 +352,4 @@ public class MultipleReposTest {
         assertEquals("There should only be one entry", 1, list.size());
     }
 
-    // TODO Replace
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.file_fat/fat/src/com/ibm/ws/security/wim/adapter/file/fat/WithRepoConfiguredWithoutIDTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.file_fat/fat/src/com/ibm/ws/security/wim/adapter/file/fat/WithRepoConfiguredWithoutIDTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.file.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -18,9 +19,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -238,7 +236,7 @@ public class WithRepoConfiguredWithoutIDTest {
         String user = "admin";
         String uniqueUserId = "uid=admin,o=defaultWIMFileBasedRealm";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
-        equalDNs("", uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("UniqueUserId is incorrect", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -444,7 +442,7 @@ public class WithRepoConfiguredWithoutIDTest {
         String group = "group1";
         String uniqueGroupId = "cn=group1,o=defaultWIMFileBasedRealm";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -670,9 +668,4 @@ public class WithRepoConfiguredWithoutIDTest {
         }
     }
 
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/ContextPoolOnLDAPFailureTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/ContextPoolOnLDAPFailureTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.updateConfigDynamically;
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/ContextPoolTimeoutTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/ContextPoolTimeoutTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.updateConfigDynamically;
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestAD.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestAD.java
@@ -11,8 +11,8 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.updateConfigDynamically;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestCustom.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestCustom.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDS.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDS.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -19,9 +20,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -106,8 +104,8 @@ public class FATTestIDS {
         String user = "vmmtestuser";
         String password = "vmmtestuserpwd";
         Log.info(c, "checkPasswordWithGoodCredentials", "Checking good credentials");
-        equalDNs("Authentication should succeed.",
-                 "cn=vmmtestuser,o=ibm,c=us", servlet.checkPassword(user, password));
+        assertDNsEqual("Authentication should succeed.",
+                       "cn=vmmtestuser,o=ibm,c=us", servlet.checkPassword(user, password));
         passwordChecker.checkForPasswordInAnyFormat(password);
     }
 
@@ -244,7 +242,7 @@ public class FATTestIDS {
         String uniqueUserId = "cn=vmmtestuser,o=ibm,c=us";
 
         Log.info(c, "getUniqueUserIdWithValidUser", "Checking with a valid user.");
-        equalDNs(null, uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("UniqueUserID is incorrect", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -418,7 +416,7 @@ public class FATTestIDS {
         String uniqueGroupId = "cn=vmmgrp1,o=ibm,c=us";
 
         Log.info(c, "getUniqueGroupIdWithValidGroup", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -443,7 +441,7 @@ public class FATTestIDS {
         String uniqueGroupId = "cn=vmmgrp1,o=ibm,c=us";
 
         Log.info(c, "getGroupSecurityNameWithValidGroup", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getGroupSecurityName(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getGroupSecurityName(group));
     }
 
     /**
@@ -482,10 +480,4 @@ public class FATTestIDS {
         fail("An invalid group should cause EntryNotFoundException");
     }
 
-    // TODO Replace
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDSFailover.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDSFailover.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDSNoFilters.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDSNoFilters.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -19,9 +20,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -107,8 +105,8 @@ public class FATTestIDSNoFilters {
         String user = "vmmtestuser";
         String password = "vmmtestuserpwd";
         Log.info(c, "checkPasswordWithGoodCredentials", "Checking good credentials");
-        equalDNs("Authentication should succeed.",
-                 "cn=vmmtestuser,o=ibm,c=us", servlet.checkPassword(user, password));
+        assertDNsEqual("Authentication should succeed.",
+                       "cn=vmmtestuser,o=ibm,c=us", servlet.checkPassword(user, password));
         passwordChecker.checkForPasswordInAnyFormat(password);
     }
 
@@ -234,7 +232,7 @@ public class FATTestIDSNoFilters {
         String uniqueUserId = "cn=vmmtestuser,o=ibm,c=us";
 
         Log.info(c, "getUniqueUserIdWithValidUser", "Checking with a valid user.");
-        equalDNs(null, uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("UniqueUserId is incorrect", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -383,7 +381,7 @@ public class FATTestIDSNoFilters {
         String uniqueGroupId = "cn=vmmgrp1,o=ibm,c=us";
 
         Log.info(c, "getUniqueGroupIdWithValidGroup", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -408,7 +406,7 @@ public class FATTestIDSNoFilters {
         String uniqueGroupId = "cn=vmmgrp1,o=ibm,c=us";
 
         Log.info(c, "getGroupSecurityNameWithValidGroup", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getGroupSecurityName(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getGroupSecurityName(group));
     }
 
     /**
@@ -447,10 +445,4 @@ public class FATTestIDSNoFilters {
         fail("An invalid group should cause EntryNotFoundException");
     }
 
-    // TODO Replace
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDSwithSSL.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDSwithSSL.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDSwithSSLTrustOnly.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDSwithSSLTrustOnly.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestPerformance.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestPerformance.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/InputOutputMappingTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/InputOutputMappingTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.updateConfigDynamically;
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -39,6 +39,7 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.LDAPFatUtils;
 import componenttest.topology.utils.LDAPUtils;
 
 /**

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPReferralTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPReferralTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.updateConfigDynamically;
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegistryDynamicUpdateTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegistryDynamicUpdateTest.java
@@ -11,12 +11,12 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.createADLdapRegistry;
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.createFederatedRepository;
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.createSunLdapRegistry;
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.createTDSLdapRegistry;
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.updateConfigDynamically;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.createADLdapRegistry;
+import static componenttest.topology.utils.LDAPFatUtils.createFederatedRepository;
+import static componenttest.topology.utils.LDAPFatUtils.createSunLdapRegistry;
+import static componenttest.topology.utils.LDAPFatUtils.createTDSLdapRegistry;
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/SearchPagingTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/SearchPagingTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.updateConfigDynamically;
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -37,6 +37,7 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.LDAPFatUtils;
 import componenttest.topology.utils.LDAPUtils;
 
 /**

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/TDSLDAP_SSLRef_BadSSLTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/TDSLDAP_SSLRef_BadSSLTest.java
@@ -15,9 +15,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -110,9 +107,4 @@ public class TDSLDAP_SSLRef_BadSSLTest {
                    servlet.checkPassword(user, password));
     }
 
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/TDSLDAP_SSLRef_NoSSLTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/TDSLDAP_SSLRef_NoSSLTest.java
@@ -14,9 +14,6 @@ package com.ibm.ws.security.wim.adapter.ldap.fat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -107,9 +104,4 @@ public class TDSLDAP_SSLRef_NoSSLTest {
                      "vmmtestuser", servlet.checkPassword(user, password));
     }
 
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_ADLDAPTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_ADLDAPTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -18,9 +19,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.Assume;
@@ -392,7 +390,7 @@ public class URAPIs_ADLDAPTest {
         String user = "vmmtestuser";
         String uniqueUserId = "CN=vmmtestuser,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
-        equalDNs("", uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("UniqueUserId is incorrect", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -655,7 +653,7 @@ public class URAPIs_ADLDAPTest {
         String group = "TelnetClients";
         String uniqueGroupId = "CN=TelnetClients,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -881,10 +879,4 @@ public class URAPIs_ADLDAPTest {
         }
     }
 
-    // TODO Replace.
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_ADLDAP_NoIdTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_ADLDAP_NoIdTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -18,9 +19,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -342,7 +340,7 @@ public class URAPIs_ADLDAP_NoIdTest {
         String user = "vmmtestuser";
         String uniqueUserId = "CN=vmmtestuser,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
-        equalDNs("", uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("UniqueUserId is incorrect", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -592,7 +590,7 @@ public class URAPIs_ADLDAP_NoIdTest {
         String group = "TelnetClients";
         String uniqueGroupId = "CN=TelnetClients,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -859,10 +857,4 @@ public class URAPIs_ADLDAP_NoIdTest {
         }
     }
 
-    // TODO REPLACE
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_ADLDAP_SSLTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_ADLDAP_SSLTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -18,9 +19,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -353,7 +351,7 @@ public class URAPIs_ADLDAP_SSLTest {
         String user = "vmmtestuser";
         String uniqueUserId = "CN=vmmtestuser,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
-        equalDNs("", uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("UniqueUserId is incorrect", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -603,7 +601,7 @@ public class URAPIs_ADLDAP_SSLTest {
         String group = "TelnetClients";
         String uniqueGroupId = "CN=TelnetClients,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -829,10 +827,4 @@ public class URAPIs_ADLDAP_SSLTest {
         }
     }
 
-    // TODO REPLACE
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_CustomLDAPTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_CustomLDAPTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_Federation_2LDAPsTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_Federation_2LDAPsTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_Federation_2LDAPs_2RealmsTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_Federation_2LDAPs_2RealmsTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_IDMapping_Test.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_IDMapping_Test.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.updateConfigDynamically;
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_PropertiesNotSupportedTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_PropertiesNotSupportedTest.java
@@ -11,15 +11,13 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -106,8 +104,8 @@ public class URAPIs_PropertiesNotSupportedTest {
         String user = "testuser";
         String password = "testuserpwd";
         Log.info(c, "checkPassword", "Checking good credentials");
-        equalDNs("Authentication should succeed.",
-                 "cn=testuser,o=ibm,c=us", servlet.checkPassword(user, password));
+        assertDNsEqual("Authentication should succeed.",
+                       "cn=testuser,o=ibm,c=us", servlet.checkPassword(user, password));
         passwordChecker.checkForPasswordInAnyFormat(password);
     }
 
@@ -170,7 +168,7 @@ public class URAPIs_PropertiesNotSupportedTest {
         String user = "testuser";
         String uniqueUserId = "cn=testuser,o=ibm,c=us";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
-        equalDNs("Unique names should be equal ", uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("Unique names should be equal ", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -182,7 +180,7 @@ public class URAPIs_PropertiesNotSupportedTest {
         String user = "testuser";
         String uniqueUserId = "cn=testuser,o=ibm,c=us";
         Log.info(c, "getUserSecurityName", "Checking with a valid user.");
-        equalDNs("", uniqueUserId, servlet.getUserSecurityName(user));
+        assertDNsEqual("UniqueUserId is incorrect", uniqueUserId, servlet.getUserSecurityName(user));
     }
 
     /**
@@ -243,7 +241,7 @@ public class URAPIs_PropertiesNotSupportedTest {
         String group = "grp1";
         String uniqueGroupId = "cn=grp1,o=ibm,c=us";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -284,9 +282,4 @@ public class URAPIs_PropertiesNotSupportedTest {
         assertEquals("There should only be one entry", 1, list.size());
     }
 
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_RealmPropertyMappingTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_RealmPropertyMappingTest.java
@@ -11,8 +11,8 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.createFederatedRepository;
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.updateConfigDynamically;
+import static componenttest.topology.utils.LDAPFatUtils.createFederatedRepository;
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAPTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAPTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAPTest_URAttrMappingVar4.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAPTest_URAttrMappingVar4.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAP_DefaultConfigTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAP_DefaultConfigTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAP_SSLTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAP_SSLTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest_URAttrMappingVar1.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest_URAttrMappingVar1.java
@@ -11,14 +11,12 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -103,8 +101,8 @@ public class URAPIs_TDSLDAPTest_URAttrMappingVar1 {
         String user = "vmmtestuser";
         String password = "vmmtestuserpwd";
         Log.info(c, "checkPassword", "Checking good credentials");
-        equalDNs("Authentication should succeed.",
-                 "cn=vmmtestuser,o=ibm,c=us", servlet.checkPassword(user, password));
+        assertDNsEqual("Authentication should succeed.",
+                       "cn=vmmtestuser,o=ibm,c=us", servlet.checkPassword(user, password));
         passwordChecker.checkForPasswordInAnyFormat(password);
     }
 
@@ -205,7 +203,7 @@ public class URAPIs_TDSLDAPTest_URAttrMappingVar1 {
         String group = "vmmgrp1";
         String userDisplayName = "cn=vmmgrp1,o=ibm,c=us";
         Log.info(c, "getGroupDisplayName", "Checking with a valid group.");
-        equalDNs(null, userDisplayName, servlet.getGroupDisplayName(group));
+        assertDNsEqual("userDisplayName is incorrect", userDisplayName, servlet.getGroupDisplayName(group));
     }
 
     /**
@@ -217,7 +215,7 @@ public class URAPIs_TDSLDAPTest_URAttrMappingVar1 {
         String group = "vmmgrp1";
         String uniqueGroupId = "cn=vmmgrp1,o=vmm";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -229,7 +227,7 @@ public class URAPIs_TDSLDAPTest_URAttrMappingVar1 {
         String uniqueGroupId = "cn=vmmgrp1,o=vmm";
         String userSecurityName = "cn=vmmgrp1,o=ibm,c=us";
         Log.info(c, "getGroupSecurityName", "Checking with a valid group.");
-        equalDNs(null, userSecurityName, servlet.getGroupSecurityName(uniqueGroupId));
+        assertDNsEqual("Groupsecurityname is incorrect", userSecurityName, servlet.getGroupSecurityName(uniqueGroupId));
     }
 
     /**
@@ -257,9 +255,4 @@ public class URAPIs_TDSLDAPTest_URAttrMappingVar1 {
         assertEquals("There should only be 2 entries", 2, list.size());
     }
 
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest_URAttrMappingVar3.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest_URAttrMappingVar3.java
@@ -11,14 +11,12 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -153,7 +151,7 @@ public class URAPIs_TDSLDAPTest_URAttrMappingVar3 {
         String user = "cn=vmmtestuser,o=ibm,c=us";
         String displayName = "cn=vmmtestuser,o=ibm,c=us";
         Log.info(c, "getUserDisplayName", "Checking with a valid user.");
-        equalDNs("External names should be equal ", displayName, servlet.getUserDisplayName(user));
+        assertDNsEqual("External names should be equal ", displayName, servlet.getUserDisplayName(user));
     }
 
     /**
@@ -165,7 +163,7 @@ public class URAPIs_TDSLDAPTest_URAttrMappingVar3 {
         String user = "cn=vmmtestuser,o=ibm,c=us";
         String uniqueUserId = "cn=vmmtestuser,o=ibm,c=us";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
-        equalDNs("External names should be equal ", uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("External names should be equal ", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -181,7 +179,7 @@ public class URAPIs_TDSLDAPTest_URAttrMappingVar3 {
         String uniqueUserId = "vmmtestuser";
 
         Log.info(c, "getUserSecurityName", "Checking with a valid user.");
-        // equalDNs("External names should be equal ", uniqueUserId, servlet.getUserSecurityName(user));
+
         assertEquals("External names should be equal ", uniqueUserId, servlet.getUserSecurityName(user));
     }
 
@@ -232,7 +230,7 @@ public class URAPIs_TDSLDAPTest_URAttrMappingVar3 {
         String group = "cn=vmmgrp1,o=vmm";
         String uniqueGroupId = "cn=vmmgrp1,o=vmm";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
-        equalDNs("UniqueNames should be equal ", uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueNames should be equal ", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -272,9 +270,4 @@ public class URAPIs_TDSLDAPTest_URAttrMappingVar3 {
         assertEquals("There should only be 3 entries", 3, list.size());
     }
 
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAP_FailoverTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAP_FailoverTest.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.assertDNsEqual;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAP_SSLTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAP_SSLTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -19,9 +20,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.Assume;
@@ -405,7 +403,7 @@ public class URAPIs_TDSLDAP_SSLTest {
         String uniqueUserId = "cn=vmmtestuser,o=ibm,c=us";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
         //assertEquals("", uniqueUserId, servlet.getUniqueUserId(user));
-        equalDNs("Unique names should be equal ", uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("Unique names should be equal ", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -675,7 +673,7 @@ public class URAPIs_TDSLDAP_SSLTest {
         String group = "vmmgrp1";
         String uniqueGroupId = "cn=vmmgrp1,o=ibm,c=us";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -926,10 +924,4 @@ public class URAPIs_TDSLDAP_SSLTest {
         }
     }
 
-    // TODO REPLACE
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_UserGroupSearchBases.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_UserGroupSearchBases.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static com.ibm.ws.security.wim.adapter.ldap.fat.LDAPFatUtils.updateConfigDynamically;
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -39,6 +39,7 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.LDAPFatUtils;
 import componenttest.topology.utils.LDAPUtils;
 
 /**

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/VMMAPIs_TDSLDAPTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/VMMAPIs_TDSLDAPTest.java
@@ -11,15 +11,12 @@
 
 package com.ibm.ws.security.wim.adapter.ldap.fat;
 
-import static org.junit.Assert.assertEquals;
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.rmi.RemoteException;
 import java.util.Map;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -156,12 +153,7 @@ public class VMMAPIs_TDSLDAPTest {
         String result = servlet.login(userName, password);
         System.out.println("Result from login : " + result.toString());
 
-        equalDNs("Returned uniqueName should be same ", "cn=vmmtestuser,o=ibm,c=us", result);
+        assertDNsEqual("Returned uniqueName should be same ", "cn=vmmtestuser,o=ibm,c=us", result);
     }
 
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmMultipleReposTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmMultipleReposTest.java
@@ -11,15 +11,13 @@
 
 package com.ibm.ws.security.wim.registry.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -175,10 +173,7 @@ public class DefaultWIMRealmMultipleReposTest {
         String uniqueUserId = "uid=vmmtestuser,o=defaultWIMFileBasedRealm";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
         try {
-            equalDNs("", uniqueUserId, servlet.getUniqueUserId(user));
-        } catch (InvalidNameException e) {
-            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
-            e.printStackTrace();
+            assertDNsEqual("UniqueUserId is incorrect", uniqueUserId, servlet.getUniqueUserId(user));
         } catch (EntryNotFoundException e) {
             // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
             e.printStackTrace();
@@ -272,10 +267,7 @@ public class DefaultWIMRealmMultipleReposTest {
         String uniqueGroupId = "cn=vmmgroup1,dc=rtp,dc=raleigh,dc=ibm,dc=com";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
         try {
-            equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
-        } catch (InvalidNameException e) {
-            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
-            e.printStackTrace();
+            assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
         } catch (EntryNotFoundException e) {
             // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
             e.printStackTrace();
@@ -296,10 +288,7 @@ public class DefaultWIMRealmMultipleReposTest {
         String uniqueGroupId = "vmmgroup1";
         Log.info(c, "getGroupSecurityName", "Checking with a valid group.");
         try {
-            equalDNs("", "cn=group1,ou=users,dc=rtp,dc=raleigh,dc=ibm,dc=com", servlet.getGroupSecurityName(uniqueGroupId));
-        } catch (InvalidNameException e) {
-            // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
-            e.printStackTrace();
+            assertDNsEqual("Group nmae is incorrect", "cn=group1,ou=users,dc=rtp,dc=raleigh,dc=ibm,dc=com", servlet.getGroupSecurityName(uniqueGroupId));
         } catch (EntryNotFoundException e) {
             // Do you need FFDC here? Remember FFDC instrumentation and @FFDCIgnore
             e.printStackTrace();
@@ -319,7 +308,7 @@ public class DefaultWIMRealmMultipleReposTest {
     public void getGroupSecurityNameAD() throws Exception {
         String uniqueGroupId = "TelnetClients";
         Log.info(c, "getGroupSecurityNameAD", "Checking with a valid group.");
-        equalDNs("", "CN=TelnetClients,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com", servlet.getGroupSecurityName(uniqueGroupId));
+        assertDNsEqual("Group name is incorrect", "CN=TelnetClients,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com", servlet.getGroupSecurityName(uniqueGroupId));
     }
 
     /**
@@ -367,9 +356,4 @@ public class DefaultWIMRealmMultipleReposTest {
         assertEquals("There should only be one entry", 2, list.size());
     }
 
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmTest.java
@@ -11,15 +11,13 @@
 
 package com.ibm.ws.security.wim.registry.fat;
 
+import static componenttest.topology.utils.LDAPFatUtils.assertDNsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -107,8 +105,8 @@ public class DefaultWIMRealmTest {
         String user = "persona1";
         String password = "ppersona1";
         Log.info(c, "checkPassword", "Checking good credentials");
-        equalDNs("Authentication should succeed.",
-                 "uid=persona1,ou=users,dc=rtp,dc=raleigh,dc=ibm,dc=com", servlet.checkPassword(user, password));
+        assertDNsEqual("Authentication should succeed.",
+                       "uid=persona1,ou=users,dc=rtp,dc=raleigh,dc=ibm,dc=com", servlet.checkPassword(user, password));
     }
 
     /**
@@ -234,7 +232,7 @@ public class DefaultWIMRealmTest {
         String user = "persona1";
         String uniqueUserId = "uid=persona1,ou=users,dc=rtp,dc=raleigh,dc=ibm,dc=com";
         Log.info(c, "getUniqueUserId", "Checking with a valid user.");
-        equalDNs("", uniqueUserId, servlet.getUniqueUserId(user));
+        assertDNsEqual("UniqueUserId is incorrect", uniqueUserId, servlet.getUniqueUserId(user));
     }
 
     /**
@@ -441,7 +439,7 @@ public class DefaultWIMRealmTest {
         String group = "vmmgroup1";
         String uniqueGroupId = "cn=vmmgroup1,ou=users,dc=rtp,dc=raleigh,dc=ibm,dc=com";
         Log.info(c, "getUniqueGroupId", "Checking with a valid group.");
-        equalDNs(null, uniqueGroupId, servlet.getUniqueGroupId(group));
+        assertDNsEqual("UniqueGroupId is incorrect", uniqueGroupId, servlet.getUniqueGroupId(group));
     }
 
     /**
@@ -474,7 +472,7 @@ public class DefaultWIMRealmTest {
     public void getGroupSecurityName() throws Exception {
         String uniqueGroupId = "vmmgroup1";
         Log.info(c, "getGroupSecurityName", "Checking with a valid group.");
-        equalDNs("", "cn=vmmgroup1,ou=users,dc=rtp,dc=raleigh,dc=ibm,dc=com", servlet.getGroupSecurityName(uniqueGroupId));
+        assertDNsEqual("Group name is incorrect", "cn=vmmgroup1,ou=users,dc=rtp,dc=raleigh,dc=ibm,dc=com", servlet.getGroupSecurityName(uniqueGroupId));
     }
 
     /**
@@ -667,9 +665,4 @@ public class DefaultWIMRealmTest {
         assertTrue("An invalid user should cause EntryNotFoundException", true);
     }
 
-    private void equalDNs(String msg, String dn1, String dn2) throws InvalidNameException {
-        LdapName ln1 = new LdapName(dn1);
-        LdapName ln2 = new LdapName(dn2);
-        assertEquals(msg, ln1, ln2);
-    }
 }

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/LDAPFatUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/LDAPFatUtils.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.security.wim.adapter.ldap.fat;
+package componenttest.topology.utils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -52,12 +52,14 @@ public class LDAPFatUtils {
         try {
             ln1 = new LdapName(dn1);
         } catch (Exception e) {
-            fail("Distinguished name 1 was invalid: " + dn1);
+            e.printStackTrace();
+            fail("Distinguished name 1 was invalid: " + dn1 + ". Exception " + e);
         }
         try {
             ln2 = new LdapName(dn2);
         } catch (Exception e) {
-            fail("Distinguished name 2 was invalid: " + dn2);
+            e.printStackTrace();
+            fail("Distinguished name 2 was invalid: " + dn2 + ". Exception " + e);
         }
 
         assertEquals(msg, ln1, ln2);


### PR DESCRIPTION
Moved LDAPFatUtils to to the common fat test package and changed all the imports/calls in VMM tests to its methods as appropriate. 