### PR TITLE
Add test.common to com.ibm.ws.junit.extensions Export-Package

### DIFF
--- a/dev/com.ibm.ws.junit.extensions/bnd.bnd
+++ b/dev/com.ibm.ws.junit.extensions/bnd.bnd
@@ -15,6 +15,8 @@ bVersion=1.0
 publish.wlp.jar.disabled: true
 instrument.disabled: true
 
+Export-Package: test.common;version=1.0.19
+
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.logging;version=latest,\


### PR DESCRIPTION
This should fix warning messages from appearing in Eclipse in unit test projects that use classes in this particular package.