### PR TITLE
avoid reducing last accessed time

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -791,8 +791,8 @@ public class CacheHashMap extends BackedHashMap {
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "session current access time: " + curAccessTime);
                 updateCount = 0;
-            } else if (sessionInfo.getLastAccess() >= nowTime) { // avoid setting last access cache already has a later time
-                updateCount = 1; // be consistent with Statement.executeUpdate which returns 1 the when row matches but no changes are made
+            } else if (sessionInfo.getLastAccess() >= nowTime) { // avoid setting last access when the cache already has a later time
+                updateCount = 1; // be consistent with Statement.executeUpdate which returns 1 when the row matches but no changes are made
             } else {
                 sessionInfo.setLastAccess(nowTime);
                 ArrayList<?> newValue = sessionInfo.getArrayList();

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -791,7 +791,7 @@ public class CacheHashMap extends BackedHashMap {
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "session current access time: " + curAccessTime);
                 updateCount = 0;
-            } else if (sessionInfo.getLastAccess() == nowTime) {
+            } else if (sessionInfo.getLastAccess() >= nowTime) { // avoid setting last access cache already has a later time
                 updateCount = 1; // be consistent with Statement.executeUpdate which returns 1 the when row matches but no changes are made
             } else {
                 sessionInfo.setLastAccess(nowTime);


### PR DESCRIPTION
Http session cache's overQualLastAccessTimeUpdate method can end up reducing the last accessed time the way it is currently written.  We can easily detect this by comparing the value to write, and avoid writing the older time.  Checked with Alan that we want to return an update count of 1 in this case, even though we didn't actually make an update, for the sake of the code using this method.