### PR TITLE
Return the correct HttpServletMapping from HttpServletRequest.getHttp…

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebAppDispatcherContext40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebAppDispatcherContext40.java
@@ -13,6 +13,9 @@ package com.ibm.ws.webcontainer40.osgi.webapp;
 import javax.servlet.http.HttpServletMapping;
 import javax.servlet.http.MappingMatch;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants;
 import com.ibm.ws.webcontainer.osgi.webapp.WebApp;
 import com.ibm.ws.webcontainer.osgi.webapp.WebAppDispatcherContext;
 import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
@@ -22,6 +25,8 @@ import com.ibm.wsspi.webcontainer.servlet.IServletWrapper;
  *
  */
 public class WebAppDispatcherContext40 extends WebAppDispatcherContext {
+
+    private static final TraceComponent tc = Tr.register(WebAppDispatcherContext40.class, WebContainerConstants.TR_GROUP, WebContainerConstants.NLS_PROPS);
 
     private HttpServletMapping _mapping;
     private MappingMatch _match;
@@ -59,11 +64,19 @@ public class WebAppDispatcherContext40 extends WebAppDispatcherContext {
         super.pushServletReference(wrapper);
 
         //Set the mapping to the parent's mapping if this is an include or an async dispatch
-        // or _match == null (when using a named dispatcher)
-        if (this.isInclude() || this.isAsync() || (_mapping == null && _match == null))
+        // or when using a named dispatcher (_match == null)
+        if (this.isInclude() || this.isAsync() || (_mapping == null && _match == null)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "This is an include, async or named dispatch. Setting the HttpServletMapping to the parent context's mapping.");
+            }
             _mapping = ((WebAppDispatcherContext40) this.getParentContext()).getServletMapping();
-        else
+
+        } else {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Setting the HttpServletMapping to the current servlet's mapping.");
+            }
             setServletMapping();
