### PR TITLE
maxPolicy strict for managed completable future

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_rx/publish/servers/com.ibm.ws.concurrent.fat.rx/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_rx/publish/servers/com.ibm.ws.concurrent.fat.rx/server.xml
@@ -22,6 +22,11 @@
     
     <application location="concurrentrxfat.war" />
 
+    <!-- Do not change the concurrency policies associated with the following executors. Tests make assumptions based on this configuration -->
+
+    <managedScheduledExecutorService id="DefaultManagedScheduledExecutorService" concurrencyPolicyRef="strict1"/>
+    <concurrencyPolicy id="strict1" max="1" maxPolicy="strict" maxQueueSize="1" runIfQueueFull="true"/>
+
     <managedScheduledExecutorService id="noContextExecutor" jndiName="concurrent/noContextExecutor">
         <concurrencyPolicy max="2" maxQueueSize="2" runIfQueueFull="false"/>
         <contextService/>

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/BlockableIncrementFunction.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/BlockableIncrementFunction.java
@@ -96,4 +96,9 @@ public class BlockableIncrementFunction implements Function<Integer, Integer> {
                 executionThread = null;
         }
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + ' ' + testIdentifier;
+    }
 }


### PR DESCRIPTION
Add test coverage for managed completable future using a managed executor whose concurrency policy has a maxPolicy of strict.