### PR TITLE
Fix cdi fat app deployments

### DIFF
--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/EnablingBeansXmlValidationTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/EnablingBeansXmlValidationTest.java
@@ -62,7 +62,6 @@ public class EnablingBeansXmlValidationTest extends LoggingTest {
         LibertyServer server = LibertyServerFactory.getLibertyServer("cdi12BeansXmlValidationServer");
         ShrinkHelper.exportDropinAppToServer(server, invalidBeansXml);
         hasSetUp = true;
-        server.waitForStringInLogUsingMark("CWWKZ0001I");
     }        
 
     @Test

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/implicit/ImplicitBeanArchiveTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/implicit/ImplicitBeanArchiveTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.cdi12.fat.tests.implicit;
  
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 
 import org.junit.AfterClass;
@@ -89,9 +91,9 @@ public class ImplicitBeanArchiveTest extends LoggingTest {
                         .addAsLibrary(archiveWithNoScanBeansXML)
                         .addAsLibrary(archiveWithAnnotatedModeBeansXML);
 
+       server.setMarkToEndOfLog(server.getDefaultLogFile());
        ShrinkHelper.exportDropinAppToServer(server, implicitBeanArchive);
-
-       server.waitForStringInLogUsingMark("CWWKZ0001I.*Application implicitBeanArchive started");
+       assertNotNull("implicitBeanArchive started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*implicitBeanArchive"));
     }
 
     @Rule

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/implicit/ImplicitEJBTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/implicit/ImplicitEJBTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.cdi12.fat.tests.implicit;
  
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 
 import org.junit.AfterClass;
@@ -62,8 +64,9 @@ public class ImplicitEJBTest {
                         .addClass("com.ibm.ws.cdi12.test.implicit.ejb.SimpleEJB")
                         .addAsLibrary(utilLib);
 
+       server.setMarkToEndOfLog(server.getDefaultLogFile());
        ShrinkHelper.exportDropinAppToServer(server, implicitEJBInWar);
-       server.waitForStringInLogUsingMark("CWWKZ0001I.*");
+       assertNotNull("implicitEJBInWar started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*implicitEJBInWar"));
     }
 
     @Rule

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/implicit/ImplicitWarLibJarsTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/implicit/ImplicitWarLibJarsTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.cdi12.fat.tests.implicit;
  
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 
 import org.junit.AfterClass;
