### PR TITLE
Removing sync between MessageLogHandler and JsonTraceService.

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/JsonTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/JsonTraceService.java
@@ -104,7 +104,6 @@ public class JsonTraceService extends BaseTraceService {
          */
         if (messageLogHandler == null) {
             messageLogHandler = new MessageLogHandler(serverName, wlpUserDir, filterdMessageSourceList);
-            messageLogHandler.setSync(sync);
             collectorMgrPipelineUtils.setMessageHandler(messageLogHandler);
         }
         if (consoleLogHandler == null) {
@@ -316,13 +315,6 @@ public class JsonTraceService extends BaseTraceService {
             counter.decrementCount();
         }
         return retMe;
-    }
-
-    @Override
-    protected void initializeWriters(LogProviderConfigImpl config) {
-        synchronized (sync) {
-            super.initializeWriters(config);
-        }
     }
 
     @Override

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/MessageLogHandler.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/MessageLogHandler.java
@@ -23,10 +23,7 @@ import com.ibm.wsspi.collector.manager.SynchronousHandler;
 public class MessageLogHandler extends JsonLogHandler implements SynchronousHandler, Formatter {
 
     private TraceWriter traceWriter;
-    /*
-     * Needed to address a synchronization issue between the syncrhonousWrite method and FileLogHolder
-     */
-    private volatile Object sync;
+
     public static final String COMPONENT_NAME = "com.ibm.ws.logging.internal.impl.MessageLogHandler";
 
     public MessageLogHandler(String serverName, String wlpUserDir, List<String> sourcesList) {
@@ -36,10 +33,6 @@ public class MessageLogHandler extends JsonLogHandler implements SynchronousHand
     @Override
     public String getHandlerName() {
         return COMPONENT_NAME;
-    }
-
-    public void setSync(Object sync) {
-        this.sync = sync;
     }
 
     public void setFileLogHolder(TraceWriter trw) {
@@ -54,18 +47,12 @@ public class MessageLogHandler extends JsonLogHandler implements SynchronousHand
     @Override
     public void synchronousWrite(Object event) {
         /*
-         * Needed to address a synchronization issue between the syncrhonousWrite method and FileLogHolder
-         */
-
-        /*
          * Given an 'object' we must determine what type of log event it originates from.
          * Knowing that it is a *Data object, we can figure what type of source it is.
          */
         String evensourcetType = getSourceTypeFromDataObject(event);
         String messageOutput = (String) formatEvent(evensourcetType, CollectorConstants.MEMORY, event, null, MAXFIELDLENGTH);
-        synchronized (sync) {
-            traceWriter.writeRecord(messageOutput);
-        }
+        traceWriter.writeRecord(messageOutput);
     }
 
 }


### PR DESCRIPTION
The original code for basic format did not guarantee order. Fixes #1439.