### PR TITLE
Ensure LTPA operation to use IBMJCE so it won't fail in HWCrypto scenario (PKCS11 provider is configured with high priority)

### DIFF
--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -10,17 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.crypto.ltpakeyutil;
 
+import com.ibm.crypto.provider.IBMJCE;
+
 import java.math.BigInteger;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.KeyFactory;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.SecureRandom;
-import java.security.Signature;
+import java.security.*;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
@@ -43,6 +36,7 @@ final class LTPACrypto {
     private static final String SIGNATURE_ALGORITHM = "SHA1withRSA";
     private static final String CRYPTO_ALGORITHM = "RSA";
     private static final String ENCRYPT_ALGORITHM = "DESede";
+    private static final String IBMJCE_NAME = "IBMJCE";
 
     private static int MAX_CACHE = 500;
 
@@ -225,7 +219,12 @@ final class LTPACrypto {
         BigInteger q = new BigInteger(key[4]);
         BigInteger d = e.modInverse((p.subtract(BigInteger.ONE)).multiply(q.subtract(BigInteger.ONE)));
         KeyFactory kFact = null;
-        kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
+        if (LTPAKeyUtil.isIBMJCEAvailable()) {
+            kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, IBMJCE_NAME);
+        } else {
+            kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
+        }
+
 
         BigInteger pep = new BigInteger(key[5]);
         BigInteger peq = new BigInteger(key[6]);
@@ -233,7 +232,12 @@ final class LTPACrypto {
         RSAPrivateCrtKeySpec privCrtKeySpec = new RSAPrivateCrtKeySpec(n, e, d, p, q, pep, peq, crtC);
         PrivateKey privKey = kFact.generatePrivate(privCrtKeySpec);
 
-        Signature rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
+        Signature rsaSig = null;
+        if (LTPAKeyUtil.isIBMJCEAvailable()) {
+            rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM, IBMJCE_NAME);
+        } else {
+            rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
+        }
         rsaSig.initSign(privKey);
         rsaSig.update(data, off, len);
         byte[] sig = rsaSig.sign();
@@ -486,10 +490,22 @@ final class LTPACrypto {
 
         BigInteger n = new BigInteger(key[0]);
         BigInteger e = new BigInteger(key[1]);
-        KeyFactory kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
+
+        KeyFactory kFact = null;
+        Signature rsaSig = null;
+
+        if (LTPAKeyUtil.isIBMJCEAvailable()) {
+            kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM, IBMJCE_NAME);
+        } else {
+            kFact = KeyFactory.getInstance(CRYPTO_ALGORITHM);
+        }
         RSAPublicKeySpec pubKeySpec = new RSAPublicKeySpec(n, e);
         PublicKey pubKey = kFact.generatePublic(pubKeySpec);
-        Signature rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
+        if (LTPAKeyUtil.isIBMJCEAvailable()) {
+            rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM, IBMJCE_NAME);
+        } else {
+            rsaSig = Signature.getInstance(SIGNATURE_ALGORITHM);
+        }
         rsaSig.initVerify(pubKey);
         rsaSig.update(data, off, len);
         verified = rsaSig.verify(sig);
