### PR TITLE
Handle re-usable field for MicroProfile Metrics 

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.1.1.cdi/src/com/ibm/ws/microprofile/metrics11/cdi/MetricResolver11.java
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1.cdi/src/com/ibm/ws/microprofile/metrics11/cdi/MetricResolver11.java
@@ -23,9 +23,20 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.metrics11.cdi;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Member;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Specializes;
 import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+import org.eclipse.microprofile.metrics.annotation.Metered;
+import org.eclipse.microprofile.metrics.annotation.Timed;
 
 import io.astefanutti.metrics.cdi.MetricName;
 import io.astefanutti.metrics.cdi.MetricResolver;
@@ -35,9 +46,64 @@ import io.astefanutti.metrics.cdi.MetricsExtension;
 @Specializes
 public class MetricResolver11 extends MetricResolver {
 
+    private final MetricRegistry registry;
+
     @Inject
-    public MetricResolver11(MetricsExtension extension, MetricName metricName) {
+    public MetricResolver11(MetricsExtension extension, MetricName metricName, MetricRegistry registry) {
         this.extension = extension;
         this.metricName = metricName;
+        this.registry = registry;
+    }
+
+    @Override
+    protected <E extends Member & AnnotatedElement, T extends Annotation> Of<T> elementResolverOf(E element, Class<T> metric) {
+        Of<T> of = super.elementResolverOf(element, metric);
+        if (of instanceof DoesHaveMetric) {
+            of.metadata().setReusable(getReusable(of.metricAnnotation()));
+            checkReusable(of);
+        }
+        return of;
+    }
+
+    @Override
+    protected <E extends Member & AnnotatedElement, T extends Annotation> Of<T> beanResolverOf(E element, Class<T> metric, Class<?> bean) {
+        Of<T> of = super.beanResolverOf(element, metric, bean);
+        if (of instanceof DoesHaveMetric) {
+            of.metadata().setReusable(getReusable(of.metricAnnotation()));
+            checkReusable(of);
+        }
+        return of;
+    }
+
+    private boolean getReusable(Annotation annotation) {
+        if (Counted.class.isInstance(annotation))
+            return ((Counted) annotation).reusable();
+        else if (Gauge.class.isInstance(annotation))
+            return false;
+        else if (Metered.class.isInstance(annotation))
+            return ((Metered) annotation).reusable();
+        else if (Timed.class.isInstance(annotation))
+            return ((Timed) annotation).reusable();
+        else
+            throw new IllegalArgumentException("Unsupported Metrics forMethod [" + annotation.getClass().getName() + "]");
+    }
+
+    /**
+     * Checks whether the metric should be re-usable
+     */
+    private <T extends Annotation> boolean checkReusable(MetricResolver.Of<T> of) {
+        String name = of.metadata().getName();
+        // If the metric has been registered before (eg. metrics found in RequestScoped beans),
+        // we don't need to worry about re-usable
+        if (!of.isInitialDiscovery()) {
+            return true;
+        }
+
+        Metadata existingMetadata = registry.getMetadata().get(name);
+        if (existingMetadata != null && (existingMetadata.isReusable() == false || of.metadata().isReusable() == false)) {
+            throw new IllegalArgumentException("Cannot reuse metric for " + of.metricName());
+        }
+        return true;
+
     }
 }

--- a/dev/com.ibm.ws.microprofile.metrics.cdi/src/io/astefanutti/metrics/cdi/MetricsInterceptor.java
+++ b/dev/com.ibm.ws.microprofile.metrics.cdi/src/io/astefanutti/metrics/cdi/MetricsInterceptor.java
@@ -73,23 +73,29 @@ import com.ibm.ws.microprofile.metrics.cdi.producer.MetricRegistryFactory;
     private Object metrics(InvocationContext context) throws Exception {
         Class<?> bean = context.getConstructor().getDeclaringClass();
 
-        // Registers the bean constructor metrics
-        registerMetrics(bean, context.getConstructor());
+        // We'll skip re-visiting methods that we already created.
+        // We don't skip Gauges because they should fail if re-registered
+        if (!extension.getBeansVisited().contains(bean)) {
+            extension.getBeansVisited().add(bean);
+            // Registers the bean constructor metrics
+            registerMetrics(bean, context.getConstructor());
 
-        // Registers the methods metrics over the bean type hierarchy
-        Class<?> type = bean;
-        do {
-            // TODO: discover annotations declared on implemented interfaces
-            for (Method method : type.getDeclaredMethods())
-                if (!method.isSynthetic() && !Modifier.isPrivate(method.getModifiers()))
-                    registerMetrics(bean, method);
-            type = type.getSuperclass();
-        } while (!Object.class.equals(type));
+            // Registers the methods metrics over the bean type hierarchy
+            Class<?> type = bean;
+            do {
+                // TODO: discover annotations declared on implemented interfaces
+                for (Method method : type.getDeclaredMethods())
+                    if (!method.isSynthetic() && !Modifier.isPrivate(method.getModifiers()))
+                        registerMetrics(bean, method);
+                type = type.getSuperclass();
+            } while (!Object.class.equals(type));
+
+        }
 
         Object target = context.proceed();
 
         // Registers the gauges over the bean type hierarchy after the target is constructed as it is required for the gauge invocations
-        type = bean;
+        Class<?> type = bean;
         do {
             // TODO: discover annotations declared on implemented interfaces
             for (Method method : type.getDeclaredMethods()) {
@@ -109,19 +115,19 @@ import com.ibm.ws.microprofile.metrics.cdi.producer.MetricRegistryFactory;
         MetricResolver.Of<Counted> counted = resolver.counted(bean, element);
         if (counted.isPresent()) {
             registry.counter(counted.metadata());
-            extension.addMetricName(counted.metadata().getName());
+            extension.addMetricName(element, counted.metricAnnotation(), counted.metadata().getName());
         }
 
         MetricResolver.Of<Metered> metered = resolver.metered(bean, element);
         if (metered.isPresent()) {
             registry.meter(metered.metadata());
-            extension.addMetricName(metered.metadata().getName());
+            extension.addMetricName(element, metered.metricAnnotation(), metered.metadata().getName());
         }
 
         MetricResolver.Of<Timed> timed = resolver.timed(bean, element);
         if (timed.isPresent()) {
             registry.timer(timed.metadata());
-            extension.addMetricName(timed.metadata().getName());
+            extension.addMetricName(element, timed.metricAnnotation(), timed.metadata().getName());
         }
     }
 


### PR DESCRIPTION
Added logic to handle reusing metrics and properly throws IllegalArgumentExceptions when invalid metadata is supplied. Fixes #1568