### PR TITLE
#3093- add CDI SE package back to the api jar

### DIFF
--- a/dev/com.ibm.websphere.javaee.cdi.2.0/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.cdi.2.0/bnd.bnd
@@ -26,7 +26,9 @@ Export-Package: javax.decorator; version=2.0, \
  javax.enterprise.inject.spi; version=2.0, \
  javax.enterprise.inject.spi.configurator; version=2.0, \
  javax.enterprise.util; version=2.0, \
- javax.inject; version=1, \
+ javax.inject; version=1
+ 
+Private-Package: javax.enterprise.inject.se
 
 Import-Package:  javax.el; version="[3.0.0,4.0.0)", \
  javax.decorator; version=2.0, \


### PR DESCRIPTION
In OL, the package javax.enterprise.inject.se was not packaged in the api jar when repackaging CDI api jar. We need to package it but not export it so that all the classes in the released api jar are present.

