### PR TITLE
Add new package to list of expected JVM packages

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
@@ -43,7 +43,7 @@ public class ServerClasspathTest {
                                                         "org.omg.CORBA", "com.sun", "org.xml.sax", "com.ibm.jit",
                                                         "com.ibm.jsse2", "com.ibm.lang.management", "com.ibm.tools.attach",
                                                         "com.ibm.virtualization.management", "com.ibm.wsspi.kernel",
-                                                        "com.ibm.ws.staticvalue",
+                                                        "com.ibm.ws.staticvalue", "com.ibm.java.lang.management.internal",
                                                         "jdk." // Java 9
     };
 


### PR DESCRIPTION
While upgrading to a newer version of JDK 8, a new package was added to
the JDK that can be loaded by JDK's classpath.  The ServerClasspathTest
checks for all known packages on the JDK classpath to ensure we're not
adding anything that we shouldn't - so this new package needs to be
added to the "expected list" in the test:
 com.ibm.java.lang.management.internal