### PR TITLE
Test servlet success message not sufficiently unique

### DIFF
--- a/dev/com.ibm.ws.componenttest/src/componenttest/app/FATServlet.java
+++ b/dev/com.ibm.ws.componenttest/src/componenttest/app/FATServlet.java
@@ -44,7 +44,7 @@ import org.junit.Assert;
  */
 @SuppressWarnings("serial")
 public abstract class FATServlet extends HttpServlet {
-    public static final String SUCCESS = "SUCCESS";
+    public static final String SUCCESS = "[TEST-SERVLET-SUCCESS]";
     public static final String TEST_METHOD = "testMethod";
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyDemoServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyDemoServlet.java
@@ -87,7 +87,7 @@ public class EEConcurrencyDemoServlet extends HttpServlet {
             else
                 out.println("missing or unrecognized test name parameter: " + test);
 
-            out.println("<!--COMPLETED SUCCESSFULLY-->");
+            out.println("<!--[TEST-SERVLET-SUCCESS]-->");
         } catch (Exception x) {
             throw new ServletException(x);
         }

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/FATServletClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/FATServletClient.java
@@ -28,13 +28,14 @@ import com.ibm.websphere.simplicity.config.dsprops.testrules.DataSourcePropertie
 import com.ibm.websphere.simplicity.config.dsprops.testrules.DataSourcePropertiesSkipRule;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.app.FATServlet;
 import componenttest.topology.impl.LibertyServer;
 
 /**
  * Utilities for running tests using {@link FATServlet}-style output.
  */
 public class FATServletClient {
-    public static final String SUCCESS = "SUCCESS";
+    public static final String SUCCESS = "[TEST-SERVLET-SUCCESS]";
     public static final String TEST_METHOD = "testMethod";
 
     @Rule


### PR DESCRIPTION
Make the success keyword used for passing result more unique so that it does not accidentally match with junit failures that happen to contain the text "SUCCESS"