### PR TITLE
JSR375: fix ACEs in the JSR 375 FAT buckets.

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_helper/WCApplicationHelper.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_helper/WCApplicationHelper.java
@@ -105,7 +105,8 @@ public class WCApplicationHelper {
         String baseDir = DIR_PUBLISH + server.getServerName() + "/" + dir + "/";
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, earName);
         if (addEarResources) {
-            ear.addAsManifestResource(new File("test-applications/" + earName + "/resources/META-INF/application.xml"));
+            ShrinkHelper.addDirectory(ear, "test-applications/" + earName + "/resources");
+
         }
         for (String warFile : warFiles) {
             WebArchive war = ShrinkWrap.createFromZipFile(WebArchive.class, new File(baseDir +  warFile));
@@ -115,12 +116,12 @@ public class WCApplicationHelper {
     }
 
 
-    public static EnterpriseArchive createEar(LibertyServer server, String dir, String earName, boolean addEarResources) {
+    public static EnterpriseArchive createEar(LibertyServer server, String dir, String earName, boolean addEarResources) throws Exception {
         String baseDir = DIR_PUBLISH + server.getServerName() + "/" + dir + "/";
         LOG.info("createEar: dir : " + dir + ", earName : " + earName + ", includes resources : " + addEarResources);
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, earName);
         if (addEarResources) {
-            ear.addAsManifestResource(new File("test-applications/" + earName + "/resources/META-INF/application.xml"));
+            ShrinkHelper.addDirectory(ear, "test-applications/" + earName + "/resources");
         }
         return ear;
     }
@@ -222,8 +223,9 @@ public class WCApplicationHelper {
             LOG.info("addEarToServer : crteate ear " + earName + ", ear include application/.xml : " + addEarResources);
             EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, earName);
             ear.addAsModule(war);
-            if (addEarResources)
-                ear.addAsManifestResource(new File("test-applications/" + earName + "/resources/META-INF/application.xml"));
+            if (addEarResources) {
+                ShrinkHelper.addDirectory(ear, "test-applications/" + earName + "/resources");
+            }
             if (deploy) {
                 ShrinkHelper.exportToServer(server, dir, ear);
             } else {
@@ -236,6 +238,5 @@ public class WCApplicationHelper {
                 ShrinkHelper.exportArtifact(war, DIR_PUBLISH + server.getServerName() + "/" + dir);
             }
         }
-
     }
 }

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/AuthMechs.jar/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/AuthMechs.jar/resources/META-INF/permissions.xml
@@ -20,4 +20,20 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>modifyPrivateCredentials</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.enterprise.identitystore.IdentityStorePermission</class-name>
+      <name>getGroups</name>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/IdentityStores.jar/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/IdentityStores.jar/resources/META-INF/permissions.xml
@@ -20,4 +20,20 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>modifyPrivateCredentials</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.enterprise.identitystore.IdentityStorePermission</class-name>
+      <name>getGroups</name>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESec.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESec.war/resources/META-INF/permissions.xml
@@ -20,4 +20,16 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>java.util.PropertyPermission</class-name>
+      <name>org.glassfish.web.rfc2109_cookie_names_enforced</name>
+      <actions>read</actions>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecAnnotatedBasicAuthServlet.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecAnnotatedBasicAuthServlet.war/resources/META-INF/permissions.xml
@@ -20,4 +20,10 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecAnnotatedBasicAuthServletDeferred.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecAnnotatedBasicAuthServletDeferred.war/resources/META-INF/permissions.xml
@@ -20,4 +20,15 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>java.io.FilePermission</class-name>
+      <name>LdapSettingsBean.props</name>
+      <actions>read</actions>
+   </permission>
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecBasicAuthServlet.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecBasicAuthServlet.war/resources/META-INF/permissions.xml
@@ -20,4 +20,9 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecFormELTest.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecFormELTest.war/resources/META-INF/permissions.xml
@@ -20,4 +20,10 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleIS.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleIS.war/resources/META-INF/permissions.xml
@@ -20,4 +20,31 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>modifyPrivateCredentials</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.enterprise.identitystore.IdentityStorePermission</class-name>
+      <name>getGroups</name>
+   </permission>
+
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>getClassLoader</name>
+   </permission>
+
+   <permission>
+      <class-name>java.net.SocketPermission</class-name>
+      <name>*</name>
+      <actions>connect,resolve</actions>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleISCustomForm.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleISCustomForm.war/resources/META-INF/permissions.xml
@@ -20,4 +20,41 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>modifyPrivateCredentials</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.enterprise.identitystore.IdentityStorePermission</class-name>
+      <name>getGroups</name>
+   </permission>
+
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>getClassLoader</name>
+   </permission>
+
+   <permission>
+      <class-name>java.security.SecurityPermission</class-name>
+      <name>getProperty.authconfigprovider.factory</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>createLoginContext.system.WEB_INBOUND</name>
+   </permission>
+
+   <permission>
+      <class-name>java.net.SocketPermission</class-name>
+      <name>*</name>
+      <actions>connect,resolve</actions>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleISCustomFormPost.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleISCustomFormPost.war/resources/META-INF/permissions.xml
@@ -20,4 +20,41 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>modifyPrivateCredentials</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.enterprise.identitystore.IdentityStorePermission</class-name>
+      <name>getGroups</name>
+   </permission>
+
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>getClassLoader</name>
+   </permission>
+
+   <permission>
+      <class-name>java.security.SecurityPermission</class-name>
+      <name>getProperty.authconfigprovider.factory</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>createLoginContext.system.WEB_INBOUND</name>
+   </permission>
+
+   <permission>
+      <class-name>java.net.SocketPermission</class-name>
+      <name>*</name>
+      <actions>connect,resolve</actions>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleISForm.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleISForm.war/resources/META-INF/permissions.xml
@@ -20,4 +20,43 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>modifyPrivateCredentials</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.enterprise.identitystore.IdentityStorePermission</class-name>
+      <name>getGroups</name>
+   </permission>
+
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>getClassLoader</name>
+   </permission>
+
+   <permission>
+      <class-name>java.net.SocketPermission</class-name>
+      <name>*</name>
+      <actions>connect,resolve</actions>
+   </permission>
+
+   <permission>
+      <class-name>java.util.PropertyPermission</class-name>
+      <name>org.glassfish.web.rfc2109_cookie_names_enforced</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>java.util.PropertyPermission</class-name>
+      <name>line.separator</name>
+      <actions>read</actions>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleISForm2.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleISForm2.war/resources/META-INF/permissions.xml
@@ -20,4 +20,20 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>modifyPrivateCredentials</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.enterprise.identitystore.IdentityStorePermission</class-name>
+      <name>getGroups</name>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleISFormPost.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecMultipleISFormPost.war/resources/META-INF/permissions.xml
@@ -20,4 +20,20 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>modifyPrivateCredentials</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.enterprise.identitystore.IdentityStorePermission</class-name>
+      <name>getGroups</name>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecUnprotected.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecUnprotected.war/resources/META-INF/permissions.xml
@@ -20,4 +20,14 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>java.security.SecurityPermission</class-name>
+      <name>getProperty.authconfigprovider.factory</name>
+   </permission>
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEEsecFormAuth.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEEsecFormAuth.war/resources/META-INF/permissions.xml
@@ -20,4 +20,10 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEEsecFormAuthRedirect.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEEsecFormAuthRedirect.war/resources/META-INF/permissions.xml
@@ -20,4 +20,10 @@
       <name>wssecurity.getRunAsSubject</name>
    </permission>
 
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/multipleModule.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/multipleModule.ear/resources/META-INF/permissions.xml
@@ -4,9 +4,56 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
+    
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>wssecurity.getCallerSubject</name>
+   </permission>
+   
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>wssecurity.applicationReadCredential</name>
+   </permission>
+   
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>wssecurity.getRunAsSubject</name>
+   </permission>
 
    <permission>
