### PR TITLE
Ensure SingleFileClient closes the input stream after reading

### DIFF
--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/SingleFileClient.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/SingleFileClient.java
@@ -95,12 +95,13 @@ public class SingleFileClient extends AbstractRepositoryClient implements Reposi
 
             idCounter = new AtomicInteger(1);
             assets = new HashMap<String, JsonObject>();
-            JsonReader reader = Json.createReader(new FileInputStream(file));
-            JsonArray assetList = reader.readArray();
-            for (JsonValue val : assetList) {
-                String id = Integer.toString(idCounter.getAndIncrement());
-                if (val.getValueType() == ValueType.OBJECT) {
-                    assets.put(id, (JsonObject) val);
+            try (JsonReader reader = Json.createReader(new FileInputStream(file))) {
+                JsonArray assetList = reader.readArray();
+                for (JsonValue val : assetList) {
+                    String id = Integer.toString(idCounter.getAndIncrement());
+                    if (val.getValueType() == ValueType.OBJECT) {
+                        assets.put(id, (JsonObject) val);
+                    }
                 }
             }
         }

--- a/dev/com.ibm.ws.repository/test/com/ibm/ws/repository/connections/test/SingleFileRepositoryConnectionTest.java
+++ b/dev/com.ibm.ws.repository/test/com/ibm/ws/repository/connections/test/SingleFileRepositoryConnectionTest.java
@@ -35,7 +35,7 @@ public class SingleFileRepositoryConnectionTest {
     @After
     public void cleanup() {
         if (FILE.exists()) {
-            FILE.delete();
+            assertThat("Test file deleted", FILE.delete(), is(true));
         }
     }
 


### PR DESCRIPTION
Also update the test to ensure the test file gets deleted as problems
here can disrupt other tests.

Follow on from #2616