### PR TITLE
Reduce FAT tracing

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.cdi/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.cdi/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all:com.ibm.ws.classloading*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.multi.client.cdi/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.multi.client.cdi/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all:com.ibm.ws.classloading*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.remoteServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.remoteServer/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:LogService=all
+com.ibm.ws.logging.trace.specification=*=info
 com.ibm.ws.logging.max.file.size=0
 osgi.console=6789
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.tolerateEE8/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.tolerateEE8/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all:com.ibm.ws.classloading*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties


### PR DESCRIPTION
Recent build analysis shows that the MP Rest Client FAT is generated a lot (~186MB) of trace which strains the build/test infrastructure.  This reduces some of that tracing.