### PR TITLE
Apply change recoomendations in review of PR #3092

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
@@ -137,18 +137,23 @@ public class BaseTraceFormatter extends Formatter {
         if (level != null) {
             int l = level.intValue();
 
-            if (l == WsLevel.FATAL.intValue())
+            //WSLevel.FATAl -> int value of 1100
+            if (l == 1100)
                 return N_FATAL;
-            if (l == WsLevel.ERROR.intValue())
+            //WSLevel.ERROR -> int value of 1000
+            if (l == 1000)
                 return N_ERROR;
-            if (l == Level.WARNING.intValue())
+            //WSLevel.WARNING -> int value of 900
+            if (l == 900)
                 return N_WARN;
-            if (l == WsLevel.AUDIT.intValue())
+            //WSLevel.AUDIT -> int value of 850
+            if (l == 850)
                 return N_AUDIT;
-            if (l == Level.INFO.intValue())
+            //WSLevel.INFO -> int value of 800
+            if (l == 800)
                 return N_INFO;
-
-            if (level == WsLevel.EVENT.intValue())
+            //WSLevel.EVENT -> int value of 500
+            if (level == 500)
                 return N_EVENT;
         }
         return "";
@@ -851,22 +856,7 @@ public class BaseTraceFormatter extends Formatter {
     }
 
     private final String generateObjectId(Object id, boolean fixedWidth) {
-        String objId;
-
-        if (id != null) {
-            objId = Integer.toHexString(System.identityHashCode(id));
-            if (objId.length() < 8) {
-                StringBuilder builder = new StringBuilder();
-                builder.append("00000000");
-                builder.append(objId);
-                objId = builder.substring(builder.length() - 8);
-            }
-        } else if (fixedWidth) {
-            objId = pad8;
-        } else {
-            objId = emptyString;
-        }
-        return objId;
+        return generateObjectId(System.identityHashCode(id), fixedWidth);
     }
 
     /**
@@ -1072,13 +1062,8 @@ public class BaseTraceFormatter extends Formatter {
      *
      * @return
      */
-    //change to public
     public WsLogRecord getWsLogRecord(LogRecord logRecord) {
-        try {
-            return (WsLogRecord) logRecord;
-        } catch (ClassCastException ex) {
-            return null;
-        }
+        return (logRecord instanceof WsLogRecord) ? (WsLogRecord) logRecord : null;
     }
 
     /**
@@ -1106,7 +1091,7 @@ public class BaseTraceFormatter extends Formatter {
             }
         }
 
-        String message = filterStackTraces(txt);
+        String message = BaseTraceService.filterStackTraces(txt);
         if (message != null) {
             if (loglevel.equals("SystemErr")) {
                 message = "[err] " + message;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -432,7 +432,7 @@ public class BaseTraceService implements TrService {
      */
     private void commonConsoleLogHandlerUpdates() {
         if (consoleLogHandler != null) {
-            consoleLogHandler.setFormatter(formatter);
+            consoleLogHandler.setBasicFormatter(formatter);
             consoleLogHandler.setConsoleLogLevel(consoleLogLevel.intValue());
             consoleLogHandler.setCopySystemStreams(copySystemStreams);
         }
@@ -444,7 +444,7 @@ public class BaseTraceService implements TrService {
     private void commonMessageLogHandlerUpdates() {
         if (messageLogHandler != null) {
             messageLogHandler.setWriter(messagesLog);
-            messageLogHandler.setFormatter(formatter);
+            messageLogHandler.setBasicFormatter(formatter);
         }
     }
 
@@ -735,7 +735,6 @@ public class BaseTraceService implements TrService {
         Level level = logRecord.getLevel();
         int levelValue = level.intValue();
         TraceWriter detailLog = traceLog;
-        //check if tracefilename is stdout
 
         if (levelValue >= Level.INFO.intValue()) {
 
@@ -1112,7 +1111,7 @@ public class BaseTraceService implements TrService {
      * @return null if the stack trace should be suppressed, or an indicator we're suppressing,
      *         or maybe the original stack trace
      */
-    private String filterStackTraces(String txt) {
+    public static String filterStackTraces(String txt) {
         // Check for stack traces, which we may want to trim
         StackTraceFlags stackTraceFlags = traceFlags.get();
         // We have a little thread-local state machine here with four states controlled by two

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/ConsoleLogHandler.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/ConsoleLogHandler.java
@@ -32,7 +32,7 @@ public class ConsoleLogHandler extends JsonLogHandler implements SynchronousHand
     private boolean isTraceStdout = false;
 
     private String format = LoggingConstants.DEFAULT_MESSAGE_FORMAT;
-    private BaseTraceFormatter formatter = null;
+    private BaseTraceFormatter basicFormatter = null;
     private Integer consoleLogLevel = null;
 
     private boolean copySystemStreams = false;
@@ -125,7 +125,7 @@ public class ConsoleLogHandler extends JsonLogHandler implements SynchronousHand
                 }
             }
 
-        } else if (format.equals(LoggingConstants.DEFAULT_CONSOLE_FORMAT) && formatter != null) {
+        } else if (format.equals(LoggingConstants.DEFAULT_CONSOLE_FORMAT) && basicFormatter != null) {
             //if traceFilename=stdout write everything to console.log in trace format
             String logLevel = ((LogTraceData) event).getLoglevel();
             if (isTraceStdout) {
@@ -133,7 +133,7 @@ public class ConsoleLogHandler extends JsonLogHandler implements SynchronousHand
                 if (levelVal == WsLevel.ERROR.intValue() || levelVal == WsLevel.FATAL.intValue()) {
                     isStderr = true;
                 }
-                messageOutput = formatter.traceFormatGenData(genData);
+                messageOutput = basicFormatter.traceFormatGenData(genData);
             } // copySystemStream and stderr/stdout (i.e WsLevel.CONFIG)
             else if (copySystemStreams && (levelVal == WsLevel.CONFIG.intValue())) {
                 if (logLevel != null) {
@@ -141,7 +141,7 @@ public class ConsoleLogHandler extends JsonLogHandler implements SynchronousHand
                         isStderr = true;
                     }
                 }
-                messageOutput = formatter.formatStreamOutput(genData);
+                messageOutput = basicFormatter.formatStreamOutput(genData);
 
                 //Null return values means we are suppressing a stack trace.. and we don't want to write a 'null' so we return.
                 if (messageOutput == null)
@@ -153,7 +153,7 @@ public class ConsoleLogHandler extends JsonLogHandler implements SynchronousHand
                 if (levelVal == WsLevel.ERROR.intValue() || levelVal == WsLevel.FATAL.intValue()) {
                     isStderr = true;
                 }
-                messageOutput = formatter.consoleLogFormat(genData);
+                messageOutput = basicFormatter.consoleLogFormat(genData);
             }
         }
 
@@ -190,7 +190,7 @@ public class ConsoleLogHandler extends JsonLogHandler implements SynchronousHand
     }
 
     /**
-     * Set copySystemStreams value that was determined from config by BasegTraceService
+     * Set copySystemStreams value that was determined from config by BaseTraceService
      *
      * @param copySystemStreams value to determine whether to copysystemstreams or not
      */
@@ -200,11 +200,13 @@ public class ConsoleLogHandler extends JsonLogHandler implements SynchronousHand
 
     /**
      * Set BaseTraceFormatter passed from BaseTraceService
+     * This Formatter is used to format the BASIC log events
+     * that pass through
      *
      * @param formatter the BaseTraceFormatter to use
      */
-    public void setFormatter(BaseTraceFormatter formatter) {
-        this.formatter = formatter;
+    public void setBasicFormatter(BaseTraceFormatter formatter) {
+        this.basicFormatter = formatter;
     }
 
     /**

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/MessageLogHandler.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/MessageLogHandler.java
@@ -25,7 +25,7 @@ public class MessageLogHandler extends JsonLogHandler implements SynchronousHand
     public static final String COMPONENT_NAME = "com.ibm.ws.logging.internal.impl.MessageLogHandler";
 
     private String format = LoggingConstants.DEFAULT_MESSAGE_FORMAT;
-    private BaseTraceFormatter formatter = null;
+    private BaseTraceFormatter basicFormatter = null;
 
     public MessageLogHandler(String serverName, String wlpUserDir, List<String> sourcesList) {
         super(serverName, wlpUserDir, sourcesList);
@@ -66,12 +66,8 @@ public class MessageLogHandler extends JsonLogHandler implements SynchronousHand
             }
             messageOutput = genData.getJsonMessage();
 
-            if (messageOutput == null) {
-                messageOutput = (String) formatEvent(eventSourceType, CollectorConstants.MEMORY, event, null, MAXFIELDLENGTH);
-            }
-
-        } else if (currFormat.equals(LoggingConstants.DEFAULT_MESSAGE_FORMAT) && formatter != null) {
-            messageOutput = formatter.messageLogFormat(genData);
+        } else if (currFormat.equals(LoggingConstants.DEFAULT_MESSAGE_FORMAT) && basicFormatter != null) {
+            messageOutput = basicFormatter.messageLogFormat(genData);
 
         }
         if (messageOutput != null && traceWriter != null) {
@@ -82,11 +78,13 @@ public class MessageLogHandler extends JsonLogHandler implements SynchronousHand
 
     /**
      * Set BaseTraceFormatter passed from BaseTraceService
+     * This formatter is used to format the BASIC log events
+     * that pass through
      *
      * @param formatter the BaseTraceFormatter to use
      */
-    public void setFormatter(BaseTraceFormatter formatter) {
-        this.formatter = formatter;
+    public void setBasicFormatter(BaseTraceFormatter formatter) {
+        this.basicFormatter = formatter;
     }
 
     /**

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
@@ -162,6 +162,8 @@ public class LogSource implements Source, WsLogHandler {
         logData.setThreadName(threadName);
 
         WsLogRecord wsLogRecord = getWsLogRecord(logRecord);
+        //Extensions KVP calculated below, but needs to bet set in the correct 'order' further below
+        KeyValuePairList extensions = null;
         if (wsLogRecord != null) {
             logData.setCorrelationId(wsLogRecord.getCorrelationId());
             logData.setOrg(wsLogRecord.getOrganization());
@@ -169,19 +171,18 @@ public class LogSource implements Source, WsLogHandler {
             logData.setComponent(wsLogRecord.getComponent());
 
             if (wsLogRecord.getExtensions() != null) {
-                KeyValuePairList extensions = new KeyValuePairList(LogFieldConstants.EXTENSIONS_KVPL);
+                extensions = new KeyValuePairList(LogFieldConstants.EXTENSIONS_KVPL);
                 Map<String, String> extMap = wsLogRecord.getExtensions();
                 for (Map.Entry<String, String> entry : extMap.entrySet()) {
                     CollectorJsonHelpers.handleExtensions(extensions, entry.getKey(), entry.getValue());
                 }
-                logData.setExtensions(extensions);
             }
         } else {
             logData.setCorrelationId(null);
             logData.setOrg(null);
             logData.setProduct(null);
             logData.setComponent(null);
-            logData.setExtensions(null);
+            extensions = null;
         }
 
         logData.setSequence(sequenceNumber.next(dateVal));
@@ -218,6 +219,8 @@ public class LogSource implements Source, WsLogHandler {
         }
 
         // cannot pass null to traceData.setObjectId(int i)
+
+        logData.setExtensions(extensions);
 
         logData.setSourceType(sourceName);
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/TraceSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/TraceSource.java
@@ -120,25 +120,26 @@ public class TraceSource implements Source, WsTraceHandler {
         traceData.setThreadName(threadName);
 
         WsLogRecord wsLogRecord = getWsLogRecord(logRecord);
+        //Extensions KVP calculated below, but needs to bet set in the correct 'order' further below
+        KeyValuePairList extensions = null;
         if (wsLogRecord != null) {
             traceData.setCorrelationId(wsLogRecord.getCorrelationId());
             traceData.setOrg(wsLogRecord.getOrganization());
             traceData.setProduct(wsLogRecord.getProduct());
             traceData.setComponent(wsLogRecord.getComponent());
             if (wsLogRecord.getExtensions() != null) {
-                KeyValuePairList extensions = new KeyValuePairList(LogFieldConstants.EXTENSIONS_KVPL);
+                extensions = new KeyValuePairList(LogFieldConstants.EXTENSIONS_KVPL);
                 Map<String, String> extMap = wsLogRecord.getExtensions();
                 for (Map.Entry<String, String> entry : extMap.entrySet()) {
                     CollectorJsonHelpers.handleExtensions(extensions, entry.getKey(), entry.getValue());
                 }
-                traceData.setExtensions(extensions);
             }
         } else {
             traceData.setCorrelationId(null);
             traceData.setOrg(null);
             traceData.setProduct(null);
             traceData.setComponent(null);
-            traceData.setExtensions(null);
+            extensions = null;
         }
 
         String sequenceNum = sequenceNumber.next(datetimeValue);
@@ -155,6 +156,8 @@ public class TraceSource implements Source, WsTraceHandler {
         }
 
         traceData.setFormattedMsg(null);
+
+        traceData.setExtensions(extensions);
 
         if (id != null) {
             int objid = System.identityHashCode(id);

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/TraceSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/TraceSource.java
@@ -15,7 +15,6 @@ import java.util.logging.LogRecord;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.logging.RoutedMessage;
 import com.ibm.ws.logging.WsTraceHandler;
 import com.ibm.ws.logging.collector.CollectorJsonHelpers;
@@ -98,12 +97,7 @@ public class TraceSource implements Source, WsTraceHandler {
     /** {@inheritDoc} */
     @Override
     public void publish(RoutedMessage routedMessage) {
-        //Publish the message if it is not coming from a handler thread
-        if (!ThreadLocalHandler.get()) {
-            if (routedMessage.getLogRecord() != null && bufferMgr != null) {
-                bufferMgr.add(parse(routedMessage, null));
-            }
-        }
+        publish(routedMessage, null);
     }
 
     public LogTraceData parse(RoutedMessage routedMessage, Object id) {
@@ -131,11 +125,20 @@ public class TraceSource implements Source, WsTraceHandler {
             traceData.setOrg(wsLogRecord.getOrganization());
             traceData.setProduct(wsLogRecord.getProduct());
             traceData.setComponent(wsLogRecord.getComponent());
+            if (wsLogRecord.getExtensions() != null) {
+                KeyValuePairList extensions = new KeyValuePairList(LogFieldConstants.EXTENSIONS_KVPL);
+                Map<String, String> extMap = wsLogRecord.getExtensions();
+                for (Map.Entry<String, String> entry : extMap.entrySet()) {
+                    CollectorJsonHelpers.handleExtensions(extensions, entry.getKey(), entry.getValue());
+                }
+                traceData.setExtensions(extensions);
+            }
         } else {
             traceData.setCorrelationId(null);
             traceData.setOrg(null);
             traceData.setProduct(null);
             traceData.setComponent(null);
+            traceData.setExtensions(null);
         }
 
         String sequenceNum = sequenceNumber.next(datetimeValue);
@@ -153,19 +156,6 @@ public class TraceSource implements Source, WsTraceHandler {
 
         traceData.setFormattedMsg(null);
 
-        if (logRecord instanceof WsLogRecord) {
-            if (((WsLogRecord) logRecord).getExtensions() != null) {
-                KeyValuePairList extensions = new KeyValuePairList(LogFieldConstants.EXTENSIONS_KVPL);
-                Map<String, String> extMap = ((WsLogRecord) logRecord).getExtensions();
-                for (Map.Entry<String, String> entry : extMap.entrySet()) {
-                    CollectorJsonHelpers.handleExtensions(extensions, entry.getKey(), entry.getValue());
-                }
-                traceData.setExtensions(extensions);
-            }
-        } else {
-            traceData.setExtensions(null);
-        }
-
         if (id != null) {
             int objid = System.identityHashCode(id);
             traceData.setObjectId(objid);
@@ -178,12 +168,7 @@ public class TraceSource implements Source, WsTraceHandler {
         return traceData;
     }
 
-    @FFDCIgnore(value = { ClassCastException.class })
     private WsLogRecord getWsLogRecord(LogRecord logRecord) {
-        try {
-            return (WsLogRecord) logRecord;
-        } catch (ClassCastException ex) {
-            return null;
-        }
+        return (logRecord instanceof WsLogRecord) ? (WsLogRecord) logRecord : null;
     }
 }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/CollectorManagerPipelineUtils.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/CollectorManagerPipelineUtils.java
@@ -111,7 +111,7 @@ public class CollectorManagerPipelineUtils implements CollectorManagerPipelineBo
     }
 
     /**
-     * Used by the collectorManagerPipelineConfigurator to identify if pipeline was spawned as part
+     * Used by the MessageRouterConfigurator and TraceRouterConfigurator to identify if pipeline was spawned as part
      * of BaseTraceService, If it is then the LogSource and Trace Source will not be set into WsMessageRouter or WsTraceRouter.
      * Otherwise it will be set into the Routers (e.g. through an HPEL BaseTraceService)
      *


### PR DESCRIPTION
- Modified comments in CollectorManagerPipelineUtils and
BaseTraceService
- Remove redundant code in MessageLogHandler
- Rename setFormatter to setBasicFormatter and the variable formatter to
basicFormatter in ConsoleLogHandler and MessageLoghandler
- Refactor code identifying if a message object is a WslogRecord and
subsequent logic of handling it in LogSource and TraceSource and
BaseTraceFormatter
- Use of explicit int values in BaseTraceFormatter for performance

Fixes #3092
