### PR TITLE
Make the timeout more lenient on FT testTimeout

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/TimeoutServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/TimeoutServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/TimeoutServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/TimeoutServlet.java
@@ -56,7 +56,7 @@ public class TimeoutServlet extends FATServlet {
             //expected!
             long timeout = System.currentTimeMillis();
             long duration = timeout - start;
-            if (duration > 2000) { //the default timeout is 1000ms, if it takes 2000ms to fail then there is something wrong
+            if (duration > 3000) { //the default timeout is 1000ms, if it takes 3000ms to fail then there is something wrong
                 throw new AssertionError("TimeoutException not thrown quickly enough: " + timeout);
             }
         } catch (ConnectException e) {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/TimeoutServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/TimeoutServlet.java
@@ -57,7 +57,7 @@ public class TimeoutServlet extends FATServlet {
             long timeout = System.currentTimeMillis();
             long duration = timeout - start;
             if (duration > 3000) { //the default timeout is 1000ms, if it takes 3000ms to fail then there is something wrong
-                throw new AssertionError("TimeoutException not thrown quickly enough: " + timeout);
+                throw new AssertionError("TimeoutException not thrown quickly enough: " + duration);
             }
         } catch (ConnectException e) {
             throw new ServletException(e);
@@ -172,7 +172,7 @@ public class TimeoutServlet extends FATServlet {
             long timeout = System.currentTimeMillis();
             long duration = timeout - start;
             if (duration > 1000) { //the configured timeout is 500ms, if it takes 1000ms to fail then there is something wrong
-                throw new AssertionError("TimeoutException not thrown quickly enough: " + timeout);
+                throw new AssertionError("TimeoutException not thrown quickly enough: " + duration);
             }
         } catch (ConnectException e) {
             throw new ServletException(e);
@@ -200,7 +200,7 @@ public class TimeoutServlet extends FATServlet {
             long timeout = System.currentTimeMillis();
             long duration = timeout - start;
             if (duration > 1000) { //the configured timeout is 500ms, if it takes 1000ms to fail then there is something wrong
-                throw new AssertionError("TimeoutException not thrown quickly enough: " + timeout);
+                throw new AssertionError("TimeoutException not thrown quickly enough: " + duration);
             }
         } catch (ConnectException e) {
             throw new ServletException(e);


### PR DESCRIPTION
Make the timeout slightly more lenient on this first test which seems to do a bit of lazy initialization which can cause a spurious failure if the build hardware is particularly slow.

The test is now checking that the method returns within 3 seconds. If the timeout doesn't fire, it would take 20 seconds.

Also fixed up some of the error messages to make them more helpful.