### PR TITLE
Remove JDK 6 specific code

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyTestServlet.java
@@ -3018,15 +3018,7 @@ public class EEConcurrencyTestServlet extends FATServlet {
 
         newThreadPriority = newThread.getPriority();
         if (newThreadPriority != 7) {
-            String osName = System.getProperty("os.name", "unknown").toLowerCase();
-            String javaVersion = System.getProperty("java.version");
-            boolean isMac = osName.indexOf("mac os") >= 0;
-            if (isMac && javaVersion.startsWith("1.6.")) {
-                System.out.println("Expecting new thread to have maximum priority of the thread group (7). Instead: " + newThreadPriority +
-                                   "\n This incorect result is expected on MAC OS with JDK 6 due to a bug in the JDK. See defect 115028 for more details. ");
-            } else {
-                throw new Exception("Expecting new thread to have maximum priority of the thread group (7). Instead: " + newThreadPriority);
-            }
+            throw new Exception("Expecting new thread to have maximum priority of the thread group (7). Instead: " + newThreadPriority);
         }
 
         Thread.currentThread().setPriority(2);


### PR DESCRIPTION
Remove code that is there for when running with Java 6.  The minimum is now Java 7 for open liberty so there is no need to maintain Java 6 specific code.