### PR TITLE
Uninstall leftover app configurations on restart

### DIFF
--- a/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootApplicationImpl.java
+++ b/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootApplicationImpl.java
@@ -95,6 +95,7 @@ import com.ibm.wsspi.classloading.ClassLoaderConfiguration;
 import com.ibm.wsspi.classloading.ClassLoadingService;
 import com.ibm.wsspi.classloading.GatewayConfiguration;
 import com.ibm.wsspi.kernel.service.location.WsResource;
+import com.ibm.wsspi.kernel.service.utils.FrameworkState;
 
 public class SpringBootApplicationImpl extends DeployedAppInfoBase implements SpringBootConfigFactory, SpringBootApplication {
     private static final TraceComponent tc = Tr.register(SpringBootApplicationImpl.class);
@@ -205,7 +206,18 @@ public class SpringBootApplicationImpl extends DeployedAppInfoBase implements Sp
             virtualHostConfig.getAndUpdate((b) -> {
                 if (b != null) {
                     try {
-                        b.uninstall();
+                        // If the framework is stopping then we avoid uninstalling the bundle.
+                        // This is necessary because config admin will no process the
+                        // config bundle deletion while the framework is shutting down.
+                        // Here we leave the bundle installed and we will clean it up
+                        // on restart when the Spring Boot app handler is activated.
+                        // This way the configurations can be removed before re-starting
+                        // the spring boot applications
+                        if (!FrameworkState.isStopping()) {
+                            b.uninstall();
+                        }
+                    } catch (IllegalStateException e) {
+                        // auto FFDC here
                     } catch (BundleException e) {
                         // auto FFDC here
                     }

--- a/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootHandler.java
+++ b/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootHandler.java
@@ -53,7 +53,7 @@ public class SpringBootHandler implements ApplicationHandler<DeployedAppInfo> {
     @Activate
     protected void activate(BundleContext context) {
         FrameworkWiring fwkWiring = context.getBundle(Constants.SYSTEM_BUNDLE_LOCATION).adapt(FrameworkWiring.class);
-
+        // Find all bundles left over from previous run that provide spring boot config
         Collection<BundleCapability> configs = fwkWiring.findProviders(new Requirement() {
             @Override
             public Resource getResource() {
@@ -76,6 +76,8 @@ public class SpringBootHandler implements ApplicationHandler<DeployedAppInfo> {
             }
         });
 
+        // We uninstall left over configs from previous shutdown to give config admin a
+        // chance to clear out the configurations now before we start any applications.
         configs.forEach((c) -> {
             try {
                 c.getRevision().getBundle().uninstall();

--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/AbstractSpringTests.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/AbstractSpringTests.java
@@ -55,15 +55,16 @@ public abstract class AbstractSpringTests {
         } finally {
             try {
                 server.deleteDirectoryFromLibertyServerRoot(SPRING_WORKAREA_DIR + SPRING_LIB_INDEX_CACHE);
+                for (RemoteFile remoteFile : dropinFiles) {
+                    remoteFile.delete();
+                }
+                server.deleteDirectoryFromLibertyInstallRoot("usr/shared/" + SHARED_SPRING_LIB_INDEX_CACHE);
             } catch (Exception e) {
                 // ignore
+            } finally {
+                dropinFiles.clear();
+                server.postStopServerArchive();
             }
-            server.postStopServerArchive();
-            for (RemoteFile remoteFile : dropinFiles) {
-                remoteFile.delete();
-            }
-            dropinFiles.clear();
-            server.deleteDirectoryFromLibertyInstallRoot("usr/shared/" + SHARED_SPRING_LIB_INDEX_CACHE);
         }
     }
 
@@ -86,6 +87,8 @@ public abstract class AbstractSpringTests {
             Set<String> features = config.getFeatureManager().getFeatures();
             features.clear();
             features.addAll(getFeatures());
+            List<SpringBootApp> apps = config.getSpringBootApps();
+            apps.clear();
             RemoteFile appFile = getApplicationFile();
             switch (getApplicationConfigType()) {
                 case DROPINS_SPR: {
@@ -106,8 +109,6 @@ public abstract class AbstractSpringTests {
                     break;
                 }
                 case SPRING_BOOT_APP_TAG: {
-                    List<SpringBootApp> apps = config.getSpringBootApps();
-                    apps.clear();
                     SpringBootApp app = new SpringBootApp();
                     app.setLocation(appFile.getName());
                     app.setName("testName");

--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/FATSuite.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/FATSuite.java
@@ -22,7 +22,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 CommonWebServerTests20Servlet40.class,
                 ConfigDropinRootTests.class,
                 ConfigSpringBootAppTagTests.class,
-                PreThinnedSpringBootTests.class
+                PreThinnedSpringBootTests.class,
+                WarmStartTests.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/WarmStartTests.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/WarmStartTests.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.springboot.support.fat;
+
+import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.RemoteFile;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.topology.utils.HttpUtils;
+
+@RunWith(FATRunner.class)
+/**
+ * This tests what is considered the ideal path a customer would use.
+ * Running from an already thinned app jar and a lib.index.cache
+ * located in the shared/resources location.
+ * Do not make this part of the FULL mode since we want to make sure
+ * this tests always runs.
+ */
+@Mode(FULL)
+public class WarmStartTests extends AbstractSpringTests {
+
+    @Override
+    public Set<String> getFeatures() {
+        return new HashSet<>(Arrays.asList("springBoot-1.5", "servlet-3.1"));
+    }
+
+    @Override
+    public String getApplication() {
+        return SPRING_BOOT_15_APP_BASE;
+    }
+
+    @Test
+    public void testWithSharedCache() throws Exception {
+        // First stop the server so we can start from a warm start
+        assertNotNull("The application was not installed", server
+                        .waitForStringInLog("CWWKZ0001I:.*"));
+        server.stopServer(false);
+
+        // remove any dropins
+        RemoteFile dropinsSpr = server.getFileFromLibertyServerRoot("dropins/spr");
+        RemoteFile[] dropinApps = dropinsSpr.list(true);
+        for (RemoteFile dropinApp : dropinApps) {
+            if (dropinApp.isFile()) {
+                dropinApp.delete();
+            }
+        }
+
+        // start server without clean; no applications should start now
+        server.startServer(false);
+
+        // set mark to end so we can test the messages after we add the dropin app back
+        server.setMarkToEndOfLog();
+        getApplicationFile().copyToDest(dropinsSpr);
+
+        // make sure we get the TCP channel message between the starting and installed message for the app
+        assertNotNull("The application is not starting", server.waitForStringInLog("CWWKZ0018I:.*"));
+        assertNotNull("The TCP Channel did not start after application starting", server.waitForStringInLog("CWWKO0219I:.*"));
+        assertNotNull("The application was not installed", server.waitForStringInLog("CWWKZ0001I:.*"));
+
+        // NOTE we set the port to the expected port according to the test application.properties
+        server.setHttpDefaultPort(8081);
+        HttpUtils.findStringInUrl(server, "", "HELLO SPRING BOOT!!");
+    }
+}


### PR DESCRIPTION
Must avoid uninstalling application configurations when
stopping an application during server shutdown.  This
is because config admin will not process the removal if
the framework is shutting down.  Instead the config bundle
must remain installed and will be cleaned up on restart.
This way config admin will have a chance to clean out
the application configuraiton before any applications
start.