### PR TITLE
Java 2 Security issues in batch-1.0 feature

### DIFF
--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/context/impl/JobContextImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/context/impl/JobContextImpl.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2012 International Business Machines Corp.
- * 
+ *
  * See the NOTICE file distributed with this work for additional information
- * regarding copyright ownership. Licensed under the Apache License, 
+ * regarding copyright ownership. Licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,8 @@
  */
 package com.ibm.jbatch.container.context.impl;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Properties;
 import java.util.logging.Logger;
 
@@ -27,74 +29,79 @@ import com.ibm.jbatch.container.instance.WorkUnitDescriptor;
 
 public class JobContextImpl implements JobContext {
 
-	private final static String sourceClass = JobContextImpl.class.getName();
-	private final static Logger logger = Logger.getLogger(sourceClass);
+    private final static String sourceClass = JobContextImpl.class.getName();
+    private final static Logger logger = Logger.getLogger(sourceClass);
 
-	private Object transientUserData = null;
+    private Object transientUserData = null;
 
-	@TCKExperimentProperty
-	private final static boolean cloneContextProperties = Boolean.getBoolean("clone.context.properties");
+    @TCKExperimentProperty
+    private final static boolean cloneContextProperties = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+        @Override
+        public Boolean run() {
+            return Boolean.getBoolean("clone.context.properties");
+        }
+    });
 
-	private WorkUnitDescriptor delegate = null;
+    private WorkUnitDescriptor delegate = null;
 
-	public JobContextImpl(WorkUnitDescriptor rwue) {
-		this.delegate = rwue;
-	}
+    public JobContextImpl(WorkUnitDescriptor rwue) {
+        this.delegate = rwue;
+    }
 
-	@Override
-	public String getExitStatus() {
-		return delegate.getExitStatus();
-	}
+    @Override
+    public String getExitStatus() {
+        return delegate.getExitStatus();
+    }
 
-	@Override
-	public void setExitStatus(String exitStatus) {
-		logger.fine("Setting exitStatus = " + exitStatus);
-		delegate.setExitStatus(exitStatus);
-	}
+    @Override
+    public void setExitStatus(String exitStatus) {
+        logger.fine("Setting exitStatus = " + exitStatus);
+        delegate.setExitStatus(exitStatus);
+    }
 
-	@Override
-	public BatchStatus getBatchStatus() {
-		return delegate.getBatchStatus();
-	}
+    @Override
+    public BatchStatus getBatchStatus() {
+        return delegate.getBatchStatus();
+    }
 
-	@Override
-	public Properties getProperties() {
-		Properties properties = delegate.getTopLevelJobProperties();
+    @Override
+    public Properties getProperties() {
+        Properties properties = delegate.getTopLevelJobProperties();
 
-		if (cloneContextProperties) {
-			logger.fine("Cloning job context properties");
-			return (Properties)properties.clone();
-		} else {
-			logger.fine("Returing ref (non-clone) to job context properties");
-			return properties;
-		}
-	}
+        if (cloneContextProperties) {
+            logger.fine("Cloning job context properties");
+            return (Properties) properties.clone();
+        } else {
+            logger.fine("Returing ref (non-clone) to job context properties");
+            return properties;
+        }
+    }
 
-	@Override
-	public String getJobName() {
-		return delegate.getTopLevelJobName();
-	}	
+    @Override
+    public String getJobName() {
+        return delegate.getTopLevelJobName();
+    }
 
-	@Override
-	public long getExecutionId() {
-		return delegate.getTopLevelExecutionId();
-	}
+    @Override
+    public long getExecutionId() {
+        return delegate.getTopLevelExecutionId();
+    }
 
-	@Override
-	public long getInstanceId() {
-		return delegate.getTopLevelInstanceId();
-	}
+    @Override
+    public long getInstanceId() {
+        return delegate.getTopLevelInstanceId();
+    }
 
-	// No need to push down to the runtime execution
-	public Object getTransientUserData() {
-		return transientUserData;
-	}
+    // No need to push down to the runtime execution
+    @Override
+    public Object getTransientUserData() {
+        return transientUserData;
+    }
 
-	// No need to push down to the runtime execution	
-	@Override
-	public void setTransientUserData(Object data) {
-		this.transientUserData = data;
-	}
+    // No need to push down to the runtime execution
+    @Override
+    public void setTransientUserData(Object data) {
+        this.transientUserData = data;
+    }
 
 }
-

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/jsl/ValidatorHelper.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/jsl/ValidatorHelper.java
@@ -1,22 +1,25 @@
 /*
  * Copyright 2012 International Business Machines Corp.
- * 
+ *
  * See the NOTICE file distributed with this work for additional information
- * regarding copyright ownership. Licensed under the Apache License, 
+ * regarding copyright ownership. Licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 package com.ibm.jbatch.container.jsl;
 
 import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 
 import javax.xml.XMLConstants;
 import javax.xml.validation.Schema;
@@ -27,27 +30,33 @@ import org.xml.sax.SAXException;
 public class ValidatorHelper {
 
     public final static String SCHEMA_LOCATION = "jobXML_1_0.xsd";
-    
+
     private static Schema schema = null;
-    
-    private static SchemaFactory sf = 
-        SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);              
+
+    private static SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
     /**
-     * This method must be synchronized as it is possible for two threads to 
-     * enter concurrently while schema == null and both will try to load and 
+     * This method must be synchronized as it is possible for two threads to
+     * enter concurrently while schema == null and both will try to load and
      * parse the schema, which may cause a parsing exception:
-     * org.xml.sax.SAXException: FWK005 parse may not be called while parsing. 
+     * org.xml.sax.SAXException: FWK005 parse may not be called while parsing.
      */
     public static synchronized Schema getXJCLSchema() {
         if (schema == null) {
+            final URL url = ValidatorHelper.class.getResource(SCHEMA_LOCATION);
             try {
-                URL url = ValidatorHelper.class.getResource(SCHEMA_LOCATION);
-                schema = sf.newSchema(url);
-            } catch (SAXException e) {
-                throw new RuntimeException(e);
+                schema = AccessController.doPrivileged(
+                                                       new PrivilegedExceptionAction<Schema>() {
+                                                           @Override
+                                                           public Schema run() throws SAXException {
+                                                               return sf.newSchema(url);
+                                                           }
+                                                       });
+            } catch (PrivilegedActionException e) {
+                throw new RuntimeException(e.getCause());
             }
+
         }
-        return schema;        
-    }     
+        return schema;
+    }
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/jsl/impl/JobModelResolverImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/jsl/impl/JobModelResolverImpl.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2012 International Business Machines Corp.
- * 
+ *
  * See the NOTICE file distributed with this work for additional information
