### PR TITLE
Revert "CWWKS4106E: LTPA CONFIGURATION ERROR IN LIBERTY when using PKCS11Impl provider "

### DIFF
--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -17,7 +17,6 @@ import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
@@ -226,7 +225,7 @@ final class LTPACrypto {
         BigInteger q = new BigInteger(key[4]);
         BigInteger d = e.modInverse((p.subtract(BigInteger.ONE)).multiply(q.subtract(BigInteger.ONE)));
         KeyFactory kFact = null;
-        kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, LTPAKeyUtil.defaultJCEProvider());
+        kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
 
         BigInteger pep = new BigInteger(key[5]);
         BigInteger peq = new BigInteger(key[6]);
@@ -234,7 +233,7 @@ final class LTPACrypto {
         RSAPrivateCrtKeySpec privCrtKeySpec = new RSAPrivateCrtKeySpec(n, e, d, p, q, pep, peq, crtC);
         PrivateKey privKey = kFact.generatePrivate(privCrtKeySpec);
 
-        Signature rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM,LTPAKeyUtil.defaultJCEProvider());
+        Signature rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
         rsaSig.initSign(privKey);
         rsaSig.update(data, off, len);
         byte[] sig = rsaSig.sign();
@@ -487,10 +486,10 @@ final class LTPACrypto {
 
         BigInteger n = new BigInteger(key[0]);
         BigInteger e = new BigInteger(key[1]);
-        KeyFactory kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM,LTPAKeyUtil.defaultJCEProvider()); 
+        KeyFactory kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
         RSAPublicKeySpec pubKeySpec = new RSAPublicKeySpec(n, e);
         PublicKey pubKey = kFact.generatePublic(pubKeySpec);
-        Signature rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM,LTPAKeyUtil.defaultJCEProvider()); 
+        Signature rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
         rsaSig.initVerify(pubKey);
         rsaSig.update(data, off, len);
         verified = rsaSig.verify(sig);
@@ -554,14 +553,14 @@ final class LTPACrypto {
      * @throws NoSuchAlgorithmException
      * @throws InvalidKeySpecException
      */
-    private static SecretKey constructSecretKey(byte[] key, String cipher) throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException,NoSuchProviderException {
+    private static SecretKey constructSecretKey(byte[] key, String cipher) throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException {
         SecretKey sKey = null;
         if (cipher.indexOf("AES") != -1) {
             // 16 bytes = 128 bit key
             sKey = new SecretKeySpec(key, 0, 16, "AES");
         } else {
             DESedeKeySpec kSpec = new DESedeKeySpec(key);
-            SecretKeyFactory kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM, LTPAKeyUtil.defaultJCEProvider());
+            SecretKeyFactory kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM);
             sKey = kFact.generateSecret(kSpec);
         }
         return sKey;
@@ -577,8 +576,8 @@ final class LTPACrypto {
      * @throws InvalidKeyException
      * @throws InvalidAlgorithmParameterException
      */
-    private static Cipher createCipher(int cipherMode, byte[] key, String cipher, SecretKey sKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException, NoSuchProviderException {
-        Cipher ci = Cipher.getInstance(cipher, LTPAKeyUtil.defaultJCEProvider());
+    private static Cipher createCipher(int cipherMode, byte[] key, String cipher, SecretKey sKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
+        Cipher ci = Cipher.getInstance(cipher);
         if (cipher.indexOf("ECB") == -1) {
             if (cipher.indexOf("AES") != -1) {
                 if (ivs16 == null) {
@@ -996,8 +995,8 @@ final class LTPACrypto {
                 KeyPairGenerator keyGen = null;
                 SecureRandom random = null;
 
-                keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, LTPAKeyUtil.defaultJCEProvider());
-                random = SecureRandom.getInstance("IBMSecureRandom", LTPAKeyUtil.defaultJCEProvider());
+                keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, "IBMJCE");
+                random = SecureRandom.getInstance("IBMSecureRandom");
 
                 keyGen.initialize(len * 8, random);
                 pair = keyGen.generateKeyPair();

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPADigSignature.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPADigSignature.java
@@ -12,7 +12,6 @@ package com.ibm.ws.crypto.ltpakeyutil;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 
 final class LTPADigSignature {
 
@@ -31,15 +30,11 @@ final class LTPADigSignature {
 
     static {
         try {
-            String jceProvider = LTPAKeyUtil.defaultJCEProvider();
-            md1JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, jceProvider);
-            md2JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, jceProvider);
+            md1JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+            md2JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
             md1 = MessageDigest.getInstance("SHA");
             md2 = MessageDigest.getInstance("SHA");
         } catch (NoSuchAlgorithmException e) {
-            // instrumented ffdc
-        }
-	catch (NoSuchProviderException ee) {
             // instrumented ffdc
         }
     }

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
@@ -13,10 +13,6 @@ package com.ibm.ws.crypto.ltpakeyutil;
 
 public final class LTPAKeyUtil {
 
-  public static final String IBMJCE_NAME = "IBMJCE";
-  public static final String SUNJCE_NAME = "SunJCE";
-  public static String defaultJCEProvider=null;
-
   public static byte[] encrypt(byte[] data, byte[] key, String cipher) throws Exception {
     return LTPACrypto.encrypt(data, key, cipher);
   }
@@ -51,22 +47,6 @@ public final class LTPAKeyUtil {
 
   public static byte[] generate3DESKey() {
     return LTPACrypto.generate3DESKey();
-  }
-
-  //In case hardware crypto provider is configured in front of JCE provider, LTPA encryption and decryption fails. This method is to find JCE provider for encrypt/decrypt to use. 
-  public static String defaultJCEProvider()
-  {
-     if (defaultJCEProvider == null) {
-	 String javaVendor = System.getProperty("java.vendor");
-	 
-	 if (javaVendor.contains("IBM")) {
-	     defaultJCEProvider = IBMJCE_NAME;
-	 }
-	 else {
-	     defaultJCEProvider = SUNJCE_NAME;
-	 }
-     }
-     return defaultJCEProvider;
   }
 
 }

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
@@ -13,7 +13,6 @@ package com.ibm.ws.security.token.ltpa.internal;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
-import java.security.NoSuchProviderException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Enumeration;
@@ -65,8 +64,8 @@ public class LTPAToken2 implements Token, Serializable {
     static {
         MessageDigest m1 = null, m2 = null;
         try {
-	    m1 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, LTPAKeyUtil.defaultJCEProvider());
-	    m2 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, LTPAKeyUtil.defaultJCEProvider());
+            m1 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+            m2 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
         } catch (Exception e) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
                 Tr.event(tc, "Error creating digest; " + e);


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#2067

see #2068, coming out to address incompatibilities with non-ibm jdks.