### PR TITLE
Skip validation of the OS/400 platform manifest for 'productInfo vali…

### DIFF
--- a/dev/com.ibm.ws.product.utility/src/com/ibm/ws/product/utility/extension/ValidateCommandTask.java
+++ b/dev/com.ibm.ws.product.utility/src/com/ibm/ws/product/utility/extension/ValidateCommandTask.java
@@ -94,6 +94,13 @@ public class ValidateCommandTask extends BaseCommandTask {
                     continue;
                 }
 
+                if (!"os/400".equalsIgnoreCase(System.getProperty("os.name")) &&
+                    "com.ibm.websphere.appserver.os400.extensions-1.0".equalsIgnoreCase(pfd.getSymbolicName())) {
+                    // Special case for the OS/400 platform manifest (wlp/lib/platform/os400Extensions.mf)
+                    // which will stick around after a minify but its referenced files will not
+                    continue;
+                }
+
                 /**
                  * cs file is valid, then check its content
                  */


### PR DESCRIPTION
…date' on non-OS/400 systems

When doing `productInfo validate` on an image where a non-OS/400 OS was used (e.g. `--os=Linux`) the OS/400 native files will be removed but the platform manifest will stick around, causing the following validation errors such as:

```
$ bin/productInfo validate
Start product validation...
Validating feature: appSecurity-1.0... PASS!
Validating feature: appSecurity-2.0... PASS!
Validating feature: appState-2.0... PASS!
Validating feature: com.ibm.websphere.appserver.autoRestConnector-2.0... PASS!
Validating feature: beanValidation-1.1... PASS!
Validating feature: cdi-1.2... PASS!
Validating feature: cloudAutowiring-1.0... PASS!
Validating feature: distributedMap-1.0... PASS!
Validating feature: ejbLite-3.2... PASS!
Validating feature: el-3.0... PASS!
Validating feature: federatedRegistry-1.0... PASS!
Validating feature: jaxrs-1.1... PASS!
Validating feature: jaxrs-2.0... PASS!
Validating feature: jaxrsClient-2.0... PASS!
Validating feature: jdbc-4.1... PASS!
Validating feature: jndi-1.0... PASS!
Validating feature: jpa-2.1... PASS!
Validating feature: jpaContainer-2.1... PASS!
Validating feature: jsf-2.2... PASS!
Validating feature: json-1.0... PASS!
Validating feature: jsonp-1.0... PASS!
Validating feature: jsp-2.2... PASS!
Validating feature: jsp-2.3... PASS!
Validating feature: jwt-1.0... PASS!
Validating feature: ldapRegistry-3.0... PASS!
Validating feature: localConnector-1.0... PASS!
Validating feature: logAnalysis-1.0... PASS!
Validating feature: managedBeans-1.0... PASS!
Validating feature: microProfile-1.0... PASS!
Validating feature: monitor-1.0... PASS!
Validating feature: oauth-2.0... PASS!
Validating feature: openid-2.0... PASS!
Validating feature: openidConnectClient-1.0... PASS!
Validating feature: openidConnectServer-1.0... PASS!
Validating feature: com.ibm.websphere.appserver.os400.extensions-1.0... FAIL!
  [ERROR] Content: lib/native/os400/bin/_iPostInstallUtility does not exist.
  [ERROR] Content: lib/native/os400/product/pgms/qwas00mx does not exist.
  [ERROR] Content: lib/native/os400/pgms/qwas00 does not exist.
  [ERROR] Content: lib/native/os400/bin/_iPreUninstallUtility does not exist.
  [ERROR] Content: lib/native/os400/srvpgms/qwlpsec does not exist.
  [ERROR] Content: lib/native/os400/product/qwas9msgf does not exist.
  [ERROR] Content: lib/native/os400/product/pgms/qwaschko does not exist.
  [ERROR] Content: lib/native/os400/product/pgms/qwas02mx does not exist.
  [ERROR] Content: lib/native/os400/pgms/qwlpstrsvr does not exist.
  [ERROR] Content: lib/native/os400/product/pgms/qwascln does not exist.
  [ERROR] Content: lib/native/os400/bin/iAdmin does not exist.
  [ERROR] Content: lib/native/os400/product/pgms/qwas01mx does not exist.
  [ERROR] Content: lib/native/os400/bin/_iAuthUtility does not exist.
  [ERROR] Content: lib/native/os400/product/pgms/qwas03mx does not exist.
  [ERROR] Content: lib/native/os400/srvpgms/qwlpcmn does not exist.
  [ERROR] Content: lib/native/os400/product/qwas05 does not exist.
  [ERROR] Content: lib/native/os400/product/qwas03 does not exist.
  [ERROR] Content: lib/native/os400/product/pgms/qwas05mx does not exist.
  [ERROR] Content: lib/native/os400/product/qwas02 does not exist.
  [ERROR] Content: lib/native/os400/product/qwas01 does not exist.
  [ERROR] Content: lib/native/os400/product/qwas00 does not exist.
Validating feature: restConnector-1.0... PASS!
Validating feature: restConnector-2.0... PASS!
Validating feature: servlet-3.0... PASS!
Validating feature: servlet-3.1... PASS!
Validating feature: socialLogin-1.0... PASS!
Validating feature: ssl-1.0... PASS!
Validating feature: transportSecurity-1.0... PASS!
Validating feature: webProfile-7.0... PASS!
Validating feature: websocket-1.0... PASS!
Validating feature: websocket-1.1... PASS!
Validating feature: appState-1.0... PASS!
Product validation was complete, and found 21 error(s).
```