### PR TITLE
Test that timed invokeAll does not run tasks on submitter's thread

### DIFF
--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -2820,6 +2820,9 @@ public class PolicyExecutorServlet extends FATServlet {
     // Use timed invokeAll to submit a group of tasks. Verify that none of them run on the submitter thread.
     // This test case is added to help guard against regression to code which relies on the behavior of
     // timed invokeAll never running tasks on the submitter thread.
+    // We think some customers might be relying on this behavior even though the JavaDoc/spec does not state it,
+    // so do not change this behavior or alter this test without having a very good reason, and in which case
+    // it should first be considered if the behavior ought to be made switchable.
     @Test
     public void testInvokeAllTimedSubmitterThreadDoesNotRunTasks() throws Exception {
         PolicyExecutor executor = provider.create("testInvokeAllTimedSubmitterThreadDoesNotRunTasks")


### PR DESCRIPTION
Add a test which helps confirm that timed invokeAll does not run tasks on the same thread that invokes invokeAll.  This will help guard against regression to this behavior for any code that may be relying upon it.