### PR TITLE
2255 master cache common fields for json logging

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
@@ -155,7 +155,7 @@ public class CollectorJsonHelpers {
     private static void addUnchangingFields(StringBuilder sb, String hostName, String wlpUserDir, String serverName) {
         if (unchangingFieldsJson == null) {
             StringBuilder temp = new StringBuilder(512);
-            addToJSON(temp, "host", hostName, false, false, false, false);
+            addToJSON(temp, "hostName", hostName, false, false, false, false);
             addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, false);
             addToJSON(temp, "serverName", serverName, false, false, false, false);
             unchangingFieldsJson = temp.toString();

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
@@ -17,21 +17,23 @@ import java.text.SimpleDateFormat;
  */
 public class CollectorJsonHelpers {
 
-    private static String start_message_json = null;
-    private static String start_message_json_1_1 = null;
-    private static String start_trace_json = null;
-    private static String start_trace_json_1_1 = null;
-    private static String start_ffdc_json = null;
-    private static String start_ffdc_json_1_1 = null;
-    private static String start_accesslog_json = null;
-    private static String start_accesslog_json_1_1 = null;
-    private static String start_gc_json = null;
-    private static String start_gc_json_1_1 = null;
-    private static String message_event_type_field_json = "\"type\":\"liberty_message\"";
-    private static String trace_event_type_field_json = "\"type\":\"liberty_trace\"";
-    private static String accesslog_event_type_field_json = "\"type\":\"liberty_accesslog\"";
-    private static String ffdc_event_type_field_json = "\"type\":\"liberty_ffdc\"";
-    private static String gc_event_type_field_json = "\"type\":\"liberty_gc\"";
+    private static String startMessageJson = null;
+    private static String startMessageJson1_1 = null;
+    private static String startTraceJson = null;
+    private static String startTraceJson1_1 = null;
+    private static String startFFDCJson = null;
+    private static String startFFDCJson1_1 = null;
+    private static String startAccessLogJson = null;
+    private static String startAccessLogJson1_1 = null;
+    private static String startGCJson = null;
+    private static String startGCJson1_1 = null;
+    private static final String messageEventTypeFieldJson = "\"type\":\"liberty_message\"";
+    private static final String traceEventTypeFieldJson = "\"type\":\"liberty_trace\"";
+    private static final String accessLogEventTypeFieldJson = "\"type\":\"liberty_accesslog\"";
+    private static final String ffdcEventTypeFieldJson = "\"type\":\"liberty_ffdc\"";
+    private static final String gcEventTypeFieldJson = "\"type\":\"liberty_gc\"";
+    private static String unchangingFieldsJson = null;
+    private static String unchangingFieldsJson1_1 = null;
 
     protected static String getEventType(String source, String location) {
         if (source.equals(CollectorConstants.GC_SOURCE) && location.equals(CollectorConstants.MEMORY)) {
@@ -150,47 +152,40 @@ public class CollectorJsonHelpers {
         }
     }
 
-    private static String unchanging_fields_json = null;
-
     private static void addUnchangingFields(StringBuilder sb, String hostName, String wlpUserDir, String serverName) {
-        if (unchanging_fields_json != null) {
-            sb.append(unchanging_fields_json);
-        } else {
+        if (unchangingFieldsJson == null) {
             StringBuilder temp = new StringBuilder(512);
             addToJSON(temp, "host", hostName, false, false, false, false);
             addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, false);
             addToJSON(temp, "serverName", serverName, false, false, false, false);
-            unchanging_fields_json = temp.toString();
-            sb.append(unchanging_fields_json);
+            unchangingFieldsJson = temp.toString();
         }
+        sb.append(unchangingFieldsJson);
     }
 
-    private static String unchanging_fields_json_1_1 = null;
-
     private static void addUnchangingFields1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName) {
-        if (unchanging_fields_json_1_1 != null) {
-            sb.append(unchanging_fields_json_1_1);
-        } else {
+        if (unchangingFieldsJson1_1 == null) {
             StringBuilder temp = new StringBuilder(512);
             addToJSON(temp, "host", hostName, false, false, false, false);
             addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, false);
             addToJSON(temp, "ibm_serverName", serverName, false, false, false, false);
-            unchanging_fields_json_1_1 = temp.toString();
-            sb.append(unchanging_fields_json_1_1);
+            unchangingFieldsJson1_1 = temp.toString();
         }
+        sb.append(unchangingFieldsJson1_1);
+
     }
 
     protected static StringBuilder startMessageJson(String hostName, String wlpUserDir, String serverName) {
         StringBuilder sb = new StringBuilder(512);
 
-        if (start_message_json != null) {
-            sb.append(start_message_json);
+        if (startMessageJson != null) {
+            sb.append(startMessageJson);
         } else {
             sb.append("{");
-            sb.append(message_event_type_field_json);
+            sb.append(messageEventTypeFieldJson);
             addUnchangingFields(sb, hostName, wlpUserDir, serverName);
 
-            start_message_json = sb.toString();
+            startMessageJson = sb.toString();
         }
 
         return sb;
@@ -199,14 +194,14 @@ public class CollectorJsonHelpers {
     protected static StringBuilder startTraceJson(String hostName, String wlpUserDir, String serverName) {
         StringBuilder sb = new StringBuilder(512);
 
-        if (start_trace_json != null) {
-            sb.append(start_trace_json);
+        if (startTraceJson != null) {
+            sb.append(startTraceJson);
         } else {
             sb.append("{");
-            sb.append(trace_event_type_field_json);
+            sb.append(traceEventTypeFieldJson);
             addUnchangingFields(sb, hostName, wlpUserDir, serverName);
 
-            start_trace_json = sb.toString();
+            startTraceJson = sb.toString();
         }
 
         return sb;
@@ -215,14 +210,14 @@ public class CollectorJsonHelpers {
     protected static StringBuilder startFFDCJson(String hostName, String wlpUserDir, String serverName) {
         StringBuilder sb = new StringBuilder(512);
 
-        if (start_ffdc_json != null) {
-            sb.append(start_ffdc_json);
+        if (startFFDCJson != null) {
+            sb.append(startFFDCJson);
         } else {
             sb.append("{");
-            sb.append(ffdc_event_type_field_json);
+            sb.append(ffdcEventTypeFieldJson);
             addUnchangingFields(sb, hostName, wlpUserDir, serverName);
 
-            start_ffdc_json = sb.toString();
+            startFFDCJson = sb.toString();
         }
 
         return sb;
@@ -231,14 +226,14 @@ public class CollectorJsonHelpers {
     protected static StringBuilder startAccessLogJson(String hostName, String wlpUserDir, String serverName) {
         StringBuilder sb = new StringBuilder(512);
 
-        if (start_accesslog_json != null) {
-            sb.append(start_accesslog_json);
+        if (startAccessLogJson != null) {
+            sb.append(startAccessLogJson);
         } else {
             sb.append("{");
-            sb.append(accesslog_event_type_field_json);
+            sb.append(accessLogEventTypeFieldJson);
             addUnchangingFields(sb, hostName, wlpUserDir, serverName);
 
-            start_accesslog_json = sb.toString();
+            startAccessLogJson = sb.toString();
         }
 
         return sb;
@@ -247,14 +242,14 @@ public class CollectorJsonHelpers {
     protected static StringBuilder startGCJson(String hostName, String wlpUserDir, String serverName) {
         StringBuilder sb = new StringBuilder(512);
 
-        if (start_gc_json != null) {
-            sb.append(start_gc_json);
+        if (startGCJson != null) {
+            sb.append(startGCJson);
         } else {
             sb.append("{");
-            sb.append(gc_event_type_field_json);
+            sb.append(gcEventTypeFieldJson);
             addUnchangingFields(sb, hostName, wlpUserDir, serverName);
 
-            start_gc_json = sb.toString();
+            startGCJson = sb.toString();
         }
 
         return sb;
@@ -263,14 +258,14 @@ public class CollectorJsonHelpers {
     protected static StringBuilder startMessageJson1_1(String hostName, String wlpUserDir, String serverName) {
         StringBuilder sb = new StringBuilder(512);
 
-        if (start_message_json_1_1 != null) {
-            sb.append(start_message_json_1_1);
+        if (startMessageJson1_1 != null) {
+            sb.append(startMessageJson1_1);
         } else {
             sb.append("{");
-            sb.append(message_event_type_field_json);
+            sb.append(messageEventTypeFieldJson);
             addUnchangingFields1_1(sb, hostName, wlpUserDir, serverName);
 
-            start_message_json_1_1 = sb.toString();
+            startMessageJson1_1 = sb.toString();
         }
 
         return sb;
@@ -279,14 +274,14 @@ public class CollectorJsonHelpers {
     protected static StringBuilder startTraceJson1_1(String hostName, String wlpUserDir, String serverName) {
         StringBuilder sb = new StringBuilder(512);
 
-        if (start_trace_json_1_1 != null) {
-            sb.append(start_trace_json_1_1);
+        if (startTraceJson1_1 != null) {
+            sb.append(startTraceJson1_1);
         } else {
             sb.append("{");
-            sb.append(trace_event_type_field_json);
+            sb.append(traceEventTypeFieldJson);
             addUnchangingFields1_1(sb, hostName, wlpUserDir, serverName);
 
-            start_trace_json_1_1 = sb.toString();
+            startTraceJson1_1 = sb.toString();
         }
 
         return sb;
@@ -295,14 +290,14 @@ public class CollectorJsonHelpers {
     protected static StringBuilder startFFDCJson1_1(String hostName, String wlpUserDir, String serverName) {
         StringBuilder sb = new StringBuilder(512);
 
-        if (start_ffdc_json_1_1 != null) {
-            sb.append(start_ffdc_json_1_1);
+        if (startFFDCJson1_1 != null) {
+            sb.append(startFFDCJson1_1);
         } else {
             sb.append("{");
-            sb.append(ffdc_event_type_field_json);
+            sb.append(ffdcEventTypeFieldJson);
             addUnchangingFields1_1(sb, hostName, wlpUserDir, serverName);
 
-            start_ffdc_json_1_1 = sb.toString();
+            startFFDCJson1_1 = sb.toString();
         }
 
         return sb;
@@ -311,14 +306,14 @@ public class CollectorJsonHelpers {
     protected static StringBuilder startAccessLogJson1_1(String hostName, String wlpUserDir, String serverName) {
         StringBuilder sb = new StringBuilder(512);
 
-        if (start_accesslog_json_1_1 != null) {
-            sb.append(start_accesslog_json_1_1);
+        if (startAccessLogJson1_1 != null) {
+            sb.append(startAccessLogJson1_1);
         } else {
             sb.append("{");
-            sb.append(accesslog_event_type_field_json);
+            sb.append(accessLogEventTypeFieldJson);
             addUnchangingFields1_1(sb, hostName, wlpUserDir, serverName);
 
-            start_accesslog_json_1_1 = sb.toString();
+            startAccessLogJson1_1 = sb.toString();
         }
 
         return sb;
@@ -327,14 +322,14 @@ public class CollectorJsonHelpers {
     protected static StringBuilder startGCJson1_1(String hostName, String wlpUserDir, String serverName) {
         StringBuilder sb = new StringBuilder(512);
 
-        if (start_gc_json_1_1 != null) {
-            sb.append(start_gc_json_1_1);
+        if (startGCJson1_1 != null) {
+            sb.append(startGCJson1_1);
         } else {
             sb.append("{");
-            sb.append(gc_event_type_field_json);
+            sb.append(gcEventTypeFieldJson);
             addUnchangingFields1_1(sb, hostName, wlpUserDir, serverName);
 
-            start_gc_json_1_1 = sb.toString();
+            startGCJson1_1 = sb.toString();
         }
 
         return sb;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
@@ -27,8 +27,11 @@ public class CollectorJsonHelpers {
     private static String start_accesslog_json_1_1 = null;
     private static String start_gc_json = null;
     private static String start_gc_json_1_1 = null;
-    private static String middle_gc_json = null;
-    private static String middle_gc_json_1_1 = null;
+    private static String message_event_type_field_json = "\"type\":\"liberty_message\"";
+    private static String trace_event_type_field_json = "\"type\":\"liberty_trace\"";
+    private static String accesslog_event_type_field_json = "\"type\":\"liberty_accesslog\"";
+    private static String ffdc_event_type_field_json = "\"type\":\"liberty_ffdc\"";
+    private static String gc_event_type_field_json = "\"type\":\"liberty_gc\"";
 
     protected static String getEventType(String source, String location) {
         if (source.equals(CollectorConstants.GC_SOURCE) && location.equals(CollectorConstants.MEMORY)) {
@@ -147,329 +150,194 @@ public class CollectorJsonHelpers {
         }
     }
 
-    protected static boolean startMessageJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                              boolean isFirstField) {
+    private static String unchanging_fields_json = null;
+
+    private static void addUnchangingFields(StringBuilder sb, String hostName, String wlpUserDir, String serverName) {
+        if (unchanging_fields_json != null) {
+            sb.append(unchanging_fields_json);
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+            addToJSON(temp, "host", hostName, false, false, false, false);
+            addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, false);
+            addToJSON(temp, "serverName", serverName, false, false, false, false);
+            unchanging_fields_json = temp.toString();
+            sb.append(unchanging_fields_json);
+        }
+    }
+
+    private static String unchanging_fields_json_1_1 = null;
+
+    private static void addUnchangingFields1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName) {
+        if (unchanging_fields_json_1_1 != null) {
+            sb.append(unchanging_fields_json_1_1);
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+            addToJSON(temp, "host", hostName, false, false, false, false);
+            addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, false);
+            addToJSON(temp, "ibm_serverName", serverName, false, false, false, false);
+            unchanging_fields_json_1_1 = temp.toString();
+            sb.append(unchanging_fields_json_1_1);
+        }
+    }
+
+    protected static StringBuilder startMessageJson(String hostName, String wlpUserDir, String serverName) {
+        StringBuilder sb = new StringBuilder(512);
+
         if (start_message_json != null) {
-            if (!start_message_json.isEmpty()) {
-                sb.append(start_message_json);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_message", false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
-
-            start_message_json = temp.toString();
             sb.append(start_message_json);
+        } else {
+            sb.append("{");
+            sb.append(message_event_type_field_json);
+            addUnchangingFields(sb, hostName, wlpUserDir, serverName);
+
+            start_message_json = sb.toString();
         }
 
-        return isFirstField;
+        return sb;
     }
 
-    protected static boolean startTraceJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                            boolean isFirstField) {
+    protected static StringBuilder startTraceJson(String hostName, String wlpUserDir, String serverName) {
+        StringBuilder sb = new StringBuilder(512);
+
         if (start_trace_json != null) {
-            if (!start_trace_json.isEmpty()) {
-                sb.append(start_trace_json);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_trace", false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
-
-            start_trace_json = temp.toString();
             sb.append(start_trace_json);
+        } else {
+            sb.append("{");
+            sb.append(trace_event_type_field_json);
+            addUnchangingFields(sb, hostName, wlpUserDir, serverName);
+
+            start_trace_json = sb.toString();
         }
 
-        return isFirstField;
+        return sb;
     }
 
-    protected static boolean startFFDCJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                           boolean isFirstField) {
+    protected static StringBuilder startFFDCJson(String hostName, String wlpUserDir, String serverName) {
+        StringBuilder sb = new StringBuilder(512);
+
         if (start_ffdc_json != null) {
-            if (!start_ffdc_json.isEmpty()) {
-                sb.append(start_ffdc_json);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_ffdc", false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
-
-            start_ffdc_json = temp.toString();
             sb.append(start_ffdc_json);
+        } else {
+            sb.append("{");
+            sb.append(ffdc_event_type_field_json);
+            addUnchangingFields(sb, hostName, wlpUserDir, serverName);
+
+            start_ffdc_json = sb.toString();
         }
 
-        return isFirstField;
+        return sb;
     }
 
-    protected static boolean startAccessLogJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                                boolean isFirstField) {
+    protected static StringBuilder startAccessLogJson(String hostName, String wlpUserDir, String serverName) {
+        StringBuilder sb = new StringBuilder(512);
+
         if (start_accesslog_json != null) {
-            if (!start_accesslog_json.isEmpty()) {
-                sb.append(start_accesslog_json);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_ffdc", false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
-
-            start_accesslog_json = temp.toString();
             sb.append(start_accesslog_json);
+        } else {
+            sb.append("{");
+            sb.append(accesslog_event_type_field_json);
+            addUnchangingFields(sb, hostName, wlpUserDir, serverName);
+
+            start_accesslog_json = sb.toString();
         }
 
-        return isFirstField;
+        return sb;
     }
 
-    protected static boolean startGenDataGCJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                                boolean isFirstField) {
+    protected static StringBuilder startGCJson(String hostName, String wlpUserDir, String serverName) {
+        StringBuilder sb = new StringBuilder(512);
+
         if (start_gc_json != null) {
-            if (!start_gc_json.isEmpty()) {
-                sb.append(start_gc_json);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_ffdc", false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
-
-            start_gc_json = temp.toString();
             sb.append(start_gc_json);
+        } else {
+            sb.append("{");
+            sb.append(gc_event_type_field_json);
+            addUnchangingFields(sb, hostName, wlpUserDir, serverName);
+
+            start_gc_json = sb.toString();
         }
 
-        return isFirstField;
+        return sb;
     }
 
-    protected static boolean startMessageJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                                 boolean isFirstField) {
+    protected static StringBuilder startMessageJson1_1(String hostName, String wlpUserDir, String serverName) {
+        StringBuilder sb = new StringBuilder(512);
+
         if (start_message_json_1_1 != null) {
-            if (!start_message_json_1_1.isEmpty()) {
-                sb.append(start_message_json_1_1);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_message", false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
-
-            start_message_json_1_1 = temp.toString();
             sb.append(start_message_json_1_1);
+        } else {
+            sb.append("{");
+            sb.append(message_event_type_field_json);
+            addUnchangingFields1_1(sb, hostName, wlpUserDir, serverName);
+
+            start_message_json_1_1 = sb.toString();
         }
 
-        return isFirstField;
+        return sb;
     }
 
-    protected static boolean startTraceJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                               boolean isFirstField) {
+    protected static StringBuilder startTraceJson1_1(String hostName, String wlpUserDir, String serverName) {
+        StringBuilder sb = new StringBuilder(512);
+
         if (start_trace_json_1_1 != null) {
-            if (!start_trace_json_1_1.isEmpty()) {
-                sb.append(start_trace_json_1_1);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_trace", false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
-
-            start_trace_json_1_1 = temp.toString();
             sb.append(start_trace_json_1_1);
+        } else {
+            sb.append("{");
+            sb.append(trace_event_type_field_json);
+            addUnchangingFields1_1(sb, hostName, wlpUserDir, serverName);
+
+            start_trace_json_1_1 = sb.toString();
         }
 
-        return isFirstField;
+        return sb;
     }
 
-    protected static boolean startFFDCJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                              boolean isFirstField) {
+    protected static StringBuilder startFFDCJson1_1(String hostName, String wlpUserDir, String serverName) {
+        StringBuilder sb = new StringBuilder(512);
+
         if (start_ffdc_json_1_1 != null) {
-            if (!start_ffdc_json_1_1.isEmpty()) {
-                sb.append(start_ffdc_json_1_1);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", CollectorConstants.FFDC_EVENT_TYPE, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
-
-            start_ffdc_json_1_1 = temp.toString();
             sb.append(start_ffdc_json_1_1);
+        } else {
+            sb.append("{");
+            sb.append(ffdc_event_type_field_json);
+            addUnchangingFields1_1(sb, hostName, wlpUserDir, serverName);
+
+            start_ffdc_json_1_1 = sb.toString();
         }
 
-        return isFirstField;
+        return sb;
     }
 
-    protected static boolean startAccessLogJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                                   boolean isFirstField) {
+    protected static StringBuilder startAccessLogJson1_1(String hostName, String wlpUserDir, String serverName) {
+        StringBuilder sb = new StringBuilder(512);
+
         if (start_accesslog_json_1_1 != null) {
-            if (!start_accesslog_json_1_1.isEmpty()) {
-                sb.append(start_accesslog_json_1_1);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", CollectorConstants.ACCESS_LOG_EVENT_TYPE, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
-
-            start_accesslog_json_1_1 = temp.toString();
             sb.append(start_accesslog_json_1_1);
+        } else {
+            sb.append("{");
+            sb.append(accesslog_event_type_field_json);
+            addUnchangingFields1_1(sb, hostName, wlpUserDir, serverName);
+
+            start_accesslog_json_1_1 = sb.toString();
         }
 
-        return isFirstField;
+        return sb;
     }
 
-    protected static boolean startGenDataGCJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                                   boolean isFirstField) {
+    protected static StringBuilder startGCJson1_1(String hostName, String wlpUserDir, String serverName) {
+        StringBuilder sb = new StringBuilder(512);
+
         if (start_gc_json_1_1 != null) {
-            if (!start_gc_json_1_1.isEmpty()) {
-                sb.append(start_gc_json_1_1);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", CollectorConstants.GC_EVENT_TYPE, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
-
-            start_gc_json_1_1 = temp.toString();
             sb.append(start_gc_json_1_1);
-        }
-
-        return isFirstField;
-    }
-
-    protected static boolean startGCJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName, long timestamp, String sequenceNum,
-                                            boolean isFirstField) {
-        String datetime = dateFormatTL.get().format(timestamp);
-
-        /* Common fields for all event types */
-
-        isFirstField = isFirstField & !addToJSON(sb, "ibm_datetime", datetime, false, false, false, isFirstField);
-
-        middleGCJson1_1(sb, hostName, wlpUserDir, serverName, timestamp, sequenceNum, isFirstField);
-
-        isFirstField = isFirstField & !addToJSON(sb, "ibm_sequence", sequenceNum, false, false, false, isFirstField);
-        return isFirstField;
-    }
-
-    protected static boolean middleGCJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName, long timestamp, String sequenceNum,
-                                             boolean isFirstField) {
-
-        if (middle_gc_json_1_1 != null) {
-            if (!middle_gc_json_1_1.isEmpty()) {
-                if (!isFirstField) {
-                    sb.append(",");
-                }
-                sb.append(middle_gc_json_1_1);
-                isFirstField = false;
-            }
         } else {
-            StringBuilder temp = new StringBuilder(512);
+            sb.append("{");
+            sb.append(gc_event_type_field_json);
+            addUnchangingFields1_1(sb, hostName, wlpUserDir, serverName);
 
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", CollectorConstants.GC_EVENT_TYPE, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
-
-            middle_gc_json_1_1 = temp.toString();
-            sb.append(middle_gc_json_1_1);
+            start_gc_json_1_1 = sb.toString();
         }
 
-        return isFirstField;
-    }
-
-    protected static boolean startGCJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName, long timestamp, String sequenceNum,
-                                         boolean isFirstField) {
-        String datetime = dateFormatTL.get().format(timestamp);
-
-        /* Common fields for all event types */
-
-        isFirstField = isFirstField & !addToJSON(sb, "datetime", datetime, false, false, false, isFirstField);
-
-        middleGCJson(sb, hostName, wlpUserDir, serverName, timestamp, sequenceNum,
-                     isFirstField);
-
-        isFirstField = isFirstField & !addToJSON(sb, "sequence", sequenceNum, false, false, false, isFirstField);
-        return isFirstField;
-    }
-
-    protected static boolean middleGCJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName, long timestamp, String sequenceNum,
-                                          boolean isFirstField) {
-
-        if (middle_gc_json != null) {
-            if (!middle_gc_json.isEmpty()) {
-                if (!isFirstField) {
-                    sb.append(",");
-                }
-                sb.append(middle_gc_json);
-                isFirstField = false;
-            }
-        } else {
-            StringBuilder temp = new StringBuilder(512);
-
-            /* Common fields for all event types */
-
-            isFirstField = isFirstField & !addToJSON(temp, "type", CollectorConstants.GC_EVENT_TYPE, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
-            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
-
-            middle_gc_json = temp.toString();
-            sb.append(middle_gc_json);
-        }
-
-        return isFirstField;
+        return sb;
     }
 
     protected static String formatMessage(String message, int maxLength) {
@@ -489,7 +357,7 @@ public class CollectorJsonHelpers {
     }
 
     protected static String jsonifyTags(String[] tags) {
-        StringBuilder sb = new StringBuilder(512);
+        StringBuilder sb = new StringBuilder(64);
 
         sb.append("[");
         for (int i = 0; i < tags.length; i++) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
@@ -17,6 +17,19 @@ import java.text.SimpleDateFormat;
  */
 public class CollectorJsonHelpers {
 
+    private static String start_message_json = null;
+    private static String start_message_json_1_1 = null;
+    private static String start_trace_json = null;
+    private static String start_trace_json_1_1 = null;
+    private static String start_ffdc_json = null;
+    private static String start_ffdc_json_1_1 = null;
+    private static String start_accesslog_json = null;
+    private static String start_accesslog_json_1_1 = null;
+    private static String start_gc_json = null;
+    private static String start_gc_json_1_1 = null;
+    private static String middle_gc_json = null;
+    private static String middle_gc_json_1_1 = null;
+
     protected static String getEventType(String source, String location) {
         if (source.equals(CollectorConstants.GC_SOURCE) && location.equals(CollectorConstants.MEMORY)) {
             return CollectorConstants.GC_EVENT_TYPE;
@@ -134,55 +147,328 @@ public class CollectorJsonHelpers {
         }
     }
 
-    protected static boolean addCommonFields(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                             boolean isFirstField, String eventType) {
+    protected static boolean startMessageJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
+                                              boolean isFirstField) {
+        if (start_message_json != null) {
+            if (!start_message_json.isEmpty()) {
+                sb.append(start_message_json);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
 
-        isFirstField = isFirstField & !addToJSON(sb, "type", eventType, false, false, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "hostName", hostName, false, false, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "serverName", serverName, false, false, false, isFirstField);
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_message", false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
+
+            start_message_json = temp.toString();
+            sb.append(start_message_json);
+        }
 
         return isFirstField;
     }
 
-    protected static boolean addCommonFields1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
-                                                boolean isFirstField, String eventType) {
+    protected static boolean startTraceJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
+                                            boolean isFirstField) {
+        if (start_trace_json != null) {
+            if (!start_trace_json.isEmpty()) {
+                sb.append(start_trace_json);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
 
-        isFirstField = isFirstField & !addToJSON(sb, "type", eventType, false, false, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "host", hostName, false, false, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "ibm_serverName", serverName, false, false, false, isFirstField);
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_trace", false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
+
+            start_trace_json = temp.toString();
+            sb.append(start_trace_json);
+        }
 
         return isFirstField;
     }
 
-    protected static boolean addCommonFieldsGC1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName, long timestamp, String sequenceNum,
-                                                  boolean isFirstField, String eventType) {
+    protected static boolean startFFDCJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
+                                           boolean isFirstField) {
+        if (start_ffdc_json != null) {
+            if (!start_ffdc_json.isEmpty()) {
+                sb.append(start_ffdc_json);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_ffdc", false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
+
+            start_ffdc_json = temp.toString();
+            sb.append(start_ffdc_json);
+        }
+
+        return isFirstField;
+    }
+
+    protected static boolean startAccessLogJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
+                                                boolean isFirstField) {
+        if (start_accesslog_json != null) {
+            if (!start_accesslog_json.isEmpty()) {
+                sb.append(start_accesslog_json);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_ffdc", false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
+
+            start_accesslog_json = temp.toString();
+            sb.append(start_accesslog_json);
+        }
+
+        return isFirstField;
+    }
+
+    protected static boolean startGenDataGCJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
+                                                boolean isFirstField) {
+        if (start_gc_json != null) {
+            if (!start_gc_json.isEmpty()) {
+                sb.append(start_gc_json);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_ffdc", false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
+
+            start_gc_json = temp.toString();
+            sb.append(start_gc_json);
+        }
+
+        return isFirstField;
+    }
+
+    protected static boolean startMessageJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
+                                                 boolean isFirstField) {
+        if (start_message_json_1_1 != null) {
+            if (!start_message_json_1_1.isEmpty()) {
+                sb.append(start_message_json_1_1);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_message", false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
+
+            start_message_json_1_1 = temp.toString();
+            sb.append(start_message_json_1_1);
+        }
+
+        return isFirstField;
+    }
+
+    protected static boolean startTraceJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
+                                               boolean isFirstField) {
+        if (start_trace_json_1_1 != null) {
+            if (!start_trace_json_1_1.isEmpty()) {
+                sb.append(start_trace_json_1_1);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", "liberty_trace", false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
+
+            start_trace_json_1_1 = temp.toString();
+            sb.append(start_trace_json_1_1);
+        }
+
+        return isFirstField;
+    }
+
+    protected static boolean startFFDCJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
+                                              boolean isFirstField) {
+        if (start_ffdc_json_1_1 != null) {
+            if (!start_ffdc_json_1_1.isEmpty()) {
+                sb.append(start_ffdc_json_1_1);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", CollectorConstants.FFDC_EVENT_TYPE, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
+
+            start_ffdc_json_1_1 = temp.toString();
+            sb.append(start_ffdc_json_1_1);
+        }
+
+        return isFirstField;
+    }
+
+    protected static boolean startAccessLogJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
+                                                   boolean isFirstField) {
+        if (start_accesslog_json_1_1 != null) {
+            if (!start_accesslog_json_1_1.isEmpty()) {
+                sb.append(start_accesslog_json_1_1);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", CollectorConstants.ACCESS_LOG_EVENT_TYPE, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
+
+            start_accesslog_json_1_1 = temp.toString();
+            sb.append(start_accesslog_json_1_1);
+        }
+
+        return isFirstField;
+    }
+
+    protected static boolean startGenDataGCJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName,
+                                                   boolean isFirstField) {
+        if (start_gc_json_1_1 != null) {
+            if (!start_gc_json_1_1.isEmpty()) {
+                sb.append(start_gc_json_1_1);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", CollectorConstants.GC_EVENT_TYPE, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
+
+            start_gc_json_1_1 = temp.toString();
+            sb.append(start_gc_json_1_1);
+        }
+
+        return isFirstField;
+    }
+
+    protected static boolean startGCJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName, long timestamp, String sequenceNum,
+                                            boolean isFirstField) {
         String datetime = dateFormatTL.get().format(timestamp);
 
         /* Common fields for all event types */
 
         isFirstField = isFirstField & !addToJSON(sb, "ibm_datetime", datetime, false, false, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "type", eventType, false, false, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "host", hostName, false, false, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "ibm_serverName", serverName, false, false, false, isFirstField);
+
+        middleGCJson1_1(sb, hostName, wlpUserDir, serverName, timestamp, sequenceNum, isFirstField);
+
         isFirstField = isFirstField & !addToJSON(sb, "ibm_sequence", sequenceNum, false, false, false, isFirstField);
         return isFirstField;
     }
 
-    protected static boolean addCommonFieldsGC(StringBuilder sb, String hostName, String wlpUserDir, String serverName, long timestamp, String sequenceNum,
-                                               boolean isFirstField, String eventType) {
+    protected static boolean middleGCJson1_1(StringBuilder sb, String hostName, String wlpUserDir, String serverName, long timestamp, String sequenceNum,
+                                             boolean isFirstField) {
+
+        if (middle_gc_json_1_1 != null) {
+            if (!middle_gc_json_1_1.isEmpty()) {
+                if (!isFirstField) {
+                    sb.append(",");
+                }
+                sb.append(middle_gc_json_1_1);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", CollectorConstants.GC_EVENT_TYPE, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_userDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "ibm_serverName", serverName, false, false, false, isFirstField);
+
+            middle_gc_json_1_1 = temp.toString();
+            sb.append(middle_gc_json_1_1);
+        }
+
+        return isFirstField;
+    }
+
+    protected static boolean startGCJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName, long timestamp, String sequenceNum,
+                                         boolean isFirstField) {
         String datetime = dateFormatTL.get().format(timestamp);
 
         /* Common fields for all event types */
 
         isFirstField = isFirstField & !addToJSON(sb, "datetime", datetime, false, false, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "type", eventType, false, false, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "hostName", hostName, false, false, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
-        isFirstField = isFirstField & !addToJSON(sb, "serverName", serverName, false, false, false, isFirstField);
+
+        middleGCJson(sb, hostName, wlpUserDir, serverName, timestamp, sequenceNum,
+                     isFirstField);
+
         isFirstField = isFirstField & !addToJSON(sb, "sequence", sequenceNum, false, false, false, isFirstField);
+        return isFirstField;
+    }
+
+    protected static boolean middleGCJson(StringBuilder sb, String hostName, String wlpUserDir, String serverName, long timestamp, String sequenceNum,
+                                          boolean isFirstField) {
+
+        if (middle_gc_json != null) {
+            if (!middle_gc_json.isEmpty()) {
+                if (!isFirstField) {
+                    sb.append(",");
+                }
+                sb.append(middle_gc_json);
+                isFirstField = false;
+            }
+        } else {
+            StringBuilder temp = new StringBuilder(512);
+
+            /* Common fields for all event types */
+
+            isFirstField = isFirstField & !addToJSON(temp, "type", CollectorConstants.GC_EVENT_TYPE, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "host", hostName, false, false, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "wlpUserDir", wlpUserDir, false, true, false, isFirstField);
+            isFirstField = isFirstField & !addToJSON(temp, "serverName", serverName, false, false, false, isFirstField);
+
+            middle_gc_json = temp.toString();
+            sb.append(middle_gc_json);
+        }
+
         return isFirstField;
     }
 
@@ -203,7 +489,7 @@ public class CollectorJsonHelpers {
     }
 
     protected static String jsonifyTags(String[] tags) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
 
         sb.append("[");
         for (int i = 0; i < tags.length; i++) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
@@ -90,22 +90,20 @@ public class CollectorJsonUtils {
 
     private static String jsonifyGCEvent(String hostName, String wlpUserDir, String serverName, HCGCData hcGCData, String[] tags) {
         String sequenceNum = hcGCData.getSequence();
-        StringBuilder sb = new StringBuilder(512);
-        boolean isFirstField = true;
-
-        sb.append("{");
 
         //                                           name        value     jsonEscapeName? jsonEscapeValue? trim?   isFirst?
         /* Common fields for all event types */
-        isFirstField = CollectorJsonHelpers.startGCJson(sb, hostName, wlpUserDir, serverName, hcGCData.getTime(), sequenceNum, isFirstField);
+        StringBuilder sb = CollectorJsonHelpers.startGCJson(hostName, wlpUserDir, serverName);
+        String datetime = CollectorJsonHelpers.dateFormatTL.get().format(hcGCData.getTime());
+        CollectorJsonHelpers.addToJSON(sb, "datetime", datetime, false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "sequence", sequenceNum, false, false, false, false);
         /* GC specific fields */
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "heap", String.valueOf((long) hcGCData.getHeap()), false, false, false, isFirstField);
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "usedHeap", String.valueOf((long) hcGCData.getUsage()), false, false, false, isFirstField);
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "maxHeap", String.valueOf(hcGCData.getMaxHeap()), false, false, false, isFirstField);
-        isFirstField = isFirstField
-                       & !CollectorJsonHelpers.addToJSON(sb, "duration", String.valueOf((long) hcGCData.getDuration() * 1000), false, false, false, isFirstField);
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "gcType", hcGCData.getType(), false, false, false, isFirstField);
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "reason", hcGCData.getReason(), false, false, false, isFirstField);
+        CollectorJsonHelpers.addToJSON(sb, "heap", String.valueOf((long) hcGCData.getHeap()), false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "usedHeap", String.valueOf((long) hcGCData.getUsage()), false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "maxHeap", String.valueOf(hcGCData.getMaxHeap()), false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "duration", String.valueOf((long) hcGCData.getDuration() * 1000), false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "gcType", hcGCData.getType(), false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "reason", hcGCData.getReason(), false, false, false, false);
 
         if (tags != null) {
             addTagNameForVersion(sb).append(CollectorJsonHelpers.jsonifyTags(tags));
@@ -119,16 +117,12 @@ public class CollectorJsonUtils {
     private static String jsonifyGCEvent(int maxFieldLength, String wlpUserDir,
                                          String serverName, String hostName, String eventType, Object event, String[] tags) {
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder(512);
-        boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
         String key = null;
         String value = null;
 
-        sb.append("{");
-
-        isFirstField = CollectorJsonHelpers.startGenDataGCJson(sb, hostName, wlpUserDir, serverName, isFirstField);
+        StringBuilder sb = CollectorJsonHelpers.startGCJson(hostName, wlpUserDir, serverName);
 
         for (Pair p : pairs) {
 
@@ -142,19 +136,19 @@ public class CollectorJsonUtils {
 
                     key = LogFieldConstants.DURATION;
                     long duration = Long.parseLong(value) * 1000;
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, Long.toString(duration), false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, Long.toString(duration), false, true, false, false, kvp.isNumber());
 
                 } else if (key.equals(LogFieldConstants.IBM_DATETIME)) {
 
                     key = LogFieldConstants.DATETIME;
                     String datetime = CollectorJsonHelpers.dateFormatTL.get().format(Long.parseLong(value));
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, isFirstField, false);
+                    CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, false, false);
 
                 } else {
                     if (key.contains(LogFieldConstants.IBM_TAG)) {
                         key = CollectorJsonHelpers.removeIBMTag(key);
                     }
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, false, kvp.isNumber());
                 }
             }
 
@@ -171,19 +165,16 @@ public class CollectorJsonUtils {
                                                  String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder(512);
-        boolean isFirstField = true;
+        StringBuilder sb = null;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
         String key = null;
         String value = null;
 
-        sb.append("{");
-
         if (eventType.equals(CollectorConstants.MESSAGES_LOG_EVENT_TYPE))
-            isFirstField = CollectorJsonHelpers.startMessageJson(sb, hostName, wlpUserDir, serverName, isFirstField);
+            sb = CollectorJsonHelpers.startMessageJson(hostName, wlpUserDir, serverName);
         if (eventType.equals(CollectorConstants.TRACE_LOG_EVENT_TYPE))
-            isFirstField = CollectorJsonHelpers.startTraceJson(sb, hostName, wlpUserDir, serverName, isFirstField);
+            sb = CollectorJsonHelpers.startTraceJson(hostName, wlpUserDir, serverName);
 
         for (Pair p : pairs) {
 
@@ -199,27 +190,26 @@ public class CollectorJsonUtils {
                 else if (key.equals(LogFieldConstants.MESSAGE)) {
 
                     String formattedValue = CollectorJsonHelpers.formatMessage(value, maxFieldLength);
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, formattedValue, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, formattedValue, false, true, false, false, kvp.isNumber());
 
                 } else if (key.equals(LogFieldConstants.IBM_THREADID)) {
                     key = LogFieldConstants.THREADID;
-                    isFirstField = isFirstField
-                                   & !CollectorJsonHelpers.addToJSON(sb, key, DataFormatHelper.padHexString(Integer.parseInt(value), 8), false, true, false, isFirstField,
-                                                                     false);
+                    CollectorJsonHelpers.addToJSON(sb, key, DataFormatHelper.padHexString(Integer.parseInt(value), 8), false, true, false, false,
+                                                   false);
 
                 } else if (key.equals(LogFieldConstants.IBM_DATETIME)) {
                     key = LogFieldConstants.DATETIME;
                     String datetime = CollectorJsonHelpers.dateFormatTL.get().format(Long.parseLong(value));
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, isFirstField, false);
+                    CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, false, false);
 
                 } else if (key.equals(LogFieldConstants.MODULE)) {
                     key = LogFieldConstants.LOGGERNAME;
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, false, kvp.isNumber());
                 } else {
                     if (key.contains(LogFieldConstants.IBM_TAG)) {
                         key = CollectorJsonHelpers.removeIBMTag(key);
                     }
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, false, kvp.isNumber());
 
                 }
             }
@@ -238,16 +228,12 @@ public class CollectorJsonUtils {
                                       String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder(512);
-        boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
         String key = null;
         String value = null;
 
-        sb.append("{");
-
-        isFirstField = CollectorJsonHelpers.startFFDCJson(sb, hostName, wlpUserDir, serverName, isFirstField);
+        StringBuilder sb = CollectorJsonHelpers.startFFDCJson(hostName, wlpUserDir, serverName);
 
         for (Pair p : pairs) {
 
@@ -263,24 +249,23 @@ public class CollectorJsonUtils {
                     if (key.equals(LogFieldConstants.IBM_STACKTRACE)) {
                         key = LogFieldConstants.STACKTRACE;
                         String formattedValue = CollectorJsonHelpers.formatMessage(value, maxFieldLength);
-                        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, formattedValue, false, true, false, isFirstField, kvp.isNumber());
+                        CollectorJsonHelpers.addToJSON(sb, key, formattedValue, false, true, false, false, kvp.isNumber());
 
                     } else if (key.equals(LogFieldConstants.IBM_THREADID)) {
                         key = LogFieldConstants.THREADID;
-                        isFirstField = isFirstField
-                                       & !CollectorJsonHelpers.addToJSON(sb, key, DataFormatHelper.padHexString(Integer.parseInt(value), 8), false, true, false, isFirstField,
-                                                                         false);
+                        CollectorJsonHelpers.addToJSON(sb, key, DataFormatHelper.padHexString(Integer.parseInt(value), 8), false, true, false, false,
+                                                       false);
 
                     } else if (key.equals(LogFieldConstants.IBM_DATETIME)) {
                         key = LogFieldConstants.DATETIME;
                         String datetime = CollectorJsonHelpers.dateFormatTL.get().format(Long.parseLong(value));
-                        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, isFirstField, false);
+                        CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, false, false);
 
                     } else {
                         if (key.contains(LogFieldConstants.IBM_TAG)) {
                             key = CollectorJsonHelpers.removeIBMTag(key);
                         }
-                        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, isFirstField, kvp.isNumber());
+                        CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, false, kvp.isNumber());
 
                     }
                 }
@@ -300,16 +285,12 @@ public class CollectorJsonUtils {
                                         String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder(512);
-        boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
         String key = null;
         String value = null;
 
-        sb.append("{");
-
-        isFirstField = CollectorJsonHelpers.startAccessLogJson(sb, hostName, wlpUserDir, serverName, isFirstField);
+        StringBuilder sb = CollectorJsonHelpers.startAccessLogJson(hostName, wlpUserDir, serverName);
 
         for (Pair p : pairs) {
 
@@ -332,7 +313,7 @@ public class CollectorJsonUtils {
                             // ignore, use the original value;
                         }
                     }
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, jsonQueryString, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, jsonQueryString, false, true, false, false, kvp.isNumber());
 
                 } else if (key.equals(LogFieldConstants.IBM_USERAGENT)) {
 
@@ -343,19 +324,19 @@ public class CollectorJsonUtils {
                         userAgent = userAgent.substring(0, MAX_USER_AGENT_LENGTH);
                     }
 
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, userAgent, false, false, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, userAgent, false, false, false, false, kvp.isNumber());
 
                 } else if (key.equals(LogFieldConstants.IBM_DATETIME)) {
 
                     key = LogFieldConstants.DATETIME;
                     String datetime = CollectorJsonHelpers.dateFormatTL.get().format(Long.parseLong(value));
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, isFirstField, false);
+                    CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, false, false);
 
                 } else {
 
                     key = CollectorJsonHelpers.removeIBMTag(key);
 
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, false, kvp.isNumber());
 
                 }
             }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
@@ -90,15 +90,14 @@ public class CollectorJsonUtils {
 
     private static String jsonifyGCEvent(String hostName, String wlpUserDir, String serverName, HCGCData hcGCData, String[] tags) {
         String sequenceNum = hcGCData.getSequence();
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         boolean isFirstField = true;
 
         sb.append("{");
 
         //                                           name        value     jsonEscapeName? jsonEscapeValue? trim?   isFirst?
         /* Common fields for all event types */
-        isFirstField = CollectorJsonHelpers.addCommonFieldsGC(sb, hostName, wlpUserDir, serverName, hcGCData.getTime(), sequenceNum, isFirstField,
-                                                              CollectorConstants.GC_EVENT_TYPE);
+        isFirstField = CollectorJsonHelpers.startGCJson(sb, hostName, wlpUserDir, serverName, hcGCData.getTime(), sequenceNum, isFirstField);
         /* GC specific fields */
         isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "heap", String.valueOf((long) hcGCData.getHeap()), false, false, false, isFirstField);
         isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "usedHeap", String.valueOf((long) hcGCData.getUsage()), false, false, false, isFirstField);
@@ -120,7 +119,7 @@ public class CollectorJsonUtils {
     private static String jsonifyGCEvent(int maxFieldLength, String wlpUserDir,
                                          String serverName, String hostName, String eventType, Object event, String[] tags) {
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
@@ -129,7 +128,7 @@ public class CollectorJsonUtils {
 
         sb.append("{");
 
-        isFirstField = CollectorJsonHelpers.addCommonFields(sb, hostName, wlpUserDir, serverName, isFirstField, eventType);
+        isFirstField = CollectorJsonHelpers.startGenDataGCJson(sb, hostName, wlpUserDir, serverName, isFirstField);
 
         for (Pair p : pairs) {
 
@@ -172,7 +171,7 @@ public class CollectorJsonUtils {
                                                  String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
@@ -181,7 +180,10 @@ public class CollectorJsonUtils {
 
         sb.append("{");
 
-        isFirstField = CollectorJsonHelpers.addCommonFields(sb, hostName, wlpUserDir, serverName, isFirstField, eventType);
+        if (eventType.equals(CollectorConstants.MESSAGES_LOG_EVENT_TYPE))
+            isFirstField = CollectorJsonHelpers.startMessageJson(sb, hostName, wlpUserDir, serverName, isFirstField);
+        if (eventType.equals(CollectorConstants.TRACE_LOG_EVENT_TYPE))
+            isFirstField = CollectorJsonHelpers.startTraceJson(sb, hostName, wlpUserDir, serverName, isFirstField);
 
         for (Pair p : pairs) {
 
@@ -236,7 +238,7 @@ public class CollectorJsonUtils {
                                       String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
@@ -245,7 +247,7 @@ public class CollectorJsonUtils {
 
         sb.append("{");
 
-        isFirstField = CollectorJsonHelpers.addCommonFields(sb, hostName, wlpUserDir, serverName, isFirstField, eventType);
+        isFirstField = CollectorJsonHelpers.startFFDCJson(sb, hostName, wlpUserDir, serverName, isFirstField);
 
         for (Pair p : pairs) {
 
@@ -298,7 +300,7 @@ public class CollectorJsonUtils {
                                         String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
@@ -307,7 +309,7 @@ public class CollectorJsonUtils {
 
         sb.append("{");
 
-        isFirstField = CollectorJsonHelpers.addCommonFields(sb, hostName, wlpUserDir, serverName, isFirstField, eventType);
+        isFirstField = CollectorJsonHelpers.startAccessLogJson(sb, hostName, wlpUserDir, serverName, isFirstField);
 
         for (Pair p : pairs) {
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils1_1.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils1_1.java
@@ -81,21 +81,20 @@ public class CollectorJsonUtils1_1 {
 
     private static String jsonifyGCEvent(String hostName, String wlpUserDir, String serverName, HCGCData hcGCData, String[] tags) {
         String sequenceNum = hcGCData.getSequence();
-        StringBuilder sb = new StringBuilder(512);
-        boolean isFirstField = true;
-
-        sb.append("{");
 
         //                                           name        value     jsonEscapeName? jsonEscapeValue? trim?   isFirst?
         /* Common fields for all event types */
-        isFirstField = CollectorJsonHelpers.startGCJson1_1(sb, hostName, wlpUserDir, serverName, hcGCData.getTime(), sequenceNum, isFirstField);
+        StringBuilder sb = CollectorJsonHelpers.startGCJson1_1(hostName, wlpUserDir, serverName);
+        String datetime = CollectorJsonHelpers.dateFormatTL.get().format(hcGCData.getTime());
+        CollectorJsonHelpers.addToJSON(sb, "ibm_datetime", datetime, false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "ibm_sequence", sequenceNum, false, false, false, false);
         /* GC specific fields */
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "ibm_heap", String.valueOf((long) hcGCData.getHeap()), false, false, false, isFirstField);
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "ibm_usedHeap", String.valueOf((long) hcGCData.getUsage()), false, false, false, isFirstField);
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "ibm_maxHeap", String.valueOf(hcGCData.getMaxHeap()), false, false, false, isFirstField);
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "ibm_duration", String.valueOf((long) hcGCData.getDuration() * 1000), false, false, false, isFirstField);
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "ibm_gcType", hcGCData.getType(), false, false, false, isFirstField);
-        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "ibm_reason", hcGCData.getReason(), false, false, false, isFirstField);
+        CollectorJsonHelpers.addToJSON(sb, "ibm_heap", String.valueOf((long) hcGCData.getHeap()), false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "ibm_usedHeap", String.valueOf((long) hcGCData.getUsage()), false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "ibm_maxHeap", String.valueOf(hcGCData.getMaxHeap()), false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "ibm_duration", String.valueOf((long) hcGCData.getDuration() * 1000), false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "ibm_gcType", hcGCData.getType(), false, false, false, false);
+        CollectorJsonHelpers.addToJSON(sb, "ibm_reason", hcGCData.getReason(), false, false, false, false);
 
         if (tags != null) {
             addTagNameForVersion(sb).append(CollectorJsonHelpers.jsonifyTags(tags));
@@ -109,16 +108,12 @@ public class CollectorJsonUtils1_1 {
     private static String jsonifyGCEvent(int maxFieldLength, String wlpUserDir,
                                          String serverName, String hostName, String eventType, Object event, String[] tags) {
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder(512);
-        boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
         String key = null;
         String value = null;
 
-        sb.append("{");
-
-        isFirstField = CollectorJsonHelpers.startGenDataGCJson1_1(sb, hostName, wlpUserDir, serverName, isFirstField);
+        StringBuilder sb = CollectorJsonHelpers.startGCJson1_1(hostName, wlpUserDir, serverName);
 
         for (Pair p : pairs) {
 
@@ -131,16 +126,16 @@ public class CollectorJsonUtils1_1 {
                 if (key.equals(LogFieldConstants.IBM_DURATION)) {
 
                     long duration = Long.parseLong(value) * 1000;
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, Long.toString(duration), false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, Long.toString(duration), false, true, false, false, kvp.isNumber());
 
                 } else if (key.equals(LogFieldConstants.IBM_DATETIME)) {
 
                     String datetime = CollectorJsonHelpers.dateFormatTL.get().format(Long.parseLong(value));
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, isFirstField, false);
+                    CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, false, false);
 
                 } else {
 
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, false, kvp.isNumber());
 
                 }
             }
@@ -158,16 +153,12 @@ public class CollectorJsonUtils1_1 {
                                       String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder(512);
-        boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
         String key = null;
         String value = null;
 
-        sb.append("{");
-
-        isFirstField = CollectorJsonHelpers.startFFDCJson1_1(sb, hostName, wlpUserDir, serverName, isFirstField);
+        StringBuilder sb = CollectorJsonHelpers.startFFDCJson1_1(hostName, wlpUserDir, serverName);
 
         for (Pair p : pairs) {
 
@@ -183,22 +174,20 @@ public class CollectorJsonUtils1_1 {
                     if (key.equals(LogFieldConstants.IBM_STACKTRACE)) {
 
                         String formattedValue = CollectorJsonHelpers.formatMessage(value, maxFieldLength);
-                        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, formattedValue, false, true, false, isFirstField, kvp.isNumber());
+                        CollectorJsonHelpers.addToJSON(sb, key, formattedValue, false, true, false, false, kvp.isNumber());
 
                     } else if (key.equals(LogFieldConstants.IBM_THREADID)) {
 
-                        isFirstField = isFirstField
-                                       & !CollectorJsonHelpers.addToJSON(sb, key, DataFormatHelper.padHexString(Integer.parseInt(value), 8), false, true, false, isFirstField,
-                                                                         false);
+                        CollectorJsonHelpers.addToJSON(sb, key, DataFormatHelper.padHexString(Integer.parseInt(value), 8), false, true, false, false, false);
 
                     } else if (key.equals(LogFieldConstants.IBM_DATETIME)) {
 
                         String datetime = CollectorJsonHelpers.dateFormatTL.get().format(Long.parseLong(value));
-                        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, isFirstField, false);
+                        CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, false, false);
 
                     } else {
 
-                        isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, isFirstField, kvp.isNumber());
+                        CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, false, kvp.isNumber());
 
                     }
                 }
@@ -218,16 +207,12 @@ public class CollectorJsonUtils1_1 {
                                        String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder(512);
-        boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
         String key = null;
         String value = null;
 
-        sb.append("{");
-
-        isFirstField = CollectorJsonHelpers.startAccessLogJson1_1(sb, hostName, wlpUserDir, serverName, isFirstField);
+        StringBuilder sb = CollectorJsonHelpers.startAccessLogJson1_1(hostName, wlpUserDir, serverName);
 
         for (Pair p : pairs) {
 
@@ -249,7 +234,7 @@ public class CollectorJsonUtils1_1 {
                             // ignore, use the original value;
                         }
                     }
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, jsonQueryString, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, jsonQueryString, false, true, false, false, kvp.isNumber());
 
                 } else if (key.equals(LogFieldConstants.IBM_USERAGENT)) {
 
@@ -259,16 +244,16 @@ public class CollectorJsonUtils1_1 {
                         userAgent = userAgent.substring(0, MAX_USER_AGENT_LENGTH);
                     }
 
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, userAgent, false, false, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, userAgent, false, false, false, false, kvp.isNumber());
 
                 } else if (key.equals(LogFieldConstants.IBM_DATETIME)) {
 
                     String datetime = CollectorJsonHelpers.dateFormatTL.get().format(Long.parseLong(value));
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, isFirstField, false);
+                    CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, false, false);
 
                 } else {
 
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, false, kvp.isNumber());
 
                 }
             }
@@ -287,19 +272,16 @@ public class CollectorJsonUtils1_1 {
                                                  String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder(512);
-        boolean isFirstField = true;
+        StringBuilder sb = null;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
         String key = null;
         String value = null;
 
-        sb.append("{");
-
         if (eventType.equals(CollectorConstants.MESSAGES_LOG_EVENT_TYPE))
-            isFirstField = CollectorJsonHelpers.startMessageJson1_1(sb, hostName, wlpUserDir, serverName, isFirstField);
+            sb = CollectorJsonHelpers.startMessageJson1_1(hostName, wlpUserDir, serverName);
         if (eventType.equals(CollectorConstants.TRACE_LOG_EVENT_TYPE))
-            isFirstField = CollectorJsonHelpers.startTraceJson1_1(sb, hostName, wlpUserDir, serverName, isFirstField);
+            sb = CollectorJsonHelpers.startTraceJson1_1(hostName, wlpUserDir, serverName);
 
         for (Pair p : pairs) {
 
@@ -315,22 +297,21 @@ public class CollectorJsonUtils1_1 {
                 else if (key.equals(LogFieldConstants.MESSAGE)) {
 
                     String formattedValue = CollectorJsonHelpers.formatMessage(value, maxFieldLength);
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, formattedValue, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, formattedValue, false, true, false, false, kvp.isNumber());
 
                 } else if (key.equals(LogFieldConstants.IBM_THREADID)) {
 
-                    isFirstField = isFirstField
-                                   & !CollectorJsonHelpers.addToJSON(sb, key, DataFormatHelper.padHexString(Integer.parseInt(value), 8), false, true, false, isFirstField,
-                                                                     false);
+                    CollectorJsonHelpers.addToJSON(sb, key, DataFormatHelper.padHexString(Integer.parseInt(value), 8), false, true, false, false,
+                                                   false);
 
                 } else if (key.equals(LogFieldConstants.IBM_DATETIME)) {
 
                     String datetime = CollectorJsonHelpers.dateFormatTL.get().format(Long.parseLong(value));
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, isFirstField, false);
+                    CollectorJsonHelpers.addToJSON(sb, key, datetime, false, true, false, false, false);
 
                 } else {
 
-                    isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, isFirstField, kvp.isNumber());
+                    CollectorJsonHelpers.addToJSON(sb, key, value, false, true, false, false, kvp.isNumber());
 
                 }
             }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils1_1.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils1_1.java
@@ -81,15 +81,14 @@ public class CollectorJsonUtils1_1 {
 
     private static String jsonifyGCEvent(String hostName, String wlpUserDir, String serverName, HCGCData hcGCData, String[] tags) {
         String sequenceNum = hcGCData.getSequence();
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         boolean isFirstField = true;
 
         sb.append("{");
 
         //                                           name        value     jsonEscapeName? jsonEscapeValue? trim?   isFirst?
         /* Common fields for all event types */
-        isFirstField = CollectorJsonHelpers.addCommonFieldsGC1_1(sb, hostName, wlpUserDir, serverName, hcGCData.getTime(), sequenceNum, isFirstField,
-                                                                 CollectorConstants.GC_EVENT_TYPE);
+        isFirstField = CollectorJsonHelpers.startGCJson1_1(sb, hostName, wlpUserDir, serverName, hcGCData.getTime(), sequenceNum, isFirstField);
         /* GC specific fields */
         isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "ibm_heap", String.valueOf((long) hcGCData.getHeap()), false, false, false, isFirstField);
         isFirstField = isFirstField & !CollectorJsonHelpers.addToJSON(sb, "ibm_usedHeap", String.valueOf((long) hcGCData.getUsage()), false, false, false, isFirstField);
@@ -110,7 +109,7 @@ public class CollectorJsonUtils1_1 {
     private static String jsonifyGCEvent(int maxFieldLength, String wlpUserDir,
                                          String serverName, String hostName, String eventType, Object event, String[] tags) {
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
@@ -119,7 +118,7 @@ public class CollectorJsonUtils1_1 {
 
         sb.append("{");
 
-        isFirstField = CollectorJsonHelpers.addCommonFields1_1(sb, hostName, wlpUserDir, serverName, isFirstField, eventType);
+        isFirstField = CollectorJsonHelpers.startGenDataGCJson1_1(sb, hostName, wlpUserDir, serverName, isFirstField);
 
         for (Pair p : pairs) {
 
@@ -159,7 +158,7 @@ public class CollectorJsonUtils1_1 {
                                       String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
@@ -168,7 +167,7 @@ public class CollectorJsonUtils1_1 {
 
         sb.append("{");
 
-        isFirstField = CollectorJsonHelpers.addCommonFields1_1(sb, hostName, wlpUserDir, serverName, isFirstField, eventType);
+        isFirstField = CollectorJsonHelpers.startFFDCJson1_1(sb, hostName, wlpUserDir, serverName, isFirstField);
 
         for (Pair p : pairs) {
 
@@ -219,7 +218,7 @@ public class CollectorJsonUtils1_1 {
                                        String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
@@ -228,7 +227,7 @@ public class CollectorJsonUtils1_1 {
 
         sb.append("{");
 
-        isFirstField = CollectorJsonHelpers.addCommonFields1_1(sb, hostName, wlpUserDir, serverName, isFirstField, eventType);
+        isFirstField = CollectorJsonHelpers.startAccessLogJson1_1(sb, hostName, wlpUserDir, serverName, isFirstField);
 
         for (Pair p : pairs) {
 
@@ -288,7 +287,7 @@ public class CollectorJsonUtils1_1 {
                                                  String serverName, String hostName, String eventType, Object event, String[] tags) {
 
         GenericData genData = (GenericData) event;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(512);
         boolean isFirstField = true;
         ArrayList<Pair> pairs = genData.getPairs();
         KeyValuePair kvp = null;
@@ -297,7 +296,10 @@ public class CollectorJsonUtils1_1 {
 
         sb.append("{");
 
-        isFirstField = CollectorJsonHelpers.addCommonFields1_1(sb, hostName, wlpUserDir, serverName, isFirstField, eventType);
+        if (eventType.equals(CollectorConstants.MESSAGES_LOG_EVENT_TYPE))
+            isFirstField = CollectorJsonHelpers.startMessageJson1_1(sb, hostName, wlpUserDir, serverName, isFirstField);
+        if (eventType.equals(CollectorConstants.TRACE_LOG_EVENT_TYPE))
+            isFirstField = CollectorJsonHelpers.startTraceJson1_1(sb, hostName, wlpUserDir, serverName, isFirstField);
 
         for (Pair p : pairs) {
 


### PR DESCRIPTION
Fixes #2255

Fields such as host, wlpUserDir, ibm_userDir, serverName, ibm_serverName stay the same for the life of the server and fields such as type stay the same for each event type. Instead of generating the string for these fields everytime for every individual event, the string will be generated the first time this type of event occurs and then stored so that it can be used for all future occurences of this event.