### PR TITLE
Add hashtable before the setCredential call for CertificateLoginModule

### DIFF
--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/jaas/modules/CertificateLoginModule.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/jaas/modules/CertificateLoginModule.java
@@ -246,9 +246,9 @@ public class CertificateLoginModule extends ServerCommonLoginModule implements L
         temporarySubject = new Subject();
         Hashtable<String, Object> hashtable = new Hashtable<String, Object>();
         hashtable.put(AttributeNameConstants.WSCREDENTIAL_UNIQUEID, AccessIdUtil.getUniqueId(accessId));
+        temporarySubject.getPublicCredentials().add(hashtable);
         setWSPrincipal(temporarySubject, username, accessId, WSPrincipal.AUTH_METHOD_CERTIFICATE);
         setCredentials(temporarySubject, username, username);
-        temporarySubject.getPublicCredentials().add(hashtable);
         temporarySubject.getPublicCredentials().remove(hashtable);
     }
 


### PR DESCRIPTION
This bug cause by the Jwt token work not in the field yet.