### PR TITLE
maxQueueSize with runIfQueueFull true for managed completable future

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_rx/publish/servers/com.ibm.ws.concurrent.fat.rx/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_rx/publish/servers/com.ibm.ws.concurrent.fat.rx/server.xml
@@ -27,6 +27,13 @@
         <contextService/>
     </managedScheduledExecutorService>
 
+    <managedExecutorService id="oneContextExecutor" jndiName="concurrent/oneContextExecutor">
+        <concurrencyPolicy max="1" maxQueueSize="1" runIfQueueFull="true"/>
+        <contextService>
+            <jeeMetadataContext/>
+        </contextService>
+    </managedExecutorService>
+
     <!-- Needed for application to shutdown the ExecutorService testThreads -->
     <javaPermission codebase="${server.config.dir}/apps/concurrentrxfat.war" className="java.lang.RuntimePermission" name="modifyThread"/>
     

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/BlockableIncrementFunction.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/BlockableIncrementFunction.java
@@ -33,14 +33,19 @@ public class BlockableIncrementFunction implements Function<Integer, Integer> {
     private final CountDownLatch continueLatch;
 
     /**
-     * String that helps track which test case or part of a test case created this instance.
-     */
-    private final String testIdentifier;
-
-    /**
      * Thread upon which the function is running.
      */
     volatile Thread executionThread;
+
+    /**
+     * Indicates whether or not the executionThread field is nulled out once the function completes.
+     */
+    private final boolean executionThreadClearedOnCompletion;
+
+    /**
+     * String that helps track which test case or part of a test case created this instance.
+     */
+    private final String testIdentifier;
 
     /**
      * Constructor for BlockableIncrementFunction
@@ -52,6 +57,22 @@ public class BlockableIncrementFunction implements Function<Integer, Integer> {
     public BlockableIncrementFunction(String testIdentifier, CountDownLatch beginLatch, CountDownLatch continueLatch) {
         this.beginLatch = beginLatch;
         this.continueLatch = continueLatch;
+        this.executionThreadClearedOnCompletion = true;
+        this.testIdentifier = testIdentifier;
+    }
+
+    /**
+     * Constructor for BlockableIncrementFunction
+     *
+     * @param testIdentifier string that helps track which test case or part of a test case created this instance.
+     * @param beginLatch if not null, this latch is counted down when the function begins.
+     * @param continueLatch if not null, this latch is awaited before the function returns a value.
+     * @param executionThreadClearedOnCompletion indicates whether or not to null out the executionThread field upon completion of the function.
+     */
+    public BlockableIncrementFunction(String testIdentifier, CountDownLatch beginLatch, CountDownLatch continueLatch, boolean executionThreadClearedOnCompletion) {
+        this.beginLatch = beginLatch;
+        this.continueLatch = continueLatch;
+        this.executionThreadClearedOnCompletion = executionThreadClearedOnCompletion;
         this.testIdentifier = testIdentifier;
     }
 
@@ -71,7 +92,8 @@ public class BlockableIncrementFunction implements Function<Integer, Integer> {
             System.out.println("BlockableIncrementFunction < apply: " + x);
             throw new CompletionException(x);
         } finally {
-            executionThread = null;
+            if (executionThreadClearedOnCompletion)
+                executionThread = null;
         }
     }
 }


### PR DESCRIPTION
Add test coverage for managed completable future using a managed executor with maxQueueSize limited and runIfQueueFull set to true, such that when no queue capacity is available, requests to submit async work can run on the invoker thread.