### PR TITLE
 copy handlePropertyHits and getAllValues to make progress on cache-entry-per-session-property path

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheClassLoader.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheClassLoader.java
@@ -12,6 +12,7 @@ package com.ibm.ws.session.store.cache;
 
 import com.ibm.ws.session.store.cache.serializable.SessionData;
 import com.ibm.ws.session.store.cache.serializable.SessionKey;
+import com.ibm.ws.session.store.cache.serializable.SessionPropertyKey;
 
 /**
  * Allows the JCache provider to deserialize specific classes from the com.ibm.ws.session.cache bundle.
@@ -24,6 +25,8 @@ public class CacheClassLoader extends ClassLoader {
 
         if (name.equals(SessionKey.class.getName()))
             c = SessionKey.class;
+        else if (name.equals(SessionPropertyKey.class.getName()))
+            c = SessionPropertyKey.class;
         else if (name.equals(SessionData.class.getName()))
             c = SessionData.class;
         else

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMapMR.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMapMR.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.session.store.cache;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Iterator;
+
+import javax.cache.Cache;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.FFDCFilter;
+import com.ibm.ws.session.SessionManagerConfig;
+import com.ibm.ws.session.SessionStatistics;
+import com.ibm.ws.session.store.cache.serializable.SessionPropertyKey;
+import com.ibm.ws.session.store.common.BackedSession;
+import com.ibm.wsspi.session.IStore;
+
+/**
+ * Hash map backed by JCache, with cache entry per session property.
+ * TODO most methods are not implemented
+ */
+public class CacheHashMapMR extends CacheHashMap {
+    private static final long serialVersionUID = 1L; // not serializable, rejects writeObject
+
+    private static final TraceComponent tc = Tr.register(CacheHashMapMR.class);
+
+    CacheStoreService cacheStoreService;
+    IStore _iStore;
+    SessionManagerConfig _smc;
+
+    public CacheHashMapMR(IStore store, SessionManagerConfig smc, CacheStoreService cacheStoreService) {
+        super(store, smc, cacheStoreService);
+        // We know we're running multi-row..if not writeAllProperties and not time-based writes,
+        // we must keep the app data tables per thread (rather than per session)
+        appDataTablesPerThread = (!_smc.writeAllProperties() && !_smc.getEnableTimeBasedWrite());
+    }
+
+    /**
+     * Loads all the properties.
+     * TODO: copy from DatabaseHashMapMR
+     */
+    protected Object getAllValues(BackedSession sess) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Object getValue(String id, BackedSession s) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+        String sessId = s.getId();
+        Object tmp = null;
+
+        SessionPropertyKey key = new SessionPropertyKey(sessId, id);
+        byte[] sessionPropBytes = cacheStoreService.getCache(getIStore().getId()).get(key);
+
+        if (trace && tc.isDebugEnabled())
+            Tr.debug(this, tc, key.toString(), sessionPropBytes == null ? null : sessionPropBytes.length);
+
+        if (sessionPropBytes == null)
+            return null;
+
+        long startTime = System.currentTimeMillis();
+
+        if (sessionPropBytes != null && sessionPropBytes.length > 0) {
+            BufferedInputStream in = new BufferedInputStream(new ByteArrayInputStream(sessionPropBytes));
+            try {
+                try {
+                    tmp = ((CacheStore) getIStore()).getLoader().loadObject(in);
+                } finally {
+                    in.close();
+                }
+            } catch (ClassNotFoundException | IOException x) {
+                FFDCFilter.processException(x, getClass().getName(), "96", s);
+                throw new RuntimeException(x);
+            }
+        }
+
+        SessionStatistics pmiStats = getIStore().getSessionStatistics();
+        if (pmiStats != null) {
+            pmiStats.readTimes(sessionPropBytes == null ? 0 : sessionPropBytes.length, System.currentTimeMillis() - startTime);
+        }
+
+        return tmp;
+    }
+
+    /**
+     * TODO: copy from DatabaseHashMapMR
+     */
+    @Override
+    boolean handlePropertyHits(BackedSession d2) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @see com.ibm.ws.session.store.common.BackedHashMap#removePersistedSession(java.lang.String)
+     */
+    @Override
+    protected void removePersistedSession(String id) {
+        super.removePersistedSession(id);
+
+        Cache<SessionPropertyKey, byte[]> cache = cacheStoreService.getCache(_iStore.getId());
+        for (Iterator<Cache.Entry<SessionPropertyKey, byte[]>> it = cache.iterator(); it.hasNext(); ) {
+            Cache.Entry<SessionPropertyKey, byte[]> entry = it.next();
+            if (entry != null && id.equals(entry.getKey().sessionId))
+                it.remove();
+        }
+    }
+
+    /**
+     * This type of hash map is not serializable.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheSession.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheSession.java
@@ -11,7 +11,9 @@
 
 package com.ibm.ws.session.store.cache;
 
+import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.logging.Level;
 
 import javax.transaction.UserTransaction;
 
@@ -31,9 +33,52 @@ public class CacheSession extends BackedSession {
     private Hashtable<?, ?> mSwappableData;
 
     private boolean populatedAppData;
+    private boolean usingMultirow;
 
     public CacheSession(CacheHashMap sessions, String id, IStoreCallback storeCallback) {
         super(sessions, id, storeCallback);
+        usingMultirow = _smc.isUsingMultirow();
+    }
+
+    /**
+     * Ensures db data is read in and attribute names are populated
+     * 
+     * @see com.ibm.wsspi.session.ISession#getAttributeNames()
+     */
+    @Override
+    @SuppressWarnings("rawtypes")
+    public synchronized Enumeration getAttributeNames() {
+        if (!populatedAppData) {
+            if (usingMultirow) {
+                getMultiRowAppData();
+            } else {
+                getSingleRowAppData();
+            }
+        }
+        return super.getAttributeNames();
+    }
+
+    /**
+     * Copied from DatabaseSession:
+     * This method may or may not be called after retrieval depending on whether we
+     * need to call listeners or get all attribute names. Therefore, we add to the
+     * existing swappable data rather than just calling setSwappable data.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private void getMultiRowAppData() {
+        populatedAppData = true;
+        Hashtable swappable = getSwappableData();
+        Hashtable props = (Hashtable) ((CacheHashMapMR) getSessions()).getAllValues(this);
+        if (props != null) {
+            Enumeration kys = props.keys();
+            while (kys.hasMoreElements()) {
+                Object key = kys.nextElement();
+                swappable.put(key, props.get(key));
+            }
+            synchronized (_attributeNames) {
+                refillAttrNames(swappable);
+            }
+        }
     }
 
     /**
@@ -69,7 +114,7 @@ public class CacheSession extends BackedSession {
     public Hashtable getSwappableData() {
         // TODO copied from DatabaseSession.getSwappableData
         if (mSwappableData == null) {
-            if (!isNew() && !populatedAppData) {
+            if (!isNew() && !usingMultirow && !populatedAppData) {
                 getSingleRowAppData(); // populate mSwappableData for single row db only, NOT multirow
             }
             //mSwappableData could have been updated
@@ -107,7 +152,11 @@ public class CacheSession extends BackedSession {
             if (!populatedAppData) {
                 try {
                     getSessions().getIStore().setThreadContext();
-                    getSingleRowAppData();
+                    if (usingMultirow) {
+                        getMultiRowAppData();
+                    } else {
+                        getSingleRowAppData();
+                    }
                 } finally {
                     getSessions().getIStore().unsetThreadContext();
                 }

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheSession.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheSession.java
@@ -13,7 +13,6 @@ package com.ibm.ws.session.store.cache;
 
 import java.util.Enumeration;
 import java.util.Hashtable;
-import java.util.logging.Level;
 
 import javax.transaction.UserTransaction;
 
@@ -79,6 +78,10 @@ public class CacheSession extends BackedSession {
                 refillAttrNames(swappable);
             }
         }
+    }
+
+    boolean getPopulatedAppData() {
+        return populatedAppData;
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStore.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStore.java
@@ -30,7 +30,10 @@ public class CacheStore extends BackedStore {
     public CacheStore(SessionManagerConfig smc, String storeId, ServletContext sc, MemoryStoreHelper storeHelper, boolean isApplicationSessionStore, CacheStoreService cacheStoreService) {
         super(smc, storeId, sc, storeHelper, cacheStoreService);
 
-        _sessions = new CacheHashMap(this, smc, cacheStoreService);
+        if (_smc.isUsingMultirow())
+            _sessions = new CacheHashMapMR(this, smc, cacheStoreService);
+        else
+            _sessions = new CacheHashMap(this, smc, cacheStoreService);
 
         _isApplicationSessionStore = isApplicationSessionStore;
         ((BackedHashMap) _sessions).setIsApplicationSessionHashMap(isApplicationSessionStore);

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -110,7 +110,7 @@ public class CacheStoreService implements SessionStoreService {
 
     @Override
     public IStore createStore(SessionManagerConfig smc, String smid, ServletContext sc, MemoryStoreHelper storeHelper, ClassLoader classLoader, boolean applicationSessionStore) {
-        if (Boolean.TRUE.equals(configurationProperties.get("useMultiRowSchema")))
+        if ("true".equals(configurationProperties.get("useMultiRowSchema")))
             smc.setUsingMultirow(true); // TODO temporary code for experimenting with cache entry per session property
         IStore store = new CacheStore(smc, smid, sc, storeHelper, applicationSessionStore, this);
         store.setLoader(new SessionLoader(serializationService, classLoader, applicationSessionStore));

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/serializable/SessionPropertyKey.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/serializable/SessionPropertyKey.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.session.store.cache.serializable;
+
+import java.io.Serializable;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Key for a session property that is stored in the cache.
+ */
+@Trivial
+public class SessionPropertyKey implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Property id.
+     */
+    public final String propId;
+
+    /**
+     * Session id.
+     */
+    public final String sessionId;
+
+    /**
+     * Construct a new cache key for a session property.
+     * 
+     * @param sessionId session id.
+     * @param propId property id.
+     */
+    public SessionPropertyKey(String sessionId, String propId) {
+        this.sessionId = sessionId;
+        this.propId = propId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        SessionPropertyKey s = o instanceof SessionPropertyKey ? (SessionPropertyKey) o : null;
+        return s != null
+                        && (sessionId == null ? s.sessionId == null : sessionId.equals(s.sessionId))
+                        && (propId == null ? s.propId == null : propId.equals(s.propId));
+    }
+
+    @Override
+    public int hashCode() {
+        return sessionId.hashCode() + propId.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("SessionPropertyKey:").append(sessionId).append('.').append(propId).toString();
+    }
+}

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/resources/META-INF/permissions.xml
@@ -52,5 +52,11 @@
    <class-name>java.lang.RuntimePermission</class-name>
    <name>getClassLoader</name>
  </permission>
+
+ <permission>
+   <class-name>java.util.PropertyPermission</class-name>
+   <name>*</name>
+   <actions>read</actions>
+ </permission>
  
 </permissions>


### PR DESCRIPTION
Implement handlePropertyHits and getAllValues based on DatabaseHashMapMR so that a basic test can complete the path where there is a cache entry for each session property.