### PR TITLE
Remove Java 8 requirement for jcacheContainer-1.1 and publish APIs

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jcacheContainer-1.1/com.ibm.websphere.appserver.jcacheContainer-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jcacheContainer-1.1/com.ibm.websphere.appserver.jcacheContainer-1.1.feature
@@ -18,6 +18,6 @@ IBM-API-Package: \
  com.ibm.websphere.appserver.bells-1.0, \
  com.ibm.websphere.appserver.classloading-1.0
 -bundles=\
- com.ibm.websphere.javaee.jcache.1.1
+ com.ibm.websphere.javaee.jcache.1.1; location:="dev/api/spec/,lib/"
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.javaee.jcache.1.1/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jcache.1.1/bnd.bnd
@@ -11,12 +11,7 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-SymbolicName: com.ibm.websphere.javaee.jcache.1.1
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Export-Package: \
    javax.cache;version="1.1", \
@@ -36,6 +31,8 @@ Include-Resource: \
   @${repo; javax.cache:cache-api;1.1.0}
 
 instrument.disabled: true
+
+publish.wlp.jar.suffix: dev/api/spec
 
 -buildpath: \
 	javax.cache:cache-api;version=1.1.0


### PR DESCRIPTION
Remove Java 8 requirement for jcacheContainer-1.1 feature.  Also removes bug where APIs were not published to dev/api/spec.