### PR TITLE
Mechanism to fail a FAT that generates more than X MB of trace while running

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
@@ -59,19 +59,18 @@ import componenttest.logging.ffdc.IgnoredFFDCs.IgnoredFFDC;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.impl.LibertyServerWrapper;
-import componenttest.topology.utils.PrivHelper;
 import junit.framework.AssertionFailedError;
 
 public class FATRunner extends BlockJUnit4ClassRunner {
     private static final Class<?> c = FATRunner.class;
 
     // Used to reduce timeouts to a sensible level when FATs are running locally
-    public static final boolean FAT_TEST_LOCALRUN = PrivHelper.getBoolean("fat.test.localrun");
+    public static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun");
 
     private static final int MAX_FFDC_LINES = 1000;
-    private static final boolean DISABLE_FFDC_CHECKING = PrivHelper.getBoolean("disable.ffdc.checking");
+    private static final boolean DISABLE_FFDC_CHECKING = Boolean.getBoolean("disable.ffdc.checking");
 
-    private static final boolean ENABLE_TMP_DIR_CHECKING = PrivHelper.getBoolean("enable.tmpdir.checking");
+    private static final boolean ENABLE_TMP_DIR_CHECKING = Boolean.getBoolean("enable.tmpdir.checking");
     private static final long TMP_DIR_SIZE_THRESHOLD = 20 * 1024; // 20k
 
     //list of filters to apply
@@ -330,6 +329,8 @@ public class FATRunner extends BlockJUnit4ClassRunner {
                         blowup("A problem was detected during post-test tidy up. New FFDC file is generated. Please check the log directory. The beginning of the FFDC file is:\n"
                                + ffdcHeader);
                     }
+
+                    LogPolice.checkUsedTrace();
                 }
             }
         };

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/LogPolice.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/LogPolice.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.custom.junit.runner;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+/**
+ * Used to ensure a single FAT does not produce too much trace logs.
+ */
+public class LogPolice {
+
+    private static final long MB = 1024000L;
+    // TODO: Start out with 4GB cap on trace in LITE mode, incrementally constrict this down to ~300MB trace allowed per bucket
+    private static final long MAX_ALLOWED_TRACE = MB * Integer.getInteger("fat.test.max.allowed.trace.mb", 4000); // 4GB max (for now), override w/ system prop
+    private static long usedTrace = 0;
+    private static long effectiveMaxTrace = effectiveMaxTrace(MAX_ALLOWED_TRACE);
+
+    /**
+     * Sets the maximum allowed trace for a given FAT bucket. If the limit is exceeded, a test failure will be generated.
+     *
+     * @param maxTraceInMB The maximum allowed trace (in MB) to be produced by the current FAT
+     */
+    public static void setMaxAllowedTraceMB(int maxTraceInMB) {
+        if (maxTraceInMB > 10000)
+            throw new RuntimeException("You know this is max trace in MB (not KB or bytes), right?");
+        effectiveMaxTrace = effectiveMaxTrace(maxTraceInMB * MB);
+        Log.info(LogPolice.class, "setMaxAllowedTraceMB", "The max allowed trace has been set to " + effectiveMaxTrace / MB +
+                                                          "MB.  In LITE mode it will be " + maxTraceInMB +
+                                                          "MB, in FULL mode it will be " + maxTraceInMB * 3 +
+                                                          ", and 85% of those when running locally.");
+    }
+
+    private LogPolice() {
+        // static-only class
+    }
+
+    public static void measureUsedTrace(long traceFileLength) {
+        usedTrace += traceFileLength;
+    }
+
+    /**
+     * Blows up if the currently running FAT has produced too much trace. See LogPolice.MAX_ALLOWED_TRACE for the current limit.
+     */
+    static void checkUsedTrace() throws Exception {
+        Log.info(LogPolice.class, "checkUsedTrace", "So far this FAT has used " + (usedTrace / MB) + "MB of trace.");
+
+        if (usedTrace > effectiveMaxTrace)
+            throw new IllegalStateException("This FAT has used up too much trace!  The maximum allowed trace is " + (effectiveMaxTrace / MB) +
+                                            "MB but so far this FAT has logged " + (usedTrace / MB) + "MB of trace.");
+    }
+
+    private static long effectiveMaxTrace(long maxAllowedTrace) {
+        long effectiveMaxTrace = maxAllowedTrace;
+        if (FATRunner.FAT_TEST_LOCALRUN)
+            effectiveMaxTrace *= 0.85;
+        if (TestModeFilter.FRAMEWORK_TEST_MODE == TestMode.FULL)
+            effectiveMaxTrace *= 3;
+        return effectiveMaxTrace;
+    }
+}

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -67,6 +67,7 @@ import com.ibm.websphere.soe_reporting.SOEHttpPostUtil;
 import componenttest.common.apiservices.Bootstrap;
 import componenttest.common.apiservices.LocalMachine;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.LogPolice;
 import componenttest.exception.TopologyException;
 import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyFileManager.LogSearchResult;
