### PR TITLE
Add java permission to Bean Validation 2.0 FAT

### DIFF
--- a/dev/com.ibm.ws.beanvalidation.v20_fat/publish/servers/beanval.v20_fat/server.xml
+++ b/dev/com.ibm.ws.beanvalidation.v20_fat/publish/servers/beanval.v20_fat/server.xml
@@ -20,4 +20,6 @@
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>
+    
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
 </server>


### PR DESCRIPTION
Add needed java permission to the bean validation 2.0 fat to fix issue #1516. 