### PR TITLE
Moving to uplevel bundle

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-3.1/com.ibm.websphere.appserver.servlet-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-3.1/com.ibm.websphere.appserver.servlet-3.1.feature
@@ -50,8 +50,10 @@ Subsystem-Category: JavaEE7Application
 -bundles=com.ibm.ws.app.manager.war, \
  com.ibm.ws.managedobject, \
  com.ibm.ws.org.apache.commons.io.1.4, \
+ com.ibm.ws.org.apache.commons.io, \
  com.ibm.websphere.security, \
  com.ibm.ws.org.apache.commons.fileupload.1.2.1, \
+ com.ibm.ws.org.apache.commons.fileupload, \
  com.ibm.ws.webcontainer.servlet.3.1, \
  com.ibm.ws.webcontainer.servlet.3.1.factories, \
  com.ibm.ws.session, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-4.0/com.ibm.websphere.appserver.servlet-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-4.0/com.ibm.websphere.appserver.servlet-4.0.feature
@@ -50,8 +50,10 @@ Subsystem-Category: JavaEE8Application
 -bundles=com.ibm.ws.app.manager.war, \
  com.ibm.ws.managedobject, \
  com.ibm.ws.org.apache.commons.io.1.4, \
+ com.ibm.ws.org.apache.commons.io, \
  com.ibm.websphere.security, \
  com.ibm.ws.org.apache.commons.fileupload.1.2.1, \
+ com.ibm.ws.org.apache.commons.fileupload, \
  com.ibm.ws.webcontainer.servlet.4.0, \
  com.ibm.ws.webcontainer.servlet.4.0.factories, \
  com.ibm.ws.webcontainer.servlet.3.1, \

--- a/dev/com.ibm.ws.microprofile.openapi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.openapi/bnd.bnd
@@ -24,7 +24,6 @@ IBM-Web-Extension-Processing-Disabled: true
 Web-ContextPath: /openapi
 
 Import-Package: \
-	org.apache.commons.io*;version=1.4;packageType=was_internal,\
 	org.eclipse.microprofile.config.*;version="[1.0,2)",\
 	*
     
@@ -79,7 +78,7 @@ instrument.classesExcludes: \
 	com.ibm.ws.anno;version=latest,\
 	com.ibm.ws.artifact.overlay;version=latest,\
 	com.ibm.websphere.appserver.spi.artifact;version=latest,\
-	com.ibm.ws.org.apache.commons.io.2.4;version=latest,\
+	com.ibm.ws.org.apache.commons.io;version=latest,\
 	com.ibm.ws.org.apache.commons.lang3.3.5;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.config.1.2.1;version=latest,\
 	com.fasterxml.jackson.core.jackson-core;version=2.9.1,\

--- a/dev/com.ibm.ws.persistence_fat/bnd.bnd
+++ b/dev/com.ibm.ws.persistence_fat/bnd.bnd
@@ -35,6 +35,6 @@ fat.project: true
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.ws.resource;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	com.ibm.ws.org.apache.commons.io.1.4;version=latest,\
+	com.ibm.ws.org.apache.commons.io;version=latest,\
 	com.ibm.ws.componenttest:provider.api;version=1.0.0,\
 	org.apache.derby:derby;version=10.11.1.1

--- a/dev/com.ibm.ws.persistence_fat/com.ibm.ws.persistence.consumer.testresource.bnd
+++ b/dev/com.ibm.ws.persistence_fat/com.ibm.ws.persistence.consumer.testresource.bnd
@@ -21,7 +21,6 @@ Export-Package: \
 
 Import-Package: \
   javax.persistence;consumer="persistenceService",\
-  org.apache.commons.io*;version=1.4;packageType="was_internal",\
   *
   
 Include-Resource: \

--- a/dev/com.ibm.ws.repository.test.utils/bnd.bnd
+++ b/dev/com.ibm.ws.repository.test.utils/bnd.bnd
@@ -28,5 +28,5 @@ publish.wlp.jar.disabled: true
 -buildpath: \
     org.hamcrest:hamcrest-all;version=1.3, \
     com.ibm.ws.repository;version=latest, \
