### PR TITLE
test libraryRef and minimum features set for httpSessionCache

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerA/server.xml
@@ -1,8 +1,8 @@
 <server>
 
     <featureManager>
-        <feature>bells-1.0</feature>
-        <feature>servlet-3.1</feature>
+        <!-- This server provides coverage for minimal feature set. Do not add more features. -->
+        <feature>servlet-4.0</feature>
         <feature>componenttest-1.0</feature>
         <feature>sessionCache-1.0</feature>
     </featureManager>
@@ -11,13 +11,12 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
 
-    <bell libraryRef="HazelcastLibA" service="javax.cache.spi.CachingProvider"/>
+    <httpSessionCache libraryRef="HazelcastLib"/>
 
-    <library id="HazelcastLibA">
+    <library id="HazelcastLib">
         <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
     </library>
-    
-    
+
     <variable name="hazelcast" value="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
     <javaPermission codebase="${hazelcast}" className="java.io.FilePermission" actions="read" name="hazelcast.xml"/>
     <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.management"/>


### PR DESCRIPTION
Update one of the test servers to supply the JCache provider via a libraryRef, in which case the bell feature is not needed.  Have this test server provide coverage for minimum feature set, which is servlet + sessionCache.