+        }
     }
 
     @Override

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebAppDispatcherContext40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebAppDispatcherContext40.java
@@ -57,7 +57,13 @@ public class WebAppDispatcherContext40 extends WebAppDispatcherContext {
     @Override
     public void pushServletReference(IServletWrapper wrapper) {
         super.pushServletReference(wrapper);
-        setServletMapping();
+
+        //Set the mapping to the parent's mapping if this is an include or an async dispatch
+        // or _match == null (when using a named dispatcher)
+        if (this.isInclude() || this.isAsync() || (_mapping == null && _match == null))
+            _mapping = ((WebAppDispatcherContext40) this.getParentContext()).getServletMapping();
+        else
+            setServletMapping();
     }
 
     @Override

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebAppDispatcherContext40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebAppDispatcherContext40.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 IBM Corporation and others.
+ * Copyright (c) 2011, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/SRTServletRequest40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/SRTServletRequest40.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 IBM Corporation and others.
+ * Copyright (c) 2011, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/SRTServletRequest40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/SRTServletRequest40.java
@@ -100,7 +100,7 @@ public class SRTServletRequest40 extends SRTServletRequest31 implements HttpServ
 
     @Override
     public HttpServletMapping getHttpServletMapping() {
-        String methodName = "getMapping";
+        String methodName = "getHttpServletMapping";
 
         if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
             logger.entering(CLASS_NAME, methodName);
@@ -120,7 +120,9 @@ public class SRTServletRequest40 extends SRTServletRequest31 implements HttpServ
 
             // Get the servlet name
             IServletWrapper servletRef = dispatchContext.getCurrentServletReference();
-            String servletName = servletRef.getServletName();
+            String servletName = null;
+            if (servletRef != null)
+                servletName = servletRef.getServletName();
 
             if (TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
                 logger.logp(Level.FINE, CLASS_NAME, methodName, "servletName was set to: " + servletName);

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCGetMappingTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCGetMappingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -111,7 +111,7 @@ public class WCGetMappingTest extends LoggingTest {
     @Mode(TestMode.FULL)
     public void test_HttpServletRequestGetMapping_ContextRootMapping_Include() throws Exception {
         SHARED_SERVER.verifyResponse(createWebBrowserForTestCase(), "/TestGetMapping/pathIncMatch?dispatchPath=/",
-                                     "Mapping values: mappingMatch: CONTEXT_ROOT matchValue:  pattern:  servletName: GetMappingTestServlet");
+                                     "ServletMapping values: mappingMatch: EXACT matchValue: pathIncMatch pattern: /pathIncMatch servletName: GetMappingIncServlet");
     }
 
     /**
@@ -125,7 +125,7 @@ public class WCGetMappingTest extends LoggingTest {
     @Mode(TestMode.FULL)
     public void test_HttpServletRequestGetMapping_ContextRootMapping_Async() throws Exception {
         SHARED_SERVER.verifyResponse(createWebBrowserForTestCase(), "/TestGetMapping/pathAsyncMatch?dispatchPath=/",
-                                     "Mapping values: mappingMatch: CONTEXT_ROOT matchValue:  pattern:  servletName: GetMappingTestServlet");
+                                     "ServletMapping values: mappingMatch: EXACT matchValue: pathAsyncMatch pattern: /pathAsyncMatch servletName: GetMappingAsyncServlet");
     }
 
     /**
@@ -165,7 +165,7 @@ public class WCGetMappingTest extends LoggingTest {
     public void test_HttpServletRequestGetMapping_PathMapping_Include() throws Exception {
         SHARED_SERVER.verifyResponse(createWebBrowserForTestCase(),
                                      "/TestGetMapping/pathIncMatch?dispatchPath=pathMatch/testPath",
-                                     "ServletMapping values: mappingMatch: PATH matchValue: testPath pattern: /pathMatch/* servletName: GetMappingTestServlet");
+                                     "ServletMapping values: mappingMatch: EXACT matchValue: pathIncMatch pattern: /pathIncMatch servletName: GetMappingIncServlet");
     }
 
     /**
@@ -179,7 +179,7 @@ public class WCGetMappingTest extends LoggingTest {
     public void test_HttpServletRequestGetMapping_PathMapping_Async() throws Exception {
         SHARED_SERVER.verifyResponse(createWebBrowserForTestCase(),
                                      "/TestGetMapping/pathAsyncMatch?dispatchPath=pathMatch/testPath",
-                                     "ServletMapping values: mappingMatch: PATH matchValue: testPath pattern: /pathMatch/* servletName: GetMappingTestServlet");
+                                     "ServletMapping values: mappingMatch: EXACT matchValue: pathAsyncMatch pattern: /pathAsyncMatch servletName: GetMappingAsyncServlet");
     }
 
     /**
@@ -217,7 +217,7 @@ public class WCGetMappingTest extends LoggingTest {
     @Mode(TestMode.FULL)
     public void test_HttpServletRequestGetMapping_DefaultMapping_Include() throws Exception {
         SHARED_SERVER.verifyResponse(createWebBrowserForTestCase(), "/TestGetMapping/pathIncMatch?dispatchPath=invalid",
-                                     "ServletMapping values: mappingMatch: DEFAULT matchValue:  pattern: / servletName: GetMappingTestServlet");
+                                     "ServletMapping values: mappingMatch: EXACT matchValue: pathIncMatch pattern: /pathIncMatch servletName: GetMappingIncServlet");
     }
 
     /**
@@ -231,7 +231,7 @@ public class WCGetMappingTest extends LoggingTest {
     public void test_HttpServletRequestGetMapping_DefaultMapping_Async() throws Exception {
         SHARED_SERVER.verifyResponse(createWebBrowserForTestCase(),
                                      "/TestGetMapping/pathAsyncMatch?dispatchPath=invalid",
-                                     "ServletMapping values: mappingMatch: DEFAULT matchValue:  pattern: / servletName: GetMappingTestServlet");
+                                     "ServletMapping values: mappingMatch: EXACT matchValue: pathAsyncMatch pattern: /pathAsyncMatch servletName: GetMappingAsyncServlet");
     }
 
     /**
@@ -271,7 +271,7 @@ public class WCGetMappingTest extends LoggingTest {
     public void test_HttpServletRequestGetMapping_ExactMapping_Include() throws Exception {
         SHARED_SERVER.verifyResponse(createWebBrowserForTestCase(),
                                      "/TestGetMapping/pathIncMatch?dispatchPath=exactMatch",
-                                     "ServletMapping values: mappingMatch: EXACT matchValue: exactMatch pattern: /exactMatch servletName: GetMappingTestServlet");
+                                     "ServletMapping values: mappingMatch: EXACT matchValue: pathIncMatch pattern: /pathIncMatch servletName: GetMappingIncServlet");
     }
 
     /**
@@ -285,7 +285,7 @@ public class WCGetMappingTest extends LoggingTest {
     public void test_HttpServletRequestGetMapping_ExactMapping_Async() throws Exception {
         SHARED_SERVER.verifyResponse(createWebBrowserForTestCase(),
                                      "/TestGetMapping/pathAsyncMatch?dispatchPath=exactMatch",
-                                     "ServletMapping values: mappingMatch: EXACT matchValue: exactMatch pattern: /exactMatch servletName: GetMappingTestServlet");
+                                     "ServletMapping values: mappingMatch: EXACT matchValue: pathAsyncMatch pattern: /pathAsyncMatch servletName: GetMappingAsyncServlet");
     }
 
     /**
@@ -328,7 +328,7 @@ public class WCGetMappingTest extends LoggingTest {
     public void test_HttpServletRequestGetMapping_ExtensionMapping_Include() throws Exception {
         SHARED_SERVER.verifyResponse(createWebBrowserForTestCase(),
                                      "/TestGetMapping/pathIncMatch?dispatchPath=extensionMatch.extension",
-                                     "ServletMapping values: mappingMatch: EXTENSION matchValue: extensionMatch pattern: *.extension servletName: GetMappingTestServlet");
+                                     "ServletMapping values: mappingMatch: EXACT matchValue: pathIncMatch pattern: /pathIncMatch servletName: GetMappingIncServlet");
     }
 
     /**
@@ -343,7 +343,7 @@ public class WCGetMappingTest extends LoggingTest {
     public void test_HttpServletRequestGetMapping_ExtensionMapping_Async() throws Exception {
         SHARED_SERVER.verifyResponse(createWebBrowserForTestCase(),
                                      "/TestGetMapping/pathAsyncMatch?dispatchPath=extensionMatch.extension",
-                                     "ServletMapping values: mappingMatch: EXTENSION matchValue: extensionMatch pattern: *.extension servletName: GetMappingTestServlet");
+                                     "ServletMapping values: mappingMatch: EXACT matchValue: pathAsyncMatch pattern: /pathAsyncMatch servletName: GetMappingAsyncServlet");
     }
 
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestGetMapping.war/src/testgetmapping/war/servlets/GetMappingFwdServlet.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestGetMapping.war/src/testgetmapping/war/servlets/GetMappingFwdServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,19 +30,18 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet(urlPatterns = { "/pathFwdMatch" }, name = "GetMappingFwdServlet")
 public class GetMappingFwdServlet extends HttpServlet {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	@Override
-	protected void doGet(HttpServletRequest request, HttpServletResponse response)
-			throws ServletException, IOException {
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 
-		String dispatchPath = request.getParameter("dispatchPath");
+        String dispatchPath = request.getParameter("dispatchPath");
 
-		System.out.println(">>>>>>>> Enter GetMappingFwdServlet : dispatch to : " + dispatchPath);
-		RequestDispatcher rd = request.getRequestDispatcher(dispatchPath);
-		rd.include(request, response);
-		System.out.println("<<<<<<<< Exit GetMappingFwdServlet");
+        System.out.println(">>>>>>>> Enter GetMappingFwdServlet : dispatch to : " + dispatchPath);
+        RequestDispatcher rd = request.getRequestDispatcher(dispatchPath);
+        rd.forward(request, response);
+        System.out.println("<<<<<<<< Exit GetMappingFwdServlet");
 
-	}
+    }
 
 }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppDispatcherContext.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppDispatcherContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2008 IBM Corporation and others.
+ * Copyright (c) 1997, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppDispatcherContext.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppDispatcherContext.java
@@ -440,7 +440,7 @@ public abstract class WebAppDispatcherContext implements Cloneable, IWebAppDispa
 
 
 
-    private WebAppDispatcherContext getParentContext() {
+    protected WebAppDispatcherContext getParentContext() {
         return this.parentContext;
     }
     /* (non-Javadoc)
@@ -984,6 +984,11 @@ public abstract class WebAppDispatcherContext implements Cloneable, IWebAppDispa
     public boolean isInclude()
     {
         return (this.dispatcherType == DispatcherType.INCLUDE);
+    }
+    
+    public boolean isAsync() 
+    {
+        return (this.dispatcherType == DispatcherType.ASYNC);
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
…ServletMapping() during include, async, and when using a named dispatcher.

Also, avoid a potential NPE when getHttpServletMapping() is called from a filter and there is no target servlet.