### PR TITLE
2106 performance and trace enhancements

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat/bnd.bnd
@@ -21,6 +21,12 @@ javac.target: 1.8
 	
 fat.project: true
 
+tested.features: mpConfig-1.2,\
+                 cdi-1.2,\
+                 cdi-2.0,\
+                 servlet-3.1,\
+                 servlet-4.0
+
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.config.1.2;version=latest,\

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat/fat/src/com/ibm/ws/microprofile/config12/test/ImplicitConverterTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat/fat/src/com/ibm/ws/microprofile/config12/test/ImplicitConverterTest.java
@@ -12,6 +12,7 @@ package com.ibm.ws.microprofile.config12.test;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -20,6 +21,8 @@ import com.ibm.ws.microprofile.config12.converter.implicit.web.ImplicitConverter
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -44,6 +47,9 @@ public class ImplicitConverterTest extends FATServletClient {
     @Server("ConverterServer")
     @TestServlet(servlet = ImplicitConverterServlet.class, contextRoot = APP_NAME)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES()).andWith(FeatureReplacementAction.EE8_FEATURES());
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat/publish/servers/ConverterServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat/publish/servers/ConverterServer/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.config.*=all:org.eclipse.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug

--- a/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/archaius/composite/CompositeConfig.java
+++ b/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/archaius/composite/CompositeConfig.java
@@ -33,6 +33,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.microprofile.config.impl.ConversionManager;
 import com.ibm.ws.microprofile.config.impl.SortedSources;
 import com.ibm.ws.microprofile.config.interfaces.SourcedValue;
