### PR TITLE
add sessionCache feature while server running

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -106,8 +106,6 @@ public class CacheStoreService implements SessionStoreService {
         // httpSessionCache writeContents accepts ONLY_SET_ATTRIBUTES in place of ONLY_UPDATED_ATTRIBUTES to better reflect the behavior provided
         if (writeContents == null || "ONLY_SET_ATTRIBUTES".equals(writeContents))
             configurationProperties.put("writeContents", "ONLY_UPDATED_ATTRIBUTES");
-        else if (!"ALL_SESSION_ATTRIBUTES".equals(writeContents))
-            throw new IllegalArgumentException("writeContents: " + writeContents);
 
         // default/disallow advanced properties from httpSessionDatabase
         configurationProperties.put("noAffinitySwitchBack", "TIME_BASED_WRITE".equals(writeFrequency));

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/FATSuite.java
@@ -26,7 +26,8 @@ import componenttest.topology.utils.HttpUtils;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                SessionCacheConfigUpdateTest.class
+                SessionCacheConfigUpdateTest.class,
+                SessionCacheErrorPathsTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -89,20 +89,17 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         // Verify default behavior: writeContents=ONLY_SET_ATTRIBUTES
         FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testWriteContents_ONLY_SET_ATTRIBUTES", new ArrayList<>());
 
-        // TODO enable once this function is implemented
         // Reconfigure writeContents=GET_AND_SET_ATTRIBUTES
-        //ServerConfiguration config = server.getServerConfiguration();
-        //HttpSessionCache httpSessionCache = config.getHttpSessionCaches().get(0);
-        //httpSessionCache.setWriteContents("GET_AND_SET_ATTRIBUTES");
-        //server.setMarkToEndOfLog();
-        //server.updateServerConfiguration(config);
-        //server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
-
-        //FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testWriteContents_GET_AND_SET_ATTRIBUTES", new ArrayList<>());
-
-        // Reconfigure writeContents=ALL_SESSION_ATTRIBUTES
         ServerConfiguration config = server.getServerConfiguration();
         HttpSessionCache httpSessionCache = config.getHttpSessionCaches().get(0);
+        httpSessionCache.setWriteContents("GET_AND_SET_ATTRIBUTES");
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
+
+        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testWriteContents_GET_AND_SET_ATTRIBUTES", new ArrayList<>());
+
+        // Reconfigure writeContents=ALL_SESSION_ATTRIBUTES
         httpSessionCache.setWriteContents("ALL_SESSION_ATTRIBUTES");
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.session.cache.config.fat;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class SessionCacheErrorPathsTest extends FATServletClient {
+
+    private static final String APP_NAME = "sessionCacheConfigApp";
+    private static final Set<String> APP_NAMES = Collections.singleton(APP_NAME);
+    private static final String[] APP_RECYCLE_LIST = new String[] { "CWWKZ0009I.*" + APP_NAME, "CWWKZ000[13]I.*" + APP_NAME };
+    private static final String[] EMPTY_RECYCLE_LIST = new String[0];
+    private static final String SERVLET_NAME = "SessionCacheConfigTestServlet";
+
+    private static String[] cleanupList = EMPTY_RECYCLE_LIST;
+
+    private static ServerConfiguration savedConfig;
+
+    @Server("sessionCacheServer")
+    public static LibertyServer server;
+
+    /**
+     * After running each test, ensure the server is stopped and restore the original configuration.
+     */
+    @After
+    public void cleanUpPerTest() throws Exception {
+        if (server.isStarted())
+            try {
+                server.stopServer();
+            } finally {
+                server.updateServerConfiguration(savedConfig);
+            }
+        System.out.println("server configuration restored");
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, "session.cache.web");
+
+        String configLocation = new File(server.getUserDir() + "/shared/resources/hazelcast/hazelcast-localhost-only.xml").getAbsolutePath();
+        server.setJvmOptions(Arrays.asList("-Dhazelcast.config=" + configLocation,
+                                           "-Dhazelcast.group.name=" + UUID.randomUUID()));
+
+        savedConfig = server.getServerConfiguration().clone();
+    }
+
+    /**
+     * Add the sessionCache-1.0 feature while the server is running. Access a session before and after,
+     * verifying that a session attribute added afterward is persisted, whereas a session attribute added before
+     * (in absence of sessionCache-1.0 feature) is not.
+     */
+    @AllowedFFDC("java.net.MalformedURLException") // TODO possible bug
+    @Test
+    public void testAddFeature() throws Exception {
+        // Start the server with sessionCache-1.0 disabled
+        ServerConfiguration config = savedConfig.clone();
+        config.getFeatureManager().getFeatures().remove("sessionCache-1.0");
+        server.updateServerConfiguration(config);
+        server.startServer();
+
+        // Session manager should warn user that sessions will be stored in memory
+        assertEquals(1, server.findStringsInLogs("SESN8501I").size());
+
+        List<String> session = new ArrayList<>();
+        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testSetAttribute&attribute=testAddFeature1&value=AF1", session);
+
+        // Add the sessionCache-1.0 feature
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(savedConfig);
+        server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
+
+        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testSetAttribute&attribute=testAddFeature2&value=AF2", session);
+
+        // second value should be written to the cache
+        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testCacheContains&attribute=testAddFeature2&value=AF2", session);
+
+        // first value should not be written to the cache
+        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testCacheContains&attribute=testAddFeature1&value=null", session);
+
+        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "invalidateSession", session);
+    }
+}

