### PR TITLE
additional cancellation tests for managed completable future

### DIFF
--- a/dev/com.ibm.ws.concurrent.rx/src/com/ibm/websphere/concurrent/rx/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent.rx/src/com/ibm/websphere/concurrent/rx/ManagedCompletableFuture.java
@@ -434,8 +434,16 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        // TODO also cancel from managed executor
-        return completableFuture.cancel(mayInterruptIfRunning);
+        boolean canceledByThisMethod = completableFuture.cancel(mayInterruptIfRunning);
+
+        // If corresponding task has been submitted to an executor, attempt to cancel it
+        if (canceledByThisMethod && futureRef != null) {
+            Future<?> future = futureRef.get();
+            if (future != null)
+                future.cancel(mayInterruptIfRunning);
+        }
+
+        return canceledByThisMethod;
     }
 
     /**
@@ -443,7 +451,16 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Override
     public boolean complete(T value) {
-        return completableFuture.complete(value);
+        boolean completedByThisMethod = completableFuture.complete(value);
+
+        // If corresponding task has been submitted to an executor, attempt to cancel it
+        if (completedByThisMethod && futureRef != null) {
+            Future<?> future = futureRef.get();
+            if (future != null)
+                future.cancel(true);
+        }
+
+        return completedByThisMethod;
     }
 
     /**
@@ -451,8 +468,16 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Override
     public boolean completeExceptionally(Throwable x) {
-        // TODO also cancel from managed executor if completed with a CancellationException
-        return completableFuture.completeExceptionally(x);
+        boolean completedByThisMethod = completableFuture.completeExceptionally(x);
+
+        // If corresponding task has been submitted to an executor, attempt to cancel it
+        if (completedByThisMethod && futureRef != null) {
+            Future<?> future = futureRef.get();
+            if (future != null)
+                future.cancel(true);
+        }
+
+        return completedByThisMethod;
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent.rx/src/com/ibm/websphere/concurrent/rx/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent.rx/src/com/ibm/websphere/concurrent/rx/ManagedCompletableFuture.java
@@ -434,16 +434,16 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        boolean canceledByThisMethod = completableFuture.cancel(mayInterruptIfRunning);
+        boolean canceled = completableFuture.cancel(mayInterruptIfRunning);
 
         // If corresponding task has been submitted to an executor, attempt to cancel it
-        if (canceledByThisMethod && futureRef != null) {
+        if (canceled && futureRef != null) {
             Future<?> future = futureRef.get();
             if (future != null)
                 future.cancel(mayInterruptIfRunning);
         }
 
-        return canceledByThisMethod;
+        return canceled;
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/BlockableIncrementFunction.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/BlockableIncrementFunction.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+/**
+ * Simple incrementing function that can block for a period of time when it runs.
+ * Latches are provided to the constructor for the test case which uses this function
+ * to know when it has started and control when it is allowed to complete.
+ */
+public class BlockableIncrementFunction implements Function<Integer, Integer> {
+    /**
+     * This latch, if supplied, is counted down when the function begins.
+     */
+    private final CountDownLatch beginLatch;
+
+    /**
+     * This latch, if supplied, is awaited before the function returns a value.
+     */
+    private final CountDownLatch continueLatch;
+
+    /**
+     * String that helps track which test case or part of a test case created this instance.
+     */
+    private final String testIdentifier;
+
+    /**
+     * Thread upon which the function is running.
+     */
+    volatile Thread executionThread;
+
+    /**
+     * Constructor for BlockableIncrementFunction
+     *
+     * @param testIdentifier string that helps track which test case or part of a test case created this instance.
+     * @param beginLatch if not null, this latch is counted down when the function begins.
+     * @param continueLatch if not null, this latch is awaited before the function returns a value.
+     */
+    public BlockableIncrementFunction(String testIdentifier, CountDownLatch beginLatch, CountDownLatch continueLatch) {
+        this.beginLatch = beginLatch;
+        this.continueLatch = continueLatch;
+        this.testIdentifier = testIdentifier;
+    }
+
+    @Override
+    public Integer apply(Integer t) {
+        executionThread = Thread.currentThread();
+        System.out.println("BlockableIncrementFunction > apply " + t + " for " + testIdentifier);
+        if (beginLatch != null)
+            beginLatch.countDown();
+        try {
+            if (continueLatch != null && !continueLatch.await(ConcurrentRxTestServlet.TIMEOUT_NS * 3, TimeUnit.NANOSECONDS))
+                throw new TimeoutException();
+
+            System.out.println("BlockableIncrementFunction < apply: " + (++t));
+            return t;
+        } catch (InterruptedException | TimeoutException x) {
+            System.out.println("BlockableIncrementFunction < apply: " + x);
+            throw new CompletionException(x);
+        } finally {
+            executionThread = null;
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/BlockableSupplier.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/BlockableSupplier.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+/**
+ * Supplier that can block for a period of time when it runs.
+ * Latches are provided to the constructor for the test case which uses this function
+ * to know when it has started and control when it is allowed to complete.
+ */
+public class BlockableSupplier<T> implements Supplier<T> {
+    /**
+     * This latch, if supplied, is counted down when the function begins.
+     */
+    private final CountDownLatch beginLatch;
+
+    /**
+     * This latch, if supplied, is awaited before the function returns a value.
+     */
+    private final CountDownLatch continueLatch;
+
+    /**
+     * Thread upon which the supplier is running.
+     */
+    volatile Thread executionThread;
+
+    /**
+     * Value that is supplied by this supplier.
+     */
+    private final T value;
+
+    /**
+     * Constructor for BlockableIncrementFunction
+     *
+     * @param value the value for this supplier to supply.
+     * @param beginLatch if not null, this latch is counted down when the function begins.
+     * @param continueLatch if not null, this latch is awaited before the function returns a value.
+     */
+    public BlockableSupplier(T value, CountDownLatch beginLatch, CountDownLatch continueLatch) {
+        this.beginLatch = beginLatch;
+        this.continueLatch = continueLatch;
+        this.value = value;
+    }
+
+    @Override
+    public T get() {
+        executionThread = Thread.currentThread();
+        System.out.println("BlockableSupplier > get: supplies the value " + value);
+        if (beginLatch != null)
+            beginLatch.countDown();
+        try {
+            if (continueLatch != null && !continueLatch.await(ConcurrentRxTestServlet.TIMEOUT_NS * 3, TimeUnit.NANOSECONDS))
+                throw new TimeoutException();
+
+            System.out.println("BlockableSupplier < get: " + value);
+            return value;
+        } catch (InterruptedException | TimeoutException x) {
+            System.out.println("BlockableSupplier < get: " + x);
+            throw new CompletionException(x);
+        } finally {
+            executionThread = null;
+        }
+    }
+}


### PR DESCRIPTION
Add tests for cancellation of managed completable future where dependent stages are involved, to ensure that dependent stages are automatically completed due to cancellation, unless the stage being canceled is already completed.  Also, cover scenarios such as verifying the effect of premature successful completion on dependent stages.