### PR TITLE
config update test to remove sessionCache feature

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config/test-applications/sessionCacheConfigApp/src/session/cache/web/SessionCacheConfigTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/test-applications/sessionCacheConfigApp/src/session/cache/web/SessionCacheConfigTestServlet.java
@@ -434,6 +434,21 @@ public class SessionCacheConfigTestServlet extends FATServlet {
     }
 
     /**
+     * Set the value of a session attribute.
+     * Precondition: in order for the test logic to be valid, the session attribute must not already have the same value.
+     */
+    public void testSetAttributeOnly(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String attrName = request.getParameter("attribute");
+
+        String stringValue = request.getParameter("value");
+        String type = request.getParameter("type");
+        Object value = toType(type, stringValue);
+
+        HttpSession session = request.getSession(true);
+        session.setAttribute(attrName, value);
+    }
+
+    /**
      * Set the value of a session attribute and specify a maxInactiveInterval for the session.
      */
     public void testSetAttributeWithTimeout(HttpServletRequest request, HttpServletResponse response) throws Exception {


### PR DESCRIPTION
Update the automated test for adding the sessionCache feature to also include removing it.  This exposes an issue where the shared library is not updated and still references previous jcache spec classes, and to work around this for now, we will need to also make an update to the library to force it to be refreshed.