### PR TITLE
enable CacheStoreService to access JCache provider

### DIFF
--- a/dev/com.ibm.websphere.appserver.sessionCache-1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.sessionCache-1.0/bnd.bnd
@@ -12,7 +12,6 @@
 
 -nobundles=true
 
-# TODO remove projects only required for session db once this feature is futher along  
 -dependson: \
     com.ibm.websphere.javaee.jcache.1.1;version=latest, \
 	com.ibm.websphere.security;version=latest, \

--- a/dev/com.ibm.websphere.appserver.sessionCache-1.0/com.ibm.websphere.appserver.sessionCache-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.sessionCache-1.0/com.ibm.websphere.appserver.sessionCache-1.0.feature
@@ -2,17 +2,27 @@
 symbolicName=com.ibm.websphere.appserver.sessionCache-1.0
 visibility=public
 IBM-ShortName: sessionCache-1.0
+#TODO remove jcache API from this feature, this is only temporary
+IBM-API-Package: \
+ javax.cache; type="spec", \
+ javax.cache.annotation; type="spec", \
+ javax.cache.configuration; type="spec", \
+ javax.cache.event; type="spec", \
+ javax.cache.expiry; type="spec", \
+ javax.cache.integration; type="spec", \
+ javax.cache.management; type="spec", \
+ javax.cache.processor; type="spec", \
+ javax.cache.spi; type="spec"
 Manifest-Version: 1.0
 Subsystem-Name: JCache Session Persistence
 -features=\
  com.ibm.websphere.appserver.appLifecycle-1.0, \
+ com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.javax.servlet-4.0; ibm.tolerates:="3.1,3.0"; apiJar=false, \
  com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:=1.1
 -bundles=\
  com.ibm.websphere.javaee.jcache.1.1, \
  com.ibm.websphere.security, \
- com.ibm.ws.container.service, \
- com.ibm.ws.serialization, \
  com.ibm.ws.session, \
  com.ibm.ws.session.cache, \
  com.ibm.ws.session.store

--- a/dev/com.ibm.ws.session.cache/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache/bnd.bnd
@@ -33,6 +33,7 @@ Include-Resource: \
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.wsspi.org.osgi.service.component.annotations,\
+	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.serialization;version=latest,\

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -12,6 +12,8 @@ package com.ibm.ws.session.store.cache;
 
 import java.util.Map;
 
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
 import javax.servlet.ServletContext;
 import javax.transaction.UserTransaction;
 
@@ -28,6 +30,7 @@ import com.ibm.ws.session.MemoryStoreHelper;
 import com.ibm.ws.session.SessionManagerConfig;
 import com.ibm.ws.session.SessionStoreService;
 import com.ibm.ws.session.utils.SessionLoader;
+import com.ibm.wsspi.library.Library;
 import com.ibm.wsspi.session.IStore;
 
 /**
@@ -38,6 +41,9 @@ public class CacheStoreService implements SessionStoreService {
     private Map<String, Object> configurationProperties;
 
     private volatile boolean completedPassivation = true;
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY, target = "(id=unbound)")
+    protected Library library;
 
     @Reference
     protected SerializationService serializationService;
@@ -54,6 +60,14 @@ public class CacheStoreService implements SessionStoreService {
      */
     protected void activate(ComponentContext context, Map<String, Object> props) {
         configurationProperties = props;
+
+        // TODO temporary code validates that the provider can be obtained but does nothing else with it
+
+        CachingProvider provider;
+        if (library == null)
+            ; // use default JCache provider specified via bell
+        else
+            provider = Caching.getCachingProvider(library.getClassLoader()); // load JCache provider from configured library
     }
 
     @Override

--- a/dev/com.ibm.ws.session.cache_fat/build.gradle
+++ b/dev/com.ibm.ws.session.cache_fat/build.gradle
@@ -9,9 +9,23 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+configurations {
+  hazelcastJCache
+}
+
 // Define G:A:V coordinates of each dependency
 dependencies {
   requiredLibs 'commons-logging:commons-logging:1.1.3'
+  hazelcastJCache 'com.hazelcast:hazelcast:3.9.2'
 }
 
-addRequiredLibraries.dependsOn addDerby
+task addHazelcastJCacheProviderToSharedDir(type: Copy) {
+  from configurations.hazelcastJCache
+  into new File(autoFvtDir, 'publish/shared/resources/hazelcast')
+  rename 'hazelcast-.*.jar', 'hazelcast.jar'
+}
+
+addRequiredLibraries {
+  dependsOn addDerby
+  dependsOn addHazelcastJCacheProviderToSharedDir
+}

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServer/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServer/server.xml
@@ -11,6 +11,8 @@
     <include location="../fatTestPorts.xml"/>
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
+
+    <httpSessionCache libraryRef="HazelcastLib"/>
     
     <!-- TODO: eventually all of this database configuration will be replaced with JCache configuration -->
     <httpSessionDatabase dataSourceRef="SessionDS"/>
@@ -22,8 +24,12 @@
 	</dataSource>
 	
 	<library id="DerbyLib">
-	    <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+	    <file name="${shared.resource.dir}/derby/derby.jar"/>
 	</library>
+
+    <library id="HazelcastLib">
+        <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    </library>
 	
 	<javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 


### PR DESCRIPTION
In order to do any further experimentation with JCache for implementation, we need to make it possible for CacheStoreService to be supplied a JCache provider.  For now, that will happen as a shared library, provided at least temporarily with access to the JCache interfaces as spec API.  This should end up being reworked, because it's not appropriate for sessionCache-1.0 feature to be the feature that provides JCache API, but it should be just enough to make further progress in other areas.