### PR TITLE
Do not instrument repository client project

### DIFF
--- a/dev/com.ibm.ws.repository/bnd.bnd
+++ b/dev/com.ibm.ws.repository/bnd.bnd
@@ -17,6 +17,8 @@ Bundle-Description: Project for storing repository client library
 
 WS-TraceGroup: repo.resource
 
+instrument.disabled: true
+
 Export-Package: com.ibm.ws.repository.common.enums;version=1.0, \
  com.ibm.ws.repository.connections;version=1.0, \
  com.ibm.ws.repository.exceptions;version=1.0, \


### PR DESCRIPTION
Command line tools depend on it and they do not all have the logging and
tracing classes available.