### PR TITLE
Fix task naming

### DIFF
--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -178,8 +178,7 @@ task publishLibNative(type: Copy) {
 task prereqFeatureResources {
   dependsOn ':cnf:copyMavenLibs'
   dependsOn publishWLPJars
-  dependsOn publishDevApiIBMJavadoc
-  dependsOn publishDevSpiIBMJavadoc
+  dependsOn publishJavadoc
   dependsOn publishToolJars
   dependsOn publishSchemaResources
   dependsOn publishPlatformFiles


### PR DESCRIPTION
publishDevApiIBMJavadoc and publishDevSpiIBMJavadoc are now done in publishJavadoc