### PR TITLE
Reapply improve build times with publishFeatureResources

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -67,105 +67,105 @@ def props = new Properties()
 rootProject.file('generated.properties').withInputStream { props.load(it) }
 
 String getGaFeatures() {
-		String features = ""
-		rootProject.fileTree(dir: '.', include: '*/*.feature').visit { element ->
-			if (element.isDirectory()) {
-				return
-			}
-			Properties featureProps = new Properties()
-			element.getFile().withInputStream { featureProps.load(it) }
-			if (featureProps['kind'] == 'ga' && featureProps['IBM-ShortName'] != null) {
-				String shortname = featureProps['IBM-ShortName']
-				features += "\n<feature>" + shortname + "</feature>"
-			}
-		}
-		
-		features
+    String features = ""
+    rootProject.fileTree(dir: '.', include: '*/*.feature').visit { element ->
+        if (element.isDirectory()) {
+            return
+        }
+        Properties featureProps = new Properties()
+        element.getFile().withInputStream { featureProps.load(it) }
+        if (featureProps['kind'] == 'ga' && featureProps['IBM-ShortName'] != null) {
+            String shortname = featureProps['IBM-ShortName']
+            features += "\n<feature>" + shortname + "</feature>"
+        }
+    }
+
+    features
 }
 
 class PackageLibertyWithFeatures extends DefaultTask {
-	String withFeatures
-	File outputTo
-	
+    String withFeatures
+    File outputTo
 
-	@TaskAction
-	void buildPackage() {
-			// Create server in order to minify an image that only includes kind=ga features
-			project.delete project.file('wlp/usr/servers/packageOpenLiberty')
-			project.exec {
-				workingDir project.file('wlp/bin')
-				def args = ["create", "packageOpenLiberty"]
-				if (OperatingSystem.current().windows) {
-					commandLine = ["cmd", "/c", "server"] + args
-				} else {
-					commandLine = ["./server"] + args
-				}
-			}
+    @TaskAction
+    void buildPackage() {
+        // Create server in order to minify an image that only includes kind=ga features
+        project.delete project.file('wlp/usr/servers/packageOpenLiberty')
+        project.exec {
+            workingDir project.file('wlp/bin')
+            def args = ["create", "packageOpenLiberty"]
+            if (OperatingSystem.current().windows) {
+                commandLine = ["cmd", "/c", "server"] + args
+            } else {
+                commandLine = ["./server"] + args
+            }
+        }
 
-			try {
-				def serverXml = project.file("wlp/usr/servers/packageOpenLiberty/server.xml")
-				serverXml.text = """<?xml version="1.0" encoding="UTF-8"?>
-		<server description="new server">
-		<featureManager>${withFeatures}
-		</featureManager>
-		</server>
-		"""
+        try {
+            def serverXml = project.file("wlp/usr/servers/packageOpenLiberty/server.xml")
+            serverXml.text = """<?xml version="1.0" encoding="UTF-8"?>
+        <server description="new server">
+        <featureManager>${withFeatures}
+        </featureManager>
+        </server>
+        """
 
-				File archive = new File(project.buildDir, 'openliberty.zip')
-				project.delete archive
-				project.exec {
-					workingDir project.file('wlp/bin')
-					def args = ["package", "packageOpenLiberty", "--archive=${archive}", "--include=minify"]
-					if (OperatingSystem.current().windows) {
-						commandLine = ["cmd", "/c", "server"] + args
-					} else {
-						commandLine = ["./server"] + args
-					}
-				}
+            File archive = new File(project.buildDir, 'openliberty.zip')
+            project.delete archive
+            project.exec {
+                workingDir project.file('wlp/bin')
+                def args = ["package", "packageOpenLiberty", "--archive=${archive}", "--include=minify"]
+                if (OperatingSystem.current().windows) {
+                    commandLine = ["cmd", "/c", "server"] + args
+                } else {
+                    commandLine = ["./server"] + args
+                }
+            }
 
-				// Postprocess to remove unwanted files
-				project.delete outputTo
-				project.copy {
-					from project.zipTree(project.file(archive))
-					exclude 'wlp/usr/servers/**'
-					exclude 'wlp/lib/versions/package_*'
-					into outputTo
-				}
-			} catch (all) {
-				println "-- EXCEPTION PACKAGING SERVER --"
-				println all
-				def messages = project.file("wlp/usr/servers/packageOpenLiberty/logs/messages.log")
-				if (messages.exists()) {
-					messages.eachLine { String line ->
-						println line
-					}
-				}
-			}
-	}
-
+            // Postprocess to remove unwanted files
+            project.delete outputTo
+            project.copy {
+                from project.zipTree(project.file(archive))
+                exclude 'wlp/usr/servers/**'
+                exclude 'wlp/lib/versions/package_*'
+                into outputTo
+            }
+        } catch (all) {
+            println "-- EXCEPTION PACKAGING SERVER --"
+            println all
+            def messages = project.file("wlp/usr/servers/packageOpenLiberty/logs/messages.log")
+            if (messages.exists()) {
+                messages.eachLine { String line ->
+                    println line
+                }
+            }
+        }
+    }
 }
 
 task packageOpenLiberty(type: PackageLibertyWithFeatures) {
-	enabled props["ghe.build.type"] == null || !props["ghe.build.type"].contains("ifix")
-	dependsOn parent.subprojects.assemble
-	dependsOn copyGeneratedToBuildImageBinTools
-	dependsOn copyGeneratedToCnfLib
-	
-	withFeatures getGaFeatures()
-	outputTo packageDir
-	
+    enabled props["ghe.build.type"] == null || !props["ghe.build.type"].contains("ifix")
+    dependsOn parent.subprojects.assemble
+    dependsOn parent.subprojects.publishFeatureResources
+    dependsOn copyGeneratedToBuildImageBinTools
+    dependsOn copyGeneratedToCnfLib
+    
+    withFeatures getGaFeatures()
+    outputTo packageDir
+
 }
 
 task packageOpenLibertyKernel(type: PackageLibertyWithFeatures) {
-	enabled props["ghe.build.type"] == null || !props["ghe.build.type"].contains("ifix")
-	
-	dependsOn parent.subprojects.assemble
-	dependsOn copyGeneratedToBuildImageBinTools
-	dependsOn copyGeneratedToCnfLib	
-	
-	withFeatures ''
-	outputTo packageDir
-	
+    enabled props["ghe.build.type"] == null || !props["ghe.build.type"].contains("ifix")
+
+    dependsOn parent.subprojects.assemble
+    dependsOn parent.subprojects.publishFeatureResources
+    dependsOn copyGeneratedToBuildImageBinTools
+    dependsOn copyGeneratedToCnfLib
+
+    withFeatures ''
+    outputTo packageDir
+    
 }
 
 // Includes only kind=ga features.
