### PR TITLE
Add javaeeddSchema-1.0 for common servlet and ejb schema

### DIFF
--- a/dev/com.ibm.websphere.appserver.ejbCore-1.0/com.ibm.websphere.appserver.ejbCore-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.ejbCore-1.0/com.ibm.websphere.appserver.ejbCore-1.0.feature
@@ -5,23 +5,9 @@ IBM-API-Package: javax.ejb; type="spec", \
  javax.ejb.spi; type="spec"
 -features=com.ibm.websphere.appserver.appmanager-1.0, \
  com.ibm.websphere.appserver.javaeePlatform-6.0, \
- com.ibm.websphere.appserver.managedBeansCore-1.0
+ com.ibm.websphere.appserver.managedBeansCore-1.0, \
+ com.ibm.websphere.appserver.javaeeddSchema-1.0
 -bundles=com.ibm.ws.app.manager.war, \
  com.ibm.ws.app.manager.ejb
--files=dev/api/ibm/schema/ibm-common-bnd_1_2.xsd, \
- dev/api/ibm/schema/ibm-application-ext_1_0.xsd, \
- dev/api/ibm/schema/ibm-ejb-jar-ext_1_1.xsd, \
- dev/api/ibm/schema/ibm-ejb-jar-bnd_1_1.xsd, \
- dev/api/ibm/schema/ibm-ejb-jar-ext_1_0.xsd, \
- dev/api/ibm/schema/ibm-application-bnd_1_2.xsd, \
- dev/api/ibm/schema/ibm-application-bnd_1_0.xsd, \
- dev/api/ibm/schema/ibm-common-ext_1_0.xsd, \
- dev/api/ibm/schema/ibm-common-bnd_1_0.xsd, \
- dev/api/ibm/schema/ibm-common-ext_1_1.xsd, \
- dev/api/ibm/schema/ibm-application-bnd_1_1.xsd, \
- dev/api/ibm/schema/ibm-application-ext_1_1.xsd, \
- dev/api/ibm/schema/ibm-ejb-jar-bnd_1_2.xsd, \
- dev/api/ibm/schema/ibm-ejb-jar-bnd_1_0.xsd, \
- dev/api/ibm/schema/ibm-common-bnd_1_1.xsd
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.javaeeddSchema-1.0/.classpath
+++ b/dev/com.ibm.websphere.appserver.javaeeddSchema-1.0/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.websphere.appserver.javaeeddSchema-1.0/.project
+++ b/dev/com.ibm.websphere.appserver.javaeeddSchema-1.0/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.websphere.appserver.javaeeddSchema-1.0</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.websphere.appserver.javaeeddSchema-1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.javaeeddSchema-1.0/bnd.bnd
@@ -13,6 +13,4 @@
 -nobundles=true
 
 -dependson: \
-	com.ibm.ws.app.manager.war;version=latest, \
-	com.ibm.ws.app.manager.ejb;version=latest, \
-	com.ibm.websphere.appserver.javaeeddSchema-1.0;version=latest
+	com.ibm.ws.javaee.dd;version=latest

