### PR TITLE
Add Java 2 security permissions for SessionCacheTest

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServer/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServer/server.xml
@@ -31,4 +31,20 @@
 
 	<javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 
+    <variable name="hazelcast" value="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    <javaPermission codebase="${hazelcast}" className="java.io.FilePermission" actions="read" name="hazelcast.xml"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.management"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.misc"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.nio.ch"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="enableContextClassLoaderOverride"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="getenv.HZ_PHONE_HOME_ENABLED"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="shutdownHooks"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.NetPermission" name="getNetworkInformation"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.SocketPermission" actions="accept,connect,listen,resolve" name="*"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.URLPermission" actions="GET:User-Agent" name="http://phonehome.hazelcast.com/ping"/>
+	<javaPermission codebase="${hazelcast}" className="java.util.PropertyPermission" actions="read,write" name="*"/>	
 </server>

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/resources/META-INF/permissions.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+ <!-- TODO remove this workaround for
+ CWWKE0912W: Current Java 2 Security policy reported a potential violation of Java 2 Security Permission.
+
+ Permission:
+      getClassLoader : access denied ("java.lang.RuntimePermission" "getClassLoader")
+
+ Code:
+     session.cache.web.SessionCacheTestServlet  in  {file:/Users/njr/lgit/open-liberty/dev/build.image/wlp/usr/servers/sessionCacheServer/dropins/sessionCacheApp.war}
+
+ java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "getClassLoader")
+	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
+	at java.security.AccessController.checkPermission(AccessController.java:884)
+	at java.lang.SecurityManager.checkPermission(SecurityManager.java:549)
+	at com.ibm.ws.kernel.launch.internal.MissingDoPrivDetectionSecurityManager.checkPermission(MissingDoPrivDetectionSecurityManager.java:45)
+	at java.lang.ClassLoader.checkClassLoaderPermission(ClassLoader.java:1528)
+	at java.lang.Thread.getContextClassLoader(Thread.java:1443)
+	at com.hazelcast.nio.ClassLoaderUtil.loadClass(ClassLoaderUtil.java:126)
+	at com.hazelcast.nio.IOUtil$ClassLoaderAwareObjectInputStream.resolveClass(IOUtil.java:591)
+	at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:1826)
+	at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1713)
+	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2000)
+	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1535)
+	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:422)
+	at com.hazelcast.internal.serialization.impl.JavaDefaultSerializers$JavaSerializer.read(JavaDefaultSerializers.java:219)
+	at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.read(StreamSerializerAdapter.java:48)
+	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toObject(AbstractSerializationService.java:185)
+	at com.hazelcast.spi.impl.operationservice.impl.InvocationFuture.resolve(InvocationFuture.java:114)
+	at com.hazelcast.spi.impl.operationservice.impl.InvocationFuture.resolveAndThrowIfException(InvocationFuture.java:79)
+	at com.hazelcast.spi.impl.AbstractInvocationFuture.get(AbstractInvocationFuture.java:155)
+	at com.hazelcast.cache.impl.AbstractCacheProxy.get(AbstractCacheProxy.java:159)
+	at com.hazelcast.cache.impl.CacheProxy.get(CacheProxy.java:80)
+	at com.hazelcast.cache.impl.CacheProxy.get(CacheProxy.java:92)
+	at com.ibm.ws.session.store.cache.CacheHashMap.getValue(CacheHashMap.java:75)
+	at com.ibm.ws.session.store.cache.CacheSession.getSingleRowAppData(CacheSession.java:57)
+	at com.ibm.ws.session.store.cache.CacheSession.getSwappableData(CacheSession.java:73)
+	at com.ibm.ws.session.store.common.BackedSession.getValueGuts(BackedSession.java:614)
+	at com.ibm.ws.session.store.common.BackedSession.getAttribute(BackedSession.java:294)
+	at com.ibm.ws.session.http.HttpSessionImpl.getAttribute(HttpSessionImpl.java:188)
+	at com.ibm.ws.session.SessionData.getSessionValue(SessionData.java:297)
+	at com.ibm.ws.session.SessionData.getAttribute(SessionData.java:157)
+	at com.ibm.ws.session.HttpSessionFacade.getAttribute(HttpSessionFacade.java:124)
+	at session.cache.web.SessionCacheTestServlet.testSerialization_complete(SessionCacheTestServlet.java:88)
+  -->
+ <permission>
+   <class-name>java.lang.RuntimePermission</class-name>
+   <name>getClassLoader</name>
+ </permission>
+ 
+</permissions>


### PR DESCRIPTION
pull fixes #2004 

Note that the addition of permissions.xml to the application is a temporary workaround.  I've asked the security team to look into why it's using the codebase of the application rather than the JCache provider jar in 2 cases, one of which is documented in the xml file.