### PR TITLE
avoid costly iterator for session property cache

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -213,7 +213,7 @@ public class CacheHashMap extends BackedHashMap {
             byte[] bytes = cacheStoreService.getCache(appName).get(key);
 
             if (trace && tc.isDebugEnabled())
-                Tr.debug(this, tc, key.toString(), bytes == null ? null : bytes.length);
+                Tr.debug(this, tc, "byte length", bytes == null ? null : bytes.length);
 
             if (bytes != null && bytes.length > 0) {
                 long startTime = System.nanoTime();

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/CacheEntryPerSessionPropertyTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/CacheEntryPerSessionPropertyTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.session.cache.fat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class CacheEntryPerSessionPropertyTest extends FATServletClient {
+
+    @Server("sessionCacheEntryPerPropServer")
+    public static LibertyServer server;
+
+    public static SessionCacheApp app = null;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        app = new SessionCacheApp(server);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    /**
+     * Ensure that various types of objects can be stored in a session,
+     * serialized when the session is evicted from memory, and deserialized
+     * when the session is accessed again.
+     */
+    @Test
+    public void testSerialization() throws Exception {
+        List<String> session = new ArrayList<>();
+        app.invokeServlet("testSerialization", session);
+        try {
+            app.invokeServlet("evictSession", null);
+            app.invokeServlet("testSerialization_complete", session);
+        } finally {
+            app.invalidateSession(session);
+        }
+    }
+
+    /**
+     * Ensure that various types of objects can be stored in a session,
+     * serialized when the session is evicted from memory, and deserialized
+     * when the session is accessed again.
+     */
+    @Test
+    public void testSerializeDataSource() throws Exception {
+        List<String> session = new ArrayList<>();
+        app.invokeServlet("testSerializeDataSource", session);
+        try {
+            app.invokeServlet("evictSession", null);
+            app.invokeServlet("testSerializeDataSource_complete", session);
+        } finally {
+            app.invalidateSession(session);
+        }
+    }
+}

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/CacheEntryPerSessionTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/CacheEntryPerSessionTest.java
@@ -24,7 +24,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
-public class SessionCacheTest extends FATServletClient {
+public class CacheEntryPerSessionTest extends FATServletClient {
 
     @Server("sessionCacheServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/FATSuite.java
@@ -24,8 +24,10 @@ import componenttest.topology.utils.HttpUtils;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                SessionCacheTest.class,
-                MultiServerCacheTest.class
+                CacheEntryPerSessionPropertyTest.class,
+                CacheEntryPerSessionTest.class,
+                MultiServerCacheEntryPerSessionPropertyTest.class,
+                MultiServerCacheEntryPerSessionTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/MultiServerCacheEntryPerSessionPropertyTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/MultiServerCacheEntryPerSessionPropertyTest.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.session.cache.fat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class MultiServerCacheEntryPerSessionPropertyTest extends FATServletClient {
+
+    @Server("sessionCacheEntryPerPropServerA")
+    public static LibertyServer serverA;
+
+    @Server("sessionCacheEntryPerPropServerB")
+    public static LibertyServer serverB;
+
+    public static SessionCacheApp appA;
+    public static SessionCacheApp appB;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        appA = new SessionCacheApp(serverA);
+        appB = new SessionCacheApp(serverB);
+        serverB.useSecondaryHTTPPort();
+
+        serverA.startServer();
+        serverB.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        try {
+            serverA.stopServer();
+        } finally {
+            serverB.stopServer();
+        }
+    }
+
+    /**
+     * Ensure that various types of objects can be stored in a session,
+     * serialized when the session is evicted from memory, and deserialized
+     * when the session is accessed again.
+     */
+    @Test
+    public void testBasicSerialization() throws Exception {
+        List<String> session = new ArrayList<>();
+        try {
+            appA.invokeServlet("testSerialization", session);
+            appB.invokeServlet("testSerialization_complete", session);
+        } finally {
+            appA.invalidateSession(session);
+            appB.invalidateSession(session);
+        }
+    }
+
+    /**
+     * Test that calling session.invalidate() on one server will propagate the
+     * invalidation to the other server
+     */
+    @Test
+    public void testCrossServerInvalidation() throws Exception {
+        List<String> session = new ArrayList<>();
+        appA.invokeServlet("testSerialization", session);
+        appB.invokeServlet("testSerialization_complete", session);
+
+        appA.invalidateSession(session);
+        appB.invokeServlet("testSessionEmpty", session);
+    }
+
+    // @Test // TODO still in progress
+    public void testMaxSessions() throws Exception {
+        List<String> session1 = new ArrayList<>();
+        List<String> session2 = new ArrayList<>();
+        appA.sessionPut("testMaxSessions-session1", "hello", session1, true);
+        appB.sessionGet("testMaxSessions-session1", "hello", session1);
+
+        // Starting a new session should push session1 out of the cache
+        appA.sessionPut("testMaxSessions-session2", "hello2", session2, true);
+
+        // Verify that session2 is in the server and session1 is not
+        appA.sessionGet("testMaxSessions-session2", "hello2", session2);
+        appB.sessionGet("testMaxSessions-session2", "hello2", session2);
+        appB.sessionGet("testMaxSessions-session1", null, session1);
+        appA.sessionGet("testMaxSessions-session1", null, session1);
+    }
+}

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/MultiServerCacheEntryPerSessionTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/MultiServerCacheEntryPerSessionTest.java
@@ -24,7 +24,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
-public class MultiServerCacheTest extends FATServletClient {
+public class MultiServerCacheEntryPerSessionTest extends FATServletClient {
 
     @Server("sessionCacheServerA")
     public static LibertyServer serverA;

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServer/bootstrap.properties
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.session.store.*=all

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServer/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServer/server.xml
@@ -1,0 +1,67 @@
+<server>
+
+    <featureManager>
+        <feature>servlet-4.0</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>jdbc-4.2</feature>
+        <feature>jndi-1.0</feature>
+        <feature>sessionCache-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
+
+    <httpSessionCache libraryRef="HazelcastLib" useMultiRowSchema="true"/>
+
+    <library id="HazelcastLib">
+        <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    </library>
+
+	<library id="DerbyLib">
+	    <file name="${shared.resource.dir}/derby/derby.jar"/>
+	</library>
+
+    <!-- Used for testing that data source can be stored in a session -->
+	<authData id="DerbyAuth" user="userName" password="userPassword"/>    
+    <dataSource jndiName="jdbc/derby" containerAuthDataRef="DerbyAuth">
+	    <jdbcDriver libraryRef="DerbyLib"/>
+	    <properties.derby.embedded createDatabase="create" databaseName="memory:testdb"/>
+	</dataSource>
+
+	<javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+	<variable name="hazelcast" value="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    <javaPermission codebase="${hazelcast}" className="java.io.FilePermission" actions="read" name="hazelcast.xml"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.management"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.misc"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.nio.ch"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.net.www.protocol.wsjar"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="enableContextClassLoaderOverride"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="getenv.HZ_PHONE_HOME_ENABLED"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="shutdownHooks"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.NetPermission" name="getNetworkInformation"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.SocketPermission" actions="accept,connect,listen,resolve" name="*"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.URLPermission" actions="GET:User-Agent" name="http://phonehome.hazelcast.com/ping"/>
+	<javaPermission codebase="${hazelcast}" className="java.util.PropertyPermission" actions="read,write" name="*"/>
+
+    <variable name="hazelcast" value="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    <javaPermission codebase="${hazelcast}" className="java.io.FilePermission" actions="read" name="hazelcast.xml"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.management"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.misc"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.nio.ch"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="enableContextClassLoaderOverride"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="getenv.HZ_PHONE_HOME_ENABLED"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="shutdownHooks"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.NetPermission" name="getNetworkInformation"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.SocketPermission" actions="accept,connect,listen,resolve" name="*"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.URLPermission" actions="GET:User-Agent" name="http://phonehome.hazelcast.com/ping"/>
+	<javaPermission codebase="${hazelcast}" className="java.util.PropertyPermission" actions="read,write" name="*"/>	
+</server>

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServerA/bootstrap.properties
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServerA/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.session.store.*=all

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServerA/server.xml
@@ -1,0 +1,41 @@
+<server>
+
+    <featureManager>
+        <feature>bells-1.0</feature>
+        <feature>servlet-3.1</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>sessionCache-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
+
+    <httpSessionCache useMultiRowSchema="true"/>
+
+    <bell libraryRef="HazelcastLibA" service="javax.cache.spi.CachingProvider"/>
+
+    <library id="HazelcastLibA">
+        <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    </library>
+    
+    
+    <variable name="hazelcast" value="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    <javaPermission codebase="${hazelcast}" className="java.io.FilePermission" actions="read" name="hazelcast.xml"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.management"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.misc"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.nio.ch"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.net.www.protocol.wsjar"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="enableContextClassLoaderOverride"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="getenv.HZ_PHONE_HOME_ENABLED"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="shutdownHooks"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.NetPermission" name="getNetworkInformation"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.SocketPermission" actions="accept,connect,listen,resolve" name="*"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.URLPermission" actions="GET:User-Agent" name="http://phonehome.hazelcast.com/ping"/>
+	<javaPermission codebase="${hazelcast}" className="java.util.PropertyPermission" actions="read,write" name="*"/>
+
+</server>

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServerB/bootstrap.properties
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServerB/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.session.store.cache=all

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServerB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheEntryPerPropServerB/server.xml
@@ -1,0 +1,47 @@
+<server>
+
+    <featureManager>
+        <feature>bells-1.0</feature>
+        <feature>servlet-3.1</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>sessionCache-1.0</feature>
+        <feature>timedexit-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestCommon.xml"/>
+
+    <!-- This server runs at the same time as sessionCacheServerA, so use a different set of ports -->    
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="${bvt.prop.HTTP_secondary}"
+                  httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+    
+    <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
+
+    <httpSessionCache useMultiRowSchema="true"/>
+
+    <bell libraryRef="HazelcastLibB" service="javax.cache.spi.CachingProvider"/>
+
+    <library id="HazelcastLibB">
+        <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    </library>
+    
+    
+    <variable name="hazelcast" value="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    <javaPermission codebase="${hazelcast}" className="java.io.FilePermission" actions="read" name="hazelcast.xml"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.management"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.misc"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.nio.ch"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.net.www.protocol.wsjar"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="enableContextClassLoaderOverride"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="getenv.HZ_PHONE_HOME_ENABLED"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.RuntimePermission" name="shutdownHooks"/>
+    <javaPermission codebase="${hazelcast}" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.NetPermission" name="getNetworkInformation"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.SocketPermission" actions="accept,connect,listen,resolve" name="*"/>
+    <javaPermission codebase="${hazelcast}" className="java.net.URLPermission" actions="GET:User-Agent" name="http://phonehome.hazelcast.com/ping"/>
+	<javaPermission codebase="${hazelcast}" className="java.util.PropertyPermission" actions="read,write" name="*"/>
+
+</server>


### PR DESCRIPTION
Avoid iterating through all values of the session property cache when we only need to update a subset of the properties.  This iteration is costly because it aggressively loads all of the cached values.