### PR TITLE
Update the generic types cache to be simpler.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -34,12 +34,12 @@ import java.lang.reflect.WildcardType;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -147,7 +147,7 @@ public abstract class ProviderFactory {
     //Liberty code change start
     //defect 178126
     //A cache for getGenericInterfaces
-    private static final ConcurrentHashMap<ClassWeakReference, Map<ClassWeakReference, Type[]>> genericInterfacesCache = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<ClassesKey, Type[]> genericInterfacesCache = new ConcurrentHashMap<>();
     private static final Type[] emptyType = new Type[] {};
 
     //Liberty code change end
@@ -1692,37 +1692,18 @@ public abstract class ProviderFactory {
 
     //Liberty code change start
     //defect 178126
-    private static final ClassWeakReference NULL_REFERENCE = new ClassWeakReference(ClassWeakReference.class);
     private static final ReferenceQueue<Class<?>> referenceQueue = new ReferenceQueue<>();
 
     private static void poll() {
         ClassWeakReference key;
         while ((key = (ClassWeakReference) referenceQueue.poll()) != null) {
-            Map<ClassWeakReference, ?> map = key.getOwningMap();
-            if (map != null) {
-                if (map instanceof ConcurrentHashMap) {
-                    map.remove(key);
-                } else {
-                    Collection<Map<ClassWeakReference, Type[]>> values = genericInterfacesCache.values();
-                    for (Iterator<Map<ClassWeakReference, Type[]>> it = values.iterator(); it.hasNext();) {
-                        Map<ClassWeakReference, Type[]> value = it.next();
-                        if (value == map) {
-                            it.remove();
-                            break;
-                        }
-                    }
-                }
-            }
+            genericInterfacesCache.remove(key.getOwningKey());
         }
     }
 
     private static Type[] getTypes(Class<?> cls, Class<?> expectedCls) {
         poll();
-        Map<ClassWeakReference, Type[]> interfacesMap = genericInterfacesCache.get(new ClassWeakReference(cls));
-        if (interfacesMap != null) {
-            return interfacesMap.get(expectedCls == null ? NULL_REFERENCE : new ClassWeakReference(expectedCls));
-        }
-        return null;
+        return genericInterfacesCache.get(new ClassesKey(cls, expectedCls));
     }
 
     /**
@@ -1736,68 +1717,78 @@ public abstract class ProviderFactory {
      */
     private static void putTypes(Class<?> cls, Class<?> expectedCls, Type[] types) {
         poll();
-        Map<ClassWeakReference, Type[]> interfacesMap = genericInterfacesCache.get(new ClassWeakReference(cls));
-        if (interfacesMap != null) {
-            if (interfacesMap instanceof ConcurrentHashMap) {
-                ClassWeakReference expectedClassRef = expectedCls == null ? NULL_REFERENCE :
-                    new ClassWeakReference(expectedCls, interfacesMap, referenceQueue);
-                interfacesMap.put(expectedClassRef, types);
-            } else {
-                // If it already got added, then we can skip making the ConcurrentHashMap.
-                if (interfacesMap.get(expectedCls == null ? NULL_REFERENCE : new ClassWeakReference(expectedCls)) == null) {
-                    // Take the old entry from the Collections.singletonMap and put it in a new ConcurrentHashMap.
-                    Map<ClassWeakReference, Type[]> oldMap = interfacesMap;
-                    interfacesMap = new ConcurrentHashMap<>();
-                    Iterator<Map.Entry<ClassWeakReference, Type[]>> it = oldMap.entrySet().iterator();
-                    if (it.hasNext()) {
-                        Map.Entry<ClassWeakReference, Type[]> entry = it.next();
-                        ClassWeakReference oldKey = entry.getKey();
-                        // Need to change the owning map to the new ConcurrentHashMap.
-                        oldKey.setOwningMap(interfacesMap);
-                        interfacesMap.put(oldKey, entry.getValue());
-                    }
+        genericInterfacesCache.put(new ClassesKey(referenceQueue, cls, expectedCls), types);
+    }
 
-                    ClassWeakReference expectedClassRef = expectedCls == null ? NULL_REFERENCE : new ClassWeakReference(expectedCls, interfacesMap, referenceQueue);
-                    interfacesMap.put(expectedClassRef, types);
-                    genericInterfacesCache.put(new ClassWeakReference(cls, genericInterfacesCache, referenceQueue),
-                                               interfacesMap);
+    private static class ClassesKey {
+        private final ClassWeakReference[] classes;
+        private final int hash;
+
+        ClassesKey(Class<?>... cl) {
+            int length = cl.length;
+            classes = new ClassWeakReference[length];
+            int hashCode = 0;
+            for (int i = 0; i < length; ++i) {
+                if (cl[i] != null) {
+                    classes[i] = new ClassWeakReference(cl[i], this);
+                    hashCode += cl[i].hashCode();
                 }
             }
-        } else {
-            if (expectedCls == null) {
-                interfacesMap = Collections.singletonMap(NULL_REFERENCE, types);
-            } else {
-                ClassWeakReference expectedClassRef = new ClassWeakReference(expectedCls, null, referenceQueue);
-                interfacesMap = Collections.singletonMap(expectedClassRef, types);
-                expectedClassRef.setOwningMap(interfacesMap);
+            hash = hashCode;
+        }
+
+        ClassesKey(ReferenceQueue<Class<?>> referenceQueue, Class<?>... cl) {
+            int length = cl.length;
+            classes = new ClassWeakReference[length];
+            int hashCode = 0;
+            for (int i = 0; i < length; ++i) {
+                if (cl[i] != null) {
+                    classes[i] = new ClassWeakReference(cl[i], this, referenceQueue);
+                    hashCode += cl[i].hashCode();
+                }
             }
-            genericInterfacesCache.put(new ClassWeakReference(cls, genericInterfacesCache, referenceQueue), interfacesMap);
+            hash = hashCode;
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            ClassesKey other = (ClassesKey) obj;
+            if (!Arrays.equals(classes, other.classes))
+                return false;
+            return true;
         }
     }
 
     private static class ClassWeakReference extends WeakReference<Class<?>> {
         private final int hash;
-        private volatile Map<ClassWeakReference, ?> owningMap;
+        private final ClassesKey owningKey;
 
-        ClassWeakReference(Class<?> referent) {
+        ClassWeakReference(Class<?> referent, ClassesKey owningKey) {
             super(referent);
-            owningMap = null;
+            this.owningKey = owningKey;
             hash = referent.hashCode();
         }
 
-        ClassWeakReference(Class<?> referent, Map<ClassWeakReference, ?> owningMap,
+        ClassWeakReference(Class<?> referent, ClassesKey owningKey,
                            ReferenceQueue<Class<?>> referenceQueue) {
             super(referent, referenceQueue);
-            this.owningMap = owningMap;
+            this.owningKey = owningKey;
             hash = referent.hashCode();
         }
 
-        Map<ClassWeakReference, ?> getOwningMap() {
-            return owningMap;
-        }
-
-        void setOwningMap(Map<ClassWeakReference, ?> owningMap) {
-            this.owningMap = owningMap;
+        ClassesKey getOwningKey() {
+            return owningKey;
         }
 
         @Override

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -1374,7 +1374,7 @@ public abstract class ProviderFactory {
         if (Object.class == cls) {
             return emptyType;
         }
-        Type[] cachedTypes = getTypes(cls, expectedClass);
+        Type[] cachedTypes = getTypes(cls, expectedClass, commonBaseCls);
         if (cachedTypes != null)
             return cachedTypes;
         if (expectedClass != null) {
@@ -1383,24 +1383,24 @@ public abstract class ProviderFactory {
                 Class<?> actualType = InjectionUtils.getActualType(genericSuperType);
                 if (actualType != null && actualType.isAssignableFrom(expectedClass)) {
                     Type[] tempTypes = new Type[] { genericSuperType };
-                    putTypes(cls, expectedClass, tempTypes);
+                    putTypes(cls, expectedClass, commonBaseCls, tempTypes);
                     return tempTypes;
                 } else if (commonBaseCls != null && commonBaseCls != Object.class
                            && commonBaseCls.isAssignableFrom(expectedClass)
                            && commonBaseCls.isAssignableFrom(actualType)
                            || expectedClass.isAssignableFrom(actualType)) {
-                    putTypes(cls, expectedClass, emptyType);
+                    putTypes(cls, expectedClass, commonBaseCls, emptyType);
                     return emptyType;
                 }
             }
         }
         Type[] types = cls.getGenericInterfaces();
         if (types.length > 0) {
-            putTypes(cls, expectedClass, types);
+            putTypes(cls, expectedClass, commonBaseCls, types);
             return types;
         }
         Type[] superGenericTypes = getGenericInterfaces(cls.getSuperclass(), expectedClass, commonBaseCls);
-        putTypes(cls, expectedClass, superGenericTypes);
+        putTypes(cls, expectedClass, commonBaseCls, superGenericTypes);
         return superGenericTypes;
     }
 
@@ -1722,9 +1722,9 @@ public abstract class ProviderFactory {
         }
     }
 
-    private static Type[] getTypes(Class<?> cls, Class<?> expectedCls) {
+    private static Type[] getTypes(Class<?> cls, Class<?> expectedCls, Class<?> commonBaseCls) {
         poll();
-        return genericInterfacesCache.get(new ClassesKey(cls, expectedCls));
+        return genericInterfacesCache.get(new ClassesKey(cls, expectedCls, commonBaseCls));
     }
 
     /**
@@ -1736,9 +1736,9 @@ public abstract class ProviderFactory {
      * @param expectedCls
      * @param types
      */
-    private static void putTypes(Class<?> cls, Class<?> expectedCls, Type[] types) {
+    private static void putTypes(Class<?> cls, Class<?> expectedCls, Class<?> commonBaseCls, Type[] types) {
         poll();
-        genericInterfacesCache.put(new ClassesKey(referenceQueue, cls, expectedCls), types);
+        genericInterfacesCache.put(new ClassesKey(referenceQueue, cls, expectedCls, commonBaseCls), types);
     }
 
     private static class ClassesKey {


### PR DESCRIPTION
This converts from a map of maps back to using a key with multiple Class
objects in it.  It is also now generic and can support having more than
2 Class objects as part of the key.