### PR TITLE
Updated the java vendor logic following the way Liberty Kernel does

### DIFF
--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -17,6 +17,7 @@ import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
@@ -225,7 +226,7 @@ final class LTPACrypto {
         BigInteger q = new BigInteger(key[4]);
         BigInteger d = e.modInverse((p.subtract(BigInteger.ONE)).multiply(q.subtract(BigInteger.ONE)));
         KeyFactory kFact = null;
-        kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
+        kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, LTPAKeyUtil.defaultJSSEProvider());
 
         BigInteger pep = new BigInteger(key[5]);
         BigInteger peq = new BigInteger(key[6]);
@@ -233,7 +234,7 @@ final class LTPACrypto {
         RSAPrivateCrtKeySpec privCrtKeySpec = new RSAPrivateCrtKeySpec(n, e, d, p, q, pep, peq, crtC);
         PrivateKey privKey = kFact.generatePrivate(privCrtKeySpec);
 
-        Signature rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
+        Signature rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM,LTPAKeyUtil.defaultJSSEProvider());
         rsaSig.initSign(privKey);
         rsaSig.update(data, off, len);
         byte[] sig = rsaSig.sign();
@@ -486,10 +487,10 @@ final class LTPACrypto {
 
         BigInteger n = new BigInteger(key[0]);
         BigInteger e = new BigInteger(key[1]);
-        KeyFactory kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
+        KeyFactory kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM,LTPAKeyUtil.defaultJSSEProvider()); 
         RSAPublicKeySpec pubKeySpec = new RSAPublicKeySpec(n, e);
         PublicKey pubKey = kFact.generatePublic(pubKeySpec);
-        Signature rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
+        Signature rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM,LTPAKeyUtil.defaultJSSEProvider()); 
         rsaSig.initVerify(pubKey);
         rsaSig.update(data, off, len);
         verified = rsaSig.verify(sig);
