### PR TITLE
Revert "Improve build times with publishFeatureResources (#2115)"

### DIFF
--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -191,8 +191,8 @@ task prereqFeatureResources {
 task publishFeatureResources {
   // Start building feature resources after all other assemble artifacts are done being published
   dependsOn {
-    bndWorkspace.getProject(project.name)?.getDependson()*.getName().collect {
-      rootProject.project(it).tasks.getByName 'prereqFeatureResources'
+    rootProject.subprojects.collect {
+      it.tasks.getByName 'prereqFeatureResources'
     }
   }
 
@@ -308,9 +308,6 @@ assemble {
   dependsOn publishBinScripts
   dependsOn publishClientScripts
   dependsOn publishLibNative
-}
-
-publish {
   dependsOn publishFeatureResources
 }
 


### PR DESCRIPTION
This reverts commit a9c2e94041da643ad20a68e826f9fecd088b4808.

From PR #2115 , this introduced a publish ordering dependency issue where the standard OL image would be the same as the kernel image (about 9MB) which is incorrect. Needs to be revisited in a way where we could hopefully reintroduce the speedup and keep the images consistent. I think it has to do with the ordering of the dependsOn items in the publish step.