### PR TITLE
Make com.ibm.ws.cdi.visibility_fat pass java 2 security testing

### DIFF
--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi12/fat/tests/VisTest.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi12/fat/tests/VisTest.java
@@ -220,7 +220,8 @@ public class VisTest extends LoggingTest {
                         .addAsModule(visTestWarAppClientLib17)
                         .addAsModule(visTestNonLib18)
                         .addAsLibrary(visTestFramework19)
-                        .addAsLibrary(visTestEarLib20);
+                        .addAsLibrary(visTestEarLib20)
+                        .addAsResource("com/ibm/ws/cdi12/fat/tests/permissions.xml", "permissions.xml");
 
        List paths = new ArrayList<String>();
        paths.add("publish/servers/visTestServer/apps");

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi12/fat/tests/permissions.xml
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi12/fat/tests/permissions.xml
@@ -1,0 +1,9 @@
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+	version="7">
+	<permission>
+		<class-name>java.lang.RuntimePermission</class-name>
+		<name>accessDeclaredMembers</name>
+	</permission>
+</permissions>

--- a/dev/com.ibm.ws.cdi.visibility_fat/publish/servers/cdi12SharedLibraryServer/bootstrap.properties
+++ b/dev/com.ibm.ws.cdi.visibility_fat/publish/servers/cdi12SharedLibraryServer/bootstrap.properties
@@ -2,3 +2,6 @@ bootstrap.include=../testports.properties
 osgi.console=7777
 org.jboss.logging.provider=slf4j
 com.ibm.ws.logging.trace.specification=*=info:JCDI=all:com.ibm.ws.cdi*=all:com.ibm.ws.weld*=all:org.jboss.*=all:Injection=all
+
+# Workaround until Weld 3.0.4 and 2.4.7 are available
+websphere.java.security.exempt=true


### PR DESCRIPTION
This test uses AnnotationLiteral which currently requires the app to
have the accessDeclaredMembers permission.