### PR TITLE
Add common security FAT web response utils class

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -95,6 +95,8 @@ net.sourceforge.htmlunit:htmlunit:2.4
 net.sourceforge.htmlunit:htmlunit:2.15
 net.sourceforge.htmlunit:htmlunit:2.27
 net.sourceforge.htmlunit:htmlunit-core-js:2.15
+net.sourceforge.htmlunit:htmlunit-core-js:2.27
+net.sourceforge.htmlunit:neko-htmlunit:2.28
 org.apache.ant:ant:1.9.6
 org.apache.ant:ant-junit:1.9.6
 org.apache.aries.jmx:org.apache.aries.jmx.api:1.1.5
@@ -270,3 +272,5 @@ org.springframework:spring-beans:5.0.4.RELEASE
 org.springframework:spring-web:5.0.4.RELEASE
 org.springframework.boot:spring-boot-autoconfigure:2.0.0.RELEASE
 org.springframework.boot:spring-boot:2.0.0.RELEASE
+xalan:xalan:2.7.1
+xerces:xercesImpl:2.11.0

--- a/dev/com.ibm.ws.security.fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.fat.common/bnd.bnd
@@ -46,7 +46,10 @@ publish.wlp.jar.disabled: true
     com.ibm.ws.componenttest:public.api;version=latest, \
     com.ibm.websphere.javaee.servlet.3.1;version=latest, \
     org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3, \
-    fattest.simplicity;version=latest
+    fattest.simplicity;version=latest, \
+    net.sourceforge.htmlunit:htmlunit;version=2.27, \
+    httpunit:httpunit;version=1.7, \
+    com.ibm.ws.org.apache.commons.lang3.3.5;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
@@ -58,4 +61,15 @@ publish.wlp.jar.disabled: true
     org.jmock:jmock;strategy=exact;version=2.5.1, \
     com.ibm.ws.org.objenesis:objenesis;version=1.0, \
     com.ibm.ws.kernel.boot;version=latest, \
