### PR TITLE
Update to in-memory Derby where possible

### DIFF
--- a/dev/com.ibm.ws.cdi.lifecycle_fat/publish/servers/cdi12PassivationServer/server.xml
+++ b/dev/com.ibm.ws.cdi.lifecycle_fat/publish/servers/cdi12PassivationServer/server.xml
@@ -18,7 +18,10 @@
     </library>        
     
     <dataSource id="jdbc/TestDataSource" jndiName="jdbc/TestDataSource" jdbcDriverRef="FATJDBCDriver">
-        <properties.derby.embedded databaseName="${shared.config.dir}/resources/databases/cdi12FatDB" createDatabase="create"/> 
+    	<!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
+    	is required beyond a single server start, configure the databaseName with a file location such as:
+    	databaseName="${shared.config.dir}/data/derbydb" -->
+        <properties.derby.embedded databaseName="memory:cdi12FatDB" createDatabase="create"/> 
     </dataSource>  
     
     <httpSessionDatabase dataSourceRef="jdbc/TestDataSource"/>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo/server.xml
@@ -26,7 +26,10 @@
   <!-- database for scheduled tasks -->
   <dataSource id="DemoDB" jndiName="jdbc/DemoDB" type="javax.sql.XADataSource">
     <jdbcDriver libraryRef="FATJDBCLib"/>
-    <properties.derby.embedded createDatabase="create" databaseName="${shared.resource.dir}/data/persistdemodb"/>
+    <!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
+    is required beyond a single server start, configure the databaseName with a file location such as:
+    databaseName="${shared.config.dir}/data/derbydb" -->
+    <properties.derby.embedded createDatabase="create" databaseName="memory:persistdemodb"/>
   </dataSource>
   <library id="FATJDBCLib">
     <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/publish/servers/com.ibm.ws.concurrent.persistent.fat.locking/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/publish/servers/com.ibm.ws.concurrent.persistent.fat.locking/server.xml
@@ -23,7 +23,10 @@
   <!-- database for scheduled tasks -->
   <dataSource id="LockTestDB">
     <jdbcDriver libraryRef="DerbyLib"/>
-    <properties.derby.embedded createDatabase="create" databaseName="${shared.resource.dir}/data/lockdb"/>
+    <!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
+    is required beyond a single server start, configure the databaseName with a file location such as:
+    databaseName="${shared.config.dir}/data/derbydb" -->
+    <properties.derby.embedded createDatabase="create" databaseName="memory:lockdb"/>
   </dataSource>
   <library id="DerbyLib">
     <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>

--- a/dev/com.ibm.ws.config_fat/publish/files/featureRemove/serverRemoveJDBC.xml
+++ b/dev/com.ibm.ws.config_fat/publish/files/featureRemove/serverRemoveJDBC.xml
@@ -23,7 +23,10 @@
     <application type="ear" id="myEJBEAR" name="myEJBEAR" location="sharedLibEJB.ear" />
 
     <dataSource id="dataSource" jndiName="jdbc/DictionaryDB" supplementalJDBCTrace="true">
-        <properties.derby.embedded createDatabase="create" databaseName="${server.config.dir}/dictionaryDB"/>
+        <!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
+    	is required beyond a single server start, configure the databaseName with a file location such as:
+    	databaseName="${shared.config.dir}/data/derbydb" -->
+        <properties.derby.embedded createDatabase="create" databaseName="memory:dictionaryDB"/>
         <jdbcDriver libraryRef="myLib" />
     </dataSource>
 

--- a/dev/com.ibm.ws.config_fat/publish/files/featureRemove/serverRemoveOpenID.xml
+++ b/dev/com.ibm.ws.config_fat/publish/files/featureRemove/serverRemoveOpenID.xml
@@ -23,7 +23,10 @@
     <application type="ear" id="myEJBEAR" name="myEJBEAR" location="sharedLibEJB.ear" />
 
     <dataSource id="dataSource" jndiName="jdbc/DictionaryDB" supplementalJDBCTrace="true">
-        <properties.derby.embedded createDatabase="create" databaseName="${server.config.dir}/dictionaryDB"/>
+        <!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
+    	is required beyond a single server start, configure the databaseName with a file location such as:
+    	databaseName="${shared.config.dir}/data/derbydb" -->
+        <properties.derby.embedded createDatabase="create" databaseName="memory:dictionaryDB"/>
         <jdbcDriver libraryRef="myLib" />
     </dataSource>
 

--- a/dev/com.ibm.ws.config_fat/publish/servers/com.ibm.ws.config.features/server.xml
+++ b/dev/com.ibm.ws.config_fat/publish/servers/com.ibm.ws.config.features/server.xml
@@ -24,7 +24,10 @@
     <application type="ear" id="myEJBEAR" name="myEJBEAR" location="sharedLibEJB.ear" />
 
     <dataSource id="dataSource" jndiName="jdbc/DictionaryDB" supplementalJDBCTrace="true">
-        <properties.derby.embedded createDatabase="create" databaseName="${server.config.dir}/dictionaryDB"/>
+        <!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
+    	is required beyond a single server start, configure the databaseName with a file location such as:
+    	databaseName="${shared.config.dir}/data/derbydb" -->
+        <properties.derby.embedded createDatabase="create" databaseName="memory:dictionaryDB"/>
         <jdbcDriver libraryRef="myLib" />
     </dataSource>
 

--- a/dev/com.ibm.ws.config_fat/publish/servers/com.ibm.ws.config.invalidJDBCoption/server.xml
+++ b/dev/com.ibm.ws.config_fat/publish/servers/com.ibm.ws.config.invalidJDBCoption/server.xml
@@ -20,8 +20,11 @@
          CWWKG0032W: Unexpected value specified for property [createDatabase], value = [whatever]. Expected value(s) are: [create][false].
     -->
     <dataSource id="jdbc/derby" jndiName="jdbc/derby"> 
+        <!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
+    	is required beyond a single server start, configure the databaseName with a file location such as:
+    	databaseName="${shared.config.dir}/data/derbydb" -->
         <properties.derby.embedded
-        databaseName="abc"
+        databaseName="memory:abc"
         createDatabase="whatever"
         user="dbuser1"
         password="{xor}Oz0vKDtu"

--- a/dev/com.ibm.ws.config_fat/publish/servers/com.ibm.ws.config.invalidOptionalInclude/server.xml
+++ b/dev/com.ibm.ws.config_fat/publish/servers/com.ibm.ws.config.invalidOptionalInclude/server.xml
@@ -23,8 +23,11 @@
 
 
     <dataSource id="jdbc/derby" jndiName="jdbc/derby"> 
+        <!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
+    	is required beyond a single server start, configure the databaseName with a file location such as:
+    	databaseName="${shared.config.dir}/data/derbydb" -->
         <properties.derby.embedded
-        databaseName="abc"
+        databaseName="memory:abc"
         createDatabase="true"
         user="dbuser1"
         password="{xor}Oz0vKDtu"


### PR DESCRIPTION
Update those buckets which are able to use derby in-memory to do so if they are not already. This will allow Derby to better function should infrastructure issues occur, reducing unnecessary defects.

Issue #2352 