### PR TITLE
Add feature units

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.features/bnd.bnd
@@ -23,4 +23,4 @@ copy.pii: false
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	biz.aQute.bnd:biz.aQute.bnd;version=3.5.0;packages=**,\
-	org.apache.aries:org.apache.aries.util;version=1.0.0
+	org.apache.aries:org.apache.aries.util;version=1.1.3

--- a/dev/com.ibm.websphere.appserver.features/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.features/bnd.bnd
@@ -19,3 +19,8 @@ instrument.disabled: true
 feature.project: true
 
 copy.pii: false
+
+-testpath: \
+	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
+	biz.aQute.bnd:biz.aQute.bnd;version=3.5.0;packages=**,\
+	org.apache.aries:org.apache.aries.util;version=1.0.0

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tasks/FeatureBnd.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tasks/FeatureBnd.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.feature.tasks;
+
+public class FeatureBnd {
+    private static final String IBM_APP_FORCE_RESTART = "IBM-App-ForceRestart";
+    /**  */
+    private static final String IBM_FEATURE_VERSION = "IBM-Feature-Version";
+    /**  */
+    private static final String IBM_INSTALL_POLICY = "IBM-Install-Policy";
+    /** */
+    public static final String IBM_PROVISION_CAPABILITY = "IBM-Provision-Capability";
+    /**  */
+    private static final String IBM_SHORT_NAME = "IBM-ShortName";
+
+    private static final String IBM_LICENSE_INFORMATION = "IBM-License-Information";
+
+    private static final String IBM_LICENSE_AGREEMENT = "IBM-License-Agreement";
+    /**  */
+    private static final String OSGI_SUBSYSTEM_FEATURE = "osgi.subsystem.feature";
+    /**  */
+    private static final String SUBSYSTEM_DESCRIPTION = "Subsystem-Description";
+    /**  */
+    private static final String SUBSYSTEM_LOCALIZATION = "Subsystem-Localization";
+    /**  */
+    private static final String SUBSYSTEM_MANIFEST_VERSION = "Subsystem-ManifestVersion";
+    /**  */
+    private static final String SUBSYSTEM_NAME = "Subsystem-Name";
+    /**  */
+    public static final String SUBSYSTEM_SYMBOLIC_NAME = "Subsystem-SymbolicName";
+    /**  */
+    private static final String SUBSYSTEM_TYPE = "Subsystem-Type";
+    /**  */
+    private static final String SUBSYSTEM_VERSION = "Subsystem-Version";
+}

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tasks/FeatureBuilder.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tasks/FeatureBuilder.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.feature.tasks;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Builder;
+
+public class FeatureBuilder extends Builder {
+
+
+    public Parameters getSubsystemContent() {
+        Parameters p = getParameters("Subsystem-Content");
+        return p;
+    }
+
+    public void setSubsystemContent(Parameters content) throws IOException {
+        setProperty("Subsystem-Content", printClauses(content.asMapMap()));
+    }
+
+    public Set<Map.Entry<String, Attrs>> getFiles() {
+        return getContent("-files");
+    }
+
+    public Set<Map.Entry<String, Attrs>> getJars() {
+        return getContent("-jars");
+    }
+
+    public Set<Map.Entry<String, Attrs>> getFeatures() {
+        return getContent("-features");
+    }
+
+    public Set<Map.Entry<String, Attrs>> getBundles() {
+        return getContent("-bundles");
+    }
+
+    private Set<Map.Entry<String, Attrs>> getContent(String contentType) {
+        String jars = getProperty(contentType, "");
+        if (jars == null || jars.length() == 0) {
+            return Collections.emptySet();
+        }
+        Parameters p = new Parameters(jars);
+        return p.entrySet();
+    }
+
+    public Set<String> getAutoFeatures() {
+    	Set<Entry<String, Attrs>> rawString = getContent(FeatureBnd.IBM_PROVISION_CAPABILITY);
+    	Set<String> processedAutoFeatures = new HashSet<String>();
+    	String OSGI_PREFIX = "osgi.identity=";
+    	Iterator<Entry<String, Attrs>> itr = rawString.iterator();
+    	String filterString = rawString.toString();
+		String[] messyAutoFeatures = filterString.split(OSGI_PREFIX);
+		for (String messyAutoFeature : messyAutoFeatures) {
+			if (!messyAutoFeature.startsWith("com"))
+				continue;
+
+			processedAutoFeatures.add(trimAutofeatureString(messyAutoFeature));
+		}
+
+    	return processedAutoFeatures;
+
+    }
+
+    private String trimAutofeatureString(String autoFeature) {
+    	if (autoFeature.indexOf(")") > 0)
+    		return autoFeature.substring(0, autoFeature.indexOf(")"));
+    	else
+    		return autoFeature;
+
+    }
+
+    public Set<Map.Entry<String, Attrs>> getIBMProvisionCapability() {
+        return getContent(FeatureBnd.IBM_PROVISION_CAPABILITY);
+    }
+
+    public void setAppliesTo(String name, Attrs attributes) throws IOException {
+        Parameters p = new Parameters();
+        p.put(name, attributes);
+
+        setProperty("IBM-AppliesTo", printClauses(p.asMapMap()));
+    }
+
+    public void setSubsystemSymbolicName(Parameters p) throws IOException {
+        setProperty(FeatureBnd.SUBSYSTEM_SYMBOLIC_NAME, printClauses(p.asMapMap()));
+    }
+
+}

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/VisibilityTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.feature.tests;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.feature.utils.FeatureInfo;
+import com.ibm.ws.feature.utils.FeatureMapFactory;
+import com.ibm.ws.feature.utils.FeatureVerifier;
+
+import org.junit.Assert;
+
+public class VisibilityTest {
+
+  private static FeatureVerifier verifier = null;
+
+	@BeforeClass
+	public static void setUpClass() {
+		Map<String, FeatureInfo> features = FeatureMapFactory.getFeatureMapFromFile("./visibility/");
+		verifier = new FeatureVerifier(features);
+	}
+
+	@Test
+	public void testVisibility() {
+		Map<String, Set<String>> violations = verifier.verifyAllFeatures();
+
+		boolean failed = false;
+		StringBuilder errorMessage = new StringBuilder();
+
+
+		for (String feature : violations.keySet()) {
+			if (!violations.get(feature).isEmpty()) {
+				failed = true;
+
+				errorMessage.append("Found issues with " + verifier.printFeature(feature) + '\n');
+				errorMessage.append("     It provisions less visible features: " + '\n');
+
+				for (String featureKindViolators : violations.get(feature)) {
+					errorMessage.append("     " + verifier.printFeature(featureKindViolators) + '\n');
+				}
+			}
+		}
+
+		Assert.assertFalse("Found features violating visibility conditions: " + '\n' + errorMessage.toString(), failed);
+
+	}
+
+
+}

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureFileList.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureFileList.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.feature.utils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+public class FeatureFileList implements Iterable<File>{
+
+	private String dirRoot;
+	private List<File> featureList = new ArrayList<File>();
+	private boolean isInit = false;
+
+	public FeatureFileList(String root) {
+		this.dirRoot = root;
+
+	}
+
+	public synchronized void populateList() {
+
+		if (isInit)
+			return;
+
+
+		Queue<File> directories = new LinkedList<File>();
+
+		File root = new File(this.dirRoot);
+
+		directories.add(root);
+
+		while (!directories.isEmpty()) {
+
+			File nextDirectory = directories.poll();
+			//System.out.println("inspecting directory: " + nextDirectory.getName());
+			File[] nextDirectoryListing = nextDirectory.listFiles();
+			if (nextDirectoryListing == null)
+				continue;
+
+			for (File file : nextDirectoryListing) {
+				if (file.isDirectory()) { //Going down just one step.
+					for (File child : file.listFiles()) {
+						if (child.getName().endsWith(".feature")) {
+							this.featureList.add(child);
+						}
+					}
+					directories.add(file); //use this if we want to search every directory and subdirectory
+					//By adding the directories we find into the queue of all directories
+
+				}
+			}
+		}
+
+		isInit = true;
+	}
+
+	@Override
+	public Iterator<File> iterator() {
+		Iterator<File> itr = new Iterator<File>() {
+			private int current = 0;
+
+			@Override
+			public void remove() {
+				return;
+			}
+
+			@Override
+			public boolean hasNext() {
+				if (!isInit)
+					populateList();
+
+				return ((current < featureList.size()) && !featureList.isEmpty());
+			}
+
+			@Override
+			public File next() {
+				if (!isInit)
+					populateList();
+
+				return featureList.get(current++);
+			}
+		};
+
+		return itr;
+
+	}
+}

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.feature.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.ibm.ws.feature.tasks.FeatureBuilder;
+
+import aQute.bnd.header.Attrs;
+
+public class FeatureInfo {
+
+
+	private String[] lockedAutoFeatures;
+	private String[] lockedDependentFeatures;
+	private String[] lockedActivatingAutoFeature;
+
+	private Set<String> autoFeatures = new LinkedHashSet<String>();
+	private Set<String> dependentFeatures = new LinkedHashSet<String>();
+	private Set<String> activatingAutoFeature = new LinkedHashSet<String>();
+
+	private String edition;
+	private String kind;
+
+	private boolean isInit = false;
+	private File feature;
+	private String name;
+
+
+	public FeatureInfo(File feature) {
+		this.feature = feature;
+	}
+
+	public String[] getAutoFeatures() {
+		if (!isInit)
+			populateInfo();
+
+		return this.lockedAutoFeatures;
+	}
+
+	public String getName() {
+		if (!isInit)
+			populateInfo();
+
+		return this.name;
+	}
+
+
+	//Activating autofeature just means "I'm an autofeature, and i *might* activate this other feature
+	//So it's like a "Sometimes" dependency, but is potentially useful for figuring out a superset of
+	//potential provisioned features.
+	protected void addActivatingAutoFeature(String featureName) {
+		if (!isInit)
+			populateInfo();
+
+		if (activatingAutoFeaturesLocked)
+			return;
+
+		this.activatingAutoFeature.add(featureName);
+	}
+
+	public String[] getActivatingAutoFeatures() {
+		if (activatingAutoFeaturesLocked)
+			return this.lockedActivatingAutoFeature;
+		else
+			return null;
+
+	}
+
+	private boolean activatingAutoFeaturesLocked = false;
+
+	protected synchronized void lockActivatingAutoFeatures() {
+		this.lockedActivatingAutoFeature = this.activatingAutoFeature.toArray(new String[this.activatingAutoFeature.size()]);
+		activatingAutoFeaturesLocked = true;
+		activatingAutoFeature = null;
+	}
+
+	public String[] getDependentFeatures() {
+		if (!isInit)
+			populateInfo();
+
+		return this.lockedDependentFeatures;
+	}
+
+	public String getEdition() {
+		if (!isInit)
+			populateInfo();
+
+		return this.edition;
+
+	}
+
+	public String getKind() {
+		if (!isInit)
+			populateInfo();
+
+		return this.kind;
+	}
+
+
+	private synchronized void populateInfo() {
+		if (isInit)
+			return;
+
+		FeatureBuilder builder = new FeatureBuilder();
+
+		try {
+			builder.setProperties(this.feature);
+
+            String edition = builder.getProperty("edition");
+            String kind = builder.getProperty("kind");
+            this.name = builder.getProperty("symbolicName");
+
+            this.edition = edition;
+            this.kind = kind;
+
+
+			for (String autoFeature : builder.getAutoFeatures()) {
+				this.autoFeatures.add(autoFeature);
+			}
+			this.lockedAutoFeatures = this.autoFeatures.toArray(new String[this.autoFeatures.size()]);
+
+            for (Map.Entry<String, Attrs> feature : builder.getFeatures()) {
+                String item = feature.getKey().toString();
+                this.dependentFeatures.add(item);
+            }
+
+            this.lockedDependentFeatures = this.dependentFeatures.toArray(new String[this.dependentFeatures.size()]);
+
+            this.autoFeatures = null;
+            this.dependentFeatures = null;
+
+			builder.close();
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} finally {
+			builder = null;
+		}
+
+
+		isInit = true;
+	}
+
+
+
+}

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureMapFactory.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureMapFactory.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.feature.utils;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class FeatureMapFactory {
+
+	public static Map<String, FeatureInfo> getFeatureMapFromFile(String fileLoc) {
+		Map<String, FeatureInfo> features = new LinkedHashMap<String, FeatureInfo>();
+
+		for (File featureFile : new FeatureFileList(fileLoc)) {
+			FeatureInfo feature = new FeatureInfo(featureFile);
+			features.put(feature.getName(), feature);
+
+		}
+
+		for (FeatureInfo feature : features.values()) {
+			for (String autoFeature : feature.getAutoFeatures()) {
+				if (features.containsKey(autoFeature)) {
+					features.get(autoFeature).addActivatingAutoFeature(feature.getName());
+				}
+			}
+		}
+
+		for (FeatureInfo feature : features.values()) {
+			feature.lockActivatingAutoFeatures();
+		}
+
+		return features;
+	}
+
+
+}

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureVerifier.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureVerifier.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.feature.utils;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class FeatureVerifier {
+
+	private Map<String, FeatureInfo> omni;
+
+	//Send in the omnibus of features.
+	public FeatureVerifier(Map<String, FeatureInfo> omni) {
+		this.omni = omni;
+	}
+
+	public Map<String, Set<String>> verifyAllFeatures() {
+
+		Set<String> lessVisible = null;
+
+		Map<String, Set<String>> violations = new HashMap<String, Set<String>>();
+
+		for (String feature : omni.keySet()) {
+			lessVisible = findViolatingFeatures(new HashSet<String>(), feature, getLevelFromKind(omni.get(feature).getKind()), "KIND");
+			lessVisible.addAll(findViolatingFeatures(new HashSet<String>(), feature, getLevelFromEdition(omni.get(feature).getEdition()), "EDITION"));
+
+			violations.put(feature, lessVisible);
+		}
+
+		return violations;
+
+
+	}
+
+	public String printFeature(String feature) {
+		return "Feature: [" + feature + "]   Edition: [" + omni.get(feature).getEdition() + "]   Kind: [" + omni.get(feature).getKind() + "]";
+	}
+
+	private Set<String> EMPTY_SET = new HashSet<String>();
+
+	private Set<String> findViolatingFeatures(Set<String> seen, String featureName, int featureVisibility, String classification) {
+
+		//short circuit if we start go go down a path we've already been down.
+		if (!omni.containsKey(featureName) || (seen.contains(featureName)))
+			return EMPTY_SET;
+
+		seen.add(featureName);
+
+		Set<String> featuresLessVisible = new HashSet<String>();
+
+		String featureClass = (classification.contentEquals("KIND") ? omni.get(featureName).getKind() : omni.get(featureName).getEdition());
+		int featureLevel = (classification.contentEquals("KIND") ? getLevelFromKind(featureClass) : getLevelFromEdition(featureClass));
+
+		if (featureLevel < featureVisibility ) {
+			featuresLessVisible.add(featureName);
+		}
+
+		for (String depFeature : omni.get(featureName).getDependentFeatures()) {
+				featuresLessVisible.addAll(findViolatingFeatures(seen, depFeature, featureVisibility, classification));
+		}
+
+		return featuresLessVisible;
+
+	}
+
+	private int getLevelFromEdition(String edition) {
+		switch(edition.toLowerCase()) {
+		    case "full": return 0;
+		    case "zos": return 1;
+			case "nd": return 2;
+			case "base": return 3;
+			case "core": return 4;
+			default: return 99;
+		}
+	}
+
+	private int getLevelFromKind(String kind) {
+		switch(kind.toLowerCase()) {
+			case "noship": return 0;
+			case "beta": return 1;
+			case "ga": return 2;
+			default: return 99;
+		}
+	}
+
+
+
+}

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.health-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.health-1.0.feature
@@ -3,4 +3,4 @@ symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.health-1.0
 singleton=true
 -bundles=com.ibm.websphere.org.eclipse.microprofile.health.1.0; location:="dev/api/stable/,lib/"
 kind=ga
-edition=full
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-1.0/com.ibm.websphere.appserver.mpHealth-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-1.0/com.ibm.websphere.appserver.mpHealth-1.0.feature
@@ -24,4 +24,4 @@ Subsystem-Name: MicroProfile Health 1.0
  com.ibm.ws.microprofile.health; apiJar=false; location:="lib/", \
  com.ibm.ws.org.joda.time.1.6.2
 kind=ga
-edition=full
+edition=core


### PR DESCRIPTION
Adding some feature verification that runs directly against raw .feature files. This means it runs fast, and runs early so if someone is attempting to promote a new feature to GA it will crawl all dependencies for both kind and edition to make sure that the child features are not less visible than the parent. In other words, making sure a feature that "Servlet" (core) includes is not base/nd.

Leaves out the idea of autoFeatures (maybe for now, maybe always) since those are cases where a feature in a less visible mode would deliberately be left out of the direct dependency tree in order to selectively load.