-    com.ibm.ws.org.apache.commons.io.2.4;version=latest, \
+    com.ibm.ws.org.apache.commons.io;version=latest, \
     fattest.simplicity;version=latest

--- a/dev/com.ibm.ws.rest.handler/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler/bnd.bnd
@@ -20,9 +20,6 @@ Web-ContextPath: ibm/api
 IBM-Authorization-Roles: com.ibm.ws.management
 IBM-Web-Extension-Processing-Disabled: true
 
-Import-Package: \
-    org.apache.commons.fileupload*;version=1.2.1;packageType="was_internal", \
-    *
   
 Private-Package: \
   com.ibm.ws.rest.handler.internal, \
@@ -47,7 +44,7 @@ instrument.classesExcludes: com/ibm/ws/rest/handler/internal/resources/*.class
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
-	com.ibm.ws.org.apache.commons.fileupload.1.2.1;version=latest,\
+	com.ibm.ws.org.apache.commons.fileupload;version=latest,\
 	com.ibm.websphere.rest.handler;version=latest,\
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.component,\

--- a/dev/com.ibm.ws.security.utility.securityutil/bnd.bnd
+++ b/dev/com.ibm.ws.security.utility.securityutil/bnd.bnd
@@ -21,7 +21,7 @@ Require-Bundle: \
     com.ibm.ws.crypto.passwordutil; version="[1,1.0.100)", \
     com.ibm.ws.kernel.service; version="[1.3,1.3.100)", \
     com.ibm.ws.logging; version="[1,1.0.100)", \
-    com.ibm.ws.org.apache.commons.io.1.4; version="[1,1.0.100)", \
+    com.ibm.ws.org.apache.commons.io; version="[1,1.0.100)", \
     com.ibm.json4j; version="[1,1.0.100)"
 
 Command-Class: com.ibm.ws.security.utility.SecurityUtility

--- a/dev/com.ibm.ws.security.utility/bnd.bnd
+++ b/dev/com.ibm.ws.security.utility/bnd.bnd
@@ -31,7 +31,7 @@ instrument.disabled: true
 	com.ibm.ws.crypto.ltpakeyutil;version=latest,\
 	com.ibm.ws.crypto.passwordutil;version=latest,\
 	com.ibm.ws.security.utility.securityutil;version=latest,\
-	com.ibm.ws.org.apache.commons.io.1.4;version=latest,\
+	com.ibm.ws.org.apache.commons.io;version=latest,\
 	com.ibm.ws.kernel.service;version=latest
 
 -testpath: \

--- a/dev/com.ibm.ws.springboot.utility.springbootutil/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.utility.springbootutil/bnd.bnd
@@ -19,7 +19,7 @@ Require-Bundle: \
     com.ibm.ws.app.manager.springboot; version="[1,1.0.100)", \
     com.ibm.ws.kernel.service; version="[1.3,1.3.100)", \
     com.ibm.ws.logging; version="[1,1.0.100)", \
-    com.ibm.ws.org.apache.commons.io.1.4; version="[1,1.0.100)", \
+    com.ibm.ws.org.apache.commons.io; version="[1,1.0.100)", \
     com.ibm.json4j; version="[1,1.0.100)"
 
 Command-Class: com.ibm.ws.springboot.utility.SpringBootUtility

--- a/dev/com.ibm.ws.webcontainer.security/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security/bnd.bnd
@@ -102,7 +102,7 @@ instrument.classesExcludes: com/ibm/ws/webcontainer/security/resources/*.class
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.websphere.org.osgi.service.cm, \
 	com.ibm.ws.injection;version=latest, \
-	com.ibm.ws.org.apache.commons.io.1.4;version=latest, \
-	com.ibm.ws.org.apache.commons.fileupload.1.2.1;version=latest, \
+	com.ibm.ws.org.apache.commons.io;version=latest, \
+	com.ibm.ws.org.apache.commons.fileupload;version=latest, \
 	com.ibm.ws.security.mp.jwt.proxy;version=latest, \
 	com.ibm.ws.kernel.service;version=latest	

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/bnd.bnd
@@ -77,8 +77,6 @@ Import-Package: \
     com.ibm.ws.webcontainer.srt.http, \
     com.ibm.ws.container.service.app.deploy, \
     com.ibm.ws.genericbnf, \
-    org.apache.commons.fileupload*;version=1.2.1;packageType="was_internal", \
-    org.apache.commons.io*;version=1.4;packageType="was_internal", \
     !com.ibm.wsspi.buffermgmt, \
     !com.ibm.ejs.sm.client.ui, \
     !com.ibm.websphere.monitor.jmx, \
@@ -109,7 +107,7 @@ instrument.disabled: true
     com.ibm.ws.managedobject;version=latest,\
     com.ibm.ws.injection;version=latest,\
     com.ibm.ws.session;version=latest,\
-    com.ibm.ws.org.apache.commons.fileupload.1.2.1;version=latest,\
+    com.ibm.ws.org.apache.commons.fileupload;version=latest,\
     com.ibm.ws.anno;version=latest, \
     com.ibm.ws.org.osgi.annotation.versioning;version=latest
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/bnd.bnd
@@ -62,7 +62,7 @@ Import-Package: \
     com.ibm.ws.managedobject;version=latest,\
     com.ibm.ws.resource;version=latest,\
     com.ibm.ws.adaptable.module;version=latest,\
-    com.ibm.ws.org.apache.commons.fileupload.1.2.1;version=latest,\
+    com.ibm.ws.org.apache.commons.fileupload;version=latest,\
     com.ibm.ws.session;version=latest,\
     com.ibm.ws.javaee.dd.common;version=latest,\
     com.ibm.ws.javaee.dd;version=latest
@@ -80,7 +80,7 @@ Import-Package: \
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
     com.ibm.ws.javaee.dd.common;version=latest, \
     com.ibm.ws.javaee.dd;version=latest, \
-    com.ibm.ws.org.apache.commons.fileupload.1.2.1;version=latest,\
-    commons-io:commons-io;version=2.4,\
+    com.ibm.ws.org.apache.commons.fileupload;version=latest,\
+    com.ibm.ws.org.apache.commons.io;version=latest,\
     com.ibm.ws.channelfw;version=latest
 

--- a/dev/com.ibm.ws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer/bnd.bnd
@@ -139,8 +139,6 @@ Import-Package: \
     com.ibm.websphere.security, \
     com.ibm.ws.container.service.app.deploy, \
     com.ibm.ws.genericbnf, \
-    org.apache.commons.fileupload*;version=1.2.1;packageType="was_internal", \
-    org.apache.commons.io*;version=1.4;packageType="was_internal", \
      !com.ibm.wsspi.buffermgmt, \
      !com.ibm.ejs.sm.client.ui, \
      !com.ibm.websphere.monitor.jmx, \
@@ -196,9 +194,9 @@ instrument.disabled: true
 	com.ibm.ws.javaee.version;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.ws.session;version=latest,\
-	com.ibm.ws.org.apache.commons.fileupload.1.2.1;version=latest,\
+	com.ibm.ws.org.apache.commons.fileupload;version=latest,\
 	com.ibm.ws.webserver.plugin.runtime.interfaces;version=latest,\
-	com.ibm.ws.org.apache.commons.io.2.4;version=latest, \
+	com.ibm.ws.org.apache.commons.io;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 
 -testpath: \

--- a/dev/com.ibm.ws.webserver.plugin.utility/bnd.bnd
+++ b/dev/com.ibm.ws.webserver.plugin.utility/bnd.bnd
@@ -30,7 +30,7 @@ instrument.disabled: true
 	com.ibm.websphere.filetransfer;version=latest,\
 	com.ibm.ws.jmx.connector.client.rest;version=latest,\
 	com.ibm.ws.http.plugin.merge;version=latest,\
-	com.ibm.ws.org.apache.commons.io.1.4;version=latest,\
+	com.ibm.ws.org.apache.commons.io;version=latest,\
 	com.ibm.ws.webserver.plugin.runtime.interfaces;version=latest,\
 	com.ibm.ws.webserver.plugin.utility.webserverPluginutil;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest


### PR DESCRIPTION
Changes to include both versions of bundles in features, and to also move dependent bundle refs to the upgraded version - and remove was_internal package import restrictions.

