### PR TITLE
Parameterize JSON4J providers

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -183,6 +183,7 @@ instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.ws.webservices.handler;version=latest,\
 	com.ibm.ws.javaee.dd.common;version=latest,\
+	com.ibm.json4j,\
 	com.ibm.websphere.javaee.mail.1.5;version=latest,\
 	com.ibm.websphere.javaee.jsonp.1.0,\
 	com.ibm.websphere.appserver.spi.logging,\

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/websphere/jaxrs/providers/json4j/JSON4JArrayProvider.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/websphere/jaxrs/providers/json4j/JSON4JArrayProvider.java
@@ -30,17 +30,15 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
+import com.ibm.json.java.JSONArray;
 import com.ibm.ws.jaxrs20.providers.json4j.utils.ProviderUtils;
 import com.ibm.ws.jaxrs20.utils.ReflectUtil;
-
-//import com.ibm.json.java.JSONArray;
 
 @SuppressWarnings("rawtypes")
 @Provider
 @Consumes({ "application/json", "application/javascript" })
 @Produces({ "application/json", "application/javascript" })
-public class JSON4JArrayProvider implements MessageBodyWriter,
-                MessageBodyReader {
+public class JSON4JArrayProvider implements MessageBodyWriter<JSONArray>, MessageBodyReader<JSONArray> {
     @Override
     public boolean isReadable(Class clazz, Type type,
                               Annotation[] annotations, MediaType mediaType) {
@@ -48,13 +46,13 @@ public class JSON4JArrayProvider implements MessageBodyWriter,
     }
 
     @Override
-    public Object readFrom(Class clazz, Type type,
+    public JSONArray readFrom(Class clazz, Type type,
                            Annotation[] annotations, MediaType mediaType,
                            MultivaluedMap headers, InputStream is)
                     throws IOException, WebApplicationException {
         try {
             Method m = ProviderUtils.getMethod("com.ibm.json.java.JSONArray", "parse", new Class<?>[] { Reader.class });
-            return ReflectUtil.invoke(m, null, new Object[] { new InputStreamReader(is, ProviderUtils
+            return (JSONArray) ReflectUtil.invoke(m, null, new Object[] { new InputStreamReader(is, ProviderUtils
                             .getCharset(mediaType)) });
         } catch (Throwable e) {
 
@@ -65,7 +63,7 @@ public class JSON4JArrayProvider implements MessageBodyWriter,
     }
 
     @Override
-    public long getSize(Object obj, Class clazz, Type type,
+    public long getSize(JSONArray obj, Class clazz, Type type,
                         Annotation[] annotations, MediaType mediaType) {
         return -1L;
     }
@@ -77,7 +75,7 @@ public class JSON4JArrayProvider implements MessageBodyWriter,
     }
 
     @Override
-    public void writeTo(Object arr, Class clazz, Type type,
+    public void writeTo(JSONArray arr, Class clazz, Type type,
                         Annotation[] annotations, MediaType mediaType,
                         MultivaluedMap headers, OutputStream os)
                     throws IOException, WebApplicationException {

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/websphere/jaxrs/providers/json4j/JSON4JObjectProvider.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/websphere/jaxrs/providers/json4j/JSON4JObjectProvider.java
@@ -30,17 +30,16 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
+import com.ibm.json.java.JSONObject;
 import com.ibm.ws.jaxrs20.providers.json4j.utils.ProviderUtils;
 import com.ibm.ws.jaxrs20.utils.ReflectUtil;
-
-//import com.ibm.json.java.JSONObject;
 
 @SuppressWarnings("rawtypes")
 @Provider
 @Consumes({ "application/json", "application/javascript" })
 @Produces({ "application/json", "application/javascript" })
-public class JSON4JObjectProvider implements MessageBodyWriter,
-                MessageBodyReader {
+public class JSON4JObjectProvider implements MessageBodyWriter<JSONObject>,
+                MessageBodyReader<JSONObject> {
     @Override
     public boolean isReadable(Class clazz, Type type,
                               Annotation[] annotations, MediaType mediaType) {
@@ -48,7 +47,7 @@ public class JSON4JObjectProvider implements MessageBodyWriter,
     }
 
     @Override
-    public Object readFrom(Class clazz, Type type,
+    public JSONObject readFrom(Class clazz, Type type,
                            Annotation[] annotations, MediaType mediaType,
                            MultivaluedMap headers, InputStream is)
                     throws IOException, WebApplicationException {
@@ -57,7 +56,7 @@ public class JSON4JObjectProvider implements MessageBodyWriter,
 
             Method m = ProviderUtils.getMethod("com.ibm.json.java.JSONObject", "parse", new Class<?>[] { Reader.class });
 
-            return ReflectUtil.invoke(m, null, new Object[] { new InputStreamReader(is, ProviderUtils
+            return (JSONObject) ReflectUtil.invoke(m, null, new Object[] { new InputStreamReader(is, ProviderUtils
                             .getCharset(mediaType)) });
         } catch (Throwable e) {
 
@@ -67,7 +66,7 @@ public class JSON4JObjectProvider implements MessageBodyWriter,
     }
 
     @Override
-    public long getSize(Object obj, Class clazz, Type type,
+    public long getSize(JSONObject obj, Class clazz, Type type,
                         Annotation[] annotations, MediaType mediaType) {
         return -1L;
     }
@@ -79,7 +78,7 @@ public class JSON4JObjectProvider implements MessageBodyWriter,
     }
 
     @Override
-    public void writeTo(Object obj, Class clazz, Type type,
+    public void writeTo(JSONObject obj, Class clazz, Type type,
                         Annotation[] annotations, MediaType mediaType,
                         MultivaluedMap headers, OutputStream os)
                     throws IOException, WebApplicationException {


### PR DESCRIPTION
In some cases, JSON4J-based return types are getting
processed by Jackson instead of the JSON4J providers. This
is because the JSON4J providers are not parameterized.
This commit resolves this by parameterizing the providers
with the JSONArray and JSONObject type so that it will be
sorted higher in the list for providers matching those
types.