### PR TITLE
update 'jdk.' to 'jdk' in com.ibm.ws.kernel.boot.ServerClasspathTest

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
@@ -44,7 +44,7 @@ public class ServerClasspathTest {
                                                         "com.ibm.jsse2", "com.ibm.lang.management", "com.ibm.tools.attach",
                                                         "com.ibm.virtualization.management", "com.ibm.wsspi.kernel",
                                                         "com.ibm.ws.staticvalue", "com.ibm.java.lang.management.internal",
-                                                        "jdk." // Java 9
+                                                        "jdk" // Java 9
     };
 
     @BeforeClass


### PR DESCRIPTION
While upgrading to JDK8 SR5 FP7, a new class was added to
the JDK under "jdk" that can be loaded by JDK's classpath. The ServerClasspathTest
checks for all known packages on the JDK classpath to ensure we're not
adding anything that we shouldn't - so the "jdk" package needs to be
added to the "expected list" in the test. We already have "jdk." so we must update it to remove the '.'