### PR TITLE
overQualLastAccessTimeUpdate is inconsistent with DatabaseHashMap

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -785,8 +785,10 @@ public class CacheHashMap extends BackedHashMap {
 
         SessionInfo sessionInfo = oldValue == null ? null : new SessionInfo(oldValue).clone();
         synchronized (sess) {
-            if (sessionInfo == null || sessionInfo.getLastAccess() != sess.getCurrentAccessTime() || sessionInfo.getLastAccess() == nowTime) {
+            if (sessionInfo == null || sessionInfo.getLastAccess() != sess.getCurrentAccessTime()) {
                 updateCount = 0;
+            } else if (sessionInfo.getLastAccess() == nowTime) {
+                updateCount = 1; // be consistent with Statement.executeUpdate which returns 1 the when row matches but no changes are made
             } else {
                 sessionInfo.setLastAccess(nowTime);
                 ArrayList<?> newValue = sessionInfo.getArrayList();


### PR DESCRIPTION
Update overQualLastAccessTimeUpdate to be consistent with DatabaseHashMap implementation.
Specifically, when the last access time already matches, we should return 1, not 0, for the number matching rather than the number changed.