- * regarding copyright ownership. Licensed under the Apache License, 
+ * regarding copyright ownership. Licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.logging.Logger;
 
 import javax.xml.bind.JAXBContext;
@@ -35,213 +37,231 @@ import com.ibm.jbatch.jsl.model.JSLJob;
 
 public class JobModelResolverImpl implements ModelResolver<JSLJob> {
 
-	private final static String sourceClass = JobModelResolverImpl.class.getName();
-	private final static Logger logger = Logger.getLogger(sourceClass);
+    private final static String sourceClass = JobModelResolverImpl.class.getName();
+    private final static Logger logger = Logger.getLogger(sourceClass);
 
-	public JobModelResolverImpl() {
-		super();
-	}    
+    public JobModelResolverImpl() {
+        super();
+    }
 
-	@Override
-	public JSLJob resolveModel(final StreamSource source) {
-		return doPrivilegedUnmarshal(source);
-	}
+    @Override
+    public JSLJob resolveModel(final StreamSource source) {
+        return unmarshalJobXML(source);
+    }
 
-	protected JSLJob doPrivilegedUnmarshal(final StreamSource source) {
-		return AccessController.doPrivileged(
-				new PrivilegedAction<JSLJob>() {
-					public JSLJob run() {
-						return unmarshalJobXML(source);
-					}
-				});
-	}
+    private JSLJob unmarshalJobXML(final StreamSource source) {
+        Object result = null;
+        JSLJob job = null;
+        InputStream is = null;
+        JSLValidationEventHandler handler = new JSLValidationEventHandler();
 
-	private JSLJob unmarshalJobXML(StreamSource source) {
-		Object result = null;
-		JSLJob job = null;
-		InputStream is = null;
-		JSLValidationEventHandler handler = new JSLValidationEventHandler();
+        try {
+            //Defect 178383: get the input stream from the source and ensure it is closed
+            //in the finally block to release the xml from being locked
+            is = source.getInputStream();
 
-		try {
-			//Defect 178383: get the input stream from the source and ensure it is closed 
-			//in the finally block to release the xml from being locked
-			is = source.getInputStream();
-			
-			logger.fine("JobModelResolver start unmarshal");
-			ClassLoader currentClassLoader = JSLJob.class.getClassLoader();
+            logger.fine("JobModelResolver start unmarshal");
+            final ClassLoader currentClassLoader = AccessController.doPrivileged(
+                                                                                 new PrivilegedAction<ClassLoader>() {
+                                                                                     @Override
+                                                                                     public ClassLoader run() {
+                                                                                         return JSLJob.class.getClassLoader();
+                                                                                     }
+                                                                                 });
 
-			logger.fine("JobModelResolver classloader obtained.");
+            logger.fine("JobModelResolver classloader obtained.");
 
-			JAXBContext ctx = JAXBContext.newInstance("com.ibm.jbatch.jsl.model", currentClassLoader);
+            JAXBContext ctx = null;
+            try {
+                ctx = AccessController.doPrivileged(
+                                                    new PrivilegedExceptionAction<JAXBContext>() {
+                                                        @Override
+                                                        public JAXBContext run() throws JAXBException {
+                                                            return JAXBContext.newInstance("com.ibm.jbatch.jsl.model", currentClassLoader);
+                                                        }
+                                                    });
+            } catch (PrivilegedActionException e) {
+                throw new IllegalArgumentException("Exception creating JAXBContext to unmarshal jobXML", e.getCause());
+            }
 
-			logger.fine("JobModelResolver JAXBContext obtained.");
+            logger.fine("JobModelResolver JAXBContext obtained.");
 
-			Unmarshaller u = ctx.createUnmarshaller();
-			u.setSchema(ValidatorHelper.getXJCLSchema());
+            final Unmarshaller u = ctx.createUnmarshaller();
+            u.setSchema(ValidatorHelper.getXJCLSchema());
 
-			u.setEventHandler(handler);
+            u.setEventHandler(handler);
 
-			result = u.unmarshal(source);
+            try {
+                result = AccessController.doPrivileged(
+                                                       new PrivilegedExceptionAction<Object>() {
+                                                           @Override
+                                                           public Object run() throws JAXBException {
+                                                               return u.unmarshal(source);
+                                                           }
+                                                       });
+            } catch (PrivilegedActionException e) {
+                throw new IllegalArgumentException("Exception unmarshalling jobXML", e.getCause());
+            }
 
-		} catch (JAXBException e) {
-			throw new IllegalArgumentException("Exception unmarshalling jobXML", e);
-		} finally {
-			if (is != null){
-				try {
-					is.close();
-				} catch (IOException e) {
-					throw new IllegalArgumentException("Exception closing the Input Stream", e);
-				}
-			}
-		}
-
-		if (handler.eventOccurred()) {
-			// Not sure we'd get here.
-			throw new IllegalArgumentException("JSL invalid per schema");
-		}
-
-		job = ((JAXBElement<JSLJob>)result).getValue();
-
-		return job;
-	}
-
-	/* Let's not worry about inheritance
-	 * 
-	private JSLJob getJslJobInheritance(String jobId) throws IOException {
-
-		JSLJob jslJob = null;
-		InputStream indexFileUrl = JobModelResolverImpl.class.getResourceAsStream("/META-INF/jobinheritance");
-
-		if (indexFileUrl != null) {
-			Properties index = new Properties();
-			index.load(indexFileUrl);
-
-			if (index.getProperty(jobId) != null) {
-				URL parentUrl = JobModelResolverImpl.class.getResource(index.getProperty(jobId));
-				String parentXml = readJobXML(parentUrl.getFile());
-
-				jslJob = resolveModel(parentXml);
-			}
-		}
-		return jslJob;
-	}
-	 */
-
-
-	// FIXME HashMap<String, Split> splitid2InstanceMap = new HashMap<String,Split>();
-	// FIXME HashMap<String, Flow> flowid2InstanceMap = new HashMap<String,Flow>();
-
-	//
-	// This is where we will implement job/step inheritance, though we don't at
-	// the moment.
-	//
-	/*
-    public static ResolvedJob resolveJob(Job job) {
-        ArrayList<ResolvedStep> steps = new ArrayList<ResolvedStep>();
-        ArrayList<ResolvedDecision> decisions = new ArrayList<ResolvedDecision>();
-        ArrayList<ResolvedSplit> splits = new ArrayList<ResolvedSplit>();
-        ArrayList<ResolvedFlow> flows = new ArrayList<ResolvedFlow>();
-
-        ResolvedJob resolvedJob = new ResolvedJob(job.getId(), steps, decisions, splits, flows);
-
-        for (Object next : job.getControlElements()) {
-            if (next instanceof Step) {
-                steps.add(new ResolvedStep(resolvedJob, (Step) next));
-            } else if (next instanceof Decision) {
-                decisions.add(new ResolvedDecision(resolvedJob, (Decision) next));
-            } else if (next instanceof Split) {
-                splits.add(new ResolvedSplit(resolvedJob, (Split) next));
-            } else if (next instanceof Flow) {
-                flows.add(new ResolvedFlow(resolvedJob, (Flow) next));
+        } catch (JAXBException e) {
+            throw new IllegalArgumentException("Exception unmarshalling jobXML", e);
+        } finally {
+            if (is != null) {
+                try {
+                    is.close();
+                } catch (IOException e) {
+                    throw new IllegalArgumentException("Exception closing the Input Stream", e);
+                }
             }
         }
 
-        return resolvedJob;
-    }
-
-
-    //FIXME We started implementing job inheritance here. Set to private so no one uses this yet.
-    private static ResolvedJob resolveModel(Job leafJob) {
-        String parentID = leafJob.getParent();
-
-        Job resolvedJob = resolveModel(leafJob, parentID);
-        // FIXME you need to create a new ResolvedJob here.
-        return null;
-
-    }
-
-    private static Job resolveModel(Job leafJob, String parentID) {
-
-        if (!parentID.equals("")) {
-            Job parentJob = jobid2InstanceMap.get(parentID);
-            if (parentJob == null) {
-                throw new BatchContainerRuntimeException(new IllegalArgumentException(), "The parent job id '" + parentID + "' on Job id '"
-                        + leafJob.getParent() + " cannot be found");
-            }
-
-            // add all the attributes, steps, flows, and splits from the parent
-            // to child if they don't exist on child            
-            leafJob.getControlElements().addAll(parentJob.getControlElements());
-
-            return resolveModel(leafJob, parentJob.getParent());
-
+        if (handler.eventOccurred()) {
+            // Not sure we'd get here.
+            throw new IllegalArgumentException("JSL invalid per schema");
         }
 
-        for (Object next : leafJob.getControlElements()) {
-            if (next instanceof Step) {
-                resolveModel((Step)next);
-            } else if (next instanceof Split) {
-                //resolveModel((Split)next);
-            } else if (next instanceof Flow) {
-                //resolveModel((Flow)next);
-            }
+        job = ((JAXBElement<JSLJob>) result).getValue();
 
-        }
-
-        return leafJob;
-
+        return job;
     }
 
-    //FIXME Set to private so no one uses this yet.
-    private static ResolvedStep resolveModel(Step leafStep) {
+    /*
+     * Let's not worry about inheritance
+     *
+     * private JSLJob getJslJobInheritance(String jobId) throws IOException {
+     *
+     * JSLJob jslJob = null;
+     * InputStream indexFileUrl = JobModelResolverImpl.class.getResourceAsStream("/META-INF/jobinheritance");
+     *
+     * if (indexFileUrl != null) {
+     * Properties index = new Properties();
+     * index.load(indexFileUrl);
+     *
+     * if (index.getProperty(jobId) != null) {
+     * URL parentUrl = JobModelResolverImpl.class.getResource(index.getProperty(jobId));
+     * String parentXml = readJobXML(parentUrl.getFile());
+     *
+     * jslJob = resolveModel(parentXml);
+     * }
+     * }
+     * return jslJob;
+     * }
+     */
 
-        String parentID = leafStep.getParent();
+    // FIXME HashMap<String, Split> splitid2InstanceMap = new HashMap<String,Split>();
+    // FIXME HashMap<String, Flow> flowid2InstanceMap = new HashMap<String,Flow>();
 
-        Step resolvedStep = resolveModel(leafStep, parentID);
-
-        // FIXME you need to clone the step to a resolved step
-        return null;
-
-    }
-
-    private static Step resolveModel(Step leafStep, String parentID) {
-        if (!parentID.equals("")) {
-            Step parentStep = stepid2InstanceMap.get(parentID);
-            if (parentStep == null) {
-                throw new BatchContainerRuntimeException(new IllegalArgumentException(), "The parent step id '" + parentID
-                        + "' on Step id '" + leafStep.getParent() + " cannot be found");
-            }
-
-            // add all the attributes, batchlets, chunks...etc from a parent
-            // step if they don't
-            // exist on the child step
-            // leafStep.getXXX().addAll(parentStep.getXXX());
-
-            return resolveModel(leafStep, parentStep.getParent());
-
-        }
-
-        // batchlet
-        //
-
-        // resolve chunks
-
-        // next, startlimit ...etc
-
-        // FIXME ...
-
-        return leafStep;
-    }
-	 */
+    //
+    // This is where we will implement job/step inheritance, though we don't at
+    // the moment.
+    //
+    /*
+     * public static ResolvedJob resolveJob(Job job) {
+     * ArrayList<ResolvedStep> steps = new ArrayList<ResolvedStep>();
+     * ArrayList<ResolvedDecision> decisions = new ArrayList<ResolvedDecision>();
+     * ArrayList<ResolvedSplit> splits = new ArrayList<ResolvedSplit>();
+     * ArrayList<ResolvedFlow> flows = new ArrayList<ResolvedFlow>();
+     *
+     * ResolvedJob resolvedJob = new ResolvedJob(job.getId(), steps, decisions, splits, flows);
+     *
+     * for (Object next : job.getControlElements()) {
+     * if (next instanceof Step) {
+     * steps.add(new ResolvedStep(resolvedJob, (Step) next));
+     * } else if (next instanceof Decision) {
+     * decisions.add(new ResolvedDecision(resolvedJob, (Decision) next));
+     * } else if (next instanceof Split) {
+     * splits.add(new ResolvedSplit(resolvedJob, (Split) next));
+     * } else if (next instanceof Flow) {
+     * flows.add(new ResolvedFlow(resolvedJob, (Flow) next));
+     * }
+     * }
+     *
+     * return resolvedJob;
+     * }
+     *
+     *
+     * //FIXME We started implementing job inheritance here. Set to private so no one uses this yet.
+     * private static ResolvedJob resolveModel(Job leafJob) {
+     * String parentID = leafJob.getParent();
+     *
+     * Job resolvedJob = resolveModel(leafJob, parentID);
+     * // FIXME you need to create a new ResolvedJob here.
+     * return null;
+     *
+     * }
+     *
+     * private static Job resolveModel(Job leafJob, String parentID) {
+     *
+     * if (!parentID.equals("")) {
+     * Job parentJob = jobid2InstanceMap.get(parentID);
+     * if (parentJob == null) {
+     * throw new BatchContainerRuntimeException(new IllegalArgumentException(), "The parent job id '" + parentID + "' on Job id '"
+     * + leafJob.getParent() + " cannot be found");
+     * }
+     *
+     * // add all the attributes, steps, flows, and splits from the parent
+     * // to child if they don't exist on child
+     * leafJob.getControlElements().addAll(parentJob.getControlElements());
+     *
+     * return resolveModel(leafJob, parentJob.getParent());
+     *
+     * }
+     *
+     * for (Object next : leafJob.getControlElements()) {
+     * if (next instanceof Step) {
+     * resolveModel((Step)next);
+     * } else if (next instanceof Split) {
+     * //resolveModel((Split)next);
+     * } else if (next instanceof Flow) {
+     * //resolveModel((Flow)next);
+     * }
+     *
+     * }
+     *
+     * return leafJob;
+     *
+     * }
+     *
+     * //FIXME Set to private so no one uses this yet.
+     * private static ResolvedStep resolveModel(Step leafStep) {
+     *
+     * String parentID = leafStep.getParent();
+     *
+     * Step resolvedStep = resolveModel(leafStep, parentID);
+     *
+     * // FIXME you need to clone the step to a resolved step
+     * return null;
+     *
+     * }
+     *
+     * private static Step resolveModel(Step leafStep, String parentID) {
+     * if (!parentID.equals("")) {
+     * Step parentStep = stepid2InstanceMap.get(parentID);
+     * if (parentStep == null) {
+     * throw new BatchContainerRuntimeException(new IllegalArgumentException(), "The parent step id '" + parentID
+     * + "' on Step id '" + leafStep.getParent() + " cannot be found");
+     * }
+     *
+     * // add all the attributes, batchlets, chunks...etc from a parent
+     * // step if they don't
+     * // exist on the child step
+     * // leafStep.getXXX().addAll(parentStep.getXXX());
+     *
+     * return resolveModel(leafStep, parentStep.getParent());
+     *
+     * }
+     *
+     * // batchlet
+     * //
+     *
+     * // resolve chunks
+     *
+     * // next, startlimit ...etc
+     *
+     * // FIXME ...
+     *
+     * return leafStep;
+     * }
+     */
 
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/navigator/AbstractNavigatorImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/navigator/AbstractNavigatorImpl.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2012 International Business Machines Corp.
- * 
+ *
  * See the NOTICE file distributed with this work for additional information
- * regarding copyright ownership. Licensed under the Apache License, 
+ * regarding copyright ownership. Licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,8 @@
  */
 package com.ibm.jbatch.container.navigator;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,231 +43,231 @@ import com.ibm.jbatch.jsl.model.helper.TransitionElement;
 
 public abstract class AbstractNavigatorImpl<T> implements ModelNavigator<T> {
 
-	private final static Logger logger = Logger.getLogger(AbstractNavigatorImpl.class.getName());
+    private final static Logger logger = Logger.getLogger(AbstractNavigatorImpl.class.getName());
 
-	private Map<String, ExecutionElement> alreadyExecutedElements = new HashMap<String, ExecutionElement>();
+    @TCKExperimentProperty
+    private final static boolean disallowDecisionLoopback = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+        @Override
+        public Boolean run() {
+            return Boolean.getBoolean("disallow.decision.loopback");
+        }
+    });
 
-	public ExecutionElement getFirstExecutionElement(List<ExecutionElement> peerExecutionElements, String restartOn) throws IllegalTransitionException {
-		final String method = "getFirstExecutionElement";
+    private final Map<String, ExecutionElement> alreadyExecutedElements = new HashMap<String, ExecutionElement>();
 
-		logger.fine(method + " , restartOn = " + restartOn);
+    public ExecutionElement getFirstExecutionElement(List<ExecutionElement> peerExecutionElements, String restartOn) throws IllegalTransitionException {
+        final String method = "getFirstExecutionElement";
 
-		ExecutionElement startElement = null;
+        logger.fine(method + " , restartOn = " + restartOn);
 
-		if (restartOn != null) {
-			startElement = getExecutionElementFromId(peerExecutionElements, restartOn);
-			if (startElement == null) {
-				throw new IllegalStateException("Didn't find an execution element maching restart-on designated element: " + restartOn);
-			}
-		} else {
-			if (peerExecutionElements.size() > 0) {                
-				startElement = peerExecutionElements.get(0);
-			} else {
-				logger.fine(method + " , Container appears to contain no execution elements.  Returning.");
-				return null;
-			}
-		}
+        ExecutionElement startElement = null;
 
-		if (logger.isLoggable(Level.FINE)) {
-			logger.fine(method + " , Found start element: " + startElement);
-		}                
+        if (restartOn != null) {
+            startElement = getExecutionElementFromId(peerExecutionElements, restartOn);
+            if (startElement == null) {
+                throw new IllegalStateException("Didn't find an execution element maching restart-on designated element: " + restartOn);
+            }
+        } else {
+            if (peerExecutionElements.size() > 0) {
+                startElement = peerExecutionElements.get(0);
+            } else {
+                logger.fine(method + " , Container appears to contain no execution elements.  Returning.");
+                return null;
+            }
+        }
 
-		if (!disallowDecisionLoopback) {
-			// We allow repeating a decision
-			if (!(startElement instanceof Decision)) {
-				alreadyExecutedElements.put(startElement.getId(), startElement);
-			}
-		} else {
-			alreadyExecutedElements.put(startElement.getId(), startElement);
-			
-		}
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine(method + " , Found start element: " + startElement);
+        }
 
-		validateElementType(startElement);
+        if (!disallowDecisionLoopback) {
+            // We allow repeating a decision
+            if (!(startElement instanceof Decision)) {
+                alreadyExecutedElements.put(startElement.getId(), startElement);
+            }
+        } else {
+            alreadyExecutedElements.put(startElement.getId(), startElement);
 
-		return startElement;
-	}
+        }
 
+        validateElementType(startElement);
 
+        return startElement;
+    }
 
