### PR TITLE
httpSessionCache use bell in absence of libraryRef

### DIFF
--- a/dev/com.ibm.websphere.appserver.sessionCache-1.0/com.ibm.websphere.appserver.sessionCache-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.sessionCache-1.0/com.ibm.websphere.appserver.sessionCache-1.0.feature
@@ -3,7 +3,10 @@ symbolicName=com.ibm.websphere.appserver.sessionCache-1.0
 visibility=public
 IBM-ShortName: sessionCache-1.0
 #TODO remove jcache API from this feature, this is only temporary
+# type="internal" allows the JCache provider to deserialize classes in the specified package when it uses thread context class loader.
+# This is a workaround for the JCache provider not deserializing classes with the supplied class loader. 
 IBM-API-Package: \
+ com.ibm.ws.session.store.cache.serializable; type="internal", \
  javax.cache; type="spec", \
  javax.cache.annotation; type="spec", \
  javax.cache.configuration; type="spec", \

--- a/dev/com.ibm.ws.session.cache/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache/bnd.bnd
@@ -15,6 +15,9 @@ Bundle-Name: JCache Store for HTTP Sessions
 Bundle-SymbolicName: com.ibm.ws.session.cache
 Bundle-Description: Allows persistence of sessions via a JCache provider, version ${bVersion}
 
+Export-Package: \
+    com.ibm.ws.session.store.cache.serializable
+
 Private-Package: \
     com.ibm.ws.session.store.cache
 

--- a/dev/com.ibm.ws.session.cache/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache/bnd.bnd
@@ -25,7 +25,8 @@ Include-Resource: \
     OSGI-INF=resources/OSGI-INF
 
 -dsannotations: \
-  com.ibm.ws.session.store.cache.CacheStoreService
+  com.ibm.ws.session.store.cache.CacheStoreService,\
+  com.ibm.ws.session.store.cache.DefaultCachingProviderSupport
 
 -buildpath: \
 	com.ibm.websphere.appserver.spi.kernel.service,\

--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
@@ -21,8 +21,7 @@
  <!-- TODO add NLS -->
  <OCD id="com.ibm.ws.session.cache" ibm:alias="httpSessionCache" name="internal" description="internal use only">
   <AD id="libraryRef"                  type="String"  required="false" ibm:type="pid" ibm:reference="com.ibm.ws.classloading.sharedlibrary" cardinality="1" name="internal" description="internal use only"/>
-  <AD id="library.target"              type="String"  default="(service.pid=${libraryRef})" ibm:final="true" name="internal" description="internal use only"/>
-  <AD id="library.cardinality.minimum" type="String"  default="${count(libraryRef)}" ibm:final="true" name="internal" description="internal use only"/>
+  <AD id="library.target"              type="String"  default="(|(service.pid=${libraryRef})(&amp;(zero=${count(libraryRef)})(id=com.ibm.ws.session.cache.defaultprovider.library)))" ibm:final="true" name="internal" description="internal use only"/>
   <!-- TODO JCache CacheManager properties -->
   <AD id="service.ranking"             type="Integer" default="50" ibm:final="true" name="internal" description="internal use only"/> <!-- httpSessionDatabase takes precedence -->
  </OCD>

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheClassLoader.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheClassLoader.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.session.store.cache;
+
+import com.ibm.ws.session.store.cache.serializable.SessionData;
+import com.ibm.ws.session.store.cache.serializable.SessionKey;
+
+/**
+ * Allows the JCache provider to deserialize specific classes from the com.ibm.ws.session.cache bundle.
+ */
+public class CacheClassLoader extends ClassLoader {
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        Class<?> c;
+
+        if (name.equals(SessionKey.class.getName()))
+            c = SessionKey.class;
+        else if (name.equals(SessionData.class.getName()))
+            c = SessionData.class;
+        else
+            c = super.findClass(name);
+
+        return c;
+    }
+}

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -36,6 +36,8 @@ import com.ibm.ws.serialization.SerializationService;
 import com.ibm.ws.session.MemoryStoreHelper;
 import com.ibm.ws.session.SessionManagerConfig;
 import com.ibm.ws.session.SessionStoreService;
