### PR TITLE
Initial commit, decoder will now ensure header names are non empty an…

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/hpack/H2Headers.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/hpack/H2Headers.java
@@ -235,6 +235,11 @@ public class H2Headers {
                 Tr.debug(tc, "Decoding header name.");
             }
             decodedName = decodeFragment(buffer);
+
+            if (decodedName.trim().isEmpty()) {
+                throw new CompressionException("Header field names must not be empty.");
+            }
+
             if (!HpackUtils.isAllLower(decodedName)) {
                 throw new CompressionException("Header field names must not contain uppercase "
                                                + "characters. Decoded header name: " + decodedName);
@@ -297,7 +302,7 @@ public class H2Headers {
             //Transfer bytes from the buffer into byte array.
             buffer.get(bytes);
 
-            if (huffman) {
+            if (huffman && bytes.length > 0) {
                 HuffmanDecoder decoder = new HuffmanDecoder();
                 bytes = decoder.convertHuffmanToAscii(bytes);
             }


### PR DESCRIPTION
…d accepts empty header values.