### PR TITLE
enable tests and fix lazy init

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -106,16 +106,6 @@ public class CacheStoreService implements Introspector, SessionStoreService {
      */
     protected void activate(ComponentContext context, Map<String, Object> props) {
         configurationProperties = new HashMap<String, Object>(props);
-    }
-
-    /**
-     * Performs deferred activation/initialization.
-     */
-    synchronized void activateLazily() {
-        if (cacheManager != null)
-            return; // lazy initialization has already completed
-
-        final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         Object scheduleInvalidationFirstHour = configurationProperties.get("scheduleInvalidationFirstHour");
         Object scheduleInvalidationSecondHour = configurationProperties.get("scheduleInvalidationSecondHour");
@@ -134,6 +124,16 @@ public class CacheStoreService implements Introspector, SessionStoreService {
         configurationProperties.put("sessionPersistenceMode", "JCACHE");
         configurationProperties.put("useInvalidatedId", false);
         configurationProperties.put("useMultiRowSchema", true);
+    }
+
+    /**
+     * Performs deferred activation/initialization.
+     */
+    synchronized void activateLazily() {
+        if (cacheManager != null)
+            return; // lazy initialization has already completed
+
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
         
         Properties vendorProperties = new Properties();
         

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheOneServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheOneServerTest.java
@@ -108,31 +108,23 @@ public class SessionCacheOneServerTest extends FATServletClient {
             for (Future<Void> future : futures)
                 future.get(); // report any exceptions that might have occurred
 
-            // Fails intermittently for same reason as last TODO comment in this file (multiple versions created due to synchronization issues with last update)
-            // TODO re-enable once fixed
-            if (false) {
-                app.invokeServlet("testAttributeNames&allowOtherAttributes=false&sessionAttributes=" + attributeNames, session);
+            app.invokeServlet("testAttributeNames&allowOtherAttributes=false&sessionAttributes=" + attributeNames, session);
 
-                futures = executor.invokeAll(gets);
-                for (Future<Void> future : futures)
-                    future.get(); // report any exceptions that might have occurred
+            futures = executor.invokeAll(gets);
+            for (Future<Void> future : futures)
+                future.get(); // report any exceptions that might have occurred
 
-                // check exact values in cache
-                app.invokeServlet("testSessionInfoCache&sessionId=" + sessionId + "&attributes=" + attributeNames, session);
-                for (int i = 1; i <= NUM_THREADS; i++)
-                    app.invokeServlet("testSessionPropertyCache&sessionId=" + sessionId
-                                      + "&type=java.lang.Character&key=testConcurrentPutNewAttributesAndRemove-key" + i
-                                      + "&values=" + (char) ('A' + i),
-                                      session);
-            }
+            // check exact values in cache
+            app.invokeServlet("testSessionInfoCache&sessionId=" + sessionId + "&attributes=" + attributeNames, session);
+            for (int i = 1; i <= NUM_THREADS; i++)
+                app.invokeServlet("testSessionPropertyCache&sessionId=" + sessionId
+                                  + "&type=java.lang.Character&key=testConcurrentPutNewAttributesAndRemove-key" + i
+                                  + "&values=" + (char) ('A' + i),
+                                  session);
 
             futures = executor.invokeAll(removes);
             for (Future<Void> future : futures)
                 future.get(); // report any exceptions that might have occurred
-
-            // TODO re-enable, see above
-            if (true)
-                return;
 
             // first and last attribute must remain, others must be removed
             app.invokeServlet("testAttributeNames&allowOtherAttributes=false&sessionAttributes=" +
@@ -193,17 +185,15 @@ public class SessionCacheOneServerTest extends FATServletClient {
 
             app.invokeServlet("testAttributeNames&allowOtherAttributes=false&sessionAttributes=testConcurrentReplaceAttributes-key1,testConcurrentReplaceAttributes-key2", session);
 
-            // TODO intermittent failure due to same issue as other TODOs. Re-enable once fixed.
-            if (false)
-                for (Map.Entry<String, String> expected : expectedValues.entrySet()) {
-                    String response = app.invokeServlet("testAttributeIsAnyOf&type=java.lang.Integer&key=" + expected.getKey() + "&values=" + expected.getValue(), session);
+            for (Map.Entry<String, String> expected : expectedValues.entrySet()) {
+                String response = app.invokeServlet("testAttributeIsAnyOf&type=java.lang.Integer&key=" + expected.getKey() + "&values=" + expected.getValue(), session);
 
-                    int start = response.indexOf("session property value: [") + 25;
-                    String value = response.substring(start, response.indexOf("]", start));
+                int start = response.indexOf("session property value: [") + 25;
+                String value = response.substring(start, response.indexOf("]", start));
 
-                    // check exact value in JCache
-                    app.invokeServlet("testSessionPropertyCache&sessionId=" + sessionId + "&type=java.lang.Integer&key=" + expected.getKey() + "&values=" + value, session);
-                }
+                // check exact value in JCache
+                app.invokeServlet("testSessionPropertyCache&sessionId=" + sessionId + "&type=java.lang.Integer&key=" + expected.getKey() + "&values=" + value, session);
+            }
 
             app.invokeServlet("testSessionInfoCache&sessionId=" + sessionId + "&attributes=testConcurrentReplaceAttributes-key1,testConcurrentReplaceAttributes-key2", session);
         } finally {


### PR DESCRIPTION
There is an issue on the lazy init path where httpSessionCache properties are processed lazily, but it is possible for session manager invoke the getConfiguration method before lazy init happens.  This processing needs to be done eagerly, upon activate, so that session manager code reads the correct values.

Also, it should be possible to enable some of the concurrency tests that have previously been commented out due to fixes that have gone in.