-	/**
-	 * Precedence is: look at elements, then look at attribute, then return quietly
-	 * 
-	 * @param currentElem
-	 * @param peerExecutionElements
-	 * @param currentExitStatus
-	 * @return
-	 * @throws IllegalTransitionException
-	 */
-	public Transition getNextTransition(ExecutionElement currentElem, List<ExecutionElement> peerExecutionElements, ExecutionStatus currentStatus) 
-			throws IllegalTransitionException {
-		final String method = "getNextTransition";
+    /**
+     * Precedence is: look at elements, then look at attribute, then return quietly
+     *
+     * @param currentElem
+     * @param peerExecutionElements
+     * @param currentExitStatus
+     * @return
+     * @throws IllegalTransitionException
+     */
+    public Transition getNextTransition(ExecutionElement currentElem, List<ExecutionElement> peerExecutionElements,
+                                        ExecutionStatus currentStatus) throws IllegalTransitionException {
+        final String method = "getNextTransition";
 
-		if (logger.isLoggable(Level.FINE)) {
-			logger.fine(method + " ,currentStatus=" + currentStatus);
-		}
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine(method + " ,currentStatus=" + currentStatus);
+        }
 
-		Transition returnTransition = new TransitionImpl();
+        Transition returnTransition = new TransitionImpl();
 
-		ExecutionElement nextExecutionElement = null;
+        ExecutionElement nextExecutionElement = null;
 
-		List<TransitionElement> transitionElements = currentElem.getTransitionElements();
+        List<TransitionElement> transitionElements = currentElem.getTransitionElements();
 
-		// Check the transition elements first.
-		if (!transitionElements.isEmpty()) {
+        // Check the transition elements first.
+        if (!transitionElements.isEmpty()) {
 
-			if (currentElem instanceof Flow) {
-				throw new IllegalStateException("Flow-level transition elements such as <next>, <stop>, <end>, <fail>, are not allowed, " + 
-			 "since the behavior is undefined by the specification.  Failing job."); // TODO - translate
-			}
+            if (currentElem instanceof Flow) {
+                throw new IllegalStateException("Flow-level transition elements such as <next>, <stop>, <end>, <fail>, are not allowed, " +
+                                                "since the behavior is undefined by the specification.  Failing job."); // TODO - translate
+            }
 
-			for (TransitionElement t : transitionElements) {
-				logger.fine(method + " Trying to match next transition element: " + t);
+            for (TransitionElement t : transitionElements) {
+                logger.fine(method + " Trying to match next transition element: " + t);
 
-				boolean isMatched = matchExitStatusAgainstOnAttribute(currentStatus.getExitStatus(), t);
-				if (isMatched) {
-					if (t instanceof Next) {
-						Next next = (Next)t;
-						nextExecutionElement = getExecutionElementFromId(peerExecutionElements, next.getTo());
-						returnTransition.setNextExecutionElement(nextExecutionElement);
-						break;
-					} else {
-						returnTransition.setTransitionElement(t);
-					}
-					return returnTransition;
-				}
-			}
-		} 
+                boolean isMatched = matchExitStatusAgainstOnAttribute(currentStatus.getExitStatus(), t);
+                if (isMatched) {
+                    if (t instanceof Next) {
+                        Next next = (Next) t;
+                        nextExecutionElement = getExecutionElementFromId(peerExecutionElements, next.getTo());
+                        returnTransition.setNextExecutionElement(nextExecutionElement);
+                        break;
+                    } else {
+                        returnTransition.setTransitionElement(t);
+                    }
+                    return returnTransition;
+                }
+            }
+        }
 
-		// We've returned already if we matched a Stop, End or Fail
-		if (nextExecutionElement == null) {
-			if (currentStatus.getExtendedBatchStatus().equals(ExtendedBatchStatus.EXCEPTION_THROWN)) {
-				logger.fine("Didn't match transition element, after exception thrown.  Need to fail job");
-				returnTransition.setNoTransitionElementMatchAfterException();
-				return returnTransition;
-			} else {
-				logger.fine("Didn't match transition element, check @next attribute now.");
-				nextExecutionElement = getNextExecutionElemFromAttribute(peerExecutionElements, currentElem);
-				returnTransition.setNextExecutionElement(nextExecutionElement);
-			}
-		}
+        // We've returned already if we matched a Stop, End or Fail
+        if (nextExecutionElement == null) {
+            if (currentStatus.getExtendedBatchStatus().equals(ExtendedBatchStatus.EXCEPTION_THROWN)) {
+                logger.fine("Didn't match transition element, after exception thrown.  Need to fail job");
+                returnTransition.setNoTransitionElementMatchAfterException();
+                return returnTransition;
+            } else {
+                logger.fine("Didn't match transition element, check @next attribute now.");
+                nextExecutionElement = getNextExecutionElemFromAttribute(peerExecutionElements, currentElem);
+                returnTransition.setNextExecutionElement(nextExecutionElement);
+            }
+        }
 
-		if (nextExecutionElement != null) {
-			if (alreadyExecutedElements.containsKey(nextExecutionElement.getId())) {
-				String errorMsg = "Execution loop detected !!!  Trying to re-execute execution element: " + nextExecutionElement.getId();
-				throw new IllegalTransitionException(errorMsg);
-			}
+        if (nextExecutionElement != null) {
+            if (alreadyExecutedElements.containsKey(nextExecutionElement.getId())) {
+                String errorMsg = "Execution loop detected !!!  Trying to re-execute execution element: " + nextExecutionElement.getId();
+                throw new IllegalTransitionException(errorMsg);
+            }
 
-			if (!disallowDecisionLoopback) {
-				// We allow repeating a decision
-				if (!(nextExecutionElement instanceof Decision)) {
-					alreadyExecutedElements.put(nextExecutionElement.getId(), nextExecutionElement);
-				}
-			} else {
-				alreadyExecutedElements.put(nextExecutionElement.getId(), nextExecutionElement);
-			}
-			logger.fine(method + " Transitioning to next element id = " + nextExecutionElement.getId());
-		} else {
-			logger.fine(method + " There is no next execution element. Mark transition to show we're finished.");
-			returnTransition.setFinishedTransitioning();
-		}
-		return returnTransition;
-	}
+            if (!disallowDecisionLoopback) {
+                // We allow repeating a decision
+                if (!(nextExecutionElement instanceof Decision)) {
+                    alreadyExecutedElements.put(nextExecutionElement.getId(), nextExecutionElement);
+                }
+            } else {
+                alreadyExecutedElements.put(nextExecutionElement.getId(), nextExecutionElement);
+            }
+            logger.fine(method + " Transitioning to next element id = " + nextExecutionElement.getId());
+        } else {
+            logger.fine(method + " There is no next execution element. Mark transition to show we're finished.");
+            returnTransition.setFinishedTransitioning();
+        }
+        return returnTransition;
+    }
 
