### PR TITLE
use valid cache names and avoid unnecessary find or create

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMapMR.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMapMR.java
@@ -20,8 +20,12 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
-import javax.cache.Cache;
+import javax.cache.CacheException;
+import javax.cache.configuration.Configuration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.EternalExpiryPolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -40,11 +44,47 @@ public class CacheHashMapMR extends CacheHashMap {
 
     private static final TraceComponent tc = Tr.register(CacheHashMapMR.class);
 
+    /**
+     * Reusable patterns for String.replaceAll
+     */
+    private static final Pattern COLON = Pattern.compile(":"), PERCENT = Pattern.compile("%"), SLASH = Pattern.compile("/");
+
     public CacheHashMapMR(IStore store, SessionManagerConfig smc, CacheStoreService cacheStoreService) {
         super(store, smc, cacheStoreService);
+
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
         // We know we're running multi-row..if not writeAllProperties and not time-based writes,
         // we must keep the app data tables per thread (rather than per session)
         appDataTablesPerThread = (!_smc.writeAllProperties() && !_smc.getEnableTimeBasedWrite());
+
+        // Build a unique per-application cache name by starting with the application context root and percent encoding
+        // the / and : characters (JCache spec does not allow these in cache names)
+        // and also the % character (which is necessary because of percent encoding)
+        String a = PERCENT.matcher(store.getId()).replaceAll("%25"); // must be done first to avoid replacing % that is added when replacing the others
+        a = SLASH.matcher(a).replaceAll("%2F");
+        a = COLON.matcher(a).replaceAll("%3A");
+        String cacheName = new StringBuilder(23 + a.length()).append("com.ibm.ws.session.app.").append(a).toString();
+
+        if (trace && tc.isDebugEnabled())
+            Tr.debug(this, tc, "find or create cache", cacheName);
+
+        sessionPropertyCache = cacheStoreService.cacheManager.getCache(cacheName, String.class, byte[].class);
+        if (sessionPropertyCache == null) {
+            Configuration<String, byte[]> config = new MutableConfiguration<String, byte[]>()
+                            .setTypes(String.class, byte[].class)
+                            .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
+            try {
+                sessionPropertyCache = cacheStoreService.cacheManager.createCache(cacheName, config);
+
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(tc, "Created a new session property cache", cacheName);
+            } catch (CacheException x) {
+                sessionPropertyCache = cacheStoreService.cacheManager.getCache(cacheName, String.class, byte[].class);
+                if (sessionPropertyCache == null)
+                    throw x;
+            }
+        }
     }
 
     /**
@@ -67,7 +107,6 @@ public class CacheHashMapMR extends CacheHashMap {
         Hashtable<String, Object> h = new Hashtable<String, Object>();
         try {
             if (propIds != null) {
-                Cache<String, byte[]> cache = cacheStoreService.getCache(appName);
                 for (String propId : propIds) {
                     // If an attribute is already in appDataRemovals or appDataChanges, then the attribute was already retrieved from the cache.  Skip retrieval from the cache here.
                     if (sess.appDataRemovals != null && sess.appDataRemovals.containsKey(propId)) {
@@ -81,7 +120,7 @@ public class CacheHashMapMR extends CacheHashMap {
                     }
 
                     String propertyKey = createSessionPropertyKey(id, propId);
-                    byte[] b = cache.get(propertyKey);
+                    byte[] b = sessionPropertyCache.get(propertyKey);
 
                     if (b != null) {
                         ByteArrayInputStream bais = new ByteArrayInputStream(b);
@@ -128,7 +167,7 @@ public class CacheHashMapMR extends CacheHashMap {
         Object tmp = null;
 
         String key = createSessionPropertyKey(sessId, id);
-        byte[] sessionPropBytes = cacheStoreService.getCache(appName).get(key);
+        byte[] sessionPropBytes = sessionPropertyCache.get(key);
 
         if (trace && tc.isDebugEnabled())
             Tr.debug(this, tc, key.toString(), sessionPropBytes == null ? null : sessionPropBytes.length);
@@ -211,8 +250,6 @@ public class CacheHashMapMR extends CacheHashMap {
             }
 
             if (propsToWrite != null) {
-                Cache<String, byte[]> cache = cacheStoreService.getCache(appName);
-
                 for (String propid : propsToWrite) {
                     long startTime = System.nanoTime();
 
@@ -236,7 +273,7 @@ public class CacheHashMapMR extends CacheHashMap {
                         Tr.debug(this, tc, "before update " + propid + " for session " + id + " size " + size);
 
                     String key = createSessionPropertyKey(id, propid);
-                    cache.put(key, objbuf);
+                    sessionPropertyCache.put(key, objbuf);
 
                     SessionStatistics pmiStats = _iStore.getSessionStatistics();
                     if (pmiStats != null) {
@@ -283,14 +320,12 @@ public class CacheHashMapMR extends CacheHashMap {
                 }
 
                 if (propsToRemove != null && !propsToRemove.isEmpty()) {
-                    Cache<String, byte[]> cache = cacheStoreService.getCache(appName);
-
                     for (String propid : propsToRemove) {
                         if (trace && tc.isDebugEnabled()) {
                             Tr.debug(this, tc, "deleting prop " + propid + " for session " + id);
                         }
                         String key = createSessionPropertyKey(id, propid);
-                        cache.remove(key);
+                        sessionPropertyCache.remove(key);
                     }
                 }
 
@@ -362,10 +397,9 @@ public class CacheHashMapMR extends CacheHashMap {
         if (propIds != null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "remove session properties", propIds);
-            Cache<String, byte[]> cache = cacheStoreService.getCache(_iStore.getId());
             for (String propId : propIds) {
                 String propertyKey = createSessionPropertyKey(id, propId);
-                cache.remove(propertyKey);
+                sessionPropertyCache.remove(propertyKey);
             }
         }
     }

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -19,7 +19,6 @@ import javax.cache.CacheManager;
 import javax.cache.Caching;
 import javax.cache.configuration.Configuration;
 import javax.cache.configuration.MutableConfiguration;
-import javax.cache.expiry.EternalExpiryPolicy;
 import javax.cache.spi.CachingProvider;
 import javax.servlet.ServletContext;
 import javax.transaction.UserTransaction;
@@ -138,37 +137,6 @@ public class CacheStoreService implements SessionStoreService {
     @Deactivate
     protected void deactivate(ComponentContext context) {
         cacheManager.close();
-    }
-
-    /**
-     * Obtains the session cache for the specified application.
-     * For multi-cache path, each session property is a separate entry in this cache.
-     * 
-     * @param appName the application name.
-     * @return the cache.
-     */
-    Cache<String, byte[]> getCache(String appName) {
-        // TODO replace / and : characters (per spec for cache names) and ensure the name is still unique.
-        String cacheName = "com.ibm.ws.session.app." + appName;
-
-        // Because byte[] does instance-based .equals, it will not be possible to use Cache.replace operations, but we are okay with that.
-        Cache<String, byte[]> cache = cacheManager.getCache(cacheName, String.class, byte[].class);
-        if (cache == null) {
-            Configuration<String, byte[]> config = new MutableConfiguration<String, byte[]>()
-                            .setTypes(String.class, byte[].class)
-                            .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
-            try {
-                cache = cacheManager.createCache(cacheName, config);
-
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                    Tr.debug(tc, "Created a new session property cache");
-            } catch (CacheException x) {
-                cache = cacheManager.getCache(cacheName, String.class, byte[].class);
-                if (cache == null)
-                    throw x;
-            }
-        }
-        return cache;
     }
 
     @Override


### PR DESCRIPTION
The : and / characters are not valid in JCache cache names.  To maintain a guarantee of uniqueness, we can't just swap the characters to another character, so I'm taking an approach of percent encoding them (along with the % character which it becomes necessary to encode as well to maintain uniqueness).  Also, I'm making updates to greatly reduce the number of find/create attempts that are made on these per-application caches.