### PR TITLE
use different managed connection factory per application

### DIFF
--- a/dev/com.ibm.ws.jca.cm/bnd.bnd
+++ b/dev/com.ibm.ws.jca.cm/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2018 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -56,6 +56,7 @@ Service-Component: \
     provide:='com.ibm.ws.jca.cm.ConnectorService'; \
     configuration-policy:=ignore; \
     authDataService=com.ibm.ws.security.jca.AuthDataService; \
+    classLoaderIdentifierService=com.ibm.ws.classloading.ClassLoaderIdentifierService; \
     configAdmin=org.osgi.service.cm.ConfigurationAdmin; \
     deferrableScheduledExecutor=java.util.concurrent.ScheduledExecutorService; \
     executor=java.util.concurrent.ExecutorService; \
@@ -75,6 +76,7 @@ instrument.disabled: true
 	com.ibm.websphere.javaee.connector.1.6;version=latest,\
 	com.ibm.ws.javaee.dd.common;version=latest,\
 	com.ibm.ws.kernel.service,\
+	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.resource;version=latest,\
 	com.ibm.ws.tx.embeddable;version=latest,\

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
@@ -161,7 +161,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
 
         isJDBC = cfSvc.getClass().getName().startsWith("com.ibm.ws.jdbc.");
 
-        int[] zosInfo = cfSvc.getThreadIdentitySecurityAndRRSSupport();
+        int[] zosInfo = cfSvc.getThreadIdentitySecurityAndRRSSupport(null); // TODO supply identifier on XA recovery path?
         rrsTransactional = zosInfo[2] > 0;
 
         // Indicates if the configured MCF requires an z/OS ACEE to be placed

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectorServiceImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 IBM Corporation and others.
+ * Copyright (c) 2011, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import org.osgi.service.component.ComponentContext;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.classloading.ClassLoaderIdentifierService;
 import com.ibm.ws.jca.cm.ConnectorService;
 import com.ibm.ws.security.jca.AuthDataService;
 import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