--- a/dev/com.ibm.websphere.appserver.javaeeddSchema-1.0/com.ibm.websphere.appserver.javaeeddSchema-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.javaeeddSchema-1.0/com.ibm.websphere.appserver.javaeeddSchema-1.0.feature
@@ -1,0 +1,25 @@
+-include= ~../cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.javaeeddSchema-1.0
+visibility=private
+-files=dev/api/ibm/schema/ibm-application-bnd_1_0.xsd, \
+ dev/api/ibm/schema/ibm-application-bnd_1_1.xsd, \
+ dev/api/ibm/schema/ibm-application-bnd_1_2.xsd, \
+ dev/api/ibm/schema/ibm-application-ext_1_0.xsd, \
+ dev/api/ibm/schema/ibm-application-ext_1_1.xsd, \
+ dev/api/ibm/schema/ibm-common-bnd_1_0.xsd, \
+ dev/api/ibm/schema/ibm-common-bnd_1_1.xsd, \
+ dev/api/ibm/schema/ibm-common-bnd_1_2.xsd, \
+ dev/api/ibm/schema/ibm-common-ext_1_0.xsd, \
+ dev/api/ibm/schema/ibm-common-ext_1_1.xsd, \
+ dev/api/ibm/schema/ibm-web-bnd_1_0.xsd, \
+ dev/api/ibm/schema/ibm-web-bnd_1_1.xsd, \
+ dev/api/ibm/schema/ibm-web-bnd_1_2.xsd, \
+ dev/api/ibm/schema/ibm-web-ext_1_0.xsd, \
+ dev/api/ibm/schema/ibm-web-ext_1_1.xsd, \
+ dev/api/ibm/schema/ibm-ejb-jar-bnd_1_0.xsd, \
+ dev/api/ibm/schema/ibm-ejb-jar-bnd_1_1.xsd, \
+ dev/api/ibm/schema/ibm-ejb-jar-bnd_1_2.xsd, \
+ dev/api/ibm/schema/ibm-ejb-jar-ext_1_0.xsd, \
+ dev/api/ibm/schema/ibm-ejb-jar-ext_1_1.xsd
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.servlet-3.1/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.servlet-3.1/bnd.bnd
@@ -28,4 +28,5 @@
 	com.ibm.ws.webserver.plugin.runtime.interfaces;version=latest, \
 	com.ibm.ws.webserver.plugin.utility;version=latest, \
 	com.ibm.websphere.appserver.api.servlet;version=latest, \
-	com.ibm.websphere.appserver.servlet-servletSpi1.0;version=latest
+	com.ibm.websphere.appserver.servlet-servletSpi1.0;version=latest, \
+	com.ibm.websphere.appserver.javaeeddSchema-1.0;version=latest

--- a/dev/com.ibm.websphere.appserver.servlet-3.1/com.ibm.websphere.appserver.servlet-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.servlet-3.1/com.ibm.websphere.appserver.servlet-3.1.feature
@@ -45,7 +45,8 @@ Subsystem-Category: JavaEE7Application
  com.ibm.websphere.appserver.javax.servlet-3.1, \
  com.ibm.websphere.appserver.requestProbes-1.0, \
  com.ibm.websphere.appserver.javaeeCompatible-6.0; ibm.tolerates:=7.0, \
- com.ibm.websphere.appserver.servlet-servletSpi1.0
+ com.ibm.websphere.appserver.servlet-servletSpi1.0, \
+ com.ibm.websphere.appserver.javaeeddSchema-1.0
 -bundles=com.ibm.ws.app.manager.war, \
  com.ibm.ws.managedobject, \
  com.ibm.ws.org.apache.commons.io, \
@@ -64,22 +65,7 @@ Subsystem-Category: JavaEE7Application
 -files=bin/tools/ws-webserverPluginutil.jar, \
  bin/pluginUtility; ibm.executable:=true; ibm.file.encoding:=ebcdic, \
  bin/pluginUtility.bat, \