-       <class-name>javax.security.auth.AuthPermission</class-name>
-       <name>wssecurity.getCallerSubject</name>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>modifyPrivateCredentials</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.enterprise.identitystore.IdentityStorePermission</class-name>
+      <name>getGroups</name>
+   </permission>
+
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>getClassLoader</name>
+   </permission>
+
+   <permission>
+      <class-name>java.security.SecurityPermission</class-name>
+      <name>getProperty.authconfigprovider.factory</name>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>createLoginContext.system.WEB_INBOUND</name>
+   </permission>
+
+   <permission>
+      <class-name>java.net.SocketPermission</class-name>
+      <name>*</name>
+      <actions>connect,resolve</actions>
    </permission>
 </permissions>

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/multipleModule2.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/multipleModule2.ear/resources/META-INF/permissions.xml
@@ -4,9 +4,42 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
+    
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>wssecurity.getCallerSubject</name>
+   </permission>
+   
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>wssecurity.applicationReadCredential</name>
+   </permission>
+   
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>wssecurity.getRunAsSubject</name>
+   </permission>
 
    <permission>
-       <class-name>javax.security.auth.AuthPermission</class-name>
-       <name>wssecurity.getCallerSubject</name>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>modifyPrivateCredentials</name>
    </permission>
+
+   <permission>
+      <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
+      <name>* * "*"</name>
+      <actions>read</actions>
+   </permission>
+
+   <permission>
+      <class-name>javax.security.enterprise.identitystore.IdentityStorePermission</class-name>
+      <name>getGroups</name>
+   </permission>
+
+   <permission>
+      <class-name>java.net.SocketPermission</class-name>
+      <name>*</name>
+      <actions>connect,resolve</actions>
+   </permission>
+
 </permissions>


### PR DESCRIPTION
When Java2 security is enabled, there are many JSR 375 FAT test buckets which reports ACEs. This pull request addresses the issue.