### PR TITLE
Fix writing of single-file-repositories

### DIFF
--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/SingleFileClient.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/SingleFileClient.java
@@ -229,7 +229,7 @@ public class SingleFileClient extends AbstractRepositoryClient implements Reposi
 
         // Iterate through the assets in id order
         Map<String, JsonObject> assetMap = assets == null ? Collections.<String, JsonObject> emptyMap() : assets;
-        for (int i = 1; i <= idCounter.get(); i++) {
+        for (int i = 1; i < idCounter.get(); i++) {
             JsonObject json = assetMap.get(Integer.toString(i));
             if (json == null) {
                 jsonToStore.addNull();


### PR DESCRIPTION
An off-by-one error in the file writing code resulted in an extra null
entry being added to the end of the file every time it was written.