### PR TITLE
Pass null for caller DN on DatabaseIdentityStore

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStore.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStore.java
@@ -26,8 +26,8 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.security.enterprise.credential.Credential;
 import javax.security.enterprise.credential.CallerOnlyCredential;
+import javax.security.enterprise.credential.Credential;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
@@ -163,7 +163,7 @@ public class DatabaseIdentityStore implements IdentityStore {
                 conn.close();
             }
         } catch (NamingException | SQLException e) {
-            Tr.warning(tc, "JAVAEESEC_WARNING_EXCEPTION_ON_GROUPS", new Object[] { caller, idStoreDefinition.getCallerQuery(), groups, e });
+            Tr.warning(tc, "JAVAEESEC_WARNING_EXCEPTION_ON_GROUPS", new Object[] { caller, idStoreDefinition.getGroupsQuery(), groups, e });
         }
 
         /*
@@ -188,12 +188,12 @@ public class DatabaseIdentityStore implements IdentityStore {
         String caller;
         ProtectedString password = null;
         if (credential instanceof UsernamePasswordCredential) {
-            caller = ((UsernamePasswordCredential)credential).getCaller();
-            password = new ProtectedString(((UsernamePasswordCredential)credential).getPassword().getValue());
+            caller = ((UsernamePasswordCredential) credential).getCaller();
+            password = new ProtectedString(((UsernamePasswordCredential) credential).getPassword().getValue());
 
         } else if (credential instanceof CallerOnlyCredential) {
             callerOnly = true;
-            caller = ((CallerOnlyCredential)credential).getCaller();
+            caller = ((CallerOnlyCredential) credential).getCaller();
         } else {
             Tr.warning(tc, "JAVAEESEC_WARNING_WRONG_CRED");
             return CredentialValidationResult.NOT_VALIDATED_RESULT;
@@ -265,8 +265,8 @@ public class DatabaseIdentityStore implements IdentityStore {
         }
 
         if (callerOnly || passwordHash.verify(password.getChars(), String.valueOf(dbPassword.getChars()))) {
-            Set<String> groups = getCallerGroups(new CredentialValidationResult(null, caller, caller, caller, null));
-            return new CredentialValidationResult(idStoreDefinition.getDataSourceLookup(), caller, caller, caller, groups);
+            Set<String> groups = getCallerGroups(new CredentialValidationResult(null, caller, null, caller, null));
+            return new CredentialValidationResult(idStoreDefinition.getDataSourceLookup(), caller, null, caller, groups);
         } else {
             if (tc.isEventEnabled()) {
                 Tr.event(tc, "PasswordHash verify check returned false for caller: " + caller);


### PR DESCRIPTION
Fixes #2757 

Pass null for caller DN in CredentialValidationResult for the DatabaseIdentityStore. The caller DN is for the Ldap DN.