### PR TITLE
Using 1.0.0.Final-SNAPSHOT to pull in what is in artifactory

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
@@ -155,8 +155,8 @@
         <dependency>
             <groupId>com.ibm.ws.org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-wlp-managed-8.5</artifactId>
-            <!-- <version>1.0.0.Final-SNAPSHOT</version> -->
-            <version>1.0.0.Final-20180108.155248-1</version>
+            <version>1.0.0.Final-SNAPSHOT</version>
+            <!-- <version>1.0.0.Final-20180108.155248-1</version> -->
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
See PR #2380, this makes it (wrongly) consistent until we can fix these up to not point at snapshots.