### PR TITLE
Handle exceptions that occur during cache operations

### DIFF
--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
@@ -20,3 +20,33 @@
 INCORRECT_URI_SYNTAX=SESN0300E: Invalid syntax in httpSessionCache URI.  Cause is {0}.
 INCORRECT_URI_SYNTAX.explanation=The syntax of the specified httpSessionCache JCache configuration URI is invalid.
 INCORRECT_URI_SYNTAX.useraction=Correct the syntax of the specified httpSessionCache configuration URI.
+
+ERROR_REMOVING_SESSION=SESN0301E: An exception occurred when removing a session from the cache. The exception is: {0}.
+ERROR_REMOVING_SESSION.explanation=An operation against the cache failed due to the specified exception.
+ERROR_REMOVING_SESSION.useraction=See the exception for more details. The JCache provider's configuration might need to be updated.
+
+PROP_HIT_ERROR=SESN0302E: An exception occurred when storing application data changes to the cache. The exception is: {0}.
+PROP_HIT_ERROR.explanation=An operation against the cache failed due to the specified exception.
+PROP_HIT_ERROR.useraction=See the exception for more details. The JCache provider's configuration might need to be updated.
+
+STORE_SESS_ERROR=SESN0303E: An exception occurred when storing a session in the cache. The exception is: {0}.
+STORE_SESS_ERROR.explanation=An operation against the cache failed due to the specified exception.
+STORE_SESS_ERROR.useraction=See the exception for more details. The JCache provider's configuration might need to be updated.
+
+LOAD_VALUE_ERROR=SESN0304E: An exception occurred when reading in an object of the application data for a session from the cache. The exception is: {0}.
+LOAD_VALUE_ERROR.explanation=An operation against the cache failed due to the specified exception.
+LOAD_VALUE_ERROR.useraction=See the exception for more details. The JCache provider's configuration might need to be updated.
+
+ERROR_CACHE_ACCESS=SESN0305E: An exception occurred while attempting to access the cache. The exception is: {0}.
+ERROR_CACHE_ACCESS.explanation=An operation against the cache failed due to the specified exception.
+ERROR_CACHE_ACCESS.useraction=See the exception for more details. The JCache provider's configuration might need to be updated.
+
+ERROR_SESSION_INVAL=SESN0306E: An exception occurred when invalidating a session in the cache. The exception is: {0}.
+ERROR_SESSION_INVAL.explanation=An operation against the cache failed due to the specified exception.
+ERROR_SESSION_INVAL.useraction=See the exception for more details. The JCache provider's configuration might need to be updated.
+
+ERROR_SESSION_INIT=SESN0307E: An exception occurred when initializing the cache. The exception is: {0}.
+ERROR_SESSION_INIT.explanation=An operation against the cache failed due to the specified exception.
+ERROR_SESSION_INIT.useraction=See the exception for more details. The JCache provider's configuration might need to be updated.
+
+INTERNAL_SERVER_ERROR=Internal Server Error

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -144,98 +144,104 @@ public class CacheHashMap extends BackedHashMap {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         // Attempt lazy initialization if necessary
-        if (cacheStoreService.cacheManager == null)
-            cacheStoreService.activateLazily();
+        try{
+            if (cacheStoreService.cacheManager == null)
+                cacheStoreService.activateLazily();
 
-        // Build a unique per-application cache name by starting with the application context root and percent encoding
-        // the / and : characters (JCache spec does not allow these in cache names)
-        // and also the % character (which is necessary because of percent encoding)
-        String a = PERCENT.matcher(_iStore.getId()).replaceAll("%25"); // must be done first to avoid replacing % that is added when replacing the others
-        a = SLASH.matcher(a).replaceAll("%2F");
-        a = COLON.matcher(a).replaceAll("%3A");
+            // Build a unique per-application cache name by starting with the application context root and percent encoding
+            // the / and : characters (JCache spec does not allow these in cache names)
+            // and also the % character (which is necessary because of percent encoding)
+            String a = PERCENT.matcher(_iStore.getId()).replaceAll("%25"); // must be done first to avoid replacing % that is added when replacing the others
+            a = SLASH.matcher(a).replaceAll("%2F");
+            a = COLON.matcher(a).replaceAll("%3A");
 
-        // Session Meta Information Cache
+            // Session Meta Information Cache
 
-        String metaCacheName = new StringBuilder(24 + a.length()).append("com.ibm.ws.session.meta.").append(a).toString();
+            String metaCacheName = new StringBuilder(24 + a.length()).append("com.ibm.ws.session.meta.").append(a).toString();
 
-        if (trace && tc.isDebugEnabled())
-            tcInvoke(cacheStoreService.tcCacheManager, "getCache", metaCacheName, "String", "ArrayList");
-
-        sessionMetaCache = cacheStoreService.cacheManager.getCache(metaCacheName, String.class, ArrayList.class);
-        boolean create;
-        if (create = sessionMetaCache == null) {
             if (trace && tc.isDebugEnabled())
-                tcReturn(cacheStoreService.tcCacheManager, "getCache", "null");
+                tcInvoke(cacheStoreService.tcCacheManager, "getCache", metaCacheName, "String", "ArrayList");
 
-            @SuppressWarnings("rawtypes")
-            MutableConfiguration<String, ArrayList> config = new MutableConfiguration<String, ArrayList>()
-                            .setTypes(String.class, ArrayList.class)
-                            .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
-            if (cacheStoreService.supportsStoreByReference)
-                config = config.setStoreByValue(false);
-            try {
+            sessionMetaCache = cacheStoreService.cacheManager.getCache(metaCacheName, String.class, ArrayList.class);
+            boolean create;
+            if (create = sessionMetaCache == null) {
                 if (trace && tc.isDebugEnabled())
-                    tcInvoke(cacheStoreService.tcCacheManager, "createCache", metaCacheName, config);
+                    tcReturn(cacheStoreService.tcCacheManager, "getCache", "null");
 
-                sessionMetaCache = cacheStoreService.cacheManager.createCache(metaCacheName, config);
-            } catch (CacheException x) {
-                create = false;
-                if (trace && tc.isDebugEnabled()) {
-                    tcReturn(cacheStoreService.tcCacheManager, "createCache", x);
-                    tcInvoke(cacheStoreService.tcCacheManager, "getCache", metaCacheName, "String", "ArrayList");
+                @SuppressWarnings("rawtypes")
+                MutableConfiguration<String, ArrayList> config = new MutableConfiguration<String, ArrayList>()
+                .setTypes(String.class, ArrayList.class)
+                .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
+                if (cacheStoreService.supportsStoreByReference)
+                    config = config.setStoreByValue(false);
+                try {
+                    if (trace && tc.isDebugEnabled())
+                        tcInvoke(cacheStoreService.tcCacheManager, "createCache", metaCacheName, config);
+
+                    sessionMetaCache = cacheStoreService.cacheManager.createCache(metaCacheName, config);
+                } catch (CacheException x) {
+                    create = false;
+                    if (trace && tc.isDebugEnabled()) {
+                        tcReturn(cacheStoreService.tcCacheManager, "createCache", x);
+                        tcInvoke(cacheStoreService.tcCacheManager, "getCache", metaCacheName, "String", "ArrayList");
+                    }
+                    sessionMetaCache = cacheStoreService.cacheManager.getCache(metaCacheName, String.class, ArrayList.class);
+                    if (sessionMetaCache == null)
+                        throw x;
                 }
-                sessionMetaCache = cacheStoreService.cacheManager.getCache(metaCacheName, String.class, ArrayList.class);
-                if (sessionMetaCache == null)
-                    throw x;
             }
-        }
 
-        tcSessionMetaCache = "MetaCache" + Integer.toHexString(System.identityHashCode(sessionMetaCache));
-        if (trace && tc.isDebugEnabled())
-            tcReturn(cacheStoreService.tcCacheManager, create ? "createCache" : "getCache", tcSessionMetaCache, sessionMetaCache);
-
-        cacheStoreService.configureMonitoring(metaCacheName);
-
-        // Session Attributes Cache
-
-        String attrCacheName = new StringBuilder(24 + a.length()).append("com.ibm.ws.session.attr.").append(a).toString();
-
-        if (trace && tc.isDebugEnabled())
-            tcInvoke(cacheStoreService.tcCacheManager, "getCache", attrCacheName, "String", "byte[]");
-
-        sessionAttributeCache = cacheStoreService.cacheManager.getCache(attrCacheName, String.class, byte[].class);
-
-        if (create = sessionAttributeCache == null) {
+            tcSessionMetaCache = "MetaCache" + Integer.toHexString(System.identityHashCode(sessionMetaCache));
             if (trace && tc.isDebugEnabled())
-                tcReturn(cacheStoreService.tcCacheManager, "getCache", "null");
+                tcReturn(cacheStoreService.tcCacheManager, create ? "createCache" : "getCache", tcSessionMetaCache, sessionMetaCache);
 
-            MutableConfiguration<String, byte[]> config = new MutableConfiguration<String, byte[]>()
-                            .setTypes(String.class, byte[].class)
-                            .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
-            if (cacheStoreService.supportsStoreByReference)
-                config = config.setStoreByValue(false);
-            try {
+            cacheStoreService.configureMonitoring(metaCacheName);
+
+            // Session Attributes Cache
+
+            String attrCacheName = new StringBuilder(24 + a.length()).append("com.ibm.ws.session.attr.").append(a).toString();
+
+            if (trace && tc.isDebugEnabled())
+                tcInvoke(cacheStoreService.tcCacheManager, "getCache", attrCacheName, "String", "byte[]");
+
+            sessionAttributeCache = cacheStoreService.cacheManager.getCache(attrCacheName, String.class, byte[].class);
+
+            if (create = sessionAttributeCache == null) {
                 if (trace && tc.isDebugEnabled())
-                    tcInvoke(cacheStoreService.tcCacheManager, "createCache", attrCacheName, config);
+                    tcReturn(cacheStoreService.tcCacheManager, "getCache", "null");
 
-                sessionAttributeCache = cacheStoreService.cacheManager.createCache(attrCacheName, config);
-            } catch (CacheException x) {
-                create = false;
-                if (trace && tc.isDebugEnabled()) {
-                    tcReturn(cacheStoreService.tcCacheManager, "createCache", x);
-                    tcInvoke(cacheStoreService.tcCacheManager, "getCache", attrCacheName, "String", "byte[]");
+                MutableConfiguration<String, byte[]> config = new MutableConfiguration<String, byte[]>()
+                                .setTypes(String.class, byte[].class)
+                                .setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
+                if (cacheStoreService.supportsStoreByReference)
+                    config = config.setStoreByValue(false);
+                try {
+                    if (trace && tc.isDebugEnabled())
+                        tcInvoke(cacheStoreService.tcCacheManager, "createCache", attrCacheName, config);
+
+                    sessionAttributeCache = cacheStoreService.cacheManager.createCache(attrCacheName, config);
+                } catch (CacheException x) {
+                    create = false;
+                    if (trace && tc.isDebugEnabled()) {
+                        tcReturn(cacheStoreService.tcCacheManager, "createCache", x);
+                        tcInvoke(cacheStoreService.tcCacheManager, "getCache", attrCacheName, "String", "byte[]");
+                    }
+                    sessionAttributeCache = cacheStoreService.cacheManager.getCache(attrCacheName, String.class, byte[].class);
+                    if (sessionAttributeCache == null)
+                        throw x;
                 }
-                sessionAttributeCache = cacheStoreService.cacheManager.getCache(attrCacheName, String.class, byte[].class);
-                if (sessionAttributeCache == null)
-                    throw x;
             }
+
+            tcSessionAttrCache = "AttrCache" + Integer.toHexString(System.identityHashCode(sessionAttributeCache));
+            if (trace && tc.isDebugEnabled())
+                tcReturn(cacheStoreService.tcCacheManager, create ? "createCache" : "getCache", tcSessionAttrCache, sessionAttributeCache);
+
+            cacheStoreService.configureMonitoring(attrCacheName);
+        } catch(Exception ex) {
+            //auto ffdc
+            Tr.error(tc, "ERROR_SESSION_INIT", ex);
+            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
         }
-
-        tcSessionAttrCache = "AttrCache" + Integer.toHexString(System.identityHashCode(sessionAttributeCache));
-        if (trace && tc.isDebugEnabled())
-            tcReturn(cacheStoreService.tcCacheManager, create ? "createCache" : "getCache", tcSessionAttrCache, sessionAttributeCache);
-
-        cacheStoreService.configureMonitoring(attrCacheName);
     }
 
     /**
@@ -352,6 +358,7 @@ public class CacheHashMap extends BackedHashMap {
             }
         } catch (Exception x) {
             // auto FFDC
+            Tr.error(tc, "ERROR_SESSION_INVAL", x);
         }
     }
 
@@ -360,6 +367,7 @@ public class CacheHashMap extends BackedHashMap {
      * Copied from DatabaseHashMapMR.
      */
     @Trivial // return value contains customer data
+    @FFDCIgnore(Exception.class) //manually logged
     Object getAllValues(BackedSession sess) {
         @SuppressWarnings("static-access")
         final boolean hideValues = _smc.isHideSessionValues();
@@ -372,19 +380,20 @@ public class CacheHashMap extends BackedHashMap {
 
         long startTime = System.nanoTime();
         long readSize = 0;
-
-        if (trace && tc.isDebugEnabled())
-            tcInvoke(tcSessionMetaCache, "get", id);
-
-        ArrayList<?> list = sessionMetaCache.get(id);
-
-        if (trace && tc.isDebugEnabled())
-            tcReturn(tcSessionMetaCache, "get", list);
-
-        Set<String> propIds = list == null ? null : new SessionInfo(list).getSessionPropertyIds();
-
         Hashtable<String, Object> h = new Hashtable<String, Object>();
+
         try {
+
+            if (trace && tc.isDebugEnabled())
+                tcInvoke(tcSessionMetaCache, "get", id);
+
+            ArrayList<?> list = sessionMetaCache.get(id);
+
+            if (trace && tc.isDebugEnabled())
+                tcReturn(tcSessionMetaCache, "get", list);
+
+            Set<String> propIds = list == null ? null : new SessionInfo(list).getSessionPropertyIds();
+
             if (propIds != null) {
                 for (String propId : propIds) {
                     // If an attribute is already in appDataRemovals or appDataChanges, then the attribute was already retrieved from the cache.  Skip retrieval from the cache here.
@@ -413,18 +422,18 @@ public class CacheHashMap extends BackedHashMap {
                         try {
                             value = deserialize(b);
                             readSize += b.length;
-                            
+
                             if (trace && tc.isDebugEnabled())
                                 if (hideValues)
                                     tcReturn(tcSessionAttrCache, "get", "byte[" + b.length + "]");
                                 else
                                     tcReturn(tcSessionAttrCache, "get", b, value);
-                        } catch (ClassNotFoundException x) {
+                        } catch (Exception x) {
                             if (trace && tc.isDebugEnabled())
                                 tcReturn(tcSessionAttrCache, "get", hideValues ? ("byte[" + b.length + "]") : b);
 
                             FFDCFilter.processException(x, getClass().getName(), "91", sess, new Object[] { hideValues ? "byte[" + b.length + "]" : TypeConversion.limitedBytesToString(b) });
-                            throw new RuntimeException(x);
+                            throw x;
                         }                   
                         if (value != null) {
                             h.put(propId, value);
@@ -437,11 +446,10 @@ public class CacheHashMap extends BackedHashMap {
             if (pmiStats != null) {
                 pmiStats.readTimes(readSize, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
             }
-        } catch (IOException e) {
-            FFDCFilter.processException(e, getClass().getName(), "319", sess);
-            if (trace && tc.isEntryEnabled())
-                Tr.exit(this, tc, "getAllValues", e);
-            throw new RuntimeException(e);
+        } catch (Exception ex) {
+            FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.getAllValues", "448", this, new Object[] { sess });
+            Tr.error(tc, "LOAD_VALUE_ERROR", ex);
+            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
         }
 
         if (trace && tc.isEntryEnabled())
@@ -461,6 +469,7 @@ public class CacheHashMap extends BackedHashMap {
      * copied from DatabaseHashMapMR
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
+    @FFDCIgnore(Exception.class) //manually logged
     private boolean handlePropertyHits(BackedSession session) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
@@ -616,7 +625,7 @@ public class CacheHashMap extends BackedHashMap {
                             TimeUnit.MILLISECONDS.sleep(backoff + (long) Math.random() * backoff);
                         } catch (InterruptedException x) {
                             FFDCFilter.processException(x, getClass().getName(), "324", new Object[] { id, backoff, propsToWrite, propsToRemove });
-                            throw new RuntimeException(x);
+                            throw x;
                         }
                     if (trace && tc.isDebugEnabled())
                         tcInvoke(tcSessionMetaCache, "get", id);
@@ -626,7 +635,7 @@ public class CacheHashMap extends BackedHashMap {
                     if (trace && tc.isDebugEnabled())
                         tcReturn(tcSessionMetaCache, "get", oldValue);
                     if (oldValue == null) 
-                        {break;} // TODO implement code path where cache entry for session is expired. Delete the property entries?
+                    {break;} // TODO implement code path where cache entry for session is expired. Delete the property entries?
                     SessionInfo sessionInfo = new SessionInfo(oldValue).clone();
                     if (propsToWrite != null)
                         sessionInfo.addSessionPropertyIds(propsToWrite);
@@ -643,9 +652,10 @@ public class CacheHashMap extends BackedHashMap {
                         tcReturn(tcSessionMetaCache, "replace", replaced);
                 }
             }
-        } catch (IOException x) {
-            FFDCFilter.processException(x, getClass().getName(), "256", session);
-            throw new RuntimeException(x);
+        } catch (Exception ex) {
+            FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.handlePropertyHits", "656", this, new Object[] { session });
+            Tr.error(tc, "PROP_HIT_ERROR", ex);
+            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
         }
 
         return true;
@@ -655,6 +665,7 @@ public class CacheHashMap extends BackedHashMap {
      * @see com.ibm.ws.session.store.common.BackedHashMap#insertSession(com.ibm.ws.session.store.common.BackedSession)
      */
     @Override
+    @FFDCIgnore(Exception.class) //manually logged
     protected void insertSession(BackedSession session) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
@@ -668,14 +679,20 @@ public class CacheHashMap extends BackedHashMap {
         SessionInfo sessionInfo = new SessionInfo(tmpCreationTime, session.getMaxInactiveInterval(), session.listenerFlag, session.getUserName());
         ArrayList<Object> list = sessionInfo.getArrayList();
 
-        if (trace && tc.isDebugEnabled())
-            tcInvoke(tcSessionMetaCache, "putIfAbsent", id, list);
+        boolean added = false;
+        try {
+            if (trace && tc.isDebugEnabled())
+                tcInvoke(tcSessionMetaCache, "putIfAbsent", id, list);
 
-        boolean added = sessionMetaCache.putIfAbsent(id, list);
+            added = sessionMetaCache.putIfAbsent(id, list);
 
-        if (trace && tc.isDebugEnabled())
-            tcReturn(tcSessionMetaCache, "putIfAbsent", added);
-
+            if (trace && tc.isDebugEnabled())
+                tcReturn(tcSessionMetaCache, "putIfAbsent", added);     
+        } catch(Exception ex) {
+            FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.insertSession", "690", this, new Object[] { session });
+            Tr.error(tc, "STORE_SESS_ERROR", ex);   
+            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
+        }
         if (!added)
             throw new IllegalStateException("Cache already contains " + id);
 
@@ -693,15 +710,23 @@ public class CacheHashMap extends BackedHashMap {
      * @see com.ibm.ws.session.store.common.BackedHashMap#isPresent(java.lang.String)
      */
     @Override
+    @FFDCIgnore(Exception.class) //manually logged
     protected boolean isPresent(String id) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
-        if (trace && tc.isDebugEnabled())
-            tcInvoke(tcSessionMetaCache, "containsKey", id);
+        boolean contains = false;
+        try {
+            if (trace && tc.isDebugEnabled())
+                tcInvoke(tcSessionMetaCache, "containsKey", id);
 
-        boolean contains = sessionMetaCache.containsKey(id);
+            contains = sessionMetaCache.containsKey(id);
 
-        if (trace && tc.isDebugEnabled())
-            tcReturn(tcSessionMetaCache, "containsKey", contains);
+            if (trace && tc.isDebugEnabled())
+                tcReturn(tcSessionMetaCache, "containsKey", contains);
+        } catch(Exception ex) {
+            FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.isPresent", "709", this, new Object[] { id });
+            Tr.error(tc, "ERROR_CACHE_ACCESS", ex);
+            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
+        }
         return contains;
     }
 
@@ -716,6 +741,7 @@ public class CacheHashMap extends BackedHashMap {
      * @see com.ibm.ws.session.store.common.BackedHashMap#loadOneValue(java.lang.String, com.ibm.ws.session.store.common.BackedSession)
      */
     @Override
+    @FFDCIgnore(Exception.class) //manually logged
     @Trivial // return value contains customer data
     protected Object loadOneValue(String attrName, BackedSession sess) {
         @SuppressWarnings("static-access")
@@ -726,53 +752,59 @@ public class CacheHashMap extends BackedHashMap {
             Tr.entry(this, tc, "loadOneValue", attrName, sess);
 
         Object value = null;
-        if (!((CacheSession) sess).getPopulatedAppData()) {
-            String id = sess.getId();
+        try {
+            if (!((CacheSession) sess).getPopulatedAppData()) {
+                String id = sess.getId();
 
-            String key = createSessionAttributeKey(id, attrName);
+                String key = createSessionAttributeKey(id, attrName);
 
-            if (trace && tc.isDebugEnabled())
-                tcInvoke(tcSessionAttrCache, "get", key);
-
-            byte[] bytes = sessionAttributeCache.get(key);
-
-            if (bytes == null || bytes.length == 0) {
                 if (trace && tc.isDebugEnabled())
-                    tcReturn(tcSessionAttrCache, "get", bytes);
-            } else {
-                long startTime = System.nanoTime();
-                try {
-                    value = deserialize(bytes);
+                    tcInvoke(tcSessionAttrCache, "get", key);
+
+                byte[] bytes = sessionAttributeCache.get(key);
+
+                if (bytes == null || bytes.length == 0) {
                     if (trace && tc.isDebugEnabled())
-                        if (hideValues)
-                            tcReturn(tcSessionAttrCache, "get", "byte[" + bytes.length + "]");
-                        else
-                            tcReturn(tcSessionAttrCache, "get", bytes, value);
-                } catch (ClassNotFoundException | IOException x) {
-                    if (trace && tc.isDebugEnabled())
-                        tcReturn(tcSessionAttrCache, "get", hideValues ? "byte[" + bytes.length + "]" : bytes);
-                    FFDCFilter.processException(x, getClass().getName(), "197", sess, new Object[] { hideValues ? bytes.length : TypeConversion.limitedBytesToString(bytes) });
-                    throw new RuntimeException(x);
+                        tcReturn(tcSessionAttrCache, "get", bytes);
+                } else {
+                    long startTime = System.nanoTime();
+                    try {
+                        value = deserialize(bytes);
+                        if (trace && tc.isDebugEnabled())
+                            if (hideValues)
+                                tcReturn(tcSessionAttrCache, "get", "byte[" + bytes.length + "]");
+                            else
+                                tcReturn(tcSessionAttrCache, "get", bytes, value);
+                    } catch (Exception x) {
+                        if (trace && tc.isDebugEnabled())
+                            tcReturn(tcSessionAttrCache, "get", hideValues ? "byte[" + bytes.length + "]" : bytes);
+                        FFDCFilter.processException(x, getClass().getName(), "197", sess, new Object[] { hideValues ? bytes.length : TypeConversion.limitedBytesToString(bytes) });
+                        throw x;
+                    }
+
+                    SessionStatistics pmiStats = getIStore().getSessionStatistics();
+                    if (pmiStats != null) {
+                        pmiStats.readTimes(bytes == null ? 0 : bytes.length, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
+                    }
                 }
 
-                SessionStatistics pmiStats = getIStore().getSessionStatistics();
-                if (pmiStats != null) {
-                    pmiStats.readTimes(bytes == null ? 0 : bytes.length, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
+                // Before returning the value, confirm that the session hasn't expired
+                if (trace && tc.isDebugEnabled())
+                    tcInvoke(tcSessionMetaCache, "containsKey", id);
+
+                boolean contains = sessionMetaCache.containsKey(id);
+
+                if (trace && tc.isDebugEnabled())
+                    tcReturn(tcSessionMetaCache, "containsKey", contains);
+
+                if (!contains) {
+                    value = null;
                 }
             }
-
-            // Before returning the value, confirm that the session hasn't expired
-            if (trace && tc.isDebugEnabled())
-                tcInvoke(tcSessionMetaCache, "containsKey", id);
-
-            boolean contains = sessionMetaCache.containsKey(id);
-
-            if (trace && tc.isDebugEnabled())
-                tcReturn(tcSessionMetaCache, "containsKey", contains);
-
-            if (!contains) {
-                value = null;
-            }
+        } catch(Exception ex) {
+            FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.loadOneValue", "778", this, new Object[] { sess });
+            Tr.error(tc, "LOAD_VALUE_ERROR", ex);
+            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
         }
 
         if (trace && tc.isEntryEnabled())
@@ -787,6 +819,7 @@ public class CacheHashMap extends BackedHashMap {
      * @see com.ibm.ws.session.store.common.BackedHashMap#overQualLastAccessTimeUpdate(com.ibm.ws.session.store.common.BackedSession, long)
      */
     @Override
+    @FFDCIgnore(Exception.class) //manually logged
     protected int overQualLastAccessTimeUpdate(BackedSession sess, long nowTime) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
@@ -794,43 +827,49 @@ public class CacheHashMap extends BackedHashMap {
 
         int updateCount;
 
-        if (trace && tc.isDebugEnabled())
-            tcInvoke(tcSessionMetaCache, "get", id);
-
-        synchronized (sess) {
-            ArrayList<?> oldValue = sessionMetaCache.get(id);
-
+        try {
             if (trace && tc.isDebugEnabled())
-                tcReturn(tcSessionMetaCache, "get", oldValue);
+                tcInvoke(tcSessionMetaCache, "get", id);
 
-            SessionInfo sessionInfo = oldValue == null ? null : new SessionInfo(oldValue).clone();
-
-            long curAccessTime = sess.getCurrentAccessTime();
-            if (sessionInfo == null || sessionInfo.getLastAccess() != curAccessTime) {
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "session current access time: " + curAccessTime);
-                updateCount = 0;
-            } else if (sessionInfo.getLastAccess() >= nowTime) { // avoid setting last access when the cache already has a later time
-                updateCount = 1; // be consistent with Statement.executeUpdate which returns 1 when the row matches but no changes are made
-            } else {
-                sessionInfo.setLastAccess(nowTime);
-                ArrayList<?> newValue = sessionInfo.getArrayList();
+            synchronized (sess) {
+                ArrayList<?> oldValue = sessionMetaCache.get(id);
 
                 if (trace && tc.isDebugEnabled())
-                    tcInvoke(tcSessionMetaCache, "replace", id, oldValue, newValue);
+                    tcReturn(tcSessionMetaCache, "get", oldValue);
 
-                boolean replaced = sessionMetaCache.replace(id, oldValue, newValue);
+                SessionInfo sessionInfo = oldValue == null ? null : new SessionInfo(oldValue).clone();
 
-                if (trace && tc.isDebugEnabled())
-                    tcReturn(tcSessionMetaCache, "replace", replaced);
-
-                if (replaced) {
-                    sess.updateLastAccessTime(nowTime);
-                    updateCount = 1;
-                } else {
+                long curAccessTime = sess.getCurrentAccessTime();
+                if (sessionInfo == null || sessionInfo.getLastAccess() != curAccessTime) {
+                    if (trace && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "session current access time: " + curAccessTime);
                     updateCount = 0;
+                } else if (sessionInfo.getLastAccess() >= nowTime) { // avoid setting last access when the cache already has a later time
+                    updateCount = 1; // be consistent with Statement.executeUpdate which returns 1 when the row matches but no changes are made
+                } else {
+                    sessionInfo.setLastAccess(nowTime);
+                    ArrayList<?> newValue = sessionInfo.getArrayList();
+
+                    if (trace && tc.isDebugEnabled())
+                        tcInvoke(tcSessionMetaCache, "replace", id, oldValue, newValue);
+
+                    boolean replaced = sessionMetaCache.replace(id, oldValue, newValue);
+
+                    if (trace && tc.isDebugEnabled())
+                        tcReturn(tcSessionMetaCache, "replace", replaced);
+
+                    if (replaced) {
+                        sess.updateLastAccessTime(nowTime);
+                        updateCount = 1;
+                    } else {
+                        updateCount = 0;
+                    }
                 }
             }
+        } catch(Exception ex) {
+            FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.overQualLastAccessTimeUpdate", "859", this, new Object[] { sess });
+            Tr.error(tc, "ERROR_CACHE_ACCESS", ex);
+            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
         }
 
         return updateCount;
@@ -919,6 +958,7 @@ public class CacheHashMap extends BackedHashMap {
             }
         } catch (Throwable t) {
             // auto FFDC
+            Tr.error(tc, "ERROR_SESSION_INVAL", t);
         }
     }
 
@@ -997,7 +1037,8 @@ public class CacheHashMap extends BackedHashMap {
                     tcReturn(tcSessionMetaCache, "replace", updated);
             }
         } catch (Exception ee) {
-            FFDCFilter.processException(ee, getClass().getName(), "272", session);
+            FFDCFilter.processException(ee, getClass().getName(), "272", this, new Object[] { session });
+            Tr.error(tc, "STORE_SESS_ERROR", ee);
             return false;
         }
         return true;
@@ -1008,6 +1049,7 @@ public class CacheHashMap extends BackedHashMap {
      * This method determines the set of sessions with session listeners which
      * need to be invalidated and processes them.
      */
+    @FFDCIgnore(Exception.class) //manually logged
     private void processInvalidListeners() {
         final boolean trace = com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled();
 
@@ -1118,7 +1160,7 @@ public class CacheHashMap extends BackedHashMap {
                             now = System.currentTimeMillis();
                         }
                     } catch (Exception e) {
-                        FFDCFilter.processException(e, getClass().getName(), "652", session);
+                        FFDCFilter.processException(e, getClass().getName(), "652", this, new Object[] { session });
                         throw e;
                     }
                 }
@@ -1130,18 +1172,26 @@ public class CacheHashMap extends BackedHashMap {
      * @see com.ibm.ws.session.store.common.BackedHashMap#readFromExternal(java.lang.String)
      */
     @Override
+    @FFDCIgnore(Exception.class) //manually logged
     protected BackedSession readFromExternal(String id) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         CacheSession sess = null;
+        ArrayList<?> value = null;
 
-        if (trace && tc.isDebugEnabled())
-            tcInvoke(tcSessionMetaCache, "get", id);
+        try {
+            if (trace && tc.isDebugEnabled())
+                tcInvoke(tcSessionMetaCache, "get", id);
 
-        ArrayList<?> value = sessionMetaCache.get(id);
+            value = sessionMetaCache.get(id);
 
-        if (trace && tc.isDebugEnabled())
-            tcReturn(tcSessionMetaCache, "get", value);
+            if (trace && tc.isDebugEnabled())
+                tcReturn(tcSessionMetaCache, "get", value);
+        } catch(Exception ex) {
+            FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.removePersistedSession", "1156", this, new Object[] { id });
+            Tr.error(tc, "ERROR_CACHE_ACCESS", ex);
+            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
+        }
 
         if (value != null) {
             SessionInfo sessionInfo = new SessionInfo(value);
@@ -1160,35 +1210,41 @@ public class CacheHashMap extends BackedHashMap {
      * @see com.ibm.ws.session.store.common.BackedHashMap#removePersistedSession(java.lang.String)
      */
     @Override
+    @FFDCIgnore(Exception.class) //manually logged
     protected void removePersistedSession(String id) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         //If the app calls invalidate, it may not be removed from the local cache yet.
         superRemove(id);
+        try {
+            if (trace && tc.isDebugEnabled())
+                tcInvoke(tcSessionMetaCache, "getAndRemove", id);
 
-        if (trace && tc.isDebugEnabled())
-            tcInvoke(tcSessionMetaCache, "getAndRemove", id);
+            ArrayList<?> removed = sessionMetaCache.getAndRemove(id);
 
-        ArrayList<?> removed = sessionMetaCache.getAndRemove(id);
+            if (trace && tc.isDebugEnabled())
+                tcReturn(tcSessionMetaCache, "getAndRemove", removed);
 
-        if (trace && tc.isDebugEnabled())
-            tcReturn(tcSessionMetaCache, "getAndRemove", removed);
+            addToRecentlyInvalidatedList(id);
 
-        addToRecentlyInvalidatedList(id);
+            Set<String> propIds = removed == null ? null : new SessionInfo(removed).getSessionPropertyIds();
+            if (propIds != null) {
+                for (String propId : propIds) {
+                    String attributeKey = createSessionAttributeKey(id, propId);
 
-        Set<String> propIds = removed == null ? null : new SessionInfo(removed).getSessionPropertyIds();
-        if (propIds != null) {
-            for (String propId : propIds) {
-                String attributeKey = createSessionAttributeKey(id, propId);
+                    if (trace && tc.isDebugEnabled())
+                        tcInvoke(tcSessionAttrCache, "remove", attributeKey);
 
-                if (trace && tc.isDebugEnabled())
-                    tcInvoke(tcSessionAttrCache, "remove", attributeKey);
+                    sessionAttributeCache.remove(attributeKey);
 
-                sessionAttributeCache.remove(attributeKey);
-
-                if (trace && tc.isDebugEnabled())
-                    tcReturn(tcSessionAttrCache, "remove");
+                    if (trace && tc.isDebugEnabled())
+                        tcReturn(tcSessionAttrCache, "remove");
+                }
             }
+        } catch(Exception ex) {
+            FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.removePersistedSession", "1204", this, new Object[] { id });
+            Tr.error(tc, "ERROR_REMOVING_SESSION", ex);
+            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
         }
     }
 
@@ -1273,6 +1329,7 @@ public class CacheHashMap extends BackedHashMap {
      * @see com.ibm.ws.session.store.common.BackedHashMap#updateLastAccessTime(com.ibm.ws.session.store.common.BackedSession, long)
      */
     @Override
+    @FFDCIgnore(Exception.class) //manually logged
     protected int updateLastAccessTime(BackedSession sess, long nowTime) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
@@ -1280,31 +1337,37 @@ public class CacheHashMap extends BackedHashMap {
 
         int updateCount = -1;
 
-        while (updateCount == -1) {
-            if (trace && tc.isDebugEnabled())
-                tcInvoke(tcSessionMetaCache, "get", id);
+        try {
+            while (updateCount == -1) {
+                if (trace && tc.isDebugEnabled())
+                    tcInvoke(tcSessionMetaCache, "get", id);
 
-            ArrayList<?> oldValue = sessionMetaCache.get(id);
-
-            if (trace && tc.isDebugEnabled())
-                tcReturn(tcSessionMetaCache, "get", oldValue);
-
-            SessionInfo sessionInfo = oldValue == null ? null : new SessionInfo(oldValue).clone();
-            if (sessionInfo == null || sessionInfo.getLastAccess() == nowTime) {
-                updateCount = 0;
-            } else {
-                sessionInfo.setLastAccess(nowTime);
-                ArrayList<Object> newValue = sessionInfo.getArrayList();
+                ArrayList<?> oldValue = sessionMetaCache.get(id);
 
                 if (trace && tc.isDebugEnabled())
-                    tcInvoke(tcSessionMetaCache, "replace", id, oldValue, newValue);
+                    tcReturn(tcSessionMetaCache, "get", oldValue);
 
-                if (sessionMetaCache.replace(id, oldValue, newValue))
-                    updateCount = 1;
+                SessionInfo sessionInfo = oldValue == null ? null : new SessionInfo(oldValue).clone();
+                if (sessionInfo == null || sessionInfo.getLastAccess() == nowTime) {
+                    updateCount = 0;
+                } else {
+                    sessionInfo.setLastAccess(nowTime);
+                    ArrayList<Object> newValue = sessionInfo.getArrayList();
 
-                if (trace && tc.isDebugEnabled())
-                    tcReturn(tcSessionMetaCache, "replace", updateCount == 1);
-            }
+                    if (trace && tc.isDebugEnabled())
+                        tcInvoke(tcSessionMetaCache, "replace", id, oldValue, newValue);
+
+                    if (sessionMetaCache.replace(id, oldValue, newValue))
+                        updateCount = 1;
+
+                    if (trace && tc.isDebugEnabled())
+                        tcReturn(tcSessionMetaCache, "replace", updateCount == 1);
+                }
+            } 
+        } catch(Exception ex) {
+            FFDCFilter.processException(ex, "com.ibm.ws.session.store.cache.CacheHashMap.updateLastAccessTime", "1326", this, new Object[] { sess });
+            Tr.error(tc, "ERROR_CACHE_ACCESS", ex);
+            throw new RuntimeException(Tr.formatMessage(tc, "INTERNAL_SERVER_ERROR"));
         }
 
         return updateCount;
@@ -1340,6 +1403,7 @@ public class CacheHashMap extends BackedHashMap {
      * writeCachedLastAccessedTimes - if we have manual writes of time-based writes, we cache the last
      * accessed times and only write them to the persistent store prior to the inval thread running.
      */
+    @FFDCIgnore(Exception.class) //manually logged
     private void writeCachedLastAccessedTimes() throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
@@ -1382,7 +1446,7 @@ public class CacheHashMap extends BackedHashMap {
                     }
                 }
             } catch (Exception x) {
-                FFDCFilter.processException(x, getClass().getName(), "649", id);
+                FFDCFilter.processException(x, getClass().getName(), "649", this, new Object[]{ id });
                 throw x;
             }
         }
@@ -1403,7 +1467,6 @@ public class CacheHashMap extends BackedHashMap {
 
         if(info != null) {
             //This is a value that can be written directly to bytes
-            //TODO handle exceptions that occur when converting to bytes
             objbuf = info.objectToBytes(value);
         } else {
             //Go through normal serialization process
@@ -1424,10 +1487,10 @@ public class CacheHashMap extends BackedHashMap {
 
     public Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException{
         Object obj = null;
-        
+
         if (bytes.length >= 4 
-                && bytes[0] == OBJECT_OUTPUT_STREAM_HEADER[0]
-                && bytes[1] == OBJECT_OUTPUT_STREAM_HEADER[1]) {    
+                        && bytes[0] == OBJECT_OUTPUT_STREAM_HEADER[0]
+                        && bytes[1] == OBJECT_OUTPUT_STREAM_HEADER[1]) {    
             //This was serialized using the standard method, deserialize with readObject
             ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
             BufferedInputStream in = new BufferedInputStream(bais);
@@ -1442,16 +1505,13 @@ public class CacheHashMap extends BackedHashMap {
                            
             BuiltinSerializationInfo<?> info = SerializationInfoCache.lookupByIndex(bytes[1]);
             if(info == null) {
-                //Stream is not in the normal serializaton or built-in format
-                //TODO improve this exception/add NLS
+            	//Stream is not in the normal serialization or built-in format
                 throw new StreamCorruptedException("invalid stream header: " + bytes[0] + " " + bytes[1]);
             }
-            //TODO handle exceptions that occur when converting to object
             obj = info.bytesToObject(bytes);       
         } else {
-            //TODO improve this exception/add NLS
             throw new StreamCorruptedException("invalid stream header: " + bytes[0] + " " + bytes[1]);
         }
         return obj;
-}
+    }
 }

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -202,8 +202,8 @@ public class CacheStoreService implements Introspector, SessionStoreService {
                 CacheHashMap.tcInvoke(tcCachingProvider, "close");
                 cachingProvider.close();
                 CacheHashMap.tcReturn(tcCachingProvider, "close");
-                throw x;
             }
+            throw x;
         }
     }
 

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
@@ -185,7 +185,6 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
      * Verify that after correcting the uri, session data is persisted.
      */
     @AllowedFFDC(value = { "javax.cache.CacheException", // for invalid uri
-                           "java.lang.NullPointerException", // from starting web app with invalid session cache config
                            "java.net.MalformedURLException" // TODO possible bug
     })
     @Test
@@ -228,7 +227,8 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
 
             run("invalidateSession", session);
         } finally {
-            server.stopServer("SRVE8059E", // An unexpected exception occurred when trying to retrieve the session context. Caused by: java.lang.IllegalArgumentException: Not available Hazelcast instance...
+            server.stopServer("SRVE8059E", // An unexpected exception occurred when trying to retrieve the session context java.lang.RuntimeException: Internal Server Error
+                              "SESN0307E", // An exception occurred when trying to initialize the cache. Exception is javax.cache.CacheException: Error opening URI
                               "SRVE0297E.*NullPointerException" // TODO fails when WebApp.destroy/SessionContext.stop invoked after deactivate
             );
         }
@@ -239,7 +239,6 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
      * verifying that a session attribute added afterward is persisted, whereas a session attribute added before is not.
      */
     @AllowedFFDC(value = { "javax.cache.CacheException", // expected on error path: No CachingProviders have been configured
-                           "java.lang.NullPointerException", // from starting web app with invalid session cache config
                            "java.net.MalformedURLException" // TODO possible bug
     })
     @Test
@@ -273,7 +272,8 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
 
             run("invalidateSession", session);
         } finally {
-            server.stopServer("SRVE8059E"); // An unexpected exception occurred when trying to retrieve the session context. javax.cache.CacheException: No CachingProviders have been configured
+            server.stopServer("SRVE8059E", // An unexpected exception occurred when trying to retrieve the session context java.lang.RuntimeException: Internal Server Error
+                              "SESN0307E"); // An exception occurred when trying to initialize the cache. Exception is: javax.cache.CacheException: No CachingProviders have been configured
         }
     }
 
@@ -314,7 +314,6 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
     }
 
     @AllowedFFDC(value = { "javax.cache.CacheException", // expected on error path: No CachingProviders have been configured
-                           "java.lang.NullPointerException", // from starting web app with invalid session cache config
                            "java.net.MalformedURLException" // TODO possible bug
     })
     @Test
@@ -345,7 +344,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
         run("testSetAttribute&attribute=testModifyFileset&value=1", session);
         run("testCacheContains&attribute=testModifyFileset&value=1", session);
 
-        server.stopServer("CWWKL0012W.*bogus", "SRVE8059E", "CWWKE0701E.*CacheException");
+        server.stopServer("CWWKL0012W.*bogus", "SRVE8059E", "CWWKE0701E.*CacheException", "SESN0307E");
     }
 
     /**


### PR DESCRIPTION
Better handle exceptions that occur during cache operations, logging appropriate FFDCs and errors as necessary and throwing generic exceptions.  Fix for issue #2798.
