### PR TITLE
Clean up redundant/unnecessary exports as well as add necessary exports

### DIFF
--- a/dev/com.ibm.ws.collector.manager/bnd.bnd
+++ b/dev/com.ibm.ws.collector.manager/bnd.bnd
@@ -10,10 +10,7 @@ Bundle-Description: Collector Manager: Collector Manager; version=${bVersion}
 WS-TraceGroup: collectorManager
 
 Export-Package: \
-	com.ibm.wsspi.collector.manager,\
-	com.ibm.ws.health.center.data,\
-	com.ibm.ws.logging.ffdc.source,\
-	com.ibm.ws.http.logging.source
+	com.ibm.ws.logging.ffdc.source
 
 Import-Package: com.ibm.ejs.ras, \
                 com.ibm.websphere.ras, \
@@ -56,8 +53,7 @@ Service-Component:\
 
 	
 Private-Package: \
-  com.ibm.ws.collector.manager.internal*, \
-  com.ibm.ws.health.center.agent
+  com.ibm.ws.collector.manager.internal*
 
 Include-Resource: \
     META-INF/MessageRouter.properties=resources/MessageRouter.properties

--- a/dev/com.ibm.ws.transport.http/bnd.bnd
+++ b/dev/com.ibm.ws.transport.http/bnd.bnd
@@ -45,10 +45,11 @@ Export-Package: \
     com.ibm.ws.http.channel.h2internal.exceptions, \
     com.ibm.ws.http.channel.h2internal.hpack, \
     com.ibm.ws.http.channel.h2internal.huffman, \
+    com.ibm.ws.http.logging.source, \
     com.ibm.ws.http.logging.data
 
 Private-Package: \
-  com.ibm.ws.http.*, \
+	com.ibm.ws.http.*, \
 	com.ibm.ws.http.dispatcher*, \
 	com.ibm.ws.http.channel*, \
 	com.ibm.ws.http.logging.internal, \


### PR DESCRIPTION
Remove duplicate package exports from `com.ibm.ws.collector.manager` bundle (They are already exported from com.ibm.ws.logging):
-       com.ibm.wsspi.collector.manager
-       com.ibm.ws.health.center.data
-       com.ibm.ws.logging.ffdc.source

Remove redundant private-package from `com.ibm.ws.collector.manager` bundle:
-        com.ibm.ws.health.center.agent

Remove erroneous package exports from `com.ibm.ws.collector.manager` bundle:
-       com.ibm.ws.http.logging.source

Add necessary export package to `com.ibm.ws.transport.http`:
-    com.ibm.ws.http.logging.source

#build 
fixes #1542 