### PR TITLE
Ensure that namespace URIs are interned when processing ra.xml

### DIFF
--- a/dev/com.ibm.ws.jca.utils/src/com/ibm/ws/jca/utils/metagen/DeploymentDescriptorParser.java
+++ b/dev/com.ibm.ws.jca.utils/src/com/ibm/ws/jca/utils/metagen/DeploymentDescriptorParser.java
@@ -72,11 +72,9 @@ public class DeploymentDescriptorParser {
 
     private static JAXBContext raContext, wlpRaContext, ra10Context = null;
 
-    private static EntityResolver resolver = new org.xml.sax.EntityResolver()
-    {
+    private static EntityResolver resolver = new org.xml.sax.EntityResolver() {
         @Override
-        public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException
-        {
+        public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
             // do not resolve the external url for the dtd.
             if (systemId != null)
                 if (systemId.toLowerCase().endsWith(".dtd") || systemId.toLowerCase().endsWith(".xsd")) {
@@ -114,7 +112,7 @@ public class DeploymentDescriptorParser {
     /**
      * This method is used to inspect the ra.xml and check if its a 1.0 RA. This is called only
      * if we fail parsing the ra.xml using JAXB for 1.5/1.6
-     * 
+     *
      * @param xmlStream The ra.xml file
      * @return whether the resource adapter is a 1.0 resource adapter
      */
@@ -141,7 +139,7 @@ public class DeploymentDescriptorParser {
 
     /**
      * Converts a ra.xml (or wlp-ra.xml) into a RaConnector/RaConnector10 or WlpRaConnector object.
-     * 
+     *
      * @param xmlStream the stream to the wlp-/ra.xml file
      * @return the parsed xml file
      * @throws SAXException
@@ -189,9 +187,9 @@ public class DeploymentDescriptorParser {
 
     /**
      * Called for parsing the ra.xml/wlp-ra.xml dd for the resource adapter.
-     * 
+     *
      * @param ddEntry Entry corresponding to the deployment descriptor
-     * 
+     *
      * @throws JAXBException
      * @throws SAXException
      * @throws ParserConfigurationException
@@ -220,7 +218,7 @@ public class DeploymentDescriptorParser {
     // That will happen in ConnectorAdapter
     /**
      * Combines a converted wlp-ra.xml into a parsed ra.xml
-     * 
+     *
      * @param raConnector the combined parsed ra.xml file, annotations, java bean properties, if any
      * @param wlpRaConnector the parsed wlp-ra.xml file
      * @throw InvalidPropertyException
@@ -307,11 +305,12 @@ public class DeploymentDescriptorParser {
                             raConnectionDefinition.copyWlpSettings(wlpConnectionDefinition);
                             if (wlpConnectionDefinition.getConfigProperties() != null) {
                                 List<WlpRaConfigProperty> wlpConfigProperties = wlpConnectionDefinition.getConfigProperties();
-                                // process connection-definition config-property 
+                                // process connection-definition config-property
                                 for (WlpRaConfigProperty wlpConfigProperty : wlpConfigProperties) {
                                     if (wlpConfigProperty.addWlpPropertyToMetatype()) {
                                         if (raConnectionDefinition.isConfigPropertyAlreadyDefined(wlpConfigProperty.getWlpPropertyName()))
-                                            throw new InvalidPropertyException(Tr.formatMessage(tc, "J2CA9908.duplicate.copy", wlpConfigProperty.getWlpPropertyName(), adapterName));
+                                            throw new InvalidPropertyException(Tr.formatMessage(tc, "J2CA9908.duplicate.copy", wlpConfigProperty.getWlpPropertyName(),
+                                                                                                adapterName));
                                         else {
                                             RaConfigProperty property = new RaConfigProperty();
                                             property.copyWlpSettings(wlpConfigProperty);
@@ -396,7 +395,7 @@ public class DeploymentDescriptorParser {
             String JCA15NamespaceURI = "http://java.sun.com/xml/ns/j2ee";
             String JCA16NamespaceURI = "http://java.sun.com/xml/ns/javaee";
             String JCA17NamespaceURI = "http://xmlns.jcp.org/xml/ns/javaee";
-            namespaceURI = namespaceURI.trim().toLowerCase();
+            namespaceURI = namespaceURI.trim().toLowerCase().intern(); // on zOS it is required that Namespace URIs are interned
             //Convert the older namespaces as we need to process for multiple namespaces with the same objects.
             if (namespaceURI.equals(JCA15NamespaceURI) || namespaceURI.equals(JCA16NamespaceURI)) {
                 super.startElement(JCA17NamespaceURI, localName, qualifiedName, attributes);


### PR DESCRIPTION
Sometimes when parsing an ra.xml deployment descriptor on zOS, we intermittently get the following error:

```
Stack Dump = javax.xml.bind.UnmarshalException: Namespace URIs and local names to the unmarshaller needs to be interned.
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallingContext.handleEvent(UnmarshallingContext.java:742)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.Loader.reportError(Loader.java:259)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.Loader.reportError(Loader.java:254)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.Loader.reportUnexpectedChildElement(Loader.java:119)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallingContext$DefaultRootLoader.childElement(UnmarshallingContext.java:1147)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallingContext._startElement(UnmarshallingContext.java:570)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallingContext.startElement(UnmarshallingContext.java:552)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.SAXConnector.startElement(SAXConnector.java:165)
	at org.xml.sax.helpers.XMLFilterImpl.startElement(Unknown Source)
	at com.ibm.ws.jca.utils.metagen.DeploymentDescriptorParser$NamespaceFilter.startElement(DeploymentDescriptorParser.java:404)
	at org.apache.xerces.parsers.AbstractSAXParser.startElement(Unknown Source)
	at org.apache.xerces.impl.XMLNSDocumentScannerImpl.scanStartElement(Unknown Source)
	at org.apache.xerces.impl.XMLNSDocumentScannerImpl$NSContentDispatcher.scanRootElementHook(Unknown Source)
	at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl$FragmentContentDispatcher.dispatch(Unknown Source)
	at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl.scanDocument(Unknown Source)
	at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
	at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
	at org.apache.xerces.parsers.XMLParser.parse(Unknown Source)
	at org.apache.xerces.parsers.AbstractSAXParser.parse(Unknown Source)
	at org.apache.xerces.jaxp.SAXParserImpl$JAXPSAXParser.parse(Unknown Source)
	at org.xml.sax.helpers.XMLFilterImpl.parse(Unknown Source)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal0(UnmarshallerImpl.java:261)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal(UnmarshallerImpl.java:232)
	at javax.xml.bind.helpers.AbstractUnmarshallerImpl.unmarshal(AbstractUnmarshallerImpl.java:151)
	at javax.xml.bind.helpers.AbstractUnmarshallerImpl.unmarshal(AbstractUnmarshallerImpl.java:134)
	at com.ibm.ws.jca.utils.metagen.DeploymentDescriptorParser.parseResourceAdapterXml(DeploymentDescriptorParser.java:180)
	at com.ibm.ws.jca.utils.metagen.DeploymentDescriptorParser.parseRaDeploymentDescriptor(DeploymentDescriptorParser.java:203)
	at com.ibm.ws.jca.internal.ConnectorAdapter.adapt(ConnectorAdapter.java:91)
	at com.ibm.ws.jca.internal.ConnectorAdapter.adapt(ConnectorAdapter.java:48)
	at com.ibm.ws.adaptable.module.internal.AdapterFactoryServiceImpl.adapt(AdapterFactoryServiceImpl.java:193)
	at com.ibm.ws.adaptable.module.internal.AdaptableContainerImpl.adapt(AdaptableContainerImpl.java:170)
	at com.ibm.ws.adaptable.module.internal.InterpretedContainerImpl.adapt(InterpretedContainerImpl.java:203)
	at com.ibm.ws.app.manager.module.internal.SimpleDeployedAppInfoBase$ModuleContainerInfoBase.<init>(SimpleDeployedAppInfoBase.java:153)
	at com.ibm.ws.app.manager.module.internal.SimpleDeployedAppInfoBase$ConnectorModuleContainerInfo.<init>(SimpleDeployedAppInfoBase.java:212)
	at com.ibm.ws.app.manager.ear.internal.EARDeployedAppInfo.createModuleContainerInfo(EARDeployedAppInfo.java:379)
	at com.ibm.ws.app.manager.ear.internal.EARDeployedAppInfo.processModuleContainerInfo(EARDeployedAppInfo.java:561)
	at com.ibm.ws.app.manager.ear.internal.EARDeployedAppInfo.findModules(EARDeployedAppInfo.java:300)
	at com.ibm.ws.app.manager.ear.internal.EARDeployedAppInfo.<init>(EARDeployedAppInfo.java:177)
	at com.ibm.ws.app.manager.ear.internal.EARDeployedAppInfoFactoryImpl.createDeployedAppInfo(EARDeployedAppInfoFactoryImpl.java:228)
	at com.ibm.ws.app.manager.ear.internal.EARApplicationHandlerImpl.setUpApplicationMonitoring(EARApplicationHandlerImpl.java:49)
	at com.ibm.ws.app.manager.internal.statemachine.StartAction.execute(StartAction.java:136)
	at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.enterState(ApplicationStateMachineImpl.java:1258)
	at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.run(ApplicationStateMachineImpl.java:873)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1153)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.lang.Thread.run(Thread.java:785)
```

Based on the error message, we will try to solve this by ensuring the namespace URIs are interned.