### PR TITLE
Replace the messageLogFormat second parameter with the appropriate value

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -675,7 +675,9 @@ public class BaseTraceService implements TrService {
         if (internalMsgRouter != null) {
             retMe &= internalMsgRouter.route(routedMessage);
         } else {
-            earlierMessages.add(routedMessage);
+            String message = formatter.messageLogFormat(routedMessage.getLogRecord(), routedMessage.getFormattedVerboseMsg());
+            RoutedMessage specialRoutedMessage = new RoutedMessageImpl(routedMessage.getFormattedMsg(), routedMessage.getFormattedVerboseMsg(), message, routedMessage.getLogRecord());
+            earlierMessages.add(specialRoutedMessage);
         }
         return retMe;
     }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -742,7 +742,7 @@ public class BaseTraceService implements TrService {
 
             RoutedMessage routedMessage = null;
             if (externalMessageRouter.get() != null) {
-                String message = formatter.messageLogFormat(logRecord, logRecord.getMessage());
+                String message = formatter.messageLogFormat(logRecord, formattedVerboseMsg);
                 routedMessage = new RoutedMessageImpl(formattedMsg, formattedVerboseMsg, message, logRecord);
             } else {
                 routedMessage = new RoutedMessageImpl(formattedMsg, formattedVerboseMsg, null, logRecord);


### PR DESCRIPTION
Replace the messageLogFormat second parameter with the appropriate value
Fix #3312 
