### PR TITLE
#1479 Don't use the TCCL when choosing a parser impl for beans.xml

### DIFF
--- a/dev/com.ibm.ws.cdi.1.2_fat_all/.classpath
+++ b/dev/com.ibm.ws.cdi.1.2_fat_all/.classpath
@@ -135,6 +135,7 @@
 	<classpathentry kind="src" path="test-applications/withAnnotationsApp.war/src"/>
 	<classpathentry kind="src" path="test-bundles/cdi.helloworld.extension/src"/>
 	<classpathentry kind="src" path="test-applications/deltaspikeTest.war/src"/>
+	<classpathentry kind="src" path="test-applications/userSAXParserFactory.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.cdi.1.2_fat_all/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.1.2_fat_all/bnd.bnd
@@ -120,6 +120,7 @@ src: \
 	test-applications/TestValidatorInJar.war/src,\
 	test-applications/TestVetoedAlternative.jar/src,\
 	test-applications/TestVetoedAlternative.war/src,\
+	test-applications/userSAXParserFactory.war/src,\
 	test-applications/utilLib.jar/src,\
 	test-applications/vetoedEJBStartup.war/src,\
 	test-applications/visTestAppClient.jar/src,\
@@ -158,13 +159,16 @@ javac.target: 1.7
 fat.project: true
 
 tested.features:\
