### PR TITLE
Add ibm_queryString as an optional key

### DIFF
--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JSONEventsTest.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JSONEventsTest.java
@@ -72,7 +72,7 @@ public abstract class JSONEventsTest {
                                                                                            "ibm_requestMethod", "ibm_uriPath", "ibm_requestProtocol", "ibm_elapsedTime",
                                                                                            "ibm_responseCode", "ibm_bytesReceived", "ibm_userAgent"));
 
-        ArrayList<String> accessLogKeysOptionalList = new ArrayList<String>();
+        ArrayList<String> accessLogKeysOptionalList = new ArrayList<String>(Arrays.asList("ibm_queryString"));
 
         getServer().addInstalledAppForValidation(APP_NAME);
         TestUtils.runApp(getServer(), "access");


### PR DESCRIPTION
Some access log messages may have an optional field ibm_queryString. 

```
Message line:{"ibm_datetime":"2018-01-29T07:38:32.287+0000","type":"liberty_accesslog","host":"ebcz4JBNuhh.hdc","ibm_userDir":"\/home\/jazz_build\/_DH-v0ASwEeiIX6lO4t6XVQ-EBC.PROD.WASRTC-4XW-000-00-00\/jbe\/build\/dev\/image\/output\/wlp\/usr\/","ibm_serverName":"com.ibm.ws.logging.json.ConsoleLogServer","ibm_sequence":"1517211512125_0000000000001","ibm_requestHost":"127.0.0.1","ibm_requestPort":"8011","ibm_remoteHost":"127.0.0.1","ibm_requestMethod":"GET","ibm_uriPath":"/LogstashApp","ibm_requestProtocol":"HTTP/1.1","ibm_queryString":"isFFDC=true","ibm_elapsedTime":"151598","ibm_responseCode":"500","ibm_bytesReceived":"1814","ibm_userAgent":"Java/1.8.0_92"}
```