@@ -29,10 +30,10 @@ import com.ibm.wsspi.kernel.service.utils.OnErrorUtil.OnError;
 
 /**
  * Provides access to services needed by various parts of J2C/RRA code.
- * 
+ *
  * A declarative services component can be completely POJO based
  * (no awareness/use of OSGi services).
- * 
+ *
  * OSGi methods (activate/deactivate) should be protected.
  */
 public class ConnectorServiceImpl extends ConnectorService {
@@ -41,32 +42,32 @@ public class ConnectorServiceImpl extends ConnectorService {
     /**
      * Auth data service.
      */
-    public final AtomicServiceReference<AuthDataService> authDataServiceRef =
-                    new AtomicServiceReference<AuthDataService>("authDataService");
+    public final AtomicServiceReference<AuthDataService> authDataServiceRef = new AtomicServiceReference<AuthDataService>("authDataService");
+
+    /**
+     * Class loader identifier service.
+     */
+    private ClassLoaderIdentifierService classLoaderIdentifierService;
 
     /**
      * Scheduled executor service for deferrable alarms.
      */
-    final AtomicServiceReference<ScheduledExecutorService> deferrableSchedXSvcRef =
-                    new AtomicServiceReference<ScheduledExecutorService>("deferrableScheduledExecutor");
+    final AtomicServiceReference<ScheduledExecutorService> deferrableSchedXSvcRef = new AtomicServiceReference<ScheduledExecutorService>("deferrableScheduledExecutor");
 
     /**
      * Executor service for PoolManager.
      */
-    final AtomicServiceReference<ExecutorService> execSvcRef =
-                    new AtomicServiceReference<ExecutorService>("executor");
+    final AtomicServiceReference<ExecutorService> execSvcRef = new AtomicServiceReference<ExecutorService>("executor");
 
     /**
      * Scheduled executor service for non-deferrable alarms.
      */
-    final AtomicServiceReference<ScheduledExecutorService> nonDeferrableSchedXSvcRef =
-                    new AtomicServiceReference<ScheduledExecutorService>("nonDeferrableScheduledExecutor");
+    final AtomicServiceReference<ScheduledExecutorService> nonDeferrableSchedXSvcRef = new AtomicServiceReference<ScheduledExecutorService>("nonDeferrableScheduledExecutor");
 
     /**
      * RRS XA resource factory service reference.
      */
-    final AtomicServiceReference<Object> rrsXAResFactorySvcRef =
-                    new AtomicServiceReference<Object>("rRSXAResourceFactory");
+    final AtomicServiceReference<Object> rrsXAResFactorySvcRef = new AtomicServiceReference<Object>("rRSXAResourceFactory");
 
     /**
      * Transaction manager service reference.
@@ -76,13 +77,12 @@ public class ConnectorServiceImpl extends ConnectorService {
     /**
      * Variable registry service reference.
      */
-    private final AtomicServiceReference<VariableRegistry> variableRegistrySvcRef =
-                    new AtomicServiceReference<VariableRegistry>("variableRegistry");
+    private final AtomicServiceReference<VariableRegistry> variableRegistrySvcRef = new AtomicServiceReference<VariableRegistry>("variableRegistry");
 
     /**
      * Declarative Services method to activate this component.
      * Best practice: this should be a protected method, not public or private
-     * 
+     *
      * @param context context for this component
      */
     protected void activate(ComponentContext context) {
@@ -99,7 +99,7 @@ public class ConnectorServiceImpl extends ConnectorService {
     /**
      * Declarative Services method to deactivate this component.
      * Best practice: this should be a protected method, not public or private
-     * 
+     *
      * @param context context for this component
      */
     protected void deactivate(ComponentContext context) {
@@ -111,6 +111,11 @@ public class ConnectorServiceImpl extends ConnectorService {
         nonDeferrableSchedXSvcRef.deactivate(context);
         rrsXAResFactorySvcRef.deactivate(context);
         variableRegistrySvcRef.deactivate(context);
+    }
+
+    @Override
+    public final ClassLoaderIdentifierService getClassLoaderIdentifierService() {
+        return classLoaderIdentifierService;
     }
 
     @Override
@@ -132,7 +137,7 @@ public class ConnectorServiceImpl extends ConnectorService {
      * Utility method that gets the onError setting.
      * This method should be invoked every time it is needed in order to allow for
      * changes to the onError setting.
-     * 
+     *
      * @return the onError setting if configured. Otherwise the default value.
      */
     private final OnError ignoreWarnOrFail(TraceComponent tc) {
@@ -154,7 +159,7 @@ public class ConnectorServiceImpl extends ConnectorService {
      * Ignore, warn, or fail when a configuration error occurs.
      * This is copied from Tim's code in tWAS and updated slightly to
      * override with the Liberty ignore/warn/fail setting.
-     * 
+     *
      * @param tc the TraceComponent from where the message originates
      * @param throwable an already created Throwable object, which can be used if the desired action is fail.
      * @param exceptionClassToRaise the class of the Throwable object to return
@@ -199,7 +204,7 @@ public class ConnectorServiceImpl extends ConnectorService {
 
     /**
      * Declarative Services method for setting the AuthDataService reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void setAuthDataService(ServiceReference<AuthDataService> ref) {
@@ -209,8 +214,17 @@ public class ConnectorServiceImpl extends ConnectorService {
     }
 
     /**
+     * Declarative Services method for setting the class loader identifier service
+     *
+     * @param svc the service
+     */
+    protected void setClassLoaderIdentifierService(ClassLoaderIdentifierService svc) {
+        classLoaderIdentifierService = svc;
+    }
+
+    /**
      * Declarative Services method for setting the deferrable scheduled executor service reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void setDeferrableScheduledExecutor(ServiceReference<ScheduledExecutorService> ref) {
@@ -221,7 +235,7 @@ public class ConnectorServiceImpl extends ConnectorService {
 
     /**
      * Declarative Services method for setting the executor service reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void setExecutor(ServiceReference<ExecutorService> ref) {
@@ -232,7 +246,7 @@ public class ConnectorServiceImpl extends ConnectorService {
 
     /**
      * Declarative Services method for setting the non-deferrable scheduled executor service reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void setNonDeferrableScheduledExecutor(ServiceReference<ScheduledExecutorService> ref) {
@@ -243,7 +257,7 @@ public class ConnectorServiceImpl extends ConnectorService {
 
     /**
      * Declarative Services method for setting the RRS XA resource factory service implementation reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void setRRSXAResourceFactory(ServiceReference<Object> ref) {
@@ -254,7 +268,7 @@ public class ConnectorServiceImpl extends ConnectorService {
 
     /**
      * Declarative Services method for setting the variable registry service implementation reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void setVariableRegistry(ServiceReference<VariableRegistry> ref) {
@@ -265,7 +279,7 @@ public class ConnectorServiceImpl extends ConnectorService {
 
     /**
      * Declarative Services method for unsetting the AuthDataService reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void unsetAuthDataService(ServiceReference<AuthDataService> ref) {
@@ -275,8 +289,17 @@ public class ConnectorServiceImpl extends ConnectorService {
     }
 
     /**
+     * Declarative Services method for unsetting the class loader identifier service
+     *
+     * @param svc the service
+     */
+    protected void unsetClassLoaderIdentifierService(ClassLoaderIdentifierService svc) {
+        classLoaderIdentifierService = null;
+    }
+
+    /**
      * Declarative Services method for unsetting the deferrable scheduled executor service reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void unsetDeferrableScheduledExecutor(ServiceReference<ScheduledExecutorService> ref) {
@@ -287,7 +310,7 @@ public class ConnectorServiceImpl extends ConnectorService {
 
     /**
      * Declarative Services method for unsetting the executor service reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void unsetExecutor(ServiceReference<ExecutorService> ref) {
@@ -298,7 +321,7 @@ public class ConnectorServiceImpl extends ConnectorService {
 
     /**
      * Declarative Services method for unsetting the non-deferrable scheduled executor service reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void unsetNonDeferrableScheduledExecutor(ServiceReference<ScheduledExecutorService> ref) {
@@ -309,7 +332,7 @@ public class ConnectorServiceImpl extends ConnectorService {
 
     /**
      * Declarative Services method for unsetting the RRS XA resource factory service implementation reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void unsetRRSXAResourceFactory(ServiceReference<Object> ref) {
@@ -320,7 +343,7 @@ public class ConnectorServiceImpl extends ConnectorService {
 
     /**
      * Declarative Services method for unsetting the variable registry service implementation reference.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void unsetVariableRegistry(ServiceReference<VariableRegistry> ref) {

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/AbstractConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/AbstractConnectionFactoryService.java
@@ -155,7 +155,7 @@ public abstract class AbstractConnectionFactoryService implements Observer, Reso
                     return conMgrSvc.getConnectionManager(resInfo, AbstractConnectionFactoryService.this);
                 }
             });
-            connectionFactory = getManagedConnectionFactory().createConnectionFactory(conMgr);
+            connectionFactory = getManagedConnectionFactory(null).createConnectionFactory(conMgr);
         } catch (Exception x) {
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "createResource", x);
@@ -277,9 +277,11 @@ public abstract class AbstractConnectionFactoryService implements Observer, Reso
      *
      * Prerequisite: the invoker must hold a read or write lock on this connection factory service instance.
      *
+     * @param identifier identifier for the class loader from which to load vendor classes (for XA recovery path). Otherwise, null.
      * @return the managed connection factory.
+     * @throws Exception if an error occurs obtaining the managed connection factory.
      */
-    public abstract ManagedConnectionFactory getManagedConnectionFactory();
+    public abstract ManagedConnectionFactory getManagedConnectionFactory(String identifier) throws Exception;
 
     /**
      * Indicates whether or not reauthentication of connections is enabled.
@@ -359,9 +361,10 @@ public abstract class AbstractConnectionFactoryService implements Observer, Reso
      *
      * Prerequisite: the invoker must hold a read or write lock on this connection factory service instance.
      *
+     * @param identifier identifier for the class loader from which to load vendor classes (for XA recovery path). Otherwise, null.
      * @return boolean array indicating whether or not each of the aforementioned capabilities are supported.
      */
-    public abstract int[] getThreadIdentitySecurityAndRRSSupport();
+    public abstract int[] getThreadIdentitySecurityAndRRSSupport(String identifier);
 
     /**
      * Indicates the level of transaction support.
@@ -413,7 +416,8 @@ public abstract class AbstractConnectionFactoryService implements Observer, Reso
                     lock.writeLock().unlock();
                 }
 
-            ManagedConnectionFactory mcf = getManagedConnectionFactory();
+            // TODO supply class loader identifier if resource was loaded from application
+            ManagedConnectionFactory mcf = getManagedConnectionFactory(null);
             Subject subject = getSubjectForRecovery(mcf, xaresinfo);
             mc = mcf.createManagedConnection(subject, null);
             xa = mc.getXAResource();

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectorService.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectorService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 IBM Corporation and others.
+ * Copyright (c) 2013, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import com.ibm.ejs.ras.TraceNLS;
 import com.ibm.websphere.logging.WsLevel;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.classloading.ClassLoaderIdentifierService;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
 import com.ibm.wsspi.kernel.service.location.VariableRegistry;
@@ -36,7 +37,7 @@ public abstract class ConnectorService {
 
     /**
      * Deserialize from an array of bytes.
-     * 
+     *
      * @param bytes serialized bytes.
      * @return deserialized object.
      */
@@ -64,8 +65,13 @@ public abstract class ConnectorService {
     }
 
     /**
+     * @return the class loader identifier service.
+     */
+    public abstract ClassLoaderIdentifierService getClassLoaderIdentifierService();
+
+    /**
      * Get a translated message from J2CAMessages file.
-     * 
+     *
      * @param key message key.
      * @param args message parameters
      * @return a translated message.
@@ -93,7 +99,7 @@ public abstract class ConnectorService {
      * Ignore, warn, or fail when a configuration error occurs.
      * This is copied from Tim's code in tWAS and updated slightly to
      * override with the Liberty ignore/warn/fail setting.
-     * 
+     *
      * @param tc the TraceComponent from where the message originates
      * @param throwable an already created Throwable object, which can be used if the desired action is fail.
      * @param exceptionClassToRaise the class of the Throwable object to return
@@ -105,7 +111,7 @@ public abstract class ConnectorService {
 
     /**
      * Logs a message from the J2CAMessages file.
-     * 
+     *
      * @param key message key.
      * @param args message parameters
      */
@@ -124,7 +130,7 @@ public abstract class ConnectorService {
 
     /**
      * Format bytes as hexadecimal text. For example, 49 42 4D
-     * 
+     *
      * @param bytes array of bytes.
      * @return hexadecimal text.
      */
@@ -135,9 +141,7 @@ public abstract class ConnectorService {
         StringBuilder sb = new StringBuilder(bytes.length * 3);
         for (int i = 0; i < bytes.length; i++) {
             int b = bytes[i] < 0 ? 0x100 + bytes[i] : bytes[i];
-            sb.append(Integer.toHexString(b / 0x10))
-                            .append(Integer.toHexString(b % 0x10))
-                            .append(' ');
+            sb.append(Integer.toHexString(b / 0x10)).append(Integer.toHexString(b % 0x10)).append(' ');
         }
 
         return new String(sb);

--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
@@ -270,11 +270,12 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
      *
      * Prerequisite: the invoker must hold a read or write lock on this connection factory service instance.
      *
+     * @param identifier identifier for the class loader from which to load vendor classes (for XA recovery path). Otherwise, null.
      * @return the managed connection factory.
      */
     @Override
     @Trivial
-    public ManagedConnectionFactory getManagedConnectionFactory() {
+    public ManagedConnectionFactory getManagedConnectionFactory(String identifier) {
         return mcf;
     }
 
@@ -302,11 +303,12 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
      *
      * Prerequisite: the invoker must hold a read or write lock on this connection factory service instance.
      *
+     * @param identifier identifier for the class loader from which to load vendor classes (for XA recovery path). Otherwise, null.
      * @return boolean array indicating whether or not each of the aforementioned capabilities are supported.
      */
     @Override
     @FFDCIgnore(NoSuchMethodException.class)
-    public int[] getThreadIdentitySecurityAndRRSSupport() {
+    public int[] getThreadIdentitySecurityAndRRSSupport(String identifier) {
         int rrsTransactional = 0;
         try {
             if (Boolean.TRUE.equals(mcf.getClass().getMethod("getRRSTransactional").invoke(mcf)))

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -195,6 +195,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
         if (cause instanceof SQLException)
             return (SQLException) cause;
 
+        // TODO need an appropriate message when sharedLib is null and classes are loaded from the application
         String sharedLibId = sharedLib.id();
         String message = sharedLibId.startsWith("com.ibm.ws.jdbc.jdbcDriver-")
                         ? AdapterUtil.getNLSMessage("DSRA4001.no.suitable.driver.nested", name)
@@ -336,9 +337,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                     lock.writeLock().lock();
                     
                     if (!isInitialized) {
-                        if (// TODO sharedLib != null
-                                   !Boolean.parseBoolean((String) properties.get("ibm.internal.nonship.function"))
-                                || !"ibm.internal.simulate.no.library.do.not.ship".equals(sharedLib.id()))
+                        if (!loadFromApp())
                             classloader = AdapterUtil.getClassLoaderWithPriv(sharedLib);
                         isInitialized = true;
                     }
@@ -395,9 +394,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                     lock.writeLock().lock();
 
                     if (!isInitialized) {
-                        if (// TODO sharedLib != null
-                                   !Boolean.parseBoolean((String) properties.get("ibm.internal.nonship.function"))
-                                || !"ibm.internal.simulate.no.library.do.not.ship".equals(sharedLib.id()))
+                        if (!loadFromApp())
                             classloader = AdapterUtil.getClassLoaderWithPriv(sharedLib);
                         isInitialized = true;
                     }
@@ -448,9 +445,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                     lock.writeLock().lock();
 
                     if (!isInitialized) {
-                        if (// TODO sharedLib != null
-                                   !Boolean.parseBoolean((String) properties.get("ibm.internal.nonship.function"))
-                                || !"ibm.internal.simulate.no.library.do.not.ship".equals(sharedLib.id()))
+                        if (!loadFromApp())
                             classloader = AdapterUtil.getClassLoaderWithPriv(sharedLib);
                         isInitialized = true;
                     }
@@ -491,9 +486,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                     lock.writeLock().lock();
 
                     if (!isInitialized) {
-                        if (// TODO sharedLib != null
-                                   !Boolean.parseBoolean((String) properties.get("ibm.internal.nonship.function"))
-                                || !"ibm.internal.simulate.no.library.do.not.ship".equals(sharedLib.id()))
+                        if (!loadFromApp())
                             classloader = AdapterUtil.getClassLoaderWithPriv(sharedLib);
                         isInitialized = true;
                     }
@@ -534,9 +527,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                     lock.writeLock().lock();
 
                     if (!isInitialized) {
-                        if (// TODO sharedLib != null
-                                   !Boolean.parseBoolean((String) properties.get("ibm.internal.nonship.function"))
-                                || !"ibm.internal.simulate.no.library.do.not.ship".equals(sharedLib.id()))
+                        if (!loadFromApp())
                             classloader = AdapterUtil.getClassLoaderWithPriv(sharedLib);
                         isInitialized = true;
                     }
@@ -630,6 +621,18 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "getClasspath", classpath);
         return classpath;
+    }
+
+    /**
+     * Returns true if configured to load the data source class from the application's thread context class loader.
+     * Otherwise, false.
+     * 
+     * @return true if configured to load the data source class from the application's thread context class loader.
+     */
+    public boolean loadFromApp() {
+        return // TODO sharedLib != null
+               Boolean.parseBoolean((String) properties.get("ibm.internal.nonship.function"))
+               && "ibm.internal.simulate.no.library.do.not.ship".equals(sharedLib.id());
     }
 
     /**


### PR DESCRIPTION
Use a different managed connection factory instance per class loader when the data source class is loaded from the application class loader.