### PR TITLE
Add missing java permissions for BvalAppClientTest_20

### DIFF
--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.ApacheBvalConfig_11/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.ApacheBvalConfig_11/client.xml
@@ -4,11 +4,6 @@
         <feature>javaeeClient-7.0</feature>
     </featureManager>
     
-    <!-- 
-    NOTE: for this bucket to run cleanly with j2sec enabled, the following permission must be manually
-    granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
-    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
-    -->
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
     
    <application id="ApacheBvalConfig" name="ApacheBvalConfig" type="ear" location="ApacheBvalConfig.ear"/>

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.ApacheBvalConfig_11/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.ApacheBvalConfig_11/client.xml
@@ -1,7 +1,7 @@
 <client>
-	<include location="../fatTestPorts.xml"/>
     <featureManager>
         <feature>javaeeClient-7.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
     
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_11/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_11/client.xml
@@ -3,12 +3,7 @@
     <featureManager>
         <feature>javaeeClient-7.0</feature>
     </featureManager>
-    
-    <!-- 
-    NOTE: for this bucket to run cleanly with j2sec enabled, the following permission must be manually
-    granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
-    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
-    -->
+
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
     
    <application id="BeanValidationCDI" name="BeanValidationCDI" type="ear" location="BeanValidationCDI.ear"/>

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_11/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_11/client.xml
@@ -1,7 +1,7 @@
 <client>
-	<include location="../fatTestPorts.xml"/>
     <featureManager>
         <feature>javaeeClient-7.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
 
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_20/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_20/client.xml
@@ -1,7 +1,7 @@
 <client>
-	<include location="../fatTestPorts.xml"/>
     <featureManager>
         <feature>javaeeClient-8.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
     
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_20/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_20/client.xml
@@ -4,12 +4,8 @@
         <feature>javaeeClient-8.0</feature>
     </featureManager>
     
-    <!-- 
-    NOTE: for this bucket to run cleanly with j2sec enabled, the following permission must be manually
-    granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
-    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
-    -->
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader" />
     
    <application id="BeanValidationCDI" name="BeanValidationCDI" type="ear" location="BeanValidationCDI.ear"/>
 

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_11/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_11/client.xml
@@ -4,11 +4,6 @@
         <feature>javaeeClient-7.0</feature>
     </featureManager>
     
-    <!-- 
-    NOTE: for this bucket to run cleanly with j2sec enabled, the following permission must be manually
-    granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
-    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
-    -->
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
     
    <application id="DefaultBeanValidationCDI" name="DefaultBeanValidationCDI" type="ear" location="DefaultBeanValidationCDI.ear"/>

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_11/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_11/client.xml
@@ -1,7 +1,7 @@
 <client>
-	<include location="../fatTestPorts.xml"/>
     <featureManager>
         <feature>javaeeClient-7.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
     
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_20/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_20/client.xml
@@ -1,7 +1,7 @@
 <client>
-	<include location="../fatTestPorts.xml"/>
     <featureManager>
         <feature>javaeeClient-8.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
     
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_20/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_20/client.xml
@@ -4,12 +4,8 @@
         <feature>javaeeClient-8.0</feature>
     </featureManager>
     
-    <!-- 
-    NOTE: for this bucket to run cleanly with j2sec enabled, the following permission must be manually
-    granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
-    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
-    -->
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader" />
     
    <application id="DefaultBeanValidationCDI" name="DefaultBeanValidationCDI" type="ear" location="DefaultBeanValidationCDI.ear"/>
 

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_11/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_11/client.xml
@@ -4,11 +4,6 @@
         <feature>javaeeClient-7.0</feature>
     </featureManager>
     
-    <!-- 
-    NOTE: for this bucket to run cleanly with j2sec enabled, the following permission must be manually
-    granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
-    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
-    -->
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
     
    <application id="beanvalidation" name="beanvalidation" type="ear" location="beanvalidation.ear"/>

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_11/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_11/client.xml
@@ -1,7 +1,7 @@
 <client>
-	<include location="../fatTestPorts.xml"/>
     <featureManager>
         <feature>javaeeClient-7.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
     
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_20/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_20/client.xml
@@ -1,7 +1,7 @@
 <client>
-	<include location="../fatTestPorts.xml"/>
     <featureManager>
         <feature>javaeeClient-8.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
     
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_20/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_20/client.xml
@@ -4,11 +4,6 @@
         <feature>javaeeClient-8.0</feature>
     </featureManager>
     
-    <!-- 
-    NOTE: for this bucket to run cleanly with j2sec enabled, the following permission must be manually
-    granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
-    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
-    -->
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
     
    <application id="beanvalidation" name="beanvalidation" type="ear" location="beanvalidation.ear"/>

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_11/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_11/client.xml
@@ -4,11 +4,6 @@
         <feature>javaeeClient-7.0</feature>
     </featureManager>
     
-    <!-- 
-    NOTE: for this bucket to run cleanly with j2sec enabled, the following permission must be manually
-    granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
-    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
-    -->
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
     
    <application id="defaultbeanvalidation" name="defaultbeanvalidation" type="ear" location="defaultbeanvalidation.ear"/>

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_11/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_11/client.xml
@@ -1,7 +1,7 @@
 <client>
-	<include location="../fatTestPorts.xml"/>
     <featureManager>
         <feature>javaeeClient-7.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
     
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_20/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_20/client.xml
@@ -1,7 +1,7 @@
 <client>
-	<include location="../fatTestPorts.xml"/>
     <featureManager>
         <feature>javaeeClient-8.0</feature>
+        <feature>timedexit-1.0</feature>
     </featureManager>
     
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_20/client.xml
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/publish/clients/com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_20/client.xml
@@ -4,11 +4,6 @@
         <feature>javaeeClient-8.0</feature>
     </featureManager>
     
-    <!-- 
-    NOTE: for this bucket to run cleanly with j2sec enabled, the following permission must be manually
-    granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
-    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
-    -->
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
     
    <application id="defaultbeanvalidation" name="defaultbeanvalidation" type="ear" location="defaultbeanvalidation.ear"/>


### PR DESCRIPTION
Add the missing java permissions for the BvalAppClientTest_20 test in the com.ibm.ws.clientcontainer.beanvalidation_fat bucket and remove the incorrect comments regarding the java permission for
accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect. 

Issue #1997