### PR TITLE
test writeContents behaviors

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -28,8 +28,8 @@ import java.util.regex.Pattern;
 
 import javax.cache.Cache;
 import javax.cache.CacheException;
-import javax.cache.configuration.Configuration;
 import javax.cache.configuration.MutableConfiguration;
+import javax.cache.configuration.OptionalFeature;
 import javax.cache.expiry.EternalExpiryPolicy;
 
 import com.ibm.websphere.ras.Tr;
@@ -120,9 +120,11 @@ public class CacheHashMap extends BackedHashMap {
         sessionInfoCache = cacheStoreService.cacheManager.getCache(infoCacheName, String.class, ArrayList.class);
         if (sessionInfoCache == null) {
             @SuppressWarnings("rawtypes")
-            Configuration<String, ArrayList> config = new MutableConfiguration<String, ArrayList>()
+            MutableConfiguration<String, ArrayList> config = new MutableConfiguration<String, ArrayList>()
                             .setTypes(String.class, ArrayList.class)
                             .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
+            if (cacheStoreService.cachingProvider.isSupported(OptionalFeature.STORE_BY_REFERENCE))
+                config = config.setStoreByValue(false);
             try {
                 sessionInfoCache = cacheStoreService.cacheManager.createCache(infoCacheName, config);
 
@@ -145,9 +147,11 @@ public class CacheHashMap extends BackedHashMap {
 
         sessionPropertyCache = cacheStoreService.cacheManager.getCache(propCacheName, String.class, byte[].class);
         if (sessionPropertyCache == null) {
-            Configuration<String, byte[]> config = new MutableConfiguration<String, byte[]>()
+            MutableConfiguration<String, byte[]> config = new MutableConfiguration<String, byte[]>()
                             .setTypes(String.class, byte[].class)
                             .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
+            if (cacheStoreService.cachingProvider.isSupported(OptionalFeature.STORE_BY_REFERENCE))
+                config = config.setStoreByValue(false);
             try {
                 sessionPropertyCache = cacheStoreService.cacheManager.createCache(propCacheName, config);
 

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -55,6 +55,7 @@ public class CacheStoreService implements SessionStoreService {
     private static final int TOTAL_PREFIX_LENGTH = BASE_PREFIX_LENGTH + 3; //3 is the length of .0.
 
     CacheManager cacheManager;
+    CachingProvider cachingProvider;
 
     private volatile boolean completedPassivation = true;
 
@@ -103,8 +104,8 @@ public class CacheStoreService implements SessionStoreService {
         }
 
         // load JCache provider from configured library, which is either specified as a libraryRef or via a bell
-        CachingProvider provider = Caching.getCachingProvider(library.getClassLoader());
-        cacheManager = provider.getCacheManager(uri, null, vendorProperties);
+        cachingProvider = Caching.getCachingProvider(library.getClassLoader());
+        cacheManager = cachingProvider.getCacheManager(uri, null, vendorProperties);
     }
 
     @Override

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerA/server.xml
@@ -11,7 +11,7 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
 
-    <httpSessionCache libraryRef="HazelcastLib"/>
+    <httpSessionCache libraryRef="HazelcastLib" writeContents="ALL_SESSION_ATTRIBUTES"/>
 
     <library id="HazelcastLib">
         <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -214,6 +214,7 @@ public class SessionCacheTestServlet extends FATServlet {
         String key = request.getParameter("key");
         String expectedValue = request.getParameter("expectedValue");
         String type = request.getParameter("type");
+        boolean compareAsString = Boolean.parseBoolean(request.getParameter("compareAsString")); // useful if the class does not implement .equals
         Object expected = toType(type, expectedValue);
         HttpSession session = request.getSession(false);
         if (expectedValue == null && session == null) {
@@ -222,7 +223,21 @@ public class SessionCacheTestServlet extends FATServlet {
         }
         Object actualValue = session.getAttribute(key);
         System.out.println("Got entry: " + key + '=' + actualValue);
-        assertEquals(expected, actualValue);
+        if (compareAsString)
+            assertEquals(expected.toString(), actualValue.toString());
+        else
+            assertEquals(expected, actualValue);
+    }
+
+    /**
+     * Get a session attribute which is a StringBuffer and append characters,
+     * but don't set the attribute with the updated value.
+     */
+    public void testStringBufferAppendWithoutSetAttribute(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String key = request.getParameter("key");
+        HttpSession session = request.getSession(true);
+        StringBuffer value = (StringBuffer) session.getAttribute(key);
+        value.append("Appended");
     }
 
     /**


### PR DESCRIPTION
Test case that covers both behaviors of writeContents config. 
This includes:
    ALL_SESSION_ATTRIBUTES
    ONLY_UPDATED_ATTRIBUTES

Also, I'm including an update to switch the JCache provider to store-by-reference when supported.
Our implementation already includes the necessary logic to clone (or deserialize objects from byte[] which creates new instances) such that store-by-value is unnecessary