--- a/dev/com.ibm.ws.session.cache_fat_config/publish/servers/sessionCacheServer/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_config/publish/servers/sessionCacheServer/server.xml
@@ -1,6 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
+    <feature>jcacheContainer-1.1</feature>
     <feature>jndi-1.0</feature>
     <feature>servlet-4.0</feature>
     <feature>sessionCache-1.0</feature>

--- a/dev/com.ibm.ws.session.cache_fat_config/test-applications/sessionCacheConfigApp/src/session/cache/web/SessionCacheConfigTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/test-applications/sessionCacheConfigApp/src/session/cache/web/SessionCacheConfigTestServlet.java
@@ -159,11 +159,14 @@ public class SessionCacheConfigTestServlet extends FATServlet {
 
         byte[] bytes;
         Cache<String, byte[]> cache = Caching.getCache("com.ibm.ws.session.attr.default_host%2FsessionCacheConfigApp", String.class, byte[].class);
-        try {
-            bytes = cache.get(key);
-        } finally {
-            cache.close();
-        }
+        if (cache == null) // cache can be null if test case disables the sessionCache-1.0 feature
+            bytes = null;
+        else
+            try {
+                bytes = cache.get(key);
+            } finally {
+                cache.close();
+            }
 
         assertFalse("Not expecting cache entry " + key + " to have value " + unexpectedValue + ". " + EOLN +
                     "Bytes observed: " + Arrays.toString(bytes),

--- a/dev/com.ibm.ws.session.store/src/com/ibm/ws/session/store/common/BackedSession.java
+++ b/dev/com.ibm.ws.session.store/src/com/ibm/ws/session/store/common/BackedSession.java
@@ -590,7 +590,7 @@ public abstract class BackedSession extends MemorySession {
 
         if (includeInAppDataChanges && appDataChanges == null) {
             if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINE)) {
-                LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[PUT_VALUE_GUTS], "init appDataChanges");
+                LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[GET_VALUE_GUTS], "init appDataChanges");
             }
             appDataChanges = new Hashtable<String, Object>();
         }
@@ -678,10 +678,10 @@ public abstract class BackedSession extends MemorySession {
             }
             if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINE)) {
                 if (!SessionManagerConfig.isHideSessionValues()) {
-                    LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[PUT_VALUE_GUTS], "storing for " + getId() + " prop " + name + " with value "
+                    LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[invoker], "storing for " + getId() + " prop " + name + " with value "
                                                                                                                   + value + " via thread " + t);
                 } else {
-                    LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[PUT_VALUE_GUTS], "storing for " + getId() + " prop " + name + " via thread "
+                    LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[invoker], "storing for " + getId() + " prop " + name + " via thread "
                                                                                                                   + t);
                 }
             }

