### PR TITLE
Use version qualifier for zip output for consistency with bundles

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -46,18 +46,17 @@ assemble {
 import groovy.json.*
 import org.gradle.internal.os.OperatingSystem
 
-// Set the generated zip version to the buildID.
-// tasks.gradle file where this task is defined
-// can't see the bnd property because it isn't
-// a bundle.
-def releaseVersion = bnd.buildID
-if (releaseVersionOverride != null) {
-    releaseVersion = releaseVersionOverride
-}
+
 
 File packageDir = new File(project.buildDir, 'openliberty')
 def props = new Properties()
 rootProject.file('generated.properties').withInputStream { props.load(it) }
+
+// Set the generated zip version to the
+// version qualifier to be consistent
+// with what is use for the individual Bundle-Versions
+// as well as the server version output.
+def releaseVersion = props.getProperty("version.qualifier")
 
 String getGaFeatures() {
     String features = ""


### PR DESCRIPTION
previously a zip package could have a label distinct from the Bundle-Version and server version. This uses the same version qualifier that those do.

#build