### PR TITLE
pool manager must avoid caching values obtained from the managed connection factory

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2017 IBM Corporation and others.
+ * Copyright (c) 1997, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,7 @@ import com.ibm.ws.jca.adapter.PurgePolicy;
 import com.ibm.ws.jca.adapter.WSManagedConnectionFactory;
 import com.ibm.ws.jca.cm.AbstractConnectionFactoryService;
 import com.ibm.ws.jca.cm.AppDefinedResource;
+import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
@@ -95,7 +96,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
 
     private int recoveryToken;
 
-    protected transient SecurityHelper securityHelper = null;
+    private final transient SecurityHelper securityHelper;
     private final boolean isJDBC;
     private transient int commitPriority = 0;
     private boolean localTranSupportSet = false;
@@ -119,6 +120,16 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
     protected transient PoolManager _pm = null;
     protected J2CGlobalConfigProperties gConfigProps = null;
 
+    /*
+     * Indicates if the configured MCF is RRSTransactional. If so,
+     * transactions will be processed using z/OS Resource Recovery
+     * Services (RRS) instead of the transaction support indicated
+     * by the connector's Deployment descriptor.
+     *
+     * This property is applicable to WAS z/OS only.
+     */
+    private final boolean rrsTransactional;
+
     /**
      * @param cfSvc connection factory service
      * @param mcfXProps MCFExtendedProperties
@@ -130,8 +141,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
     ConnectionManager(AbstractConnectionFactoryService cfSvc,
                       PoolManager pm,
                       J2CGlobalConfigProperties gconfigProps,
-                      CommonXAResourceInfo jxri,
-                      SecurityHelper securityHelper) {
+                      CommonXAResourceInfo jxri) {
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.entry(this, tc, "<init>");
@@ -151,14 +161,28 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
 
         isJDBC = cfSvc.getClass().getName().startsWith("com.ibm.ws.jdbc.");
 
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+        int[] zosInfo = cfSvc.getThreadIdentitySecurityAndRRSSupport();
+        rrsTransactional = zosInfo[2] > 0;
 
+        // Indicates if the configured MCF requires an z/OS ACEE to be placed
+        // on the thread (TCB) when "current thread identity" is used for
+        // getConnection() processing.
+        boolean threadSecurity = zosInfo[1] > 0;
+
+        // Indicates if the configured MCF allows "current thread identity" to be used for getConnection() processing.
+        int threadIdentitySupport = zosInfo[0];
+
+        // If thread identity is enabled, a ThreadIdentitySecurityHelper; otherwise a DefaultSecurityHelper.
+        if (ThreadIdentityManager.isThreadIdentityEnabled() && threadIdentitySupport != AbstractConnectionFactoryService.THREAD_IDENTITY_NOT_ALLOWED)
+            securityHelper = new ThreadIdentitySecurityHelper(threadIdentitySupport, threadSecurity);
+        else
+            securityHelper = new DefaultSecurityHelper();
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(this, tc, " globalConfigProps " + gConfigProps);
             Tr.debug(this, tc, " jxri      " + jxri);
             Tr.debug(this, tc, " securityHelper " + securityHelper);
         }
-
-        this.securityHelper = securityHelper;
 
         containerManagedAuth = (cmConfig.getAuth() == J2CConstants.AUTHENTICATION_CONTAINER);
 
@@ -177,7 +201,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
 
         EmbeddableWebSphereTransactionManager tm = pm.connectorSvc.transactionManager;
         if (tm != null) {
-            if (!gConfigProps.rrsTransactional) {
+            if (!rrsTransactional) {
                 recoveryToken = registerXAResourceInfo(tm, jxri, commitPriority);
             } else {
                 if (!TransactionSupportLevel.NoTransaction.equals(gconfigProps.transactionSupport)) {
@@ -793,7 +817,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
                     // resource adapter supports neither resource manager nor JTA transactions
                     case NoTransaction:
 
-                        if (!mcWrapper.gConfigProps.rrsTransactional) { // No RRS-coordinated transaction support
+                        if (!rrsTransactional) { // No RRS-coordinated transaction support
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                 if (uowCoord.isGlobal()) {
                                     Tr.debug(this, tc, "Creating NoTransactionWrapper for use in Global Transaction. RA supports No Transaction.");
@@ -818,7 +842,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
                                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                         Tr.debug(this, tc, "Creating LocalTransactionWrapper for use in Local Transaction under RRSTransactional adapter.");
                                     }
-                                    wrapper = mcWrapper.getLocalTransactionWrapper(mcWrapper.gConfigProps.rrsTransactional);
+                                    wrapper = mcWrapper.getLocalTransactionWrapper(rrsTransactional);
                                 } else { // not CICS ECI resource adapter
                                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                         Tr.debug(this, tc, "Creating RRSLocalTransactionWrapper for use in Local Transaction under RRSTransactional adapter.");
@@ -833,7 +857,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
                     // resource adapter supports resource manager local transactios
                     case LocalTransaction:
 
-                        if (!mcWrapper.gConfigProps.rrsTransactional) { // No RRS-coordinated transaction support
+                        if (!rrsTransactional) { // No RRS-coordinated transaction support
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                 if (uowCoord.isGlobal()) { // global transaction scope
                                     Tr.debug(this, tc, "Creating LocalTransactionWrapper for use in Global Transaction. RA supports Local Transaction.");
@@ -862,7 +886,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
                                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                         Tr.debug(this, tc, "Creating LocalTransactionWrapper for use in Local Transaction under RRSTransactional adapter.");
                                     }
-                                    wrapper = mcWrapper.getLocalTransactionWrapper(mcWrapper.gConfigProps.rrsTransactional);
+                                    wrapper = mcWrapper.getLocalTransactionWrapper(rrsTransactional);
                                 } else { // not CICS ECI resource adapter
                                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                         Tr.debug(this, tc, "Creating RRSLocalTransactionWrapper for use in Local Transaction under RRSTransactional adapter.");
@@ -877,7 +901,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
                     // resource adapter supports both resource manager local and JTA transactions
                     case XATransaction:
 
-                        if (!mcWrapper.gConfigProps.rrsTransactional) { // No RRS-coordinated transaction support
+                        if (!rrsTransactional) { // No RRS-coordinated transaction support
                             if (uowCoord.isGlobal()) { // global transaction scope
                                 if (isJDBC && mcWrapper.getManagedConnection().getXAResource() instanceof com.ibm.tx.jta.OnePhaseXAResource) {
                                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -915,7 +939,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
                                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                         Tr.debug(this, tc, "Creating LocalTransactionWrapper for use in Local Transaction under RRSTransactional adapter.");
                                     }
-                                    wrapper = mcWrapper.getLocalTransactionWrapper(mcWrapper.gConfigProps.rrsTransactional);
+                                    wrapper = mcWrapper.getLocalTransactionWrapper(rrsTransactional);
                                 } else { // Not CICS ECI resource adapter
                                     wrapper = mcWrapper.getRRSLocalTransactionWrapper();
                                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -996,7 +1020,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
                         //  necessary to track states via the enlistment, and this needs to be done as soon as
                         //  the connection is obtained
 
-                        if (!mcWrapper.gConfigProps.isDynamicEnlistmentSupported() || mcWrapper.gConfigProps.rrsTransactional) {
+                        if (!mcWrapper.gConfigProps.isDynamicEnlistmentSupported() || rrsTransactional) {
 
                             wrapper.enlist();
                             enlisted = true;

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
@@ -62,39 +62,6 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
     protected final String cfName; // The jndi name if there is one, if not the base of the xpath id.
                                    // Used for jca.cm messages, not passed out externally.
 
-    /*
-     * Indicates if the configured MCF is RRSTransactional. If so,
-     * transactions will be processed using z/OS Resource Recovery
-     * Services (RRS) instead of the transaction support indicated
-     * by the connector's Deployment descriptor.
-     *
-     * This property is applicable to WAS z/OS only.
-     */
-    protected final boolean rrsTransactional;
-
-    /*
-     * Indicates if the configured MCF requires an z/OS ACEE to be placed
-     * on the thread (TCB) when "current thread identity" is used for
-     * getConnection() processing.
-     *
-     * This property is applicable to WAS z/OS only.
-     */
-    protected final boolean threadSecurity;
-
-    /*
-     * Indicates if the configured MCF allows "current thread identity"
-     * to be used for getConnection() processing.
-     *
-     * This property may be set to "NOTALLOWED", "REQUIRED", or
-     * "ALLOWED".
-     *
-     * This property is applicable to WAS z/OS only.
-     */
-    static final String THREADIDENTITY_NOTALLOWED = "NOTALLOWED";
-    static final String THREADIDENTITY_REQUIRED = "REQUIRED";
-    static final String THREADIDENTITY_ALLOWED = "ALLOWED";
-
-    protected final String threadIdentitySupport;
     protected final boolean logMissingTranContext;
 
     protected final boolean validatingMCFSupported;