+    private ExecutionElement getExecutionElementFromId(List<ExecutionElement> executionElements, String id) throws IllegalTransitionException {
+        if (id != null) {
+            logger.finer("attribute value is " + id);
+            for (ExecutionElement elem : executionElements) {
+                if (elem.getId().equals(id)) {
+                    validateElementType(elem);
+                    return elem;
+                }
+            }
+            throw new IllegalTransitionException("No execution element found with id = " + id);
+        } else {
+            logger.finer("attribute value is <null>, so simply exiting...");
+            return null;
+        }
+    }
 
-	private ExecutionElement getExecutionElementFromId(List<ExecutionElement> executionElements, String id) 
-			throws IllegalTransitionException {
-		if (id != null) {
-			logger.finer("attribute value is " + id);
-			for (ExecutionElement elem : executionElements) {
-				if (elem.getId().equals(id)) {
-					validateElementType(elem);
-					return elem;
-				}
-			}
-			throw new IllegalTransitionException("No execution element found with id = " + id);
-		} else {
-			logger.finer("attribute value is <null>, so simply exiting...");
-			return null;
-		}
-	}
+    private static boolean matchSpecifiedExitStatus(String currentStepExitStatus, String exitStatusPattern) {
 
-	private static boolean matchSpecifiedExitStatus(String currentStepExitStatus, String exitStatusPattern) {
+        logger.finer("matchSpecifiedExitStatus, matching current exitStatus  " + currentStepExitStatus + " against pattern: " + exitStatusPattern);
 
-		logger.finer("matchSpecifiedExitStatus, matching current exitStatus  " + currentStepExitStatus + " against pattern: " + exitStatusPattern);
+        GlobPatternMatcherImpl matcher = new GlobPatternMatcherImpl();
+        boolean match = matcher.matchWithoutBackslashEscape(currentStepExitStatus, exitStatusPattern);
 
-		GlobPatternMatcherImpl matcher = new GlobPatternMatcherImpl(); 
-		boolean match = matcher.matchWithoutBackslashEscape(currentStepExitStatus, exitStatusPattern);
+        if (match) {
+            logger.finer("matchSpecifiedExitStatus, match=YES");
+            return true;
+        } else {
+            logger.finer("matchSpecifiedExitStatus, match=NO");
+            return false;
+        }
+    }
 
-		if (match) {
-			logger.finer("matchSpecifiedExitStatus, match=YES");
-			return true;
-		}
-		else {
-			logger.finer("matchSpecifiedExitStatus, match=NO");
-			return false;
-		}
-	}
+    private boolean matchExitStatusAgainstOnAttribute(String exitStatus, TransitionElement elem) {
+        logger.fine("Trying to match exitStatus = " + exitStatus + " , against transition element: " + elem);
+        String exitStatusToMatch = null;
 
-	private boolean matchExitStatusAgainstOnAttribute(String exitStatus, TransitionElement elem) {
-		logger.fine("Trying to match exitStatus = " + exitStatus + " , against transition element: " + elem);
-		String exitStatusToMatch = null;
+        if (elem instanceof End) {
+            exitStatusToMatch = ((End) elem).getOn();
+        } else if (elem instanceof Fail) {
+            exitStatusToMatch = ((Fail) elem).getOn();
+            return matchSpecifiedExitStatus(exitStatus, exitStatusToMatch);
+        } else if (elem instanceof Stop) {
+            exitStatusToMatch = ((Stop) elem).getOn();
+        } else if (elem instanceof Next) {
+            exitStatusToMatch = ((Next) elem).getOn();
+        } else {
+            throw new IllegalStateException("Shouldn't be possible to get here. Unknown transition element,  " + elem.toString());
+        }
 
-		if (elem instanceof End) {
-			exitStatusToMatch = ((End) elem).getOn();
-		} else if (elem instanceof Fail) {
-			exitStatusToMatch = ((Fail) elem).getOn();
-			return matchSpecifiedExitStatus(exitStatus, exitStatusToMatch);
-		} else if (elem instanceof Stop) {
-			exitStatusToMatch = ((Stop) elem).getOn();
-		} else if (elem instanceof Next) {
-			exitStatusToMatch = ((Next) elem).getOn();
-		} else {
-			throw new IllegalStateException("Shouldn't be possible to get here. Unknown transition element,  " + elem.toString());
-		}
+        boolean match = matchSpecifiedExitStatus(exitStatus, exitStatusToMatch);
+        String logMsg = match ? "Matched" : "Didn't match";
+        logger.fine(logMsg);
+        return match;
+    }
 
-		boolean match = matchSpecifiedExitStatus(exitStatus, exitStatusToMatch);
-		String logMsg = match ? "Matched" : "Didn't match";
-		logger.fine(logMsg);
-		return match;
-	}
+    private ExecutionElement getNextExecutionElemFromAttribute(List<ExecutionElement> peerExecutionElements, ExecutionElement currentElem) throws IllegalTransitionException {
+        ExecutionElement nextExecutionElement = null;
+        String nextAttrId = null;
+        if (currentElem instanceof Step) {
+            nextAttrId = ((Step) currentElem).getNextFromAttribute();
+            nextExecutionElement = getExecutionElementFromId(peerExecutionElements, nextAttrId);
+        } else if (currentElem instanceof Split) {
+            nextAttrId = ((Split) currentElem).getNextFromAttribute();
+            nextExecutionElement = getExecutionElementFromId(peerExecutionElements, nextAttrId);
+        } else if (currentElem instanceof Flow) {
+            nextAttrId = ((Flow) currentElem).getNextFromAttribute();
+            nextExecutionElement = getExecutionElementFromId(peerExecutionElements, nextAttrId);
+        } else if (currentElem instanceof Decision) {
+            // Nothing special to do in this case.
+        }
 
-	private ExecutionElement getNextExecutionElemFromAttribute(List<ExecutionElement> peerExecutionElements, ExecutionElement currentElem) throws IllegalTransitionException {
-		ExecutionElement nextExecutionElement = null;
-		String nextAttrId = null;
-		if (currentElem instanceof Step) {
-			nextAttrId = ((Step) currentElem).getNextFromAttribute();
-			nextExecutionElement = getExecutionElementFromId(peerExecutionElements, nextAttrId);
-		} else if (currentElem instanceof Split) {
-			nextAttrId = ((Split) currentElem).getNextFromAttribute();
-			nextExecutionElement = getExecutionElementFromId(peerExecutionElements, nextAttrId);
-		} else if (currentElem instanceof Flow) {
-			nextAttrId = ((Flow) currentElem).getNextFromAttribute();
-			nextExecutionElement = getExecutionElementFromId(peerExecutionElements, nextAttrId);
-		} else if (currentElem instanceof Decision) {
-			// Nothing special to do in this case.
-		}
+        validateElementType(nextExecutionElement);
 
-		validateElementType(nextExecutionElement);
+        logger.fine("From currentElem = " + currentElem + " , return @next attribute execution element: " + nextExecutionElement);
+        return nextExecutionElement;
+    }
 
-		logger.fine("From currentElem = " + currentElem + " , return @next attribute execution element: " + nextExecutionElement);
-		return nextExecutionElement;
-	}
+    @Override
+    public ExecutionElement getFirstExecutionElement() throws IllegalTransitionException {
+        return getFirstExecutionElement(null);
+    }
 
