### PR TITLE
Issue #1763: Export packages to thread context

### DIFF
--- a/dev/com.ibm.ws.transaction.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cdi/bnd.bnd
@@ -30,7 +30,7 @@ Import-Package: \
 
 Export-Package: \
  com.ibm.tx.jta.cdi,\
- com.ibm.tx.jta.cdi.interceptors
+ com.ibm.tx.jta.cdi.interceptors;thread-context=true;mandatory:="thread-context"
 
 -dsannotations-inherit: true
 -dsannotations: \


### PR DESCRIPTION
Export packages to thread context to address
ClassNotFoundException, similar to :
java.lang.ClassNotFoundException:
com.ibm.tx.jta.cdi.interceptors.Required