### PR TITLE
eclipse and bnd updates for new springboot components.

### DIFF
--- a/dev/com.ibm.ws.app.manager.springboot/bnd.bnd
+++ b/dev/com.ibm.ws.app.manager.springboot/bnd.bnd
@@ -12,6 +12,8 @@
 -nouses=true
 bVersion=1.0
 
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
 javac.source: 1.8
 javac.target: 1.8
 

--- a/dev/com.ibm.ws.springboot.support.shutdown/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support.shutdown/bnd.bnd
@@ -13,6 +13,8 @@
 
 bVersion=1.0
 
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
 javac.source: 1.8
 javac.target: 1.8
 

--- a/dev/com.ibm.ws.springboot.support.version15.test.app/.settings/org.eclipse.buildship.core.prefs
+++ b/dev/com.ibm.ws.springboot.support.version15.test.app/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=..
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.springboot.support.version15.test.app/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.springboot.support.version15.test.app/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.springboot.support.version20.test.app/.settings/org.eclipse.buildship.core.prefs
+++ b/dev/com.ibm.ws.springboot.support.version20.test.app/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=..
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.springboot.support.version20.test.app/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.springboot.support.version20.test.app/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.springboot.support.web.server.version15/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support.web.server.version15/bnd.bnd
@@ -13,6 +13,8 @@
 
 bVersion=1.0
 
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
 javac.source: 1.8
 javac.target: 1.8
 

--- a/dev/com.ibm.ws.springboot.support.web.server.version20/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support.web.server.version20/bnd.bnd
@@ -13,6 +13,8 @@
 
 bVersion=1.0
 
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
 javac.source: 1.8
 javac.target: 1.8
 

--- a/dev/com.ibm.ws.springboot.support.web.server/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support.web.server/bnd.bnd
@@ -13,6 +13,8 @@
 
 bVersion=1.0
 
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
 javac.source: 1.8
 javac.target: 1.8
 


### PR DESCRIPTION
Update springboot eclipse settings for test projects to be 1.8
compatibility checking.
Added the buildship eclipse files that eclipse and buildship likes to
see.
Added Require-Capacity for Java 8 in bnd files.