### PR TITLE
Revert "Fix ConcurrentModificationException during app startup"

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppConfiguration.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppConfiguration.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -207,7 +206,7 @@ public abstract class WebAppConfiguration extends BaseConfiguration implements W
      */
     public WebAppConfiguration(String id) {
         super(id);
-        this.servletInfo = new ConcurrentHashMap<String, IServletConfig>(); //PI93226
+        this.servletInfo = new HashMap<String, IServletConfig>();
         this.servletMappings = new HashMap<String, List<String>>();
         this.filterInfo = new HashMap<String, IFilterConfig>();
         this.filterMappings = new ArrayList();
@@ -239,9 +238,6 @@ public abstract class WebAppConfiguration extends BaseConfiguration implements W
     }
 
     public void addServletInfo(String name, IServletConfig info) {
-        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
-            logger.logp(Level.FINE, CLASS_NAME, "addServletInfo", "name = " + name);
-        }
         this.servletInfo.put(name, info);
     }
 


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#2175

Caused an NPE due to API differences in concurrent vs normal hashmap, which makes a hard JDBC break, so this is being reverted. Holds open issue #1952 