### PR TITLE
Repackage Commons Compress as com.ibm.ws.* package

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -84,3 +84,4 @@ org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.1-bd47e8f
 org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.1-bd47e8f
 org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.1-bd47e8f
 com.ibm.ws.lars:larsServer-memoryBackend:war:1.0.1
+com.ibm.ws.org.apache.commons:commons-compress:1.16.1

--- a/dev/com.ibm.ws.kernel.boot.core/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.boot.core/bnd.bnd
@@ -29,11 +29,11 @@ Export-Package: \
 	com.ibm.wsspi.kernel.embeddable
 	
 Private-Package: \
- 	org.apache.commons.compress.archivers, \
- 	org.apache.commons.compress.archivers.zip, \
- 	org.apache.commons.compress.compressors, \
- 	org.apache.commons.compress.compressors.lzw, \
- 	org.apache.commons.compress.utils
+	com.ibm.ws.org.apache.commons.compress.archivers, \
+	com.ibm.ws.org.apache.commons.compress.archivers.zip, \
+	com.ibm.ws.org.apache.commons.compress.compressors, \
+	com.ibm.ws.org.apache.commons.compress.compressors.lzw, \
+	com.ibm.ws.org.apache.commons.compress.utils
 
 instrument.disabled: true
 
@@ -46,4 +46,4 @@ publish.wlp.jar.disabled: true
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.ws.logging;version=latest, \
 	com.ibm.ws.kernel.boot.java7;version=latest, \
-	org.apache.commons:commons-compress;version=1.10
+	com.ibm.ws.org.apache.commons:commons-compress;version=1.16.1

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/archive/internal/ZipArchive.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/archive/internal/ZipArchive.java
@@ -16,8 +16,8 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.List;
 
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import com.ibm.ws.org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import com.ibm.ws.org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 
 import com.ibm.ws.kernel.boot.archive.UnixModeHelper;
 import com.ibm.ws.kernel.boot.cmdline.Utils;
@@ -45,7 +45,7 @@ public class ZipArchive extends AbstractArchive {
 
     /**
      * Create an archive
-     * 
+     *
      * @param archiveFile the target zip file.
      */
     public ZipArchive(File archiveFile) throws IOException {
@@ -84,8 +84,8 @@ public class ZipArchive extends AbstractArchive {
             return;
         }
 
-        // Ignore the file if it happens to be the zipfile's path we are writing to. 
-        // Use Canonical instead of equals method - this compares paths in a system dependent way 
+        // Ignore the file if it happens to be the zipfile's path we are writing to.
+        // Use Canonical instead of equals method - this compares paths in a system dependent way
         if (archiveFile.getCanonicalFile().equals(sourceFile.getCanonicalFile())) {
             return;
         }


### PR DESCRIPTION
Various kernel boot utilities like server package minify require the
Apache Commons Compress APIs.  However, by putting them in the kernel
boot bundle (which is also used in the classpath to start the Liberty
server) it ends up on the classpath for applications.  This causes
unintended classloading behavior when customer applications attempt to
package their own version of Commons Compress.  In order to ensure that
we can use it, and ensure that user apps can't load it, we need to 
re-package these classes into com.ibm.ws.* packages.