@@ -191,6 +191,7 @@ publish.dependsOn zipOpenLibertyKernel
 // Includes all features.
 task zipOpenLibertyAll(type: Zip) {
     dependsOn parent.subprojects.assemble
+    dependsOn parent.subprojects.publishFeatureResources
     dependsOn copyGeneratedToBuildImageBinTools
     dependsOn copyGeneratedToCnfLib
     baseName 'openliberty-all'

--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -191,8 +191,8 @@ task prereqFeatureResources {
 task publishFeatureResources {
   // Start building feature resources after all other assemble artifacts are done being published
   dependsOn {
-    rootProject.subprojects.collect {
-      it.tasks.getByName 'prereqFeatureResources'
+    bndWorkspace.getProject(project.name)?.getDependson()*.getName().collect {
+      rootProject.project(it).tasks.getByName 'prereqFeatureResources'
     }
   }
 
@@ -308,6 +308,9 @@ assemble {
   dependsOn publishBinScripts
   dependsOn publishClientScripts
   dependsOn publishLibNative
+}
+
+publish {
   dependsOn publishFeatureResources
 }
 


### PR DESCRIPTION
This reverts commit ca8b80372fb26fea4d52a5a076aae060a6f4a5b8.

Upon moving publishFeatureResources to run after assemble, packaging tasks started to build images with missing features.

Move publishFeatureResources to run after assemble and it also must be run before packaging tasks. Add dependsOn parent.subprojects.publishFeatureResources to packaging tasks to preserve that ordering.