### PR TITLE
session info cache per app

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -17,8 +17,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
-import java.util.ConcurrentModificationException;
-import java.util.Hashtable;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import javax.cache.Cache;
@@ -437,29 +436,24 @@ public class CacheHashMap extends BackedHashMap {
         ObjectOutputStream oos = null;
         byte[] objbuf = null;
 
-        try {
-            @SuppressWarnings("rawtypes")
-            Hashtable ht;
-            synchronized (d2) {
-                ht = d2.getSwappableData();
-            }
-
-            // serialize session (app data only) into byte array buffer
-            baos = new ByteArrayOutputStream();
-            oos = cacheStoreService.serializationService.createObjectOutputStream(baos);
-            oos.writeObject(ht);
-            oos.flush();
-            objbuf = baos.toByteArray();
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(this, tc,  "success - size of byte array is " + objbuf.length);
-            }
-
-            oos.close();
-            baos.close();
-        } catch (ConcurrentModificationException cme) {
-            // TODO copied from DatabaseHashMap, but this seems suspicious. Need to investigate further. 
-            Tr.event(this, tc,  "CacheHashMap.deferWrite", d2.getId());
+        Map<Object, Object> ht;
+        synchronized (d2) {
+            ht = d2.getSwappableData();
         }
+
+        // serialize session (app data only) into byte array buffer
+        baos = new ByteArrayOutputStream();
+        oos = cacheStoreService.serializationService.createObjectOutputStream(baos);
+        oos.writeObject(ht);
+        oos.flush();
+        objbuf = baos.toByteArray();
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(this, tc,  "success - size of byte array is " + objbuf.length);
+        }
+
+        oos.close();
+        baos.close();
+
         return objbuf;
     }
 

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMapMR.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMapMR.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -226,8 +227,8 @@ public class CacheHashMapMR extends CacheHashMap {
             // we are not synchronized here - were not in old code either
             Hashtable tht = null;
             if (_smc.writeAllProperties()) {
-                Hashtable ht = d2.getSwappableData();
-                propsToWrite = ht.keySet();
+                Map<?, ?> ht = d2.getSwappableData();
+                propsToWrite = (Set<String>) ht.keySet();
                 if (trace && tc.isDebugEnabled()) {
                     Tr.debug(this, tc, "doing app changes for ALL mSwappable Data", ht);
                 }

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMapMR.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMapMR.java
@@ -20,8 +20,12 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
-import javax.cache.Cache;
+import javax.cache.CacheException;
+import javax.cache.configuration.Configuration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.EternalExpiryPolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -40,11 +44,47 @@ public class CacheHashMapMR extends CacheHashMap {
 
     private static final TraceComponent tc = Tr.register(CacheHashMapMR.class);
 
+    /**
+     * Reusable patterns for String.replaceAll
+     */
+    private static final Pattern COLON = Pattern.compile(":"), PERCENT = Pattern.compile("%"), SLASH = Pattern.compile("/");
+
     public CacheHashMapMR(IStore store, SessionManagerConfig smc, CacheStoreService cacheStoreService) {
         super(store, smc, cacheStoreService);
+
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
         // We know we're running multi-row..if not writeAllProperties and not time-based writes,
         // we must keep the app data tables per thread (rather than per session)
         appDataTablesPerThread = (!_smc.writeAllProperties() && !_smc.getEnableTimeBasedWrite());
+
+        // Build a unique per-application cache name by starting with the application context root and percent encoding
+        // the / and : characters (JCache spec does not allow these in cache names)
+        // and also the % character (which is necessary because of percent encoding)
+        String a = PERCENT.matcher(store.getId()).replaceAll("%25"); // must be done first to avoid replacing % that is added when replacing the others
+        a = SLASH.matcher(a).replaceAll("%2F");
+        a = COLON.matcher(a).replaceAll("%3A");
+        String cacheName = new StringBuilder(23 + a.length()).append("com.ibm.ws.session.app.").append(a).toString();
+
+        if (trace && tc.isDebugEnabled())
+            Tr.debug(this, tc, "find or create cache", cacheName);
+
+        sessionPropertyCache = cacheStoreService.cacheManager.getCache(cacheName, String.class, byte[].class);
+        if (sessionPropertyCache == null) {
+            Configuration<String, byte[]> config = new MutableConfiguration<String, byte[]>()
+                            .setTypes(String.class, byte[].class)
+                            .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
+            try {
+                sessionPropertyCache = cacheStoreService.cacheManager.createCache(cacheName, config);
+
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(tc, "Created a new session property cache", cacheName);
+            } catch (CacheException x) {
+                sessionPropertyCache = cacheStoreService.cacheManager.getCache(cacheName, String.class, byte[].class);
+                if (sessionPropertyCache == null)
+                    throw x;
+            }
+        }
     }
 
     /**
@@ -67,7 +107,6 @@ public class CacheHashMapMR extends CacheHashMap {
         Hashtable<String, Object> h = new Hashtable<String, Object>();
         try {
             if (propIds != null) {
-                Cache<String, byte[]> cache = cacheStoreService.getCache(appName);
                 for (String propId : propIds) {
                     // If an attribute is already in appDataRemovals or appDataChanges, then the attribute was already retrieved from the cache.  Skip retrieval from the cache here.
                     if (sess.appDataRemovals != null && sess.appDataRemovals.containsKey(propId)) {
@@ -81,7 +120,7 @@ public class CacheHashMapMR extends CacheHashMap {
                     }
 
                     String propertyKey = createSessionPropertyKey(id, propId);
-                    byte[] b = cache.get(propertyKey);
+                    byte[] b = sessionPropertyCache.get(propertyKey);
 
                     if (b != null) {
                         ByteArrayInputStream bais = new ByteArrayInputStream(b);
@@ -128,7 +167,7 @@ public class CacheHashMapMR extends CacheHashMap {
         Object tmp = null;
 
         String key = createSessionPropertyKey(sessId, id);
-        byte[] sessionPropBytes = cacheStoreService.getCache(appName).get(key);
+        byte[] sessionPropBytes = sessionPropertyCache.get(key);
 
         if (trace && tc.isDebugEnabled())
             Tr.debug(this, tc, key.toString(), sessionPropBytes == null ? null : sessionPropBytes.length);
@@ -211,8 +250,6 @@ public class CacheHashMapMR extends CacheHashMap {
             }
 
             if (propsToWrite != null) {
-                Cache<String, byte[]> cache = cacheStoreService.getCache(appName);
-
                 for (String propid : propsToWrite) {
                     long startTime = System.nanoTime();
 
@@ -236,7 +273,7 @@ public class CacheHashMapMR extends CacheHashMap {
                         Tr.debug(this, tc, "before update " + propid + " for session " + id + " size " + size);
 
                     String key = createSessionPropertyKey(id, propid);
-                    cache.put(key, objbuf);
+                    sessionPropertyCache.put(key, objbuf);
 
                     SessionStatistics pmiStats = _iStore.getSessionStatistics();
                     if (pmiStats != null) {
@@ -283,14 +320,12 @@ public class CacheHashMapMR extends CacheHashMap {
                 }
 
                 if (propsToRemove != null && !propsToRemove.isEmpty()) {
-                    Cache<String, byte[]> cache = cacheStoreService.getCache(appName);
-
                     for (String propid : propsToRemove) {
                         if (trace && tc.isDebugEnabled()) {
                             Tr.debug(this, tc, "deleting prop " + propid + " for session " + id);
                         }
                         String key = createSessionPropertyKey(id, propid);
-                        cache.remove(key);
+                        sessionPropertyCache.remove(key);
                     }
                 }
 
@@ -362,10 +397,9 @@ public class CacheHashMapMR extends CacheHashMap {
         if (propIds != null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "remove session properties", propIds);
-            Cache<String, byte[]> cache = cacheStoreService.getCache(_iStore.getId());
             for (String propId : propIds) {
                 String propertyKey = createSessionPropertyKey(id, propId);
-                cache.remove(propertyKey);
+                sessionPropertyCache.remove(propertyKey);
             }
         }
     }

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheSession.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheSession.java
@@ -36,6 +36,10 @@ public class CacheSession extends BackedSession {
     private boolean populatedAppData;
     private boolean usingMultirow;
 
+    CacheSession() {
+        super();
+    }
+
     public CacheSession(CacheHashMap sessions, String id, IStoreCallback storeCallback) {
         super(sessions, id, storeCallback);
         usingMultirow = _smc.isUsingMultirow();

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -10,16 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.session.store.cache;
 
-import java.util.ArrayList;
 import java.util.Map;
 
-import javax.cache.Cache;
 import javax.cache.CacheException;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
-import javax.cache.configuration.Configuration;
-import javax.cache.configuration.MutableConfiguration;
-import javax.cache.expiry.EternalExpiryPolicy;
 import javax.cache.spi.CachingProvider;
 import javax.servlet.ServletContext;
 import javax.transaction.UserTransaction;
@@ -36,7 +31,6 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.serialization.SerializationService;
 import com.ibm.ws.session.MemoryStoreHelper;
 import com.ibm.ws.session.SessionManagerConfig;
@@ -53,15 +47,7 @@ public class CacheStoreService implements SessionStoreService {
     
     private static final TraceComponent tc = Tr.register(CacheStoreService.class);
     
-    private Map<String, Object> configurationProperties;
-
-    /**
-     * For single-cache path, the whole session is store as an entry in this cache.
-     * For multi-cache path, separate caches are created per application to store the session properties each as their own cache entry,
-     * and this cache only contains information about the session rather than its contents.
-     */
-    @SuppressWarnings("rawtypes")
-    Cache<String, ArrayList> cache;
+    Map<String, Object> configurationProperties;
 
     CacheManager cacheManager;
 
@@ -84,41 +70,12 @@ public class CacheStoreService implements SessionStoreService {
      * @param props service properties
      */
     @Activate
-    @FFDCIgnore(CacheException.class)
     protected void activate(ComponentContext context, Map<String, Object> props) {
         configurationProperties = props;
-
-        // Use different cache names depending on whether session property values are all stored in a single entry
-        // within this main cache vs as separate entries in other caches.
-        // The use of different cache names prevents servers from colliding on the same cache when they have different
-        // options selected for how to store session properties.
-        String cacheName = "true".equals(configurationProperties.get("useMultiRowSchema"))
-                                        ? "com.ibm.ws.session.info"   // no session property values are kept in this cache
-                                        : "com.ibm.ws.session.cache"; // all session property values are stored in a single entry per session
 
         // load JCache provider from configured library, which is either specified as a libraryRef or via a bell
         CachingProvider provider = Caching.getCachingProvider(library.getClassLoader());
         cacheManager = provider.getCacheManager(null, null, null);
-        cache = cacheManager.getCache(cacheName, String.class, ArrayList.class);
-        if (cache == null) {
-            @SuppressWarnings("rawtypes")
-            Configuration<String, ArrayList> config = new MutableConfiguration<String, ArrayList>()
-                            .setTypes(String.class, ArrayList.class)
-                            .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
-            try {
-                cache = cacheManager.createCache(cacheName, config);
-
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                    Tr.debug(tc, "Created a new session info cache", cache);
-            } catch (CacheException x) {
-                cache = cacheManager.getCache(cacheName, String.class, ArrayList.class);
-                if (cache == null)
-                    throw x;
-            }
-        }
-
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(tc, "Using session info cache", cache);
     }
 
     @Override

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -19,6 +19,7 @@ import javax.cache.CacheManager;
 import javax.cache.Caching;
 import javax.cache.configuration.Configuration;
 import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.EternalExpiryPolicy;
 import javax.cache.spi.CachingProvider;
 import javax.servlet.ServletContext;
 import javax.transaction.UserTransaction;
@@ -101,7 +102,9 @@ public class CacheStoreService implements SessionStoreService {
         cache = cacheManager.getCache(cacheName, String.class, ArrayList.class);
         if (cache == null) {
             @SuppressWarnings("rawtypes")
-            Configuration<String, ArrayList> config = new MutableConfiguration<String, ArrayList>().setTypes(String.class, ArrayList.class);
+            Configuration<String, ArrayList> config = new MutableConfiguration<String, ArrayList>()
+                            .setTypes(String.class, ArrayList.class)
+                            .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
             try {
                 cache = cacheManager.createCache(cacheName, config);
 

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -19,7 +19,6 @@ import javax.cache.CacheManager;
 import javax.cache.Caching;
 import javax.cache.configuration.Configuration;
 import javax.cache.configuration.MutableConfiguration;
-import javax.cache.expiry.EternalExpiryPolicy;
 import javax.cache.spi.CachingProvider;
 import javax.servlet.ServletContext;
 import javax.transaction.UserTransaction;
@@ -138,37 +137,6 @@ public class CacheStoreService implements SessionStoreService {
     @Deactivate
     protected void deactivate(ComponentContext context) {
         cacheManager.close();
-    }
-
-    /**
-     * Obtains the session cache for the specified application.
-     * For multi-cache path, each session property is a separate entry in this cache.
-     * 
-     * @param appName the application name.
-     * @return the cache.
-     */
-    Cache<String, byte[]> getCache(String appName) {
-        // TODO replace / and : characters (per spec for cache names) and ensure the name is still unique.
-        String cacheName = "com.ibm.ws.session.app." + appName;
-
-        // Because byte[] does instance-based .equals, it will not be possible to use Cache.replace operations, but we are okay with that.
-        Cache<String, byte[]> cache = cacheManager.getCache(cacheName, String.class, byte[].class);
-        if (cache == null) {
-            Configuration<String, byte[]> config = new MutableConfiguration<String, byte[]>()
-                            .setTypes(String.class, byte[].class)
-                            .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
-            try {
-                cache = cacheManager.createCache(cacheName, config);
-
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                    Tr.debug(tc, "Created a new session property cache");
-            } catch (CacheException x) {
-                cache = cacheManager.getCache(cacheName, String.class, byte[].class);
-                if (cache == null)
-                    throw x;
-            }
-        }
-        return cache;
     }
 
     @Override

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/SessionData.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/SessionData.java
@@ -16,6 +16,7 @@ import java.util.BitSet;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 /**
@@ -56,7 +57,7 @@ class SessionData {
      * @param list ArrayList obtained from the cache.
      */
     @SuppressWarnings("unchecked")
-    SessionData(ArrayList<?> list) {
+    SessionData(@Sensitive ArrayList<?> list) { // avoid tracing all of the bytes
         this.list = (ArrayList<Object>) list;
     }
 

--- a/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseHashMap.java
+++ b/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseHashMap.java
@@ -28,6 +28,7 @@ import java.sql.Statement;
 import java.util.ConcurrentModificationException;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.logging.Level;
 
 import javax.sql.DataSource;
@@ -2387,7 +2388,7 @@ public class DatabaseHashMap extends BackedHashMap {
         byte[] objbuf = null;
 
         try {
-            Hashtable ht = null;
+            Map<Object, Object> ht = null;
             if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINE)) {
                 LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[SERIALIZE_APP_DATA], "get swappableData and convert to byte array");
             }

--- a/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseHashMapMR.java
+++ b/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseHashMapMR.java
@@ -171,7 +171,7 @@ public class DatabaseHashMapMR extends DatabaseHashMap {
             // we are not synchronized here - were not in old code either
             Hashtable sht = null;
             if (_smc.writeAllProperties()) {
-                Hashtable ht = d2.getSwappableData();
+                Hashtable ht = (Hashtable) d2.getSwappableData();
                 vEnum = ht.keys();
                 doWrite = true;
                 if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINE)) {

--- a/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseSession.java
+++ b/dev/com.ibm.ws.session.db/src/com/ibm/ws/session/store/db/DatabaseSession.java
@@ -12,6 +12,7 @@ package com.ibm.ws.session.store.db;
 
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.logging.Level;
 
 import javax.transaction.UserTransaction;
@@ -28,7 +29,7 @@ public class DatabaseSession extends BackedSession {
     protected boolean usingMultirow = false;
 
     // The swappable data
-    Hashtable mSwappableData;
+    Map<Object, Object> mSwappableData;
 
     private static final int GET_SWAPPABLE_DATA = 0;
     private static final int GET_SWAPPABLE_LISTENERS = 1;
@@ -70,7 +71,7 @@ public class DatabaseSession extends BackedSession {
     /*
      * To get at the swappable data
      */
-    public Hashtable getSwappableData() {
+    public Map<Object, Object> getSwappableData() {
         if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINER)) {
             LoggingUtil.SESSION_LOGGER_WAS.entering(methodClassName, methodNames[GET_SWAPPABLE_DATA]);
         }
@@ -185,7 +186,7 @@ public class DatabaseSession extends BackedSession {
             LoggingUtil.SESSION_LOGGER_WAS.entering(methodClassName, methodNames[GET_MULTI_ROW_APP_DATA]);
         }
         populatedAppData = true;
-        Hashtable swappable = getSwappableData();
+        Map<Object, Object> swappable = getSwappableData();
         Hashtable props = (Hashtable) ((DatabaseHashMap) getSessions()).getAllValues(this);
         if (props != null) {
             Enumeration kys = props.keys();
@@ -217,7 +218,7 @@ public class DatabaseSession extends BackedSession {
      * setSwappableData
      */
     @Override
-    public void setSwappableData(Hashtable ht) {
+    public void setSwappableData(Map<Object, Object> ht) {
         mSwappableData = ht;
     }
 }

--- a/dev/com.ibm.ws.session.store/src/com/ibm/ws/session/store/common/BackedSession.java
+++ b/dev/com.ibm.ws.session.store/src/com/ibm/ws/session/store/common/BackedSession.java
@@ -15,6 +15,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.logging.Level;
 
 //import javax.ejb.EJBHome;
@@ -381,7 +382,7 @@ public abstract class BackedSession extends MemorySession {
      * refillAttrNames
      * sets attribute names based on what is contained in swappable data
      */
-    protected void refillAttrNames(Hashtable swappable) {
+    protected void refillAttrNames(Map<Object, Object> swappable) {
         if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINE)) {
             LoggingUtil.SESSION_LOGGER_WAS.entering(methodClassName, methodNames[REFILL_ATTR_NAMES]);
         }
@@ -411,7 +412,7 @@ public abstract class BackedSession extends MemorySession {
     /*
      * setSwappableData
      */
-    public abstract void setSwappableData(Hashtable ht);
+    public abstract void setSwappableData(Map<Object, Object> ht);
 
     protected abstract SerializationService getSerializationService();
 
@@ -884,7 +885,7 @@ public abstract class BackedSession extends MemorySession {
         invalidate(false);
     }
 
-    public abstract Hashtable getSwappableData();
+    public abstract Map<Object, Object> getSwappableData();
 
     public abstract boolean getSwappableListeners(short listener);
 }

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/store/memory/MemorySession.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/store/memory/MemorySession.java
@@ -884,7 +884,7 @@ public class MemorySession implements ISession {
      * To get at the data that can by Serialized and stored externally
      * called from mBean
      */
-    public Hashtable getSwappableData() {
+    public Map<Object, Object> getSwappableData() {
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
             LoggingUtil.SESSION_LOGGER_CORE.entering(methodClassName, methodNames[GET_SWAPPABLE_DATA], appNameAndIdString);
         }


### PR DESCRIPTION
Refactor session cache code to have a per-application cache for session info, as we do for session properties.  This will eliminate inefficient queries across all applications.