### PR TITLE
Reduce use of StringBuilder in a few other places in JAX-RS.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -118,25 +118,32 @@ public final class HttpUtils {
 
     private static String componentEncode(String reservedChars, String value) {
 
-        StringBuilder buffer = new StringBuilder();
-        StringBuilder bufferToEncode = new StringBuilder();
-
-        for (int i = 0; i < value.length(); i++) {
+        // Liberty Change for CXF Begin
+        StringBuilder buffer = null;
+        int length = value.length();
+        int startingIndex = 0;
+        for (int i = 0; i < length; i++) {
             char currentChar = value.charAt(i);
             if (reservedChars.indexOf(currentChar) != -1) {
-                if (bufferToEncode.length() > 0) {
-                    buffer.append(urlEncode(bufferToEncode.toString()));
-                    bufferToEncode.setLength(0);
+                if (buffer == null) {
+                    buffer = new StringBuilder(length + 8);
+                }
+                // If it is going to be an empty string nothing to encode.
+                if (i != startingIndex) {
+                    buffer.append(urlEncode(value.substring(startingIndex, i)));
                 }
                 buffer.append(currentChar);
-            } else {
-                bufferToEncode.append(currentChar);
+                startingIndex = i + 1;
             }
         }
 
-        if (bufferToEncode.length() > 0) {
-            buffer.append(urlEncode(bufferToEncode.toString()));
+        if (buffer == null) {
+            return urlEncode(value);
         }
+        if (startingIndex < length) {
+            buffer.append(urlEncode(value.substring(startingIndex, length)));
+        }
+        // Liberty Change for CXF Begin
 
         return buffer.toString();
     }

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
@@ -552,22 +552,21 @@ public final class ResourceUtils {
             return getClassNameandPath(className, path.value()); 
         }        
     }
-    
-    private static String getClassNameandPath (String className, String pathValue) {        
-        if (pathValue == null) {
-            pathValue = "/";
-        } else if (!pathValue.startsWith("/")) {
-            pathValue = "/" + pathValue;
-        }     
-        
-        StringBuilder sb = new StringBuilder().append("/").append(className).append(pathValue);
-        
-        for (int index = 0; index < sb.length(); index++) {
-            if (sb.charAt(index) == '.') {
-                sb.setCharAt(index, '_');
+
+    private static String getClassNameandPath (String className, String pathValue) {
+        int pathLength = pathValue == null ? 0 : pathValue.length();
+        StringBuilder sb = new StringBuilder(className.length() + pathLength + 1);
+        sb.append('/').append(className);
+
+        if (pathLength == 0) {
+            sb.append('/');
+        } else {
+            if (pathValue.charAt(0) != '/') {
+                sb.append('/');
             }
+            sb.append(pathValue);
         }
-        
+
         return sb.toString();
     }
 // end Liberty change

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -119,25 +119,32 @@ public final class HttpUtils {
 
     private static String componentEncode(String reservedChars, String value) {
 
-        StringBuilder buffer = new StringBuilder();
-        StringBuilder bufferToEncode = new StringBuilder();
-
-        for (int i = 0; i < value.length(); i++) {
+        // Liberty Change for CXF Begin
+        StringBuilder buffer = null;
+        int length = value.length();
+        int startingIndex = 0;
+        for (int i = 0; i < length; i++) {
             char currentChar = value.charAt(i);
             if (reservedChars.indexOf(currentChar) != -1) {
-                if (bufferToEncode.length() > 0) {
-                    buffer.append(urlEncode(bufferToEncode.toString()));
-                    bufferToEncode.setLength(0);
+                if (buffer == null) {
+                    buffer = new StringBuilder(length + 8);
+                }
+                // If it is going to be an empty string nothing to encode.
+                if (i != startingIndex) {
+                    buffer.append(urlEncode(value.substring(startingIndex, i)));
                 }
                 buffer.append(currentChar);
-            } else {
-                bufferToEncode.append(currentChar);
+                startingIndex = i + 1;
             }
         }
 
-        if (bufferToEncode.length() > 0) {
-            buffer.append(urlEncode(bufferToEncode.toString()));
+        if (buffer == null) {
+            return urlEncode(value);
         }
+        if (startingIndex < length) {
+            buffer.append(urlEncode(value.substring(startingIndex, length)));
+        }
+        // Liberty Change for CXF Begin
 
         return buffer.toString();
     }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
@@ -552,21 +552,20 @@ public final class ResourceUtils {
         }        
     }
     
-    private static String getClassNameandPath (String className, String pathValue) {        
-        if (pathValue == null) {
-            pathValue = "/";
-        } else if (!pathValue.startsWith("/")) {
-            pathValue = "/" + pathValue;
-        }     
-        
-        StringBuilder sb = new StringBuilder().append("/").append(className).append(pathValue);
-        
-        for (int index = 0; index < sb.length(); index++) {
-            if (sb.charAt(index) == '.') {
-                sb.setCharAt(index, '_');
+    private static String getClassNameandPath (String className, String pathValue) {
+        int pathLength = pathValue == null ? 0 : pathValue.length();
+        StringBuilder sb = new StringBuilder(className.length() + pathLength + 1);
+        sb.append('/').append(className);
+
+        if (pathLength == 0) {
+            sb.append('/');
+        } else {
+            if (pathValue.charAt(0) != '/') {
+                sb.append('/');
             }
+            sb.append(pathValue);
         }
-        
+
         return sb.toString();
     }
 // end Liberty change


### PR DESCRIPTION
In HttpUtils only use at most one StringBuilder in componentEncode.
In ResourceUtils update the logic for getClassNameandPath to use less
StringBuilders.