- dev/api/ibm/schema/ibm-common-bnd_1_2.xsd, \
- dev/api/ibm/schema/ibm-web-bnd_1_0.xsd, \
- dev/api/ibm/schema/ibm-application-ext_1_0.xsd, \
- dev/api/ibm/schema/ibm-web-ext_1_0.xsd, \
- dev/api/ibm/schema/ibm-web-bnd_1_2.xsd, \
- dev/api/ibm/schema/ibm-web-bnd_1_1.xsd, \
- dev/api/ibm/schema/ibm-application-bnd_1_2.xsd, \
- dev/api/ibm/schema/ibm-application-bnd_1_0.xsd, \
- dev/api/ibm/schema/ibm-common-ext_1_0.xsd, \
- dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.servlet_1.1-javadoc.zip, \
- dev/api/ibm/schema/ibm-common-bnd_1_0.xsd, \
- dev/api/ibm/schema/ibm-common-ext_1_1.xsd, \
- dev/api/ibm/schema/ibm-application-bnd_1_1.xsd, \
- dev/api/ibm/schema/ibm-application-ext_1_1.xsd, \
- dev/api/ibm/schema/ibm-common-bnd_1_1.xsd, \
- dev/api/ibm/schema/ibm-web-ext_1_1.xsd
+ dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.servlet_1.1-javadoc.zip
 Subsystem-Name: Java Servlets 3.1
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.servlet-4.0/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.servlet-4.0/bnd.bnd
@@ -28,4 +28,5 @@
 	com.ibm.ws.webserver.plugin.runtime.interfaces;version=latest, \
 	com.ibm.ws.webserver.plugin.utility;version=latest, \
 	com.ibm.websphere.appserver.api.servlet;version=latest, \
-	com.ibm.websphere.appserver.servlet-servletSpi1.0;version=latest
+	com.ibm.websphere.appserver.servlet-servletSpi1.0;version=latest, \
+	com.ibm.websphere.appserver.javaeeddSchema-1.0;version=latest

--- a/dev/com.ibm.websphere.appserver.servlet-4.0/com.ibm.websphere.appserver.servlet-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.servlet-4.0/com.ibm.websphere.appserver.servlet-4.0.feature
@@ -45,7 +45,8 @@ Subsystem-Category: JavaEE8Application
  com.ibm.websphere.appserver.javax.servlet-4.0, \
  com.ibm.websphere.appserver.requestProbes-1.0, \
  com.ibm.websphere.appserver.javaeeCompatible-8.0, \
- com.ibm.websphere.appserver.servlet-servletSpi1.0
+ com.ibm.websphere.appserver.servlet-servletSpi1.0, \
+ com.ibm.websphere.appserver.javaeeddSchema-1.0
 -bundles=com.ibm.ws.app.manager.war, \
  com.ibm.ws.managedobject, \
  com.ibm.ws.org.apache.commons.io, \
@@ -65,22 +66,7 @@ Subsystem-Category: JavaEE8Application
 -files=bin/tools/ws-webserverPluginutil.jar, \
  bin/pluginUtility; ibm.executable:=true; ibm.file.encoding:=ebcdic, \
  bin/pluginUtility.bat, \
- dev/api/ibm/schema/ibm-common-bnd_1_2.xsd, \
- dev/api/ibm/schema/ibm-web-bnd_1_0.xsd, \
- dev/api/ibm/schema/ibm-application-ext_1_0.xsd, \
- dev/api/ibm/schema/ibm-web-ext_1_0.xsd, \
- dev/api/ibm/schema/ibm-web-bnd_1_2.xsd, \
- dev/api/ibm/schema/ibm-web-bnd_1_1.xsd, \
- dev/api/ibm/schema/ibm-application-bnd_1_2.xsd, \
- dev/api/ibm/schema/ibm-application-bnd_1_0.xsd, \
- dev/api/ibm/schema/ibm-common-ext_1_0.xsd, \
- dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.servlet_1.1-javadoc.zip, \
- dev/api/ibm/schema/ibm-common-bnd_1_0.xsd, \
- dev/api/ibm/schema/ibm-common-ext_1_1.xsd, \
- dev/api/ibm/schema/ibm-application-bnd_1_1.xsd, \
- dev/api/ibm/schema/ibm-application-ext_1_1.xsd, \
- dev/api/ibm/schema/ibm-common-bnd_1_1.xsd, \
- dev/api/ibm/schema/ibm-web-ext_1_1.xsd
+ dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.servlet_1.1-javadoc.zip
 Subsystem-Name: Java Servlets 4.0
 kind=beta
 edition=core


### PR DESCRIPTION
Create a private feature that includes schema files common among several open-liberty and was-liberty features in order to remove the co-requisite between com.ibm.ws.javaee.dd and servlet-3.0.