### PR TITLE
force sessionCache feature to use different CachingProviding instances than applications

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CachingProviderClassLoader.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CachingProviderClassLoader.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.session.store.cache;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Class loader that exists for the sole purpose of ensuring that the session cache feature
+ * uses a different CachingProvider instance than applications.
+ */
+@Trivial
+class CachingProviderClassLoader extends ClassLoader {
+    private ClassLoader parent;
+
+    CachingProviderClassLoader(ClassLoader parent) {
+        super(parent);
+        this.parent = parent;
+    }
+
+    public String toString() {
+        return new StringBuilder("CachingProviderClassLoader@")
+                        .append(Integer.toHexString(System.identityHashCode(this)))
+                        .append(" for ")
+                        .append(parent)
+                        .toString();
+    }
+}

--- a/dev/com.ibm.ws.session.cache_fat_config/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat_config/bnd.bnd
@@ -24,4 +24,6 @@ javac.target: 1.8
 -buildpath: \
     com.ibm.websphere.javaee.jcache.1.1;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
+    com.ibm.websphere.org.osgi.core,\
+    com.ibm.websphere.org.osgi.service.component,\
     com.ibm.ws.session;version=latest

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -108,7 +108,7 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.waitForConfigUpdateInLogUsingMark(appNames, EMPTY_RECYCLE_LIST);
 
         // Application obtains the CachingProvider for the same configured library and closes the provider
-        // TODO FATSuite.run(server, "jcacheApp/JCacheConfigTestServlet", "testCloseCachingProvider", null);
+        FATSuite.run(server, "jcacheApp/JCacheConfigTestServlet", "testCloseCachingProvider", null);
 
         // Access a session - this will only work if sessionCache feature has used a different CachingProvider instance
         List<String> session = new ArrayList<>();

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
@@ -114,7 +114,9 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
      * Start the server with an invalid Hazelcast uri configured on httpSessionCache.
      * Verify that after correcting the uri, session data is persisted.
      */
-    @AllowedFFDC("java.net.MalformedURLException") // TODO possible bug
+    @AllowedFFDC(value = { "javax.cache.CacheException", // for invalid uri
+                           "java.net.MalformedURLException" // TODO possible bug
+    })
     @Test
     public void testInvalidURI() throws Exception {
         // Start the server with invalid httpSessionCache uri

--- a/dev/com.ibm.ws.session.cache_fat_config/publish/servers/sessionCacheServer/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_config/publish/servers/sessionCacheServer/server.xml
@@ -59,4 +59,8 @@
   <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.sun.net.www.protocol.wsjar"/>
 
   <javaPermission codebase="${shared.resource.dir}/hazelcast/hazelcast.jar" className="java.security.AllPermission"/>
+
+  <!-- Allow the application to access OSGi service registry in order to obtain the CacheManager instance that is used by sessionCache feature -->
+  <javaPermission codebase="${server.config.dir}/apps/sessionCacheConfigApp.war" className="org.osgi.framework.AdminPermission" name="*" actions="*"/>
+  <javaPermission codebase="${server.config.dir}/apps/sessionCacheConfigApp.war" className="org.osgi.framework.ServicePermission" name="*" actions="get"/>
 </server>


### PR DESCRIPTION
Avoid interference between sessionCache feature and applications using the same CachingProvider instance (which results in them closing eachothers' cache managers and so forth) by forcing the sessionCache feature to use a unique CachingProvider instance by wrapping the ClassLoader with which it obtains the CachingProvider.  The ClassLoader is used as key and so this will cause it not to match with application usage.