### PR TITLE
Add autoStart for activation specs

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.mdb/resources/com/ibm/ws/ejbcontainer/mdb/resources/EJBMDBMessages.nlsprops
+++ b/dev/com.ibm.ws.ejbcontainer.mdb/resources/com/ibm/ws/ejbcontainer/mdb/resources/EJBMDBMessages.nlsprops
@@ -67,6 +67,10 @@ MDB_DESTINATION_NOT_FOUND_CNTR4016W=CNTR4016W: The message endpoint for the {0} 
 MDB_DESTINATION_NOT_FOUND_CNTR4016W.explanation=The server is starting the message-driven bean but is unable to activate the message endpoint because the destination could not be found. The message endpoint will not receive messages until the endpoint can be activated.
 MDB_DESTINATION_NOT_FOUND_CNTR4016W.useraction=Verify that a destination has been configured with the specified name. If the configuration exists, wait for the destination to become available.
 
+MDB_ENDPOINT_NOT_ACTIVATED_AUTOSTART_CNTR4116I=CNTR4116I: The message endpoint for the {0} message-driven bean in the {1} module of the {2} application was not activated because the {3} activation specification was configured with autoStart=false.
+MDB_ENDPOINT_NOT_ACTIVATED_AUTOSTART_CNTR4116I.explanation=The message endpoint has not been activated beause the activation specification was configured with autoStart=false.  The message endpoint will be activated when it is issued a resume command.
+MDB_ENDPOINT_NOT_ACTIVATED_AUTOSTART_CNTR4116I.useraction=No action is required.
+
 MDB_ENDPOINT_ALREADY_INACTIVE_CNTR4117I=CNTR4117I: The pause operation did not have any effect because the message endpoint for the {0} bean in the {1} module of the {2} application is already paused.
 MDB_ENDPOINT_ALREADY_INACTIVE_CNTR4117I.explanation=The message endpoint can only be paused when it is in an active state.
 MDB_ENDPOINT_ALREADY_INACTIVE_CNTR4117I.useraction=No action is required.

--- a/dev/com.ibm.ws.ejbcontainer.mdb/src/com/ibm/ws/ejbcontainer/mdb/internal/MessageEndpointFactoryImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer.mdb/src/com/ibm/ws/ejbcontainer/mdb/internal/MessageEndpointFactoryImpl.java
@@ -100,6 +100,12 @@ public class MessageEndpointFactoryImpl extends BaseMessageEndpointFactory imple
      */
     boolean runtimeActivated;
 
+    /**
+     * Indicates whether the message endpoint should be activated. 
+     * False if autoStart is set to false until a resume command is issued
+     */
+    boolean shouldActivate;
+
     public MessageEndpointFactoryImpl() throws RemoteException {
         super();
         mdbRuntime = MDBRuntimeImpl.instance();
@@ -511,6 +517,7 @@ public class MessageEndpointFactoryImpl extends BaseMessageEndpointFactory imple
     @Override
     public void resume() throws PauseableComponentException {
         try {
+            shouldActivate = true;
             if (ivState == INACTIVE_STATE) {
                 activateEndpoint();
             } else if (ivState == ACTIVE_STATE) {

--- a/dev/com.ibm.ws.ejbcontainer.mdb/test/com/ibm/ws/ejbcontainer/mdb/internal/MDBRuntimeImplTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.mdb/test/com/ibm/ws/ejbcontainer/mdb/internal/MDBRuntimeImplTest.java
@@ -152,6 +152,8 @@ public class MDBRuntimeImplTest {
                 will(returnValue(id));
                 allowing(easSR).getProperty("maxEndpoints");
                 will(returnValue(0));
+                allowing(easSR).getProperty("autoStart");
+                will(returnValue(true));
             }
         });
         return easSR;

--- a/dev/com.ibm.ws.ejbcontainer/resources/com/ibm/ws/ejbcontainer/osgi/internal/resources/EJBContainerMessages.nlsprops
+++ b/dev/com.ibm.ws.ejbcontainer/resources/com/ibm/ws/ejbcontainer/osgi/internal/resources/EJBContainerMessages.nlsprops
@@ -196,6 +196,9 @@ INVALID_CLASS_CNTR4115E.explanation=Either the ejb-jar.xml file specifies an inv
 INVALID_CLASS_CNTR4115E.useraction=Correct the class name in the ejb-jar.xml file, or package the class file in the application.
 
 # In use in EJBMDBMessages.nlsprops
+# MDB_ENDPOINT_NOT_ACTIVATED_AUTOSTART_CNTR4116I
+
+# In use in EJBMDBMessages.nlsprops
 # MDB_ENDPOINT_ALREADY_INACTIVE_CNTR4117I
 
 # In use in EJBMDBMessages.nlsprops

--- a/dev/com.ibm.ws.jca/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jca/resources/OSGI-INF/l10n/metatype.properties
@@ -37,3 +37,6 @@ maxEndpoints.desc=The maximum number of endpoints to dispatch to.
 recoveryAuth=Recovery Authentication Data
 recoveryAuth$Ref=Recovery authentication data reference
 recoveryAuth.desc=Authentication data for transaction recovery.
+
+autoStart=Auto start
+autoStart.desc=Configures whether the message endpoints associated with this activation specification start automatically or need to be manually started using the resume command.

--- a/dev/com.ibm.ws.jca/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jca/resources/OSGI-INF/metatype/metatype.xml
@@ -27,6 +27,7 @@
   <AD id="bootstrapContext.target"            type="String"  default="(id=${properties.0.resourceAdapterConfig.id})" ibm:final="true" name="internal" description="internal use only"/>
   <AD id="destination.target"                 type="String"  default="(service.pid=${properties.0.destinationRef})" ibm:final="true" name="internal" description="internal use only"/>
   <AD id="maxEndpoints"                       type="Integer" required="false" name="%maxEndpoints" description="%maxEndpoints.desc" min="0" default="500"/>
+  <AD id="autoStart"                          type="Boolean" required="false" default="true" name="%autoStart" description="%autoStart.desc"/>
  </OCD>
 
  <!-- Admin Object -->


### PR DESCRIPTION
Add the autoStart functionality for activation specifications, which will allow for the initial state of message endpoints associated with the activation spec to be set.