### PR TITLE
copy additional methods and enable basic cache test

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -11,10 +11,20 @@
 
 package com.ibm.ws.session.store.cache;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.sql.Blob;
+import java.util.logging.Level;
 
+import javax.cache.CacheException;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.session.SessionManagerConfig;
+import com.ibm.ws.session.SessionStatistics;
 import com.ibm.ws.session.store.common.BackedHashMap;
 import com.ibm.ws.session.store.common.BackedSession;
 import com.ibm.wsspi.session.IStore;
@@ -25,6 +35,14 @@ import com.ibm.wsspi.session.IStore;
  */
 public class CacheHashMap extends BackedHashMap {
     private static final long serialVersionUID = 1L; // not serializable, rejects writeObject
+
+    private static final TraceComponent tc = Tr.register(CacheHashMap.class);
+
+    /**
+     * Array indices (and size) for Object array values that are stored in the cache.
+     * TODO this is a temporary approach that will almost certainly be replaced
+     */
+    private static final int LISTENER_COUNT = 0, LAST_ACCESS = 1, CREATION_TIME = 2, MAX_INACTIVE_TIME = 3, USER_NAME = 4, BYTES = 5, SIZE = 6;
 
     CacheStoreService cacheStoreService;
 
@@ -43,11 +61,79 @@ public class CacheHashMap extends BackedHashMap {
     }
 
     /**
+     * TODO rewrite this. For now, it is copied based on DatabaseHashMap.getValue
+     */
+    protected Object getValue(String id, BackedSession s) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+        Object tmp = null;
+
+        String key = s.getId() + '+' + id + '@' + getIStore().getId();
+        Object[] value = (Object[]) cacheStoreService.cache.get(key);
+
+        if (trace && tc.isDebugEnabled())
+            Tr.debug(this, tc, key, value);
+
+        if (value == null)
+            return null;
+
+        long startTime = System.currentTimeMillis();
+        byte[] bytes = (byte[]) value[BYTES];
+
+        if (bytes != null && bytes.length > 0) {
+            BufferedInputStream in = new BufferedInputStream(new ByteArrayInputStream(bytes));
+            try {
+                try {
+                    tmp = ((CacheStore) getIStore()).getLoader().loadObject(in);
+                } finally {
+                    in.close();
+                }
+            } catch (ClassNotFoundException | IOException x) {
+                FFDCFilter.processException(x, getClass().getName(), "96", s);
+                throw new RuntimeException(x);
+            }
+        }
+
+        SessionStatistics pmiStats = getIStore().getSessionStatistics();
+        if (pmiStats != null) {
+            pmiStats.readTimes(bytes == null ? 0 : bytes.length, System.currentTimeMillis() - startTime);
+        }
+
+        return tmp;
+    }
+
+    /**
      * @see com.ibm.ws.session.store.common.BackedHashMap#insertSession(com.ibm.ws.session.store.common.BackedSession)
      */
     @Override
     protected void insertSession(BackedSession d2) {
-        throw new UnsupportedOperationException();
+        // TODO rewrite this. For now, it is copied based on DatabaseHashMap.insertSession
+        String key = d2.getId() + '+' + d2.getId() + '@' + d2.getAppName();
+
+        listenerFlagUpdate(d2);
+
+        long tmpCreationTime = d2.getCreationTime();
+        d2.setLastWriteLastAccessTime(tmpCreationTime);
+
+        Object[] value = new Object[SIZE];
+        value[LISTENER_COUNT] = d2.listenerFlag;
+        value[LAST_ACCESS] = tmpCreationTime;
+        value[CREATION_TIME] = tmpCreationTime;
+        value[MAX_INACTIVE_TIME] = d2.getMaxInactiveInterval();
+        value[USER_NAME] = d2.getUserName();
+        //value[BYTES] = null;
+
+        if (!cacheStoreService.cache.putIfAbsent(key, value))
+            throw new IllegalStateException("Cache already contains " + key);
+
+        d2.needToInsert = false;
+
+        removeFromRecentlyInvalidatedList(d2.getId());
+
+        d2.update = null;
+        d2.userWriteHit = false;
+        d2.maxInactWriteHit = false;
+        d2.listenCntHit = false;
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheSession.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheSession.java
@@ -15,6 +15,8 @@ import java.util.Hashtable;
 
 import javax.transaction.UserTransaction;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.serialization.SerializationService;
 import com.ibm.ws.session.store.common.BackedSession;
 import com.ibm.wsspi.session.IStoreCallback;
@@ -23,6 +25,8 @@ import com.ibm.wsspi.session.IStoreCallback;
  * TODO most methods are not implemented
  */
 public class CacheSession extends BackedSession {
+    private static final TraceComponent tc = Tr.register(CacheSession.class);
+
     // The swappable data
     private Hashtable<?, ?> mSwappableData;
 
@@ -81,12 +85,37 @@ public class CacheSession extends BackedSession {
     }
 
     /**
+     * Copied from DatabaseSession.getSwappableListeners.
+     * Get the swappable listeners
+     * Called to load session attributes if the session contains Activation or Binding listeners
+     * Note, we always load ALL attributes here since we can't tell which are listeners until they
+     * are loaded.
+     * 
      * @see com.ibm.ws.session.store.common.BackedSession#getSwappableListeners(short)
      */
     @Override
-    public boolean getSwappableListeners(short listener) {
-        throw new UnsupportedOperationException();
+    public boolean getSwappableListeners(short requestedListener) {
+        short thisListenerFlag = getListenerFlag();
+        boolean rc = false;
+        // check session's listenrCnt to see if it has any of the type we want
+        // input listener is either BINDING or ACTIVATION, so if the session has both, its a match
+        if (thisListenerFlag == requestedListener || thisListenerFlag == HTTP_SESSION_BINDING_AND_ACTIVATION_LISTENER) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "loading data because we have listener match for " + requestedListener);
+
+            rc = true;
+            if (!populatedAppData) {
+                try {
+                    getSessions().getIStore().setThreadContext();
+                    getSingleRowAppData();
+                } finally {
+                    getSessions().getIStore().unsetThreadContext();
+                }
+            }
+        }
+        return rc;
     }
+
 
     /**
      * @see com.ibm.ws.session.store.common.BackedSession#getUserTransaction()

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTest.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -55,6 +56,7 @@ public class SessionCacheTest extends FATServletClient {
      * serialized when the session is evicted from memory, and deserialized
      * when the session is accessed again.
      */
+    @AllowedFFDC("java.lang.UnsupportedOperationException") // TODO remove once we implement performInvalidation and possibly other methods
     @Test
     public void testSerialization() throws Exception {
         List<String> session = new ArrayList<>();

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServer/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServer/server.xml
@@ -1,11 +1,11 @@
 <server>
 
     <featureManager>
+        <feature>bells-1.0</feature>
         <feature>servlet-3.1</feature>
         <feature>componenttest-1.0</feature>
         <feature>jdbc-4.1</feature>
         <feature>sessionCache-1.0</feature>
-        <feature>sessionDatabase-1.0</feature> <!-- TODO remove sessionDatabase-1.0 and httpSessionDatabase once sessionCache-1.0 is working -->
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>
@@ -13,24 +13,24 @@
     <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
 
     <httpSessionCache libraryRef="HazelcastLib"/>
-    
-    <!-- TODO: eventually all of this database configuration will be replaced with JCache configuration -->
-    <httpSessionDatabase dataSourceRef="SessionDS"/>
 
-	<authData id="SessionAuth" user="userName" password="userPassword"/>    
-    <dataSource id="SessionDS" jndiName="jdbc/SessionDS" type="javax.sql.ConnectionPoolDataSource" transactional="false" containerAuthDataRef="SessionAuth">
-	    <jdbcDriver libraryRef="DerbyLib"/>
-	    <properties.derby.embedded createDatabase="create" databaseName="memory:sessionCacheServer"/>
-	</dataSource>
-	
-	<library id="DerbyLib">
-	    <file name="${shared.resource.dir}/derby/derby.jar"/>
-	</library>
+    <bell libraryRef="HazelcastLib"/> <!-- TODO Either need httpSessionCache or bell, not both. Split into 2 tests -->
 
     <library id="HazelcastLib">
         <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
     </library>
-	
+
+	<library id="DerbyLib">
+	    <file name="${shared.resource.dir}/derby/derby.jar"/>
+	</library>
+
+    <!-- Used for testing that data source can be stored in a session -->
+	<authData id="DerbyAuth" user="userName" password="userPassword"/>    
+    <dataSource jndiName="jdbc/derby" containerAuthDataRef="DerbyAuth">
+	    <jdbcDriver libraryRef="DerbyLib"/>
+	    <properties.derby.embedded createDatabase="create" databaseName="memory:testdb"/>
+	</dataSource>
+
 	<javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 
 </server>

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,8 +20,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.sql.DataSource;
 
-import org.junit.Test;
-
 import componenttest.app.FATServlet;
 import junit.framework.Assert;
 
@@ -29,7 +27,7 @@ import junit.framework.Assert;
 @WebServlet("/SessionCacheTestServlet")
 public class SessionCacheTestServlet extends FATServlet {
 
-    @Resource(lookup = "jdbc/SessionDS")
+    @Resource(lookup = "jdbc/derby")
     DataSource dataSource;
 
     /**


### PR DESCRIPTION
After copying a sufficient number of methods from DatabaseHashMap/Session to CacheHashMap/Session, it is possible to execute some basic code path covered by the com.ibm.ws.session.cache_fat bucket.  This pull also switches over the fat bucket to use the very early stage and experimental sessionCache-1.0 feature, which will give us a starting point towards putting a proper implementation in place.