### PR TITLE
make MemoryPersistence tolerate a JPAQueryHelper object and perform t…

### DIFF
--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IJPAQueryHelper.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IJPAQueryHelper.java
@@ -22,6 +22,11 @@ import com.ibm.jbatch.container.persistence.jpa.JobInstanceEntity;
 public interface IJPAQueryHelper {
 
     /**
+     * Base Query String
+     */
+    final String DEFAULT_QUERY = "SELECT x from JobInstanceEntity x ORDER BY x.createTime DESC";
+
+    /**
      * Get the JPQL query string
      */
     String getQuery();

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImpl.java
@@ -1332,8 +1332,17 @@ public class MemoryPersistenceManagerImpl extends AbstractPersistenceManager imp
     @Override
     public List<JobInstanceEntity> getJobInstances(IJPAQueryHelper queryHelper, int page, int pageSize) {
         // TODO: Should we implement this for Memory Persistence?
-        throw new UnsupportedOperationException("The REST URL search parameters requesting this function "
-                                                + "are not supported by the Java batch memory-based persistence configuration.");
+        //throw new UnsupportedOperationException("The REST URL search parameters requesting this function "
+        //   + "are not supported by the Java batch memory-based persistence configuration.");
+
+        String delieveredQuery = queryHelper.getQuery();
+
+        if (delieveredQuery.equals(queryHelper.DEFAULT_QUERY)) {
+            return getJobInstances(page, pageSize);
+        } else {
+            throw new UnsupportedOperationException("The REST URL search parameters requesting this function"
+                                                    + "are not supported by the Java batch memory-based persistence configuration.");
+        }
     }
 
     @Override


### PR DESCRIPTION
defect 250599 - WDT unable to access JobInstances using MemoryPersistence.
MemoryPersistence should tolerate a BASE JPAQueryHelper query and perform the equivalent retrieval.