### PR TITLE
Update isPaused to throw an exception if invalid args are input

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.cmdline/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.cmdline/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -678,6 +678,10 @@ error.server.resume.command.port.disabled=CWWKE0945E: A resume request was recei
 error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the resume request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
 error.server.resume.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this resume can alternatively be requested from the operator console.
 
+warning.server.status.invalid.targets=CWWKE0946W: A status request was received for specific components, but the component list on the target option was empty. No action was taken.
+warning.server.status.invalid.targets.explanation=A user issued a status request with an empty target list on the target option. The request completed but no action was taken.
+warning.server.status.invalid.targets.useraction=Specify on the target option a list of components to check their status. To check the cumulative status of all pause capable components in the server, issue status request without the target option.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot.core/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.core/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -671,6 +671,10 @@ error.server.resume.command.port.disabled=CWWKE0945E: A resume request was recei
 error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the resume request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
 error.server.resume.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this resume can alternatively be requested from the operator console.
 
+warning.server.status.invalid.targets=CWWKE0946W: A status request was received for specific components, but the component list on the target option was empty. No action was taken.
+warning.server.status.invalid.targets.explanation=A user issued a status request with an empty target list on the target option. The request completed but no action was taken.
+warning.server.status.invalid.targets.useraction=Specify on the target option a list of components to check their status. To check the cumulative status of all pause capable components in the server, issue status request without the target option.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot.nested/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot.nested/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -670,6 +670,10 @@ error.server.resume.command.port.disabled=CWWKE0945E: A resume request was recei
 error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the resume request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
 error.server.resume.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this resume can alternatively be requested from the operator console.
 
+warning.server.status.invalid.targets=CWWKE0946W: A status request was received for specific components, but the component list on the target option was empty. No action was taken.
+warning.server.status.invalid.targets.explanation=A user issued a status request with an empty target list on the target option. The request completed but no action was taken.
+warning.server.status.invalid.targets.useraction=Specify on the target option a list of components to check their status. To check the cumulative status of all pause capable components in the server, issue status request without the target option.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/PauseableComponentControllerImpl.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/PauseableComponentControllerImpl.java
@@ -381,6 +381,11 @@ public class PauseableComponentControllerImpl implements PauseableComponentContr
 
         Set<String> targetList = createTargetList(targets);
 
+        if (targetList.isEmpty()) {
+            Tr.warning(tc, "warning.server.status.invalid.targets");
+            throw new PauseableComponentControllerRequestFailedException(Tr.formatMessage(tc, "warning.server.status.invalid.targets"));
+        }
+
         //Add each pauseable component to this list. If the tracked values get modified
         //while we are iterating and we start over, skip anyone already in this list
         Set<PauseableComponent> processedList = new HashSet<PauseableComponent>();

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -680,6 +680,10 @@ error.server.resume.command.port.disabled=CWWKE0945E: A resume request was recei
 error.server.resume.command.port.disabled.explanation=The server command port is required for communication with a running server. The command port is disabled for this server, therefore the resume request could not be processed. Note that the command port is disabled by default when a server is started as a started task on z/OS.
 error.server.resume.command.port.disabled.useraction=Enable the command port for this server. If the server is running as a started task on z/OS, this resume can alternatively be requested from the operator console.
 
+warning.server.status.invalid.targets=CWWKE0946W: A status request was received for specific components, but the component list on the target option was empty. No action was taken.
+warning.server.status.invalid.targets.explanation=A user issued a status request with an empty target list on the target option. The request completed but no action was taken.
+warning.server.status.invalid.targets.useraction=Specify on the target option a list of components to check their status. To check the cumulative status of all pause capable components in the server, issue status request without the target option.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/service/ServerEndpointControlMBeanTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/service/ServerEndpointControlMBeanTest.java
@@ -341,6 +341,33 @@ public class ServerEndpointControlMBeanTest {
         Log.exiting(c, METHOD_NAME);
     }
 
+    //Test that an exception is thrown when isPaused(String targets) is supplied with an empty string
+    //or null for the target
+    @ExpectedFFDC(PAUSEABLE_EXCEPTION_CLASS)
+    @Test
+    public void testIsPausedInvalidArgs() throws Exception {
+        final String METHOD_NAME = "testIsPausedInvalidArgs";
+        Log.entering(c, METHOD_NAME);
+        restoreSavedConfig = false;
+
+        try {
+            mbean.isPaused("");
+            fail("Failed to get expected exception from calling isPaused(\"\")");
+        } catch (MBeanException e) {
+            // expected
+        }
+
+        try {
+            mbean.isPaused(null);
+            fail("Failed to get expected exception from calling isPaused(null)");
+        } catch (MBeanException e) {
+            // expected
+        }
+
+        assertNotNull("Didn't find CWWKE0946W in logs as expected.", server.waitForStringInLog("CWWKE0946W"));
+        Log.exiting(c, METHOD_NAME);
+    }
+
     /**
      * Tests that the expected exception is thrown if the MBean resume method is issued with empty target list
      *


### PR DESCRIPTION
If invalid args are input to isPaused(String targets) on the PauseableComponentController then an exception should be thrown similar to pause and resume.

Issue #1674