### PR TITLE
include session attribute names in session cache introspector

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -407,7 +407,7 @@ public class CacheStoreService implements Introspector, SessionStoreService {
                                     if (entry != null) {
                                         // deserialization of the value might require the application's class loader, which is not available during introspection
                                         byte[] bytes = (byte[]) entry.getValue();
-                                        out.println(INDENT + INDENT + "session " + entry.getKey() + ": " + (bytes == null ? null : ("byte[" + bytes.length + "]")));
+                                        out.println(INDENT + INDENT + "session attribute " + entry.getKey() + ": " + (bytes == null ? null : ("byte[" + bytes.length + "]")));
                                     }
                                 }
                             } else if (isMetaCache) {

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -399,7 +399,18 @@ public class CacheStoreService implements Introspector, SessionStoreService {
                             } catch (MalformedObjectNameException x) {
                                 // Internal error on diagnostics path, allow to continue after auto-logging FFDC
                             }
-                            if (isMetaCache) {
+                            if (isAttrCache) {
+                                out.println(INDENT + "First 100 entries:");
+                                int i = 0;
+                                for (Iterator<?> it = cache.iterator(); i++ < 50 && it.hasNext(); ) {
+                                    Entry<?, ?> entry = (Entry<?, ?>) it.next();
+                                    if (entry != null) {
+                                        // deserialization of the value might require the application's class loader, which is not available during introspection
+                                        byte[] bytes = (byte[]) entry.getValue();
+                                        out.println(INDENT + INDENT + "session " + entry.getKey() + ": " + (bytes == null ? null : ("byte[" + bytes.length + "]")));
+                                    }
+                                }
+                            } else if (isMetaCache) {
                                 out.println(INDENT + "First 50 entries:");
                                 int i = 0;
                                 for (Iterator<?> it = cache.iterator(); i++ < 50 && it.hasNext(); ) {

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheOneServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheOneServerTest.java
@@ -271,10 +271,9 @@ public class SessionCacheOneServerTest extends FATServletClient {
             app.invokeServlet("testSessionPropertyCache&sessionId=" + sessionId + "&type=java.lang.Integer&key=testConcurrentSetGetAndRemove-key&values=" + expectedValues,
                               session);
 
-            // The following fails intermittently and is being investigated. // TODO re-enable
             // verify the property name is present in the session info cache
-            //if (!"null".equals(value))
-            //    app.invokeServlet("testSessionInfoCache&sessionId=" + sessionId + "&attributes=testConcurrentSetGetAndRemove-key", session);
+            if (!"null".equals(value))
+                app.invokeServlet("testSessionInfoCache&sessionId=" + sessionId + "&attributes=testConcurrentSetGetAndRemove-key", session);
         } finally {
             app.invalidateSession(session);
         }


### PR DESCRIPTION
It would be helpful for the session cache introspector to include with session attributes are actually in the cache for debugging purposes.  Avoid values, which could include sensitive data, and in any case, cannot be guaranteed to deserialize from the introspector's class loader.