-    com.ibm.ws.security.test.common;version=latest
+    com.ibm.ws.security.test.common;version=latest, \
+    org.apache.httpcomponents:httpclient;version=4.3.1, \
+    org.apache.httpcomponents:httpcore;version=4.3, \
+    net.sourceforge.htmlunit:htmlunit;version=2.27, \
+    net.sourceforge.htmlunit:htmlunit-core-js;version=2.27, \
+    org.apache.commons:commons-lang3;version=3.5, \
+    commons-codec:commons-codec;version=1.6, \
+    org.eclipse.birt.runtime:org.w3c.css.sac;version=1.3.1.v200903091627, \
+    commons-logging:commons-logging;version=1.1.3, \
+    xalan:xalan;version=2.7.1, \
+    net.sourceforge.htmlunit:neko-htmlunit;version=2.28, \
+    xerces:xercesImpl;version=2.11.0

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/web/WebResponseUtils.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/web/WebResponseUtils.java
@@ -1,0 +1,250 @@
+package com.ibm.ws.security.fat.common.web;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.gargoylesoftware.htmlunit.CookieManager;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebResponse;
+import com.gargoylesoftware.htmlunit.util.Cookie;
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import com.ibm.websphere.simplicity.log.Log;
+
+public class WebResponseUtils {
+    public static Class<?> thisClass = WebResponseUtils.class;
+
+    public static String getResponseText(Object pageOrResponse) throws Exception {
+        if (pageOrResponse == null) {
+            Log.info(thisClass, "getResponseText", "pageOrResponse is null");
+            return null;
+        }
+        if (pageOrResponse instanceof com.meterware.httpunit.WebResponse) {
+            return ((com.meterware.httpunit.WebResponse) pageOrResponse).getText();
+        }
+        WebResponse response = getWebResponseObject(pageOrResponse);
+        if (response != null) {
+            return response.getContentAsString();
+        }
+        return null;
+    }
+
+    private static WebResponse getWebResponseObject(Object pageOrResponse) throws Exception {
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.WebResponse) {
+            return ((com.gargoylesoftware.htmlunit.WebResponse) pageOrResponse);
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.html.HtmlPage) {
+            return ((com.gargoylesoftware.htmlunit.html.HtmlPage) pageOrResponse).getWebResponse();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.TextPage) {
+            return ((com.gargoylesoftware.htmlunit.TextPage) pageOrResponse).getWebResponse();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.xml.XmlPage) {
+            return ((com.gargoylesoftware.htmlunit.xml.XmlPage) pageOrResponse).getWebResponse();
+        }
+        throw new Exception("Unknown response type: " + pageOrResponse.getClass().getName());
+    }
+
+    public static int getResponseStatusCode(Object pageOrResponse) throws Exception {
+        if (pageOrResponse == null) {
+            Log.info(thisClass, "getResponseStatusCode", "pageOrResponse is null");
+            return -1;
+        }
+        if (pageOrResponse instanceof com.meterware.httpunit.WebResponse) {
+            return ((com.meterware.httpunit.WebResponse) pageOrResponse).getResponseCode();
+        }
+        WebResponse response = getWebResponseObject(pageOrResponse);
+        if (response != null) {
+            return response.getStatusCode();
+        }
+        return -1;
+    }
+
+    public static String getResponseTitle(Object pageOrResponse) throws Exception {
+        if (pageOrResponse == null) {
+            Log.info(thisClass, "getResponseTitle", "pageOrResponse is null");
+            return null;
+        }
+        if (pageOrResponse instanceof com.meterware.httpunit.WebResponse) {
+            return ((com.meterware.httpunit.WebResponse) pageOrResponse).getTitle();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.WebResponse) {
+            throw new Exception("get Title not supported with type: " + pageOrResponse.getClass().getName());
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.html.HtmlPage) {
+            return ((com.gargoylesoftware.htmlunit.html.HtmlPage) pageOrResponse).getTitleText();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.TextPage) {
+            return "TextPage has no title";
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.xml.XmlPage) {
+            return "XmlPage has no title";
+        }
+        throw new Exception("Unknown response type: " + pageOrResponse.getClass().getName());
+    }
+
+    public static String getResponseUrl(Object pageOrResponse) throws Exception {
+        if (pageOrResponse == null) {
+            Log.info(thisClass, "getResponseUrl", "pageOrResponse is null");
+            return null;
+        }
+        URL url = getResponseUrlObject(pageOrResponse);
+        if (url != null) {
+            return url.toString();
+        }
+        return null;
+    }
+
+    private static URL getResponseUrlObject(Object pageOrResponse) throws Exception {
+        if (pageOrResponse instanceof com.meterware.httpunit.WebResponse) {
+            return ((com.meterware.httpunit.WebResponse) pageOrResponse).getURL();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.WebResponse) {
+            throw new Exception("Get URL not supported with type: " + pageOrResponse.getClass().getName());
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.html.HtmlPage) {
+            return ((com.gargoylesoftware.htmlunit.html.HtmlPage) pageOrResponse).getUrl();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.TextPage) {
+            return ((com.gargoylesoftware.htmlunit.TextPage) pageOrResponse).getUrl();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.xml.XmlPage) {
+            return ((com.gargoylesoftware.htmlunit.xml.XmlPage) pageOrResponse).getUrl();
+        }
+        throw new Exception("Unknown response type: " + pageOrResponse.getClass().getName());
+    }
+
+    public static String getResponseMessage(Object pageOrResponse) throws Exception {
+        if (pageOrResponse == null) {
+            Log.info(thisClass, "getResponseMessage", "pageOrResponse is null");
+            return null;
+        }
+        if (pageOrResponse instanceof com.meterware.httpunit.WebResponse) {
+            return ((com.meterware.httpunit.WebResponse) pageOrResponse).getResponseMessage();
+        }
+        WebResponse response = getWebResponseObject(pageOrResponse);
+        if (response != null) {
+            return response.getStatusMessage();
+        }
+        return null;
+    }
+
+    public static String[] getResponseHeaderNames(Object pageOrResponse) throws Exception {
+        if (pageOrResponse == null) {
+            Log.info(thisClass, "getResponseHeaderNames", "pageOrResponse is null");
+            return null;
+        }
+        if (pageOrResponse instanceof com.meterware.httpunit.WebResponse) {
+            return ((com.meterware.httpunit.WebResponse) pageOrResponse).getHeaderFieldNames();
+        }
+        List<NameValuePair> headerMap = getResponseHeaderList(pageOrResponse);
+        return convertHeaderListToNameArray(headerMap);
+    }
+
+    public static List<NameValuePair> getResponseHeaderList(Object pageOrResponse) throws Exception {
+        if (pageOrResponse == null) {
+            Log.info(thisClass, "getResponseHeaderList", "pageOrResponse is null");
+            return null;
+        }
+        if (pageOrResponse instanceof com.meterware.httpunit.WebResponse) {
+            throw new Exception("Getting response header list not supported with type: " + pageOrResponse.getClass().getName());
+        }
+        List<NameValuePair> headerList = null;
+        WebResponse response = getWebResponseObject(pageOrResponse);
+        if (response != null) {
+            headerList = response.getResponseHeaders();
+        }
+        return headerList;
+    }
+
+    static String[] convertHeaderListToNameArray(List<NameValuePair> headerList) {
+        if (headerList == null) {
+            return new String[0];
+        }
+        String[] returnList = new String[headerList.size()];
+        int count = 0;
+        for (NameValuePair headerNameAndValue : headerList) {
+            returnList[count] = headerNameAndValue.getName();
+            count++;
+        }
+        return returnList;
+    }
+
+    public static String getResponseHeaderField(Object pageOrResponse, String headerName) throws Exception {
+        if (pageOrResponse == null) {
+            Log.info(thisClass, "getResponseHeaderField", "pageOrResponse is null");
+            return null;
+        }
+        if (pageOrResponse instanceof com.meterware.httpunit.WebResponse) {
+            return ((com.meterware.httpunit.WebResponse) pageOrResponse).getHeaderField(headerName);
+        }
+        WebResponse response = getWebResponseObject(pageOrResponse);
+        if (response != null) {
+            return response.getResponseHeaderValue(headerName);
+        }
+        return null;
+    }
+
+    public static String[] getResponseCookieNames(Object pageOrResponse) throws Exception {
+        if (pageOrResponse == null) {
+            Log.info(thisClass, "getResponseCookieNames", "pageOrResponse is null");
+            return null;
+        }
+        if (pageOrResponse instanceof com.meterware.httpunit.WebResponse) {
+            return ((com.meterware.httpunit.WebResponse) pageOrResponse).getNewCookieNames();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.html.HtmlPage) {
+            return getCookieNamesFromHtmlPage((com.gargoylesoftware.htmlunit.html.HtmlPage) pageOrResponse);
+        }
+        throw new Exception("Getting cookie names not supported with type: " + pageOrResponse.getClass().getName() + " (cookies come from webClient)");
+    }
+
+    static String[] getCookieNamesFromHtmlPage(com.gargoylesoftware.htmlunit.html.HtmlPage page) throws Exception {
+        WebClient webClient = page.getWebClient();
+        if (webClient == null) {
+            throw new Exception("Cannot get cookies in response because the web client cannot be found.");
+        }
+        CookieManager cookieManager = webClient.getCookieManager();
+        if (cookieManager == null) {
+            throw new Exception("Cannot get cookies in response because the cookie manager cannot be found.");
+        }
+        Set<Cookie> cookies = cookieManager.getCookies();
+        if (cookies == null) {
+            return new String[0];
+        }
+        List<String> cookieNames = new ArrayList<String>();
+        for (Cookie cookie : cookies) {
+            if (cookie == null) {
+                continue;
+            }
+            cookieNames.add(cookie.getName());
+        }
+        return cookieNames.toArray(new String[cookieNames.size()]);
+    }
+
+    public static boolean getResponseIsHtml(Object pageOrResponse) throws Exception {
+        if (pageOrResponse == null) {
+            Log.info(thisClass, "getResponseIsHtml", "pageOrResponse is null");
+            return false;
+        }
+        if (pageOrResponse instanceof com.meterware.httpunit.WebResponse) {
+            return ((com.meterware.httpunit.WebResponse) pageOrResponse).isHTML();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.WebResponse) {
+            // let's assume true for now
+            return true;
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.html.HtmlPage) {
+            return ((com.gargoylesoftware.htmlunit.html.HtmlPage) pageOrResponse).isHtmlPage();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.TextPage) {
+            return ((com.gargoylesoftware.htmlunit.TextPage) pageOrResponse).isHtmlPage();
+        }
+        if (pageOrResponse instanceof com.gargoylesoftware.htmlunit.xml.XmlPage) {
+            return ((com.gargoylesoftware.htmlunit.xml.XmlPage) pageOrResponse).isHtmlPage();
+        }
+        throw new Exception("Unknown response type: " + pageOrResponse.getClass().getName());
+    }
+
+}

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/web/package-info.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/web/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.20")
+package com.ibm.ws.security.fat.common.web;

