### PR TITLE
Update webcontainer formlogin app to support ShrinkWrap

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/apps/CommonFatApplications.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/apps/CommonFatApplications.java
@@ -20,10 +20,20 @@ public class CommonFatApplications {
         return ShrinkHelper.buildDefaultAppFromPath("testmarker", getPathToTestApps(), "com.ibm.ws.security.fat.common.apps.testmarker.*");
     }
 
+    public static WebArchive getFormLoginApp() throws Exception {
+        return ShrinkHelper.buildDefaultAppFromPath("formlogin", getPathToWebcontainerSecurityApps(), "web.common", "web.formlogin");
+    }
+
     private static String getPathToTestApps() {
         // When executing FATs, the "user.dir" property is <OL root>/dev/<FAT project>/build/libs/autoFVT/
         // Hence, to get back to this project, we have to navigate a few levels up.
         return System.getProperty("user.dir") + "/../../../../com.ibm.ws.security.fat.common/";
+    }
+
+    private static String getPathToWebcontainerSecurityApps() {
+        // When executing FATs, the "user.dir" property is <OL root>/dev/<FAT project>/build/libs/autoFVT/
+        // Hence, to get back to the webcontainer servlet project, we have to navigate a few levels up.
+        return System.getProperty("user.dir") + "/../../../../com.ibm.ws.webcontainer.security_test.servlets/";
     }
 
 }

--- a/dev/com.ibm.ws.security.fat.common/test-applications/testmarker/src/com/ibm/ws/security/fat/common/apps/testmarker/TestMarker.java
+++ b/dev/com.ibm.ws.security.fat.common/test-applications/testmarker/src/com/ibm/ws/security/fat/common/apps/testmarker/TestMarker.java
@@ -23,6 +23,9 @@ import javax.servlet.http.HttpServletResponse;
 public class TestMarker extends HttpServlet {
     private static final long serialVersionUID = 1L;
 
+    public static final String PARAM_ACTION = "action";
+    public static final String PARAM_TEST_NAME = "testCaseName";
+
     public TestMarker() {
         super();
     }
@@ -35,7 +38,7 @@ public class TestMarker extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         System.out.println("-----------------------------------------------------------------------------------------");
-        System.out.println(request.getParameter("action") + " TEST CASE: " + request.getParameter("testCaseName"));
+        System.out.println(request.getParameter(PARAM_ACTION) + " TEST CASE: " + request.getParameter(PARAM_TEST_NAME));
         System.out.println("-----------------------------------------------------------------------------------------");
     }
 }

--- a/dev/com.ibm.ws.webcontainer.security_test.servlets/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security_test.servlets/bnd.bnd
@@ -53,4 +53,5 @@ test.project: true
 	com.ibm.ws.componenttest:public.api;version=latest, \
 	fattest.simplicity;version=latest, \
 	org.apache.httpcomponents:httpclient;version=4.1.2, \
-	org.apache.httpcomponents:httpcore;version=4.1.2
+	org.apache.httpcomponents:httpcore;version=4.1.2, \
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.webcontainer.security_test.servlets/common-classes/src/web/common/package-info.java
+++ b/dev/com.ibm.ws.webcontainer.security_test.servlets/common-classes/src/web/common/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.20")
+package web.common;

--- a/dev/com.ibm.ws.webcontainer.security_test.servlets/test-applications/formlogin/src/web/formlogin/package-info.java
+++ b/dev/com.ibm.ws.webcontainer.security_test.servlets/test-applications/formlogin/src/web/formlogin/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.20")
+package web.formlogin;


### PR DESCRIPTION
Updates the formlogin servlets under `com.ibm.ws.webcontainer.security_test.servlets` to be exported by the enclosing bundle, allowing ShrinkWrap to be able to package the application for FATs. Adds a method in the `com.ibm.ws.security.fat.common` project that will create and return that packaged ShrinkWrap application.