### PR TITLE
additional multihreaded tests for session cache

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat/bnd.bnd
@@ -21,5 +21,6 @@ javac.source: 1.8
 javac.target: 1.8
 
 -buildpath: \
+    com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.jcache.1.1;version=latest,\
     com.ibm.websphere.javaee.servlet.3.1;version=latest

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.session.cache.fat;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,7 +40,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         appA = new SessionCacheApp(serverA, "session.cache.web"); // no HttpSessionListeners are registered by this app
-        appB = new SessionCacheApp(serverB, "session.cache.web", "session.cache.web.listener1");
+        appB = new SessionCacheApp(serverB, "session.cache.web", "session.cache.web.cdi", "session.cache.web.listener1");
         serverB.useSecondaryHTTPPort();
 
         serverA.startServer();
@@ -180,6 +182,24 @@ public class SessionCacheTwoServerTest extends FATServletClient {
             appA.sessionGet("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyNewValueAppended"), session);
         } finally {
             appA.invalidateSession(session);
+        }
+    }
+
+    /**
+     * Verify that SessionScoped CDI bean preserves its state across session calls.
+     */
+    @Test
+    public void testSessionScopedBean() throws Exception {
+        List<String> session = new ArrayList<>();
+        appB.sessionPut("testSessionScopedBean-key", 123.4f, session, true);
+        try {
+            String response1 = FATSuite.run(serverB, SessionCacheApp.APP_NAME + "/SessionCDITestServlet", "testUpdateSessionScopedBean&newValue=SSB1", session);
+            String response2 = FATSuite.run(serverB, SessionCacheApp.APP_NAME + "/SessionCDITestServlet", "testUpdateSessionScopedBean&newValue=SSB2", session);
+
+            assertTrue(response1, response1.contains("previous value for SessionScopedBean: [null]"));
+            assertTrue(response2, response2.contains("previous value for SessionScopedBean: [SSB1]"));
+        } finally {
+            appB.invalidateSession(session);
         }
     }
 }

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerB/server.xml
@@ -2,7 +2,8 @@
 
     <featureManager>
         <feature>bells-1.0</feature>
-        <feature>servlet-3.1</feature>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
         <feature>componenttest-1.0</feature>
         <feature>sessionCache-1.0</feature>
         <feature>timedexit-1.0</feature>
@@ -22,7 +23,6 @@
     <library id="HazelcastLibB">
         <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
     </library>
