### PR TITLE
Issue 2430: Make `@RegisterRestClient` a bean-defining annotation

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client.cdi/src/com/ibm/ws/microprofile/rest/client/cdi/LibertyRestClientExtension.java
+++ b/dev/com.ibm.ws.microprofile.rest.client.cdi/src/com/ibm/ws/microprofile/rest/client/cdi/LibertyRestClientExtension.java
@@ -33,11 +33,11 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.cdi.extension.WebSphereCDIExtension;
 
-@Component(configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true, property = { "api.classes=" +
-                                                                                            "org.eclipse.microprofile.rest.client.inject.RegisterRestClient;" +
-                                                                                            "org.eclipse.microprofile.rest.client.inject.RestClient;",
-                                                                                            "service.vendor=IBM"
-})
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true, property = 
+    { "api.classes=org.eclipse.microprofile.rest.client.inject.RegisterRestClient;" +
+                  "org.eclipse.microprofile.rest.client.inject.RestClient",
+      "bean.defining.annotations=org.eclipse.microprofile.rest.client.inject.RegisterRestClient",
+      "service.vendor=IBM"})
 public class LibertyRestClientExtension implements WebSphereCDIExtension, Extension {
     private final static TraceComponent tc = Tr.register(LibertyRestClientExtension.class);
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/BasicServiceClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/BasicServiceClient.java
@@ -12,7 +12,6 @@ package mpRestClient10.basicCdi;
 
 import java.util.Set;
 
-import javax.enterprise.context.Dependent;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -32,7 +31,6 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 @RegisterProvider(UnknownWidgetExceptionMapper.class)
 @RegisterRestClient
 @Path("/")
-@Dependent
 public interface BasicServiceClient {
     @GET
     Set<String> getWidgetNames();


### PR DESCRIPTION
Modifies an existing test to remove the `@Dependent` annotation to ensure
that the change works.

Resolved issue #2430