### PR TITLE
testActivationSpecXARecovery is not waiting for expected EJBException to appear

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -93,7 +93,10 @@ public class DerbyResourceAdapterTest extends FATServletClient {
                     "com.ibm.websphere.csi.CSITransactionRolledbackException" })
     @Test
     public void testActivationSpecXARecovery() throws Exception {
+        server.setMarkToEndOfLog();
         runTest(DerbyRAAnnoServlet);
+        // Wait for FFDC messages which can be reported asynchronously to the servlet thread
+        server.waitForStringInLogUsingMark("FFDC1015I.*EJBException");
     }
 
     @Test


### PR DESCRIPTION
Update test case to wait for the expected FFDC message to appear before ending the test such that the ExpectedFFDC validation will be able to see it.  Note that switching to AllowedFFDC did not seem like a good option, because it would leave open the possibility that the FFDC could appear during the next test that runs, which would not be expecting it, and could lead to other intermittent failures.