### PR TITLE
write tests for JCache MXBeans

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/bnd.bnd
+++ b/dev/com.ibm.ws.session.cache_fat/bnd.bnd
@@ -23,4 +23,5 @@ javac.target: 1.8
 -buildpath: \
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.jcache.1.1;version=latest,\
-    com.ibm.websphere.javaee.servlet.3.1;version=latest
+    com.ibm.websphere.javaee.servlet.4.0;version=latest,\
+    com.ibm.ws.session;version=latest

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -196,6 +196,23 @@ public class SessionCacheTwoServerTest extends FATServletClient {
     }
 
     /**
+     * Verify that CacheMXBean and CacheStatisticsMXBean provided for each of the caches created by the sessionCache feature
+     * can be obtained and report statistics about the cache.
+     */
+    // TODO enable once sessionCache is tied in to monitor feature @Test
+    public void testMXBeansEnabled() throws Exception {
+        appB.invokeServlet("testMXBeansEnabled", new ArrayList<>());
+    }
+
+    /**
+     * Verify that CacheMXBean and CacheStatisticsMXBean are not registered.
+     */
+    @Test
+    public void testMXBeansNotEnabled() throws Exception {
+        appA.invokeServlet("testMXBeansNotEnabled", new ArrayList<>());
+    }
+
+    /**
      * Verify that SessionScoped CDI bean preserves its state across session calls.
      */
     @Test

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerA/server.xml
@@ -42,4 +42,8 @@
     
     <javaPermission codebase="${shared.resource.dir}/hazelcast/hazelcast.jar" className="java.security.AllPermission"/>
 
+    <!--  Permissions for application to access mbeans -->
+    <javaPermission codebase="${server.config.dir}/dropins/sessionCacheApp.war" className="javax.management.MBeanPermission" actions="queryNames"/>
+    <javaPermission codebase="${server.config.dir}/dropins/sessionCacheApp.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
+
 </server>

--- a/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/servers/sessionCacheServerB/server.xml
@@ -3,6 +3,7 @@
     <featureManager>
         <feature>bells-1.0</feature>
         <feature>cdi-2.0</feature>
+        <feature>monitor-1.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componenttest-1.0</feature>
         <feature>sessionCache-1.0</feature>
@@ -46,5 +47,8 @@
     <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.sun.net.www.protocol.wsjar"/>
     
     <javaPermission codebase="${shared.resource.dir}/hazelcast/hazelcast.jar" className="java.security.AllPermission"/>
+
+    <!--  Permissions for application to access mbeans -->
+    <javaPermission codebase="${server.config.dir}/dropins/sessionCacheApp.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
 
 </server>


### PR DESCRIPTION
Write tests for JCache spec defined MXBeans that can report statistics on the sessionCache-1.0 feature's usage of the the caches it creates.  One test will verify availability of each MXBean (management and statistics) for each cache, and another will verify that none of the MXBeans are available - the case where monitoring is not enabled.  The former test will be disabled for now, because we haven't implemented enablement of the MXBeans yet.  When that is done in a subsequent pull, the test can be switched on.