### PR TITLE
Check if an already created buffer for a certain source has already been registered

### DIFF
--- a/dev/com.ibm.ws.collector.manager/src/com/ibm/ws/collector/manager/internal/CollectorManagerImpl.java
+++ b/dev/com.ibm.ws.collector.manager/src/com/ibm/ws/collector/manager/internal/CollectorManagerImpl.java
@@ -382,6 +382,13 @@ public class CollectorManagerImpl implements CollectorManager {
     }
 
     private synchronized void startSourceWithBufferManager(String sourceId, Handler handler) {
+        /*
+         * An active Buffer already exists. This must mean we subscribed two handlers wanting
+         * the same source really quickly back-to-back before the source was set into CollectorManager
+         */
+        if (activeBuffMgrServices.containsKey(sourceId)) {
+            return;
+        }
         //result[0] is sourceName
         //result[1] is location
         String[] result = sourceId.split("\\|");


### PR DESCRIPTION
Check if an already created buffer for a certain source has already been registered in CollectorManager before creating a new Buffer. This is to avoid the creation of two Buffers for the same source which can cause unregistration problems.

#build
fixes #2385 