### PR TITLE
Set log mark before deploying CDI extension app

### DIFF
--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi12/fat/tests/AppExtensionTest.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi12/fat/tests/AppExtensionTest.java
@@ -61,8 +61,9 @@ public class AppExtensionTest extends LoggingTest {
                         .addAsLibrary(applicationExtensionJar);
 
         server = LibertyServerFactory.getStartedLibertyServer("cdi12AppExtensionServer");
+        server.setMarkToEndOfLog(server.getDefaultLogFile());
         ShrinkHelper.exportDropinAppToServer(server, applicationExtension);
-        server.waitForStringInLogUsingMark("CWWKZ0001I.*Application applicationExtension started");
+        server.waitForStringInLogUsingMark("CWWKZ000[13]I.*applicationExtension"); // App started or updated
 
     }
 


### PR DESCRIPTION
It seems like in some cases the app may be already deployed. The test
framework copies the app to dropins and then looks for the app started
message. Without setting the log mark, it will find the earlier message
from when the old app was started, meaning that it will start making
requests before the app is ready.