### PR TITLE
Enable testEnvironmentConfigSource

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -18,8 +18,7 @@
                     <![CDATA[
                         !method.getDeclaringClass().getSimpleName().startsWith("ClassConverterTest") &&
                         !method.getDeclaringClass().getSimpleName().startsWith("ImplicitConverterTest") &&
-                        !method.getName().contains("testDuckConversionWithMultipleConverters") &&
-                        !method.getName().contains("testEnvironmentConfigSource")
+                        !method.getName().contains("testDuckConversionWithMultipleConverters")
                     ]]>
                     </script>
                 </method-selector>


### PR DESCRIPTION
Signed-off-by: Gordon Hutchison <gordon.hutchison@gmail.com>

checked
 <microprofile.config.version>1.2.1</microprofile.config.version>
...
<dependency>
            <groupId>org.eclipse.microprofile.config</groupId>
            <artifactId>microprofile-config-tck</artifactId>
            <version>${microprofile.config.version}</version>
</dependency>
and
https://github.com/eclipse/microprofile-config/blob/1.2.1/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigProviderTest.java