@@ -553,14 +554,14 @@ final class LTPACrypto {
      * @throws NoSuchAlgorithmException
      * @throws InvalidKeySpecException
      */
-    private static SecretKey constructSecretKey(byte[] key, String cipher) throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException {
+    private static SecretKey constructSecretKey(byte[] key, String cipher) throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException,NoSuchProviderException {
         SecretKey sKey = null;
         if (cipher.indexOf("AES") != -1) {
             // 16 bytes = 128 bit key
             sKey = new SecretKeySpec(key, 0, 16, "AES");
         } else {
             DESedeKeySpec kSpec = new DESedeKeySpec(key);
-            SecretKeyFactory kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM);
+            SecretKeyFactory kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM, LTPAKeyUtil.defaultJCEProvider());
             sKey = kFact.generateSecret(kSpec);
         }
         return sKey;
@@ -576,8 +577,8 @@ final class LTPACrypto {
      * @throws InvalidKeyException
      * @throws InvalidAlgorithmParameterException
      */
-    private static Cipher createCipher(int cipherMode, byte[] key, String cipher, SecretKey sKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
-        Cipher ci = Cipher.getInstance(cipher);
+    private static Cipher createCipher(int cipherMode, byte[] key, String cipher, SecretKey sKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException, NoSuchProviderException {
+        Cipher ci = Cipher.getInstance(cipher, LTPAKeyUtil.defaultJCEProvider());
         if (cipher.indexOf("ECB") == -1) {
             if (cipher.indexOf("AES") != -1) {
                 if (ivs16 == null) {
@@ -995,8 +996,8 @@ final class LTPACrypto {
                 KeyPairGenerator keyGen = null;
                 SecureRandom random = null;
 
-                keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, "IBMJCE");
-                random = SecureRandom.getInstance("IBMSecureRandom");
+                keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, LTPAKeyUtil.defaultJCEProvider());
+                random = SecureRandom.getInstance("IBMSecureRandom", LTPAKeyUtil.defaultJCEProvider());
 
                 keyGen.initialize(len * 8, random);
                 pair = keyGen.generateKeyPair();

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPADigSignature.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPADigSignature.java
@@ -12,6 +12,7 @@ package com.ibm.ws.crypto.ltpakeyutil;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 
 final class LTPADigSignature {
 
@@ -30,11 +31,15 @@ final class LTPADigSignature {
 
     static {
         try {
-            md1JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
-            md2JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+            String jceProvider = LTPAKeyUtil.defaultJCEProvider();
+            md1JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, jceProvider);
+            md2JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, jceProvider);
             md1 = MessageDigest.getInstance("SHA");
             md2 = MessageDigest.getInstance("SHA");
         } catch (NoSuchAlgorithmException e) {
+            // instrumented ffdc
+        }
+	catch (NoSuchProviderException ee) {
             // instrumented ffdc
         }
     }

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
@@ -10,43 +10,98 @@
  *******************************************************************************/
 package com.ibm.ws.crypto.ltpakeyutil;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 
 public final class LTPAKeyUtil {
 
-  public static byte[] encrypt(byte[] data, byte[] key, String cipher) throws Exception {
-    return LTPACrypto.encrypt(data, key, cipher);
-  }
+	public static final String IBMJCE_NAME = "IBMJCE";
+	public static final String SUNJCE_NAME = "SunJCE";
+	public static final String SUNJSSE_NAME = "SunJSSE";
+	private static Vendor myVendor = null;
 
-  public static byte[] decrypt(byte[] msg, byte[] key, String cipher) throws Exception {
-    return LTPACrypto.decrypt(msg, key, cipher);
-  }
+	public static enum Vendor {
+		IBM, OPENJ9, ORACLE, UNKNOWN
+	}
 
-  public static boolean verifyISO9796(byte[][] key, byte[] data, int off, int len, byte[] sig, int sigOff, int sigLen) throws Exception {
-    return LTPACrypto.verifyISO9796(key, data, off, len, sig, sigOff, sigLen);
-  }
+	public static byte[] encrypt(byte[] data, byte[] key, String cipher) throws Exception {
+		return LTPACrypto.encrypt(data, key, cipher);
+	}
 
-  public static byte[] signISO9796(byte[][] key, byte[] data, int off, int len) throws Exception {
-    return LTPACrypto.signISO9796(key, data, off, len);
-  }
+	public static byte[] decrypt(byte[] msg, byte[] key, String cipher) throws Exception {
+		return LTPACrypto.decrypt(msg, key, cipher);
+	}
 
-  public static void setRSAKey(byte[][] key) {
-    LTPACrypto.setRSAKey(key);
-  }
+	public static boolean verifyISO9796(byte[][] key, byte[] data, int off, int len, byte[] sig, int sigOff, int sigLen)
+			throws Exception {
+		return LTPACrypto.verifyISO9796(key, data, off, len, sig, sigOff, sigLen);
+	}
 
-  public static byte[][] getRawKey(LTPAPrivateKey privKey) {
-    return privKey.getRawKey();
-  }
+	public static byte[] signISO9796(byte[][] key, byte[] data, int off, int len) throws Exception {
+		return LTPACrypto.signISO9796(key, data, off, len);
+	}
 
-  public static byte[][] getRawKey(LTPAPublicKey pubKey) {
-    return pubKey.getRawKey();
-  }
+	public static void setRSAKey(byte[][] key) {
+		LTPACrypto.setRSAKey(key);
+	}
 
-  public static LTPAKeyPair generateLTPAKeyPair() {
-    return LTPADigSignature.generateLTPAKeyPair();
-  }
+	public static byte[][] getRawKey(LTPAPrivateKey privKey) {
+		return privKey.getRawKey();
+	}
 
-  public static byte[] generate3DESKey() {
-    return LTPACrypto.generate3DESKey();
-  }
+	public static byte[][] getRawKey(LTPAPublicKey pubKey) {
+		return pubKey.getRawKey();
+	}
+
+	public static LTPAKeyPair generateLTPAKeyPair() {
+		return LTPADigSignature.generateLTPAKeyPair();
+	}
+
+	public static byte[] generate3DESKey() {
+		return LTPACrypto.generate3DESKey();
+	}
+
+	// In case hardware crypto provider is configured in front of JCE provider,
+	// LTPA encryption and decryption fails. This method is to find JCE provider
+	// for encrypt/decrypt to use.
+	public static String defaultJCEProvider() {
+		if (getVendor() == Vendor.IBM) {
+			return IBMJCE_NAME;
+		} else {
+			return SUNJCE_NAME;
+		}
+	}
+
+	public static String defaultJSSEProvider() {
+		if (getVendor() == Vendor.IBM) {
+			return IBMJCE_NAME;
+		} else {
+			return SUNJSSE_NAME;
+		}
+	}
+
+	private static Vendor getVendor() {
+		if (myVendor == null) {
+			String vendor = getSystemProperty("java.vendor").toLowerCase();
+			if (vendor.contains("ibm"))
+				myVendor = Vendor.IBM;
+			else if (vendor.contains("openj9"))
+				myVendor = Vendor.OPENJ9;
+			else if (vendor.contains("oracle"))
+				myVendor = Vendor.ORACLE;
+			else
+				myVendor = Vendor.UNKNOWN;
+		}
+		return myVendor;
+	}
+
+	private static final String getSystemProperty(final String propName) {
+		return AccessController.doPrivileged(new PrivilegedAction<String>() {
+			@Override
+			public String run() {
+				return System.getProperty(propName);
+			}
+		});
+	}
 
 }

--- a/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
+++ b/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
@@ -74,6 +74,7 @@ instrument.classesExcludes: com/ibm/ws/security/token/ltpa/internal/resources/*.
 	com.ibm.ws.common.encoder;version=latest, \
 	com.ibm.ws.crypto.ltpakeyutil;version=latest, \
 	com.ibm.ws.logging;version=latest, \
+	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 
 -testpath: \

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
@@ -13,11 +13,13 @@ package com.ibm.ws.security.token.ltpa.internal;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
+import java.security.NoSuchProviderException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Map;
 
+import com.ibm.ws.kernel.service.util.JavaInfo;
 import javax.crypto.BadPaddingException;
 
 import com.ibm.websphere.ras.Tr;
@@ -61,11 +63,19 @@ public class LTPAToken2 implements Token, Serializable {
     private final LTPAPublicKey publicKey;
     private String cipher = null;
 
+
     static {
         MessageDigest m1 = null, m2 = null;
         try {
-            m1 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
-            m2 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+	    if (JavaInfo.vendor() == JavaInfo.Vendor.IBM) {
+	       m1 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, LTPAKeyUtil.defaultJCEProvider());
+	       m2 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, LTPAKeyUtil.defaultJCEProvider());
+	    }
+	    else {
+	       //MessageDigest SHA is in SUN, which is always at the top of provider list. No need to worry about other provider gets picked. 
+	       m1 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+	       m2 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+	    }
         } catch (Exception e) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
                 Tr.event(tc, "Error creating digest; " + e);


### PR DESCRIPTION
We keep LTPAKeyUtil only java crypto stuff,    independent of Liberty packages.   But follow the way Liberty Kernel checks the vendor. 