### PR TITLE
remove allow http config attribute for token requests

### DIFF
--- a/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
@@ -50,9 +50,7 @@ jwkSigningKeySize.desc=Size measured in bits of the signing key.
 jwkSigningKeySize.1024=1024 bits
 jwkSigningKeySize.2048=2048 bits
 jwkSigningKeySize.4096=4096 bits
-
-tokenEndpointHttpsRequired=Token generation endpoint HTTPS required
-tokenEndpointHttpsRequired.desc=Indicates whether HTTPS is required for communication with the token generation endpoint. 
+ 
 #Do not translate "aud"
 audiences=Trusted audiences
 audiences.desc=The trusted audience list to be included in the aud claim in the JSON web token.

--- a/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -27,7 +27,7 @@
             	<Option label="%tokenSignAlgorithm.RS256" value="RS256" />
             	<Option label="%tokenSignAlgorithm.HS256" value="HS256" />
          </AD>
-         <AD id="tokenEndpointHttpsRequired" name="%tokenEndpointHttpsRequired" description="%tokenEndpointHttpsRequired.desc" required="false" type="Boolean" default="true" />
+        
          <AD id="sharedKey" name="%sharedKey" description="%sharedKey.desc" required="false" type="String" ibm:type="password" />
 		 <AD id="jti" name="%jti" description="%jti.desc" required="false" type="Boolean" default="false"/>
          <AD id="keyStoreRef" name="%keyStoreRef" description="%keyStoreRef.desc" required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.keystore" />

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/config/JwtConfig.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/config/JwtConfig.java
@@ -60,6 +60,4 @@ public interface JwtConfig {
 
 	PublicKey getPublicKey();
 
-	boolean isTokenEndpointHttpsRequired();
-
 }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/JwtComponent.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/JwtComponent.java
@@ -64,7 +64,6 @@ public class JwtComponent implements JwtConfig {
 	private String trustedAlias;
 	private long jwkRotationTime;
 	private int jwkSigningKeySize;
-	private boolean tokenEndpointHttpsRequired;
 
 	private PublicKey publicKey = null;
 	private PrivateKey privateKey = null;
@@ -158,7 +157,6 @@ public class JwtComponent implements JwtConfig {
 		// Rotation time is in minutes, so convert value to milliseconds
 		jwkRotationTime = jwkRotationTime * 60 * 1000;
 		jwkSigningKeySize = ((Long) props.get(JwtUtils.CFG_KEY_JWK_SIGNING_KEY_SIZE)).intValue();
-		tokenEndpointHttpsRequired = (Boolean) props.get(JwtUtils.CFG_KEY_TOKEN_ENDPOINT_HTTPS_REQD);
 
 		if ("RS256".equals(sigAlg)) {
 			initializeJwkProvider(this);
@@ -310,11 +308,6 @@ public class JwtComponent implements JwtConfig {
 	public boolean isJwkEnabled() {
 		// TODO Auto-generated method stub
 		return isJwkEnabled;
-	}
-
-	@Override
-	public boolean isTokenEndpointHttpsRequired() {
-		return tokenEndpointHttpsRequired;
 	}
 
 	@Override

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtUtils.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtUtils.java
@@ -81,7 +81,6 @@ public class JwtUtils {
 	public static final String CFG_KEY_CLOCK_SKEW = "clockSkew";
 	public static final String CFG_KEY_VALIDATION_REQUIRED = "validationRequired";
 	public static final String CFG_KEY_SSL_REF = "sslRef";
-	public static final String CFG_KEY_TOKEN_ENDPOINT_HTTPS_REQD = "tokenEndpointHttpsRequired";
 
 	public static final String JCEPROVIDER_IBM = "IBMJCE";
 	public static final String SECRANDOM_SHA1PRNG = "SHA1PRNG";

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/web/JwtEndpointServices.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/web/JwtEndpointServices.java
@@ -206,7 +206,7 @@ public class JwtEndpointServices {
 		}
 
 		String value = req.getHeader("X-Forwarded-Proto");
-		if (value != null & value.toLowerCase().equals("https")) {
+		if (value != null && value.toLowerCase().equals("https")) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
During externals review it was requested that this attribute be removed. 