### PR TITLE
Save datasource on DBIDStore when datasourceLookup is set

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStore.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStore.java
@@ -60,6 +60,10 @@ public class DatabaseIdentityStore implements IdentityStore {
 
     private InitialContext initialContext = null;
 
+    private DataSource dataSource = null;
+
+    private boolean evaluateAlways = false;
+
     /**
      * Construct a new {@link DatabaseIdentityStore} instance using the specified definitions.
      *
@@ -138,6 +142,16 @@ public class DatabaseIdentityStore implements IdentityStore {
                 Tr.event(tc, "Setting up InitializeContext failed, will try later.", e);
             }
         }
+
+        /*
+         * Check if the datasource is either a set string or an immediate EL expression.
+         * If it is, we can store the datasource on first lookup. If it is a deferred EL expression,
+         * we will look it up every time.
+         */
+        evaluateAlways = !this.idStoreDefinition.isDataSourceEvaluated();
+        if (tc.isEventEnabled()) {
+            Tr.event(tc, "Always evaluate Datasource: " + evaluateAlways);
+        }
     }
 
     @Override
@@ -162,7 +176,7 @@ public class DatabaseIdentityStore implements IdentityStore {
         String groupsQuery = "not_resolved";
         try {
             groupsQuery = idStoreDefinition.getGroupsQuery();
-            Connection conn = getConnection(caller);
+            Connection conn = getConnection();
             try {
                 prep = conn.prepareStatement(groupsQuery);
                 prep.setString(1, caller);
@@ -238,18 +252,23 @@ public class DatabaseIdentityStore implements IdentityStore {
         PreparedStatement prep = null;
         String callerQuery = "not_resolved";
         try {
-            Connection conn = getConnection(caller);
+            Connection conn = getConnection();
             try {
                 callerQuery = idStoreDefinition.getCallerQuery();
                 if (callerQuery == null || callerQuery.isEmpty()) {
                     if (tc.isEventEnabled()) {
-                        Tr.event(tc, "The 'callerQuery' parameter can not be  " + callerQuery == null ? "null." : "empty.");
+                        Tr.event(tc, "The 'callerQuery' parameter can not be " + callerQuery == null ? "null." : "empty.");
                     }
                     return CredentialValidationResult.INVALID_RESULT;
                 }
 
                 prep = conn.prepareStatement(callerQuery);
                 prep.setString(1, caller);
+                /*
+                 * Only 1 row should be returned. If two rows (users) are returned, we can log an error to help debug the problem.
+                 * If someone sends in a malicious statement (such as select * from), we can cut off the results.
+                 */
+                prep.setMaxRows(2);
 
                 ResultSet result = runQuery(prep, caller);
 
@@ -324,18 +343,31 @@ public class DatabaseIdentityStore implements IdentityStore {
         return result;
     }
 
-    private Connection getConnection(String caller) throws NamingException, SQLException {
+    private Connection getConnection() throws NamingException, SQLException {
         if (initialContext == null) {
             initialContext = new InitialContext();
         }
-        // datasource could be an expression, look it up fresh every time.
-        String dataSourceLookup = idStoreDefinition.getDataSourceLookup();
-        if (dataSourceLookup == null || dataSourceLookup.isEmpty()) {
-            throw new IllegalArgumentException("The 'dataSourceLookup' configuration cannot be empty or null.");
+
+        DataSource localDataSource;
+        if (evaluateAlways || dataSource == null) {
+            String dataSourceLookup = idStoreDefinition.getDataSourceLookup();
+            if (dataSourceLookup == null || dataSourceLookup.isEmpty()) {
+                throw new IllegalArgumentException("The 'dataSourceLookup' configuration cannot be " + dataSourceLookup == null ? "null." : "empty.");
+            }
+            localDataSource = (DataSource) initialContext.lookup(dataSourceLookup);
+
+            if (!evaluateAlways) { // first lookup of an evaluated dataSourceLookup, save permanently
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "DataSource is stored for " + dataSourceLookup);
+                }
+                dataSource = localDataSource;
+            }
+        } else {
+            localDataSource = dataSource;
         }
 
-        DataSource dataSource = (DataSource) initialContext.lookup(dataSourceLookup);
-
-        return dataSource.getConnection();
+        Connection conn = localDataSource.getConnection();
+        conn.setReadOnly(true);
+        return conn;
     }
 }

--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStoreDefinitionWrapper.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStoreDefinitionWrapper.java
@@ -64,6 +64,8 @@ public class DatabaseIdentityStoreDefinitionWrapper {
     /** The ValidationTypes this IdentityStore can be used for. Will be null when set by a deferred EL expression. */
     private final Set<ValidationType> useFor;
 
+    private boolean datasourceEvaluated = false;
+
     /**
      * Create a new instance of an {@link DatabaseIdentityStoreDefinitionWrapper} that will provide
      * convenience methods to access configuration from the {@link DatabaseIdentityStoreDefinition}
@@ -87,6 +89,9 @@ public class DatabaseIdentityStoreDefinitionWrapper {
          */
         this.callerQuery = evaluateCallerQuery(true);
         this.dataSourceLookup = evaluateDataSourceLookup(true);
+        if (this.dataSourceLookup != null) {
+            datasourceEvaluated = true;
+        }
         this.groupsQuery = evaluateGroupsQuery(true);
         this.hashAlgorithm = evaluateHashAlgorithm();
         this.hashAlgorithmParameters = evaluateHashAlgorithmParameters();
@@ -356,5 +361,9 @@ public class DatabaseIdentityStoreDefinitionWrapper {
      */
     Set<ValidationType> getUseFor() {
         return (this.useFor != null) ? this.useFor : evaluateUseFor(false);
+    }
+
+    boolean isDataSourceEvaluated() {
+        return datasourceEvaluated;
     }
 }

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.security.javaeesec.fat;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -129,6 +130,32 @@ public class HttpAuthenticationMechanismDBTest extends JavaEESecTestBase {
                                                    Constants.DB_USER2_PWD,
                                                    HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + Constants.DB_USER2, Constants.getRemoteUserFound + Constants.DB_USER2);
+        Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
+    }
+
+    @Mode(TestMode.LITE)
+    @Test
+    public void testJaspiAnnotatedDBMultiAccess() throws Exception {
+        Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
+
+        String msg = "DataSource is stored for "; // trace
+        List<String> foundResults = myServer.findStringsInLogsAndTrace(msg);
+        assertEquals("Expected saving the datasource once: " + msg, 1, foundResults.size());
+
+        String msg2 = "Always evaluate Datasource: false"; //trace
+        foundResults = myServer.findStringsInLogsAndTrace(msg2);
+        assertEquals("Expected datasource to be evaluated: " + msg2, 1, foundResults.size());
+
+        for (int i = 0; i < 10; i++) {
+            String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, Constants.DB_USER1,
+                                                              Constants.DB_USER1_PWD,
+                                                              HttpServletResponse.SC_OK);
+            verifyUserResponse(response, Constants.getUserPrincipalFound + Constants.DB_USER1, Constants.getRemoteUserFound + Constants.DB_USER1);
+        }
+
+        foundResults = myServer.findStringsInLogsAndTrace(msg);
+        assertEquals("Should not have saved the datasource again.", 1, foundResults.size());
+
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
     }
 


### PR DESCRIPTION
fixes #2966 

Integrating testing into existing FAT tests.