### PR TITLE
Moving test bundles bnd to project root folder to fix Eclipse errors

### DIFF
--- a/dev/com.ibm.ws.logging_fat/accesslog.source.handler.bnd
+++ b/dev/com.ibm.ws.logging_fat/accesslog.source.handler.bnd
@@ -1,13 +1,13 @@
--include= ~../../../cnf/resources/bnd/bundle.props
+-include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0.0
 
 # For more information, see http://was.pok.ibm.com/xwiki/bin/view/Liberty/UsingBnd
 
-Bundle-Name: FFDC Source Handler
-Bundle-SymbolicName: ffdc.source.handler
-Bundle-Description: FFDC SourceHandler: Sample source and handler for collector manager framework; version=${bVersion}
+Bundle-Name: Access Log Source Handler
+Bundle-SymbolicName: accesslog.source.handler
+Bundle-Description: AccessLog SourceHandler: Sample source and handler for collector manager framework; version=${bVersion}
   
-WS-TraceGroup: FFDCHandler
+WS-TraceGroup: AccessLogHandler
 
 Import-Package: com.ibm.ejs.ras, \
                 com.ibm.websphere.ras, \
@@ -17,16 +17,17 @@ Import-Package: com.ibm.ejs.ras, \
                 com.ibm.wsspi.kernel.service.location, \
                 com.ibm.wsspi.kernel.service.utils, \
                 org.osgi.framework, \
-                com.ibm.wsspi.collector.manager               
+                com.ibm.wsspi.collector.manager
+               
 
-Private-Package: ffdc.source.handler
+Private-Package: accesslog.source.handler
 
 Include-Resource: \
-        OSGI-INF=resources/OSGI-INF
-        
+        OSGI-INF=test-bundles/accesslog.source.handler/resources/OSGI-INF
+ 
 Service-Component: \
-  FFDCHandler;\
-    implementation:=ffdc.source.handler.FFDCHandlerImpl;\
+  AccessLogHandler;\
+    implementation:=accesslog.source.handler.AccessLogHandlerImpl;\
     provide:=com.ibm.wsspi.collector.manager.Handler; \
      executor=java.util.concurrent.ExecutorService; \
     modified:='modified'; \

--- a/dev/com.ibm.ws.logging_fat/bnd.bnd
+++ b/dev/com.ibm.ws.logging_fat/bnd.bnd
@@ -11,14 +11,7 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
--sub: *.bnd, \
-	test-bundles/message.source.handler/bnd.bnd, \
-	test-bundles/sample.source.handler/bnd.bnd, \
-	test-bundles/ffdc.source.handler/bnd.bnd, \
-	test-bundles/accesslog.source.handler/bnd.bnd, \
-	test-bundles/trace.source.handler/bnd.bnd, \
-	test-bundles/test.configuration.fallalloverthefloor.ibmfeature/bnd.bnd, \
-	test-bundles/test.configuration.fallalloverthefloor.userfeature/bnd.bnd
+-sub: *.bnd
 
 src: \
 	fat/src,\

--- a/dev/com.ibm.ws.logging_fat/ffdc.source.handler.bnd
+++ b/dev/com.ibm.ws.logging_fat/ffdc.source.handler.bnd
@@ -1,13 +1,13 @@
--include= ~../../../cnf/resources/bnd/bundle.props
+-include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0.0
 
 # For more information, see http://was.pok.ibm.com/xwiki/bin/view/Liberty/UsingBnd
 
-Bundle-Name: Access Log Source Handler
-Bundle-SymbolicName: accesslog.source.handler
-Bundle-Description: AccessLog SourceHandler: Sample source and handler for collector manager framework; version=${bVersion}
+Bundle-Name: FFDC Source Handler
+Bundle-SymbolicName: ffdc.source.handler
+Bundle-Description: FFDC SourceHandler: Sample source and handler for collector manager framework; version=${bVersion}
   
-WS-TraceGroup: AccessLogHandler
+WS-TraceGroup: FFDCHandler
 
 Import-Package: com.ibm.ejs.ras, \
                 com.ibm.websphere.ras, \
@@ -17,17 +17,16 @@ Import-Package: com.ibm.ejs.ras, \
                 com.ibm.wsspi.kernel.service.location, \
                 com.ibm.wsspi.kernel.service.utils, \
                 org.osgi.framework, \
-                com.ibm.wsspi.collector.manager
-               
+                com.ibm.wsspi.collector.manager               
 