+import com.ibm.ws.microprofile.config.sources.InternalConfigSource;
 
 public class CompositeConfig implements Closeable, ConfigListener {
 
@@ -83,6 +84,12 @@ public class CompositeConfig implements Closeable, ConfigListener {
      * @return
      */
     private PollingDynamicConfig addConfig(ConfigSource source, ScheduledExecutorService executor, long refreshInterval) {
+        //if it is an internal config source then it should not refresh
+        //this is a hack for now ... dynamic config sources will be fixed properly in the next version
+        if (source instanceof InternalConfigSource) {
+            refreshInterval = 0;
+        }
+
         //we wrap each source up as an archaius config
         PollingDynamicConfig archaiusConfig = new PollingDynamicConfig(source, executor, refreshInterval);
 

--- a/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/converters/PriorityConverter.java
+++ b/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/converters/PriorityConverter.java
@@ -12,6 +12,8 @@ package com.ibm.ws.microprofile.config.converters;
 
 import java.lang.reflect.Type;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 /**
  * A converter with an explicit Type and priority
  */
@@ -35,6 +37,7 @@ public abstract class PriorityConverter {
     /**
      * @return the priority of this converter
      */
+    @Trivial
     public int getPriority() {
         return priority;
     }
@@ -42,6 +45,7 @@ public abstract class PriorityConverter {
     /**
      * @return the type of this converter
      */
+    @Trivial
     public Type getType() {
         return this.type;
     }

--- a/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/converters/PriorityConverterMap.java
+++ b/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/converters/PriorityConverterMap.java
@@ -15,6 +15,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 /**
  * A Map of PriorityConverters, that only stores the PriorityConverter with the highest priority for each Type
  */
@@ -35,7 +37,7 @@ public class PriorityConverterMap {
      */
     public PriorityConverterMap(PriorityConverterMap toCopy) {
         for (PriorityConverter converter : toCopy.getAll()) {
-            addConverter(converter);
+            _addConverter(converter);
         }
     }
 
@@ -49,6 +51,12 @@ public class PriorityConverterMap {
      * @return the new converter if it was added or the existing converter if it was not
      */
     public PriorityConverter addConverter(PriorityConverter converter) {
+        PriorityConverter existing = _addConverter(converter);
+        return existing;
+    }
+
+    @Trivial
+    private PriorityConverter _addConverter(PriorityConverter converter) {
         if (this.unmodifiable) {
             throw new UnsupportedOperationException();
         }
@@ -70,7 +78,7 @@ public class PriorityConverterMap {
      */
     public void addAll(PriorityConverterMap convertersToAdd) {
         for (PriorityConverter converter : convertersToAdd.converters.values()) {
-            addConverter(converter);
+            _addConverter(converter);
         }
     }
 
@@ -111,5 +119,10 @@ public class PriorityConverterMap {
      */
     public Collection<? extends Type> getTypes() {
         return converters.keySet();
+    }
+
+    @Override
+    public String toString() {
+        return "PriorityConverterMap:" + converters;
     }
 }

--- a/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/sources/EnvConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/sources/EnvConfigSource.java
@@ -25,7 +25,7 @@ import com.ibm.ws.microprofile.config.interfaces.ConfigConstants;
 /**
  *
  */
-public class EnvConfigSource extends AbstractConfigSource implements ConfigSource {
+public class EnvConfigSource extends InternalConfigSource implements ConfigSource {
 
     private static final TraceComponent tc = Tr.register(EnvConfigSource.class);
 

--- a/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/sources/InternalConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/sources/InternalConfigSource.java
@@ -15,12 +15,12 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 /**
  *
  */
-public abstract class AbstractConfigSource implements ConfigSource {
+public abstract class InternalConfigSource implements ConfigSource {
 
     private final int ordinal;
     private final String id;
 
-    public AbstractConfigSource(int ordinal, String id) {
+    public InternalConfigSource(int ordinal, String id) {
         this.ordinal = ordinal;
         this.id = id;
     }

--- a/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/sources/PropertiesConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/sources/PropertiesConfigSource.java
@@ -26,7 +26,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.microprofile.config.interfaces.ConfigConstants;
 import com.ibm.ws.microprofile.config.interfaces.ConfigException;
 
-public class PropertiesConfigSource extends AbstractConfigSource implements ConfigSource {
+public class PropertiesConfigSource extends InternalConfigSource implements ConfigSource {
 
     private static final TraceComponent tc = Tr.register(PropertiesConfigSource.class);
 

--- a/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/sources/SystemConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config/src/com/ibm/ws/microprofile/config/sources/SystemConfigSource.java
@@ -26,7 +26,7 @@ import com.ibm.ws.microprofile.config.interfaces.ConfigConstants;
 /**
  *
  */
-public class SystemConfigSource extends AbstractConfigSource implements ConfigSource {
+public class SystemConfigSource extends InternalConfigSource implements ConfigSource {
 
     private static final TraceComponent tc = Tr.register(SystemConfigSource.class);
 

--- a/dev/com.ibm.ws.microprofile.config_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config_fat/bnd.bnd
@@ -39,6 +39,11 @@ javac.target: 1.8
 	
 fat.project: true
 
+tested.features: mpConfig-1.1,\
+                 mpConfig-1.2,\
+                 cdi-1.2,\
+                 cdi-2.0
+
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.config.1.1;version=latest,\

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/FATSuite.java
@@ -11,7 +11,6 @@
 package com.ibm.ws.microprofile.config.fat.suite;
 
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -36,9 +35,6 @@ import com.ibm.ws.microprofile.config.fat.tests.OrdinalsForDefaultsTest;
 import com.ibm.ws.microprofile.config.fat.tests.SharedLibTest;
 import com.ibm.ws.microprofile.config.fat.tests.StressTest;
 import com.ibm.ws.microprofile.config.fat.tests.TypesTest;
-
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 
 /**
  * Tests specific to appConfig
@@ -69,10 +65,6 @@ import componenttest.rules.repeater.RepeatTests;
 })
 
 public class FATSuite {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new FeatureReplacementAction("mpConfig-1.1", "mpConfig-1.2"));
 
     /**
      * @see {@link FatLogHandler#generateHelpFile()}

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig11.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig11.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config.fat.suite;
+
+import componenttest.rules.repeater.FeatureReplacementAction;
+
+/**
+ *
+ */
+public class RepeatConfig11 extends FeatureReplacementAction {
+
+    public static final FeatureReplacementAction INSTANCE = new RepeatConfig11();
+
+    public RepeatConfig11() {
+        super("mpConfig-1.2", "mpConfig-1.1");
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig11CDI12.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig11CDI12.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config.fat.suite;
+
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+
+/**
+ *
+ */
+public class RepeatConfig11CDI12 extends EE7FeatureReplacementAction {
+
+    public static final FeatureReplacementAction INSTANCE = new RepeatConfig11CDI12();
+
+    public RepeatConfig11CDI12() {
+        super();
+        removeFeature("mpConfig-1.2");
+        addFeature("mpConfig-1.1");
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig11EE7.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig11EE7.java
@@ -10,17 +10,20 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config.fat.suite;
 
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 
 /**
  *
  */
-public class RepeatConfig11 extends FeatureReplacementAction {
+public class RepeatConfig11EE7 extends EE7FeatureReplacementAction {
 
-    public static final FeatureReplacementAction INSTANCE = new RepeatConfig11();
+    public static final FeatureReplacementAction INSTANCE = new RepeatConfig11EE7();
 
-    public RepeatConfig11() {
-        super("mpConfig-1.2", "mpConfig-1.1");
+    public RepeatConfig11EE7() {
+        super();
+        removeFeature("mpConfig-1.2");
+        addFeature("mpConfig-1.1");
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig11EE8.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig11EE8.java
@@ -8,18 +8,22 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.microprofile.config12.test;
+package com.ibm.ws.microprofile.config.fat.suite;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                ConverterPriorityTest.class,
-                TypeConverterTest.class,
-                ImplicitConverterTest.class,
-})
-public class FATSuite {
+/**
+ *
+ */
+public class RepeatConfig11EE8 extends EE8FeatureReplacementAction {
+
+    public static final FeatureReplacementAction INSTANCE = new RepeatConfig11EE8();
+
+    public RepeatConfig11EE8() {
+        super();
+        removeFeature("mpConfig-1.2");
+        addFeature("mpConfig-1.1");
+    }
 
 }

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig12EE7.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig12EE7.java
@@ -8,18 +8,22 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.microprofile.config12.test;
+package com.ibm.ws.microprofile.config.fat.suite;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                ConverterPriorityTest.class,
-                TypeConverterTest.class,
-                ImplicitConverterTest.class,
-})
-public class FATSuite {
+/**
+ *
+ */
+public class RepeatConfig12EE7 extends EE7FeatureReplacementAction {
+
+    public static final FeatureReplacementAction INSTANCE = new RepeatConfig12EE7();
+
+    public RepeatConfig12EE7() {
+        super();
+        removeFeature("mpConfig-1.1");
+        addFeature("mpConfig-1.2");
+    }
 
 }

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig12EE8.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/RepeatConfig12EE8.java
@@ -10,20 +10,20 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config.fat.suite;
 
-import componenttest.rules.repeater.EE7FeatureReplacementAction;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 
 /**
  *
  */
-public class RepeatConfig11CDI12 extends EE7FeatureReplacementAction {
+public class RepeatConfig12EE8 extends EE8FeatureReplacementAction {
 
-    public static final FeatureReplacementAction INSTANCE = new RepeatConfig11CDI12();
+    public static final FeatureReplacementAction INSTANCE = new RepeatConfig12EE8();
 
-    public RepeatConfig11CDI12() {
+    public RepeatConfig12EE8() {
         super();
-        removeFeature("mpConfig-1.2");
-        addFeature("mpConfig-1.1");
+        removeFeature("mpConfig-1.1");
+        addFeature("mpConfig-1.2");
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/SharedShrinkWrapApps.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/suite/SharedShrinkWrapApps.java
@@ -17,8 +17,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-import com.ibm.websphere.simplicity.ShrinkHelper;
-
 /**
  *
  */
@@ -37,7 +35,7 @@ public class SharedShrinkWrapApps {
     public static Archive brokenConfigServerApps() {
         final String APP_NAME = "brokenCDIConfig";
 
-        if (brokenCDIConfig_war != null){
+        if (brokenCDIConfig_war != null) {
             return brokenCDIConfig_war;
         }
 
@@ -52,8 +50,8 @@ public class SharedShrinkWrapApps {
     public static Archive cdiConfigServerApps() {
         final String APP_NAME = "cdiConfig";
 
-        if (cdiConfig_war != null){
-            return(cdiConfig_war);
+        if (cdiConfig_war != null) {
+            return (cdiConfig_war);
         }
 
         cdiConfig_war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
@@ -64,7 +62,7 @@ public class SharedShrinkWrapApps {
                                                "services/org.eclipse.microprofile.config.spi.Converter")
                         .addAsLibrary(cdiConfigJar());
 
-        return(cdiConfig_war);
+        return (cdiConfig_war);
     }
 
     private static JavaArchive cdiConfigJar() {

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/AbstractConfigApiTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/AbstractConfigApiTest.java
@@ -1,19 +1,18 @@
- /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+/*******************************************************************************
+* Copyright (c) 2016 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
 
 package com.ibm.ws.microprofile.config.fat.tests;
 
 import org.junit.rules.TestName;
 
-import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.browser.WebBrowser;
 
@@ -44,5 +43,5 @@ public abstract class AbstractConfigApiTest extends LoggingTest {
     public static String upperCaseInitialLetter(String string) {
         return string != null && string.length() >= 1 ? string.substring(0, 1).toUpperCase() + string.substring(1) : "";
     }
-   
+
 }

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIBrokenMethodInjectionTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIBrokenMethodInjectionTest.java
@@ -16,19 +16,19 @@ import java.util.List;
 
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
+import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
-/**
- *
- */
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+@Mode(TestMode.FULL)
 public class CDIBrokenMethodInjectionTest extends LoggingTest {
 
     @ClassRule
@@ -46,7 +46,8 @@ public class CDIBrokenMethodInjectionTest extends LoggingTest {
 
     @Test
     public void testMethodUnnamed() throws Exception {
-        List<String> errors = getSharedServer().getLibertyServer().findStringsInLogs("ConfigUnnamedMethodInjectionBean.*setSimpleKey6.*The property name must be specified for Constructor and Method configuration property injection");
+        List<String> errors = getSharedServer().getLibertyServer()
+                        .findStringsInLogs("ConfigUnnamedMethodInjectionBean.*setSimpleKey6.*The property name must be specified for Constructor and Method configuration property injection");
         assertTrue(errors.size() > 0);
     }
 

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIBrokenXtorInjectionTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIBrokenXtorInjectionTest.java
@@ -16,19 +16,19 @@ import java.util.List;
 
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
+import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
-/**
- *
- */
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+@Mode(TestMode.FULL)
 public class CDIBrokenXtorInjectionTest extends LoggingTest {
 
     @ClassRule
@@ -46,7 +46,8 @@ public class CDIBrokenXtorInjectionTest extends LoggingTest {
 
     @Test
     public void testConstructorUnnamed() throws Exception {
-        List<String> errors = getSharedServer().getLibertyServer().findStringsInLogs("ConfigUnnamedConstructorInjectionBean.*The property name must be specified for Constructor and Method configuration property injection");
+        List<String> errors = getSharedServer().getLibertyServer()
+                        .findStringsInLogs("ConfigUnnamedConstructorInjectionBean.*The property name must be specified for Constructor and Method configuration property injection");
         assertTrue(errors.size() > 0);
     }
 

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIBuiltInConverterTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIBuiltInConverterTest.java
@@ -21,9 +21,9 @@ import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11CDI12;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
-import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -33,7 +33,7 @@ public class CDIBuiltInConverterTest extends LoggingTest {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(RepeatConfig11CDI12.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIBuiltInConverterTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIBuiltInConverterTest.java
@@ -21,7 +21,8 @@ import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;
-import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11CDI12;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11EE7;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig12EE8;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 import componenttest.rules.repeater.RepeatTests;
@@ -32,8 +33,7 @@ import componenttest.rules.repeater.RepeatTests;
 public class CDIBuiltInConverterTest extends LoggingTest {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(RepeatConfig11CDI12.INSTANCE);
+    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE7.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIConfigPropertyTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIConfigPropertyTest.java
@@ -19,9 +19,9 @@ import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11CDI12;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
-import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -31,7 +31,7 @@ public class CDIConfigPropertyTest extends LoggingTest {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(RepeatConfig11CDI12.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIConfigPropertyTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIConfigPropertyTest.java
@@ -19,7 +19,8 @@ import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;
-import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11CDI12;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11EE7;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig12EE8;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 import componenttest.rules.repeater.RepeatTests;
@@ -30,8 +31,7 @@ import componenttest.rules.repeater.RepeatTests;
 public class CDIConfigPropertyTest extends LoggingTest {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(RepeatConfig11CDI12.INSTANCE);
+    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE7.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIFieldInjectionTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIFieldInjectionTest.java
@@ -19,12 +19,19 @@ import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
+
+import componenttest.rules.repeater.RepeatTests;
 
 /**
  *
  */
 public class CDIFieldInjectionTest extends LoggingTest {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(RepeatConfig11.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIFieldInjectionTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIFieldInjectionTest.java
@@ -19,7 +19,8 @@ import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;
-import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11EE8;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig12EE8;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 import componenttest.rules.repeater.RepeatTests;
@@ -30,8 +31,7 @@ import componenttest.rules.repeater.RepeatTests;
 public class CDIFieldInjectionTest extends LoggingTest {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(RepeatConfig11.INSTANCE);
+    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE8.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIMethodInjectionTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIMethodInjectionTest.java
@@ -10,14 +10,12 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config.fat.tests;
 
-import org.junit.BeforeClass;
+import org.jboss.shrinkwrap.api.Archive;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.jboss.shrinkwrap.api.Archive;
-
-import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
+import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIScopeTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIScopeTest.java
@@ -10,14 +10,12 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config.fat.tests;
 
-import org.junit.BeforeClass;
+import org.jboss.shrinkwrap.api.Archive;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.jboss.shrinkwrap.api.Archive;
-
-import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
+import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIXtorInjectionTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIXtorInjectionTest.java
@@ -19,7 +19,8 @@ import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;
-import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11CDI12;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11EE7;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig12EE8;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 import componenttest.rules.repeater.RepeatTests;
@@ -33,8 +34,7 @@ public class CDIXtorInjectionTest extends LoggingTest {
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(RepeatConfig11CDI12.INSTANCE);
+    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE7.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
 
     @BuildShrinkWrap
     public static Archive buildApp() {

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIXtorInjectionTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIXtorInjectionTest.java
@@ -19,9 +19,9 @@ import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11CDI12;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
-import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -34,7 +34,7 @@ public class CDIXtorInjectionTest extends LoggingTest {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(RepeatConfig11CDI12.INSTANCE);
 
     @BuildShrinkWrap
     public static Archive buildApp() {

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ClassLoadersTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ClassLoadersTest.java
@@ -1,29 +1,26 @@
- /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
- 
+/*******************************************************************************
+* Copyright (c) 2016 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
 package com.ibm.ws.microprofile.config.fat.tests;
 
 import java.io.File;
 
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
-import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
@@ -53,7 +50,7 @@ public class ClassLoadersTest extends AbstractConfigApiTest {
                         .addAsManifestResource(new File("test-applications/" + APP_NAME + ".war/resources/META-INF/microprofile-config.properties"),
                                                "microprofile-config.properties")
                         .add(new FileAsset(new File("test-applications/" + APP_NAME + ".war/resources/CUSTOM-DIR/META-INF/microprofile-config.properties")),
-                                       "/CUSTOM-DIR/META-INF/microprofile-config.properties")
+                             "/CUSTOM-DIR/META-INF/microprofile-config.properties")
                         .addAsWebInfResource(new File("test-applications/" + APP_NAME + ".war/resources/WEB-INF/classes/META-INF/microprofile-config.properties"),
                                              "classes/META-INF/microprofile-config.properties");
 

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ConvertersTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ConvertersTest.java
@@ -23,7 +23,8 @@ import org.junit.rules.TestName;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
-import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11EE8;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig12EE8;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 import componenttest.annotation.ExpectedFFDC;
@@ -37,8 +38,7 @@ public class ConvertersTest extends AbstractConfigApiTest {
     private final static String testClassName = "ConvertersTest";
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(RepeatConfig11.INSTANCE);
+    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE8.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("ConvertersServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ConvertersTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ConvertersTest.java
@@ -23,10 +23,10 @@ import org.junit.rules.TestName;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 import componenttest.annotation.ExpectedFFDC;
-import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -38,7 +38,7 @@ public class ConvertersTest extends AbstractConfigApiTest {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(RepeatConfig11.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("ConvertersServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CustomSourcesTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CustomSourcesTest.java
@@ -15,19 +15,15 @@ import java.io.File;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
-import com.ibm.websphere.simplicity.ShrinkHelper;
-import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
-import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
-
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
+import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 /**
  *
@@ -39,7 +35,7 @@ public class CustomSourcesTest extends AbstractConfigApiTest {
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CustomSourcesServer");
 
-    @BuildShrinkWrap    
+    @BuildShrinkWrap
     public static Archive buildApp() {
         String APP_NAME = "customSources";
         WebArchive customSources_war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
@@ -51,7 +47,7 @@ public class CustomSourcesTest extends AbstractConfigApiTest {
                                                "services/org.eclipse.microprofile.config.spi.ConfigSourceProvider")
                         .addAsManifestResource(new File("test-applications/" + APP_NAME + ".war/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource"),
                                                "services/org.eclipse.microprofile.config.spi.ConfigSource");
- 
+
         return customSources_war;
     }
 

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DefaultSourcesTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DefaultSourcesTest.java
@@ -26,9 +26,9 @@ import org.junit.rules.TestName;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11CDI12;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
-import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -40,7 +40,7 @@ public class DefaultSourcesTest extends AbstractConfigApiTest {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(RepeatConfig11CDI12.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("SimpleConfigSourcesServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DefaultSourcesTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DefaultSourcesTest.java
@@ -26,7 +26,8 @@ import org.junit.rules.TestName;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
-import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11CDI12;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11EE7;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig12EE8;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 import componenttest.rules.repeater.RepeatTests;
@@ -39,8 +40,7 @@ public class DefaultSourcesTest extends AbstractConfigApiTest {
     private final static String testClassName = "DefaultSourcesTest";
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(RepeatConfig11CDI12.INSTANCE);
+    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE7.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("SimpleConfigSourcesServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DynamicSourcesTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DynamicSourcesTest.java
@@ -23,7 +23,8 @@ import org.junit.rules.TestName;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
-import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11CDI12;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11EE7;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig12EE8;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 import componenttest.custom.junit.runner.Mode;
@@ -39,8 +40,7 @@ public class DynamicSourcesTest extends AbstractConfigApiTest {
     private final static String testClassName = "DynamicSourcesTest";
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(RepeatConfig11CDI12.INSTANCE);
+    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE7.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("DynamicSourcesServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DynamicSourcesTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DynamicSourcesTest.java
@@ -23,11 +23,11 @@ import org.junit.rules.TestName;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
+import com.ibm.ws.microprofile.config.fat.suite.RepeatConfig11CDI12;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -40,7 +40,7 @@ public class DynamicSourcesTest extends AbstractConfigApiTest {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(RepeatConfig11CDI12.INSTANCE);
 
     @ClassRule
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("DynamicSourcesServer");

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/OrdinalsForDefaultsTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/OrdinalsForDefaultsTest.java
@@ -1,13 +1,13 @@
- /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+/*******************************************************************************
+* Copyright (c) 2016 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
 
 package com.ibm.ws.microprofile.config.fat.tests;
 
@@ -16,7 +16,6 @@ import java.io.File;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,9 +23,6 @@ import org.junit.rules.TestName;
 
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
-import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
-
-import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/SharedLibTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/SharedLibTest.java
@@ -10,16 +10,14 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config.fat.tests;
 
-
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import java.io.File;
 
-import org.jboss.shrinkwrap.api.Archive;	
+import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.BeforeClass;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,8 +26,6 @@ import org.junit.rules.TestName;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
-
-import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 /**
@@ -47,10 +43,10 @@ public class SharedLibTest extends AbstractConfigApiTest {
     }
 
     @BuildShrinkWrap
-    public static Map<Archive,String> buildApps() {
+    public static Map<Archive, String> buildApps() {
         String APP_NAME = "sharedLibUser";
 
-        //TODO differentiate the pacakage names for these two jars. 
+        //TODO differentiate the pacakage names for these two jars.
         JavaArchive sharedLib_jar = ShrinkWrap.create(JavaArchive.class, "sharedLib.jar")
                         .addClass("com.ibm.ws.microprofile.archaius.impl.fat.tests.PingableSharedLibClass")
                         .addAsManifestResource(new File("test-applications/sharedLib.jar/resources/META-INF/microprofile-config.json"), "microprofile-config.json")
@@ -64,8 +60,8 @@ public class SharedLibTest extends AbstractConfigApiTest {
                         .addAsLibrary(sharedLibUser_jar)
                         .addAsLibrary(SharedShrinkWrapApps.getTestAppUtilsJar())
                         .addAsManifestResource(new File("test-applications/" + APP_NAME + ".war/resources/META-INF/permissions.xml"), "permissions.xml");
- 
-        Map<Archive,String> toReturn = new HashMap<Archive,String>();
+
+        Map<Archive, String> toReturn = new HashMap<Archive, String>();
         toReturn.put(sharedLib_jar, "publish/servers/SharedLibUserServer/shared");
         toReturn.put(sharedLibUser_war, "publish/servers/SharedLibUserServer/apps");
         return toReturn;

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/StressTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/StressTest.java
@@ -15,7 +15,6 @@ import java.io.File;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,10 +23,8 @@ import org.junit.rules.TestName;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
-
-import com.ibm.websphere.simplicity.ShrinkHelper;
-import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
+
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/TypesTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/TypesTest.java
@@ -1,13 +1,13 @@
- /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+/*******************************************************************************
+* Copyright (c) 2016 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
 
 package com.ibm.ws.microprofile.config.fat.tests;
 
@@ -16,7 +16,6 @@ import java.io.File;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,8 +24,6 @@ import org.junit.rules.TestName;
 import com.ibm.ws.fat.util.BuildShrinkWrap;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.ShrinkWrapSharedServer;
-
-import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
 /**
@@ -43,7 +40,7 @@ public class TypesTest extends AbstractConfigApiTest {
     public static Archive buildApp() {
         String APP_NAME = "types";
 
-        WebArchive types_war = ShrinkWrap.create(WebArchive.class, APP_NAME  + ".war")
+        WebArchive types_war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addPackages(true, "com.ibm.ws.microprofile.appConfig.types.test")
                         .addAsLibrary(SharedShrinkWrapApps.getTestAppUtilsJar())
                         .addAsManifestResource(new File("test-applications/" + APP_NAME + ".war/resources/META-INF/permissions.xml"), "permissions.xml");

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CDIConfigServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CDIConfigServer/bootstrap.properties
@@ -1,6 +1,6 @@
 bootstrap.include=../testports.properties
 osgi.console=7771
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.config.*=all:org.eclipse.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug
 SIMPLE_KEY4=VALUE4
 SIMPLE_KEY6=VALUE6
 com.ibm.ws.microprofile.appConfig.cdi.beans.ConfigPropertyBean.nullKey=nullKeyValue

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CDIConfigServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CDIConfigServer/server.xml
@@ -4,9 +4,9 @@
 
     <featureManager>
         <feature>osgiconsole-1.0</feature>
-        <feature>cdi-1.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-    	<feature>mpConfig-1.1</feature>
-	</featureManager>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ClassLoadersServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ClassLoadersServer/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
 osgi.console=7772
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.config.*=all:org.eclipse.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ClassLoadersServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ClassLoadersServer/server.xml
@@ -4,9 +4,9 @@
 
     <featureManager>
         <feature>osgiconsole-1.0</feature>
-        <feature>cdi-1.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-    	<feature>mpConfig-1.1</feature>
-	</featureManager>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConverterServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConverterServer/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.config.*=all:org.eclipse.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConverterServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConverterServer/server.xml
@@ -3,12 +3,12 @@
 	<include location="../fatTestPorts.xml" />
 
 	<featureManager>
-		<feature>osgiconsole-1.0</feature>
-		<feature>cdi-2.0</feature>
-		<feature>servlet-4.0</feature>
-		<feature>componentTest-1.0</feature>
-		<feature>mpConfig-1.2</feature>
-	</featureManager>
+        <feature>osgiconsole-1.0</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>componentTest-1.0</feature>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 
 	<application location="converterApp.war" />
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConvertersServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConvertersServer/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.config.*=all:org.eclipse.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConvertersServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConvertersServer/server.xml
@@ -4,9 +4,9 @@
 
     <featureManager>
         <feature>osgiconsole-1.0</feature>
-        <feature>cdi-1.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-    	<feature>mpConfig-1.1</feature>
-	</featureManager>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CustomSourcesServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CustomSourcesServer/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
 osgi.console=7774
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.config.*=all:org.eclipse.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CustomSourcesServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CustomSourcesServer/server.xml
@@ -3,10 +3,10 @@
 	<include location="../fatTestPorts.xml" />
 
 	<featureManager>
-		<feature>osgiconsole-1.0</feature>
-		<feature>cdi-1.2</feature>
-		<feature>servlet-3.1</feature>
-		<feature>componentTest-1.0</feature>
-		<feature>mpConfig-1.1</feature>
-	</featureManager>
+        <feature>osgiconsole-1.0</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>componentTest-1.0</feature>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/DynamicSourcesServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/DynamicSourcesServer/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
 osgi.console=7775
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.config.*=all:org.eclipse.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/DynamicSourcesServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/DynamicSourcesServer/server.xml
@@ -3,10 +3,10 @@
 	<include location="../fatTestPorts.xml" />
 
 	<featureManager>
-		<feature>osgiconsole-1.0</feature>
-		<feature>cdi-1.2</feature>
-		<feature>servlet-3.1</feature>
-		<feature>componentTest-1.0</feature>
-		<feature>mpConfig-1.1</feature>
-	</featureManager>
+        <feature>osgiconsole-1.0</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>componentTest-1.0</feature>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/OrdForDefaultsServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/OrdForDefaultsServer/bootstrap.properties
@@ -2,7 +2,7 @@ bootstrap.include=../testports.properties
 config_ordinal=330
 bootstrap.properties.appConfig=bootstrap.properties.defaultValue
 osgi.console=7776
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.com.ibm.ws.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug
 fileOverriddenInSysProps=fileOverriddenInSysProps.sysPropsValue
 fileOverriddenInEnvAndSysProps=fileOverriddenInEnvAndSysProps.sysPropsValue
 envOverriddenInSysProps=envOverriddenInSysProps.sysPropsValue

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/OrdForDefaultsServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/OrdForDefaultsServer/server.xml
@@ -4,9 +4,9 @@
 
     <featureManager>
         <feature>osgiconsole-1.0</feature>
-        <feature>cdi-1.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-    	<feature>mpConfig-1.1</feature>
-	</featureManager>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SharedLibUserServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SharedLibUserServer/bootstrap.properties
@@ -1,4 +1,4 @@
 bootstrap.include=../testports.properties
 bootstrap.properties.appConfig=bootstrap.properties.defaultValue
 osgi.console=7778
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.com.ibm.ws.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SharedLibUserServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SharedLibUserServer/server.xml
@@ -4,11 +4,11 @@
 
     <featureManager>
         <feature>osgiconsole-1.0</feature>
-        <feature>cdi-1.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-    	<feature>mpConfig-1.1</feature>
-	</featureManager>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 	
 	<variable name="server.xml.variable.value" value="server.xml.variable.v1" />
 	

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SimpleConfigSourcesServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SimpleConfigSourcesServer/bootstrap.properties
@@ -1,4 +1,4 @@
 bootstrap.include=../testports.properties
 bootstrap.properties.appConfig=bootstrap.properties.defaultValue
 osgi.console=7778
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.com.ibm.ws.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SimpleConfigSourcesServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SimpleConfigSourcesServer/server.xml
@@ -3,12 +3,12 @@
 	<include location="../fatTestPorts.xml" />
 
 	<featureManager>
-		<feature>osgiconsole-1.0</feature>
-		<feature>cdi-1.2</feature>
-		<feature>servlet-3.1</feature>
-		<feature>componentTest-1.0</feature>
-		<feature>mpConfig-1.1</feature>
-	</featureManager>
+        <feature>osgiconsole-1.0</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>componentTest-1.0</feature>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 
 	<variable name="server.xml.variable.value" value="server.xml.variable.v1" />
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/StressServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/StressServer/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
 osgi.console=7779
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.config.*=all:org.eclipse.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/StressServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/StressServer/server.xml
@@ -4,9 +4,9 @@
 
     <featureManager>
         <feature>osgiconsole-1.0</feature>
-        <feature>cdi-1.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-    	<feature>mpConfig-1.1</feature>
-	</featureManager>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/TypesServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/TypesServer/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
 osgi.console=7780
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.config.*=all:org.eclipse.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/TypesServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/TypesServer/server.xml
@@ -4,9 +4,9 @@
 
     <featureManager>
         <feature>osgiconsole-1.0</feature>
-        <feature>cdi-1.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-    	<feature>mpConfig-1.1</feature>
-	</featureManager>
+        <feature>mpConfig-1.2</feature>
+    </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/brokenCDIConfigServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/brokenCDIConfigServer/bootstrap.properties
@@ -1,6 +1,6 @@
 bootstrap.include=../testports.properties
 osgi.console=7771
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.config.*=all:org.eclipse.microprofile.config.*=all
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=debug
 SIMPLE_KEY4=VALUE4
 SIMPLE_KEY6=VALUE6
 com.ibm.ws.microprofile.appConfig.cdi.beans.ConfigPropertyBean.nullKey=nullKeyValue

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/brokenCDIConfigServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/brokenCDIConfigServer/server.xml
@@ -4,9 +4,9 @@
 
     <featureManager>
         <feature>osgiconsole-1.0</feature>
-        <feature>cdi-1.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-    	<feature>mpConfig-1.1</feature>
+    	<feature>mpConfig-1.2</feature>
 	</featureManager>
 </server>

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
@@ -309,9 +309,10 @@ public class FeatureReplacementAction implements RepeatTestAction {
             }
             Log.info(c, m, "Resulting features: " + features);
 
-            if (isServerConfig)
+            if (isServerConfig) {
+                Log.info(c, m, "Config: " + serverConfig);
                 ServerConfigurationFactory.toFile(configFile, serverConfig);
-            else
+            } else
                 ClientConfigurationFactory.toFile(configFile, clientConfig);
         }
     }


### PR DESCRIPTION
This PR does multiple things, all aimed at improving test performance and reliablity
1. stop the internal config sources from being dynamic
2. only invalidate the cache if a source really has updated
3. remove entry exit trace from some methods
4. make the FAT tests only trace out at debug level (i.e. not dump/all)
5. by default run using EE8 and mpConfig-1.2 ... some tests also run with EE7 and/or mpConfig-1.1

fixes #2106 
fixes #2101 
#build 