-    
     
     <variable name="hazelcast" value="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
     <javaPermission codebase="${hazelcast}" className="java.io.FilePermission" actions="read" name="hazelcast.xml"/>

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -211,7 +211,7 @@ public class SessionCacheTestServlet extends FATServlet {
         ArrayList<String> attributeNames = Collections.list(session.getAttributeNames());
         String attributeNamesString = attributeNames.toString();
         assertTrue(attributeNamesString, attributeNames.containsAll(Arrays.asList("map", "str", "appObject")));
-        assertEquals(attributeNamesString, 3, attributeNames.size());
+        assertEquals(attributeNamesString, attributeNames.contains("WELD_S_HASH") ? 4 : 3, attributeNames.size());
     }
 
     public void testSerializeDataSource(HttpServletRequest request, HttpServletResponse response) throws Throwable {

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -209,9 +209,15 @@ public class SessionCacheTestServlet extends FATServlet {
         assertTrue("indirect AppObject not deserialized properly", object.deserialized);
 
         ArrayList<String> attributeNames = Collections.list(session.getAttributeNames());
+        int weldCount = 0;
+        for (int i = attributeNames.size(); i-- > 0;) {
+            String name = attributeNames.get(i);
+            if (name.startsWith("WELD_S_") || name.contains(".weld."))
+                weldCount++;
+        }
         String attributeNamesString = attributeNames.toString();
         assertTrue(attributeNamesString, attributeNames.containsAll(Arrays.asList("map", "str", "appObject")));
-        assertEquals(attributeNamesString, attributeNames.contains("WELD_S_HASH") ? 4 : 3, attributeNames.size());
+        assertEquals(attributeNamesString, weldCount + 3, attributeNames.size());
     }
 
     public void testSerializeDataSource(HttpServletRequest request, HttpServletResponse response) throws Throwable {

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -27,6 +27,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -73,6 +74,24 @@ public class SessionCacheTestServlet extends FATServlet {
             System.out.println("Invalidating session: " + session.getId());
             session.invalidate();
         }
+    }
+
+    /**
+     * Verify that a session attribute has any of the specified values.
+     */
+    public void testAttributeIsAnyOf(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String key = request.getParameter("key");
+        String expectedValues = request.getParameter("values");
+        String type = request.getParameter("type");
+        Set<Object> expected = new HashSet<Object>();
+        for (String v : expectedValues.split(","))
+            expected.add(toType(type, v));
+
+        HttpSession session = request.getSession(false);
+        Object actualValue = session.getAttribute(key);
+        System.out.println("Got entry: " + key + '=' + actualValue + " from sessionID=" + session.getId());
+
+        assertTrue("value is " + actualValue + ", was expecting any of " + expected, expected.contains(actualValue));
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -324,6 +324,12 @@ public class SessionCacheTestServlet extends FATServlet {
             assertEquals(expectedValue, actualValue);
     }
 
+    public void sessionRemoveAttribute(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        String key = request.getParameter("key");
+        HttpSession session = request.getSession(false);
+        session.removeAttribute(key);
+    }
+
     /**
      * Get a session attribute which is a StringBuffer and append characters,
      * but don't set the attribute with the updated value.

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/cdi/SessionCDITestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/cdi/SessionCDITestServlet.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package session.cache.web.cdi;
+
+import java.io.IOException;
+import java.util.Enumeration;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/SessionCDITestServlet")
+public class SessionCDITestServlet extends FATServlet {
+    @Inject
+    SessionScopedBean bean;
+
+    /**
+     * Update a session scoped CDI bean with a new value supplied via the "newValue" parameter,
+     * writing the previous value to the servlet response.
+     */
+    public void testUpdateSessionScopedBean(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String newValue = request.getParameter("newValue");
+
+        HttpSession session = request.getSession();
+        String sessionId = session.getId();
+        System.out.println("session id is " + sessionId);
+
+        String previousValue = bean.stringValue;
+        System.out.println("previous value: " + previousValue);
+        bean.stringValue = newValue;
+        System.out.println("made update to: " + newValue);
+
+        response.getWriter().write("previous value for SessionScopedBean: [" + previousValue + "]");
+
+        for (Enumeration<String> attrs = session.getAttributeNames(); attrs.hasMoreElements();) {
+            String name = attrs.nextElement();
+            System.out.println("Session attribute " + name + ": " + session.getAttribute(name));
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/cdi/SessionScopedBean.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/cdi/SessionScopedBean.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package session.cache.web.cdi;
+
+import java.io.Serializable;
+
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+
+@Named
+@SessionScoped
+public class SessionScopedBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    String stringValue;
+}

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/cdi/SessionScopedBean1.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/cdi/SessionScopedBean1.java
@@ -17,8 +17,18 @@ import javax.inject.Named;
 
 @Named
 @SessionScoped
-public class SessionScopedBean implements Serializable {
+public class SessionScopedBean1 implements Serializable {
     private static final long serialVersionUID = 1L;
+    private String stringValue;
 
-    String stringValue;
+    public SessionScopedBean1() {}
+
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    public void setStringValue(String str) {
+        System.out.println("SessionScopedBean.setStringValue: [" + stringValue + "] -> [" + str + "]");
+        stringValue = str;
+    }
 }

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/cdi/SessionScopedBean2.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/cdi/SessionScopedBean2.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package session.cache.web.cdi;
+
+import java.io.Serializable;
+
+import javax.enterprise.context.SessionScoped;
+
+@SessionScoped
+public class SessionScopedBean2 implements Serializable {
+    private static final long serialVersionUID = 8257261434327004664L;
+    private String str;
+
+    public SessionScopedBean2() {}
+
+    public String getStr() {
+        return str;
+    }
+
+    public void setStr(String str) {
+        System.out.println("SessionScopedBean2.setStringValue: [" + this.str + "] -> [" + str + "]");
+        this.str = str;
+    }
+}


### PR DESCRIPTION
Various tests of session cache when multiple threads are attempting to perform updates/gets/removals of session attributes