### PR TITLE
Add FFDCIgnore to updateNonRecurseFileMonitorService to match other methods

### DIFF
--- a/dev/com.ibm.ws.artifact.loose/src/com/ibm/ws/artifact/loose/internal/LooseArtifactNotifier.java
+++ b/dev/com.ibm.ws.artifact.loose/src/com/ibm/ws/artifact/loose/internal/LooseArtifactNotifier.java
@@ -339,6 +339,7 @@ public class LooseArtifactNotifier implements ArtifactNotifier, FileMonitor {
         }
     }
 
+    @FFDCIgnore(IllegalStateException.class)
     private synchronized void updateNonRecurseFileMonitorService(Set<String> dirs, Set<String> files) {
         if (nonRecurseService == null) {
             nonRecurseServiceProperties.put(Constants.SERVICE_VENDOR, "IBM");


### PR DESCRIPTION
There's a slim chance on server stop that and FFDC like this will emit:


``` Exception = java.lang.IllegalStateException
Source = com.ibm.ws.artifact.loose.internal.LooseArtifactNotifier
probeid = 383
Stack Dump = java.lang.IllegalStateException: The service has been unregistered
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.unregister(ServiceRegistrationImpl.java:206)
	at com.ibm.ws.artifact.loose.internal.LooseArtifactNotifier.updateNonRecurseFileMonitorService(LooseArtifactNotifier.java:382)
	at com.ibm.ws.artifact.loose.internal.LooseArtifactNotifier.updateFileMonitorService(LooseArtifactNotifier.java:290)
	at com.ibm.ws.artifact.loose.internal.LooseArtifactNotifier.processMonitoredPathList(LooseArtifactNotifier.java:238)
	at com.ibm.ws.artifact.loose.internal.LooseArtifactNotifier.removeListener(LooseArtifactNotifier.java:265)
	at com.ibm.ws.artifact.overlay.internal.DirectoryBasedOverlayNotifier.removeListener(DirectoryBasedOverlayNotifier.java:176)
	at com.ibm.ws.adaptable.module.internal.NotifierImpl.removeListener(NotifierImpl.java:87) 
```

the key part being the cut through LooseArchiveNotifier.updateNonRecurseFileMonitorService. The other methods in that class have FFDCIgnore on them, and the method itself simply eats the exception. It happens if we're still doing processing during a shutdown, and doesn't need to emit as an actual problem. 