### PR TITLE
Add FatExceptionsUtils and ServerTracker to common security FAT

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/apps/CommonFatApplications.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/apps/CommonFatApplications.java
@@ -20,10 +20,20 @@ public class CommonFatApplications {
         return ShrinkHelper.buildDefaultAppFromPath("testmarker", getPathToTestApps(), "com.ibm.ws.security.fat.common.apps.testmarker.*");
     }
 
+    public static WebArchive getFormLoginApp() throws Exception {
+        return ShrinkHelper.buildDefaultAppFromPath("formlogin", getPathToWebcontainerSecurityApps(), "web.common", "web.formlogin");
+    }
+
     private static String getPathToTestApps() {
         // When executing FATs, the "user.dir" property is <OL root>/dev/<FAT project>/build/libs/autoFVT/
         // Hence, to get back to this project, we have to navigate a few levels up.
         return System.getProperty("user.dir") + "/../../../../com.ibm.ws.security.fat.common/";
+    }
+
+    private static String getPathToWebcontainerSecurityApps() {
+        // When executing FATs, the "user.dir" property is <OL root>/dev/<FAT project>/build/libs/autoFVT/
+        // Hence, to get back to the webcontainer servlet project, we have to navigate a few levels up.
+        return System.getProperty("user.dir") + "/../../../../com.ibm.ws.webcontainer.security_test.servlets/";
     }
 
 }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/exceptions/FatExceptionUtils.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/exceptions/FatExceptionUtils.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.fat.common.exceptions;
