### PR TITLE
Revert "make MemoryPersistence tolerate a JPAQueryHelper object and perform t…"

### DIFF
--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IJPAQueryHelper.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IJPAQueryHelper.java
@@ -22,11 +22,6 @@ import com.ibm.jbatch.container.persistence.jpa.JobInstanceEntity;
 public interface IJPAQueryHelper {
 
     /**
-     * Base Query String
-     */
-    final String DEFAULT_QUERY = "SELECT x from JobInstanceEntity x ORDER BY x.createTime DESC";
-
-    /**
      * Get the JPQL query string
      */
     String getQuery();

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImpl.java
@@ -1332,17 +1332,8 @@ public class MemoryPersistenceManagerImpl extends AbstractPersistenceManager imp
     @Override
     public List<JobInstanceEntity> getJobInstances(IJPAQueryHelper queryHelper, int page, int pageSize) {
         // TODO: Should we implement this for Memory Persistence?
-        //throw new UnsupportedOperationException("The REST URL search parameters requesting this function "
-        //   + "are not supported by the Java batch memory-based persistence configuration.");
-
-        String delieveredQuery = queryHelper.getQuery();
-
-        if (delieveredQuery.equals(queryHelper.DEFAULT_QUERY)) {
-            return getJobInstances(page, pageSize);
-        } else {
-            throw new UnsupportedOperationException("The REST URL search parameters requesting this function"
-                                                    + "are not supported by the Java batch memory-based persistence configuration.");
-        }
+        throw new UnsupportedOperationException("The REST URL search parameters requesting this function "
+                                                + "are not supported by the Java batch memory-based persistence configuration.");
     }
 
     @Override


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#2062

The release build and continuous builds have been failing since Liberty Continuous Build - EBC 20180214-1741

251418: (HOT) Test Failure (20180214-2336): com.ibm.ws.ui.tool.javaBatch_fat.gui.tests.JavaBatchBasicTests.testInMemoryUnsupportedErrorPopup

The test is generating a FFDC with "java.lang.UnsupportedOperationException: The REST URL search parameters requesting this functionare not supported by the Java batch memory-based persistence configuration."

This seems directly related the above change
