### PR TITLE
Issue #1920: Exempting artifact BVT from java sec.

### DIFF
--- a/dev/com.ibm.ws.artifact_fat_bvt/publish/servers/com.ibm.ws.artifact.fat_bvt/bootstrap.properties
+++ b/dev/com.ibm.ws.artifact_fat_bvt/publish/servers/com.ibm.ws.artifact.fat_bvt/bootstrap.properties
@@ -10,6 +10,6 @@ com.ibm.ws.logging.exception.log.append=false
 
 bootstrap.include=../testports.properties
 
-
-
-
+# This BVT is creating an internal app that reaches into the kernel.  It should
+# not be utilizing java 2 security given the nature of its activities.
+websphere.java.security.exempt=true


### PR DESCRIPTION
The com.ibm.ws.artifact_fat_bvt bucket fails whenenver java 2 security is enabled. This BVT is creating an internal application that interacts with the internal of the kernel. It should not be using java 2 security.