### PR TITLE
Fix MicroProfile FATs which repeat tests at the class level

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.2_fat/fat/src/com/ibm/ws/microprofile/config12/test/ImplicitConverterTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat/fat/src/com/ibm/ws/microprofile/config12/test/ImplicitConverterTest.java
@@ -43,13 +43,16 @@ import componenttest.topology.utils.FATServletClient;
 public class ImplicitConverterTest extends FATServletClient {
 
     public static final String APP_NAME = "converterApp";
+    private static final String SERVER_NAME = "ConverterServer";
 
-    @Server("ConverterServer")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = ImplicitConverterServlet.class, contextRoot = APP_NAME)
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES()).andWith(FeatureReplacementAction.EE8_FEATURES());
+    public static RepeatTests r = RepeatTests
+                    .with(FeatureReplacementAction.EE7_FEATURES().forServers(SERVER_NAME))
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().forServers(SERVER_NAME));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIBuiltInConverterTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIBuiltInConverterTest.java
@@ -33,10 +33,12 @@ import componenttest.rules.repeater.RepeatTests;
 public class CDIBuiltInConverterTest extends LoggingTest {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE7.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
+    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");
 
     @ClassRule
-    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");
+    public static RepeatTests r = RepeatTests
+                    .with(RepeatConfig11EE7.INSTANCE.forServers(SHARED_SERVER.getServerName()))
+                    .andWith(RepeatConfig12EE8.INSTANCE.forServers(SHARED_SERVER.getServerName()));
 
     @BuildShrinkWrap
     public static Archive buildApp() {

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIConfigPropertyTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIConfigPropertyTest.java
@@ -31,10 +31,12 @@ import componenttest.rules.repeater.RepeatTests;
 public class CDIConfigPropertyTest extends LoggingTest {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE7.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
+    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");
 
     @ClassRule
-    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");
+    public static RepeatTests r = RepeatTests
+                    .with(RepeatConfig11EE7.INSTANCE.forServers(SHARED_SERVER.getServerName()))
+                    .andWith(RepeatConfig12EE8.INSTANCE.forServers(SHARED_SERVER.getServerName()));
 
     @BuildShrinkWrap
     public static Archive buildApp() {

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIFieldInjectionTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIFieldInjectionTest.java
@@ -31,10 +31,12 @@ import componenttest.rules.repeater.RepeatTests;
 public class CDIFieldInjectionTest extends LoggingTest {
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE8.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
+    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");
 
     @ClassRule
-    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");
+    public static RepeatTests r = RepeatTests
+                    .with(RepeatConfig11EE8.INSTANCE.forServers(SHARED_SERVER.getServerName()))
+                    .andWith(RepeatConfig12EE8.INSTANCE.forServers(SHARED_SERVER.getServerName()));
 
     @BuildShrinkWrap
     public static Archive buildApp() {

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIXtorInjectionTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/CDIXtorInjectionTest.java
@@ -34,7 +34,9 @@ public class CDIXtorInjectionTest extends LoggingTest {
     public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("CDIConfigServer");
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE7.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
+    public static RepeatTests r = RepeatTests
+                    .with(RepeatConfig11EE7.INSTANCE.forServers(SHARED_SERVER.getServerName()))
+                    .andWith(RepeatConfig12EE8.INSTANCE.forServers(SHARED_SERVER.getServerName()));
 
     @BuildShrinkWrap
     public static Archive buildApp() {

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ConvertersTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ConvertersTest.java
@@ -38,10 +38,12 @@ public class ConvertersTest extends AbstractConfigApiTest {
     private final static String testClassName = "ConvertersTest";
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE8.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
+    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("ConvertersServer");
 
     @ClassRule
-    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("ConvertersServer");
+    public static RepeatTests r = RepeatTests
+                    .with(RepeatConfig11EE8.INSTANCE.forServers(SHARED_SERVER.getServerName()))
+                    .andWith(RepeatConfig12EE8.INSTANCE.forServers(SHARED_SERVER.getServerName()));
 
     @BuildShrinkWrap
     public static Archive buildApp() {

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DefaultSourcesTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DefaultSourcesTest.java
@@ -40,10 +40,12 @@ public class DefaultSourcesTest extends AbstractConfigApiTest {
     private final static String testClassName = "DefaultSourcesTest";
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE7.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
+    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("SimpleConfigSourcesServer");
 
     @ClassRule
-    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("SimpleConfigSourcesServer");
+    public static RepeatTests r = RepeatTests
+                    .with(RepeatConfig11EE7.INSTANCE.forServers(SHARED_SERVER.getServerName()))
+                    .andWith(RepeatConfig12EE8.INSTANCE.forServers(SHARED_SERVER.getServerName()));
 
     @BuildShrinkWrap
     public static Archive buildApp() {

--- a/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DynamicSourcesTest.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/DynamicSourcesTest.java
@@ -40,10 +40,12 @@ public class DynamicSourcesTest extends AbstractConfigApiTest {
     private final static String testClassName = "DynamicSourcesTest";
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(RepeatConfig11EE7.INSTANCE).andWith(RepeatConfig12EE8.INSTANCE);
+    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("DynamicSourcesServer");
 
     @ClassRule
-    public static SharedServer SHARED_SERVER = new ShrinkWrapSharedServer("DynamicSourcesServer");
+    public static RepeatTests r = RepeatTests
+                    .with(RepeatConfig11EE7.INSTANCE.forServers(SHARED_SERVER.getServerName()))
+                    .andWith(RepeatConfig12EE8.INSTANCE.forServers(SHARED_SERVER.getServerName()));
 
     public DynamicSourcesTest() {
         super("/dynamicSources/");

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/FATSuite.java
@@ -15,7 +15,6 @@ import java.io.File;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -33,7 +32,6 @@ import com.ibm.websphere.microprofile.faulttolerance_fat.tests.CDITimeoutTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.tests.TxRetryTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.validation.ValidationTest;
 import com.ibm.websphere.simplicity.ShrinkHelper;
-import com.ibm.ws.fat.util.SharedServer;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -51,8 +49,6 @@ import com.ibm.ws.fat.util.SharedServer;
 })
 
 public class FATSuite {
-
-    public static SharedServer MULTI_MODULE_SERVER = new SharedServer("FaultToleranceMultiModule");
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -76,14 +72,6 @@ public class FATSuite {
                         .addAsLibraries(faulttolerance_jar);
 
         ShrinkHelper.exportArtifact(txFaultTolerance_war, "publish/servers/TxFaultTolerance/dropins/");
-    }
-
-    @AfterClass
-    public static void shutdownMultiModuleServer() throws Exception {
-        if (MULTI_MODULE_SERVER.getLibertyServer().isStarted()) {
-            MULTI_MODULE_SERVER.getLibertyServer().stopServer("CWMFT50[01][0-9]E.*badMethod",
-                                                              "CWMFT5019W.*badMethod");
-        }
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIAsyncTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIAsyncTest.java
@@ -28,12 +28,13 @@ import componenttest.rules.repeater.RepeatTests;
 @Mode(TestMode.FULL)
 public class CDIAsyncTest extends LoggingTest {
 
+    @ClassRule
+    public static SharedServer SHARED_SERVER = new SharedServer("CDIFaultTolerance");
+
     //run against both EE8 and EE7 features
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE7_FEATURES());
-    @ClassRule
-    public static SharedServer SHARED_SERVER = new SharedServer("CDIFaultTolerance");
+                    .andWith(FeatureReplacementAction.EE7_FEATURES().forServers(SHARED_SERVER.getServerName()));
 
     @Test
     public void testAsync() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIFallbackTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIFallbackTest.java
@@ -33,7 +33,7 @@ public class CDIFallbackTest extends LoggingTest {
     //run against both EE8 and EE7 features
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE7_FEATURES());
+                    .andWith(FeatureReplacementAction.EE7_FEATURES().forServers(SHARED_SERVER.getServerName()));
 
     @Test
     public void testFallback() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIRetryTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIRetryTest.java
@@ -28,13 +28,13 @@ import componenttest.rules.repeater.RepeatTests;
 @Mode(TestMode.LITE)
 public class CDIRetryTest extends LoggingTest {
 
+    @ClassRule
+    public static SharedServer SHARED_SERVER = new SharedServer("CDIFaultTolerance");
+
     //run at least one test class with mpConfig-1.2 as well as 1.1
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new FeatureReplacementAction("mpConfig-1.1", "mpConfig-1.2"));
-
-    @ClassRule
-    public static SharedServer SHARED_SERVER = new SharedServer("CDIFaultTolerance");
+                    .andWith(new FeatureReplacementAction("mpConfig-1.1", "mpConfig-1.2").forServers(SHARED_SERVER.getServerName()));
 
     @Test
     public void testRetry() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDITimeoutTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDITimeoutTest.java
@@ -33,7 +33,7 @@ public class CDITimeoutTest extends LoggingTest {
     //run against both EE8 and EE7 features
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE7_FEATURES());
+                    .andWith(FeatureReplacementAction.EE7_FEATURES().forServers(SHARED_SERVER.getServerName()));
 
     @Test
     public void testTimeout() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/validation/AppValidator.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/validation/AppValidator.java
@@ -137,7 +137,8 @@ public class AppValidator {
                 RemoteFile logFile = server.getDefaultLogFile();
                 server.setMarkToEndOfLog(logFile);
 
-                ShrinkHelper.exportToServer(server, "dropins", app);
+                ShrinkHelper.exportArtifact(app, "tmp/apps");
+                server.copyFileToLibertyServerRoot("tmp/apps", "dropins", archiveName);
 
                 for (String stringToFind : stringsToFind) {
                     String logLine = server.waitForStringInLogUsingMark(stringToFind + "|" + APP_START_CODE + "|" + APP_FAIL_CODE);

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/validation/ValidationTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/validation/ValidationTest.java
@@ -10,20 +10,33 @@
  *******************************************************************************/
 package com.ibm.websphere.microprofile.faulttolerance_fat.validation;
 
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import com.ibm.websphere.microprofile.faulttolerance_fat.suite.FATSuite;
 import com.ibm.ws.fat.util.SharedServer;
 
+import componenttest.annotation.AllowedFFDC;
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+@AllowedFFDC
 public class ValidationTest {
 
     @ClassRule
-    public static SharedServer SHARED_SERVER = FATSuite.MULTI_MODULE_SERVER;
+    public static SharedServer SHARED_SERVER = new SharedServer("FaultToleranceMultiModule");
+
+    @AfterClass
+    public static void shutdown() throws Exception {
+        if (SHARED_SERVER.getLibertyServer().isStarted()) {
+            SHARED_SERVER.getLibertyServer().stopServer("CWMFT50[01][0-9]E.*badMethod",
+                                                        "CWMFT5019W.*badMethod");
+        }
+    }
 
     @Test
     public void testAsyncMethodNotReturningFuture() throws Exception {


### PR DESCRIPTION
When using RepeatTests at the class level (rather than the suite level)
you need to specify which servers should be updated, otherwise your
updates don't get propagated to the server.

Also, RepeatTests needs the server to be shut down at the end of the test class, so we can't start the server once in the suite and use it in multiple classes.

Also, `ShrinkHelper.exportToServer()` writes apps to the `publish` directory. This means that when the test is repeated, the app is already deployed to the server. In some cases this isn't desirable, so we either need to not use `exportToServer()` or we need to manually clean out the `publish` directory at the end of the test.