### PR TITLE
update existing test to use writeContents=GET_AND_SET_ATTRIBUTES

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -168,12 +168,11 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         appA.sessionGet("testMaxSessions-session1", null, session1);
     }
 
-    // TODO will need to update this test & corresponding server config if the design ends up switching the default to ALL_SESSION_ATTRIBUTES
     /**
      * Test httpSessionCache's writeContents configuration.
-     * App B on server B uses the default of ONLY_UPDATED_ATTRIBUTES, which means that an update made locally to an attribute
+     * App B on server B uses the default of ONLY_SET_ATTRIBUTES, which means that an update made locally to an attribute
      * without performing a putAttribute will not be written to the persistent store even though it remains in the local cache.
-     * App A on server A uses ALL_SESSION_ATTRIBUTES, which means that an update made locally to an attribute
+     * App A on server A uses GET_AND_SET_ATTRIBUTES, which means that an update made locally to an attribute after getting it
      * without performing a putAttribute will be written to the persistent store.
      */
     @Test
@@ -182,12 +181,12 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         appA.sessionPut("testModifyWithoutPut-key", new StringBuffer("MyValue"), session, true);
         try {
             appB.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
-            // appA should not see the update because it does not get written to the persistent store without a putAttribute per writeContents=ONLY_UPDATED_ATTRIBUTES
+            // appA should not see the update because it does not get written to the persistent store without a putAttribute per writeContents=ONLY_SET_ATTRIBUTES
             appA.sessionGet("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyValue"), session);
 
             appB.sessionPut("testModifyWithoutPut-key", new StringBuffer("MyNewValue"), session, false);
             appA.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
-            // appB should see the update because it is written to the persistent store despite lack of a putAttribute. This is due to writeContents=ALL_SESSION_ATTRIBUTES
+            // appB should see the update because it is written to the persistent store despite lack of a putAttribute. This is due to writeContents=GET_AND_SET_ATTRIBUTES
             appB.sessionGet("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyNewValueAppended"), session);
             // appA sees the update which is made locally in the in-memory cache as well as to the persistent store
             appA.sessionGet("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyNewValueAppended"), session);

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerA/server.xml
@@ -11,7 +11,7 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" invalidationTimeout="10m"/>
 
-    <httpSessionCache libraryRef="HazelcastLib" writeContents="ALL_SESSION_ATTRIBUTES">
+    <httpSessionCache libraryRef="HazelcastLib" writeContents="GET_AND_SET_ATTRIBUTES">
         <properties hazelcast.config.location="file:${shared.resource.dir}/hazelcast/hazelcast-localhost-only.xml"/>
     </httpSessionCache>
 


### PR DESCRIPTION
Remove TODO comments from existing test around the writeContents=GET_AND_SET_ATTRIBUTES, and update test to use this configuration option, rather than the more heavy handed ALL_SESSION_ATTRIBUTES option.