-	cdi-2.0,\
-        servlet-4.0,\
-        jdbc-4.2,\
-        jpa-2.2,\
-        beanValidation-2.0,\
-        jaxrs-2.1,\
-        jsf-2.3
+    cdi-2.0,\
+    servlet-4.0,\
+    jdbc-4.2,\
+    jpa-2.2,\
+    beanValidation-2.0,\
+    jaxrs-2.1,\
+    jsf-2.3,\
+    jsonb-1.0,\
+    appsecurity-3.0,\
+    webprofile-8.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.cdi.1.2_fat_all/fat/src/com/ibm/ws/cdi12/fat/tests/CustomerProvidedXMLParserFactoryTest.java
+++ b/dev/com.ibm.ws.cdi.1.2_fat_all/fat/src/com/ibm/ws/cdi12/fat/tests/CustomerProvidedXMLParserFactoryTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi12.fat.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.ibm.ws.cdi12.suite.ShutDownSharedServer;
+import com.ibm.ws.fat.util.LoggingTest;
+
+/**
+ * Tests the case where a customer provides their own SAX parser factory.
+ * It is possible that an application that contains a beans.xml might also
+ * package their own implementation of SAXParserFactory. In that case Liberty
+ * needs to ensure that it uses a Liberty-supplied parser factory, and not the
+ * customer's. If we use the customer's then we run into classloading problems
+ * because we have already loaded and use the JDK's version of <code>
+ * javax.xml.parsers.SAXParserFactory</code> - if the application provides this
+ * same class, we will have a ClassCastException. This test verifies that we
+ * can parse the beans.xml file without loading the customer's SAXParserFactory
+ * when one is supplied.
+ */
+public class CustomerProvidedXMLParserFactoryTest extends LoggingTest {
+
+    @ClassRule
+    // Create the server.
+    public static ShutDownSharedServer SHARED_SERVER = new ShutDownSharedServer("cdi12UserSAXParserFactory");
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.ibm.ws.fat.LoggingTest#getSharedServer()
+     */
+    @Override
+    protected ShutDownSharedServer getSharedServer() {
+        return SHARED_SERVER;
+    }
+
+    /**
+     * Test bean manager can be looked up via java:comp/BeanManager
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testBeansXMLIsParsedWithoutUsingCustomerSAXParserFactory() throws Exception {
+        assertTrue("App with custom SAXParserFactory did not start successfully",
+                   SHARED_SERVER.getLibertyServer().findStringsInLogs("CWWKZ0001I.*userSAXParserFactory").size() > 0);
+        assertEquals("User's SAXParserFactory impl was used instead of Liberty's", 0,
+                     SHARED_SERVER.getLibertyServer().findStringsInLogs("FAILED").size());
+
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.1.2_fat_all/fat/src/com/ibm/ws/cdi12/suite/CDI1220Suite.java
+++ b/dev/com.ibm.ws.cdi.1.2_fat_all/fat/src/com/ibm/ws/cdi12/suite/CDI1220Suite.java
@@ -10,36 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.cdi12.suite;
 
-import java.nio.file.Files; 
-import java.nio.file.StandardCopyOption; 
-import java.nio.file.attribute.FileAttribute; 
-import java.io.File;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-
-import componenttest.rules.FeatureReplacementAction;
-import componenttest.rules.RepeatTests;
-
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ArchivePaths;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.FileAsset;
-import org.jboss.shrinkwrap.api.importer.ZipImporter;
-import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-
-import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import com.ibm.ws.cdi12.fat.tests.AfterTypeDiscoveryTest;
 import com.ibm.ws.cdi12.fat.tests.AlterableContextTest;
@@ -61,6 +35,7 @@ import com.ibm.ws.cdi12.fat.tests.ClassExclusionTest;
 import com.ibm.ws.cdi12.fat.tests.ClassLoadPrereqLogger;
 import com.ibm.ws.cdi12.fat.tests.ClassMaskingTest;
 import com.ibm.ws.cdi12.fat.tests.ConversationFilterTest;
+import com.ibm.ws.cdi12.fat.tests.CustomerProvidedXMLParserFactoryTest;
 import com.ibm.ws.cdi12.fat.tests.DecoratorOnBuiltInBeansTest;
 import com.ibm.ws.cdi12.fat.tests.DeltaSpikeSchedulerTest;
 import com.ibm.ws.cdi12.fat.tests.DisablingBeansXmlValidationTest;
@@ -104,7 +79,9 @@ import com.ibm.ws.cdi12.fat.tests.implicit.ImplicitBeanArchiveTest;
 import com.ibm.ws.cdi12.fat.tests.implicit.ImplicitBeanArchivesDisabledTest;
 import com.ibm.ws.cdi12.fat.tests.implicit.ImplicitWarLibJarsTest;
 import com.ibm.ws.cdi12.fat.tests.implicit.ImplicitWarTest;
-import com.ibm.ws.fat.util.FatLogHandler;
+
+import componenttest.rules.FeatureReplacementAction;
+import componenttest.rules.RepeatTests;
 
 /**
  * Tests that run on CDI 1.2 and again on CDI 2.0
@@ -131,6 +108,7 @@ import com.ibm.ws.fat.util.FatLogHandler;
                 ClassLoadPrereqLogger.class,
                 ClassMaskingTest.class,
                 ConversationFilterTest.class,
+                CustomerProvidedXMLParserFactoryTest.class,
                 DecoratorOnBuiltInBeansTest.class,
                 DeltaSpikeSchedulerTest.class,
                 DisablingBeansXmlValidationTest.class,
@@ -175,12 +153,11 @@ import com.ibm.ws.fat.util.FatLogHandler;
                 VisTest.class,
                 WarLibsAccessWarBeansTest.class,
                 WebBeansBeansXmlInWeldTest.class,
-                WithAnnotationsTest.class                
+                WithAnnotationsTest.class
 })
 public class CDI1220Suite {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES);
+    public static RepeatTests r = RepeatTests.withoutModification().andWith(FeatureReplacementAction.EE8_FEATURES);
 
 }

--- a/dev/com.ibm.ws.cdi.1.2_fat_all/fat/src/com/ibm/ws/cdi12/suite/FATSuite.java
+++ b/dev/com.ibm.ws.cdi.1.2_fat_all/fat/src/com/ibm/ws/cdi12/suite/FATSuite.java
@@ -930,6 +930,10 @@ public class FATSuite {
                         .addClass("com.ibm.ws.cdi12.test.priority.WarDecorator")
                         .addClass("com.ibm.ws.cdi12.test.priority.GlobalPriorityTestServlet")
                         .add(new FileAsset(new File("test-applications/globalPriorityWebApp.war/resources/WEB-INF/beans.xml")), "/WEB-INF/beans.xml");
+        WebArchive userSAXParserFactoryWebApp = ShrinkWrap.create(WebArchive.class, "userSAXParserFactory.war")
+                        .addPackage("my.parsers")
+                        .add(new FileAsset(new File("test-applications/userSAXParserFactory.war/resources/META-INF/services/javax.xml.parsers.SAXParserFactory")), "/META-INF/services/javax.xml.parsers.SAXParserFactory")
+                        .add(new FileAsset(new File("test-applications/userSAXParserFactory.war/resources/WEB-INF/beans.xml")), "/WEB-INF/beans.xml");
 
 
         ResourceAdapterArchive jarInRar173 = ShrinkWrap.create(ResourceAdapterArchive.class,"jarInRar.rar")
@@ -1155,6 +1159,7 @@ public class FATSuite {
         
         exportAppToServer("cdi12SharedLibraryServer", sharedLibrary33, "/InjectionSharedLibrary");
         exportAppToServer("cdi12JSFWithSharedLibServer", sharedLibrary33, "/InjectionSharedLibrary");
+        exportAppToServer("cdi12UserSAXParserFactory", userSAXParserFactoryWebApp);
         
         exportAppToClient("cdiClientSecurity", appClientSecurity122, "/apps");
         exportAppToClient("cdiClient", HelloAppClient72, "/apps");

--- a/dev/com.ibm.ws.cdi.1.2_fat_all/publish/servers/cdi12UserSAXParserFactory/bootstrap.properties
+++ b/dev/com.ibm.ws.cdi.1.2_fat_all/publish/servers/cdi12UserSAXParserFactory/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info:JCDI=all:com.ibm.ws.cdi*=all:com.ibm.ws.weld*=all:org.jboss.*:Injection=all

--- a/dev/com.ibm.ws.cdi.1.2_fat_all/publish/servers/cdi12UserSAXParserFactory/server.xml
+++ b/dev/com.ibm.ws.cdi.1.2_fat_all/publish/servers/cdi12UserSAXParserFactory/server.xml
@@ -1,0 +1,11 @@
+<server description="Server for testing a CDI app that contains a beans.xml file and it's own XML parser factory">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>webProfile-7.0</feature>
+    </featureManager>
+
+    <logging traceSpecification="**=info:JCDI=all:com.ibm.ws.cdi*=all:com.ibm.ws.weld*=all:org.jboss.*=all:Injection=all"/>
+
+</server>

--- a/dev/com.ibm.ws.cdi.1.2_fat_all/test-applications/userSAXParserFactory.war/resources/META-INF/services/javax.xml.parsers.SAXParserFactory
+++ b/dev/com.ibm.ws.cdi.1.2_fat_all/test-applications/userSAXParserFactory.war/resources/META-INF/services/javax.xml.parsers.SAXParserFactory
@@ -1,0 +1,1 @@
+my.parsers.MySAXParserFactory

--- a/dev/com.ibm.ws.cdi.1.2_fat_all/test-applications/userSAXParserFactory.war/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.cdi.1.2_fat_all/test-applications/userSAXParserFactory.war/resources/WEB-INF/beans.xml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" 
+bean-discovery-mode="all"
+       version="1.1"> 
+   <interceptors>
+   </interceptors>
+
+   <decorators>
+   </decorators>
+</beans>

--- a/dev/com.ibm.ws.cdi.1.2_fat_all/test-applications/userSAXParserFactory.war/src/my/parsers/MySAXParserFactory.java
+++ b/dev/com.ibm.ws.cdi.1.2_fat_all/test-applications/userSAXParserFactory.war/src/my/parsers/MySAXParserFactory.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package my.parsers;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+public class MySAXParserFactory extends SAXParserFactory {
+
+    @Override
+    public SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
+        throw fail();
+    }
+
+    @Override
+    public void setFeature(String name, boolean value) throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+        throw fail();
+    }
+
+    @Override
+    public boolean getFeature(String name) throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+        throw fail();
+    }
+
+    private ParserConfigurationException fail() {
+        System.out.println("FAILED - User's ParserFactory was invoked");
+        ParserConfigurationException ex = new ParserConfigurationException("FAILED - User's ParserFactory was invoked");
+        ex.printStackTrace();
+        return ex;
+    }
+}


### PR DESCRIPTION
This fix ensures that beans.xml is parsed using the SAXParserFactory 
that is visible to Liberty components.  The Weld code loads a parser
factory from the thread context classloader while the app is starting.  
This means that it could load a parser factory from the user application 
which could have undesired consequences.  This fix resolves it by 
temporarily setting the thread context classloader to be the CDI bundle 
loader - this means that Liberty will find the parser factory that ships 
with Liberty or the JDK, rather than any that might ship with the app.

This commit also includes a test case of this scenario where the app 
provides a parser factory that simply throws an exception.  The test
fails if it detects that exception, and passes if the app starts without
exception.

Issue #1479