### PR TITLE
Direct stderr to the same output file when running Maven in the build

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
@@ -257,6 +257,7 @@ public class MvnUtils {
         ProcessBuilder pb = new ProcessBuilder(cmd);
         pb.directory(workingDirectory);
         pb.redirectOutput(outputFile);
+        pb.redirectErrorStream(true);
         log("Running command " + Arrays.asList(cmd));
         Process p = pb.start();
         int exitCode = p.waitFor();


### PR DESCRIPTION
This fixes a problem where _fat_tck projects would hang if they
outputted enough data to stderr. If nothing was consuming stderr, the
surefire thread that was processing messages would hang trying to write
to it and stop processing messages. This would either result in the
whole build hanging, or in surefire reporting that the forked vm did not
shut down properly at the end of the test run.

Fixes #2506 