### PR TITLE
test application closes CachingProvider

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -140,18 +140,27 @@ public class CacheStoreService implements SessionStoreService {
         }
 
         // load JCache provider from configured library, which is either specified as a libraryRef or via a bell
-        cachingProvider = Caching.getCachingProvider(library.getClassLoader());
+        ClassLoader loader = library.getClassLoader();
+
+        if (trace && tc.isDebugEnabled())
+            CacheHashMap.tcInvoke("Caching", "getCachingProvider", loader);
+
+        cachingProvider = Caching.getCachingProvider(loader);
 
         tcCachingProvider = "CachingProvider" + Integer.toHexString(System.identityHashCode(cachingProvider));
-        if (trace && tc.isDebugEnabled())
+
+        if (trace && tc.isDebugEnabled()) {
+            CacheHashMap.tcReturn("Caching", "getCachingProvider", tcCachingProvider, cachingProvider);
+            Tr.debug(this, tc, "caching provider class is " + cachingProvider.getClass().getName());
             CacheHashMap.tcInvoke(tcCachingProvider, "getCacheManager", uri, null, vendorProperties);
+        }
 
         cacheManager = cachingProvider.getCacheManager(uri, null, vendorProperties);
 
         tcCacheManager = "CacheManager" + Integer.toHexString(System.identityHashCode(cacheManager));
 
         if (trace && tc.isDebugEnabled()) {
-            CacheHashMap.tcReturn(tcCachingProvider, "getCacheManager", tcCacheManager);
+            CacheHashMap.tcReturn(tcCachingProvider, "getCacheManager", tcCacheManager, cacheManager);
             CacheHashMap.tcInvoke(tcCachingProvider, "isSupported", "STORE_BY_REFERENCE");
         }
 

--- a/dev/com.ibm.ws.session.cache_fat_config/.classpath
+++ b/dev/com.ibm.ws.session.cache_fat_config/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/sessionCacheConfigApp/src"/>
+	<classpathentry kind="src" path="test-applications/jcacheApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.session.cache_fat_config/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat_config/bnd.bnd
@@ -13,6 +13,7 @@ bVersion=1.0
 
 src: \
 	fat/src,\
+	test-applications/jcacheApp/src,\
 	test-applications/sessionCacheConfigApp/src
 
 fat.project: true

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 
 import org.junit.After;
@@ -27,6 +28,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.Application;
+import com.ibm.websphere.simplicity.config.ClassloaderElement;
 import com.ibm.websphere.simplicity.config.HttpSessionCache;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
