### PR TITLE
Issue #1652:  Java 2 security error in ServerClasspathTest

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/test-applications/checkJvmAppClasspath/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/test-applications/checkJvmAppClasspath/resources/META-INF/permissions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+	
+   <permission>
+   		<class-name>java.lang.RuntimePermission</class-name>
+   		<name>*</name>
+   		<actions>*</actions>
+   	</permission>
+      
+</permissions>


### PR DESCRIPTION
Java 2 security error in com.ibm.ws.kernel.boot_fat for the ServerClasspathTest.

Adding a permissions.xml file for the test application to resolve the
problem.