### PR TITLE
ext.gitClone now clone is bucket is in spawn.experimentalfat

### DIFF
--- a/dev/cnf/gradle/scripts/fat.gradle
+++ b/dev/cnf/gradle/scripts/fat.gradle
@@ -363,7 +363,7 @@ ext.gitClone = { proj, branch = 'NOT_SET', folder = '', site = 'git@github.com',
   File gitReposDir = new File(project.buildDir, 'gitRepos')
 
   // If running locally use git directly
-  if( System.properties['fat.test.localrun'] ){
+  if( System.properties['fat.test.localrun'] || System.properties['spawn.experimentalfat.buckets'].contains(proj)){
 
     File repoDir = new File(gitReposDir, folder)
     String into = repoDir.getAbsolutePath()
@@ -379,24 +379,8 @@ ext.gitClone = { proj, branch = 'NOT_SET', folder = '', site = 'git@github.com',
     proc.err.eachLine { line -> println cmd + ':\n' + line }
     proc.waitFor()
     
-  } else {
-    // Make use of the EBC clone mechanism
-    project.logger.lifecycle('ebc clone')
-    ebcClone(url) 
-    
-    //EBC clones in dev/../../../<repo>
-    File ebcCloneDir = new File( project, "./../../../" )
-    copy {
-      from ebcCloneDir
-      include proj
-      into gitReposDir
-    }
   }
   
-}
-
-def ebcClone(String url, String branch, String repoPath){
-  // Non-local cloning is not implemented for now  
 }
 
 build {


### PR DESCRIPTION
Changing ext.gitClone so it no longer calls an unimplemented ebcClone method.
We do not need a separate method for cloning on our production machines, 
we just need to make the clone optional based on if the bucket is experimental, so not every build will clone

#build
