### PR TITLE
fix for issue 2877 - correct tag file errors in loose jars

### DIFF
--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/inputsource/JspURLConnection.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/inputsource/JspURLConnection.java
@@ -64,7 +64,7 @@ public class JspURLConnection extends URLConnection {
             is = conn.getInputStream();
         }
         catch (IOException e) {
-            if (relativeUrl.endsWith(".tld") || relativeUrl.endsWith(".jar") || searchOnClasspath) {
+            if (relativeUrl.endsWith(".tag") || relativeUrl.endsWith(".tld") || relativeUrl.endsWith(".jar") || searchOnClasspath) { // .tag file will now be in WEB-INF/lib
                 String s = relativeUrl;
                 if (s.charAt(0) == '/')
                     s = s.substring(1);

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/utils/JspTranslatorUtil.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/utils/JspTranslatorUtil.java
@@ -291,7 +291,7 @@ public class JspTranslatorUtil {
                         tagFileResources = tlc.getTagFileResources(tagFileResources);
                         translationResult.getTagFileDependencyList().add(tagFileResources);
         
-                        if (forceTagFileTranslation && tagFileResources.getGeneratedSourceFile().getParentFile().exists() == false) {
+                        if (forceTagFileTranslation || tagFileResources.getGeneratedSourceFile().getParentFile().exists() == false) { //get a folder if it doesn't exist
                             tagFileResources.getGeneratedSourceFile().getParentFile().mkdirs();
                         }
                         if (forceTagFileTranslation || tagFileResources.isOutdated() ) {


### PR DESCRIPTION
Correct the following JspCoreException errors that might result from a tag file existing in a loose jar file:

JSPG0036E: Failed to find resource /META-INF/tags/...

JSPG0047E: Unable to locate tag library for uri ...

fixes #2877
#build