### PR TITLE
Remove JaxRsModuleMetaData from overlay cache on app shutdown

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/component/JaxRsModuleMetaDataListener.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/component/JaxRsModuleMetaDataListener.java
@@ -168,6 +168,21 @@ public class JaxRsModuleMetaDataListener implements ModuleMetaDataListener, Modu
             Tr.debug(tc, "moduleMetaDataDestroyed(" + event.getMetaData().getName() + ") : " + event.getMetaData());
         }
 
+        try {
+            Container moduleContainer = event.getContainer();
+            if (moduleContainer != null) {
+                NonPersistentCache overlayCache = moduleContainer.adapt(NonPersistentCache.class);
+                overlayCache.removeFromCache(JaxRsModuleMetaData.class);
+            }
+        } catch (UnableToAdaptException ex) {
+            // FFDC
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "moduleMetaDataDestroyed(" + event.getMetaData().getName() +
+                             ") : Failed to remove metadata from overlay cache",
+                         ex);
+            }
+        }
+
         JaxRsModuleMetaData moduleMetaData = JaxRsMetaDataManager.getJaxRsModuleMetaData(event.getMetaData());
         if (moduleMetaData != null) {
             JaxRsMetaDataManager.setJaxRsModuleMetaData(event.getMetaData(), null);

--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/component/JaxRsModuleMetaDataListener.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/component/JaxRsModuleMetaDataListener.java
@@ -168,6 +168,20 @@ public class JaxRsModuleMetaDataListener implements ModuleMetaDataListener, Modu
             Tr.debug(tc, "moduleMetaDataDestroyed(" + event.getMetaData().getName() + ") : " + event.getMetaData());
         }
 
+        try {
+            Container moduleContainer = event.getContainer();
+            if (moduleContainer != null) {
+                NonPersistentCache overlayCache = moduleContainer.adapt(NonPersistentCache.class);
+                overlayCache.removeFromCache(JaxRsModuleMetaData.class);
+            }
+        } catch (UnableToAdaptException ex) {
+            // FFDC
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "moduleMetaDataDestroyed(" + event.getMetaData().getName() + 
+                              ") : Failed to remove metadata from overlay cache", ex);
+            }
+        }
+
         JaxRsModuleMetaData moduleMetaData = JaxRsMetaDataManager.getJaxRsModuleMetaData(event.getMetaData());
         if (moduleMetaData != null) {
             JaxRsMetaDataManager.setJaxRsModuleMetaData(event.getMetaData(), null);


### PR DESCRIPTION
It is possible to leak classloaders because the JaxRsModuleMetaData references an app's thread context classloader and is stored in the NonpersistentOverlayCache.  Normally this isn't a problem because the cache is removed when the classloader is removed - which happens at app shutdown, but common shared libraries have their own classloader that does not recycle when the app does - so it remains in the heap, referencing the overlay cache which references the JaxRsModuleMetaData, which references the thread context classloader - leaking it.  

The solution is to remove the JaxRsModuleMetaData from the cache when the metadata is destroyed (as part of app shutdown).