### PR TITLE
autodetect Microsoft JDBC driver version 4.1 and above

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDrivers.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDrivers.java
@@ -76,8 +76,8 @@ public class JDBCDrivers {
                                 "com.microsoft.sqlserver.jdbc.SQLServerXADataSource"
         };
         classNamesByPID.put("com.ibm.ws.jdbc.dataSource.properties.microsoft.sqlserver", classes);
-        classNamesByKey.put("SQLJDBC4.JAR", classes);
-        classNamesByKey.put("SQLJDBC.JAR", classes);
+        classNamesByKey.put("MSSQL-JDBC", classes);
+        classNamesByKey.put("SQLJDBC", classes);
 
         // Informix JDBC driver
         classes = new String[] {


### PR DESCRIPTION
Pull fixes #1597
Update JDBC driver auto-detection so that Liberty can recognize the JAR files for v4.1 and above of the  Microsoft JDBC driver.