### PR TITLE
Assign test counts on rootProject

### DIFF
--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -456,11 +456,11 @@ test {
     jvmArgs ant.jvmargPorts.tokenize()
   }
   afterSuite { desc, result ->
-    if (!desc.parent && desc.parent != null) { // will match the outermost suite
-      testCountTotal = testCountTotal + result.testCount
-      successfulTestCountTotal = successfulTestCountTotal + result.successfulTestCount
-      failedTestCountTotal = failedTestCountTotal + result.failedTestCount
-      skippedTestCountTotal = skippedTestCountTotal + result.skippedTestCount
+    if (!desc.parent) { // will match the outermost suite
+      rootProject.ext.testCountTotal = rootProject.ext.testCountTotal + result.testCount
+      rootProject.ext.successfulTestCountTotal = rootProject.ext.successfulTestCountTotal + result.successfulTestCount
+      rootProject.ext.failedTestCountTotal = rootProject.ext.failedTestCountTotal + result.failedTestCount
+      rootProject.ext.skippedTestCountTotal = rootProject.ext.skippedTestCountTotal + result.skippedTestCount
     }
   }
 }


### PR DESCRIPTION
Root project should always have the running tally of total, successful, failed and skipped tests.