### PR TITLE
Don't wait for a feature update

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/service/ServerEndpointControlMBeanTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/service/ServerEndpointControlMBeanTest.java
@@ -414,7 +414,7 @@ public class ServerEndpointControlMBeanTest {
         // save
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);
-        assertNotNull("Didn't get expected config update log messages", server.waitForConfigUpdateInLogUsingMark(null, true));
+        assertNotNull("Didn't get expected config update log messages", server.waitForConfigUpdateInLogUsingMark(null));
 
         Log.exiting(c, METHOD_NAME);
         return targets;


### PR DESCRIPTION
We don't need to wait for a feature update in the createHttpEndpoints method