### PR TITLE
Revert "Fix build break caused by PR #2525"

### DIFF
--- a/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/test/EMQSychronousHandlerTest.java
+++ b/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/test/EMQSychronousHandlerTest.java
@@ -9,7 +9,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.ibm.ws.collector.manager.buffer.BufferManagerEMQHelper;
 import com.ibm.ws.collector.manager.buffer.BufferManagerImpl;
 
 import test.common.SharedOutputManager;
@@ -113,7 +112,7 @@ public class EMQSychronousHandlerTest {
         }
         testBufferManager.addSyncHandler(syncHandler);
         assertEquals(200, syncHandler.getNumOfMessages());
-        BufferManagerEMQHelper.removeEMQTrigger();
+        BufferManagerImpl.removeEMQTrigger();
 
         DummyHandler syncHandler2 = new DummyHandler();
         testBufferManager.add(syncHandler2);
@@ -122,8 +121,8 @@ public class EMQSychronousHandlerTest {
 
     @Test
     public void RemoveEMQ() {
-        BufferManagerEMQHelper.removeEMQTrigger();
-        assertTrue(BufferManagerEMQHelper.getEMQRemovedFlag());
+        BufferManagerImpl.removeEMQTrigger();
+        assertTrue(BufferManagerImpl.getEMQRemovedFlag());
     }
 
 }


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#2585


Shouldn't have gone in as a compile fix, the root PR that caused the break doesn't seem to have ever passed a build so we need to revert it instead of patching in place.