@@ -88,10 +90,11 @@ public class ImplicitWarLibJarsTest extends LoggingTest {
                         .addAsLibrary(implicitBeanExplicitArchive)
                         .addAsLibrary(utilLib);
 
+       server.setMarkToEndOfLog(server.getDefaultLogFile());
        ShrinkHelper.exportDropinAppToServer(server, implicitEJBInWar);
        ShrinkHelper.exportDropinAppToServer(server, implicitBeanDiscovery);
-
-       server.waitForStringInLogUsingMark("CWWKZ0001I.*Application implicitBeanDiscovery started");
+       assertNotNull("implicitBeanDiscovery started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*implicitEJBInWar"));
+       assertNotNull("implicitBeanDiscovery started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*implicitBeanDiscovery"));
     }
 
     /**

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/implicit/ImplicitWarTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/implicit/ImplicitWarTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.cdi12.fat.tests.implicit;
  
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 
 import org.junit.AfterClass;
@@ -62,9 +64,9 @@ public class ImplicitWarTest {
                         .addClass("com.ibm.ws.cdi12.test.implicitWar.AnnotatedBean")
                         .addAsLibrary(utilLib);
 
+       server.setMarkToEndOfLog(server.getDefaultLogFile());
        ShrinkHelper.exportDropinAppToServer(server, implicitWarApp);
-
-       server.waitForStringInLogUsingMark("CWWKZ0001I.*Application implicitWarApp started");
+       assertNotNull("implicitWarApp started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*implicitWarApp"));
     }
 
     @Rule

--- a/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi12/fat/tests/AroundConstructTestBase.java
+++ b/dev/com.ibm.ws.cdi.ejb_fat/fat/src/com/ibm/ws/cdi12/fat/tests/AroundConstructTestBase.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.cdi12.fat.tests;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 
 import org.junit.AfterClass;
@@ -105,9 +107,11 @@ public abstract class AroundConstructTestBase extends LoggingTest {
                         .add(new FileAsset(new File("test-applications/postConstructErrorMessageApp.war/resources/WEB-INF/beans.xml")), "/WEB-INF/beans.xml")
                         .addAsLibrary(utilLib);
 
+        server.setMarkToEndOfLog(server.getDefaultLogFile());
         ShrinkHelper.exportDropinAppToServer(server, aroundConstructApp);
         ShrinkHelper.exportDropinAppToServer(server, postConstructErrorMessageApp);
-        server.waitForStringInLogUsingMark("CWWKZ0001I.*Application aroundConstructApp started");
+        assertNotNull("aroundConstructApp started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*aroundConstructApp"));
+        assertNotNull("postConstructErrorMessageApp started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*postConstructErrorMessageApp"));
     }
 
     @ClassRule

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi12/fat/tests/AppExtensionTest.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi12/fat/tests/AppExtensionTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.cdi12.fat.tests;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 
 import org.junit.Assert;
@@ -63,7 +65,7 @@ public class AppExtensionTest extends LoggingTest {
         server = LibertyServerFactory.getStartedLibertyServer("cdi12AppExtensionServer");
         server.setMarkToEndOfLog(server.getDefaultLogFile());
         ShrinkHelper.exportDropinAppToServer(server, applicationExtension);
-        server.waitForStringInLogUsingMark("CWWKZ000[13]I.*applicationExtension"); // App started or updated
+        assertNotNull("applicationExtension started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*applicationExtension"));
 
     }
 

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi12/fat/tests/SimpleJSPTest.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi12/fat/tests/SimpleJSPTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.cdi12.fat.tests;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 
 import org.junit.AfterClass;
@@ -60,8 +62,9 @@ public class SimpleJSPTest extends LoggingTest {
                         .add(new FileAsset(new File("test-applications/simpleJSPApp.war/resources/WEB-INF/beans.xml")), "/WEB-INF/beans.xml")
                         .add(new FileAsset(new File("test-applications/simpleJSPApp.war/resources/index.jsp")), "/index.jsp");
         server = SHARED_SERVER.getLibertyServer();
+        server.setMarkToEndOfLog(server.getDefaultLogFile());
         ShrinkHelper.exportDropinAppToServer(server, simpleJSPApp);
-        server.waitForStringInLogUsingMark("CWWKZ0001I.*Application simpleJSPApp started");
+        assertNotNull("simpleJSPApp started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*simpleJSPApp"));
     }
 
     @Test

--- a/dev/com.ibm.ws.cdi.noncontextual_fat/fat/src/com/ibm/ws/cdi12/fat/tests/NonContextualInjectionPointTest.java
+++ b/dev/com.ibm.ws.cdi.noncontextual_fat/fat/src/com/ibm/ws/cdi12/fat/tests/NonContextualInjectionPointTest.java
@@ -12,6 +12,8 @@ package com.ibm.ws.cdi12.fat.tests;
 
 import java.net.MalformedURLException;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 
 import org.junit.Assert;
@@ -58,8 +60,9 @@ public class NonContextualInjectionPointTest extends LoggingTest {
                         .addClass("test.non.contextual.NonContextualBean")
                         .addClass("test.non.contextual.Bar")
                         .add(new FileAsset(new File("test-applications/appNonContextual.war/resources/WEB-INF/beans.xml")), "/WEB-INF/beans.xml");
+        server.setMarkToEndOfLog(server.getDefaultLogFile());
         ShrinkHelper.exportDropinAppToServer(server, appNonContextual);
-        server.waitForStringInLogUsingMark("CWWKZ0001I.*Application appNonContextual started");
+        assertNotNull("appNonContextual started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*appNonContextual"));
     }
 
     @Test

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi12/fat/tests/JarInRarTest.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi12/fat/tests/JarInRarTest.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.cdi12.fat.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -42,10 +44,19 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 public class JarInRarTest {
 
     private static LibertyServer server;
+    
+    private static boolean hasSetup = false;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        
+        server = LibertyServerFactory.getStartedLibertyServer("cdi12JarInRar");
 
+        if (hasSetup) {
+            // Server already set up, app should have already been deployed when the server was started up, make sure the app has started
+            assertNotNull("jarInRar started message", server.waitForStringInLogUsingMark("CWWKZ0001I.*jarInRar"));
+            return;
+        }
 
         JavaArchive jarInRarJar = ShrinkWrap.create(JavaArchive.class,"jarInRar.jar")
                         .addClass("com.ibm.ws.cdi12.fat.jarinrar.rar.Amigo")
@@ -64,9 +75,10 @@ public class JarInRarTest {
         EnterpriseArchive jarInRarEar = ShrinkWrap.create(EnterpriseArchive.class,"jarInRar.ear")
                         .addAsModule(jarInRarEjb)
                         .addAsModule(jarInRarRar);
-        server = LibertyServerFactory.getStartedLibertyServer("cdi12JarInRar");
+        
         ShrinkHelper.exportDropinAppToServer(server, jarInRarEar);
-        server.waitForStringInLogUsingMark("CWWKZ0001I.*");
+        assertNotNull("jarInRar started message", server.waitForStringInLogUsingMark("CWWKZ0001I.*jarInRar"));
+        hasSetup = true;
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi12/fat/tests/PackagePrivateAccessTest.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi12/fat/tests/PackagePrivateAccessTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.cdi12.fat.tests;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 
 import org.junit.AfterClass;
@@ -54,8 +56,9 @@ public class PackagePrivateAccessTest extends LoggingTest {
                         .addClass("jp.test.bean.MyBean")
                         .add(new FileAsset(new File("test-applications/packagePrivateAccessApp.war/resources/WEB-INF/web.xml")), "/WEB-INF/web.xml");    
         server = LibertyServerFactory.getStartedLibertyServer("packagePrivateAccessServer");
+        server.setMarkToEndOfLog(server.getDefaultLogFile());
         ShrinkHelper.exportDropinAppToServer(server, packagePrivateAccessApp);
-        server.waitForStringInLogUsingMark("CWWKZ0001I.*Application packagePrivateAccessApp started");
+        assertNotNull("packagePrivateAccessApp started or updated message", server.waitForStringInLogUsingMark("CWWKZ000[13]I.*packagePrivateAccessApp"));
     }
 
     @Test


### PR DESCRIPTION
Fix tests where we don't deploy the app properly when using RepeatTests

The general problem is that when the test runs a second time, the app will already be deployed and there will be an app started message in the log.

Some of the tests redeploy the app. In these cases, we need to set the mark before deploying and check for either the app started or app updated message.

This causes intermittent build breaks if the server processes the redeployment while a test is running.

This fixes #2302 