+import com.ibm.ws.session.store.cache.serializable.SessionData;
+import com.ibm.ws.session.store.cache.serializable.SessionKey;
 import com.ibm.ws.session.utils.SessionLoader;
 import com.ibm.wsspi.library.Library;
 import com.ibm.wsspi.session.IStore;
@@ -47,7 +49,7 @@ import com.ibm.wsspi.session.IStore;
 public class CacheStoreService implements SessionStoreService {
     private Map<String, Object> configurationProperties;
 
-    Cache<String, Object[]> cache;
+    Cache<SessionKey, SessionData> cache;
     CacheManager cacheManager;
 
     private volatile boolean completedPassivation = true;
@@ -78,10 +80,10 @@ public class CacheStoreService implements SessionStoreService {
             ; // use default JCache provider specified via bell
         else {
             CachingProvider provider = Caching.getCachingProvider(library.getClassLoader()); // load JCache provider from configured library
-            cacheManager = provider.getCacheManager(null, null, null);
+            cacheManager = provider.getCacheManager(null, new CacheClassLoader(), null); // TODO When class loader is specified, it isn't being used for deserialization. Why?
             cache = cacheManager.getCache("com.ibm.ws.session.cache");
             if (cache == null) {
-                Configuration<String, Object[]> config = new MutableConfiguration<String, Object[]>().setTypes(String.class, Object[].class);
+                Configuration<SessionKey, SessionData> config = new MutableConfiguration<SessionKey, SessionData>().setTypes(SessionKey.class, SessionData.class);
                 try {
                     cache = cacheManager.createCache("com.ibm.ws.session.cache", config);
                 } catch (CacheException x) {

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/DefaultCachingProviderSupport.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/DefaultCachingProviderSupport.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.session.store.cache;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import javax.cache.spi.CachingProvider;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+import com.ibm.wsspi.kernel.service.utils.FilterUtils;
+import com.ibm.wsspi.library.Library;
+
+/**
+ * Registers the library of the javax.cache.spi.CachingProvider bell with a predetermined id and properties
+ * that enable the httpSessionCache metatype to default to it in the absence of a libraryRef.
+ */
+@Component(name = "com.ibm.ws.session.cache.defaultprovidersupport", configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true)
+public class DefaultCachingProviderSupport {
+    private String libraryId;
+    private ServiceRegistration<Library> registration;
+
+    @Activate
+    protected void activate(ComponentContext context) throws InvalidSyntaxException {
+        BundleContext bundleContext = context.getBundleContext();
+
+        String filter = FilterUtils.createPropertyFilter("id", libraryId);
+        ServiceReference<Library> libraryRef = bundleContext.getServiceReferences(Library.class, filter).iterator().next();
+        Library library = bundleContext.getService(libraryRef);
+
+        Dictionary<String, Object> serviceProps = new Hashtable<String, Object>();
+        serviceProps.put("id", "com.ibm.ws.session.cache.defaultprovider.library");
+        serviceProps.put("service.ranking", -1); // prefer other libraries
+        serviceProps.put("zero", 0); // useful for writing a filter that matches only when ${count(libraryRef)} is 0.
+
+        registration = context.getBundleContext().registerService(Library.class, library, serviceProps);
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext context) {
+        registration.unregister();
+    }
+
+    @Reference(service = CachingProvider.class)
+    protected void setCachingProvider(ServiceReference<CachingProvider> ref) {
+        libraryId = (String) ref.getProperty("exported.from");
+    }
+
+    protected void unsetCachingProvider(ServiceReference<CachingProvider> ref) {
+        libraryId = null;
+    }
+}

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/serializable/SessionData.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/serializable/SessionData.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.session.store.cache.serializable;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * A compound value that can be stored in the cache because it is serializable and supports hashCode/equals.
+ */
+@Trivial
+public class SessionData implements Cloneable, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private byte[] bytes;
+    private long creationTime;
+    private long lastAccess;
+    private short listenerCount;
+    private int maxInactiveTime;
+    private String userName;
+
+    @Override
+    public SessionData clone() {
+        try {
+            return (SessionData) super.clone();
+        } catch (CloneNotSupportedException x) {
+            throw new Error(x); // unreachable
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        SessionData s = o instanceof SessionData ? (SessionData) o : null;
+        return s != null
+                        && creationTime == s.creationTime
+                        && lastAccess == s.lastAccess
+                        && listenerCount == s.listenerCount
+                        && maxInactiveTime == s.maxInactiveTime
+                        && (userName == null ? s.userName == null : userName.equals(s.userName))
+                        && Arrays.equals(bytes, s.bytes);
+    }
+
+    public byte[] getBytes() {
+        return bytes;
+    }
+
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    public long getLastAccess() {
+        return lastAccess;
+    }
+
+    public short getListenerCount() {
+        return listenerCount;
+    }
+
+    public int getMaxInactiveTime() {
+        return maxInactiveTime;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) (bytes.length + creationTime + lastAccess + listenerCount + maxInactiveTime);
+    }
+
+    public void setBytes(byte[] value) {
+        bytes = value;
+    }
+
+    public void setCreationTime(long value) {
+        creationTime = value;
+    }
+
+    public void setLastAccess(long value) {
+        lastAccess = value;
+    }
+
+    public void setListenerCount(short value) {
+        listenerCount = value;
+    }
+
+    public void setMaxInactiveTime(int value) {
+        maxInactiveTime = value;
+    }
+
+    public void setUserName(String value) {
+        userName = value;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("SessionInfo[").append(bytes.length)
+                        .append("] for ").append(userName)
+                        .append(" created ").append(creationTime)
+                        .append(" accessed " ).append(lastAccess)
+                        .append(" listeners ").append(listenerCount)
+                        .append(" maxInactive ").append(maxInactiveTime)
+                        .toString();
+    }
+}

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/serializable/SessionKey.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/serializable/SessionKey.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.session.store.cache.serializable;
+
+import java.io.Serializable;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Key for entries that are stored in the cache.
+ */
+@Trivial
+public class SessionKey implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Application name.
+     */
+    public final String app;
+
+    /**
+     * Session id.
+     */
+    public final String id;
+
+    /**
+     * Construct a new cache key for a session.
+     * 
+     * @param sessionId session id.
+     * @param appName application name.
+     */
+    public SessionKey(String sessionId, String appName) {
+        id = sessionId;
+        app = appName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        SessionKey s = o instanceof SessionKey ? (SessionKey) o : null;
+        return s != null
+                        && (id == null ? s.id == null : id.equals(s.id))
+                        && (app == null ? s.app == null : app.equals(s.app));
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("SessionKey:").append(id).append('@').append(app).toString();
+    }
+}

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/serializable/SessionKey.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/serializable/SessionKey.java
@@ -52,7 +52,7 @@ public class SessionKey implements Serializable {
 
     @Override
     public int hashCode() {
-        return id.hashCode();
+        return id.hashCode() + app.hashCode();
     }
 
     @Override

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/serializable/package-info.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/serializable/package-info.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+// This package is exported and made available as type="internal" API so that the
+// JCache provider can deserialize classes that reside in this package.
+@org.osgi.annotation.versioning.Version("1.1.0")
+package com.ibm.ws.session.store.cache.serializable;

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServer/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServer/server.xml
@@ -12,9 +12,7 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
 
-    <httpSessionCache libraryRef="HazelcastLib"/>
-
-    <bell libraryRef="HazelcastLib"/> <!-- TODO Either need httpSessionCache or bell, not both. Split into 2 tests -->
+    <bell libraryRef="HazelcastLib"/>
 
     <library id="HazelcastLib">
         <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>


### PR DESCRIPTION
Default JCache CachingProvider should be loaded from a bell in the absence of a configured libraryRef on httpSessionCache.  Need to arrange declarative services dependency such that libraryRef is prefered, bell is backup, and exactly one must be supplied to the service component.  This requires a creative filter and an intermediate service that re-registers the library of the bell in a place where httpSessionCache can default to it.