### PR TITLE
Switch MicroProfile TCKs to use non-snapshot arquillian-wlp-managed-8.5

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.ibm.ws.org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-wlp-managed-8.5</artifactId>
-            <version>1.0.0.Final-SNAPSHOT</version>
+            <version>1.0.0-20180227</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.config_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat_tck/publish/tckRunner/tck/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.ibm.ws.org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-wlp-managed-8.5</artifactId>
-            <version>1.0.0.Final-SNAPSHOT</version>
+            <version>1.0.0-20180227</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.ibm.ws.org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-wlp-managed-8.5</artifactId>
-            <version>1.0.0.Final-SNAPSHOT</version>
+            <version>1.0.0-20180227</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.ibm.ws.org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-wlp-managed-8.5</artifactId>
-            <version>1.0.0.Final-SNAPSHOT</version>
+            <version>1.0.0-20180227</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
@@ -15,7 +15,7 @@
         <microprofile.openapi.version>1.0.1</microprofile.openapi.version>
         <surefire.version>2.19.1</surefire.version>
         <arquillian.version>1.1.14.Final</arquillian.version>
-        <arquillian-wlp.version>1.0.0.Beta2</arquillian-wlp.version>
+        <arquillian-wlp.version>1.0.0-20180227</arquillian-wlp.version>
         
         <suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>
         <targetDirectory>${project.basedir}/target</targetDirectory>
@@ -75,7 +75,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
+            <groupId>com.ibm.ws.org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-wlp-managed-8.5</artifactId>
             <version>${arquillian-wlp.version}</version>
             <scope>test</scope>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
@@ -155,8 +155,7 @@
         <dependency>
             <groupId>com.ibm.ws.org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-wlp-managed-8.5</artifactId>
-            <version>1.0.0.Final-SNAPSHOT</version>
-            <!-- <version>1.0.0.Final-20180108.155248-1</version> -->
+            <version>1.0.0-20180227</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
The new version is identical to the current latest snapshot build so
should not change how the tests run.

The purpose of this change is to ensure that the 18.0.0.1 build is
reproducable in future.