### PR TITLE
Remove SessionManager instance when app is stopped.

### DIFF
--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionContext.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionContext.java
@@ -542,9 +542,15 @@ public class SessionContext {
             ((ITimer) _storer).stop();
         }
 
-        SessionContextRegistry.remove(_sap.getAppName());
+        String appName = _sap.getAppName();
+        SessionContextRegistry.remove(appName);
         // need to update the SessionManagerRegistry to free up memory
-        SessionManagerRegistry.getSessionManagerRegistry().unregisterSessionManager(_sap.getAppName());
+        SessionManagerRegistry.getSessionManagerRegistry().unregisterSessionManager(appName);
+
+        SessionManager removedSessionManager = SessionManager.removeSessionManager(appName);
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINEST)) {
+            LoggingUtil.SESSION_LOGGER_CORE.logp(Level.FINEST, methodClassName, methodNames[STOP], "Removed session manager: " + removedSessionManager);
+        }
 
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
             LoggingUtil.SESSION_LOGGER_CORE.exiting(methodClassName, methodNames[STOP]);

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionManager.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionManager.java
@@ -210,6 +210,10 @@ public class SessionManager implements IGenericSessionManager, ISessionManagerCu
         return sessionManagerMap.get(id);
     }
 
+    public static SessionManager removeSessionManager(String id) {
+        return sessionManagerMap.remove(id);
+    }
+
     // ----------------------------------------
     // Public methods
     // ----------------------------------------


### PR DESCRIPTION
This avoids leaking the SessionManager instance which references
classes that reference the classloader, leaking it.