### PR TITLE
Revert "1560 shrinkwrap helper should not default to overwiting when exporting artifacts to the server"

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleClassLoading.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleClassLoading.java
@@ -54,7 +54,7 @@ public class TestMultiModuleClassLoading extends LoggingTest {
                         .addAsModule(war2)
                         .setApplicationXML(TestServlet.class.getResource("application.xml"));
 
-        ShrinkHelper.exportToServer(SHARED_SERVER.getLibertyServer(), "dropins", ear, true);
+        ShrinkHelper.exportToServer(SHARED_SERVER.getLibertyServer(), "dropins", ear);
         SHARED_SERVER.getLibertyServer().addInstalledAppForValidation("MultiModuleClassLoading");
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleConfigLoad.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleConfigLoad.java
@@ -85,7 +85,7 @@ public class TestMultiModuleConfigLoad extends LoggingTest {
                         .addAsLibrary(jar)
                         .setApplicationXML(RetryTesterServlet.class.getResource("multi-module-application.xml"));
 
-        ShrinkHelper.exportToServer(SHARED_SERVER.getLibertyServer(), "dropins", ear, true);
+        ShrinkHelper.exportToServer(SHARED_SERVER.getLibertyServer(), "dropins", ear);
         SHARED_SERVER.getLibertyServer().addInstalledAppForValidation("FaultToleranceMultiModule");
     }
 

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
@@ -41,7 +41,9 @@ public class ShrinkHelper {
      * autoFVT/publish/... and wlp/usr/...
      */
     public static void exportToServer(LibertyServer server, String path, Archive<?> a) throws Exception {
-        exportToServer(server, path, a, false);
+        String serverDir = "publish/servers/" + server.getServerName();
+        exportArtifact(a, serverDir + '/' + path);
+        server.copyFileToLibertyServerRoot(serverDir + "/" + path, path, a.getName());
     }
 
     /**
@@ -49,37 +51,9 @@ public class ShrinkHelper {
      * autoFVT/publish/... and wlp/usr/...
      */
     public static void exportToClient(LibertyClient client, String path, Archive<?> a) throws Exception {
-        exportToClient(client, path, a, false);
-    }
-
-    /**
-     * Export an artifact to servers/$server.getName()/$path/$a.getName() under two directories:
-     * autoFVT/publish/... and wlp/usr/...
-     */
-    public static void exportToServer(LibertyServer server, String path, Archive<?> a, boolean overWrite) throws Exception {
-        String serverDir = "publish/servers/" + server.getServerName();
-        File outputFile = new File(serverDir + '/' + path, a.getName());
-        if (! outputFile.exists() || overWrite) {
-            exportArtifact(a, serverDir + '/' + path, true, overWrite);
-            server.copyFileToLibertyServerRoot(serverDir + "/" + path, path, a.getName());
-        } else {
-            Log.info(ShrinkHelper.class, "exportToServer", "Not exporting artifact because it already exists at " + outputFile.getAbsolutePath());
-        }
-    }
-
-    /**
-     * Export an artifact to clients/$client.getName()/$path/$a.getName() under two directories:
-     * autoFVT/publish/... and wlp/usr/...
-     */
-    public static void exportToClient(LibertyClient client, String path, Archive<?> a, boolean overWrite) throws Exception {
         String clientDir = "publish/clients/" + client.getClientName();
-        File outputFile = new File(clientDir + '/' + path, a.getName());
-        if (! outputFile.exists() || overWrite) {
-            exportArtifact(a, clientDir + '/' + path, true, overWrite);
-            client.copyFileToLibertyClientRoot(clientDir + "/" + path, path, a.getName());
-        } else {
-            Log.info(ShrinkHelper.class, "exportToClient", "Not exporting artifact because it already exists at " + outputFile.getAbsolutePath());
-        }
+        exportArtifact(a, clientDir + '/' + path);
+        client.copyFileToLibertyClientRoot(clientDir + "/" + path, path, a.getName());
     }
 
     /**


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#1986

Causes a failure among com.ibm.ws.CDI FATs due to a soft conflict with something @Azquelt delivered. 