### PR TITLE
Optimize primitive object caching

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/BuiltinSerializationInfo.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/BuiltinSerializationInfo.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.session.store.cache;
+
+public interface BuiltinSerializationInfo<T> {
+    public T bytesToObject(byte[] bytes);
+    public byte[] objectToBytes(Object object);
+    public byte getIndex();
+    public Class<T> getObjectClass();
+}

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/SerializationInfoCache.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/SerializationInfoCache.java
@@ -1,0 +1,569 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.session.store.cache;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.ibm.ws.session.store.cache.TypeConversion;
+
+public class SerializationInfoCache {    
+
+    public static BuiltinSerializationInfo<?> lookupByClass(Class<?> c) {
+        return BUILTIN_MAPPINGS.get(c);
+    }
+
+    public static BuiltinSerializationInfo<?> lookupByIndex(byte index) {
+        BuiltinSerializationInfo<?> returnValue = null;
+        if (index < BUILTIN_SIZE && index > -1) {
+            returnValue = BUILTIN_ARRAY[index];
+        }
+        return returnValue;
+    }
+
+    public static final byte LONG = 0;
+    public static final BuiltinSerializationInfo<Long> LONG_INFO = new LongInfo();
+
+    public static final byte INTEGER = 1;
+    public static final BuiltinSerializationInfo<Integer> INTEGER_INFO = new IntegerInfo();
+
+    public static final byte SHORT = 2;
+    public static final BuiltinSerializationInfo<Short> SHORT_INFO = new ShortInfo();
+
+    public static final byte BYTE = 3;
+    public static final BuiltinSerializationInfo<Byte> BYTE_INFO = new ByteInfo();
+
+    public static final byte FLOAT = 4;
+    public static final BuiltinSerializationInfo<Float> FLOAT_INFO = new FloatInfo();
+
+    public static final byte DOUBLE = 5;
+    public static final BuiltinSerializationInfo<Double> DOUBLE_INFO = new DoubleInfo();
+
+    public static final byte CHARACTER = 6;
+    public static final BuiltinSerializationInfo<Character> CHARACTER_INFO = new CharacterInfo();
+
+    public static final byte BOOLEAN = 7;
+    public static final BuiltinSerializationInfo<Boolean> BOOLEAN_INFO = new BooleanInfo();
+
+    public static final byte DATE = 8;
+    public static final BuiltinSerializationInfo<java.util.Date> DATE_INFO = new DateInfo();
+
+    public static final byte SQL_DATE = 9;
+    public static final BuiltinSerializationInfo<java.sql.Date> SQL_DATE_INFO = new SqlDateInfo();
+
+    public static final byte SQL_TIMESTAMP = 10;
+    public static final BuiltinSerializationInfo<Timestamp> SQL_TIMESTAMP_INFO = new SqlTimestampInfo();
+
+    public static final byte SQL_TIME = 11;
+    public static final BuiltinSerializationInfo<Time> SQL_TIME_INFO = new SqlTimeInfo();
+
+    public static final byte BIG_DECIMAL = 12;
+    public static final BuiltinSerializationInfo<BigDecimal> BIG_DECIMAL_INFO = new BigDecimalInfo();
+
+    public static final byte BIG_INTEGER = 13;
+    public static final BuiltinSerializationInfo<BigInteger> BIG_INTEGER_INFO = new BigIntegerInfo();
+
+    public static final byte BYTE_ARRAY = 14;
+    public static final BuiltinSerializationInfo<byte[]> BYTE_ARRAY_INFO = new ByteArrayInfo();
+
+    public static final byte ATOMIC_INTEGER = 15;
+    public static final BuiltinSerializationInfo<AtomicInteger> ATOMIC_INTEGER_INFO = new AtomicIntegerInfo();
+
+    public static final byte ATOMIC_LONG = 16;
+    public static final BuiltinSerializationInfo<AtomicLong> ATOMIC_LONG_INFO = new AtomicLongInfo();
+
+    public static final byte BUILTIN_SIZE = 17;
+    
+    public static final byte BUILTIN_SERIALIZATION = 0;
+
+    private static final Map<Class<?>, BuiltinSerializationInfo<?>> BUILTIN_MAPPINGS = new HashMap<Class<?>, BuiltinSerializationInfo<?>>();
+    private static final BuiltinSerializationInfo<?>[] BUILTIN_ARRAY = new BuiltinSerializationInfo[BUILTIN_SIZE];
+
+    private static void addBuiltinSerializationInfo(BuiltinSerializationInfo<?> info) {
+        BUILTIN_MAPPINGS.put(info.getObjectClass(), info);
+        BUILTIN_ARRAY[info.getIndex()] = info;
+    }
+
+    static {
+        addBuiltinSerializationInfo(LONG_INFO);
+        addBuiltinSerializationInfo(INTEGER_INFO);
+        addBuiltinSerializationInfo(SHORT_INFO);
+        addBuiltinSerializationInfo(BYTE_INFO);
+        addBuiltinSerializationInfo(FLOAT_INFO);
+        addBuiltinSerializationInfo(DOUBLE_INFO);
+        addBuiltinSerializationInfo(CHARACTER_INFO);
+        addBuiltinSerializationInfo(BOOLEAN_INFO);
+        addBuiltinSerializationInfo(DATE_INFO);
+        addBuiltinSerializationInfo(SQL_DATE_INFO);
+        addBuiltinSerializationInfo(SQL_TIMESTAMP_INFO);
+        addBuiltinSerializationInfo(SQL_TIME_INFO);
+        addBuiltinSerializationInfo(BIG_DECIMAL_INFO);
+        addBuiltinSerializationInfo(BIG_INTEGER_INFO);
+        addBuiltinSerializationInfo(BYTE_ARRAY_INFO);
+        addBuiltinSerializationInfo(ATOMIC_INTEGER_INFO);
+        addBuiltinSerializationInfo(ATOMIC_LONG_INFO);
+    }
+
+    public static final class LongInfo implements BuiltinSerializationInfo<Long> {
+        public byte getIndex() {
+            return LONG;
+        }
+
+        public Class<Long> getObjectClass() {
+            return Long.class;
+        }
+
+        public Long bytesToObject(byte[] bytes) {
+            return Long.valueOf(TypeConversion.varIntBytesToLong(bytes, 2));
+        }
+
+        public byte[] objectToBytes(Object object) {
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, LONG, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            int numWritten = TypeConversion.writeLongAsVarIntBytes(((Long)object).longValue(), bytes, 2);
+            if(numWritten < 12) {
+                byte[] smallArray = new byte[numWritten];
+                System.arraycopy(bytes, 0, smallArray, 0, numWritten);
+                return smallArray;
+            }
+            return bytes;
+        }
+    }
+
+    public static final class IntegerInfo implements BuiltinSerializationInfo<Integer> {
+        public byte getIndex() {
+            return INTEGER;
+        }
+
+        public Class<Integer> getObjectClass() {
+            return Integer.class;
+        }
+
+        public Integer bytesToObject(byte[] bytes) {
+            return Integer.valueOf(TypeConversion.varIntBytesToInt(bytes, 2));
+        }
+
+        public byte[] objectToBytes(Object object) {
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, INTEGER, 0, 0, 0, 0, 0};
+            int numWritten = TypeConversion.writeIntAsVarIntBytes(((Integer)object).intValue(), bytes, 2);
+            if(numWritten < 7) {
+                byte[] smallArray = new byte[numWritten];
+                System.arraycopy(bytes, 0, smallArray, 0, numWritten);
+                return smallArray;
+            }
+            return bytes;
+        }
+    }
+
+    public static final class ShortInfo implements BuiltinSerializationInfo<Short> {
+        public byte getIndex() {
+            return SHORT;
+        }
+
+        public Class<Short> getObjectClass() {
+            return Short.class;
+        }
+
+        public Short bytesToObject(byte[] bytes) {
+            return Short.valueOf(TypeConversion.bytesToShort(bytes, 2));
+        }
+
+        public byte[] objectToBytes(Object object) {
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, SHORT, 0, 0};
+            TypeConversion.shortToBytes(((Short)object).shortValue(), bytes, 2);
+            return bytes;
+        }
+
+    }
+
+    public static final class ByteInfo implements BuiltinSerializationInfo<Byte> {
+        public byte getIndex() {
+            return BYTE;
+        }
+
+        public Class<Byte> getObjectClass() {
+            return Byte.class;
+        }
+
+        public Byte bytesToObject(byte[] bytes) {
+            return Byte.valueOf(bytes[2]);
+        }
+
+        public byte[] objectToBytes(Object object) {
+            byte b = ((Byte) object).byteValue();
+            return new byte[] {BUILTIN_SERIALIZATION, BYTE, b};
+        }
+    }
+
+    public static final class FloatInfo implements BuiltinSerializationInfo<Float> {
+        public byte getIndex() {
+            return FLOAT;
+        }
+
+        public Class<Float> getObjectClass() {
+            return Float.class;
+        }
+
+        public Float bytesToObject(byte[] bytes) {
+            int floatBits = TypeConversion.varIntBytesToInt(bytes, 2);
+            return new Float(Float.intBitsToFloat(floatBits));
+        }
+
+        public byte[] objectToBytes(Object object) {
+            float f = ((Float) object).floatValue();
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, FLOAT, 0, 0, 0, 0, 0};
+            int numWritten = TypeConversion.writeIntAsVarIntBytes(Float.floatToIntBits(f), bytes, 2);
+            if(numWritten < 7) {
+                byte[] smallArray = new byte[numWritten];
+                System.arraycopy(bytes, 0, smallArray, 0, numWritten);
+                return smallArray;
+            }
+            return bytes;
+        }
+    }
+
+    public static final class DoubleInfo implements BuiltinSerializationInfo<Double> {
+        public byte getIndex() {
+            return DOUBLE;
+        }
+
+        public Class<Double> getObjectClass() {
+            return Double.class;
+        }
+
+        public Double bytesToObject(byte[] bytes) {
+            long doubleBits = TypeConversion.varIntBytesToLong(bytes, 2);
+            return new Double(Double.longBitsToDouble(doubleBits));
+        }
+
+        public byte[] objectToBytes(Object object) {
+            double d = ((Double) object).doubleValue();
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, DOUBLE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            int numWritten = TypeConversion.writeLongAsVarIntBytes(Double.doubleToLongBits(d), bytes, 2);
+            if(numWritten < 12) {
+                byte[] smallArray = new byte[numWritten];
+                System.arraycopy(bytes, 0, smallArray, 0, numWritten);
+                return smallArray;
+            }
+            return bytes;
+        }
+    }
+
+    public static final class CharacterInfo implements BuiltinSerializationInfo<Character> {
+        public byte getIndex() {
+            return CHARACTER;
+        }
+
+        public Class<Character> getObjectClass() {
+            return Character.class;
+        }
+
+        public Character bytesToObject(byte[] bytes) {
+            return Character.valueOf(TypeConversion.bytesToChar(bytes, 2));
+        }
+
+        public byte[] objectToBytes(Object object) {
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, CHARACTER, 0, 0};
+            TypeConversion.charToBytes(((Character)object).charValue(), bytes, 2);
+            return bytes;
+        }
+    }
+
+    public static final class BooleanInfo implements BuiltinSerializationInfo<Boolean> {
+        private static final byte[] TRUE_BYTES = {BUILTIN_SERIALIZATION, BOOLEAN, 1};
+        private static final byte[] FALSE_BYTES = {BUILTIN_SERIALIZATION, BOOLEAN, 0};
+
+        public byte getIndex() {
+            return BOOLEAN;
+        }
+
+        public Class<Boolean> getObjectClass() {
+            return Boolean.class;
+        }
+
+        public Boolean bytesToObject(byte[] bytes) {
+            return bytes[2] == 0 ? Boolean.FALSE : Boolean.TRUE;
+        }
+
+        public byte[] objectToBytes(Object object) {
+            return ((Boolean)object).booleanValue() ? TRUE_BYTES : FALSE_BYTES;
+        }
+    }
+
+    public static final class DateInfo implements BuiltinSerializationInfo<java.util.Date> {
+        public byte getIndex() {
+            return DATE;
+        }
+
+        public Class<java.util.Date> getObjectClass() {
+            return java.util.Date.class;
+        }
+
+        public java.util.Date bytesToObject(byte[] bytes) {
+            long l = TypeConversion.varIntBytesToLong(bytes, 2);
+            return new java.util.Date(l);
+        }
+
+        public byte[] objectToBytes(Object object) {
+            long l = ((java.util.Date)object).getTime();
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, DATE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            int numWritten = TypeConversion.writeLongAsVarIntBytes(l, bytes, 2);
+            if(numWritten < 12) {
+                byte[] smallArray = new byte[numWritten];
+                System.arraycopy(bytes, 0, smallArray, 0, numWritten);
+                return smallArray;
+            }
+            return bytes;
+        }
+    }
+
+    public static final class SqlDateInfo implements BuiltinSerializationInfo<java.sql.Date> {
+        public byte getIndex() {
+            return SQL_DATE;
+        }
+
+        public Class<java.sql.Date> getObjectClass() {
+            return java.sql.Date.class;
+        }
+
+        public java.sql.Date bytesToObject(byte[] bytes) {
+            long l = TypeConversion.varIntBytesToLong(bytes, 2);
+            return new java.sql.Date(l);
+        }
+
+        public byte[] objectToBytes(Object object) {
+            long l = ((java.sql.Date)object).getTime();
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, SQL_DATE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            int numWritten = TypeConversion.writeLongAsVarIntBytes(l, bytes, 2);
+            if(numWritten < 12) {
+                byte[] smallArray = new byte[numWritten];
+                System.arraycopy(bytes, 0, smallArray, 0, numWritten);
+                return smallArray;
+            }
+            return bytes;
+        }
+    }
+
+    public static final class SqlTimestampInfo implements BuiltinSerializationInfo<Timestamp> {
+        public byte getIndex() {
+            return SQL_TIMESTAMP;
+        }
+
+        public Class<Timestamp> getObjectClass() {
+            return Timestamp.class;
+        }
+
+        public Timestamp bytesToObject(byte[] bytes) {
+            long l = TypeConversion.bytesToLong(bytes, 2);
+            int nanos = TypeConversion.bytesToInt(bytes, 10);
+            Timestamp returnValue = new Timestamp(l);
+            returnValue.setNanos(nanos);
+            return returnValue;
+        }
+
+        public byte[] objectToBytes(Object object) {
+            Timestamp time = (Timestamp)object;
+            long l = time.getTime();
+            int nanos = time.getNanos();
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, SQL_TIMESTAMP, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            TypeConversion.longToBytes(l, bytes, 2);
+            TypeConversion.intToBytes(nanos, bytes, 10);
+            return bytes;
+        }
+
+        public byte[] convertBytes(byte[] originalBytes, short version) {
+            return originalBytes;
+        }
+    }
+
+    public static final class SqlTimeInfo implements BuiltinSerializationInfo<Time> {
+        public byte getIndex() {
+            return SQL_TIME;
+        }
+
+        public Class<Time> getObjectClass() {
+            return Time.class;
+        }
+
+        public Time bytesToObject(byte[] bytes) {
+            long l = TypeConversion.varIntBytesToLong(bytes, 2);
+            return new Time(l);
+        }
+
+        public byte[] objectToBytes(Object object) {
+            long l = ((Time)object).getTime();
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, SQL_TIME, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            int numWritten = TypeConversion.writeLongAsVarIntBytes(l, bytes, 2);
+            if(numWritten < 12) {
+                byte[] smallArray = new byte[numWritten];
+                System.arraycopy(bytes, 0, smallArray, 0, numWritten);
+                return smallArray;
+            }
+            return bytes;
+        }
+    }
+
+    public static final class BigDecimalInfo implements BuiltinSerializationInfo<BigDecimal> {
+        public byte getIndex() {
+            return BIG_DECIMAL;
+        }
+
+        public Class<BigDecimal> getObjectClass() {
+            return BigDecimal.class;
+        }
+
+        public BigDecimal bytesToObject(byte[] bytes) {
+            int length = TypeConversion.bytesToInt(bytes, 2);
+            byte[] decimalBytes = new byte[length];
+            System.arraycopy(bytes, 6, decimalBytes, 0, length);
+            int scale = TypeConversion.bytesToInt(bytes, length + 6);
+            return new BigDecimal(new BigInteger(decimalBytes), scale);
+        }
+
+        public byte[] objectToBytes(Object object) {
+            BigDecimal bd = (BigDecimal) object;
+            BigInteger bi = bd.unscaledValue();
+            byte[] decimalBytes = bi.toByteArray();
+            int length = decimalBytes.length;
+
+            byte[] bytes = new byte[length + 10];
+            bytes[0] = BUILTIN_SERIALIZATION;
+            bytes[1] = BIG_DECIMAL;
+
+            TypeConversion.intToBytes(length, bytes, 2);
+            System.arraycopy(decimalBytes, 0, bytes, 6, length);
+            TypeConversion.intToBytes(bd.scale(), bytes, length + 6);
+
+            return bytes;
+        }
+    }
+
+    public static final class BigIntegerInfo implements BuiltinSerializationInfo<BigInteger> {
+        public byte getIndex() {
+            return BIG_INTEGER;
+        }
+
+        public Class<BigInteger> getObjectClass() {
+            return BigInteger.class;
+        }
+
+        public BigInteger bytesToObject(byte[] bytes) {
+            int length = TypeConversion.bytesToInt(bytes, 2);
+            byte[] integerBytes = new byte[length];
+            System.arraycopy(bytes, 6, integerBytes, 0, length);
+            return new BigInteger(integerBytes);
+        }
+
+        public byte[] objectToBytes(Object object) {
+            BigInteger bi = (BigInteger) object;
+            byte[] integerBytes = bi.toByteArray();
+            int length = integerBytes.length;
+
+            byte[] bytes = new byte[length + 6];
+            bytes[0] = BUILTIN_SERIALIZATION;
+            bytes[1] = BIG_INTEGER;
+
+            TypeConversion.intToBytes(length, bytes, 2);
+            System.arraycopy(integerBytes, 0, bytes, 6, length);
+
+            return bytes;
+        }
+    }
+
+    public static final class ByteArrayInfo implements BuiltinSerializationInfo<byte[]> {
+        public byte getIndex() {
+            return BYTE_ARRAY;
+        }
+
+        public Class<byte[]> getObjectClass() {
+            return byte[].class;
+        }
+
+        public byte[] bytesToObject(byte[] bytes) {
+            int length = TypeConversion.bytesToInt(bytes, 2);
+            byte[] returnBytes = new byte[length];
+            System.arraycopy(bytes, 6, returnBytes, 0, length);
+            return returnBytes;
+        }
+
+        public byte[] objectToBytes(Object object) {
+            byte[] bytes = (byte[]) object;
+            int length = bytes.length;
+
+            byte[] returnBytes = new byte[length + 6];
+            returnBytes[0] = BUILTIN_SERIALIZATION;
+            returnBytes[1] = BYTE_ARRAY;
+
+            TypeConversion.intToBytes(length, returnBytes, 2);
+            System.arraycopy(bytes, 0, returnBytes, 6, length);
+
+            return returnBytes;
+        }
+    }
+    
+    public static final class AtomicIntegerInfo implements BuiltinSerializationInfo<AtomicInteger> {
+        public byte getIndex() {
+            return ATOMIC_INTEGER;
+        }
+
+        public Class<AtomicInteger> getObjectClass() {
+            return AtomicInteger.class;
+        }
+
+        public AtomicInteger bytesToObject(byte[] bytes) {
+            int atomicIntValue = TypeConversion.varIntBytesToInt(bytes, 2);
+            return new AtomicInteger(atomicIntValue);
+        }
+
+        public byte[] objectToBytes(Object object) {
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, ATOMIC_INTEGER, 0, 0, 0, 0, 0};
+            int numWritten = TypeConversion.writeIntAsVarIntBytes(((AtomicInteger)object).get(), bytes, 2);
+            if(numWritten < 7) {
+                byte[] smallArray = new byte[numWritten];
+                System.arraycopy(bytes, 0, smallArray, 0, numWritten);
+                return smallArray;
+            }
+            return bytes;
+        }
+    }
+
+    public static final class AtomicLongInfo implements BuiltinSerializationInfo<AtomicLong> {
+        public byte getIndex() {
+            return ATOMIC_LONG;
+        }
+
+        public Class<AtomicLong> getObjectClass() {
+            return AtomicLong.class;
+        }
+
+        public AtomicLong bytesToObject(byte[] bytes) {
+            long atomicLongValue = TypeConversion.varIntBytesToLong(bytes, 2);
+            return new AtomicLong(atomicLongValue);
+        }
+
+        public byte[] objectToBytes(Object object) {
+            byte[] bytes = new byte[] {BUILTIN_SERIALIZATION, ATOMIC_LONG, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            int numWritten = TypeConversion.writeLongAsVarIntBytes(((AtomicLong)object).get(), bytes, 2);
+            if(numWritten < 12) {
+                byte[] smallArray = new byte[numWritten];
+                System.arraycopy(bytes, 0, smallArray, 0, numWritten);
+                return smallArray;
+            }
+            return bytes;
+        }
+    }
+}

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/TypeConversion.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/TypeConversion.java
@@ -1,0 +1,275 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.session.store.cache;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * A utility class for converting primitives and potentially Object types.
+ * 
+ */
+public final class TypeConversion {
+    /**
+     * A utility method to convert the int from the byte array to an int.
+     * 
+     * @param bytes
+     *            The byte array containing the int.
+     * @param offset
+     *            The index at which the int is located.
+     * @return The int value.
+     */
+    public static int bytesToInt(byte[] bytes, int offset) {
+        return ((bytes[offset + 3] & 0xFF) << 0) + ((bytes[offset + 2] & 0xFF) << 8)
+                        + ((bytes[offset + 1] & 0xFF) << 16) + ((bytes[offset + 0] & 0xFF) << 24);
+    }
+
+    /**
+     * A utility method to convert the short from the byte array to a short.
+     * 
+     * @param bytes
+     *            The byte array containing the short.
+     * @param offset
+     *            The index at which the short is located.
+     * @return The short value.
+     */
+    public static short bytesToShort(byte[] bytes, int offset) {
+        short result = 0x0;
+        for (int i = offset; i < offset + 2; ++i) {
+            result = (short) ((result) << 8);
+            result |= (bytes[i] & 0x00FF);
+        }
+        return result;
+    }
+
+    /**
+     * A utility method to convert the long from the byte array to a long.
+     * 
+     * @param bytes
+     *            The byte array containing the long.
+     * @param offset
+     *            The index at which the long is located.
+     * @return The long value.
+     */
+    public static long bytesToLong(byte[] bytes, int offset) {
+        long result = 0x0;
+        for (int i = offset; i < offset + 8; ++i) {
+            result = result << 8;
+            result |= (bytes[i] & 0x00000000000000FFl);
+        }
+        return result;
+    }
+
+    /**
+     * A utility method to convert the char from the byte array to a char.
+     * 
+     * @param bytes
+     *            The byte array containing the char.
+     * @param offset
+     *            The index at which the char is located.
+     * @return The char value.
+     */
+    public static char bytesToChar(byte[] bytes, int offset) {
+        char result = 0x0;
+        for (int i = offset; i < offset + 2; ++i) {
+            result = (char) ((result) << 8);
+            result |= (bytes[i] & 0x00FF);
+        }
+        return result;
+    }
+
+    public static void charToBytes(char value, byte[] bytes, int offset) {
+        for (int i = offset + 1; i >= offset; --i) {
+            bytes[i] = (byte) value;
+            value = (char) ((value) >> 8);
+        }
+    }
+
+    /**
+     * A utility method to convert an int into bytes in an array.
+     * 
+     * @param value
+     *            An int.
+     * @param bytes
+     *            The byte array to which the int should be copied.
+     * @param offset
+     *            The index where the int should start.
+     */
+    public static void intToBytes(int value, byte[] bytes, int offset) {
+        bytes[offset + 3] = (byte) (value >>> 0);
+        bytes[offset + 2] = (byte) (value >>> 8);
+        bytes[offset + 1] = (byte) (value >>> 16);
+        bytes[offset + 0] = (byte) (value >>> 24);
+    }
+
+    /**
+     * A utility method to convert a short into bytes in an array.
+     * 
+     * @param value
+     *            A short.
+     * @param bytes
+     *            The byte array to which the short should be copied.
+     * @param offset
+     *            The index where the short should start.
+     */
+    public static void shortToBytes(short value, byte[] bytes, int offset) {
+        for (int i = offset + 1; i >= offset; --i) {
+            bytes[i] = (byte) value;
+            value = (short) ((value) >> 8);
+        }
+    }
+
+    /**
+     * A utility method to convert the long into bytes in an array.
+     * 
+     * @param value
+     *            The long.
+     * @param bytes
+     *            The byte array to which the long should be copied.
+     * @param offset
+     *            The index where the long should start.
+     */
+    public static void longToBytes(long value, byte[] bytes, int offset) {
+        for (int i = offset + 7; i >= offset; --i) {
+            bytes[i] = (byte) value;
+            value = value >> 8;
+        }
+    }
+
+    /**
+     * Reads a long from the byte array in the Varint format.
+     * @param bytes - byte buffer to read
+     * @param offset - the offset within the bytes buffer to start reading
+     * @return - returns the long value
+     */
+    public static long varIntBytesToLong(byte[] bytes, int offset) {
+        int shift = 0;
+        long result = 0;
+        while (shift < 64) {
+            final byte b = bytes[offset++];
+            result |= (long)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0) {
+                return result;
+            }
+            shift += 7;
+        }
+        throw new IllegalStateException("Varint representation is invalid or exceeds 64-bit value");
+    }   
+
+    /**
+     * Reads an int from the byte array in the Varint format.
+     * @param bytes - byte buffer to read
+     * @param offset - the offset within the bytes buffer to start reading
+     * @return - returns the int value
+     */    
+    public static int varIntBytesToInt(byte[] bytes, int offset) {
+
+        byte tmp = bytes[offset++];
+        if (tmp >= 0) {
+            return tmp;
+        }
+        int result = tmp & 0x7f;
+        if ((tmp = bytes[offset++]) >= 0) {
+            result |= tmp << 7;
+        } else {
+            result |= (tmp & 0x7f) << 7;
+            if ((tmp = bytes[offset++]) >= 0) {
+                result |= tmp << 14;
+            } else {
+                result |= (tmp & 0x7f) << 14;
+                if ((tmp = bytes[offset++]) >= 0) {
+                    result |= tmp << 21;
+                } else {
+                    result |= (tmp & 0x7f) << 21;
+                    result |= (tmp = bytes[offset++]) << 28;
+                    if (tmp < 0) {
+                        // Discard upper 32 bits.
+                        for (int i = 0; i < 5; i++) {
+                            if (bytes[offset++] >= 0) {
+                                return result;
+                            }
+                        }
+                        //TODO NLS
+                        throw new IllegalStateException("Varint representation is invalid or exceeds 32-bit value");
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Writes a long to the byte array in the Varint format.
+     * @param v - long value to write to the bytes buffer in the Varint format 
+     * @param bytes - byte buffer to write to - must contain enough space for maximum 
+     *                length which is 10 bytes.
+     * @param offset - the offset within the bytes buffer to start writing
+     * @return - returns the number of bytes used from the bytes buffer
+     */
+    public static int writeLongAsVarIntBytes(long v, byte[] bytes, int offest) {
+        int pos = offest;
+
+        while (true) {
+            if ((v & ~0x7FL) == 0) {
+                bytes[pos++] = ((byte)v);
+                return pos;
+            } else {
+                bytes[pos++] = (byte)((v & 0x7F) | 0x80);
+                v >>>= 7;
+            }
+        }    
+    }
+
+
+    /**
+     * Writes an integer to the byte array in the Varint format.
+     * @param intVal - integer value to write to the bytes buffer in the Varint format 
+     * @param bytes - byte buffer to write to - must contain enough space for maximum 
+     *                length which is 5 bytes.
+     * @param offset - the offset within the bytes buffer to start writing
+     * @return - returns the number of bytes used from the bytes buffer
+     */
+    public static int writeIntAsVarIntBytes(int intVal, byte[] bytes, int offset) {
+        int pos = offset;
+        int v = intVal;
+
+        if ((v & ~0x7F) == 0) {
+            bytes[pos++] = ((byte) v);
+            return 1 + offset;
+        }
+
+        while (true) {
+            if ((v & ~0x7F) == 0) {
+                bytes[pos++] = ((byte) v);
+                return pos;
+            } else {
+                bytes[pos++] = (byte) ((v & 0x7F) | 0x80);
+                v >>>= 7;
+            }
+        }
+    }
+    
+    /**
+     * If the byte array length is less than 1000, returns the result of calling Arrays.toString on the
+     * supplied byte array.  Otherwise returns the result of calling Arrays.toString on a byte array containing
+     * the first 1000 bytes in the supplied byte array.
+     */
+    public static String limitedBytesToString(byte[] bytes) {
+        if(bytes.length <= 1000) {
+            return Arrays.toString(bytes);
+        } else {
+            byte[] firstBytes = new byte[1000];
+            System.arraycopy(bytes, 0, firstBytes, 0, 1000);
+            return Arrays.toString(firstBytes);
+        }
+    }
+}

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -22,10 +22,16 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.lang.management.ManagementFactory;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,6 +41,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.cache.Cache;
 import javax.cache.Caching;
@@ -278,6 +286,90 @@ public class SessionCacheTestServlet extends FATServlet {
         AppObject object = new AppObject();
         session.setAttribute("appObject", object);
         sessionMap.put("appObject", object);
+
+        //Test the serialization of performance improved primitives
+        Calendar cal = Calendar.getInstance();
+        cal.clear();
+        cal.set(2018, 4, 19, 9, 23, 45);
+        java.util.Date date = cal.getTime();
+        session.setAttribute("date", date);
+
+        java.sql.Date sqlDate = new java.sql.Date(1524236907331l);
+        session.setAttribute("sqlDate", sqlDate);
+
+        double d = 55901.55902;
+        session.setAttribute("double", d);
+
+        float f = 12345.6789f;
+        session.setAttribute("float", f);
+
+        byte b = Byte.parseByte("3");
+        session.setAttribute("byte", b);
+
+        Timestamp timestamp = new Timestamp(255073580786543l);
+        session.setAttribute("timestamp", timestamp);
+
+        Time time = new Time(345033920786213l);
+        session.setAttribute("time", time);
+
+        BigInteger bigint = new BigInteger("1234567891011121314151617181920");
+        session.setAttribute("BigInteger", bigint);
+
+        BigInteger negBigInt = new BigInteger("-1234567890000098765432198349834");
+        session.setAttribute("NegativeBigInteger", negBigInt);
+
+        BigDecimal bigDecimal = new BigDecimal("12345678910.11121314151617181920");
+        session.setAttribute("BigDecimal", bigDecimal);
+
+        BigDecimal negBigDecimal = new BigDecimal("-12345678900000987.65432198349834");
+        session.setAttribute("NegativeBigDecimal", negBigDecimal);
+
+        long long0 = 0l;
+        session.setAttribute("long0", long0);
+
+        long longNeg1 = -1l;
+        session.setAttribute("longNeg1", longNeg1);
+
+        long maxLong = Long.MAX_VALUE;
+        session.setAttribute("maxLong", maxLong);
+
+        long minLong = Long.MIN_VALUE;
+        session.setAttribute("minLong", minLong);
+
+        int int0 = 0;
+        session.setAttribute("int0", int0);
+
+        int intNeg1 = -1;
+        session.setAttribute("intNeg1", intNeg1);
+
+        int maxInt = Integer.MAX_VALUE;
+        session.setAttribute("maxInt", maxInt);
+
+        int minInt = Integer.MIN_VALUE;
+        session.setAttribute("minInt", minInt);
+
+        short sh = 24;
+        session.setAttribute("short", sh);
+
+        char ch = 'A';
+        session.setAttribute("char", ch);
+
+        boolean bool = true;
+        session.setAttribute("boolean", bool);
+
+        byte[] bytes = "Rochester, Minnesota, United States of America".getBytes();
+        session.setAttribute("byte array", bytes);
+
+        ArrayList<Integer> arrayList = new ArrayList<Integer>();
+        arrayList.add(1000);
+        arrayList.add(2);
+        session.setAttribute("arrayList", arrayList);
+
+        AtomicInteger atomicInt = new AtomicInteger(55901);
+        session.setAttribute("atomicInteger", atomicInt);
+
+        AtomicLong atomicLong = new AtomicLong(559015590255903l);
+        session.setAttribute("atomicLong", atomicLong);
     }
 
     /**
@@ -314,7 +406,104 @@ public class SessionCacheTestServlet extends FATServlet {
         }
         String attributeNamesString = attributeNames.toString();
         assertTrue(attributeNamesString, attributeNames.containsAll(Arrays.asList("map", "str", "appObject")));
-        assertEquals(attributeNamesString, weldCount + 3, attributeNames.size());
+        assertEquals(attributeNamesString, weldCount + 29, attributeNames.size());
+
+        //Test the serialization of performance improved primitives (that aren't tested elsewhere)
+        java.util.Date actualDate = (Date) session.getAttribute("date");
+        Calendar cal = Calendar.getInstance();
+        cal.clear();
+        cal.set(2018, 4, 19, 9, 23, 45);
+        java.util.Date expectedDate = cal.getTime();
+        assertEquals(expectedDate.getTime(), actualDate.getTime());
+
+        java.sql.Date expectedSqlDate = new java.sql.Date(1524236907331l);
+        java.sql.Date actualSqlDate = (java.sql.Date) session.getAttribute("sqlDate");
+        assertEquals(expectedSqlDate.getTime(), actualSqlDate.getTime());
+
+        double actualDouble = (double) session.getAttribute("double");
+        assertEquals(55901.55902, actualDouble, 0);
+
+        float actualFloat = (float) session.getAttribute("float");
+        assertEquals(12345.6789f, actualFloat, 0);
+
+        byte expectedByte = Byte.parseByte("3");
+        byte actualByte = (byte) session.getAttribute("byte");
+        assertEquals(expectedByte, actualByte);
+
+        Timestamp expectedTimestamp = new Timestamp(255073580786543l);
+        Timestamp actualTimestamp = (Timestamp) session.getAttribute("timestamp");
+        assertEquals(expectedTimestamp.getTime(), actualTimestamp.getTime());
+
+        Time expectedTime = new Time(345033920786213l);
+        Time actualTime = (Time) session.getAttribute("time");
+        assertEquals(expectedTime.getTime(), actualTime.getTime());
+
+        BigInteger expectedBigint = new BigInteger("1234567891011121314151617181920");
+        BigInteger actualBigint = (BigInteger) session.getAttribute("BigInteger");
+        assertEquals(expectedBigint.longValue(), actualBigint.longValue());
+
+        BigInteger expectedNegBigint = new BigInteger("-1234567890000098765432198349834");
+        BigInteger actualNegBigint = (BigInteger) session.getAttribute("NegativeBigInteger");
+        assertEquals(expectedNegBigint.longValue(), actualNegBigint.longValue());
+
+        BigDecimal expectedBigDecimal = new BigDecimal("12345678910.11121314151617181920");
+        BigDecimal actualBigDecimal = (BigDecimal) session.getAttribute("BigDecimal");
+        assertEquals(expectedBigDecimal.longValue(), actualBigDecimal.longValue());
+
+        BigDecimal expectedNegBigDecimal = new BigDecimal("-12345678900000987.65432198349834");
+        BigDecimal actualNegBigDecimal = (BigDecimal) session.getAttribute("NegativeBigDecimal");
+        assertEquals(expectedNegBigDecimal.longValue(), actualNegBigDecimal.longValue());
+
+        long actualLong0 = (long) session.getAttribute("long0");
+        assertEquals(0l, actualLong0);
+
+        long actualLongNeg1 = (long) session.getAttribute("longNeg1");
+        assertEquals(-1l, actualLongNeg1);
+
+        long actualMaxLong = (long) session.getAttribute("maxLong");
+        assertEquals(Long.MAX_VALUE, actualMaxLong);
+
+        long actualMinLong = (long) session.getAttribute("minLong");
+        assertEquals(Long.MIN_VALUE, actualMinLong);
+
+        long actualint0 = (int) session.getAttribute("int0");
+        assertEquals(0, actualint0);
+
+        long actualIntNeg1 = (int) session.getAttribute("intNeg1");
+        assertEquals(-1, actualIntNeg1);
+
+        long actualMaxInt = (int) session.getAttribute("maxInt");
+        assertEquals(Integer.MAX_VALUE, actualMaxInt);
+
+        long actualMinInt = (int) session.getAttribute("minInt");
+        assertEquals(Integer.MIN_VALUE, actualMinInt);
+
+        short actualShort = (short) session.getAttribute("short");
+        assertEquals(24, actualShort);
+
+        char expectedChar = 'A';
+        char actualChar = (char) session.getAttribute("char");
+        assertEquals(expectedChar, actualChar);
+
+        boolean expectedBoolean = true;
+        boolean actualBoolean = (boolean) session.getAttribute("boolean");
+        assertEquals(expectedBoolean, actualBoolean);
+
+        byte[] expectedBytes = "Rochester, Minnesota, United States of America".getBytes();
+        byte[] actualBytes = (byte[]) session.getAttribute("byte array");
+        assertTrue(Arrays.equals(expectedBytes, actualBytes));
+
+        @SuppressWarnings({ "unchecked" })
+        ArrayList<Integer> actualArrayList = (ArrayList<Integer>) session.getAttribute("arrayList");
+        assertEquals(2, actualArrayList.size());
+        assertTrue("Expected arrayList to contain 2", actualArrayList.contains(2));
+        assertTrue("Expected arrayList to contain 1000", actualArrayList.contains(1000));
+
+        AtomicInteger actualAtomicInt = (AtomicInteger) session.getAttribute("atomicInteger");
+        assertEquals(55901, actualAtomicInt.get());
+
+        AtomicLong actualAtomicLong = (AtomicLong) session.getAttribute("atomicLong");
+        assertEquals(559015590255903l, actualAtomicLong.get());
     }
 
     public void testSerializeDataSource(HttpServletRequest request, HttpServletResponse response) throws Throwable {
@@ -408,6 +597,42 @@ public class SessionCacheTestServlet extends FATServlet {
 
     private static final byte[] toBytes(Object o) throws Exception {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        if (o instanceof Character) {
+            byte[] bytes = new byte[] { 0, 6, 0, 0 };
+            char value = (char) o;
+            for (int i = 2 + 1; i >= 2; --i) {
+                bytes[i] = (byte) value;
+                value = (char) ((value) >> 8);
+            }
+            return bytes;
+        } else if (o instanceof Integer) {
+            byte[] bytes = new byte[] { 0, 1, 0, 0, 0, 0, 0 };
+            int pos = 2;
+            int numWritten = 0;
+            int v = ((Integer) o).intValue();
+
+            if ((v & ~0x7F) == 0) {
+                bytes[pos++] = ((byte) v);
+                numWritten = 3;
+            } else {
+                while (true) {
+                    if ((v & ~0x7F) == 0) {
+                        bytes[pos++] = ((byte) v);
+                        numWritten = pos;
+                        break;
+                    } else {
+                        bytes[pos++] = (byte) ((v & 0x7F) | 0x80);
+                        v >>>= 7;
+                    }
+                }
+            }
+            if (numWritten < 7) {
+                byte[] smallArray = new byte[numWritten];
+                System.arraycopy(bytes, 0, smallArray, 0, numWritten);
+                return smallArray;
+            }
+            return bytes;
+        }
         try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
             oos.writeObject(o);
             return bos.toByteArray();
@@ -510,9 +735,9 @@ public class SessionCacheTestServlet extends FATServlet {
         Cache<String, byte[]> cacheA = Caching.getCache("com.ibm.ws.session.attr.default_host%2FsessionCacheApp", String.class, byte[].class);
         byte[] result = cacheA.get(key);
         assertEquals(value, result == null ? null : Arrays.toString(result));
-        
+
         //Validate session existence/deletion if we pass in a sessionId
-        if (sessionId != null) { 
+        if (sessionId != null) {
             @SuppressWarnings("rawtypes")
             Cache<String, ArrayList> cacheM = Caching.getCache("com.ibm.ws.session.meta.default_host%2FsessionCacheApp", String.class, ArrayList.class);
             assertEquals(cacheM.containsKey(sessionId), value == null ? false : true);


### PR DESCRIPTION
Reduce the size of byte arrays which are written for primitive values.  PR for story #2801.