### PR TITLE
decouple DSConfig from managed connection factory

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/AbstractConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/AbstractConnectionFactoryService.java
@@ -275,6 +275,8 @@ public abstract class AbstractConnectionFactoryService implements Observer, Reso
     /**
      * Returns the managed connection factory.
      *
+     * Prerequisite: the invoker must hold a read or write lock on this connection factory service instance.
+     *
      * @return the managed connection factory.
      */
     public abstract ManagedConnectionFactory getManagedConnectionFactory();
@@ -355,7 +357,7 @@ public abstract class AbstractConnectionFactoryService implements Observer, Reso
      * <li>The third element indicates support for RRS transactions. 1=supported, 0=not supported.</li>
      * </ul>
      *
-     * Prerequisite: invoker must ensure this instance has been initialized when this method is invoked.
+     * Prerequisite: the invoker must hold a read or write lock on this connection factory service instance.
      *
      * @return boolean array indicating whether or not each of the aforementioned capabilities are supported.
      */

--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
@@ -268,6 +268,8 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
     /**
      * Returns the managed connection factory.
      *
+     * Prerequisite: the invoker must hold a read or write lock on this connection factory service instance.
+     *
      * @return the managed connection factory.
      */
     @Override
@@ -298,7 +300,7 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
      * <li>The third element indicates support for RRS transactions. 1=supported, 0=not supported.</li>
      * </ul>
      *
-     * Prerequisite: invoker must ensure this instance has been initialized when this method is invoked.
+     * Prerequisite: the invoker must hold a read or write lock on this connection factory service instance.
      *
      * @return boolean array indicating whether or not each of the aforementioned capabilities are supported.
      */

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -283,14 +283,7 @@ META_DATA_EXCEPTION=DSRA7018I: Database metadata access caused a non-stale conne
 META_DATA_EXCEPTION.explanation=An exception occurred when the Application Server was trying to get or access the metadata object for the database.
 META_DATA_EXCEPTION.useraction=Verify that the metadata is enabled on the backend database.
 
-# 7019-7039 deleted
-
-# DSRA7040I	WAS_CONNECTION_POOLING_DISABLED_INFO
-WAS_CONNECTION_POOLING_DISABLED_INFO=DSRA7040I: The application server has disabled internal connection pooling.
-WAS_CONNECTION_POOLING_DISABLED_INFO.explanation=The application server has detected the enablement of connection caching through the database. Connection pooling in the application server will be disabled.
-WAS_CONNECTION_POOLING_DISABLED_INFO.useraction=If you do not want to disable connection pooling in the application server, disable connection pooling for the database server.
-
-# 7041-7042 deleted
+# 7019-7042 deleted
 # 7600-7606 deleted
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
As the next step in working towards allowing JDBC drivers to be loaded from the application, decouple DSConfig from WSManagedConnectionFactoryImpl such that we will be able to construct a different managed connection factory instance per class loader.

In one of these changes, I came across DSConfig using the managed connection factory to check if UCP (which isn't supported in Liberty) was enabled in unreachable codepath (because metatype always sets a value) that tries to default the _statement cache_ to disabled, and then, in other codepath logs a message which erroneously claims that Liberty is automatically disabling its _connection pooling_ due to detecting UCP.  I deleted this portion of the code, as it is incorrect.  If support is ever added for UCP, a better approach would include documenting the settings available that the user can use to disable connection pooling and/or statement caching if that is advantageous.