### PR TITLE
Add com.ibm.websphere.kernel.server api to kernelCore-1.0.mf file

### DIFF
--- a/dev/com.ibm.ws.kernel.boot/publish/platform/kernelCore-1.0.mf
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/kernelCore-1.0.mf
@@ -29,7 +29,8 @@ Subsystem-Content: org.eclipse.osgi; version="[3.10,4)"; type="boot.jar",
 WebSphere-SystemBundleProvider: true
 IBM-API-Package: com.ibm.websphere.config.mbeans; type="ibm-api",
  com.ibm.websphere.logging; type="ibm-api",
- com.ibm.websphere.logging.hpel; type="ibm-api"
+ com.ibm.websphere.logging.hpel; type="ibm-api",
+ com.ibm.websphere.kernel.server; type="ibm-api"
 IBM-SPI-Package: com.ibm.websphere.crypto,
  com.ibm.wsspi.config,
  com.ibm.wsspi.kernel.filemonitor,


### PR DESCRIPTION
Add com.ibm.websphere.kernel.server api to the kernelCore-1.0.mf file so that the API is available to applications.

Fix for issue #3106 