### PR TITLE
Suggestion for improvement of ENTRY logging

### DIFF
--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/WsLogger.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/WsLogger.java
@@ -432,13 +432,7 @@ public class WsLogger extends Logger implements TraceStateChangeListener {
     public void entering(String sourceClass, String sourceMethod, Object params[]) {
         if (isLoggable(Level.FINER)) {
             String msg = "ENTRY";
-            if (params != null) {
-                StringBuilder sb = new StringBuilder(msg);
-                for (int i = 0; i < params.length; i++) {
-                    sb.append(" {").append(i).append("}");
-                }
-                msg = sb.toString();
-            }
+            msg = buildParamsMsg(msg, params);
             logp(Level.FINER, sourceClass, sourceMethod, msg, params);
         }
     }
@@ -704,6 +698,26 @@ public class WsLogger extends Logger implements TraceStateChangeListener {
      */
     public void setProduct(String product) {
         this.ivProduct = product;
+    }
+
+    private String buildParamsMsg(String prefix, Object params[]) {
+        if (params != null) {
+            StringBuilder sb = new StringBuilder(prefix);
+            sb.append("[").append(params.length).append("]");
+            for (int i = 0; i < params.length; i++) {
+                if(params[i] instanceof String) {
+                    String s = (String)params[i];
+                    if (s != null && s.length() == 0)
+                        sb.append(" ''''");
+                    else
+                        sb.append(" ").append(s);
+                } else {
+                    sb.append(" {").append(i).append("}");
+                }
+            }
+            return sb.toString();
+        }
+        return prefix;
     }
 
 }


### PR DESCRIPTION
Improves scenarios where otherwise the difference between entry(null) and entry("null") as well as entry("") and entry() is not easily identifiable. - Noticed this while working on my previous pull requests and I think this might make debugging easier.

The new format introduced by this commit is only a discussion proposal, and once accepted that it makes sense, will also need to be added to other codepaths, in which case I'll be happy to provide the implementation as part of this PR; if you don't feel this adds value or the performance overhead will be too large, feel free to reject this.