### PR TITLE
Lazily initialize CacheManager in sessionCache-1.0

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -142,13 +142,9 @@ public class CacheHashMap extends BackedHashMap {
         a = COLON.matcher(a).replaceAll("%3A");
 
         // Session Meta Information Cache
-
         String metaCacheName = new StringBuilder(24 + a.length()).append("com.ibm.ws.session.meta.").append(a).toString();
-
-        if (trace && tc.isDebugEnabled())
-            tcInvoke(cacheStoreService.tcCacheManager, "getCache", metaCacheName, "String", "ArrayList");
-
         sessionMetaCache = cacheStoreService.getCacheManager().getCache(metaCacheName, String.class, ArrayList.class);
+        
         boolean create;
         if (create = sessionMetaCache == null) {
             if (trace && tc.isDebugEnabled())

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -148,7 +148,7 @@ public class CacheHashMap extends BackedHashMap {
         if (trace && tc.isDebugEnabled())
             tcInvoke(cacheStoreService.tcCacheManager, "getCache", metaCacheName, "String", "ArrayList");
 
-        sessionMetaCache = cacheStoreService.cacheManager.getCache(metaCacheName, String.class, ArrayList.class);
+        sessionMetaCache = cacheStoreService.getCacheManager().getCache(metaCacheName, String.class, ArrayList.class);
         boolean create;
         if (create = sessionMetaCache == null) {
             if (trace && tc.isDebugEnabled())
@@ -164,14 +164,14 @@ public class CacheHashMap extends BackedHashMap {
                 if (trace && tc.isDebugEnabled())
                     tcInvoke(cacheStoreService.tcCacheManager, "createCache", metaCacheName, config);
 
-                sessionMetaCache = cacheStoreService.cacheManager.createCache(metaCacheName, config);
+                sessionMetaCache = cacheStoreService.getCacheManager().createCache(metaCacheName, config);
             } catch (CacheException x) {
                 create = false;
                 if (trace && tc.isDebugEnabled()) {
                     tcReturn(cacheStoreService.tcCacheManager, "createCache", x);
                     tcInvoke(cacheStoreService.tcCacheManager, "getCache", metaCacheName, "String", "ArrayList");
                 }
-                sessionMetaCache = cacheStoreService.cacheManager.getCache(metaCacheName, String.class, ArrayList.class);
+                sessionMetaCache = cacheStoreService.getCacheManager().getCache(metaCacheName, String.class, ArrayList.class);
                 if (sessionMetaCache == null)
                     throw x;
             }
@@ -190,7 +190,7 @@ public class CacheHashMap extends BackedHashMap {
         if (trace && tc.isDebugEnabled())
             tcInvoke(cacheStoreService.tcCacheManager, "getCache", attrCacheName, "String", "byte[]");
 
-        sessionAttributeCache = cacheStoreService.cacheManager.getCache(attrCacheName, String.class, byte[].class);
+        sessionAttributeCache = cacheStoreService.getCacheManager().getCache(attrCacheName, String.class, byte[].class);
 
         if (create = sessionAttributeCache == null) {
             if (trace && tc.isDebugEnabled())
@@ -205,14 +205,14 @@ public class CacheHashMap extends BackedHashMap {
                 if (trace && tc.isDebugEnabled())
                     tcInvoke(cacheStoreService.tcCacheManager, "createCache", attrCacheName, config);
 
-                sessionAttributeCache = cacheStoreService.cacheManager.createCache(attrCacheName, config);
+                sessionAttributeCache = cacheStoreService.getCacheManager().createCache(attrCacheName, config);
             } catch (CacheException x) {
                 create = false;
                 if (trace && tc.isDebugEnabled()) {
                     tcReturn(cacheStoreService.tcCacheManager, "createCache", x);
                     tcInvoke(cacheStoreService.tcCacheManager, "getCache", attrCacheName, "String", "byte[]");
                 }
-                sessionAttributeCache = cacheStoreService.cacheManager.getCache(attrCacheName, String.class, byte[].class);
+                sessionAttributeCache = cacheStoreService.getCacheManager().getCache(attrCacheName, String.class, byte[].class);
                 if (sessionAttributeCache == null)
                     throw x;
             }

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -72,12 +72,12 @@ public class CacheStoreService implements SessionStoreService {
     /**
      * Trace identifier for the cache manager
      */
-    volatile String tcCacheManager = "CacheManager-uninitialized";
+    volatile String tcCacheManager;
 
     /**
      * Trace identifier for the caching provider.
      */
-    private volatile String tcCachingProvider = "CachingProvider-uninitialized";
+    private volatile String tcCachingProvider;
 
     volatile UserTransaction userTransaction;
 

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -53,8 +53,8 @@ public class CacheStoreService implements SessionStoreService {
     private static final int BASE_PREFIX_LENGTH = BASE_PREFIX.length();
     private static final int TOTAL_PREFIX_LENGTH = BASE_PREFIX_LENGTH + 3; //3 is the length of .0.
 
-    CacheManager cacheManager;
-    CachingProvider cachingProvider;
+    private volatile CacheManager cacheManager;
+    private volatile CachingProvider cachingProvider;
 
     private volatile boolean completedPassivation = true;
 
@@ -72,12 +72,12 @@ public class CacheStoreService implements SessionStoreService {
     /**
      * Trace identifier for the cache manager
      */
-    String tcCacheManager;
+    volatile String tcCacheManager = "CacheManager-uninitialized";
 
     /**
      * Trace identifier for the caching provider.
      */
-    private String tcCachingProvider;
+    private volatile String tcCachingProvider = "CachingProvider-uninitialized";
 
     volatile UserTransaction userTransaction;
 
@@ -89,9 +89,20 @@ public class CacheStoreService implements SessionStoreService {
      * @param props service properties
      */
     protected void activate(ComponentContext context, Map<String, Object> props) {
-        final boolean trace = TraceComponent.isAnyTracingEnabled();
-
         configurationProperties = new HashMap<String, Object>(props);
+    }
+    
+    CacheManager getCacheManager() {
+        if(cacheManager == null)
+            lazyActivate();
+        return cacheManager;
+    }
+    
+    private synchronized void lazyActivate() {
+        if(cacheManager != null)
+            return;
+        
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         Object scheduleInvalidationFirstHour = configurationProperties.get("scheduleInvalidationFirstHour");
         Object scheduleInvalidationSecondHour = configurationProperties.get("scheduleInvalidationSecondHour");
@@ -113,7 +124,7 @@ public class CacheStoreService implements SessionStoreService {
         
         Properties vendorProperties = new Properties();
         
-        String uriValue = (String) props.get("uri");
+        String uriValue = (String) configurationProperties.get("uri");
         URI uri = null;
         if(uriValue != null)
             try {
@@ -122,7 +133,7 @@ public class CacheStoreService implements SessionStoreService {
                 throw new IllegalArgumentException(Tr.formatMessage(tc, "INCORRECT_URI_SYNTAX", e), e);
             }
         
-        for (Map.Entry<String, Object> entry : props.entrySet()) {
+        for (Map.Entry<String, Object> entry : configurationProperties.entrySet()) {
             String key = entry.getKey();
             Object value = entry.getValue();
 
@@ -219,6 +230,9 @@ public class CacheStoreService implements SessionStoreService {
      * @param context for this component instance
      */
     protected void deactivate(ComponentContext context) {
+        if(cachingProvider == null)
+            return;
+        
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         // Block the progress of deactivate so that session manager is able to access the cache until it finishes stopping applications.

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -47,7 +47,6 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
     private static final String APP_DEFAULT = "sessionCacheConfigApp";
     private static final String APP_JCACHE = "jcacheApp";
     private static final Set<String> APP_NAMES = Collections.singleton(APP_DEFAULT); // jcacheApp not included because it isn't normally configured
-    private static final String[] APP_RECYCLE_LIST = new String[] { "CWWKZ0009I.*" + APP_DEFAULT, "CWWKZ000[13]I.*" + APP_DEFAULT };
     private static final String[] EMPTY_RECYCLE_LIST = new String[0];
     private static final String SERVLET_NAME = "SessionCacheConfigTestServlet";
 
@@ -124,7 +123,7 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
      */
     @Test
     public void testMonitoring() throws Exception {
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testMXBeansNotEnabled", new ArrayList<>());
+        run("testMXBeansNotEnabled", new ArrayList<>());
 
         // add monitor-1.0 feature
         ServerConfiguration config = server.getServerConfiguration();
@@ -134,7 +133,7 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.updateServerConfiguration(config);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
 
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testMXBeansEnabled", new ArrayList<>());
+        run("testMXBeansEnabled", new ArrayList<>());
 
         // add monitor configuration that doesn't include Session
         Monitor monitor = new Monitor();
@@ -145,7 +144,7 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.updateServerConfiguration(config);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
 
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testMXBeansNotEnabled", new ArrayList<>());
+        run("testMXBeansNotEnabled", new ArrayList<>());
 
         // switch to monitor configuration that includes Session
         monitor.setFilter("ThreadPool,WebContainer,Session");
@@ -154,14 +153,14 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.updateServerConfiguration(config);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
 
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testMXBeansEnabled", new ArrayList<>());
+        run("testMXBeansEnabled", new ArrayList<>());
 
         // remove monitor-1.0 feature (and monitor config)
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(savedConfig);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
 
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testMXBeansNotEnabled", new ArrayList<>());
+        run("testMXBeansNotEnabled", new ArrayList<>());
     }
 
     @Test
@@ -182,8 +181,8 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
 
         ArrayList<String> session = new ArrayList<>();
-        String response = FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testSetAttributeWithTimeout&attribute=testScheduleInvalidation&value=si1&maxInactiveInterval=1",
-                                       session);
+        String response = run("testSetAttributeWithTimeout&attribute=testScheduleInvalidation&value=si1&maxInactiveInterval=1",
+                              session);
         int start = response.indexOf("session id: [") + 13;
         String sessionId = response.substring(start, response.indexOf(']', start));
 
@@ -191,11 +190,10 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         TimeUnit.SECONDS.sleep(35);
 
         // confirm that invalidated data remains in the cache
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testCacheContains&attribute=testScheduleInvalidation&value=si1&sessionId=" + sessionId, null);
+        run("testCacheContains&attribute=testScheduleInvalidation&value=si1&sessionId=" + sessionId, null);
 
         // Add another attribute, but don't wait for it to be written
-        response = FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testSetAttributeWithTimeout&attribute=testTimeBasedWriteNoSync&value=si2&maxInactiveInterval=60",
-                                session);
+        run("testSetAttributeWithTimeout&attribute=testTimeBasedWriteNoSync&value=si2&maxInactiveInterval=60", session);
         start = response.indexOf("session id: [") + 13;
         sessionId = response.substring(start, response.indexOf(']', start));
     }
@@ -253,7 +251,7 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
 
         // TODO enable if manual sync is supported across same session spanning multiple servlet requests:
         // Perform a manual sync under a subsequent servlet request and verify the previously set value is updated
-        // FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testManualSync&attribute=testWriteFrequency&value=2_MANUAL_UPDATE", session);
+        // run("testManualSync&attribute=testWriteFrequency&value=2_MANUAL_UPDATE", session);
 
         // Perform a manual update within the same servlet request
         run("testManualUpdate&attribute=testWriteFrequency&value=3_MANUAL_UPDATE", session);

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -44,9 +44,10 @@ import componenttest.topology.utils.FATServletClient;
 @RunWith(FATRunner.class)
 public class SessionCacheConfigUpdateTest extends FATServletClient {
 
-    private static final String APP_NAME = "sessionCacheConfigApp";
-    private static final Set<String> APP_NAMES = Collections.singleton(APP_NAME); // jcacheApp not included because it isn't normally configured
-    private static final String[] APP_RECYCLE_LIST = new String[] { "CWWKZ0009I.*" + APP_NAME, "CWWKZ000[13]I.*" + APP_NAME };
+    private static final String APP_DEFAULT = "sessionCacheConfigApp";
+    private static final String APP_JCACHE = "jcacheApp";
+    private static final Set<String> APP_NAMES = Collections.singleton(APP_DEFAULT); // jcacheApp not included because it isn't normally configured
+    private static final String[] APP_RECYCLE_LIST = new String[] { "CWWKZ0009I.*" + APP_DEFAULT, "CWWKZ000[13]I.*" + APP_DEFAULT };
     private static final String[] EMPTY_RECYCLE_LIST = new String[0];
     private static final String SERVLET_NAME = "SessionCacheConfigTestServlet";
 
@@ -71,9 +72,9 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        ShrinkHelper.defaultApp(server, APP_NAME, "session.cache.web");
-        ShrinkHelper.defaultApp(server, "jcacheApp", "test.cache.web");
-        server.removeInstalledAppForValidation("jcacheApp"); // This application is available for tests to add but not configured by default.
+        ShrinkHelper.defaultApp(server, APP_DEFAULT, "session.cache.web");
+        ShrinkHelper.defaultApp(server, APP_JCACHE, "test.cache.web");
+        server.removeInstalledAppForValidation(APP_JCACHE); // This application is available for tests to add but not configured by default.
 
         String configLocation = new File(server.getUserDir() + "/shared/resources/hazelcast/hazelcast-localhost-only.xml").getAbsolutePath();
         server.setJvmOptions(Arrays.asList("-Dhazelcast.config=" + configLocation,
@@ -99,23 +100,23 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         ClassloaderElement jcacheApp_classloader = new ClassloaderElement();
         jcacheApp_classloader.getCommonLibraryRefs().add("HazelcastLib");
         jcacheApp.getClassloaders().add(jcacheApp_classloader);
-        jcacheApp.setLocation("jcacheApp.war");
+        jcacheApp.setLocation(APP_JCACHE + ".war");
         config.getApplications().add(jcacheApp);
 
         Set<String> appNames = new TreeSet<String>(APP_NAMES);
-        appNames.add("jcacheApp");
+        appNames.add(APP_JCACHE);
 
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);
         server.waitForConfigUpdateInLogUsingMark(appNames, EMPTY_RECYCLE_LIST);
 
         // Application obtains the CachingProvider for the same configured library and closes the provider
-        FATSuite.run(server, "jcacheApp/JCacheConfigTestServlet", "testCloseCachingProvider", null);
+        FATSuite.run(server, APP_JCACHE + "/JCacheConfigTestServlet", "testCloseCachingProvider", null);
 
         // Access a session - this will only work if sessionCache feature has used a different CachingProvider instance
         List<String> session = new ArrayList<>();
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "getSessionId", session);
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "invalidateSession", session);
+        run("getSessionId", session);
+        run("invalidateSession", session);
     }
 
     /**
@@ -205,7 +206,7 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
     @Test
     public void testWriteContents() throws Exception {
         // Verify default behavior: writeContents=ONLY_SET_ATTRIBUTES
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testWriteContents_ONLY_SET_ATTRIBUTES", new ArrayList<>());
+        run("testWriteContents_ONLY_SET_ATTRIBUTES", new ArrayList<>());
 
         // Reconfigure writeContents=GET_AND_SET_ATTRIBUTES
         ServerConfiguration config = server.getServerConfiguration();
@@ -215,7 +216,7 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.updateServerConfiguration(config);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
 
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testWriteContents_GET_AND_SET_ATTRIBUTES", new ArrayList<>());
+        run("testWriteContents_GET_AND_SET_ATTRIBUTES", new ArrayList<>());
 
         // Reconfigure writeContents=ALL_SESSION_ATTRIBUTES
         httpSessionCache.setWriteContents("ALL_SESSION_ATTRIBUTES");
@@ -223,7 +224,7 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.updateServerConfiguration(config);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
 
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testWriteContents_ALL_SESSION_ATTRIBUTES", new ArrayList<>());
+        run("testWriteContents_ALL_SESSION_ATTRIBUTES", new ArrayList<>());
     }
 
     /**
@@ -235,8 +236,8 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
     public void testWriteFrequency() throws Exception {
         // Verify default behavior: writeFrequency=END_OF_SERVLET_SERVICE
         List<String> session = new ArrayList<>();
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testSetAttribute&attribute=testWriteFrequency&value=1_END_OF_SERVLET_SERVICE", session);
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testCacheContains&attribute=testWriteFrequency&value=1_END_OF_SERVLET_SERVICE", session);
+        run("testSetAttribute&attribute=testWriteFrequency&value=1_END_OF_SERVLET_SERVICE", session);
+        run("testCacheContains&attribute=testWriteFrequency&value=1_END_OF_SERVLET_SERVICE", session);
 
         // Reconfigure writeFrequency=MANUAL_UPDATE
         ServerConfiguration config = server.getServerConfiguration();
@@ -247,16 +248,16 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
 
         // Set a new attribute value without performing a manual sync, the value in the cache should not be updated
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testSetAttribute&attribute=testWriteFrequency&value=2_MANUAL_UPDATE", session);
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testCacheContains&attribute=testWriteFrequency&value=1_END_OF_SERVLET_SERVICE", session);
+        run("testSetAttribute&attribute=testWriteFrequency&value=2_MANUAL_UPDATE", session);
+        run("testCacheContains&attribute=testWriteFrequency&value=1_END_OF_SERVLET_SERVICE", session);
 
         // TODO enable if manual sync is supported across same session spanning multiple servlet requests:
         // Perform a manual sync under a subsequent servlet request and verify the previously set value is updated
         // FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testManualSync&attribute=testWriteFrequency&value=2_MANUAL_UPDATE", session);
 
         // Perform a manual update within the same servlet request
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testManualUpdate&attribute=testWriteFrequency&value=3_MANUAL_UPDATE", session);
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "invalidateSession", session);
+        run("testManualUpdate&attribute=testWriteFrequency&value=3_MANUAL_UPDATE", session);
+        run("invalidateSession", session);
     }
 
     /**
@@ -266,8 +267,8 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
     public void testWriteInterval() throws Exception {
         // Verify default behavior: writeFrequency=END_OF_SERVLET_SERVICE, writeInterval ignored
         List<String> session = new ArrayList<>();
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testSetAttribute&attribute=testWriteInterval&value=0_END_OF_SERVLET_SERVICE", session);
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testCacheContains&attribute=testWriteInterval&value=0_END_OF_SERVLET_SERVICE", session);
+        run("testSetAttribute&attribute=testWriteInterval&value=0_END_OF_SERVLET_SERVICE", session);
+        run("testCacheContains&attribute=testWriteInterval&value=0_END_OF_SERVLET_SERVICE", session);
 
         // Reconfigure writeFrequency=TIME_BASED_WRITE and writeInterval=5s
         ServerConfiguration config = server.getServerConfiguration();
@@ -284,9 +285,9 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         String newValue = null;
         for (int numAttempts = 1; numAttempts < 20; numAttempts++) {
             newValue = numAttempts + "_TIME_BASED_WRITE";
-            FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testSetAttribute&attribute=testWriteFrequency&value=" + newValue, session);
+            run("testSetAttribute&attribute=testWriteFrequency&value=" + newValue, session);
 
-            String response = FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "getValueFromCache&attribute=testWriteFrequency", session);
+            String response = run("getValueFromCache&attribute=testWriteFrequency", session);
             int start = response.indexOf("value from cache: [") + 19;
             String cachedValue = response.substring(start, response.indexOf(']', start));
 
@@ -300,15 +301,23 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
                     "having the time based write align with servlet request completion",
                     previousValue.equals(newValue));
 
-        String response = FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "getSessionId", session);
-        int start = response.indexOf("session id: [") + 13;
-        String sessionId = response.substring(start, response.indexOf(']', start));
+        String sessionId = getSessionId(session);
 
         // Due to TIME_BASED_WRITE, the value should be written to cache some time within the next 5 seconds. Poll for it,
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME,
+        FATSuite.run(server, APP_DEFAULT + '/' + SERVLET_NAME,
                      "testPollCache&attribute=testWriteFrequency&value=" + newValue + "&sessionId=" + sessionId,
                      null); // Avoid having the servlet access the session here because this will block 5 cycles of the time based write.
 
-        FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "invalidateSession", session);
+        run("invalidateSession", session);
+    }
+
+    private static String run(String testMethod, List<String> session) throws Exception {
+        return FATSuite.run(server, APP_DEFAULT + '/' + SERVLET_NAME, testMethod, session);
+    }
+
+    private static String getSessionId(List<String> session) throws Exception {
+        String response = run("getSessionId", session);
+        int start = response.indexOf("session id: [") + 13;
+        return response.substring(start, response.indexOf(']', start));
     }
 }

--- a/dev/com.ibm.ws.session.cache_fat_config/test-applications/sessionCacheConfigApp/src/session/cache/web/SessionCacheConfigTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/test-applications/sessionCacheConfigApp/src/session/cache/web/SessionCacheConfigTestServlet.java
@@ -42,6 +42,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.junit.Assert;
+
 import com.ibm.websphere.servlet.session.IBMSession;
 
 import componenttest.app.FATServlet;
@@ -412,6 +414,13 @@ public class SessionCacheConfigTestServlet extends FATServlet {
                    "Bytes expected: " + Arrays.toString(expectedBytes) + EOLN +
                    "Bytes observed: " + Arrays.toString(bytes),
                    found);
+    }
+
+    /**
+     * Verify that sessions are not available, even if requesting a new session
+     */
+    public void testSessionCacheNotAvailable(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        Assert.assertNull(request.getSession(true));
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTRequestContext.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTRequestContext.java
@@ -98,11 +98,14 @@ protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.
 		// Looks like the session wasn't obtained during the preinvoke
 		// call.  Should only happen if session doesn't exist at preinvoke.
 		//
-		session = webapp.getSessionContext().getIHttpSession(localrequest, (HttpServletResponse) request.getResponse(), create);
+		IHttpSessionContext ctx = webapp.getSessionContext();
+		if(ctx != null) {
+		    session = ctx.getIHttpSession(localrequest, (HttpServletResponse) request.getResponse(), create);
+		}
 		if ( session == null) {
 		    if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  
-	            logger.exiting(CLASS_NAME,"getSession", "null");
-	        }
+        	                logger.exiting(CLASS_NAME,"getSession", "null");
+        	            }
 		    return null;
 		}
 		else  {

--- a/dev/com.ibm.ws.webserver.plugin.runtime/src/com/ibm/ws/webserver/plugin/runtime/listeners/GeneratePluginConfigListener.java
+++ b/dev/com.ibm.ws.webserver.plugin.runtime/src/com/ibm/ws/webserver/plugin/runtime/listeners/GeneratePluginConfigListener.java
@@ -45,10 +45,8 @@ import com.ibm.wsspi.webcontainer.osgi.mbeans.GeneratePluginConfig;
 /**
  *
  */
-@Component(service = { ApplicationStateListener.class, RuntimeUpdateListener.class },
-                configurationPolicy = ConfigurationPolicy.IGNORE,
-                immediate = true,
-                property = { "service.vendor=IBM" })
+@Component(service = { ApplicationStateListener.class,
+                       RuntimeUpdateListener.class }, configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true, property = { "service.vendor=IBM" })
 public class GeneratePluginConfigListener implements RuntimeUpdateListener, ApplicationStateListener {
 
     private static final TraceComponent tc = Tr.register(GeneratePluginConfigListener.class);
@@ -85,8 +83,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
             Tr.debug(this, tc, "GPCL: deactivate called.");
     }
 
-    @Reference(service = com.ibm.wsspi.webcontainer.osgi.mbeans.GeneratePluginConfig.class,
-                    cardinality = ReferenceCardinality.MANDATORY)
+    @Reference(service = com.ibm.wsspi.webcontainer.osgi.mbeans.GeneratePluginConfig.class, cardinality = ReferenceCardinality.MANDATORY)
     protected void setGeneratePluginConfig(GeneratePluginConfig mb) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "GPCL: GPC set");
@@ -99,8 +96,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
         gpc = null;
     }
 
-    @Reference(service = java.util.concurrent.ExecutorService.class,
-                    cardinality = ReferenceCardinality.MANDATORY)
+    @Reference(service = java.util.concurrent.ExecutorService.class, cardinality = ReferenceCardinality.MANDATORY)
     /** Required static reference: called before activate */
     protected void setExecutor(ExecutorService executorSrvc) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
@@ -112,8 +108,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
         this.executorSrvc = null;
     }
 
-    @Reference(service = SessionManager.class,
-                    cardinality = ReferenceCardinality.MANDATORY)
+    @Reference(service = SessionManager.class, cardinality = ReferenceCardinality.MANDATORY)
     protected void setSessionManager(SessionManager ref) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "Session Manager set");
@@ -123,8 +118,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
     /** Required static reference: will be called after deactivate. Avoid NPE */
     protected void unsetSessionManager(SessionManager ref) {}
 
-    @Reference(service = WsLocationAdmin.class,
-                    cardinality = ReferenceCardinality.MANDATORY)
+    @Reference(service = WsLocationAdmin.class, cardinality = ReferenceCardinality.MANDATORY)
     protected void setLocationService(WsLocationAdmin ref) {
         locationService = ref;
     }
@@ -133,7 +127,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
 
     /*
      * (non-Javadoc
-     * 
+     *
      * @see com.ibm.ws.container.service.state.ApplicationStateListener#applicationStarting(com.ibm.ws.container.service.app.deploy.ApplicationInfo)
      */
     @Override
@@ -149,7 +143,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.container.service.state.ApplicationStateListener#applicationStarted(com.ibm.ws.container.service.app.deploy.ApplicationInfo)
      */
     @Override
@@ -163,7 +157,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.container.service.state.ApplicationStateListener#applicationStopping(com.ibm.ws.container.service.app.deploy.ApplicationInfo)
      */
     @Override
@@ -177,7 +171,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.container.service.state.ApplicationStateListener#applicationStopped(com.ibm.ws.container.service.app.deploy.ApplicationInfo)
      */
     @Override
@@ -192,7 +186,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.runtime.update.RuntimeUpdateListener#notificationCreated(com.ibm.ws.runtime.update.RuntimeUpdateManager, com.ibm.ws.runtime.update.RuntimeUpdateNotification)
      */
     @Override
@@ -216,7 +210,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
 
         /*
          * (non-Javadoc)
-         * 
+         *
          * @see com.ibm.ws.threading.listeners.CompletionListener#successfulCompletion(java.util.concurrent.Future, java.lang.Object)
          */
         @Override
@@ -226,7 +220,7 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
 
         /*
          * (non-Javadoc)
-         * 
+         *
          * @see com.ibm.ws.threading.listeners.CompletionListener#failedCompletion(java.util.concurrent.Future, java.lang.Throwable)
          */
         @Override
@@ -293,9 +287,9 @@ public class GeneratePluginConfigListener implements RuntimeUpdateListener, Appl
         String cookieName = this.cookieNames.get(webApp.getApplicationName());
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "application initialized, app : " + webApp.getApplicationName() + ", old cookie name : " + this.cookieNames.get(webApp.getApplicationName())
-                               + ", new cookie name : " + sccfg.getName());
+                               + ", new cookie name : " + sccfg != null ? sccfg.getName() : null);
 
-        if (cookieName != null && !cookieName.equals(sccfg.getName())) {
+        if (cookieName != null && sccfg != null && !cookieName.equals(sccfg.getName())) {
             synchronized (this) {
                 if (isFuturePluginTask()) {
                     submitGeneratePluginTask();


### PR DESCRIPTION
Due to a race condition in dynamic the ShareLibrary implementation,
a modification event may propagate to a depending service before the
ClassLoader is updated. We have opened issue #2917 to hopefully get
this fixed.

In the immediate term, we will work around this race condition by lazily
initializing the CacheManager, instead of eagerly initializing it in
CacheStoreService activation.

Due to the number of test updates involved, this pull is being split apart and delivered in separate chunks under #3175, #3182, and other pull (add number here once opened)