### PR TITLE
Cache constructor parameters and annotations.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/lifecycle/PerRequestResourceProvider.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/lifecycle/PerRequestResourceProvider.java
@@ -19,9 +19,11 @@
 
 package org.apache.cxf.jaxrs.lifecycle;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Map;
 
@@ -50,8 +52,9 @@ public class PerRequestResourceProvider implements ResourceProvider {
     private final Method postConstructMethod;
     private final Method preDestroyMethod;
     // Liberty Change for CXF Begin
-    private final Boolean released = false;
-
+    private final Class<?>[] params;
+    private final Annotation[][] anns;
+    private final Type[] genericTypes;
     //Liberty Change for CXF End
     public PerRequestResourceProvider(Class<?> clazz) {
         c = ResourceUtils.findResourceConstructor(clazz, true);
@@ -59,6 +62,11 @@ public class PerRequestResourceProvider implements ResourceProvider {
             throw new RuntimeException("Resource class " + clazz
                                        + " has no valid constructor");
         }
+        // Liberty Change for CXF Begin
+        params = c.getParameterTypes();
+        anns = c.getParameterAnnotations();
+        genericTypes = c.getGenericParameterTypes();
+        //Liberty Change for CXF End
         postConstructMethod = ResourceUtils.findPostConstructMethod(clazz);
         preDestroyMethod = ResourceUtils.findPreDestroyMethod(clazz);
     }
@@ -84,13 +92,15 @@ public class PerRequestResourceProvider implements ResourceProvider {
                         (ProviderInfo<?>) m.getExchange().getEndpoint().get(Application.class.getName());
         Map<Class<?>, Object> mapValues = CastUtils.cast(application == null ? null
                         : Collections.singletonMap(Application.class, application.getProvider()));
-        Object[] values = ResourceUtils.createConstructorArguments(c, m, true, mapValues);
+        // Liberty Change for CXF Begin
+        Object[] values = ResourceUtils.createConstructorArguments(c, m, true, mapValues, params, anns, genericTypes);
+        // Liberty Change for CXF End
         try {
             Object instance = values.length > 0 ? c.newInstance(values) : c.newInstance(new Object[] {});
-//Liberty Change for CXF Begain
+//Liberty Change for CXF Begin
             //do not call postConstruct here as no context injection happens
 //            InjectionUtils.invokeLifeCycleMethod(instance, postConstructMethod);
-//Liberty Change for CXF End            
+//Liberty Change for CXF End
             return instance;
         } catch (InstantiationException ex) {
             String msg = "Resource class " + c.getDeclaringClass().getName() + " can not be instantiated";

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/model/URITemplate.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/model/URITemplate.java
@@ -137,11 +137,34 @@ public final class URITemplate {
 
     private static String escapeCharacters(String expression) {
 
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < expression.length(); i++) {
-            char ch = expression.charAt(i);
-            sb.append(isReservedCharacter(ch) ? "\\" + ch : ch);
+        // Liberty Change for CXF Begin
+        int length = expression.length();
+        int i = 0;
+        char ch = ' ';
+        for (; i < length; ++i) {
+            ch = expression.charAt(i);
+            if (isReservedCharacter(ch)) {
+                break;
+            }
         }
+
+        if (i == length) {
+            return expression;
+        }
+
+        StringBuilder sb = new StringBuilder(length + 8);
+        sb.append(expression, 0, i);
+        sb.append('\\');
+        sb.append(ch);
+        ++i;
+        for (; i < length; ++i) {
+            ch = expression.charAt(i);
+            if (isReservedCharacter(ch)) {
+                sb.append('\\');
+            }
+            sb.append(ch);
+        }
+        // Liberty Change for CXF End
         return sb.toString();
     }
 

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
@@ -847,12 +847,24 @@ public final class ResourceUtils {
                                                       Message m,
                                                       boolean perRequest,
                                                       Map<Class<?>, Object> contextValues) {
-        if (m == null) {
-            m = new MessageImpl();
-        }
+        // Liberty Change for CXF Begin
         Class<?>[] params = c.getParameterTypes();
         Annotation[][] anns = c.getParameterAnnotations();
         Type[] genericTypes = c.getGenericParameterTypes();
+        return createConstructorArguments(c, m, perRequest, contextValues, params, anns, genericTypes);
+    }
+
+    public static Object[] createConstructorArguments(Constructor<?> c,
+                                                      Message m,
+                                                      boolean perRequest,
+                                                      Map<Class<?>, Object> contextValues,
+                                                      Class<?>[] params,
+                                                      Annotation[][] anns,
+                                                      Type[] genericTypes) {
+        if (m == null) {
+            m = new MessageImpl();
+        }
+        // Liberty Change for CXF End
         @SuppressWarnings("unchecked")
         MultivaluedMap<String, String> templateValues =
             (MultivaluedMap<String, String>)m.get(URITemplate.TEMPLATE_PARAMETERS);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/model/URITemplate.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/model/URITemplate.java
@@ -138,11 +138,34 @@ public final class URITemplate {
 
     private static String escapeCharacters(String expression) {
 
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < expression.length(); i++) {
-            char ch = expression.charAt(i);
-            sb.append(isReservedCharacter(ch) ? "\\" + ch : ch);
+        // Liberty Change for CXF Begin
+        int length = expression.length();
+        int i = 0;
+        char ch = ' ';
+        for (; i < length; ++i) {
+            ch = expression.charAt(i);
+            if (isReservedCharacter(ch)) {
+                break;
+            }
         }
+
+        if (i == length) {
+            return expression;
+        }
+
+        StringBuilder sb = new StringBuilder(length + 8);
+        sb.append(expression, 0, i);
+        sb.append('\\');
+        sb.append(ch);
+        ++i;
+        for (; i < length; ++i) {
+            ch = expression.charAt(i);
+            if (isReservedCharacter(ch)) {
+                sb.append('\\');
+            }
+            sb.append(ch);
+        }
+        // Liberty Change for CXF End
         return sb.toString();
     }
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
@@ -847,12 +847,24 @@ public final class ResourceUtils {
                                                       Message m,
                                                       boolean perRequest,
                                                       Map<Class<?>, Object> contextValues) {
-        if (m == null) {
-            m = new MessageImpl();
-        }
+        // Liberty Change for CXF Begin
         Class<?>[] params = c.getParameterTypes();
         Annotation[][] anns = c.getParameterAnnotations();
         Type[] genericTypes = c.getGenericParameterTypes();
+        return createConstructorArguments(c, m, perRequest, contextValues, params, anns, genericTypes);
+    }
+
+    public static Object[] createConstructorArguments(Constructor<?> c,
+                                                      Message m,
+                                                      boolean perRequest,
+                                                      Map<Class<?>, Object> contextValues,
+                                                      Class<?>[] params,
+                                                      Annotation[][] anns,
+                                                      Type[] genericTypes) {
+        if (m == null) {
+            m = new MessageImpl();
+        }
+        // Liberty Change for CXF End
         @SuppressWarnings("unchecked")
         MultivaluedMap<String, String> templateValues =
             (MultivaluedMap<String, String>)m.get(URITemplate.TEMPLATE_PARAMETERS);


### PR DESCRIPTION
It was found when profiling having to get the annotations for parameters
for the constructor got expensive.  This should help performance.

Also including a change to set the StringBuilder length initially and not do a String + operation when we already have a StringBuilder.  This should help also with path length and expanding arrays since we aren't using the default StringBuilder size.