### PR TITLE
Issue #1780:  Fixing two FAT failures in Kernel Boot FAT.

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
@@ -47,6 +47,8 @@ public class CreateCommandTest {
         machine.setWorkDir(null);
         installPath = LibertyFileManager.getInstallPath(bootstrap);
         defaultServerPath = installPath + "/usr/servers/" + serverName;
+        // Use absolute path in case this is running on Windows without CYGWIN
+        bootstrap.setValue("libertyInstallPath", installPath);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/StartCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/StartCommandTest.java
@@ -47,6 +47,8 @@ public class StartCommandTest {
         machine.setWorkDir(null);
         installPath = LibertyFileManager.getInstallPath(bootstrap);
         defaultServerPath = installPath + "/usr/servers/" + defaultServerName;
+        // Use absolute path in case this is running on Windows without CYGWIN
+        bootstrap.setValue("libertyInstallPath", installPath);
     }
 
     @AfterClass


### PR DESCRIPTION
The testIsServerEnvCreated() and
testIsServerEnvCreatedForImplicitServerCreate() cases fail with a filepath
issue when running locally.  This is due to these two cases manually
setting up a server to use the /bin/server command to run the
tests.