### PR TITLE
test cache contents after multithreaded usage

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServer/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServer/server.xml
@@ -13,7 +13,7 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false"/>
     
-    <bell libraryRef="HazelcastLib"/>
+    <bell libraryRef="HazelcastLib" service="javax.cache.spi.CachingProvider"/>
 
     <library id="HazelcastLib">
         <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>


### PR DESCRIPTION
Update tests to check contents of cache after multithreaded access to sessions.
This caught a bug where the bytes for the value null were being written to the cache in the case where an attribute was simultaneously being removed.