### PR TITLE
Improve build times with publishFeatureResources

### DIFF
--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -191,8 +191,8 @@ task prereqFeatureResources {
 task publishFeatureResources {
   // Start building feature resources after all other assemble artifacts are done being published
   dependsOn {
-    rootProject.subprojects.collect {
-      it.tasks.getByName 'prereqFeatureResources'
+    bndWorkspace.getProject(project.name)?.getDependson()*.getName().collect {
+      rootProject.project(it).tasks.getByName 'prereqFeatureResources'
     }
   }
 
@@ -308,6 +308,9 @@ assemble {
   dependsOn publishBinScripts
   dependsOn publishClientScripts
   dependsOn publishLibNative
+}
+
+publish {
   dependsOn publishFeatureResources
 }
 


### PR DESCRIPTION
- Changes publishFeatureResources to collect it's bnd Project dependencies, from those it gathers a list of it's dependencies' Gradle Projects, then using those it dependsOn their prereqFeatureResources task. Speeds up full :releaseNeeded by several minutes.
- Moves publishFeatureResources out from :assemble and into :publish so that local developers aren't slowed down. That drastically reduced :assemble time from 20 minutes to 9m 17s.