--- a/dev/com.ibm.ws.session.store/src/com/ibm/ws/session/store/common/BackedSession.java
+++ b/dev/com.ibm.ws.session.store/src/com/ibm/ws/session/store/common/BackedSession.java
@@ -292,7 +292,7 @@ public abstract class BackedSession extends MemorySession {
             LoggingUtil.SESSION_LOGGER_WAS.entering(methodClassName, methodNames[GET_ATTRIBUTE], "name= " + name);
         }
 
-        Object value = getValueGuts(name.toString());
+        Object value = getValueGuts(name.toString(), _smc.writeGetAndSetAttributes());
 
         if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINE)) {
             if (!SessionManagerConfig.isHideSessionValues()) {
@@ -318,7 +318,7 @@ public abstract class BackedSession extends MemorySession {
             }
         }
         _attributes.put(name, value);
-        Object oldValue = getValueGuts((String) name);
+        Object oldValue = getValueGuts((String) name, false);
         putValueGuts((String) name, value);
         Boolean oldIsListener = (Boolean) _attributeNames.put(name, newIsListener);
         _storeCallback.sessionAttributeSet(this, name, oldValue, oldIsListener, value, newIsListener);
@@ -490,26 +490,7 @@ public abstract class BackedSession extends MemorySession {
 
         if (swappable) {
             // Still want to update lists since whole session may not get written at first EOS
-            if (appDataTablesPerThread) {
-                Thread t = Thread.currentThread();
-                Hashtable sht = (Hashtable) appDataChanges.get(t);
-                if (sht == null) {
-                    sht = new Hashtable();
-                    appDataChanges.put(t, sht);
-                }
-                if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINE)) {
-                    if (!SessionManagerConfig.isHideSessionValues()) {
-                        LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[PUT_VALUE_GUTS], "storing for " + getId() + " prop " + pName + " with value "
-                                                                                                                      + pValue + " via thread " + t);
-                    } else {
-                        LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[PUT_VALUE_GUTS], "storing for " + getId() + " prop " + pName + " via thread "
-                                                                                                                      + t);
-                    }
-                }
-                sht.put(pName, convObj);
-            } else { // appDataTablesPerSession
-                appDataChanges.put(pName, convObj);
-            }
+            includeInAppDataChanges(pName, _smc.writeGetAndSetAttributes() ? pValue : convObj, PUT_VALUE_GUTS);
 
             boolean listenerFlagSetInMethod = false; //a check for instanceof was moved into the individual instancof blocks ... still only want to get getListenerFlag() once.
 
@@ -600,11 +581,18 @@ public abstract class BackedSession extends MemorySession {
     /*
      * GetValueGuts
      */
-    synchronized Object getValueGuts(String id) {
+    synchronized Object getValueGuts(String id, boolean includeInAppDataChanges) {
         //create local variable - JIT performance improvement
         final boolean isTraceOn = com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINER)) {
             LoggingUtil.SESSION_LOGGER_WAS.entering(methodClassName, methodNames[GET_VALUE_GUTS]);
+        }
+
+        if (includeInAppDataChanges && appDataChanges == null) {
+            if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINE)) {
+                LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[PUT_VALUE_GUTS], "init appDataChanges");
+            }
+            appDataChanges = new Hashtable<String, Object>();
         }
 
         Object returnValue = (mNonswappableData == null) ? null : getNonswappableData().get(id);
@@ -620,6 +608,8 @@ public abstract class BackedSession extends MemorySession {
                 LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[GET_VALUE_GUTS], "Retrieved cached object for " + id);
             }
             returnValue = resolveObject(returnValue);
