### PR TITLE
Set qualifiers to timestamps and upload a zip artifact of .feature files

### DIFF
--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -319,17 +319,17 @@ task zipGradleBootstrap(type: Zip) {
     dependsOn createGaESAList
     dependsOn createIndex
     baseName 'gradle-bootstrap'
-    into 'prereq.published', { from new File(project.buildDir, 'dependencies.gradle'),
-                                    new File(project.buildDir, 'gaFeatures.txt'),
-                                    new File(project.buildDir, 'excludeList.txt') }
+    into 'prereq.published', {
+        from new File(project.buildDir, 'dependencies.gradle'),
+             new File(project.buildDir, 'gaFeatures.txt'),
+             new File(project.buildDir, 'excludeList.txt')
+    }
     from new File(project.buildDir, 'replacements')
-}
-
-task zipDotFeatureFiles(type: Zip) {
-    baseName 'openliberty-features'
-    from rootProject.fileTree(dir: '.', include: '*/*.feature').collect {
-        if (!it.isDirectory()) {
-            it
+    into 'com.ibm.websphere.features.internal.openliberty', {
+        from rootProject.fileTree(dir: '.', include: '*/*.feature').collect {
+            if (!it.isDirectory()) {
+                it
+            }
         }
     }
 }
@@ -340,11 +340,6 @@ publishing {
         artifactId 'gradle-bootstrap'
         version project.version
         artifact zipGradleBootstrap
-    }
-    features(MavenPublication) {
-        artifactId 'openliberty-features'
-        version project.version
-        artifact zipDotFeatureFiles
     }
   }
 }

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -325,12 +325,26 @@ task zipGradleBootstrap(type: Zip) {
     from new File(project.buildDir, 'replacements')
 }
 
+task zipDotFeatureFiles(type: Zip) {
+    baseName 'openliberty-features'
+    from rootProject.fileTree(dir: '.', include: '*/*.feature').collect {
+        if (!it.isDirectory()) {
+            it
+        }
+    }
+}
+
 publishing {
   publications {
     gradle(MavenPublication) {
         artifactId 'gradle-bootstrap'
         version project.version
         artifact zipGradleBootstrap
+    }
+    features(MavenPublication) {
+        artifactId 'openliberty-features'
+        version project.version
+        artifact zipDotFeatureFiles
     }
   }
 }

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -130,27 +130,22 @@ task createGradleBootstrap {
         rootProject.fileTree(dir: '.', include: '**/*.feature').visit { feature ->
             if (feature.isDirectory()) return
 
+            Properties props = new Properties()
+            props.load(new FileInputStream(feature.getFile()))
+
             String text = feature.getFile().getText()
-            if (text.contains("kind=ga") || text.contains("kind=beta")) {
-                String name = null
-                int index = text.indexOf("symbolicName=")
-                if (index != -1) {
-                    int endIndex = text.indexOf("\n", index)
-                    if (endIndex == -1) {
-                        endIndex = text.length()
-                    }
-                    // symbolicName= is length 13
-                    name = text.substring(index + 13, endIndex)
-                    name = name.replaceAll("\\s+", "")
-                } else {
-                    name = feature.name.substring(0, feature.name.size() - 8)
+            if (props['kind']=="ga" || props['kind']=="beta") {
+                String featureArtifactId = props['symbolicName']
+                String featureName = feature.name.substring(0, feature.name.size() - ".feature".length())
+                if (featureArtifactId == null) {
+                    featureArtifactId = featureName
                 }
 
-                String featureName = feature.name.substring(0, feature.name.size() - 8)
                 String rev = projectPathToVersion.get(featureName)
                 if (rev != null) {
-                    depsList = depsList + '    compile \'' + org + ':' + name + ':' + rev + '@esa\'\n'
-                    depsList = depsList + '    compile \'' + org + ':' + name + ':' + rev + '@esa.metadata.zip\'\n'
+                    depsList = depsList + '    compile \'' + org + ':' + featureArtifactId + ':' + rev + '@esa\'\n'
+                    depsList = depsList + '    compile \'' + org + ':' + featureArtifactId + ':' + rev + '@esa.metadata.zip\'\n'
+                    depsList = depsList + '    compile \'' + org + ':' + featureArtifactId + ':' + rev + '@pom\'\n'
                 }
             }
         }

--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -133,7 +133,8 @@ def loadBuildProps() {
   }
 
   // Must be run after isRelease is set
-  def (qualifier, timestamp) = getVersionQualifier(isRelease)
+  def timestamp = new SimpleDateFormat("yyyyMMddHHmm").format(new java.util.Date())
+  def qualifier = timestamp
   
   //For release builds we can use a consistent qualifier of the build label.
   //This comes from the RTC build engines


### PR DESCRIPTION
- Sets the Bnd bundles version qualifiers to timestamps instead of branch names.
- Adds all .feature file sources to gradle-bootstrap.