### PR TITLE
Revert "Revert "Update autoStart metatype name to Automatically start for clarity""

### DIFF
--- a/dev/com.ibm.ws.jca.feature/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jca.feature/resources/OSGI-INF/l10n/metatype.properties
@@ -42,7 +42,7 @@ authData=Authentication Data
 authData$Ref=Authentication data reference
 authData.desc=Default authentication data for an activation specification.
 
-autoStart=Auto start
+autoStart=Automatically start
 autoStart.desc=Configures whether a resource adapter starts automatically upon deployment of the resource adapter or lazily upon injection or lookup of a resource. 
 
 cntrAuth=Container Managed Authentication Data

--- a/dev/com.ibm.ws.jca/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jca/resources/OSGI-INF/l10n/metatype.properties
@@ -38,5 +38,5 @@ recoveryAuth=Recovery Authentication Data
 recoveryAuth$Ref=Recovery authentication data reference
 recoveryAuth.desc=Authentication data for transaction recovery.
 
-autoStart=Auto start
+autoStart=Automatically start
 autoStart.desc=Configures whether the message endpoints associated with this activation specification start automatically or need to be manually started using the resume command.


### PR DESCRIPTION
It was determined this was likely not the cause of the build breaks, so redelivering these changes.

Reverts OpenLiberty/open-liberty#2093