### PR TITLE
Remove sync block to improve concurrency in WebContainer

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/CacheServletWrapper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/CacheServletWrapper.java
@@ -56,7 +56,6 @@ protected final static Logger logger = LoggerFactory.getInstance().getLogger("co
 	{
 		super();
 		cacheTarget = wrapper;
-		cacheTarget.addServletReferenceListener(this);
 		this._pathInfo=req.getPathInfo();
 		this._servletPath = req.getServletPath();
 		this.requestUri = req.getRequestURI();

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/FileServletWrapper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/FileServletWrapper.java
@@ -161,7 +161,7 @@ public abstract class FileServletWrapper implements IServletWrapper, IServletWra
 
   }
 
-    public void addServletReferenceListener(ServletReferenceListener wrapper) {
+    public synchronized void addServletReferenceListener(ServletReferenceListener wrapper) {
         if (listeners == null) {
       listeners = new ArrayList();
     }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/ServletWrapper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/ServletWrapper.java
@@ -1932,7 +1932,7 @@ public abstract class ServletWrapper extends GenericServlet implements RequestPr
      * @seecom.ibm.ws.webcontainer.util.CacheTarget#addCacheWrapper(com.ibm.ws.
      * webcontainer.util.CacheWrapper)
      */
-    public void addServletReferenceListener(ServletReferenceListener listener) {
+    public synchronized void addServletReferenceListener(ServletReferenceListener listener) {
         if (this.cacheWrappers == null) {
             cacheWrappers = new ArrayList();
         }


### PR DESCRIPTION
Use putIfAbsent instead of containsKey / put in WebContainer.

Update to call IServletWrapper.addServletReferenceListener outside of
the constructor so that we aren't adding in wrappers we don't actually
keep around and keep the logic consistent.

Make addServletReferenceListener synchronized in order to not have
issues with concurrency when adding to the list.