@@ -553,14 +569,19 @@ final class LTPACrypto {
      * @throws NoSuchAlgorithmException
      * @throws InvalidKeySpecException
      */
-    private static SecretKey constructSecretKey(byte[] key, String cipher) throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException {
+    private static SecretKey constructSecretKey(byte[] key, String cipher) throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException, NoSuchProviderException {
         SecretKey sKey = null;
         if (cipher.indexOf("AES") != -1) {
             // 16 bytes = 128 bit key
             sKey = new SecretKeySpec(key, 0, 16, "AES");
         } else {
             DESedeKeySpec kSpec = new DESedeKeySpec(key);
-            SecretKeyFactory kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM);
+            SecretKeyFactory kFact = null;
+            if (LTPAKeyUtil.isIBMJCEAvailable()) {
+                kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM, IBMJCE_NAME);
+            } else {
+                kFact = SecretKeyFactory.getInstance(ENCRYPT_ALGORITHM);
+            }
             sKey = kFact.generateSecret(kSpec);
         }
         return sKey;
@@ -576,8 +597,15 @@ final class LTPACrypto {
      * @throws InvalidKeyException
      * @throws InvalidAlgorithmParameterException
      */
-    private static Cipher createCipher(int cipherMode, byte[] key, String cipher, SecretKey sKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
-        Cipher ci = Cipher.getInstance(cipher);
+    private static Cipher createCipher(int cipherMode, byte[] key, String cipher, SecretKey sKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException, NoSuchProviderException {
+
+        Cipher ci = null;
+
+        if (LTPAKeyUtil.isIBMJCEAvailable()) {
+            ci = Cipher.getInstance(cipher, IBMJCE_NAME);
+        } else {
+            ci = Cipher.getInstance(cipher);
+        }
         if (cipher.indexOf("ECB") == -1) {
             if (cipher.indexOf("AES") != -1) {
                 if (ivs16 == null) {
@@ -995,8 +1023,13 @@ final class LTPACrypto {
                 KeyPairGenerator keyGen = null;
                 SecureRandom random = null;
 
-                keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, "IBMJCE");
-                random = SecureRandom.getInstance("IBMSecureRandom");
+                if (LTPAKeyUtil.isIBMJCEAvailable()) {
+                    keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM, IBMJCE_NAME);
+                    random = SecureRandom.getInstance("IBMSecureRandom");
+                } else {
+                    keyGen = KeyPairGenerator.getInstance(CRYPTO_ALGORITHM);
+                    random = SecureRandom.getInstance("SHA1PRNG");
+                }
 
                 keyGen.initialize(len * 8, random);
                 pair = keyGen.generateKeyPair();

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -10,15 +10,23 @@
  *******************************************************************************/
 package com.ibm.ws.crypto.ltpakeyutil;
 
-import com.ibm.crypto.provider.IBMJCE;
-
 import java.math.BigInteger;
-import java.security.*;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Signature;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPrivateCrtKeySpec;
 import java.security.spec.RSAPublicKeySpec;
+import java.security.NoSuchProviderException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.concurrent.ConcurrentHashMap;

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPADigSignature.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPADigSignature.java
@@ -12,6 +12,7 @@ package com.ibm.ws.crypto.ltpakeyutil;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 
 final class LTPADigSignature {
 
@@ -27,15 +28,26 @@ final class LTPADigSignature {
     static private Object lockObj2 = new Object();
     static long created = 0;
     static long cacheHits = 0;
+    private static final String IBMJCE_NAME = "IBMJCE";
 
     static {
         try {
-            md1JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
-            md2JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
-            md1 = MessageDigest.getInstance("SHA");
-            md2 = MessageDigest.getInstance("SHA");
+            if (LTPAKeyUtil.isIBMJCEAvailable()) {
+                md1JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, IBMJCE_NAME);
+                md2JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, IBMJCE_NAME);
+                md1 = MessageDigest.getInstance("SHA", IBMJCE_NAME);
+                md2 = MessageDigest.getInstance("SHA", IBMJCE_NAME);
+            } else {
+                md1JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+                md2JCE = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+                md1 = MessageDigest.getInstance("SHA");
+                md2 = MessageDigest.getInstance("SHA");
+            }
+
         } catch (NoSuchAlgorithmException e) {
             // instrumented ffdc
+        } catch (NoSuchProviderException e) {
+            // instrumented ffdc;
         }
     }
 

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyUtil.java
@@ -11,7 +11,13 @@
 package com.ibm.ws.crypto.ltpakeyutil;
 
 
+import java.security.Provider;
+import java.security.Security;
+
 public final class LTPAKeyUtil {
+
+  public static boolean ibmJCEAvailable = false;
+  public static boolean providerChecked = false;
 
   public static byte[] encrypt(byte[] data, byte[] key, String cipher) throws Exception {
     return LTPACrypto.encrypt(data, key, cipher);
@@ -47,6 +53,23 @@ public final class LTPAKeyUtil {
 
   public static byte[] generate3DESKey() {
     return LTPACrypto.generate3DESKey();
+  }
+
+  public static boolean isIBMJCEAvailable() {
+    if (providerChecked) {
+      return ibmJCEAvailable;
+    }
+    else {
+      Provider[] providers = Security.getProviders();
+      for (int i = 0; i < providers.length; i++) {
+        if (providers[i].toString().contains("IBMJCE")) {
+          ibmJCEAvailable = true;
+        }
+      }
+      providerChecked = true;
+      return ibmJCEAvailable;
+    }
+
   }
 
 }

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
@@ -60,12 +60,18 @@ public class LTPAToken2 implements Token, Serializable {
     private final LTPAPrivateKey privateKey;
     private final LTPAPublicKey publicKey;
     private String cipher = null;
+    private static final String IBMJCE_NAME = "IBMJCE";
 
     static {
         MessageDigest m1 = null, m2 = null;
         try {
-            m1 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
-            m2 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+            if (LTPAKeyUtil.isIBMJCEAvailable()) {
+                m1 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, IBMJCE_NAME);
+                m2 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM, IBMJCE_NAME);
+            } else {
+                m1 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+                m2 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+            }
         } catch (Exception e) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
                 Tr.event(tc, "Error creating digest; " + e);


### PR DESCRIPTION
Check availability of IBMJCE provider, and if so, use it for LTPA operation. 
For Sun providers, let Java to use the right provider for now.  