### PR TITLE
update fallback from jwt to ltpa

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
@@ -116,7 +116,9 @@ public class SSOAuthenticator implements WebAuthenticator {
         }
 
         authResult = handleJwtSSO(req, res);
-        if ((authResult != null && authResult.getStatus().equals(AuthResult.SUCCESS)) || !JwtSSOTokenHelper.shouldFallbackToLtpaCookie()) {
+        // If there is a jwtSSOToken in a request, fallback to LTPA will not be allowed.
+        // If there is NO jwtSSOToken in a request and shouldFallbackToLtpaCookie is true, fall back to LTPA will be allowed
+        if (authResult != null || !JwtSSOTokenHelper.shouldFallbackToLtpaCookie()) {
             return authResult;
         }
 
@@ -158,6 +160,8 @@ public class SSOAuthenticator implements WebAuthenticator {
     }
 
     /**
+     * If there is no jwtSSOToken, we will return null. Otherwise, we will AuthenticationResult.
+     * 
      * @param cookies
      * @return
      */


### PR DESCRIPTION
Alow fallback to ltpa only if there is no jwtSSOToken in the request and shouldFallbackToLtpaCookie is true.