### PR TITLE
No longer WARN on 404 NotFound

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/interceptor/JAXRSInInterceptor.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/interceptor/JAXRSInInterceptor.java
@@ -27,6 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.ws.rs.HttpMethod;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -225,7 +226,8 @@ public class JAXRSInInterceptor extends AbstractPhaseInterceptor<Message> {
                                                 BUNDLE,
                                                 message.get(Message.REQUEST_URI),
                                                 rawPath);
-                LOG.warning(errorMsg.toString());
+                Level logLevel = JAXRSUtils.getExceptionLogLevel(message, NotFoundException.class);
+                LOG.log(logLevel == null ? Level.FINE : logLevel, errorMsg.toString());
                 Response resp = JAXRSUtils.createResponse(resources, message, errorMsg.toString(),
                                                           Response.Status.NOT_FOUND.getStatusCode(), false);
                 throw ExceptionUtils.toNotFoundException(null, resp);

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -46,6 +46,7 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.logging.Level;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HttpMethod;
@@ -544,6 +545,23 @@ public final class JAXRSUtils {
             createResponse(getRootResources(message), message, errorMsg.toString(), status, methodMatched == 0);
         throw ExceptionUtils.toHttpException(null, response);
 
+    }
+
+    public static Level getExceptionLogLevel(Message message, Class<? extends WebApplicationException> exClass) {
+        Level logLevel = null;
+        Object logLevelProp = message.get(exClass.getName() + ".log.level");
+        if (logLevelProp != null) {
+            if (logLevelProp instanceof Level) {
+                logLevel = (Level) logLevelProp;
+            } else {
+                try {
+                    logLevel = Level.parse(logLevelProp.toString());
+                } catch (Exception ex) {
+                    // ignore
+                }
+            }
+        }
+        return logLevel;
     }
 
     public static List<MediaType> intersectSortMediaTypes(List<MediaType> acceptTypes,


### PR DESCRIPTION
This aligns with CXF-7389 which we will pull in from the next
release of CXF.

This change only affects jaxrs-2.0. This fix is already
applied to jaxrs-2.1.