### PR TITLE
Externalize httpSessionCache config and add messages

### DIFF
--- a/dev/com.ibm.websphere.appserver.sessionCache-1.0/resources/l10n/com.ibm.websphere.appserver.sessionCache-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.sessionCache-1.0/resources/l10n/com.ibm.websphere.appserver.sessionCache-1.0.properties
@@ -14,4 +14,7 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=TODO write useful description for this feature before we beta it
+description=This feature enables persistence of HTTP sessions using JCache. Persisting \
+ HTTP session data using JCache allows for high performance HTTP session persistence \
+ without the use of a relational database. Failover of HTTP sessions can be achieved \
+ by configuring multiple servers to persist data to the same location.

--- a/dev/com.ibm.ws.session.cache/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache/bnd.bnd
@@ -21,7 +21,8 @@ javac.source: 1.8
 javac.target: 1.8
 
 Private-Package: \
-    com.ibm.ws.session.store.cache
+    com.ibm.ws.session.store.cache,\
+    com.ibm.ws.session.store.cache.resources
 
 Include-Resource: \
     OSGI-INF=resources/OSGI-INF

--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
@@ -14,3 +14,12 @@
 #NLS_ENCODING=UNICODE
 #NLS_MESSAGEFORMAT_NONE
 #
+
+libraryRef=Shared Library
+libraryRef.desc=Identifies JCache provider files.
+
+uri=JCache Configuration URI
+uri.desc=Vendor specific JCache configuration URI, which is passed to the JCache provider when obtaining the CacheManager.
+
+properties=JCache Configuration Properties
+properties.desc=List of vendor specific JCache configuration properties, which are passed to the JCache provider when obtaining the CacheManager.

--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
@@ -15,6 +15,9 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
+httpSessionCache=HTTP Session Cache
+httpSessionCache.desc=Controls how HTTP sessions are persisted using JCache.
+
 libraryRef=Shared Library
 libraryRef.desc=Identifies JCache provider files.
 

--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
@@ -18,12 +18,11 @@
   <Object ocdref="com.ibm.ws.session.cache"/>
  </Designate>
 
- <!-- TODO add NLS -->
  <OCD id="com.ibm.ws.session.cache" ibm:alias="httpSessionCache" name="internal" description="internal use only">
-  <AD id="libraryRef"                  type="String"  required="false" ibm:type="pid" ibm:reference="com.ibm.ws.classloading.sharedlibrary" cardinality="1" name="internal" description="internal use only"/>
+  <AD id="libraryRef"                  type="String"  required="false" ibm:type="pid" ibm:reference="com.ibm.ws.classloading.sharedlibrary" cardinality="1" name="%libraryRef" description="%libraryRef.desc"/>
   <AD id="library.target"              type="String"  default="(|(service.pid=${libraryRef})(&amp;(zero=${count(libraryRef)})(id=com.ibm.ws.session.cache.defaultprovider.library)))" ibm:final="true" name="internal" description="internal use only"/>  
   <AD id="service.ranking"             type="Integer" default="50" ibm:final="true" name="internal" description="internal use only"/> <!-- httpSessionDatabase takes precedence -->
-  <AD id="uri" type="String" ibm:type="location" required="false" name="internal" description="internal use only"/>
+  <AD id="uri" type="String" ibm:type="location" required="false" name="%uri" description="%uri.desc"/>
   <AD id="properties" name="internal" description="internal use only" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.session.cache.properties" ibm:flat="true"/>
  </OCD>
  
@@ -31,6 +30,6 @@
   	<Object ocdref="com.ibm.ws.session.cache.properties"/>
   </Designate>
  
- <OCD id="com.ibm.ws.session.cache.properties" name="internal" description="internal use only" ibmui:extraProperties="true" ibm:alias="properties" />
+ <OCD id="com.ibm.ws.session.cache.properties" name="%properties" description="%properties.desc" ibmui:extraProperties="true" ibm:alias="properties" />
  
 </metatype:MetaData>

