### PR TITLE
Test that maxInactiveInterval is properly used for invalidation

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerA/server.xml
@@ -9,7 +9,7 @@
     
     <include location="../fatTestPorts.xml"/>
     
-    <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
+    <httpSession maxInMemorySessionCount="1" allowOverflow="false" invalidationTimeout="10m"/>
 
     <httpSessionCache libraryRef="HazelcastLib" writeContents="ALL_SESSION_ATTRIBUTES"/>
 

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerB/server.xml
@@ -16,7 +16,7 @@
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
     
-    <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
+    <httpSession maxInMemorySessionCount="1" allowOverflow="false" invalidationTimeout="10m"/>
 
     <bell libraryRef="HazelcastLibB" service="javax.cache.spi.CachingProvider"/>
 

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -342,6 +342,14 @@ public class SessionCacheTestServlet extends FATServlet {
     }
 
     /**
+     * Set the maxInactiveInterval for the given session to 1 second
+     */
+    public void setMaxInactiveInterval(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        HttpSession session = request.getSession(false);
+        session.setMaxInactiveInterval(1);
+    }
+
+    /**
      * Convert a String value to the specified type.
      * This is valid for the primitive wrapper classes (such as java.lang.Integer)
      * and any other type that has a single argument String constructor.


### PR DESCRIPTION
Adds a test to ensure that the value set on a session via setMaxInactiveInterval is used to invalidation in a session cache.