### PR TITLE
Fix ACE log not generated on j2sec error/warning from com.ibm.jbatch code

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/ACEScanner.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/ACEScanner.java
@@ -35,7 +35,8 @@ public class ACEScanner {
     public static final Pattern JAVA_2_SEC_NORETHROW = Pattern.compile("^\\[WARNING \\] CWWKE09(21W|12W|13E|14W|15W|16W):.*");
     public static final String JAVA_2_SEC_RETHROW = "ERROR: java.security.AccessControlException:";
     public static final String JAVA_2_SEC_SYSERR = "[err] java.security.AccessControlException:";
-    private static final Pattern IBM_STACK = Pattern.compile("^(\\s*at )?com\\.ibm\\.ws.*");
+    // Matches: com.ibm.ws.*, com.ibm.wsspi.*, com.ibm.jbatch.*
+    private static final Pattern IBM_STACK = Pattern.compile("^(\\s*at )?(com\\.ibm\\.ws|com\\.ibm\\.jbatch\\.).*");
     private static final Class<?> c = ACEScanner.class;
     private static final boolean DEBUG = false;
     private final Map<String, String> exceptionMap = new HashMap<String, String>();
@@ -64,7 +65,7 @@ public class ACEScanner {
     public void run() {
         try {
             Log.info(c, "run", "Processing log file: " + INPUT_FILE);
-            
+
             // Find all the unique ACEs and store them in a map
             BufferedReader infile = new BufferedReader(new FileReader(INPUT_FILE));
             String curLine;


### PR DESCRIPTION
The problem here is that although a j2sec warning/error generated out of **com.ibm.jbatch** code properly fails a FAT test on the stop server check, it doesn't actually generate an ACE log as it says it does.

Stepping through I realized the reason this wasn't generating an ACE log was that it only treats **com.ibm.ws** entries in the stack as interesting starting points.  The **com.ibm.jbatch** code has a separate prefix based on its heritage, but would rather it be treated the same here.