### PR TITLE
Add new DataSource class names for MySQL JDBC drivers newer than 6.0

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDrivers.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDrivers.java
@@ -129,13 +129,23 @@ public class JDBCDrivers {
         classes = new String[] { className, className, className };
         classNamesByKey.put("MARIADB-JAVA-CLIENT", classes);
 
-        // MySQL
+        // MySQL before version 6.0
         classes = new String[] {
                                 "com.mysql.jdbc.jdbc2.optional.MysqlDataSource",                                
                                 "com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource",
                                 "com.mysql.jdbc.jdbc2.optional.MysqlXADataSource"
         };
-        classNamesByKey.put("MYSQL-CONNECTOR-JAVA", classes);
+        classNamesByKey.put("MYSQL-CONNECTOR-JAVA-2", classes);
+        classNamesByKey.put("MYSQL-CONNECTOR-JAVA-3", classes);
+        classNamesByKey.put("MYSQL-CONNECTOR-JAVA-5", classes);
+        
+        // MySQL after version 6.0
+        classes = new String[] {
+                                "com.mysql.cj.jdbc.MysqlDataSource",                                
+                                "com.mysql.cj.jdbc.MysqlConnectionPoolDataSource",
+                                "com.mysql.cj.jdbc.MysqlXADataSource"
+        };
+        classNamesByKey.put("MYSQL-CONNECTOR-JAVA-", classes);
 
         // Sybase JDBC 4 driver
         classes = new String[] {


### PR DESCRIPTION
In [this StackOverflow question](https://stackoverflow.com/questions/48484113/configuring-mysql-datasource-with-ibm-websphere-application-server-liberty-profi) a user had configured DS class names on their `<jdbcDriver>` element, but Liberty had outdated DataSource impl classes that were taking precedence over user-configured values.

An example of the config:
```xml
<dataSource ...>
  <jdbcDriver javax.sql.XADataSource="com.mysql.cj.jdbc.MysqlXADataSource" .../>
  <properties ... />
</dataSource>
```

And this would blow up with the following error:
> java.lang.ClassNotFoundException: com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource

It looks like as of MySQL 6.0 the datasource class names were changed, so we should use the new class names going forward.