--- a/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/web/WebResponseUtilsTest.java
+++ b/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/web/WebResponseUtilsTest.java
@@ -1,0 +1,2376 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.fat.common.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.gargoylesoftware.htmlunit.util.Cookie;
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class WebResponseUtilsTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.fat.common.*=all");
+
+    private final com.gargoylesoftware.htmlunit.WebResponse htmlunitWebResponse = mockery.mock(com.gargoylesoftware.htmlunit.WebResponse.class);
+    private final com.gargoylesoftware.htmlunit.html.HtmlPage htmlunitHtmlPage = mockery.mock(com.gargoylesoftware.htmlunit.html.HtmlPage.class);
+    private final com.gargoylesoftware.htmlunit.TextPage htmlunitTextPage = mockery.mock(com.gargoylesoftware.htmlunit.TextPage.class);
+    private final com.gargoylesoftware.htmlunit.xml.XmlPage htmlunitXmlPage = mockery.mock(com.gargoylesoftware.htmlunit.xml.XmlPage.class);
+    private final com.gargoylesoftware.htmlunit.WebClient htmlunitWebClient = mockery.mock(com.gargoylesoftware.htmlunit.WebClient.class);
+    private final com.gargoylesoftware.htmlunit.CookieManager htmlunitCookieManager = mockery.mock(com.gargoylesoftware.htmlunit.CookieManager.class);
+
+    private final String HELLO_WORLD = "Hello, world!";
+    private final String URL_STRING = "http://localhost:8010";
+    private final String HEADER_NAME_1 = "headerName1";
+    private final String HEADER_NAME_2 = "headerName2";
+    private final String HEADER_NAME_3 = "headerName3";
+    private final String HEADER_VALUE_1 = "headerValue1";
+    private final String HEADER_VALUE_2 = "headerValue2";
+    private final String HEADER_VALUE_3 = "headerValue3";
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void before() {
+        System.out.println("Entering test: " + testName.getMethodName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        outputMgr.resetStreams();
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    /************************************** getResponseText **************************************/
+
+    /**
+     * Tests:
+     * - Argument: null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseText_nullArgument() {
+        try {
+            Object pageOrResponse = null;
+
+            String result = WebResponseUtils.getResponseText(pageOrResponse);
+
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: Unknown/unsupported object type
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseText_unknownObject() {
+        try {
+            Object pageOrResponse = "some unknown object";
+            try {
+                String result = WebResponseUtils.getResponseText(pageOrResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "Unknown response type: java.lang.String");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - Returned content is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseText_htmlunitWebResponse_nullContent() {
+        try {
+            final String content = null;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getContentAsString();
+                    will(returnValue(content));
+                }
+            });
+            String result = WebResponseUtils.getResponseText(htmlunitWebResponse);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - Returned content is not null
+     * Expects:
+     * - Result match the content
+     */
+    @Test
+    public void test_getResponseText_htmlunitWebResponse_nonNullContent() {
+        try {
+            final String content = HELLO_WORLD;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getContentAsString();
+                    will(returnValue(content));
+                }
+            });
+            String result = WebResponseUtils.getResponseText(htmlunitWebResponse);
+            assertEquals("Result did not match expected value.", content, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - Returned WebResponse object is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseText_htmlunitHtmlPage_nullWebResponse() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(null));
+                }
+            });
+            String result = WebResponseUtils.getResponseText(htmlunitHtmlPage);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - Returned content is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseText_htmlunitHtmlPage_nullContent() {
+        try {
+            final String content = null;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getContentAsString();
+                    will(returnValue(content));
+                }
+            });
+            String result = WebResponseUtils.getResponseText(htmlunitHtmlPage);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - Returned content is not null
+     * Expects:
+     * - Result match the content
+     */
+    @Test
+    public void test_getResponseText_htmlunitHtmlPage_nonNullContent() {
+        try {
+            final String content = HELLO_WORLD;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getContentAsString();
+                    will(returnValue(content));
+                }
+            });
+            String result = WebResponseUtils.getResponseText(htmlunitHtmlPage);
+            assertEquals("Result did not match expected value.", content, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * - Returned content is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseText_htmlunitTextPage_nullContent() {
+        try {
+            final String content = null;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getContentAsString();
+                    will(returnValue(content));
+                }
+            });
+            String result = WebResponseUtils.getResponseText(htmlunitTextPage);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * - Returned content is not null
+     * Expects:
+     * - Result match the content
+     */
+    @Test
+    public void test_getResponseText_htmlunitTextPage_nonNullContent() {
+        try {
+            final String content = HELLO_WORLD;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getContentAsString();
+                    will(returnValue(content));
+                }
+            });
+            String result = WebResponseUtils.getResponseText(htmlunitTextPage);
+            assertEquals("Result did not match expected value.", content, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * - Returned content is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseText_htmlunitXmlPage_nullContent() {
+        try {
+            final String content = null;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitXmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getContentAsString();
+                    will(returnValue(content));
+                }
+            });
+            String result = WebResponseUtils.getResponseText(htmlunitXmlPage);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * - Returned content is not null
+     * Expects:
+     * - Result match the content
+     */
+    @Test
+    public void test_getResponseText_htmlunitXmlPage_nonNullContent() {
+        try {
+            final String content = HELLO_WORLD;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitXmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getContentAsString();
+                    will(returnValue(content));
+                }
+            });
+            String result = WebResponseUtils.getResponseText(htmlunitXmlPage);
+            assertEquals("Result did not match expected value.", content, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getResponseStatusCode **************************************/
+
+    /**
+     * Tests:
+     * - Argument: null
+     * Expects:
+     * - Result should be a bogus status code
+     */
+    @Test
+    public void test_getResponseStatusCode_nullArgument() {
+        try {
+            Object pageOrResponse = null;
+
+            int result = WebResponseUtils.getResponseStatusCode(pageOrResponse);
+
+            assertEquals("Result did not match the expected status code for a null argument.", -1, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: Unknown/unsupported object type
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseStatusCode_unknownObject() {
+        try {
+            Object pageOrResponse = "some unknown object";
+            try {
+                int result = WebResponseUtils.getResponseStatusCode(pageOrResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "Unknown response type: java.lang.String");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * Expects:
+     * - Result should match expected status code
+     */
+    @Test
+    public void test_getResponseStatusCode_htmlunitWebResponse() {
+        try {
+            final int statusCode = 200;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getStatusCode();
+                    will(returnValue(statusCode));
+                }
+            });
+            int result = WebResponseUtils.getResponseStatusCode(htmlunitWebResponse);
+            assertEquals("Result did not match the expected status code.", statusCode, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * Expects:
+     * - Result should match expected status code
+     */
+    @Test
+    public void test_getResponseStatusCode_htmlunitHtmlPage() {
+        try {
+            final int statusCode = 200;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getStatusCode();
+                    will(returnValue(statusCode));
+                }
+            });
+            int result = WebResponseUtils.getResponseStatusCode(htmlunitHtmlPage);
+            assertEquals("Result did not match the expected status code.", statusCode, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * - Returned WebResponse object is null
+     * Expects:
+     * - Result should match expected status code
+     */
+    @Test
+    public void test_getResponseStatusCode_htmlunitTextPage_nullWebResponse() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).getWebResponse();
+                    will(returnValue(null));
+                }
+            });
+            int result = WebResponseUtils.getResponseStatusCode(htmlunitTextPage);
+            assertEquals("Result did not match the expected status code for an unsuccessful result.", -1, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * Expects:
+     * - Result should match expected status code
+     */
+    @Test
+    public void test_getResponseStatusCode_htmlunitTextPage() {
+        try {
+            final int statusCode = 200;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getStatusCode();
+                    will(returnValue(statusCode));
+                }
+            });
+            int result = WebResponseUtils.getResponseStatusCode(htmlunitTextPage);
+            assertEquals("Result did not match the expected status code.", statusCode, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * Expects:
+     * - Result should match expected status code
+     */
+    @Test
+    public void test_getResponseStatusCode_htmlunitXmlPage() {
+        try {
+            final int statusCode = 200;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitXmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getStatusCode();
+                    will(returnValue(statusCode));
+                }
+            });
+            int result = WebResponseUtils.getResponseStatusCode(htmlunitXmlPage);
+            assertEquals("Result did not match the expected status code.", statusCode, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getResponseTitle **************************************/
+
+    /**
+     * Tests:
+     * - Argument: null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseTitle_nullArgument() {
+        try {
+            Object pageOrResponse = null;
+
+            String result = WebResponseUtils.getResponseTitle(pageOrResponse);
+
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: Unknown/unsupported object type
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseTitle_unknownObject() {
+        try {
+            Object pageOrResponse = "some unknown object";
+            try {
+                String result = WebResponseUtils.getResponseTitle(pageOrResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "Unknown response type: java.lang.String");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * Expects:
+     * - Exception should be thrown since getting the title isn't supported with this object
+     */
+    @Test
+    public void test_getResponseTitle_htmlunitWebResponse() {
+        try {
+            try {
+                String result = WebResponseUtils.getResponseTitle(htmlunitWebResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "not supported.+" + "com.gargoylesoftware.htmlunit.WebResponse");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - Returned content is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseTitle_htmlunitHtmlPage_nullContent() {
+        try {
+            final String content = null;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getTitleText();
+                    will(returnValue(content));
+                }
+            });
+            String result = WebResponseUtils.getResponseTitle(htmlunitHtmlPage);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - Returned content is not null
+     * Expects:
+     * - Result match the content
+     */
+    @Test
+    public void test_getResponseTitle_htmlunitHtmlPage_nonNullContent() {
+        try {
+            final String content = HELLO_WORLD;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getTitleText();
+                    will(returnValue(content));
+                }
+            });
+            String result = WebResponseUtils.getResponseTitle(htmlunitHtmlPage);
+            assertEquals("Result did not match expected value.", content, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * Expects:
+     * - Result should be "TextPage has no title"
+     */
+    @Test
+    public void test_getResponseTitle_htmlunitTextPage() {
+        try {
+            String result = WebResponseUtils.getResponseTitle(htmlunitTextPage);
+            assertEquals("Result did not match expected value.", "TextPage has no title", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * Expects:
+     * - Result should be "XmlPage has no title"
+     */
+    @Test
+    public void test_getResponseTitle_htmlunitXmlPage() {
+        try {
+            String result = WebResponseUtils.getResponseTitle(htmlunitXmlPage);
+            assertEquals("Result did not match expected value.", "XmlPage has no title", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getResponseUrl **************************************/
+
+    /**
+     * Tests:
+     * - Argument: null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseUrl_nullArgument() {
+        try {
+            Object pageOrResponse = null;
+
+            String result = WebResponseUtils.getResponseUrl(pageOrResponse);
+
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: Unknown/unsupported object type
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseUrl_unknownObject() {
+        try {
+            Object pageOrResponse = "some unknown object";
+            try {
+                String result = WebResponseUtils.getResponseUrl(pageOrResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "Unknown response type: java.lang.String");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * Expects:
+     * - Exception should be thrown since getting the title isn't supported with this object
+     */
+    @Test
+    public void test_getResponseUrl_htmlunitWebResponse() {
+        try {
+            try {
+                String result = WebResponseUtils.getResponseUrl(htmlunitWebResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "not supported.+" + "com.gargoylesoftware.htmlunit.WebResponse");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - Returned URL object is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseUrl_htmlunitHtmlPage_nullUrl() {
+        try {
+            final URL url = null;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getUrl();
+                    will(returnValue(url));
+                }
+            });
+            String result = WebResponseUtils.getResponseUrl(htmlunitHtmlPage);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * Expects:
+     * - Result should match the expected URL string
+     */
+    @Test
+    public void test_getResponseUrl_htmlunitHtmlPage() {
+        try {
+            final URL url = new URL(URL_STRING);
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getUrl();
+                    will(returnValue(url));
+                }
+            });
+            String result = WebResponseUtils.getResponseUrl(htmlunitHtmlPage);
+            assertEquals("Result did not match expected value.", URL_STRING, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * Expects:
+     * - Result should match the expected URL string
+     */
+    @Test
+    public void test_getResponseUrl_htmlunitTextPage() {
+        try {
+            final URL url = new URL(URL_STRING);
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).getUrl();
+                    will(returnValue(url));
+                }
+            });
+            String result = WebResponseUtils.getResponseUrl(htmlunitTextPage);
+            assertEquals("Result did not match expected value.", URL_STRING, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * Expects:
+     * - Result should match the expected URL string
+     */
+    @Test
+    public void test_getResponseUrl_htmlunitXmlPage() {
+        try {
+            final URL url = new URL(URL_STRING);
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitXmlPage).getUrl();
+                    will(returnValue(url));
+                }
+            });
+            String result = WebResponseUtils.getResponseUrl(htmlunitXmlPage);
+            assertEquals("Result did not match expected value.", URL_STRING, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getResponseMessage **************************************/
+
+    /**
+     * Tests:
+     * - Argument: null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseMessage_nullArgument() {
+        try {
+            Object pageOrResponse = null;
+
+            String result = WebResponseUtils.getResponseMessage(pageOrResponse);
+
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: Unknown/unsupported object type
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseMessage_unknownObject() {
+        try {
+            Object pageOrResponse = "some unknown object";
+            try {
+                String result = WebResponseUtils.getResponseMessage(pageOrResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "Unknown response type: java.lang.String");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - Status message is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseMessage_htmlunitWebResponse_nullMessage() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getStatusMessage();
+                    will(returnValue(null));
+                }
+            });
+            String result = WebResponseUtils.getResponseMessage(htmlunitWebResponse);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * Expects:
+     * - Result should match the expected response string
+     */
+    @Test
+    public void test_getResponseMessage_htmlunitWebResponse() {
+        try {
+            final String message = "This is the response message.";
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getStatusMessage();
+                    will(returnValue(message));
+                }
+            });
+            String result = WebResponseUtils.getResponseMessage(htmlunitWebResponse);
+            assertEquals("Result did not match expected value.", message, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * Expects:
+     * - Result should match the expected response string
+     */
+    @Test
+    public void test_getResponseMessage_htmlunitHtmlPage() {
+        try {
+            final String message = "This is the response message.";
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getStatusMessage();
+                    will(returnValue(message));
+                }
+            });
+            String result = WebResponseUtils.getResponseMessage(htmlunitHtmlPage);
+            assertEquals("Result did not match expected value.", message, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * Expects:
+     * - Result should match the expected response string
+     */
+    @Test
+    public void test_getResponseMessage_htmlunitTextPage() {
+        try {
+            final String message = "This is the response message.";
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getStatusMessage();
+                    will(returnValue(message));
+                }
+            });
+            String result = WebResponseUtils.getResponseMessage(htmlunitTextPage);
+            assertEquals("Result did not match expected value.", message, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * - WebResponse object is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseMessage_htmlunitXmlPage_nullWebResponse() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitXmlPage).getWebResponse();
+                    will(returnValue(null));
+                }
+            });
+            String result = WebResponseUtils.getResponseMessage(htmlunitXmlPage);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * Expects:
+     * - Result should match the expected response string
+     */
+    @Test
+    public void test_getResponseMessage_htmlunitXmlPage() {
+        try {
+            final String message = "This is the response message.";
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitXmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getStatusMessage();
+                    will(returnValue(message));
+                }
+            });
+            String result = WebResponseUtils.getResponseMessage(htmlunitXmlPage);
+            assertEquals("Result did not match expected value.", message, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getResponseHeaderNames **************************************/
+
+    /**
+     * Tests:
+     * - Argument: null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseHeaderNames_nullArgument() {
+        try {
+            Object pageOrResponse = null;
+
+            String[] result = WebResponseUtils.getResponseHeaderNames(pageOrResponse);
+
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: Unknown/unsupported object type
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseHeaderNames_unknownObject() {
+        try {
+            Object pageOrResponse = "some unknown object";
+            try {
+                String[] result = WebResponseUtils.getResponseHeaderNames(pageOrResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "Unknown response type: java.lang.String");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - List of headers is null
+     * Expects:
+     * - Result should be an empty array
+     */
+    @Test
+    public void test_getResponseHeaderNames_htmlunitWebResponse_nullHeaders() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(null));
+                }
+            });
+            String[] result = WebResponseUtils.getResponseHeaderNames(htmlunitWebResponse);
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result should have been an empty array but was not.", Arrays.toString(new String[0]), Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - List of headers is empty
+     * Expects:
+     * - Result should be an empty array
+     */
+    @Test
+    public void test_getResponseHeaderNames_htmlunitWebResponse_noHeaders() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            String[] result = WebResponseUtils.getResponseHeaderNames(htmlunitWebResponse);
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result should have been an empty array but was not.", Arrays.toString(new String[0]), Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - List of headers contains one header
+     * Expects:
+     * - Result should be array containing just the name of the header
+     */
+    @Test
+    public void test_getResponseHeaderNames_htmlunitWebResponse_oneHeader() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            String[] result = WebResponseUtils.getResponseHeaderNames(htmlunitWebResponse);
+            assertNotNull("Result should not have been null but was.", result);
+
+            String expectedResult = Arrays.toString(new String[] { HEADER_NAME_1 });
+            assertEquals("Result did not match the list of expected header names.", expectedResult, Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - List of headers contains multiple headers
+     * Expects:
+     * - Result should be array containing the names of each header
+     */
+    @Test
+    public void test_getResponseHeaderNames_htmlunitWebResponse_multipleHeaders() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            headers.add(new NameValuePair(HEADER_NAME_2, HEADER_VALUE_2));
+            headers.add(new NameValuePair(HEADER_NAME_3, HEADER_VALUE_3));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            String[] result = WebResponseUtils.getResponseHeaderNames(htmlunitWebResponse);
+            assertNotNull("Result should not have been null but was.", result);
+
+            String expectedResult = Arrays.toString(new String[] { HEADER_NAME_1, HEADER_NAME_2, HEADER_NAME_3 });
+            assertEquals("Result did not match the list of expected header names.", expectedResult, Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - WebResponse object is null
+     * Expects:
+     * - Result should be an empty array
+     */
+    @Test
+    public void test_getResponseHeaderNames_htmlunitHtmlPage_nullWebResponse() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(null));
+                }
+            });
+            String[] result = WebResponseUtils.getResponseHeaderNames(htmlunitHtmlPage);
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result should have been an empty array but was not.", Arrays.toString(new String[0]), Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * Expects:
+     * - Result should be array containing the names of each header
+     */
+    @Test
+    public void test_getResponseHeaderNames_htmlunitHtmlPage() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            headers.add(new NameValuePair(HEADER_NAME_2, HEADER_VALUE_2));
+            headers.add(new NameValuePair(HEADER_NAME_3, HEADER_VALUE_3));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            String[] result = WebResponseUtils.getResponseHeaderNames(htmlunitHtmlPage);
+            assertNotNull("Result should not have been null but was.", result);
+
+            String expectedResult = Arrays.toString(new String[] { HEADER_NAME_1, HEADER_NAME_2, HEADER_NAME_3 });
+            assertEquals("Result did not match the list of expected header names.", expectedResult, Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * Expects:
+     * - Result should be array containing the names of each header
+     */
+    @Test
+    public void test_getResponseHeaderNames_htmlunitTextPage() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            headers.add(new NameValuePair(HEADER_NAME_2, HEADER_VALUE_2));
+            headers.add(new NameValuePair(HEADER_NAME_3, HEADER_VALUE_3));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            String[] result = WebResponseUtils.getResponseHeaderNames(htmlunitTextPage);
+            assertNotNull("Result should not have been null but was.", result);
+
+            String expectedResult = Arrays.toString(new String[] { HEADER_NAME_1, HEADER_NAME_2, HEADER_NAME_3 });
+            assertEquals("Result did not match the list of expected header names.", expectedResult, Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * Expects:
+     * - Result should be array containing the names of each header
+     */
+    @Test
+    public void test_getResponseHeaderNames_htmlunitXmlPage() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            headers.add(new NameValuePair(HEADER_NAME_2, HEADER_VALUE_2));
+            headers.add(new NameValuePair(HEADER_NAME_3, HEADER_VALUE_3));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitXmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            String[] result = WebResponseUtils.getResponseHeaderNames(htmlunitXmlPage);
+            assertNotNull("Result should not have been null but was.", result);
+
+            String expectedResult = Arrays.toString(new String[] { HEADER_NAME_1, HEADER_NAME_2, HEADER_NAME_3 });
+            assertEquals("Result did not match the list of expected header names.", expectedResult, Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getResponseHeaderList **************************************/
+
+    /**
+     * Tests:
+     * - Argument: null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseHeaderList_nullArgument() {
+        try {
+            Object pageOrResponse = null;
+
+            List<NameValuePair> result = WebResponseUtils.getResponseHeaderList(pageOrResponse);
+
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: Unknown/unsupported object type
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseHeaderList_unknownObject() {
+        try {
+            Object pageOrResponse = "some unknown object";
+            try {
+                List<NameValuePair> result = WebResponseUtils.getResponseHeaderList(pageOrResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "Unknown response type: java.lang.String");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - List of headers is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseHeaderList_htmlunitWebResponse_nullHeaders() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(null));
+                }
+            });
+            List<NameValuePair> result = WebResponseUtils.getResponseHeaderList(htmlunitWebResponse);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - List of headers is empty
+     * Expects:
+     * - Result should be an empty list
+     */
+    @Test
+    public void test_getResponseHeaderList_htmlunitWebResponse_noHeaders() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            List<NameValuePair> result = WebResponseUtils.getResponseHeaderList(htmlunitWebResponse);
+            assertEquals("Result should have been an empty list but was not.", headers, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - List of headers contains one header
+     * Expects:
+     * - Result should match the list of headers
+     */
+    @Test
+    public void test_getResponseHeaderList_htmlunitWebResponse_oneHeader() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            List<NameValuePair> result = WebResponseUtils.getResponseHeaderList(htmlunitWebResponse);
+            assertEquals("Result did not match the expected list of headers.", headers, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - List of headers contains multiple headers
+     * Expects:
+     * - Result should match the list of headers
+     */
+    @Test
+    public void test_getResponseHeaderList_htmlunitWebResponse_multipleHeaders() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            headers.add(new NameValuePair(HEADER_NAME_2, HEADER_VALUE_2));
+            headers.add(new NameValuePair(HEADER_NAME_3, HEADER_VALUE_3));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            List<NameValuePair> result = WebResponseUtils.getResponseHeaderList(htmlunitWebResponse);
+            assertEquals("Result did not match the expected list of headers.", headers, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - WebResponse object is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseHeaderList_htmlunitHtmlPage_nullWebResponse() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(null));
+                }
+            });
+            List<NameValuePair> result = WebResponseUtils.getResponseHeaderList(htmlunitHtmlPage);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * Expects:
+     * - Result should match the list of headers
+     */
+    @Test
+    public void test_getResponseHeaderList_htmlunitHtmlPage() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            headers.add(new NameValuePair(HEADER_NAME_2, HEADER_VALUE_2));
+            headers.add(new NameValuePair(HEADER_NAME_3, HEADER_VALUE_3));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            List<NameValuePair> result = WebResponseUtils.getResponseHeaderList(htmlunitHtmlPage);
+            assertEquals("Result did not match the expected list of headers.", headers, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * Expects:
+     * - Result should match the list of headers
+     */
+    @Test
+    public void test_getResponseHeaderList_htmlunitTextPage() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            headers.add(new NameValuePair(HEADER_NAME_2, HEADER_VALUE_2));
+            headers.add(new NameValuePair(HEADER_NAME_3, HEADER_VALUE_3));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            List<NameValuePair> result = WebResponseUtils.getResponseHeaderList(htmlunitTextPage);
+            assertEquals("Result did not match the expected list of headers.", headers, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * Expects:
+     * - Result should be array containing the names of each header
+     */
+    @Test
+    public void test_getResponseHeaderList_htmlunitXmlPage() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            headers.add(new NameValuePair(HEADER_NAME_2, HEADER_VALUE_2));
+            headers.add(new NameValuePair(HEADER_NAME_3, HEADER_VALUE_3));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitXmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getResponseHeaders();
+                    will(returnValue(headers));
+                }
+            });
+            List<NameValuePair> result = WebResponseUtils.getResponseHeaderList(htmlunitXmlPage);
+            assertEquals("Result did not match the expected list of headers.", headers, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** convertHeaderListToNameArray **************************************/
+
+    /**
+     * Tests:
+     * - List: null
+     * Expects:
+     * - Result should be an empty array
+     */
+    @Test
+    public void test_convertHeaderListToNameArray_nullList() {
+        try {
+            final List<NameValuePair> headers = null;
+
+            String[] result = WebResponseUtils.convertHeaderListToNameArray(headers);
+
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result should have been an empty array but was not.", Arrays.toString(new String[0]), Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - List: Empty
+     * Expects:
+     * - Result should be an empty array
+     */
+    @Test
+    public void test_convertHeaderListToNameArray_emptyList() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+
+            String[] result = WebResponseUtils.convertHeaderListToNameArray(headers);
+
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result should have been an empty array but was not.", Arrays.toString(new String[0]), Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - List: One entry with a null name
+     * Expects:
+     * - Result should be an array with a single null entry
+     */
+    @Test
+    public void test_convertHeaderListToNameArray_singleEntry_nullName() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(null, HEADER_VALUE_1));
+
+            String[] result = WebResponseUtils.convertHeaderListToNameArray(headers);
+
+            assertNotNull("Result should not have been null but was.", result);
+            String expectedResult = Arrays.toString(new String[] { null });
+            assertEquals("Result did not match the list of expected header names.", expectedResult, Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - List: One entry with an empty name
+     * Expects:
+     * - Result should be an array with a single empty string entry
+     */
+    @Test
+    public void test_convertHeaderListToNameArray_singleEntry_emptyName() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair("", HEADER_VALUE_1));
+
+            String[] result = WebResponseUtils.convertHeaderListToNameArray(headers);
+
+            assertNotNull("Result should not have been null but was.", result);
+            String expectedResult = Arrays.toString(new String[] { "" });
+            assertEquals("Result did not match the list of expected header names.", expectedResult, Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - List: Multiple entries
+     * Expects:
+     * - Result should be an array with the corresponding names of each entry
+     */
+    @Test
+    public void test_convertHeaderListToNameArray_multipleEntries() {
+        try {
+            final List<NameValuePair> headers = new ArrayList<NameValuePair>();
+            headers.add(new NameValuePair(null, "nullNameValue"));
+            headers.add(new NameValuePair("", "emptyNameValue"));
+            headers.add(new NameValuePair(HEADER_NAME_1, HEADER_VALUE_1));
+            headers.add(new NameValuePair("`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/? ", "special char name value"));
+
+            String[] result = WebResponseUtils.convertHeaderListToNameArray(headers);
+
+            assertNotNull("Result should not have been null but was.", result);
+            String expectedResult = Arrays.toString(new String[] { null, "", HEADER_NAME_1, "`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/? " });
+            assertEquals("Result did not match the list of expected header names.", expectedResult, Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getResponseHeaderField **************************************/
+
+    /**
+     * Tests:
+     * - Response argument: null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseHeaderField_nullArgument() {
+        try {
+            Object pageOrResponse = null;
+            String headerName = null;
+
+            String result = WebResponseUtils.getResponseHeaderField(pageOrResponse, headerName);
+
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Response argument: Unknown/unsupported object type
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseHeaderField_unknownObject() {
+        try {
+            Object pageOrResponse = "some unknown object";
+            String headerName = null;
+            try {
+                String result = WebResponseUtils.getResponseHeaderField(pageOrResponse, headerName);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "Unknown response type: java.lang.String");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - Header name is null
+     * - Header value is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseHeaderField_htmlunitWebResponse_nullHeaderName_nullValue() {
+        try {
+            final String headerName = null;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaderValue(headerName);
+                    will(returnValue(null));
+                }
+            });
+            String result = WebResponseUtils.getResponseHeaderField(htmlunitWebResponse, headerName);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - Header name is null
+     * - Header value is non-null
+     * Expects:
+     * - Result should match expected header value
+     */
+    @Test
+    public void test_getResponseHeaderField_htmlunitWebResponse_nullHeaderName_nonNullValue() {
+        try {
+            final String headerName = null;
+            final String headerValue = HEADER_VALUE_1;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaderValue(headerName);
+                    will(returnValue(headerValue));
+                }
+            });
+            String result = WebResponseUtils.getResponseHeaderField(htmlunitWebResponse, headerName);
+            assertEquals("Returned header value did not match expected value.", headerValue, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - Header name is empty
+     * - Header value is non-null
+     * Expects:
+     * - Result should match expected header value
+     */
+    @Test
+    public void test_getResponseHeaderField_htmlunitWebResponse_emptyHeaderName() {
+        try {
+            final String headerName = "";
+            final String headerValue = HEADER_VALUE_1;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaderValue(headerName);
+                    will(returnValue(headerValue));
+                }
+            });
+            String result = WebResponseUtils.getResponseHeaderField(htmlunitWebResponse, headerName);
+            assertEquals("Returned header value did not match expected value.", headerValue, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * - Header name is non-null
+     * - Header value is non-null
+     * Expects:
+     * - Result should match expected header value
+     */
+    @Test
+    public void test_getResponseHeaderField_htmlunitWebResponse() {
+        try {
+            final String headerName = HEADER_NAME_1;
+            final String headerValue = HEADER_VALUE_1;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitWebResponse).getResponseHeaderValue(headerName);
+                    will(returnValue(headerValue));
+                }
+            });
+            String result = WebResponseUtils.getResponseHeaderField(htmlunitWebResponse, headerName);
+            assertEquals("Returned header value did not match expected value.", headerValue, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - WebResponse object is null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseHeaderField_htmlunitHtmlPage_nullWebResponse() {
+        try {
+            final String headerName = HEADER_NAME_1;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(null));
+                }
+            });
+            String result = WebResponseUtils.getResponseHeaderField(htmlunitHtmlPage, headerName);
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * Expects:
+     * - Result should match expected header value
+     */
+    @Test
+    public void test_getResponseHeaderField_htmlunitHtmlPage() {
+        try {
+            final String headerName = HEADER_NAME_1;
+            final String headerValue = HEADER_VALUE_1;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getResponseHeaderValue(headerName);
+                    will(returnValue(headerValue));
+                }
+            });
+            String result = WebResponseUtils.getResponseHeaderField(htmlunitHtmlPage, headerName);
+            assertEquals("Returned header value did not match expected value.", headerValue, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * Expects:
+     * - Result should match expected header value
+     */
+    @Test
+    public void test_getResponseHeaderField_htmlunitTextPage() {
+        try {
+            final String headerName = HEADER_NAME_1;
+            final String headerValue = HEADER_VALUE_1;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getResponseHeaderValue(headerName);
+                    will(returnValue(headerValue));
+                }
+            });
+            String result = WebResponseUtils.getResponseHeaderField(htmlunitTextPage, headerName);
+            assertEquals("Returned header value did not match expected value.", headerValue, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * Expects:
+     * - Result should match expected header value
+     */
+    @Test
+    public void test_getResponseHeaderField_htmlunitXmlPage() {
+        try {
+            final String headerName = HEADER_NAME_1;
+            final String headerValue = HEADER_VALUE_1;
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitXmlPage).getWebResponse();
+                    will(returnValue(htmlunitWebResponse));
+                    one(htmlunitWebResponse).getResponseHeaderValue(headerName);
+                    will(returnValue(headerValue));
+                }
+            });
+            String result = WebResponseUtils.getResponseHeaderField(htmlunitXmlPage, headerName);
+            assertEquals("Returned header value did not match expected value.", headerValue, result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getResponseCookieNames **************************************/
+
+    /**
+     * Tests:
+     * - Argument: null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseCookieNames_nullArgument() {
+        try {
+            Object pageOrResponse = null;
+
+            String[] result = WebResponseUtils.getResponseCookieNames(pageOrResponse);
+
+            assertNull("Result should have been null but was [" + result + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: Unknown/unsupported object type
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseCookieNames_unknownObject() {
+        try {
+            Object pageOrResponse = "some unknown object";
+            try {
+                String[] result = WebResponseUtils.getResponseCookieNames(pageOrResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "not supported.+" + "java.lang.String");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseCookieNames_htmlunitWebResponse() {
+        try {
+            try {
+                String[] result = WebResponseUtils.getResponseCookieNames(htmlunitWebResponse);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "not supported.+" + "com.gargoylesoftware.htmlunit.WebResponse");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * Expects:
+     * - Result should match the expected list of cookie names
+     */
+    @Test
+    public void test_getResponseCookieNames_htmlunitHtmlPage() {
+        try {
+            final Set<Cookie> cookies = new HashSet<Cookie>();
+            cookies.add(new Cookie("/", "name", "value"));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebClient();
+                    will(returnValue(htmlunitWebClient));
+                    one(htmlunitWebClient).getCookieManager();
+                    will(returnValue(htmlunitCookieManager));
+                    one(htmlunitCookieManager).getCookies();
+                    will(returnValue(cookies));
+                }
+            });
+            String[] result = WebResponseUtils.getResponseCookieNames(htmlunitHtmlPage);
+
+            assertNotNull("Result should not have been null but was.", result);
+            String expectedResult = Arrays.toString(new String[] { "name" });
+            assertEquals("Result did not match the expected list of cookie names.", expectedResult, Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseCookieNames_htmlunitTextPage() {
+        try {
+            try {
+                String[] result = WebResponseUtils.getResponseCookieNames(htmlunitTextPage);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "not supported.+" + "com.gargoylesoftware.htmlunit.TextPage");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseCookieNames_htmlunitXmlPage() {
+        try {
+            try {
+                String[] result = WebResponseUtils.getResponseCookieNames(htmlunitXmlPage);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "not supported.+" + "com.gargoylesoftware.htmlunit.xml.XmlPage");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getCookieNamesFromHtmlPage **************************************/
+
+    /**
+     * Tests:
+     * - WebClient is null
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getCookieNamesFromHtmlPage_nullWebClient() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebClient();
+                    will(returnValue(null));
+                }
+            });
+            try {
+                String[] result = WebResponseUtils.getCookieNamesFromHtmlPage(htmlunitHtmlPage);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "Cannot get cookies.+web client cannot be found");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - CookieManager is null
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getCookieNamesFromHtmlPage_nullCookieManager() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebClient();
+                    will(returnValue(htmlunitWebClient));
+                    one(htmlunitWebClient).getCookieManager();
+                    will(returnValue(null));
+                }
+            });
+            try {
+                String[] result = WebResponseUtils.getCookieNamesFromHtmlPage(htmlunitHtmlPage);
+                fail("Should have thrown an exception but got result [" + result + "].");
+            } catch (Exception e) {
+                verifyException(e, "Cannot get cookies.+cookie manager cannot be found");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Cookie set is null
+     * Expects:
+     * - Result should be an empty array
+     */
+    @Test
+    public void test_getCookieNamesFromHtmlPage_nullCookieSet() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebClient();
+                    will(returnValue(htmlunitWebClient));
+                    one(htmlunitWebClient).getCookieManager();
+                    will(returnValue(htmlunitCookieManager));
+                    one(htmlunitCookieManager).getCookies();
+                    will(returnValue(null));
+                }
+            });
+            String[] result = WebResponseUtils.getCookieNamesFromHtmlPage(htmlunitHtmlPage);
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result should have been an empty array but was not.", Arrays.toString(new String[0]), Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Cookie set is empty
+     * Expects:
+     * - Result should be an empty array
+     */
+    @Test
+    public void test_getCookieNamesFromHtmlPage_emptyCookieSet() {
+        try {
+            final Set<Cookie> cookies = new HashSet<Cookie>();
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebClient();
+                    will(returnValue(htmlunitWebClient));
+                    one(htmlunitWebClient).getCookieManager();
+                    will(returnValue(htmlunitCookieManager));
+                    one(htmlunitCookieManager).getCookies();
+                    will(returnValue(cookies));
+                }
+            });
+            String[] result = WebResponseUtils.getCookieNamesFromHtmlPage(htmlunitHtmlPage);
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result should have been an empty array but was not.", Arrays.toString(new String[0]), Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Cookie set includes null cookie
+     * Expects:
+     * - Result should be an empty array
+     */
+    @Test
+    public void test_getCookieNamesFromHtmlPage_cookieSetWithNullCookie() {
+        try {
+            final Set<Cookie> cookies = new HashSet<Cookie>();
+            cookies.add(null);
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebClient();
+                    will(returnValue(htmlunitWebClient));
+                    one(htmlunitWebClient).getCookieManager();
+                    will(returnValue(htmlunitCookieManager));
+                    one(htmlunitCookieManager).getCookies();
+                    will(returnValue(cookies));
+                }
+            });
+            String[] result = WebResponseUtils.getCookieNamesFromHtmlPage(htmlunitHtmlPage);
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result should have been an empty array but was not.", Arrays.toString(new String[0]), Arrays.toString(result));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Cookie set includes multiple cookies
+     * Expects:
+     * - Result should be array containing the names of each cookie
+     */
+    @Test
+    public void test_getCookieNamesFromHtmlPage_multipleCookies() {
+        try {
+            final Set<Cookie> cookies = new HashSet<Cookie>();
+            cookies.add(new Cookie("/", "", "emptyNameValue"));
+            cookies.add(new Cookie("/", "name1", "value1"));
+            cookies.add(new Cookie("/", "`~!@#$%^&*() -_=+[{]}\\|;:'\",<.>/?", "special char name value"));
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).getWebClient();
+                    will(returnValue(htmlunitWebClient));
+                    one(htmlunitWebClient).getCookieManager();
+                    will(returnValue(htmlunitCookieManager));
+                    one(htmlunitCookieManager).getCookies();
+                    will(returnValue(cookies));
+                }
+            });
+            String[] result = WebResponseUtils.getCookieNamesFromHtmlPage(htmlunitHtmlPage);
+
+            assertNotNull("Result should not have been null but was.", result);
+            assertEquals("Result did not contain the expected number of entries. Result was " + Arrays.toString(result), 3, result.length);
+            List<String> resultAsList = Arrays.asList(result);
+            assertTrue("Result did not contain expected empty cookie name.", resultAsList.contains(""));
+            assertTrue("Result did not contain expected cookie name [" + "name1" + "].", resultAsList.contains("name1"));
+            assertTrue("Result did not contain expected cookie name [" + "`~!@#$%^&*() -_=+[{]}\\|;:'\",<.>/?" + "].", resultAsList.contains("`~!@#$%^&*() -_=+[{]}\\|;:'\",<.>/?"));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getResponseIsHtml **************************************/
+
+    /**
+     * Tests:
+     * - Argument: null
+     * Expects:
+     * - Result should be null
+     */
+    @Test
+    public void test_getResponseIsHtml_nullArgument() {
+        try {
+            Object pageOrResponse = null;
+
+            boolean result = WebResponseUtils.getResponseIsHtml(pageOrResponse);
+
+            assertFalse("Response should not have been considered HTML but was.", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: Unknown/unsupported object type
+     * Expects:
+     * - Exception should be thrown
+     */
+    @Test
+    public void test_getResponseIsHtml_unknownObject() {
+        try {
+            Object pageOrResponse = "some unknown object";
+            try {
+                boolean result = WebResponseUtils.getResponseIsHtml(pageOrResponse);
+                fail("Should have thrown an exception, but result was " + ((result ? "" : "not ")) + "considered HTML.");
+            } catch (Exception e) {
+                verifyException(e, "Unknown response type: java.lang.String");
+            }
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.WebResponse
+     * Expects:
+     * - Result should be true
+     */
+    @Test
+    public void test_getResponseIsHtml_htmlunitWebResponse() {
+        try {
+            boolean result = WebResponseUtils.getResponseIsHtml(htmlunitWebResponse);
+            assertTrue("A com.gargoylesoftware.htmlunit.WebResponse object should be considered HTML but was not.", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - Object is mocked to return false
+     * Expects:
+     * - Result should match expected value
+     */
+    @Test
+    public void test_getResponseIsHtml_htmlunitHtmlPage_false() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).isHtmlPage();
+                    will(returnValue(false));
+                }
+            });
+            boolean result = WebResponseUtils.getResponseIsHtml(htmlunitHtmlPage);
+            assertFalse("Assertion did not match the expected value (false).", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.html.HtmlPage
+     * - Object is mocked to return true
+     * Expects:
+     * - Result should match expected value
+     */
+    @Test
+    public void test_getResponseIsHtml_htmlunitHtmlPage_true() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitHtmlPage).isHtmlPage();
+                    will(returnValue(true));
+                }
+            });
+            boolean result = WebResponseUtils.getResponseIsHtml(htmlunitHtmlPage);
+            assertTrue("Assertion did not match the expected value (true).", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * - Object is mocked to return false
+     * Expects:
+     * - Result should match expected value
+     */
+    @Test
+    public void test_getResponseIsHtml_htmlunitTextPage_false() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).isHtmlPage();
+                    will(returnValue(false));
+                }
+            });
+            boolean result = WebResponseUtils.getResponseIsHtml(htmlunitTextPage);
+            assertFalse("Assertion did not match the expected value (false).", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.TextPage
+     * - Object is mocked to return true
+     * Expects:
+     * - Result should match expected value
+     */
+    @Test
+    public void test_getResponseIsHtml_htmlunitTextPage_true() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).isHtmlPage();
+                    will(returnValue(true));
+                }
+            });
+            boolean result = WebResponseUtils.getResponseIsHtml(htmlunitTextPage);
+            assertTrue("Assertion did not match the expected value (true).", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * - Object is mocked to return false
+     * Expects:
+     * - Result should match expected value
+     */
+    @Test
+    public void test_getResponseIsHtml_htmlunitXmlPage_false() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitTextPage).isHtmlPage();
+                    will(returnValue(false));
+                }
+            });
+            boolean result = WebResponseUtils.getResponseIsHtml(htmlunitTextPage);
+            assertFalse("Assertion did not match the expected value (false).", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /**
+     * Tests:
+     * - Argument: com.gargoylesoftware.htmlunit.xml.XmlPage
+     * - Object is mocked to return true
+     * Expects:
+     * - Result should match expected value
+     */
+    @Test
+    public void test_getResponseIsHtml_htmlunitXmlPage_true() {
+        try {
+            mockery.checking(new org.jmock.Expectations() {
+                {
+                    one(htmlunitXmlPage).isHtmlPage();
+                    will(returnValue(true));
+                }
+            });
+            boolean result = WebResponseUtils.getResponseIsHtml(htmlunitXmlPage);
+            assertTrue("Assertion did not match the expected value (true).", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+}


### PR DESCRIPTION
Creates the `WebResponseUtils` class that can be used to get response text, status codes, titles, etc. from various web automation response objects. HtmlUnit, HttpUnit, and other web automation tools wrap requests and responses differently, so this is intended to provide a single, standard front end to extract useful information from these objects regardless of which testing framework is being employed.