--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
@@ -18,7 +18,7 @@
   <Object ocdref="com.ibm.ws.session.cache"/>
  </Designate>
 
- <OCD id="com.ibm.ws.session.cache" ibm:alias="httpSessionCache" name="internal" description="internal use only">
+ <OCD id="com.ibm.ws.session.cache" ibm:alias="httpSessionCache" name="%httpSessionCache" description="%httpSessionCache.desc">
   <AD id="libraryRef"                  type="String"  required="false" ibm:type="pid" ibm:reference="com.ibm.ws.classloading.sharedlibrary" cardinality="1" name="%libraryRef" description="%libraryRef.desc"/>
   <AD id="library.target"              type="String"  default="(|(service.pid=${libraryRef})(&amp;(zero=${count(libraryRef)})(id=com.ibm.ws.session.cache.defaultprovider.library)))" ibm:final="true" name="internal" description="internal use only"/>  
   <AD id="service.ranking"             type="Integer" default="50" ibm:final="true" name="internal" description="internal use only"/> <!-- httpSessionDatabase takes precedence -->

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
@@ -1,0 +1,22 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+
+# The range SESN0300 - SESN0350 has been reserved for use in this file
+
+INCORRECT_URI_SYNTAX=SESN0300E: Invalid syntax in httpSessionCache URI.  Cause is {0}.
+INCORRECT_URI_SYNTAX.explanation=The syntax of the specified httpSessionCache JCache configuration URI is invalid.
+INCORRECT_URI_SYNTAX.useraction=Correct the syntax of the specified httpSessionCache configuration URI.

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_cs.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_cs.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_de.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_de.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_es.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_es.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_fr.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_fr.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_hu.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_hu.nlsprops
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_it.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_it.nlsprops
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_ja.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_ja.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_ko.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_ko.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_pl.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_pl.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_pt_BR.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_pt_BR.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_ro.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_ro.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_ru.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_ru.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_zh.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_zh.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_zh_TW.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache_zh_TW.nlsprops
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+#COMPONENTPREFIX SESN
+#COMPONENTNAMEFOR SESN Session
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -87,7 +87,7 @@ public class CacheStoreService implements SessionStoreService {
             try {
                 uri = new URI(uriValue);
             } catch (URISyntaxException e) {
-                // TODO log error here
+                throw new IllegalArgumentException(Tr.formatMessage(tc, "INCORRECT_URI_SYNTAX", e), e);
             }
         
         for (Map.Entry<String, Object> entry : props.entrySet()) {
@@ -100,7 +100,6 @@ public class CacheStoreService implements SessionStoreService {
                 if (!key.equals("config.referenceType")) 
                     vendorProperties.setProperty(key, (String) value);
             }
-            //TODO add support for JCache spec "properties" 
         }
 
         // load JCache provider from configured library, which is either specified as a libraryRef or via a bell

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/package-info.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/package-info.java
@@ -9,5 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 @org.osgi.annotation.versioning.Version("1.1.0")
+@TraceOptions(messageBundle = "com.ibm.ws.session.store.cache.resources.WASSessionCache")
 package com.ibm.ws.session.store.cache;
 
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.session/resources/com/ibm/ws/session/resources/WASSessionCore.nlsprops
+++ b/dev/com.ibm.ws.session/resources/com/ibm/ws/session/resources/WASSessionCore.nlsprops
@@ -14,6 +14,11 @@
 #ISMESSAGEFILE TRUE
 #NLS_MESSAGEFORMAT_VAR
 #NLS_ENCODING=UNICODE
+
+# Note:
+# SESN0300 - SESN0350 has been reserved for use in: 
+# com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+
 SessionContext.createWhenStop=SESN0006E: There was an attempt to create a session while the application server was stopping.
 SessionContext.createWhenStop.explanation=This error occurs when a session request is received while the server is stopping.
 SessionContext.createWhenStop.useraction=Restart the server.


### PR DESCRIPTION
Externalize httpSessionCache config, add message files, and add a message for when a syntactically incorrect URI is specified.

Story #1829