### PR TITLE
Issue #2577 - prevent arquillian based tests running on Java 9

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/fat/src/com/ibm/ws/microprofile/config12/tck/Config12TCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/fat/src/com/ibm/ws/microprofile/config12/tck/Config12TCKLauncher.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -26,6 +27,7 @@ import componenttest.topology.utils.MvnUtils;
  * There is a detailed output on specific
  */
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 1.8)
 public class Config12TCKLauncher {
 
     @Server("Config12TCKServer")

--- a/dev/com.ibm.ws.microprofile.config_fat_tck/fat/src/com/ibm/ws/microprofile/config/tck/ConfigTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.config_fat_tck/fat/src/com/ibm/ws/microprofile/config/tck/ConfigTCKLauncher.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -26,6 +27,7 @@ import componenttest.topology.utils.MvnUtils;
  * There is a detailed output on specific
  */
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 1.8)
 public class ConfigTCKLauncher {
 
     @Server("ConfigTCKServer")

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTckLauncher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTckLauncher.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -29,6 +30,7 @@ import componenttest.topology.utils.MvnUtils;
  * location.
  */
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 1.8)
 public class FaultToleranceTckLauncher {
 
     @Server("FaultToleranceTCKServer")

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -33,6 +34,7 @@ import componenttest.topology.utils.MvnUtils;
  * There is a detailed output on specific
  */
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 1.8)
 public class MetricsTCKLauncher {
     private static Class<?> c = MetricsTCKLauncher.class;
 

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsTCKLauncher.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -33,6 +34,7 @@ import componenttest.topology.utils.MvnUtils;
  * There is a detailed output on specific
  */
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 1.8)
 public class MetricsTCKLauncher {
     private static Class<?> c = MetricsTCKLauncher.class;
 

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/fat/src/org/eclipse/microprofile/openapi/fat/tck/OpenAPITckTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/fat/src/org/eclipse/microprofile/openapi/fat/tck/OpenAPITckTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -33,7 +34,7 @@ import com.ibm.websphere.simplicity.log.Log;
  * This is a test class that runs a whole Maven TCK as one test FAT test.
  * There is a detailed output on specific
  */
-@SuppressWarnings("restriction")
+@MaximumJavaLevel(javaLevel = 1.8)
 @RunWith(FATRunner.class)
 public class OpenAPITckTest {
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -11,11 +11,11 @@
 package org.eclipse.microprofile.rest.client.tck;
 
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -26,6 +26,7 @@ import componenttest.topology.utils.MvnUtils;
  * There is a detailed output on specific
  */
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 1.8)
 public class RestClientTckPackageTest {
 
     @Server("FATServer")


### PR DESCRIPTION
#build 
fixes #2577 