### PR TITLE
Rearrange getCallerQuery on DatabaseIdentityStore

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStore.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStore.java
@@ -252,15 +252,17 @@ public class DatabaseIdentityStore implements IdentityStore {
         PreparedStatement prep = null;
         String callerQuery = "not_resolved";
         try {
-            Connection conn = getConnection();
-            try {
-                callerQuery = idStoreDefinition.getCallerQuery();
-                if (callerQuery == null || callerQuery.isEmpty()) {
-                    if (tc.isEventEnabled()) {
-                        Tr.event(tc, "The 'callerQuery' parameter can not be " + callerQuery == null ? "null." : "empty.");
-                    }
-                    return CredentialValidationResult.INVALID_RESULT;
+            callerQuery = idStoreDefinition.getCallerQuery();
+            if (callerQuery == null || callerQuery.isEmpty()) {
+                if (tc.isEventEnabled()) {
+                    Tr.event(tc, "The 'callerQuery' parameter can not be " + callerQuery == null ? "null." : "empty.");
                 }
+                return CredentialValidationResult.INVALID_RESULT;
+            }
+
+            Connection conn = getConnection();
+
+            try {
 
                 prep = conn.prepareStatement(callerQuery);
                 prep.setString(1, caller);


### PR DESCRIPTION
Fixes #3158 

Rearranged the DatabaseIdentityStore validate code to look up the callerQuery first so it can be referenced if the datasource look up fails.

Otherwise, if we can't look up the datasource, we can't fill in the query on the CWWKS1918E message.

CWWKS1918E: The credentials for the user2 caller cannot be validated. The DatabaseIdentityStore object failed to run the 'not_resolved' query with an error: javax.naming.NameNotFoundException

Checked the groups method, but it already does this is in the right order.
