### PR TITLE
sso clients may end up in  a loop of logins if the request contains invalid LTPA cookie

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -695,8 +695,8 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
         if (result != null) {
             return result.booleanValue();
         }
-        if (webRequest.hasAuthenticationData())
-            return true;
+//        if (webRequest.hasAuthenticationData())
+//            return true;
         return isUnprotectedResourceAuthenRequired(webRequest);
     }
 


### PR DESCRIPTION
Many sso clients have callback servlets to accept response from SSO services. The callback servlets are designed to be unprotected without authorization constraint, and are used to redirect user to the original requests. If ltpa cookie is in request, authentication is automatically performed regardless of authorization constraint,  and then the authentication starts sso if sso client is configured, which causes an infinite loop of logins. 