### PR TITLE
Jaxrs21tck issues

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/org/apache/cxf/jaxrs/client/spec/InvocationBuilderImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/org/apache/cxf/jaxrs/client/spec/InvocationBuilderImpl.java
@@ -257,10 +257,13 @@ public class InvocationBuilderImpl implements Invocation.Builder {
 
     @Override
     public Builder headers(MultivaluedMap<String, Object> headers) {
-        RuntimeDelegate rd = HttpUtils.getOtherRuntimeDelegate();
-        for (Map.Entry<String, List<Object>> entry : headers.entrySet()) {
-            for (Object value : entry.getValue()) {
-                doSetHeader(rd, entry.getKey(), value);
+        webClient.removeAllHeaders();
+        if (headers != null) {
+            RuntimeDelegate rd = HttpUtils.getOtherRuntimeDelegate();
+            for (Map.Entry<String, List<Object>> entry : headers.entrySet()) {
+                for (Object value : entry.getValue()) {
+                    doSetHeader(rd, entry.getKey(), value);
+                }
             }
         }
         return this;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/Headers.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/Headers.java
@@ -41,6 +41,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.cxf.common.util.PropertyUtils;
+import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.helpers.HttpHeaderHelper;
 import org.apache.cxf.message.Message;
@@ -588,9 +589,10 @@ public class Headers {
     public static String toHttpLanguage(Locale locale) {
         StringBuilder sb = new StringBuilder();
         sb.append(locale.getLanguage());
-        if (locale.getCountry() != null) {
+        String country = locale.getCountry();
+        if (!StringUtils.isEmpty(country)) {
             // Locale.toString() will add "_" instead, '-' is typically expected
-            sb.append('-').append(locale.getCountry());
+            sb.append('-').append(country);
         }
         return sb.toString();
     }


### PR DESCRIPTION
Two issues:
1. Invocation.Builder.headers(...) should replace/remove all pre-existing headers.
2. An empty, but non-null country portion of a Locale should be treated similar to a null country - i.e. new Locale("en", "") should result in "en", not "en-".