-Private-Package: accesslog.source.handler
+Private-Package: ffdc.source.handler
 
 Include-Resource: \
-        OSGI-INF=resources/OSGI-INF
- 
+        OSGI-INF=test-bundles/ffdc.source.handler/resources/OSGI-INF
+        
 Service-Component: \
-  AccessLogHandler;\
-    implementation:=accesslog.source.handler.AccessLogHandlerImpl;\
+  FFDCHandler;\
+    implementation:=ffdc.source.handler.FFDCHandlerImpl;\
     provide:=com.ibm.wsspi.collector.manager.Handler; \
      executor=java.util.concurrent.ExecutorService; \
     modified:='modified'; \

--- a/dev/com.ibm.ws.logging_fat/message.source.handler.bnd
+++ b/dev/com.ibm.ws.logging_fat/message.source.handler.bnd
@@ -1,4 +1,4 @@
--include= ~../../../cnf/resources/bnd/bundle.props
+-include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0.0
 
 # For more information, see http://was.pok.ibm.com/xwiki/bin/view/Liberty/UsingBnd
@@ -22,7 +22,7 @@ Import-Package: com.ibm.ejs.ras, \
 Private-Package: message.source.handler
 
 Include-Resource: \
-        OSGI-INF=resources/OSGI-INF
+        OSGI-INF=test-bundles/message.source.handler/resources/OSGI-INF
         
 Service-Component: \
   MessageHandler;\

--- a/dev/com.ibm.ws.logging_fat/sample.source.handler.bnd
+++ b/dev/com.ibm.ws.logging_fat/sample.source.handler.bnd
@@ -1,4 +1,4 @@
--include= ~../../../cnf/resources/bnd/bundle.props
+-include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0.0
 
 # For more information, see http://was.pok.ibm.com/xwiki/bin/view/Liberty/UsingBnd
@@ -22,7 +22,7 @@ Import-Package: com.ibm.ejs.ras, \
 Private-Package: sample.source.handler
 
 Include-Resource: \
-        OSGI-INF=resources/OSGI-INF
+        OSGI-INF=test-bundles/sample.source.handler/resources/OSGI-INF
         
 Service-Component: \
    CollectorSource;\

--- a/dev/com.ibm.ws.logging_fat/test.configuration.fallalloverthefloor.ibmfeature.bnd
+++ b/dev/com.ibm.ws.logging_fat/test.configuration.fallalloverthefloor.ibmfeature.bnd
@@ -19,7 +19,7 @@ Private-Package: \
   com.ibm.ws.logging.fat.fallalloverthefloor.ibmfeature
 
 Include-Resource: \
-  OSGI-INF=resources/OSGI-INF
+  OSGI-INF=test-bundles/test.configuration.fallalloverthefloor.ibmfeature/resources/OSGI-INF
 
 Service-Component: \
   com.ibm.ws.logging.fat.brokenfeature; \

--- a/dev/com.ibm.ws.logging_fat/test.configuration.fallalloverthefloor.userfeature.bnd
+++ b/dev/com.ibm.ws.logging_fat/test.configuration.fallalloverthefloor.userfeature.bnd
@@ -18,7 +18,7 @@ Private-Package: \
   com.ibm.ws.logging.fat.fallalloverthefloor.userfeature
 
 Include-Resource: \
-  OSGI-INF=resources/OSGI-INF
+  OSGI-INF=test-bundles/test.configuration.fallalloverthefloor.userfeature/resources/OSGI-INF
 
 Service-Component: \
   com.ibm.ws.logging.fat.brokenfeature; \

--- a/dev/com.ibm.ws.logging_fat/trace.source.handler.bnd
+++ b/dev/com.ibm.ws.logging_fat/trace.source.handler.bnd
@@ -1,4 +1,4 @@
--include= ~../../../cnf/resources/bnd/bundle.props
+-include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0.0
 
 # For more information, see http://was.pok.ibm.com/xwiki/bin/view/Liberty/UsingBnd
@@ -34,7 +34,7 @@ Service-Component: \
     properties:="service.vendor=IBM"
 
 Include-Resource: \
-        OSGI-INF=resources/OSGI-INF
+        OSGI-INF=test-bundles/trace.source.handler/resources/OSGI-INF
         
 -dsannotations: \
    collector.manager_fat.RESTHandlerTraceLogger


### PR DESCRIPTION
Fixes "Eclipse: Cannot find associated project for <test-bundles>" that occur in eclipse.