### PR TITLE
Eclipse settings files updates

### DIFF
--- a/dev/com.ibm.ws.clientcontainer.json_fat/.classpath
+++ b/dev/com.ibm.ws.clientcontainer.json_fat/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/JsonbAppClient.jar/src"/>
 	<classpathentry kind="src" path="test-applications/JsonpAppClient.jar/src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.clientcontainer.json_fat/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.clientcontainer.json_fat/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.microprofile.config_fat_tck/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.config_fat_tck/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.microprofile.config_fat_tck/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.microprofile.config_fat_tck/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/.classpath
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="publish/tckRunner/tck/src"/>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/bnd.overrides
@@ -3,6 +3,8 @@ bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2
 
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
 Export-Package: \
   org.apache.cxf.microprofile.client;version="3.2.2",\
   org.apache.cxf.microprofile.client.cdi;version="3.2.2",\

--- a/dev/com.ibm.ws.security.javaeesec_fat/.classpath
+++ b/dev/com.ibm.ws.security.javaeesec_fat/.classpath
@@ -16,28 +16,5 @@
 	<classpathentry kind="src" path="test-applications/securityContextHamApp.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="lib" path="C:/Users/IBM_ADMIN/.m2/repository/javax/security/enterprise/javax.security.enterprise-api/1.0/javax.security.enterprise-api-1.0.jar">
-		<attributes>
-			<attribute name="bsn" value="javax.security.enterprise:javax.security.enterprise-api"/>
-			<attribute name="type" value="REPO"/>
-			<attribute name="project" value="com.ibm.websphere.javaee.security.1.0"/>
-			<attribute name="version" value="latest"/>
-		</attributes>
-		<accessrules>
-			<accessrule kind="accessible" pattern="javax/security/enterprise/*"/>
-			<accessrule kind="accessible" pattern="javax/security/enterprise/authentication/mechanism/http/*"/>
-			<accessrule kind="accessible" pattern="javax/security/enterprise/credential/*"/>
-			<accessrule kind="accessible" pattern="javax/security/enterprise/identitystore/*"/>
-			<accessrule ignoreifbetter="true" kind="discouraged" pattern="**"/>
-		</accessrules>
-	</classpathentry>
-	<classpathentry kind="lib" path="C:/Users/IBM_ADMIN/.m2/repository/javax/javaee-api/7.0/javaee-api-7.0.jar">
-		<attributes>
-			<attribute name="bsn" value="javax:javaee-api"/>
-			<attribute name="type" value="REPO"/>
-			<attribute name="project" value="com.ibm.ws.ejbcontainer_test"/>
-			<attribute name="version" value="7.0"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Add bndtool prefs for new components.
Add Java 8 settings to new Java 8 components.
Remove libraries from .classpath that are in the bnd file and had hard
coded path to a windows path.