-	@Override
-	public ExecutionElement getFirstExecutionElement()
-			throws IllegalTransitionException {
-		return getFirstExecutionElement(null);
-	}
+    private void validateElementType(ExecutionElement elem) {
+        if (elem != null) {
+            if (!((elem instanceof Decision) || (elem instanceof Flow) || (elem instanceof Split) || (elem instanceof Step))) {
+                throw new IllegalArgumentException("Unknown execution element found, elem = " + elem + ", found with type: " + elem.getClass().getCanonicalName() +
+                                                   " , which is not an instance of Decision, Flow, Split, or Step.");
+            }
+        }
+    }
 
-	private void validateElementType(ExecutionElement elem) {
-		if (elem != null) {
-			if (!((elem instanceof Decision) || (elem instanceof Flow) || (elem instanceof Split) || (elem instanceof Step))) { 
-				throw new IllegalArgumentException("Unknown execution element found, elem = " + elem + ", found with type: " + elem.getClass().getCanonicalName() +
-						" , which is not an instance of Decision, Flow, Split, or Step.");
-			} 
-		}
-	}
-
-	@TCKExperimentProperty
-	private final static boolean disallowDecisionLoopback = Boolean.getBoolean("disallow.decision.loopback");
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntity.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.jbatch.container.persistence.jpa;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -59,6 +61,14 @@ import com.ibm.jbatch.container.ws.WSJobExecution;
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @ClassExtractor(JobExecutionEntityExtractor.class)
 public class JobExecutionEntity extends JobThreadExecutionBase implements JobExecution, WSJobExecution {
+
+    // Repeat everywhere we use so caller has to think through granting privilege
+    protected static String eol = AccessController.doPrivileged(new PrivilegedAction<String>() {
+        @Override
+        public String run() {
+            return System.getProperty("line.separator");
+        }
+    });
 
     public static final String UPDATE_JOB_EXECUTION_AND_INSTANCE_SERVER_NOT_SET = "JobExecutionEntity.updateJobExecutionAndInstanceServerNotSet";
     public static final String UPDATE_JOB_EXECUTION_SERVERID_AND_RESTURL_FOR_STARTING_JOB = "JobExecutionEntity.updateJobExecutionServerIdAndRestUrlForStartingJob";
@@ -200,7 +210,7 @@ public class JobExecutionEntity extends JobThreadExecutionBase implements JobExe
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();
-        buf.append(super.toString() + System.getProperty("line.separator"));
+        buf.append(super.toString() + eol);
         buf.append("For JobExecutionEntity:");
         buf.append(" execution Id = " + jobExecId);
         buf.append(", execution sequence num = " + executionNumberForThisInstance);

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
@@ -10,43 +10,57 @@
  *******************************************************************************/
 package com.ibm.jbatch.container.persistence.jpa;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Date;
 
 import javax.batch.runtime.JobExecution;
 import javax.persistence.Column;
-import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
 import javax.persistence.Temporal;
-import javax.persistence.UniqueConstraint;
 
 import com.ibm.jbatch.container.ws.RemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSRemotablePartitionExecution;
 
 /**
  * @author skurz
- * 
+ *
  */
-/* 222050 - Backout 205106
-@NamedQueries({
-
-               @NamedQuery(name = RemotablePartitionEntity.GET_ALL_RELATED_REMOTABLE_PARTITIONS,
-                               query = "SELECT r FROM RemotablePartitionEntity r WHERE r.stepExecutionEntity.stepExecutionId IN (SELECT s.stepExecutionId FROM StepThreadExecutionEntity s WHERE s.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId AND TYPE(s) = StepThreadExecutionEntity ) ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
-               @NamedQuery(name = RemotablePartitionEntity.GET_PARTITION_STEP_THREAD_EXECUTIONIDS_BY_SERVERID_AND_STATUSES_QUERY,
-                               query = "SELECT r FROM RemotablePartitionEntity r WHERE r.serverId = :serverid AND r.stepExecutionEntity.batchStatus IN :status ORDER BY r.stepExecutionEntity.startTime DESC"),
-})*/
+/*
+ * 222050 - Backout 205106
+ *
+ * @NamedQueries({
+ *
+ * @NamedQuery(name = RemotablePartitionEntity.GET_ALL_RELATED_REMOTABLE_PARTITIONS,
+ * query =
+ * "SELECT r FROM RemotablePartitionEntity r WHERE r.stepExecutionEntity.stepExecutionId IN (SELECT s.stepExecutionId FROM StepThreadExecutionEntity s WHERE s.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId AND TYPE(s) = StepThreadExecutionEntity ) ORDER BY r.stepExecutionEntity.partitionNumber ASC"
+ * ),
+ *
+ * @NamedQuery(name = RemotablePartitionEntity.GET_PARTITION_STEP_THREAD_EXECUTIONIDS_BY_SERVERID_AND_STATUSES_QUERY,
+ * query = "SELECT r FROM RemotablePartitionEntity r WHERE r.serverId = :serverid AND r.stepExecutionEntity.batchStatus IN :status ORDER BY r.stepExecutionEntity.startTime DESC"),
+ * })
+ */
 @IdClass(RemotablePartitionKey.class)
 
-/* 222050 - Backout 205106
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = { "FK_JOBEXECUTIONID", "STEPNAME", "PARTNUM" }))
-@Entity
-*/
+/*
+ * 222050 - Backout 205106
+ *
+ * @Table(uniqueConstraints = @UniqueConstraint(columnNames = { "FK_JOBEXECUTIONID", "STEPNAME", "PARTNUM" }))
+ *
+ * @Entity
+ */
 public class RemotablePartitionEntity implements WSRemotablePartitionExecution {
+
+    // Repeat everywhere we use so caller has to think through granting privilege
+    protected static String eol = AccessController.doPrivileged(new PrivilegedAction<String>() {
+        @Override
+        public String run() {
+            return System.getProperty("line.separator");
+        }
+    });
 
     public static final String GET_ALL_RELATED_REMOTABLE_PARTITIONS = "RemotablePartitionEntity.getAllRelatedRemotablePartitions";
     public static final String GET_PARTITION_STEP_THREAD_EXECUTIONIDS_BY_SERVERID_AND_STATUSES_QUERY = "RemotablePartitionEntity.getPartitionStepExecutionByServerIdAndStatusesQuery";
@@ -191,7 +205,7 @@ public class RemotablePartitionEntity implements WSRemotablePartitionExecution {
         StringBuilder buf = new StringBuilder();
 
         Long jobExecutionId = jobExec == null ? null : jobExec.getExecutionId();
-        buf.append(super.toString() + System.getProperty("line.separator"));
+        buf.append(super.toString() + eol);
         buf.append("For RemotablePartitionExecutionEntity:");
         buf.append(", job executionId = " + jobExecutionId);
         buf.append(" stepName = " + stepName);

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotableSplitFlowEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotableSplitFlowEntity.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package com.ibm.jbatch.container.persistence.jpa;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.ManyToOne;
@@ -22,60 +25,69 @@ import javax.persistence.ManyToOne;
 @IdClass(RemotableSplitFlowKey.class)
 public class RemotableSplitFlowEntity extends JobThreadExecutionBase {
 
-	@Id
-	private String flowName;
-	
-	@Id @ManyToOne
-	private JobExecutionEntity jobExec;
-	
-	private int internalStatus;
+    // Repeat everywhere we use so caller has to think through granting privilege
+    protected static String eol = AccessController.doPrivileged(new PrivilegedAction<String>() {
+        @Override
+        public String run() {
+            return System.getProperty("line.separator");
+        }
+    });
 
-	public RemotableSplitFlowEntity() {}
+    @Id
+    private String flowName;
 
-	/**
-	 * @return the flowName
-	 */
-	public String getFlowName() {
-		return flowName;
-	}
+    @Id
+    @ManyToOne
+    private JobExecutionEntity jobExec;
 
-	/**
-	 * @param flowName the flowName to set
-	 */
-	public void setFlowName(String flowName) {
-		this.flowName = flowName;
-	}
+    private int internalStatus;
 
-	/**
-	 * @return the jobExecution
-	 */
-	public JobExecutionEntity getJobExecution() {
-		return jobExec;
-	}
+    public RemotableSplitFlowEntity() {}
 
-	/**
-	 * @param jobExecution the jobExecution to set
-	 */
-	public void setJobExecution(JobExecutionEntity jobExec) {
-		this.jobExec = jobExec;
-	}
-	
-	public int getInternalStatus() {
-		return internalStatus;
-	}
+    /**
+     * @return the flowName
+     */
+    public String getFlowName() {
+        return flowName;
+    }
 
-	public void setInternalStatus(int internalStatus) {
-		this.internalStatus = internalStatus;
-	}
-	
-	@Override
-	public String toString() {
-		StringBuilder buf = new StringBuilder();
-		buf.append(super.toString() + System.getProperty("line.separator"));
-		buf.append("For RemotableSplitFlowExecutionEntity:");
-		buf.append(" flowName = " + flowName);
-		buf.append(", internal status = " + internalStatus);
-		return buf.toString();
-	}
+    /**
+     * @param flowName the flowName to set
+     */
+    public void setFlowName(String flowName) {
+        this.flowName = flowName;
+    }
+
+    /**
+     * @return the jobExecution
+     */
+    public JobExecutionEntity getJobExecution() {
+        return jobExec;
+    }
+
+    /**
+     * @param jobExecution the jobExecution to set
+     */
+    public void setJobExecution(JobExecutionEntity jobExec) {
+        this.jobExec = jobExec;
+    }
+
+    public int getInternalStatus() {
+        return internalStatus;
+    }
+
+    public void setInternalStatus(int internalStatus) {
+        this.internalStatus = internalStatus;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder();
+        buf.append(super.toString() + eol);
+        buf.append("For RemotableSplitFlowExecutionEntity:");
+        buf.append(" flowName = " + flowName);
+        buf.append(", internal status = " + internalStatus);
+        return buf.toString();
+    }
 
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/BatchSecurityHelperImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/BatchSecurityHelperImpl.java
@@ -16,7 +16,10 @@
  */
 package com.ibm.jbatch.container.services.impl;
 
+import java.security.AccessController;
 import java.security.Principal;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Set;
 
 import javax.security.auth.Subject;
@@ -60,9 +63,15 @@ public class BatchSecurityHelperImpl implements BatchSecurityHelper {
     @Override
     public Subject getRunAsSubject() {
         try {
-            return WSSubject.getRunAsSubject();
-        } catch (WSSecurityException wse) {
-            throw new BatchContainerRuntimeException(wse);
+            return AccessController.doPrivileged(
+                                                 new PrivilegedExceptionAction<Subject>() {
+                                                     @Override
+                                                     public Subject run() throws WSSecurityException {
+                                                         return WSSubject.getRunAsSubject();
+                                                     }
+                                                 });
+        } catch (PrivilegedActionException e) {
+            throw new BatchContainerRuntimeException(e.getCause());
         }
     }
 


### PR DESCRIPTION
The **batch-1.0** feature does not even allow a simple job execution to complete.

This problem is resolved mostly by adding doPrivileged callls to the  **com.ibm.jbatch.container** and ** com.ibm.websphere.javaee.batch.1.0**  bundles.

However JAXB unmarshaling (of the job XML) does not succeed even with these additions.   I learned that the server.xml needs to configure the **jaxb-2.2** feature in order to avoid requiring additional permissions (instead of using JAXB from the JRE).