@@ -40,7 +43,7 @@ import componenttest.topology.utils.FATServletClient;
 public class SessionCacheConfigUpdateTest extends FATServletClient {
 
     private static final String APP_NAME = "sessionCacheConfigApp";
-    private static final Set<String> APP_NAMES = Collections.singleton(APP_NAME);
+    private static final Set<String> APP_NAMES = Collections.singleton(APP_NAME); // jcacheApp not included because it isn't normally configured
     private static final String[] APP_RECYCLE_LIST = new String[] { "CWWKZ0009I.*" + APP_NAME, "CWWKZ000[13]I.*" + APP_NAME };
     private static final String[] EMPTY_RECYCLE_LIST = new String[0];
     private static final String SERVLET_NAME = "SessionCacheConfigTestServlet";
@@ -67,6 +70,8 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         ShrinkHelper.defaultApp(server, APP_NAME, "session.cache.web");
+        ShrinkHelper.defaultApp(server, "jcacheApp", "test.cache.web");
+        server.removeInstalledAppForValidation("jcacheApp"); // This application is available for tests to add but not configured by default.
 
         String configLocation = new File(server.getUserDir() + "/shared/resources/hazelcast/hazelcast-localhost-only.xml").getAbsolutePath();
         server.setJvmOptions(Arrays.asList("-Dhazelcast.config=" + configLocation,
@@ -79,6 +84,36 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer("SRVE0297E.*IllegalStateException"); // TODO remove this temporarily allowed error once OSGi dependencies in session manager code are fixed
+    }
+
+    /**
+     * Verify that application usage of a caching provider does not interfere with the sessionCache feature.
+     */
+    @Test
+    public void testApplicationClosesCachingProvider() throws Exception {
+        // Add application: jcacheApp
+        ServerConfiguration config = server.getServerConfiguration();
+        Application jcacheApp = new Application();
+        ClassloaderElement jcacheApp_classloader = new ClassloaderElement();
+        jcacheApp_classloader.getCommonLibraryRefs().add("HazelcastLib");
+        jcacheApp.getClassloaders().add(jcacheApp_classloader);
+        jcacheApp.setLocation("jcacheApp.war");
+        config.getApplications().add(jcacheApp);
+
+        Set<String> appNames = new TreeSet<String>(APP_NAMES);
+        appNames.add("jcacheApp");
+
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(appNames, EMPTY_RECYCLE_LIST);
+
+        // Application obtains the CachingProvider for the same configured library and closes the provider
+        // TODO FATSuite.run(server, "jcacheApp/JCacheConfigTestServlet", "testCloseCachingProvider", null);
+
+        // Access a session - this will only work if sessionCache feature has used a different CachingProvider instance
+        List<String> session = new ArrayList<>();
+        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "getSessionId", session);
+        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "invalidateSession", session);
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache_fat_config/publish/servers/sessionCacheServer/bootstrap.properties
+++ b/dev/com.ibm.ws.session.cache_fat_config/publish/servers/sessionCacheServer/bootstrap.properties
@@ -10,4 +10,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.session.*=all
-websphere.java.security=true

--- a/dev/com.ibm.ws.session.cache_fat_config/publish/servers/sessionCacheServer/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_config/publish/servers/sessionCacheServer/server.xml
@@ -22,6 +22,22 @@
   </library>
 
   <!-- Needed because the application uses Hazelcast directly   -->
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.io.FilePermission" actions="read" name="${shared.resource.dir}/hazelcast/hazelcast-localhost-only.xml"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.management"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.misc"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.nio.ch"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.RuntimePermission" name="enableContextClassLoaderOverride"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.RuntimePermission" name="getenv.HZ_PHONE_HOME_ENABLED"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.RuntimePermission" name="modifyThread"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.RuntimePermission" name="shutdownHooks"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.net.NetPermission" name="getNetworkInformation"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.net.SocketPermission" actions="accept,connect,listen,resolve" name="*"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="java.net.URLPermission" actions="GET:User-Agent" name="http://phonehome.hazelcast.com/ping"/>
+  <javaPermission codebase="${server.config.dir}/apps/jcacheApp.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
   <javaPermission codebase="${server.config.dir}/apps/sessionCacheConfigApp.war" className="java.io.FilePermission" actions="read" name="${shared.resource.dir}/hazelcast/hazelcast-localhost-only.xml"/>
   <javaPermission codebase="${server.config.dir}/apps/sessionCacheConfigApp.war" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.management"/>
   <javaPermission codebase="${server.config.dir}/apps/sessionCacheConfigApp.war" className="java.lang.RuntimePermission" name="accessClassInPackage.sun.misc"/>

--- a/dev/com.ibm.ws.session.cache_fat_config/test-applications/jcacheApp/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.session.cache_fat_config/test-applications/jcacheApp/resources/META-INF/permissions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+ <!-- TODO remove this workaround for
+ CWWKE0912W: Current Java 2 Security policy reported a potential violation of Java 2 Security Permission.
+
+ Permission:
+      getClassLoader : access denied ("java.lang.RuntimePermission" "getClassLoader")
+  -->
+ <permission>
+   <class-name>java.lang.RuntimePermission</class-name>
+   <name>getClassLoader</name>
+ </permission>
+
+ <permission>
+   <class-name>java.util.PropertyPermission</class-name>
+   <name>*</name>
+   <actions>read</actions>
+ </permission>
+ 
+</permissions>

--- a/dev/com.ibm.ws.session.cache_fat_config/test-applications/jcacheApp/src/test/cache/web/JCacheConfigTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/test-applications/jcacheApp/src/test/cache/web/JCacheConfigTestServlet.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.cache.web;
+
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/JCacheConfigTestServlet")
+public class JCacheConfigTestServlet extends FATServlet {
+    /**
+     * Have the application obtain and close the caching provider instance for the configured Hazelcast library.
+     * The session cache implementation ultimately uses this library but would like to do so in a way that is
+     * isolated from applications so that it controls its own life cycle and makes it more difficult for
+     * applications to access cached session data other than through the proper HttpSession API.
+     */
+    public void testCloseCachingProvider(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        // Try to end up with the same CachingProvider instance as the sessionCache feature by using the configured library's class loader.
+        ClassLoader hazelcastClassLoader = Class.forName("com.hazelcast.cache.HazelcastCachingProvider").getClassLoader();
+        System.out.println("Class loader for HazelcastCachingProvider is " + hazelcastClassLoader);
+        CachingProvider cachingProvider = Caching.getCachingProvider(hazelcastClassLoader);
+        System.out.println("Provider instance is " + Integer.toHexString(System.identityHashCode(cachingProvider)) + " " + cachingProvider);
+        cachingProvider.close();
+    }
+}


### PR DESCRIPTION
Write a test case where an application closes the CachingProvider for the configured JCache provider library.  We need to update the session cache code, if possible, to use a different CachingProvider instance so that we are isolated from application code such as this.  The test will initially be failing because we don't have that level of isolation yet.