@@ -425,9 +392,6 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
         }
 
         dynamicEnlistmentSupported = false; // Will become true later if managed connection implements LazyEnlistableManagedConnection
-        this.rrsTransactional = cfSvc.getRRSTransactional();
-        this.threadSecurity = cfSvc.getThreadSecurity();
-        this.threadIdentitySupport = cfSvc.getThreadIdentitySupport();
         this.logMissingTranContext = _logMissingTranContext;
         this.transactionSupport = cfSvc.getTransactionSupport();
         this.smartHandleSupport = false; // Will become true later if managed connection implements DissociatableManagedConnection
@@ -884,9 +848,6 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
         buf.append(nl + "  <-- Read Only -->" + nl);
         buf.append("  jndiName                        : " + jndiName + nl);
         buf.append("  transactionResourceRegistration : " + transactionResourceRegistration + nl);
-        buf.append("  rrsTransactional                : " + rrsTransactional + nl);
-        buf.append("  threadSecurity                  : " + threadSecurity + nl);
-        buf.append("  threadIdentitySupport           : " + threadIdentitySupport + nl);
         buf.append("  cciLocalTranSupported           : " + cciLocalTranSupported + nl);
         buf.append("  logMissingTranContext           : " + logMissingTranContext + nl);
         buf.append("  embeddedRa                      : " + embeddedRa + nl);

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ThreadIdentitySecurityHelper.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ThreadIdentitySecurityHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.j2c.SecurityHelper;
+import com.ibm.ws.jca.cm.AbstractConnectionFactoryService;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityException;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 
@@ -157,7 +158,7 @@ import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
  */
 public class ThreadIdentitySecurityHelper implements SecurityHelper {
     private final boolean m_ThreadSecurity;
-    private String m_ThreadIdentitySupport = null;
+    private final int m_ThreadIdentitySupport;
 
     private static TraceComponent tc = Tr.register(ThreadIdentitySecurityHelper.class,
                                                    J2CConstants.traceSpec,
@@ -165,10 +166,8 @@ public class ThreadIdentitySecurityHelper implements SecurityHelper {
 
     /**
      * Constructor for ThreadIdentitySecurityHelper
-     *
-     * @param WSManagedConnectionFactory
      */
-    public ThreadIdentitySecurityHelper(String threadIdentitySupport, boolean threadSecurity) throws ResourceException {
+    public ThreadIdentitySecurityHelper(int threadIdentitySupport, boolean threadSecurity) {
 
         if (tc.isEntryEnabled())
             Tr.entry(this, tc, "<init>", threadIdentitySupport, threadSecurity);
@@ -307,8 +306,7 @@ public class ThreadIdentitySecurityHelper implements SecurityHelper {
             // supports using ThreadIdentity. If so, continue processing.
             // Otherwise get out.
 
-            if ((m_ThreadIdentitySupport.equals(J2CGlobalConfigProperties.THREADIDENTITY_ALLOWED)) ||
-                (m_ThreadIdentitySupport.equals(J2CGlobalConfigProperties.THREADIDENTITY_REQUIRED))) {
+            if ((m_ThreadIdentitySupport != AbstractConnectionFactoryService.THREAD_IDENTITY_NOT_ALLOWED)) {
 
                 if (subj != null) {
                     // resauth = CONTAINER
@@ -519,7 +517,7 @@ public class ThreadIdentitySecurityHelper implements SecurityHelper {
         if (cmConfigData.getAuth() == J2CConstants.AUTHENTICATION_CONTAINER) {
             // resauth=Container, so continue.
 
-            if (m_ThreadIdentitySupport.equals(J2CGlobalConfigProperties.THREADIDENTITY_ALLOWED)) {
+            if (m_ThreadIdentitySupport == AbstractConnectionFactoryService.THREAD_IDENTITY_ALLOWED) {
 
                 // The current resource adapter MCF Configuration supports
                 // using ThreadIdentity.
@@ -550,7 +548,7 @@ public class ThreadIdentitySecurityHelper implements SecurityHelper {
                     }
                 }
 
-            } else if (m_ThreadIdentitySupport.equals(J2CGlobalConfigProperties.THREADIDENTITY_REQUIRED)) {
+            } else if (m_ThreadIdentitySupport == AbstractConnectionFactoryService.THREAD_IDENTITY_REQUIRED) {
 
                 // The connector this helper is associated with
                 // always requires that the user associated with
@@ -869,7 +867,7 @@ public class ThreadIdentitySecurityHelper implements SecurityHelper {
 
         // Check if ThreadIdentitySupport is "REQUIRED"
 
-        if (m_ThreadIdentitySupport.equals(J2CGlobalConfigProperties.THREADIDENTITY_REQUIRED)) {
+        if (m_ThreadIdentitySupport == AbstractConnectionFactoryService.THREAD_IDENTITY_REQUIRED) {
 
             // ThreadIdentitySupport indicates that the use of thread
             // identity is "REQUIRED" by the connector, but the

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/AbstractConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/AbstractConnectionFactoryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 IBM Corporation and others.
+ * Copyright (c) 2012, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,6 +67,13 @@ public abstract class AbstractConnectionFactoryService implements Observer, Reso
 
     private static final Pattern DEFAULT_NESTED_PATTERN = Pattern.compile(".*(\\[default-\\d*\\])$");
     private static final Pattern DEFAULT_PATTERN = Pattern.compile("(default-\\d*)$");
+
+    /**
+     * Thread identity support constants.
+     */
+    public static final int THREAD_IDENTITY_NOT_ALLOWED = 0,
+                    THREAD_IDENTITY_ALLOWED = 1,
+                    THREAD_IDENTITY_REQUIRED = 2;
 
     /**
      * Set of names of applications that have accessed this connection factory
@@ -338,34 +345,21 @@ public abstract class AbstractConnectionFactoryService implements Observer, Reso
     }
 
     /**
-     * Indicates whether or not this managed connection factory is RRS-enabled.
-     * Prerequisite: invoker must ensure this instance has been initialized when this method is invoked.
-     *
-     * @return true if RRS-enabled, otherwise false.
-     */
-    public abstract boolean getRRSTransactional();
-
-    /**
-     * Indicates whether or not this managed connection factory supports thread identity.
-     * Prerequisite: invoker must ensure this instance has been initialized when this method is invoked.
-     *
-     * @return Thread Identity Support: Either "ALLOWED", "REQUIRED", or "NOTALLOWED"
-     */
-    public String getThreadIdentitySupport() {
-        return "NOTALLOWED";
-    }
-
-    /**
-     * Indicates whether or not we should "synch to thread" for the
+     * Indicates whether or not thread identity, sync-to-thread, and RRS transactions are supported.
+     * The result is a 3 element array, of which,
+     * <ul>
+     * <li>The first element indicates support for thread identity. 2=REQUIRED, 1=ALLOWED, 0=NOT ALLOWED.</li>
+     * <li>The second element indicates support for "synch to thread" for the
      * allocateConnection, i.e., push an ACEE corresponding to the current java
-     * Subject on the native OS thread.
+     * Subject on the native OS thread. 1=supported, 0=not supported.</li>
+     * <li>The third element indicates support for RRS transactions. 1=supported, 0=not supported.</li>
+     * </ul>
+     *
      * Prerequisite: invoker must ensure this instance has been initialized when this method is invoked.
      *
-     * @return true if we should "synch to thread", otherwise false.
+     * @return boolean array indicating whether or not each of the aforementioned capabilities are supported.
      */
-    public boolean getThreadSecurity() {
-        return false;
-    }
+    public abstract int[] getThreadIdentitySecurityAndRRSSupport();
 
     /**
      * Indicates the level of transaction support.

--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 IBM Corporation and others.
+ * Copyright (c) 2011, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -287,17 +287,34 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
         return Boolean.TRUE.equals(bootstrapContextRef.getReference().getProperty(REAUTHENTICATION_SUPPORT));
     }
 
+    /**
+     * Indicates whether or not thread identity, sync-to-thread, and RRS transactions are supported.
+     * The result is a 3 element array, of which,
+     * <ul>
+     * <li>The first element indicates support for thread identity. 2=REQUIRED, 1=ALLOWED, 0=NOT ALLOWED.</li>
+     * <li>The second element indicates support for "synch to thread" for the
+     * allocateConnection, i.e., push an ACEE corresponding to the current java
+     * Subject on the native OS thread. 1=supported, 0=not supported.</li>
+     * <li>The third element indicates support for RRS transactions. 1=supported, 0=not supported.</li>
+     * </ul>
+     *
+     * Prerequisite: invoker must ensure this instance has been initialized when this method is invoked.
+     *
+     * @return boolean array indicating whether or not each of the aforementioned capabilities are supported.
+     */
     @Override
     @FFDCIgnore(NoSuchMethodException.class)
-    public boolean getRRSTransactional() {
+    public int[] getThreadIdentitySecurityAndRRSSupport() {
+        int rrsTransactional = 0;
         try {
-            return (Boolean) mcf.getClass().getMethod("getRRSTransactional").invoke(mcf);
+            if (Boolean.TRUE.equals(mcf.getClass().getMethod("getRRSTransactional").invoke(mcf)))
+                rrsTransactional = 1;
         } catch (NoSuchMethodException x) {
-            return false;
         } catch (Exception x) {
-            FFDCFilter.processException(x, getClass().getName(), "296", new Object[] { mcf.getClass() });
-            return false;
+            FFDCFilter.processException(x, getClass().getName(), "327", new Object[] { mcf.getClass() });
         }
+
+        return new int[] { 0, 0, rrsTransactional };
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -235,7 +235,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                     ClassLoader loader, origTCCL = Thread.currentThread().getContextClassLoader();
                     try {
                         if (classloader == null)
-                            loader = origTCCL; // Use thread context class loader of appliaction in absence of server configured library
+                            loader = origTCCL; // Use thread context class loader of application in absence of server configured library
                         else
                             Thread.currentThread().setContextClassLoader(loader = classloader);
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2Helper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2Helper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2017 IBM Corporation and others.
+ * Copyright (c) 2003, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.Transaction.UOWCoordinator;
 import com.ibm.ws.Transaction.UOWCurrent;
+import com.ibm.ws.jca.cm.AbstractConnectionFactoryService;
 import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.DSConfig;
@@ -51,7 +52,7 @@ public class DB2Helper extends DatabaseHelper {
     private String currentSQLid = null;
     String osType;
     boolean isRRSTransaction = false;
-    String threadIdentitySupport = THREAD_IDENTITY_SUPPORT_NOTALLOWED;
+    int threadIdentitySupport = AbstractConnectionFactoryService.THREAD_IDENTITY_NOT_ALLOWED;
     boolean threadSecurity = false;
     boolean localZOS = false;
     String productName = null;
@@ -82,7 +83,7 @@ public class DB2Helper extends DatabaseHelper {
         // flag. therefore, it is saved to use this flag to indicate that this is a zOS database.
         if (localZOS) {
             isRRSTransaction = true;
-            threadIdentitySupport = THREAD_IDENTITY_SUPPORT_ALLOWED;
+            threadIdentitySupport = AbstractConnectionFactoryService.THREAD_IDENTITY_ALLOWED;
             threadSecurity = true;
         }
 
@@ -203,13 +204,10 @@ public class DB2Helper extends DatabaseHelper {
     }
 
     /**
-     * Feature WS14621 
-     * 
      * @return string to indicate whether the DataSource allows Thread Identity Support.
      */
     @Override
-    public String getThreadIdentitySupport() {
-        //return THREAD_IDENTITY_SUPPORT_ALLOWED;
+    public int getThreadIdentitySupport() {
         return threadIdentitySupport; 
     }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2017 IBM Corporation and others.
+ * Copyright (c) 2003, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,6 +41,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.jca.adapter.WSConnectionManager;
+import com.ibm.ws.jca.cm.AbstractConnectionFactoryService;
 import com.ibm.ws.jdbc.internal.PropertyService;
 import com.ibm.ws.kernel.service.util.PrivHelper;
 import com.ibm.ws.resource.ResourceRefInfo;
@@ -126,7 +127,7 @@ public class DB2JCCHelper extends DB2Helper {
                            -1776);
 
         isRRSTransaction = false;
-        threadIdentitySupport = THREAD_IDENTITY_SUPPORT_NOTALLOWED;
+        threadIdentitySupport = AbstractConnectionFactoryService.THREAD_IDENTITY_NOT_ALLOWED;
         threadSecurity = false;
         boolean traceAppend = false;
         String traceDir = null;
@@ -161,7 +162,7 @@ public class DB2JCCHelper extends DB2Helper {
                 throw new ResourceException(AdapterUtil.getNLSMessage("DB2ZOS_TYPE2_ERROR"));
             } else if (dsClassName.equals("com.ibm.db2.jcc.DB2ConnectionPoolDataSource")) {
                 isRRSTransaction = true;
-                threadIdentitySupport = THREAD_IDENTITY_SUPPORT_ALLOWED;
+                threadIdentitySupport = AbstractConnectionFactoryService.THREAD_IDENTITY_ALLOWED;
                 threadSecurity = true;
                 Tr.info(tc, "DB2ZOS_CONFIG_INFO");
             }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
@@ -20,6 +20,7 @@ import java.sql.SQLWarning;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jca.cm.AbstractConnectionFactoryService;
 import com.ibm.ws.rsadapter.AdapterUtil;
 
 import java.util.Collections;
@@ -61,7 +62,7 @@ public class DB2iToolboxHelper extends DB2Helper {
 
         localZOS = false;
         isRRSTransaction = false;
-        threadIdentitySupport = THREAD_IDENTITY_SUPPORT_NOTALLOWED;
+        threadIdentitySupport = AbstractConnectionFactoryService.THREAD_IDENTITY_NOT_ALLOWED;
         threadSecurity = false;
 
         Properties props = mcf.dsConfig.get().vendorProps;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2017 IBM Corporation and others.
+ * Copyright (c) 2003, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.jca.adapter.WSConnectionManager;
+import com.ibm.ws.jca.cm.AbstractConnectionFactoryService;
 import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.DSConfig;
@@ -58,11 +59,6 @@ import com.ibm.ws.rsadapter.jdbc.WSJdbcStatement;
  * This class may be subclassed as needed for databases requiring different behavior.
  */
 public class DatabaseHelper {
-    // Thread identity support constants.
-    static final String THREAD_IDENTITY_SUPPORT_ALLOWED = "ALLOWED",
-                    THREAD_IDENTITY_SUPPORT_REQUIRED = "REQUIRED",
-                    THREAD_IDENTITY_SUPPORT_NOTALLOWED = "NOTALLOWED";
-
     // register the generic database trace needed for enabling database jdbc logging/tracing
     @SuppressWarnings("deprecation")
     private static final com.ibm.ejs.ras.TraceComponent databaseTc = com.ibm.ejs.ras.Tr.register("com.ibm.ws.database.logwriter", "WAS.database", null); 
@@ -300,8 +296,8 @@ public class DatabaseHelper {
      * @return "NOTALLOWED", assuming a generic DataSource does not allow Thread Identity
      *         Support.
      */
-    public String getThreadIdentitySupport() {
-        return THREAD_IDENTITY_SUPPORT_NOTALLOWED;
+    public int getThreadIdentitySupport() {
+        return AbstractConnectionFactoryService.THREAD_IDENTITY_NOT_ALLOWED;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2017 IBM Corporation and others.
+ * Copyright (c) 1997, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -66,6 +66,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.FFDCSelfIntrospectable;
 import com.ibm.ws.jca.adapter.WSConnectionManager;
 import com.ibm.ws.jca.adapter.WSManagedConnectionFactory;
+import com.ibm.ws.jca.cm.AbstractConnectionFactoryService;
 import com.ibm.ws.jca.cm.ConnectorService;
 import com.ibm.ws.jdbc.internal.PropertyService;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
@@ -514,11 +515,10 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
             // checks for Basic Password Credential and for Kerberos  
             // will be skipped.                                       
 
-            String threadIdentitySupport = helper.getThreadIdentitySupport();
+            int threadIdentitySupport = helper.getThreadIdentitySupport();
             boolean subjectHasUtokenCred = false; 
 
-            if ((threadIdentitySupport.equals("ALLOWED")) || 
-                (threadIdentitySupport.equals("REQUIRED"))) 
+            if (threadIdentitySupport != AbstractConnectionFactoryService.THREAD_IDENTITY_NOT_ALLOWED) 
             {
                 if (isAnyTraceOn && tc.isDebugEnabled())
                     Tr.debug(this, tc, "The JDBC Provider supports the use of Thread Identity for authentication."); 
@@ -575,9 +575,7 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
                         break;
                     }
                 }
-                if ((!subjectHasUtokenCred) && 
-                    (threadIdentitySupport.equals("REQUIRED"))) 
-                {
+                if (!subjectHasUtokenCred && threadIdentitySupport == AbstractConnectionFactoryService.THREAD_IDENTITY_REQUIRED) {
                     String message = "createManagedConnection() error: Jdbc Provider requires ThreadIdentitySupport, but no UTOKEN generic credential was found."; 
 
                     ResourceException resX = new DataStoreAdapterException("WS_INTERNAL_ERROR", null, getClass(), message);


### PR DESCRIPTION
The following values are being obtained from the managed connection factory and cached in the pool manager properties,
rrsTransactional
threadIdentitySupport
threadSecurity

The pool manager needs to stop depending on a particular managed connection factory so that it will be possible in later changes to allow loading the JDBC driver from the application, so I'm refactoring these.  The last two don't need to be cached in the JCA layer at all.  All of these can be kept on the connection manager instance (or its SecurityHelper), which is safe because a single com.ibm.ejs.j2c.ConnectionManager instance (different from connectionManager config element) will not be shared across managed connection factories.