### PR TITLE
Work around file system issue

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/wsspi/kernel/embeddable/EmbeddedServerMergeProductExtensionTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/wsspi/kernel/embeddable/EmbeddedServerMergeProductExtensionTest.java
@@ -101,7 +101,11 @@ public class EmbeddedServerMergeProductExtensionTest {
         server.deleteDirectoryFromLibertyInstallRoot("../wlp_ext_products");
 
         // Restore the previous bootstrap.properties (if applicable)
-        server.renameLibertyServerRootFile("bootstrap.properties.restore", "bootstrap.properties");
+        if (server.fileExistsInLibertyServerRoot("bootstrap.properties.restore")) {
+            Log.info(c, "testCleanup", "Restoring old bootstrap.properties");
+            server.renameLibertyServerRootFile("bootstrap.properties", "bootstrap.properties.old");
+            server.renameLibertyServerRootFile("bootstrap.properties.restore", "bootstrap.properties");
+        }
     }
 
     @Test


### PR DESCRIPTION
Windows may be prevented from deleting a file because of an open file handle. 