### PR TITLE
test concurrent putAttribute for new session attributes

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheOneServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheOneServerTest.java
@@ -12,6 +12,10 @@ package com.ibm.ws.session.cache.fat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -31,6 +35,8 @@ public class SessionCacheOneServerTest extends FATServletClient {
 
     public static SessionCacheApp app = null;
 
+    public static final ExecutorService executor = Executors.newFixedThreadPool(10);
+
     @BeforeClass
     public static void setUp() throws Exception {
         app = new SessionCacheApp(server, "session.cache.web", "session.cache.web.listener1", "session.cache.web.listener2");
@@ -39,7 +45,57 @@ public class SessionCacheOneServerTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        executor.shutdownNow();
         server.stopServer();
+    }
+
+    /**
+     * Submit concurrent requests to put new attributes into a single session.
+     * Verify that all of the attributes (and no others) are added to the session, with their respective values.
+     */
+    @Test
+    public void testConcurrentPutNewAttributes() throws Exception {
+        final int NUM_THREADS = 9;
+
+        List<String> session = new ArrayList<>();
+
+        StringBuilder attributeNames = new StringBuilder("testConcurrentPutNewAttributes-key0");
+
+        List<Callable<Void>> puts = new ArrayList<Callable<Void>>();
+        List<Callable<Void>> gets = new ArrayList<Callable<Void>>();
+        for (int i = 1; i <= NUM_THREADS; i++) {
+            final int offset = i;
+            attributeNames.append(",testConcurrentPutNewAttributes-key").append(i);
+            puts.add(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    app.sessionPut("testConcurrentPutNewAttributes-key" + offset, 'A' + offset, session, true);
+                    return null;
+                }
+            });
+            gets.add(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    app.sessionGet("testConcurrentPutNewAttributes-key" + offset, 'A' + offset, session);
+                    return null;
+                }
+            });
+        }
+
+        app.sessionPut("testConcurrentPutNewAttributes-key0", 'A', session, true);
+        try {
+            List<Future<Void>> futures = executor.invokeAll(puts);
+            for (Future<Void> future : futures)
+                future.get(); // report any exceptions that might have occurred
+
+            app.invokeServlet("testAttributeNames&allowOtherAttributes=false&sessionAttributes=" + attributeNames, session);
+
+            futures = executor.invokeAll(gets);
+            for (Future<Void> future : futures)
+                future.get(); // report any exceptions that might have occurred
+        } finally {
+            app.invalidateSession(session);
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -20,8 +20,11 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -69,6 +72,24 @@ public class SessionCacheTestServlet extends FATServlet {
             System.out.println("Invalidating session: " + session.getId());
             session.invalidate();
         }
+    }
+
+    /**
+     * Verify that the session contains the specified attribute names.
+     */
+    public void testAttributeNames(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String[] expectedAttributes = request.getParameter("sessionAttributes").split(",");
+        boolean allowOtherAttributes = Boolean.parseBoolean(request.getParameter("allowOtherAttributes"));
+
+        HttpSession session = request.getSession(false);
+        Enumeration<String> attributeNames = session.getAttributeNames();
+
+        Collection<String> expected = Arrays.asList(expectedAttributes);
+        Collection<String> observed = Collections.list(attributeNames);
+        if (allowOtherAttributes)
+            assertTrue("Expected " + expected + ". Observed " + observed, observed.containsAll(expected));
+        else
+            assertEquals(new HashSet<String>(expected), new HashSet<String>(observed));
     }
 
     /**


### PR DESCRIPTION
Add a test that has multiple threads concurrently invoke putAttribute for the same session (but different session attributes).  Verify that all of the attributes get added and have the correct values, and that the list of attributes for the session is consistent.