### PR TITLE
Initial prototype of jcache vendor property config for sessionCache

### DIFF
--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
@@ -21,9 +21,16 @@
  <!-- TODO add NLS -->
  <OCD id="com.ibm.ws.session.cache" ibm:alias="httpSessionCache" name="internal" description="internal use only">
   <AD id="libraryRef"                  type="String"  required="false" ibm:type="pid" ibm:reference="com.ibm.ws.classloading.sharedlibrary" cardinality="1" name="internal" description="internal use only"/>
-  <AD id="library.target"              type="String"  default="(|(service.pid=${libraryRef})(&amp;(zero=${count(libraryRef)})(id=com.ibm.ws.session.cache.defaultprovider.library)))" ibm:final="true" name="internal" description="internal use only"/>
-  <!-- TODO JCache CacheManager properties -->
+  <AD id="library.target"              type="String"  default="(|(service.pid=${libraryRef})(&amp;(zero=${count(libraryRef)})(id=com.ibm.ws.session.cache.defaultprovider.library)))" ibm:final="true" name="internal" description="internal use only"/>  
   <AD id="service.ranking"             type="Integer" default="50" ibm:final="true" name="internal" description="internal use only"/> <!-- httpSessionDatabase takes precedence -->
+  <AD id="uri" type="String" ibm:type="location" required="false" name="internal" description="internal use only"/>
+  <AD id="properties" name="internal" description="internal use only" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.session.cache.properties" ibm:flat="true"/>
  </OCD>
-
+ 
+  <Designate pid="com.ibm.ws.session.cache.properties">
+  	<Object ocdref="com.ibm.ws.session.cache.properties"/>
+  </Designate>
+ 
+ <OCD id="com.ibm.ws.session.cache.properties" name="internal" description="internal use only" ibmui:extraProperties="true" ibm:alias="properties" />
+ 
 </metatype:MetaData>


### PR DESCRIPTION
Initial prototype to allow for vendor properties to be passed to the JCache provider used for session caching.  The properties can be passed in either as a URI to their vendor config file, or as vendor specific key value pairs on the properties element.

PR for story #1829