### PR TITLE
Reduce trace in javaeesec fat bucket

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBAuthAliasTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBAuthAliasTest.java
@@ -111,7 +111,6 @@ public class HttpAuthenticationMechanismDBAuthAliasTest extends JavaEESecTestBas
      * <LI> Servlet is accessed and it prints information about the subject: getAuthType, getUserPrincipal, getRemoteUser.
      * </OL>
      */
-    @Mode(TestMode.LITE)
     @Test
     public void testJaspiAnnotatedDBBasicAuthValidUserInRole_AllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBNoUserTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBNoUserTest.java
@@ -110,7 +110,6 @@ public class HttpAuthenticationMechanismDBNoUserTest extends JavaEESecTestBase {
      * <LI> Servlet is accessed and it prints information about the subject: getAuthType, getUserPrincipal, getRemoteUser.
      * </OL>
      */
-    @Mode(TestMode.LITE)
     @Test
     public void testAllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
@@ -141,7 +140,6 @@ public class HttpAuthenticationMechanismDBNoUserTest extends JavaEESecTestBase {
      * <LI> Return code 403
      * </OL>
      */
-    @Mode(TestMode.LITE)
     @Test
     public void testInvalidUser() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
@@ -163,7 +161,6 @@ public class HttpAuthenticationMechanismDBNoUserTest extends JavaEESecTestBase {
      * <LI> Return code 403
      * </OL>
      */
-    @Mode(TestMode.LITE)
     @Test
     public void testValidUser_NoAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBShortNameTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBShortNameTest.java
@@ -110,7 +110,6 @@ public class HttpAuthenticationMechanismDBShortNameTest extends JavaEESecTestBas
      * <LI> Servlet is accessed and it prints information about the subject: getAuthType, getUserPrincipal, getRemoteUser.
      * </OL>
      */
-    @Mode(TestMode.LITE)
     @Test
     public void testJaspiAnnotatedDBBasicAuthValidUserInRole_AllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
@@ -141,7 +140,6 @@ public class HttpAuthenticationMechanismDBShortNameTest extends JavaEESecTestBas
      * <LI> Return code 403
      * </OL>
      */
-    @Mode(TestMode.LITE)
     @Test
     public void testJaspiAnnotatedDBBasicAuthValidUser_NoAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.db.authalias.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.db.authalias.fat/bootstrap.properties
@@ -1,8 +1,5 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:\
 com.ibm.ws.security.*=all=enabled:\
-com.ibm.websphere.security.*=all=enabled:\
-com.ibm.ws.apacheds.*=all=enabled:\
-com.ibm.wsspi.security.*=all=enabled:
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.db.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.db.fat/bootstrap.properties
@@ -1,8 +1,5 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:\
 com.ibm.ws.security.*=all=enabled:\
-com.ibm.websphere.security.*=all=enabled:\
-com.ibm.ws.apacheds.*=all=enabled:\
-com.ibm.wsspi.security.*=all=enabled:
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.db.nouser.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.db.nouser.fat/bootstrap.properties
@@ -1,8 +1,5 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:\
 com.ibm.ws.security.*=all=enabled:\
-com.ibm.websphere.security.*=all=enabled:\
-com.ibm.ws.apacheds.*=all=enabled:\
-com.ibm.wsspi.security.*=all=enabled:
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.db.shortname.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.db.shortname.fat/bootstrap.properties
@@ -1,8 +1,5 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:\
 com.ibm.ws.security.*=all=enabled:\
-com.ibm.websphere.security.*=all=enabled:\
-com.ibm.ws.apacheds.*=all=enabled:\
-com.ibm.wsspi.security.*=all=enabled:
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.dbidstore.deferred.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.dbidstore.deferred.fat/bootstrap.properties
@@ -1,8 +1,5 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:\
 com.ibm.ws.security.*=all=enabled:\
-com.ibm.websphere.security.*=all=enabled:\
-com.ibm.ws.apacheds.*=all=enabled:\
-com.ibm.wsspi.security.*=all=enabled:
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.ejb.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.ejb.fat/bootstrap.properties
@@ -1,13 +1,5 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:\
 com.ibm.ws.security.*=all=enabled:\
-com.ibm.websphere.security.*=all=enabled:\
-com.ibm.ws.apacheds.*=all=enabled:\
-com.ibm.wsspi.security.*=all=enabled:\
-com.ibm.ws.webcontainer.security.*=all=enabled:\
-JCDI=all=enabled:\
-com.ibm.ws.cdi*=all=enabled:\
-com.ibm.ws.weld*=all=enabled:\
-org.jboss.weld*=all=enabled 
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.fat/bootstrap.properties
@@ -1,13 +1,5 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:\
 com.ibm.ws.security.*=all=enabled:\
-com.ibm.websphere.security.*=all=enabled:\
-com.ibm.ws.apacheds.*=all=enabled:\
-com.ibm.wsspi.security.*=all=enabled:\
-com.ibm.ws.webcontainer.security.*=all=enabled:\
-JCDI=all=enabled:\
-com.ibm.ws.cdi*=all=enabled:\
-com.ibm.ws.weld*=all=enabled:\
-org.jboss.weld*=all=enabled 
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.jaxrs.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.jaxrs.fat/bootstrap.properties
@@ -1,13 +1,5 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:\
 com.ibm.ws.security.*=all=enabled:\
-com.ibm.websphere.security.*=all=enabled:\
-com.ibm.ws.apacheds.*=all=enabled:\
-com.ibm.wsspi.security.*=all=enabled:\
-com.ibm.ws.webcontainer.security.*=all=enabled:\
-JCDI=all=enabled:\
-com.ibm.ws.cdi*=all=enabled:\
-com.ibm.ws.weld*=all=enabled:\
-org.jboss.weld*=all=enabled 
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.ldapidstore.deferred.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.ldapidstore.deferred.fat/bootstrap.properties
@@ -1,8 +1,5 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:\
 com.ibm.ws.security.*=all=enabled:\
-com.ibm.websphere.security.*=all=enabled:\
-com.ibm.ws.apacheds.*=all=enabled:\
-com.ibm.wsspi.security.*=all=enabled:
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug


### PR DESCRIPTION
Reduce to just ws.security trace. Bump some of the DB fat tests to full bucket.