### PR TITLE
Initial version of jCacheContainer-1.1 feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.jCacheContainer-1.1/.classpath
+++ b/dev/com.ibm.websphere.appserver.jCacheContainer-1.1/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>
+

--- a/dev/com.ibm.websphere.appserver.jCacheContainer-1.1/.project
+++ b/dev/com.ibm.websphere.appserver.jCacheContainer-1.1/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.websphere.appserver.jCacheContainer-1.1</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.websphere.appserver.jCacheContainer-1.1/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.jCacheContainer-1.1/bnd.bnd
@@ -1,0 +1,16 @@
+#*******************************************************************************
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/liberty-release.props
+
+-nobundles=true
+
+-dependson: \
+    com.ibm.websphere.javaee.jcache.1.1;version=latest

--- a/dev/com.ibm.websphere.appserver.jCacheContainer-1.1/com.ibm.websphere.appserver.jCacheContainer-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.jCacheContainer-1.1/com.ibm.websphere.appserver.jCacheContainer-1.1.feature
@@ -1,0 +1,23 @@
+-include= ~../cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.jCacheContainer-1.1
+visibility=public
+IBM-ShortName: jCacheContainer-1.1
+Manifest-Version: 1.0
+Subsystem-Name: JCache via Bells
+IBM-API-Package: \
+ javax.cache; type="spec", \
+ javax.cache.annotation; type="spec", \
+ javax.cache.configuration; type="spec", \
+ javax.cache.event; type="spec", \
+ javax.cache.expiry; type="spec", \
+ javax.cache.integration; type="spec", \
+ javax.cache.management; type="spec", \
+ javax.cache.processor; type="spec", \
+ javax.cache.spi; type="spec"
+-features=\
+ com.ibm.websphere.appserver.bells-1.0, \
+ com.ibm.websphere.appserver.classloading-1.0
+-bundles=\
+ com.ibm.websphere.javaee.jcache.1.1
+kind=noship
+edition=full

--- a/dev/com.ibm.websphere.appserver.jCacheContainer-1.1/resources/l10n/com.ibm.websphere.appserver.jCacheContainer-1.1.properties
+++ b/dev/com.ibm.websphere.appserver.jCacheContainer-1.1/resources/l10n/com.ibm.websphere.appserver.jCacheContainer-1.1.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#################################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=TODO write useful description for this feature before we beta it

--- a/dev/com.ibm.websphere.appserver.sessionCache-1.0/com.ibm.websphere.appserver.sessionCache-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.sessionCache-1.0/com.ibm.websphere.appserver.sessionCache-1.0.feature
@@ -2,26 +2,15 @@
 symbolicName=com.ibm.websphere.appserver.sessionCache-1.0
 visibility=public
 IBM-ShortName: sessionCache-1.0
-#TODO remove jcache API from this feature, this is only temporary
-IBM-API-Package: \
- javax.cache; type="spec", \
- javax.cache.annotation; type="spec", \
- javax.cache.configuration; type="spec", \
- javax.cache.event; type="spec", \
- javax.cache.expiry; type="spec", \
- javax.cache.integration; type="spec", \
- javax.cache.management; type="spec", \
- javax.cache.processor; type="spec", \
- javax.cache.spi; type="spec"
 Manifest-Version: 1.0
 Subsystem-Name: JCache Session Persistence
 -features=\
  com.ibm.websphere.appserver.appLifecycle-1.0, \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.javax.servlet-4.0; ibm.tolerates:="3.1,3.0"; apiJar=false, \
+ com.ibm.websphere.appserver.jCacheContainer-1.1, \
  com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:=1.1
 -bundles=\
- com.ibm.websphere.javaee.jcache.1.1, \
  com.ibm.websphere.security, \
  com.ibm.ws.session, \
  com.ibm.ws.session.cache, \


### PR DESCRIPTION
Split the javax.cache API into a separate public feature called `jCacheContainer-1.1` instead of exposing it via the `sessionCache-1.0` feature.