@@ -1510,6 +1511,10 @@ public class LibertyClient {
 
             RemoteFile toCopy = new RemoteFile(machine, remoteDirectory, l);
             LocalFile toReceive = new LocalFile(destination, l);
+            String absPath = toCopy.getAbsolutePath();
+
+            if (absPath.endsWith(".log"))
+                LogPolice.measureUsedTrace(toCopy.length());
 
             if (toCopy.isDirectory()) {
                 // Recurse
@@ -1517,18 +1522,18 @@ public class LibertyClient {
             } else {
                 try {
                     if (skipArchives
-                        && (toCopy.getAbsolutePath().endsWith(".jar")
-                            || toCopy.getAbsolutePath().endsWith(".war")
-                            || toCopy.getAbsolutePath().endsWith(".ear")
-                            || toCopy.getAbsolutePath().endsWith(".rar")
+                        && (absPath.endsWith(".jar")
+                            || absPath.endsWith(".war")
+                            || absPath.endsWith(".ear")
+                            || absPath.endsWith(".rar")
                             //If we're only getting logs, skip jars, wars, ears, zips, unless they are client dump zips
-                            || (toCopy.getAbsolutePath().endsWith(".zip") && !toCopy.getName().contains(clientToUse + ".dump")))) {
+                            || (absPath.endsWith(".zip") && !toCopy.getName().contains(clientToUse + ".dump")))) {
                         continue;
                     }
 
                     // We're only going to attempt to move log files. Because of ffdc log checking, we
                     // can't move those. But we should move other log files..
-                    boolean isLog = (toCopy.getAbsolutePath().contains("logs") && !toCopy.getAbsolutePath().contains("ffdc"))
+                    boolean isLog = (absPath.contains("logs") && !absPath.contains("ffdc"))
                                     || toCopy.getName().contains("javacore")
                                     || toCopy.getName().contains("heapdump")
                                     || toCopy.getName().contains("Snap")

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -89,6 +89,7 @@ import com.ibm.ws.fat.util.ACEScanner;
 import componenttest.common.apiservices.Bootstrap;
 import componenttest.common.apiservices.LocalMachine;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.LogPolice;
 import componenttest.depchain.FeatureDependencyProcessor;
 import componenttest.exception.TopologyException;
 import componenttest.topology.impl.JavaInfo.Vendor;
@@ -2324,7 +2325,11 @@ public class LibertyServer implements LogMonitorClient {
 
             RemoteFile toCopy = new RemoteFile(machine, remoteDirectory, l);
             LocalFile toReceive = new LocalFile(destination, l);
-            Log.finest(c, "recursivelyCopyDirectory", "Getting: " + toCopy.getAbsolutePath());
+            String absPath = toCopy.getAbsolutePath();
+            Log.finest(c, "recursivelyCopyDirectory", "Getting: " + absPath);
+
+            if (absPath.endsWith(".log"))
+                LogPolice.measureUsedTrace(toCopy.length());
 
             if (toCopy.isDirectory()) {
                 // Recurse
@@ -2332,19 +2337,19 @@ public class LibertyServer implements LogMonitorClient {
             } else {
                 try {
                     if (skipArchives
-                        && (toCopy.getAbsolutePath().endsWith(".jar")
-                            || toCopy.getAbsolutePath().endsWith(".war")
-                            || toCopy.getAbsolutePath().endsWith(".ear")
-                            || toCopy.getAbsolutePath().endsWith(".rar")
+                        && (absPath.endsWith(".jar")
+                            || absPath.endsWith(".war")
+                            || absPath.endsWith(".ear")
+                            || absPath.endsWith(".rar")
                             //If we're only getting logs, skip jars, wars, ears, zips, unless they are server dump zips
-                            || (toCopy.getAbsolutePath().endsWith(".zip") && !toCopy.getName().contains(serverToUse + ".dump")))) {
-                        Log.finest(c, "recursivelyCopyDirectory", "Skipping: " + toCopy.getAbsolutePath());
+                            || (absPath.endsWith(".zip") && !toCopy.getName().contains(serverToUse + ".dump")))) {
+                        Log.finest(c, "recursivelyCopyDirectory", "Skipping: " + absPath);
                         continue;
                     }
 
                     // We're only going to attempt to move log files. Because of ffdc log checking, we
                     // can't move those. But we should move other log files..
-                    boolean isLog = (toCopy.getAbsolutePath().contains("logs") && !toCopy.getAbsolutePath().contains("ffdc"))
+                    boolean isLog = (absPath.contains("logs") && !absPath.contains("ffdc"))
                                     || toCopy.getName().contains("javacore")
                                     || toCopy.getName().contains("heapdump")
                                     || toCopy.getName().contains("Snap")


### PR DESCRIPTION
We have found out the hard way that some FATs are putting out great deal of trace (11 buckets >1GB in lite mode, with the highest being 3.4GB).  This has caused us to max out on disk IO in our build cloud and we need a mechanism to cap how much trace a FAT can put out in order to prevent individual FATs from saturating the build hardware and dragging builds down.

This PR introduces a mechanism to measure the size of log files during server stop (as they are brought into the autoFVT directory) and raise a JUnit failure if the threshold is exceeded.

- The limit is currently 4GB in LITE mode (intentionally set high).
- When running in FULL mode, the limit is increased by a factor of 3.
- When running locally, the limit is 85% of what it would be otherwise (in order to try and catch buckets running close to the limit locally)
- The limit can be overridden manually by setting the property: `fat.test.max.allowed.trace.mb` to the trace limit (in MB) for LITE mode.  This sets the pre-adjusted limit (i.e. before FULl or local mode is taken into account).
- The trace limit for a FAT can be overridden programatically for a specific FAT in the following way:
```java
static {
  LogPolice.setMaxAllowedTraceMB(2000); // sets trace limit for the bucket to 2GB
}
```