### PR TITLE
useInvalidatedId should not be configurable

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -107,7 +107,7 @@ public class CacheStoreService implements SessionStoreService {
         configurationProperties.put("optimizeCacheIdIncrements", true);
         configurationProperties.put("scheduleInvalidation", scheduleInvalidationFirstHour != null || scheduleInvalidationSecondHour != null);
         configurationProperties.put("sessionPersistenceMode", "JCACHE");
-        // TODO decide whether or not to externalize useInvalidatedId
+        configurationProperties.put("useInvalidatedId", false);
         configurationProperties.put("useMultiRowSchema", true);
         
         Properties vendorProperties = new Properties();


### PR DESCRIPTION
The useInvalidatedId option supported by httpSessionDatabase is not being externalized for httpSessionCache, so we should not permit it to be configurable.  This will better allow for it or a similar capability to be added in the future if there is a desire to do so.