+            if (includeInAppDataChanges)
+                includeInAppDataChanges(id, returnValue, GET_VALUE_GUTS);
         } else {
             //if this is a new session, don't access the database because
             //the session in memory is up-to-date..
@@ -648,6 +638,8 @@ public abstract class BackedSession extends MemorySession {
                 }
                 if (returnValue != null) {
                     returnValue = resolveObject(returnValue);
+                    if (includeInAppDataChanges)
+                        includeInAppDataChanges(id, returnValue, GET_VALUE_GUTS);
                     if (returnValue instanceof HttpSessionBindingListener) {
                         _attributeNames.put(id, Boolean.TRUE);
                     } else {
@@ -667,6 +659,38 @@ public abstract class BackedSession extends MemorySession {
         return returnValue;
     }
 
+    /**
+     * Adds a session attribute to the tracked list of changed data.
+     * 
+     * Precondition: invoker must be synchronized on BackedSession instance
+     * 
+     * @param name name of session attribute
+     * @param value value of session attribute
+     * @param invoker constant indicating the invoking method: GET_VALUE_GUTS or PUT_VALUE_GUTS
+     */
+    private void includeInAppDataChanges(String name, Object value, int invoker) {
+        if (appDataTablesPerThread) {
+            Thread t = Thread.currentThread();
+            Hashtable sht = (Hashtable) appDataChanges.get(t);
+            if (sht == null) {
+                sht = new Hashtable();
+                appDataChanges.put(t, sht);
+            }
+            if (com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINE)) {
+                if (!SessionManagerConfig.isHideSessionValues()) {
+                    LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[PUT_VALUE_GUTS], "storing for " + getId() + " prop " + name + " with value "
+                                                                                                                  + value + " via thread " + t);
+                } else {
+                    LoggingUtil.SESSION_LOGGER_WAS.logp(Level.FINE, methodClassName, methodNames[PUT_VALUE_GUTS], "storing for " + getId() + " prop " + name + " via thread "
+                                                                                                                  + t);
+                }
+            }
+            sht.put(name, value);
+        } else { // appDataTablesPerSession
+            appDataChanges.put(name, value);
+        }
+    }
+
     /*
      * removeValueGuts - To remove the values
      */
@@ -677,7 +701,7 @@ public abstract class BackedSession extends MemorySession {
             LoggingUtil.SESSION_LOGGER_WAS.entering(methodClassName, methodNames[REMOVE_VALUE_GUTS], "session " + getId() + " prop id " + pName);
         }
 
-        Object tmp = getValueGuts(pName);
+        Object tmp = getValueGuts(pName, false);
         // if object does not acutally exist, just return
         if (tmp == null) {
             if (isTraceOn && LoggingUtil.SESSION_LOGGER_WAS.isLoggable(Level.FINER)) {

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionManagerConfig.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionManagerConfig.java
@@ -71,6 +71,7 @@ public class SessionManagerConfig implements Cloneable {
     private boolean enableTimeBasedWrite = false;
     private long mPropertyWriterInterval = 120;
     private boolean writeAllProperties = false;
+    private boolean writeGetAndSetAttributes; 
 
     // Tells us if scheduledInvalidation is enabled and contains parameters
     private boolean scheduledInvalidation = false;
@@ -608,6 +609,17 @@ public class SessionManagerConfig implements Cloneable {
 
     public final void setwriteAllProperties() {
         writeAllProperties = true;
+    }
+
+    /**
+     * @returns true if writeContents is configured to GET_AND_SET_ATTRIBUTES
+     */
+    public final boolean writeGetAndSetAttributes() {
+        return writeGetAndSetAttributes;
+    }
+
+    final void setWriteGetAndSetAttributes() {
+        writeGetAndSetAttributes = true;
     }
 
     // scheduledInvalidation

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionProperties.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionProperties.java
@@ -841,8 +841,12 @@ final public class SessionProperties {
         }
         s = "writeContents";
         sValue = propertyToString(xtpProperties.get(s));
-        if (sValue != null && sValue.equals("ALL_SESSION_ATTRIBUTES")) {
-            smc.setwriteAllProperties(); // otherwise, default to ONLY_UPDATED_ATTRIBUTES
+        if (sValue != null) {
+            if (sValue.equals("ALL_SESSION_ATTRIBUTES"))
+                smc.setwriteAllProperties();
+            else if (sValue.equals("GET_AND_SET_ATTRIBUTES"))
+                smc.setWriteGetAndSetAttributes();
+            // otherwise, default to ONLY_UPDATED_ATTRIBUTES
         }
 
         return true;


### PR DESCRIPTION
Add a test case that starts the server without the sessionCache-1.0 feature, uses a session, and then adds the feature at a later point, verifying that afterwards session updates are persisted.