+
+import java.util.List;
+
+public class FatExceptionUtils {
+
+    protected static Class<?> thisClass = FatExceptionUtils.class;
+
+    public static Exception buildCumulativeException(List<Exception> exceptions) {
+        if (exceptions == null) {
+            return null;
+        }
+        Exception cumulativeException = null;
+        int exceptionNum = 0;
+        for (Exception e : exceptions) {
+            if (e == null) {
+                continue;
+            }
+            String prevExceptionMsg = (cumulativeException == null) ? "" : (cumulativeException.getMessage() + "\n<br/>");
+            cumulativeException = new Exception(prevExceptionMsg + "[Exception #" + (++exceptionNum) + "]: " + e.getMessage());
+        }
+        return cumulativeException;
+    }
+
+}

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/exceptions/package-info.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/exceptions/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.20")
+package com.ibm.ws.security.fat.common.exceptions;

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.fat.common.servers;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.ibm.ws.security.fat.common.exceptions.FatExceptionUtils;
+
+import componenttest.topology.impl.LibertyServer;
+
+public class ServerTracker {
+
+    protected static Class<?> thisClass = ServerTracker.class;
+
+    Set<LibertyServer> libertyServers = new HashSet<LibertyServer>();
+
+    public void addServer(LibertyServer server) {
+        libertyServers.add(server);
+    }
+
+    public Set<LibertyServer> getServers() {
+        return new HashSet<LibertyServer>(libertyServers);
+    }
+
+    public void stopAllServers() throws Exception {
+        List<Exception> exceptions = new ArrayList<Exception>();
+        for (LibertyServer server : libertyServers) {
+            try {
+                stopServerOrThrowException(server);
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        }
+        if (!exceptions.isEmpty()) {
+            throw FatExceptionUtils.buildCumulativeException(exceptions);
+        }
+    }
+
+    void stopServerOrThrowException(LibertyServer server) throws Exception {
+        if (server == null) {
+            return;
+        }
+        try {
+            server.stopServer();
+        } catch (Exception e) {
+            e.printStackTrace(System.out);
+            throw e;
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/package-info.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.20")
+package com.ibm.ws.security.fat.common.servers;

--- a/dev/com.ibm.ws.security.fat.common/test-applications/testmarker/src/com/ibm/ws/security/fat/common/apps/testmarker/TestMarker.java
+++ b/dev/com.ibm.ws.security.fat.common/test-applications/testmarker/src/com/ibm/ws/security/fat/common/apps/testmarker/TestMarker.java
@@ -23,6 +23,9 @@ import javax.servlet.http.HttpServletResponse;
 public class TestMarker extends HttpServlet {
     private static final long serialVersionUID = 1L;
 
+    public static final String PARAM_ACTION = "action";
+    public static final String PARAM_TEST_NAME = "testCaseName";
+
     public TestMarker() {
         super();
     }
@@ -35,7 +38,7 @@ public class TestMarker extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         System.out.println("-----------------------------------------------------------------------------------------");
-        System.out.println(request.getParameter("action") + " TEST CASE: " + request.getParameter("testCaseName"));
+        System.out.println(request.getParameter(PARAM_ACTION) + " TEST CASE: " + request.getParameter(PARAM_TEST_NAME));
         System.out.println("-----------------------------------------------------------------------------------------");
     }
 }

--- a/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/exceptions/FatExceptionUtilsTest.java
+++ b/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/exceptions/FatExceptionUtilsTest.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.fat.common.exceptions;
+
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class FatExceptionUtilsTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.fat.common.*=all");
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void before() {
+        System.out.println("Entering test: " + testName.getMethodName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        outputMgr.resetStreams();
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    /************************************** buildCumulativeException **************************************/
+
+    /**
+     * Tests:
+     * - Null exception list provided
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_buildCumulativeException_nullExceptionList() {
+        try {
+            List<Exception> exceptions = null;
+            Exception result = FatExceptionUtils.buildCumulativeException(exceptions);
+            assertNull("Result should have been null but was: " + result, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Exception list includes only a null Exception object
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_buildCumulativeException_listIncludesNullException() {
+        try {
+            List<Exception> exceptions = new ArrayList<Exception>();
+            exceptions.add(null);
+
+            Exception result = FatExceptionUtils.buildCumulativeException(exceptions);
+            assertNull("Result should have been null but was: " + result, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Exception list includes only one Exception object
+     * Expects:
+     * - Exception message should indicate only one exception and include that exception's error message.
+     */
+    @Test
+    public void test_buildCumulativeException_oneException() {
+        try {
+            List<Exception> exceptions = new ArrayList<Exception>();
+            exceptions.add(new Exception(defaultExceptionMsg));
+
+            Exception result = FatExceptionUtils.buildCumulativeException(exceptions);
+            verifyException(result, Pattern.quote("[Exception #1]: " + defaultExceptionMsg));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Exception list includes multiple exceptions
+     * Expects:
+     * - Cumulative exception message should include each exception message
+     */
+    @Test
+    public void test_buildCumulativeException_multipleExceptions() {
+        try {
+            List<Exception> exceptions = new ArrayList<Exception>();
+            exceptions.add(new Exception("First exception"));
+            exceptions.add(new Exception("Second exception"));
+            exceptions.add(new Exception("Third exception"));
+
+            Exception result = FatExceptionUtils.buildCumulativeException(exceptions);
+            verifyException(result, Pattern.quote("[Exception #1]: " + "First exception" + "\n<br/>"));
+            verifyException(result, Pattern.quote("[Exception #2]: " + "Second exception" + "\n<br/>"));
+            verifyException(result, Pattern.quote("[Exception #3]: " + "Third exception"));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/servers/ServerTrackerTest.java
+++ b/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/servers/ServerTrackerTest.java
@@ -1,0 +1,367 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.fat.common.servers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import componenttest.topology.impl.LibertyServer;
+import test.common.SharedOutputManager;
+
+public class ServerTrackerTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.fat.common.*=all");
+
+    private final LibertyServer server1 = mockery.mock(LibertyServer.class, "server1");
+    private final LibertyServer server2 = mockery.mock(LibertyServer.class, "server2");
+    private final LibertyServer server3 = mockery.mock(LibertyServer.class, "server3");
+
+    ServerTracker tracker = new ServerTracker();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void before() {
+        System.out.println("Entering test: " + testName.getMethodName());
+        tracker = new ServerTracker();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        outputMgr.resetStreams();
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    /************************************** addServer **************************************/
+
+    /**
+     * Tests:
+     * - Add a null server instance to empty server tracker
+     * Expects:
+     * - Object should be successfully added
+     */
+    @Test
+    public void test_addServer_nullServer() {
+        try {
+            LibertyServer server = null;
+
+            tracker.addServer(server);
+
+            Set<LibertyServer> servers = tracker.getServers();
+            assertEquals("Server size did not match expected value.", 1, servers.size());
+            LibertyServer addedServer = servers.iterator().next();
+            assertNull("Single entry should have been null but was: " + addedServer, addedServer);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Add a server instance to empty server tracker
+     * Expects:
+     * - Object should be successfully added
+     */
+    @Test
+    public void test_addServer_addOneServer() {
+        try {
+            tracker.addServer(server1);
+
+            Set<LibertyServer> servers = tracker.getServers();
+            assertEquals("Server size did not match expected value.", 1, servers.size());
+            assertTrue("Retrieved server set did not contain expected server " + server1 + ". Set was " + servers, servers.contains(server1));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Add a server instance twice
+     * Expects:
+     * - Object should be successfully added, but only one instance should be stored
+     */
+    @Test
+    public void test_addServer_addSameServerTwice() {
+        try {
+            tracker.addServer(server1);
+            tracker.addServer(server1);
+
+            Set<LibertyServer> servers = tracker.getServers();
+            assertEquals("Server size did not match expected value.", 1, servers.size());
+            assertTrue("Retrieved server set did not contain expected server " + server1 + ". Set was " + servers, servers.contains(server1));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Add multiple different servers
+     * Expects:
+     * - Each object should be successfully added
+     */
+    @Test
+    public void test_addServer_addMultipleServers() {
+        try {
+            tracker.addServer(server1);
+            tracker.addServer(server2);
+            tracker.addServer(server3);
+
+            Set<LibertyServer> servers = tracker.getServers();
+            assertEquals("Server size did not match expected value.", 3, servers.size());
+            assertTrue("Retrieved server set did not contain expected server " + server1 + ". Set was " + servers, servers.contains(server1));
+            assertTrue("Retrieved server set did not contain expected server " + server2 + ". Set was " + servers, servers.contains(server2));
+            assertTrue("Retrieved server set did not contain expected server " + server3 + ". Set was " + servers, servers.contains(server3));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** stopAllServers **************************************/
+
+    /**
+     * Tests:
+     * - No servers currently tracked
+     * Expects:
+     * - Nothing should happen
+     */
+    @Test
+    public void test_stopAllServers_noServers() {
+        try {
+            tracker.stopAllServers();
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - One null server tracked
+     * Expects:
+     * - Nothing should happen
+     */
+    @Test
+    public void test_stopAllServers_oneNullServer() {
+        try {
+            tracker.addServer(null);
+
+            tracker.stopAllServers();
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - One server tracked
+     * Expects:
+     * - Server should be stopped
+     */
+    @Test
+    public void test_stopAllServers_oneServer() {
+        try {
+            tracker.addServer(server1);
+
+            mockery.checking(new Expectations() {
+                {
+                    one(server1).stopServer();
+                }
+            });
+
+            tracker.stopAllServers();
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - One server tracked
+     * - Exception thrown while stopping the server
+     * Expects:
+     * - Cumulative exception should be thrown that includes the underlying exception message
+     */
+    @Test
+    public void test_stopAllServers_oneServerExceptionThrown() {
+        try {
+            tracker.addServer(server1);
+
+            mockery.checking(new Expectations() {
+                {
+                    one(server1).stopServer();
+                    will(throwException(new Exception(defaultExceptionMsg)));
+                }
+            });
+
+            try {
+                tracker.stopAllServers();
+                fail("Should have thrown an exception but did not.");
+            } catch (Exception e) {
+                verifyException(e, Pattern.quote(defaultExceptionMsg));
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Multiple servers tracked
+     * Expects:
+     * - All servers should be stopped successfully
+     */
+    @Test
+    public void test_stopAllServers_multipleServers() {
+        try {
+            tracker.addServer(server1);
+            tracker.addServer(server2);
+            tracker.addServer(server3);
+
+            mockery.checking(new Expectations() {
+                {
+                    one(server1).stopServer();
+                    one(server2).stopServer();
+                    one(server3).stopServer();
+                }
+            });
+
+            tracker.stopAllServers();
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Multiple servers tracked
+     * - Exceptions thrown while stopping some servers
+     * Expects:
+     * - Cumulative exception should be thrown that includes the underlying exception message from each exception
+     */
+    @Test
+    public void test_stopAllServers_multipleServersExceptionsThrown() {
+        try {
+            tracker.addServer(server1);
+            tracker.addServer(server2);
+            tracker.addServer(server3);
+
+            mockery.checking(new Expectations() {
+                {
+                    one(server1).stopServer();
+                    will(throwException(new Exception("Server 1 exception")));
+                    one(server2).stopServer();
+                    one(server3).stopServer();
+                    will(throwException(new Exception("Server 3 exception")));
+                }
+            });
+
+            try {
+                tracker.stopAllServers();
+                fail("Should have thrown an exception but did not.");
+            } catch (Exception e) {
+                verifyException(e, Pattern.quote("Server 1 exception"));
+                verifyException(e, Pattern.quote("Server 3 exception"));
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** stopServerOrThrowException **************************************/
+
+    /**
+     * Tests:
+     * - Provided server is null
+     * Expects:
+     * - Nothing should happen
+     */
+    @Test
+    public void test_stopServerOrThrowException_nullServer() {
+        try {
+            LibertyServer server = null;
+            tracker.stopServerOrThrowException(server);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Exception thrown while stopping the server
+     * Expects:
+     * - Exception should be re-thrown
+     */
+    @Test
+    public void test_stopServerOrThrowException_stoppingThrowsException() {
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(server1).stopServer();
+                    will(throwException(new Exception(defaultExceptionMsg)));
+                }
+            });
+            try {
+                tracker.stopServerOrThrowException(server1);
+                fail("Should have thrown an exception but did not.");
+            } catch (Exception e) {
+                verifyException(e, Pattern.quote(defaultExceptionMsg));
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Successful server stop
+     * Expects:
+     * - Nothing should happen other than the server stop invocation
+     */
+    @Test
+    public void test_stopServerOrThrowException_successfulStop() {
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(server1).stopServer();
+                }
+            });
+            tracker.stopServerOrThrowException(server1);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.webcontainer.security_test.servlets/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security_test.servlets/bnd.bnd
@@ -53,4 +53,5 @@ test.project: true
 	com.ibm.ws.componenttest:public.api;version=latest, \
 	fattest.simplicity;version=latest, \
 	org.apache.httpcomponents:httpclient;version=4.1.2, \
-	org.apache.httpcomponents:httpcore;version=4.1.2
+	org.apache.httpcomponents:httpcore;version=4.1.2, \
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.webcontainer.security_test.servlets/common-classes/src/web/common/package-info.java
+++ b/dev/com.ibm.ws.webcontainer.security_test.servlets/common-classes/src/web/common/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.20")
+package web.common;

--- a/dev/com.ibm.ws.webcontainer.security_test.servlets/test-applications/formlogin/src/web/formlogin/package-info.java
+++ b/dev/com.ibm.ws.webcontainer.security_test.servlets/test-applications/formlogin/src/web/formlogin/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.20")
+package web.formlogin;


### PR DESCRIPTION
`FatExceptionsUtils`: Intended to include logic for exception handling in FATs

`ServerTracker`: Intended to help track and perform operations on groups of `LibertyServer` instances used in a given FAT