### PR TITLE
Issue #2935: Move DSDTest to injection_fat in open-liberty

### DIFF
--- a/dev/com.ibm.ws.injection_fat/.classpath
+++ b/dev/com.ibm.ws.injection_fat/.classpath
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/DSDAnnEJB.jar/src"/>
+	<classpathentry kind="src" path="test-applications/DSDAnnWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/DSDMixEJB.jar/src"/>
+	<classpathentry kind="src" path="test-applications/DSDMixWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/DSDXMLEJB.jar/src"/>
+	<classpathentry kind="src" path="test-applications/DSDXMLWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/EnvEntryAnnWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/EnvEntryMixWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/EnvEntryXMLWeb.war/src"/>

--- a/dev/com.ibm.ws.injection_fat/bnd.bnd
+++ b/dev/com.ibm.ws.injection_fat/bnd.bnd
@@ -13,6 +13,12 @@ bVersion=1.0
 
 src: \
 	fat/src,\
+	test-applications/DSDAnnEJB.jar/src,\
+	test-applications/DSDAnnWeb.war/src,\
+	test-applications/DSDMixEJB.jar/src,\
+	test-applications/DSDMixWeb.war/src,\
+	test-applications/DSDXMLEJB.jar/src,\
+	test-applications/DSDXMLWeb.war/src,\
 	test-applications/EnvEntryAnnWeb.war/src,\
 	test-applications/EnvEntryMixWeb.war/src,\
 	test-applications/EnvEntryXMLWeb.war/src,\
@@ -28,13 +34,14 @@ javac.target: 1.8
 fat.project: true
 
 tested.features: \
-	servlet-4.0, jpa-2.2, jdbc-4.2
+	servlet-4.0, jpa-2.2, jdbc-4.2, ejbLite-3.2
 	
 -buildpath.bootclasspath: \
 	com.ibm.websphere.javaee.annotation.1.3;version=latest;boot=true,\
 	${javac.bootclasspath.${javac.source}}
 
 -buildpath: \
+	com.ibm.websphere.javaee.ejb.3.1;version=latest,\
 	com.ibm.websphere.javaee.persistence.2.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1; version=latest, \

--- a/dev/com.ibm.ws.injection_fat/build.gradle
+++ b/dev/com.ibm.ws.injection_fat/build.gradle
@@ -28,16 +28,7 @@ dependencies {
 
 task addEJBTools(type: Copy) {
   from configurations.ejbTools
-  into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.injection.fat.EnvEntryServer/lib/global"
-
-  from configurations.ejbTools
-  into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.injection.fat.JPAServer/lib/global"
-
-  from configurations.ejbTools
-  into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.injection.fat.ResRefServer/lib/global"
-
-  from configurations.ejbTools
-  into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.injection.fat.TranServer/lib/global"
+  into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.injection.fat.DSDServer/lib/global"
 }
 
 addRequiredLibraries {

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/DSDTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/DSDTest.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.injection.fat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.injection.dsdann.web.BasicDSDAnnServlet;
+import com.ibm.ws.injection.dsdmix.web.BasicDSDMixServlet;
+import com.ibm.ws.injection.dsdxml.web.BasicDSDXMLServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class DSDTest extends FATServletClient {
+    @Server("com.ibm.ws.injection.fat.DSDServer")
+    @TestServlets({ @TestServlet(servlet = BasicDSDAnnServlet.class, contextRoot = "DSDAnnWeb"),
+                    @TestServlet(servlet = BasicDSDMixServlet.class, contextRoot = "DSDMixWeb"),
+                    @TestServlet(servlet = BasicDSDXMLServlet.class, contextRoot = "DSDXMLWeb")
+    })
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.DSDServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.DSDServer"));
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Use ShrinkHelper to build the ears
+        JavaArchive DSDAnnEJB = ShrinkHelper.buildJavaArchive("DSDAnnEJB.jar", "com.ibm.ws.injection.dsdann.ejb.");
+        WebArchive DSDAnnWeb = ShrinkHelper.buildDefaultApp("DSDAnnWeb.war", "com.ibm.ws.injection.dsdann.web.");
+        EnterpriseArchive DSDAnnTest = ShrinkWrap.create(EnterpriseArchive.class, "DSDAnnTest.ear");
+		DSDAnnTest.addAsModule(DSDAnnEJB).addAsModule(DSDAnnWeb);
+
+        JavaArchive DSDMixEJB = ShrinkHelper.buildJavaArchive("DSDMixEJB.jar", "com.ibm.ws.injection.dsdmix.ejb.");
+        WebArchive DSDMixWeb = ShrinkHelper.buildDefaultApp("DSDMixWeb.war", "com.ibm.ws.injection.dsdmix.web.");
+        EnterpriseArchive DSDMixTest = ShrinkWrap.create(EnterpriseArchive.class, "DSDMixTest.ear");
+		DSDMixTest.addAsModule(DSDMixEJB).addAsModule(DSDMixWeb);
+
+        JavaArchive DSDXMLEJB = ShrinkHelper.buildJavaArchive("DSDXMLEJB.jar", "com.ibm.ws.injection.dsdxml.ejb.");
+        WebArchive DSDXMLWeb = ShrinkHelper.buildDefaultApp("DSDXMLWeb.war", "com.ibm.ws.injection.dsdxml.web.");
+        EnterpriseArchive DSDXMLTest = ShrinkWrap.create(EnterpriseArchive.class, "DSDXMLTest.ear");
+		DSDXMLTest.addAsModule(DSDXMLEJB).addAsModule(DSDXMLWeb);
+
+        ShrinkHelper.exportAppToServer(server, DSDAnnTest);
+        ShrinkHelper.exportAppToServer(server, DSDMixTest);
+        ShrinkHelper.exportAppToServer(server, DSDXMLTest);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+}

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/DSDTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/DSDTest.java
@@ -51,17 +51,17 @@ public class DSDTest extends FATServletClient {
         JavaArchive DSDAnnEJB = ShrinkHelper.buildJavaArchive("DSDAnnEJB.jar", "com.ibm.ws.injection.dsdann.ejb.");
         WebArchive DSDAnnWeb = ShrinkHelper.buildDefaultApp("DSDAnnWeb.war", "com.ibm.ws.injection.dsdann.web.");
         EnterpriseArchive DSDAnnTest = ShrinkWrap.create(EnterpriseArchive.class, "DSDAnnTest.ear");
-		DSDAnnTest.addAsModule(DSDAnnEJB).addAsModule(DSDAnnWeb);
+        DSDAnnTest.addAsModule(DSDAnnEJB).addAsModule(DSDAnnWeb);
 
         JavaArchive DSDMixEJB = ShrinkHelper.buildJavaArchive("DSDMixEJB.jar", "com.ibm.ws.injection.dsdmix.ejb.");
         WebArchive DSDMixWeb = ShrinkHelper.buildDefaultApp("DSDMixWeb.war", "com.ibm.ws.injection.dsdmix.web.");
         EnterpriseArchive DSDMixTest = ShrinkWrap.create(EnterpriseArchive.class, "DSDMixTest.ear");
-		DSDMixTest.addAsModule(DSDMixEJB).addAsModule(DSDMixWeb);
+        DSDMixTest.addAsModule(DSDMixEJB).addAsModule(DSDMixWeb);
 
         JavaArchive DSDXMLEJB = ShrinkHelper.buildJavaArchive("DSDXMLEJB.jar", "com.ibm.ws.injection.dsdxml.ejb.");
         WebArchive DSDXMLWeb = ShrinkHelper.buildDefaultApp("DSDXMLWeb.war", "com.ibm.ws.injection.dsdxml.web.");
         EnterpriseArchive DSDXMLTest = ShrinkWrap.create(EnterpriseArchive.class, "DSDXMLTest.ear");
-		DSDXMLTest.addAsModule(DSDXMLEJB).addAsModule(DSDXMLWeb);
+        DSDXMLTest.addAsModule(DSDXMLEJB).addAsModule(DSDXMLWeb);
 
         ShrinkHelper.exportAppToServer(server, DSDAnnTest);
         ShrinkHelper.exportAppToServer(server, DSDMixTest);

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/FATSuite.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+                DSDTest.class,
                 EnvEntryTest.class,
                 JPATest.class,
                 RepeatableEnvEntryTest.class,

--- a/dev/com.ibm.ws.injection_fat/publish/servers/com.ibm.ws.injection.fat.DSDServer/.gitignore
+++ b/dev/com.ibm.ws.injection_fat/publish/servers/com.ibm.ws.injection.fat.DSDServer/.gitignore
@@ -1,0 +1,4 @@
+/apps
+/derby
+/dropins
+/lib

--- a/dev/com.ibm.ws.injection_fat/publish/servers/com.ibm.ws.injection.fat.DSDServer/bootstrap.properties
+++ b/dev/com.ibm.ws.injection_fat/publish/servers/com.ibm.ws.injection.fat.DSDServer/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:Injection=all

--- a/dev/com.ibm.ws.injection_fat/publish/servers/com.ibm.ws.injection.fat.DSDServer/server.xml
+++ b/dev/com.ibm.ws.injection_fat/publish/servers/com.ibm.ws.injection.fat.DSDServer/server.xml
@@ -1,0 +1,27 @@
+<server>
+    <featureManager>
+		<feature>componenttest-1.0</feature>
+		<feature>ejbLite-3.2</feature>
+		<feature>jdbc-4.1</feature>
+        <feature>servlet-3.1</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+
+    <library id="DerbyLib" filesetRef="DerbyFileset"/>
+    <fileset id="DerbyFileset" dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+
+	<application type="ear" id="DSDAnnTest" name="DSDAnnTest" location="${server.config.dir}/apps/DSDAnnTest.ear">
+        <classloader commonLibraryRef="DerbyLib,global"/>
+    </application>
+    
+    <application type="ear" id="DSDMixTest" name="DSDMixTest" location="${server.config.dir}/apps/DSDMixTest.ear">
+        <classloader commonLibraryRef="DerbyLib,global"/>
+    </application>
+    
+    <application type="ear" id="DSDXMLTest" name="DSDXMLTest" location="${server.config.dir}/apps/DSDXMLTest.ear">
+        <classloader commonLibraryRef="DerbyLib,global"/>
+    </application>
+	
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnEJB.jar/src/com/ibm/ws/injection/dsdann/ejb/DSDSingletonBean.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnEJB.jar/src/com/ibm/ws/injection/dsdann/ejb/DSDSingletonBean.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.injection.dsdann.ejb;
+
+import java.util.logging.Logger;
+
+import javax.annotation.sql.DataSourceDefinition;
+import javax.ejb.Singleton;
+
+@DataSourceDefinition(name = "java:module/ann_SingletonModLevelDS",
+                      className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                      databaseName = "dsdAnnTest",
+                      loginTimeout = 25,
+                      properties = { "createDatabase=create" })
+@Singleton
+public class DSDSingletonBean {
+    private static String CLASSNAME = DSDSingletonBean.class.getName();
+    private static Logger svLogger = Logger.getLogger(CLASSNAME);
+
+    public void test() {
+        svLogger.info("--> Called the Singleton bean.");
+    }
+}

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnEJB.jar/src/com/ibm/ws/injection/dsdann/ejb/DSDStatefulBean.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnEJB.jar/src/com/ibm/ws/injection/dsdann/ejb/DSDStatefulBean.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.injection.dsdann.ejb;
+
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+import javax.annotation.sql.DataSourceDefinition;
+import javax.annotation.sql.DataSourceDefinitions;
+import javax.ejb.Stateful;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
+@DataSourceDefinitions({
+                        @DataSourceDefinition(name = "java:module/ann_BasicModLevelDS",
+                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                              databaseName = "dsdAnnTest",
+                                              loginTimeout = 14,
+                                              properties = { "createDatabase=create" }),
+                        @DataSourceDefinition(name = "java:app/ann_BasicAppLevelDS",
+                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                              databaseName = "dsdAnnTest",
+                                              loginTimeout = 19,
+                                              properties = { "createDatabase=create" }),
+                        @DataSourceDefinition(name = "java:global/ann_BasicGlobalLevelDS", // change to java:global per RTC86337
+                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                              databaseName = "dsdAnnTest",
+                                              loginTimeout = 6,
+                                              properties = { "createDatabase=create" }),
+                        @DataSourceDefinition(name = "ann_BasicCompLevelDS",
+                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                              databaseName = "dsdAnnTest",
+                                              loginTimeout = 15,
+                                              properties = { "createDatabase=create" })
+})
+@Stateful
+public class DSDStatefulBean {
+    private static String CLASSNAME = DSDStatefulBean.class.getName();
+    private static Logger svLogger = Logger.getLogger(CLASSNAME);
+
+    public int testDS(String jndi) throws NamingException, SQLException {
+        svLogger.info("--> Attempting to lookup the DS defined via annotations using: '" + jndi + "' ");
+
+        InitialContext ctx = new InitialContext();
+
+        DataSource ds = (DataSource) ctx.lookup(jndi);
+        svLogger.info("--> Successfully looked up the DS using: '" + jndi + "' ");
+
+        svLogger.info("--> Access the DS to verify it is the one we want...");
+        int loginTO = ds.getLoginTimeout();
+        svLogger.info("--> The DS login timeout returned is: " + loginTO);
+        return loginTO;
+    }
+}

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnEJB.jar/src/com/ibm/ws/injection/dsdann/ejb/DSDStatefulBean.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnEJB.jar/src/com/ibm/ws/injection/dsdann/ejb/DSDStatefulBean.java
@@ -21,26 +21,26 @@ import javax.naming.NamingException;
 import javax.sql.DataSource;
 
 @DataSourceDefinitions({
-                        @DataSourceDefinition(name = "java:module/ann_BasicModLevelDS",
-                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
-                                              databaseName = "dsdAnnTest",
-                                              loginTimeout = 14,
-                                              properties = { "createDatabase=create" }),
-                        @DataSourceDefinition(name = "java:app/ann_BasicAppLevelDS",
-                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
-                                              databaseName = "dsdAnnTest",
-                                              loginTimeout = 19,
-                                              properties = { "createDatabase=create" }),
-                        @DataSourceDefinition(name = "java:global/ann_BasicGlobalLevelDS", // change to java:global per RTC86337
-                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
-                                              databaseName = "dsdAnnTest",
-                                              loginTimeout = 6,
-                                              properties = { "createDatabase=create" }),
-                        @DataSourceDefinition(name = "ann_BasicCompLevelDS",
-                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
-                                              databaseName = "dsdAnnTest",
-                                              loginTimeout = 15,
-                                              properties = { "createDatabase=create" })
+                         @DataSourceDefinition(name = "java:module/ann_BasicModLevelDS",
+                                               className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                               databaseName = "dsdAnnTest",
+                                               loginTimeout = 14,
+                                               properties = { "createDatabase=create" }),
+                         @DataSourceDefinition(name = "java:app/ann_BasicAppLevelDS",
+                                               className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                               databaseName = "dsdAnnTest",
+                                               loginTimeout = 19,
+                                               properties = { "createDatabase=create" }),
+                         @DataSourceDefinition(name = "java:global/ann_BasicGlobalLevelDS", // change to java:global per RTC86337
+                                               className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                               databaseName = "dsdAnnTest",
+                                               loginTimeout = 6,
+                                               properties = { "createDatabase=create" }),
+                         @DataSourceDefinition(name = "ann_BasicCompLevelDS",
+                                               className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                               databaseName = "dsdAnnTest",
+                                               loginTimeout = 15,
+                                               properties = { "createDatabase=create" })
 })
 @Stateful
 public class DSDStatefulBean {

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnWeb.war/resources/WEB-INF/ibm-web-ext.xml
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnWeb.war/resources/WEB-INF/ibm-web-ext.xml
@@ -1,0 +1,8 @@
+<web-ext
+  xmlns="http://websphere.ibm.com/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+  version="1.0"
+>
+  <context-root uri="DSDAnnWeb"/>
+</web-ext>

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnWeb.war/src/com/ibm/ws/injection/dsdann/web/BasicDSDAnnServlet.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnWeb.war/src/com/ibm/ws/injection/dsdann/web/BasicDSDAnnServlet.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.injection.dsdann.web;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.logging.Logger;
+
+import javax.servlet.annotation.WebServlet;
+
+import com.ibm.ws.injection.dsdann.ejb.DSDSingletonBean;
+import com.ibm.ws.injection.dsdann.ejb.DSDStatefulBean;
+
+import org.junit.Test;
+
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/BasicDSDAnnServlet")
+public class BasicDSDAnnServlet extends FATServlet {
+    private static final String CLASSNAME = BasicDSDAnnServlet.class.getName();
+    private static final Logger svLogger = Logger.getLogger(CLASSNAME);
+
+    /**
+     * Lookup the bean and call the testDS method with the jndi name provided by
+     * the test method and verify it returns the expected loginTimeout value of
+     * the defined DataSource
+     * 
+     * @param jndi
+     * @param loginTO
+     * @throws Exception
+     */
+    public void getAndVerifyResult(String jndi, int loginTO) throws Exception {
+        svLogger.info("--> Looking up bean...");
+        DSDStatefulBean bean = (DSDStatefulBean) FATHelper.lookupDefaultBindingEJBJavaApp(DSDStatefulBean.class.getName(), "DSDAnnEJB", "DSDStatefulBean");
+
+        svLogger.info("--> Calling test() on the SFSB that defines the DS...");
+        int result = bean.testDS(jndi);
+        svLogger.info("--> result = " + result);
+
+        assertTrue("--> Expecting the returned login timeout for the DS to be " + loginTO + ". Actual value = " + result, loginTO == result);
+    }
+
+    /**
+     * Verify that a DS defined in a SFSB using the DataSourceDefinition
+     * annotation can be successfully looked up from the SFSB using the
+     * java:module namespace
+     * 
+     * @throws Exception
+     * 
+     */
+	@Test
+    public void testDSDModLevel() throws Exception {
+        getAndVerifyResult("java:module/ann_BasicModLevelDS", 14);
+    }
+
+    /**
+     * Verify that a DS defined in a SFSB using the DataSourceDefinition
+     * annotation can be successfully looked up from the SFSB using the java:app
+     * namespace
+     * 
+     * @throws Exception
+     * 
+     */
+	@Test
+    public void testDSDAppLevel() throws Exception {
+        getAndVerifyResult("java:app/ann_BasicAppLevelDS", 19);
+    }
+
+    /**
+     * Verify that a DS defined in a SFSB using the DataSourceDefinition
+     * annotation can be successfully looked up from the SFSB using the
+     * java:global namespace
+     * 
+     * @throws Exception
+     * 
+     */
+	@Test
+    public void testDSDGlobalLevel() throws Exception {
+        getAndVerifyResult("java:global/ann_BasicGlobalLevelDS", 6);
+    }
+
+    /**
+     * Verify that a DS defined in a SFSB using the DataSourceDefinition
+     * annotation can be successfully looked up from the SFSB using the java:comp
+     * namespace
+     * 
+     * @throws Exception
+     */
+	@Test
+    public void testDSDCompLevel() throws Exception {
+        getAndVerifyResult("java:comp/env/ann_BasicCompLevelDS", 15);
+    }
+
+    /**
+     * Verify that a DS defined in a Singleton using the DataSourceDefinition
+     * annotation can be successfully looked up from the SFSB using the
+     * java:module
+     * namespace
+     * 
+     * @throws Exception
+     * 
+     */
+	@Test
+    public void testSingletonDSDModLevel() throws Exception {
+        svLogger.info("--> Looking up the Singleton bean...");
+        DSDSingletonBean bean = (DSDSingletonBean) FATHelper.lookupDefaultBindingEJBJavaApp(DSDSingletonBean.class.getName(), "DSDAnnEJB", "DSDSingletonBean");
+
+        svLogger.info("-->The DS defined in the Singleton bean should have been created when the Singleton was looked up (i.e. initialized), just to be sure we call its test()...");
+        bean.test();
+
+        getAndVerifyResult("java:module/ann_SingletonModLevelDS", 25);
+    }
+}

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnWeb.war/src/com/ibm/ws/injection/dsdann/web/BasicDSDAnnServlet.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDAnnWeb.war/src/com/ibm/ws/injection/dsdann/web/BasicDSDAnnServlet.java
@@ -16,12 +16,12 @@ import java.util.logging.Logger;
 
 import javax.servlet.annotation.WebServlet;
 
-import com.ibm.ws.injection.dsdann.ejb.DSDSingletonBean;
-import com.ibm.ws.injection.dsdann.ejb.DSDStatefulBean;
-
 import org.junit.Test;
 
 import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
+import com.ibm.ws.injection.dsdann.ejb.DSDSingletonBean;
+import com.ibm.ws.injection.dsdann.ejb.DSDStatefulBean;
+
 import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
@@ -34,7 +34,7 @@ public class BasicDSDAnnServlet extends FATServlet {
      * Lookup the bean and call the testDS method with the jndi name provided by
      * the test method and verify it returns the expected loginTimeout value of
      * the defined DataSource
-     * 
+     *
      * @param jndi
      * @param loginTO
      * @throws Exception
@@ -54,11 +54,11 @@ public class BasicDSDAnnServlet extends FATServlet {
      * Verify that a DS defined in a SFSB using the DataSourceDefinition
      * annotation can be successfully looked up from the SFSB using the
      * java:module namespace
-     * 
+     *
      * @throws Exception
-     * 
+     *
      */
-	@Test
+    @Test
     public void testDSDModLevel() throws Exception {
         getAndVerifyResult("java:module/ann_BasicModLevelDS", 14);
     }
@@ -67,11 +67,11 @@ public class BasicDSDAnnServlet extends FATServlet {
      * Verify that a DS defined in a SFSB using the DataSourceDefinition
      * annotation can be successfully looked up from the SFSB using the java:app
      * namespace
-     * 
+     *
      * @throws Exception
-     * 
+     *
      */
-	@Test
+    @Test
     public void testDSDAppLevel() throws Exception {
         getAndVerifyResult("java:app/ann_BasicAppLevelDS", 19);
     }
@@ -80,11 +80,11 @@ public class BasicDSDAnnServlet extends FATServlet {
      * Verify that a DS defined in a SFSB using the DataSourceDefinition
      * annotation can be successfully looked up from the SFSB using the
      * java:global namespace
-     * 
+     *
      * @throws Exception
-     * 
+     *
      */
-	@Test
+    @Test
     public void testDSDGlobalLevel() throws Exception {
         getAndVerifyResult("java:global/ann_BasicGlobalLevelDS", 6);
     }
@@ -93,10 +93,10 @@ public class BasicDSDAnnServlet extends FATServlet {
      * Verify that a DS defined in a SFSB using the DataSourceDefinition
      * annotation can be successfully looked up from the SFSB using the java:comp
      * namespace
-     * 
+     *
      * @throws Exception
      */
-	@Test
+    @Test
     public void testDSDCompLevel() throws Exception {
         getAndVerifyResult("java:comp/env/ann_BasicCompLevelDS", 15);
     }
@@ -106,11 +106,11 @@ public class BasicDSDAnnServlet extends FATServlet {
      * annotation can be successfully looked up from the SFSB using the
      * java:module
      * namespace
-     * 
+     *
      * @throws Exception
-     * 
+     *
      */
-	@Test
+    @Test
     public void testSingletonDSDModLevel() throws Exception {
         svLogger.info("--> Looking up the Singleton bean...");
         DSDSingletonBean bean = (DSDSingletonBean) FATHelper.lookupDefaultBindingEJBJavaApp(DSDSingletonBean.class.getName(), "DSDAnnEJB", "DSDSingletonBean");

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDMixEJB.jar/resources/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDMixEJB.jar/resources/META-INF/ejb-jar.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar id="ejb-jar_ID" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd" metadata-complete="false" version="3.1">
+  <display-name>DSDMixEJB</display-name>
+  <enterprise-beans>
+    <session>
+      <ejb-name>DSDMixedBean</ejb-name>
+      <ejb-class>com.ibm.ws.injection.dsdmix.ejb.DSDMixedBean</ejb-class>
+      <session-type>Stateless</session-type>
+      <data-source>
+        <description>Test that annotation and xml get merged</description>
+        <name>java:module/mix_MergeSLSBModLevelDS</name>
+        <class-name>org.apache.derby.jdbc.EmbeddedXADataSource40</class-name>
+        <isolation-level>TRANSACTION_READ_UNCOMMITTED</isolation-level>
+      </data-source>
+      <data-source>
+        <description>Test that the attributes defined both via annotation and xml get overridden, and other attributes get merged</description>
+        <name>java:module/mix_XMLOverrideSLSBModLevelDS</name>
+        <class-name>org.apache.derby.jdbc.EmbeddedXADataSource40</class-name>
+        <user>dsdTesterXMLKing</user>
+        <login-timeout>128</login-timeout>
+        <isolation-level>TRANSACTION_REPEATABLE_READ</isolation-level>
+      </data-source>
+      <data-source>
+        <description>Test that a ds defined only in xml is created even if there are other ds's created via annotation or a combination of annotations and xml.</description>
+        <name>java:module/mix_XMLOnlySLSBModLevelDS</name>
+        <class-name>org.apache.derby.jdbc.EmbeddedXADataSource40</class-name>
+        <database-name>dsdMixTestXML</database-name>
+        <user>dsdTesterXML</user>
+        <password>dsdPassword</password>
+        <property>
+          <name>createDatabase</name>
+          <value>create</value>
+        </property>
+        <login-timeout>130</login-timeout>
+        <isolation-level>TRANSACTION_READ_COMMITTED</isolation-level>
+      </data-source>
+    </session>
+  </enterprise-beans>
+</ejb-jar>

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDMixEJB.jar/src/com/ibm/ws/injection/dsdmix/ejb/DSDMixedBean.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDMixEJB.jar/src/com/ibm/ws/injection/dsdmix/ejb/DSDMixedBean.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.injection.dsdmix.ejb;
+
+import static java.sql.Connection.TRANSACTION_READ_COMMITTED;
+import static java.sql.Connection.TRANSACTION_SERIALIZABLE;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.sql.DataSourceDefinition;
+import javax.annotation.sql.DataSourceDefinitions;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
+@DataSourceDefinitions({
+                         @DataSourceDefinition(name = "java:module/mix_MergeSLSBModLevelDS",
+                                               className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                               databaseName = "dsdMixTestMerge",
+                                               loginTimeout = 126,
+                                               properties = { "createDatabase=create" },
+                                               user = "dsdTesterMerge"),
+                         @DataSourceDefinition(name = "java:module/mix_XMLOverrideSLSBModLevelDS",
+                                               className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                               databaseName = "dsdMixTestOverride",
+                                               loginTimeout = 127,
+                                               isolationLevel = TRANSACTION_READ_COMMITTED,
+                                               properties = { "createDatabase=create" },
+                                               user = "dsdTesterAnn") })
+@DataSourceDefinition(name = "java:module/mix_AnnOnlySLSBModLevelDS",
+                      className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                      databaseName = "dsdMixTestAnn",
+                      loginTimeout = 129,
+                      isolationLevel = TRANSACTION_SERIALIZABLE,
+                      properties = { "createDatabase=create" },
+                      user = "dsdTesterAnn")
+public class DSDMixedBean {
+    private static String CLASSNAME = DSDMixedBean.class.getName();
+    private static Logger svLogger = Logger.getLogger(CLASSNAME);
+
+    public boolean testDS(String jndi, int expectedLTO, int expectedIso, String expectedUser) throws NamingException, SQLException {
+        boolean result = true;
+        Connection dsCon = null;
+        try {
+            svLogger.info("--> Attempting to lookup the DS defined via annotations using: '" + jndi + "' ");
+
+            InitialContext ctx = new InitialContext();
+            DataSource ds = (DataSource) ctx.lookup(jndi);
+
+            svLogger.info("--> Get connection...");
+            dsCon = ds.getConnection();
+
+            svLogger.info("--> Verify the loginTimeout value...");
+            int loginTO = ds.getLoginTimeout();
+            svLogger.info("--> The expected loginTimeout is: " + expectedLTO + ". The returned loginTimeout is: " + loginTO);
+            if (expectedLTO != loginTO) {
+                result = false;
+            }
+
+            svLogger.info("--> Verify the isolation level value...");
+            int isoLevel = dsCon.getTransactionIsolation();
+            svLogger.info("--> The expected isolation level is: " + expectedIso + ". The returned isolation level is: " + isoLevel);
+            if (expectedIso != isoLevel) {
+                result = false;
+            }
+
+            svLogger.info("--> Getting DatabaseMetaData...");
+            DatabaseMetaData metaD = dsCon.getMetaData();
+
+            svLogger.info("--> Verirfy the user name... ");
+            String userName = metaD.getUserName();
+            svLogger.info("--> The expected user name is: " + expectedUser + ". The returned user name is: " + userName);
+            if (!(userName.equals(expectedUser))) {
+                result = false;
+            }
+
+            return result;
+        } finally {
+            if (dsCon != null) {
+                try {
+                    dsCon.close();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    svLogger.log(Level.INFO, "--> Caught unexpected exception in the finally block", e);
+                }
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDMixWeb.war/resources/WEB-INF/ibm-web-ext.xml
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDMixWeb.war/resources/WEB-INF/ibm-web-ext.xml
@@ -1,0 +1,8 @@
+<web-ext
+  xmlns="http://websphere.ibm.com/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+  version="1.0"
+>
+  <context-root uri="DSDMixWeb"/>
+</web-ext>

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDMixWeb.war/src/com/ibm/ws/injection/dsdmix/web/BasicDSDMixServlet.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDMixWeb.war/src/com/ibm/ws/injection/dsdmix/web/BasicDSDMixServlet.java
@@ -16,12 +16,12 @@ import java.util.logging.Logger;
 
 import javax.servlet.annotation.WebServlet;
 
-import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
-
 import org.junit.Test;
 
-import componenttest.app.FATServlet;
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
 import com.ibm.ws.injection.dsdmix.ejb.DSDMixedBean;
+
+import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
 @WebServlet("/BasicDSDMixServlet")
@@ -59,7 +59,7 @@ public class BasicDSDMixServlet extends FATServlet {
      * @throws Exception
      *
      */
-	@Test
+    @Test
     public void testDSDMerge() throws Exception {
         getAndVerifyResult("java:module/mix_MergeSLSBModLevelDS", 126, 1, "dsdTesterMerge");
     }
@@ -73,7 +73,7 @@ public class BasicDSDMixServlet extends FATServlet {
      * @throws Exception
      *
      */
-	@Test
+    @Test
     public void testDSDOverride() throws Exception {
         getAndVerifyResult("java:module/mix_XMLOverrideSLSBModLevelDS", 128, 4, "dsdTesterXMLKing");
     }
@@ -86,7 +86,7 @@ public class BasicDSDMixServlet extends FATServlet {
      * @throws Exception
      *
      */
-	@Test
+    @Test
     public void testDSDAnnOnly() throws Exception {
         getAndVerifyResult("java:module/mix_AnnOnlySLSBModLevelDS", 129, 8, "dsdTesterAnn");
     }
@@ -99,7 +99,7 @@ public class BasicDSDMixServlet extends FATServlet {
      * @throws Exception
      *
      */
-	@Test
+    @Test
     public void testDSDXMLOnly() throws Exception {
         getAndVerifyResult("java:module/mix_XMLOnlySLSBModLevelDS", 130, 2, "dsdTesterXML");
     }

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDMixWeb.war/src/com/ibm/ws/injection/dsdmix/web/BasicDSDMixServlet.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDMixWeb.war/src/com/ibm/ws/injection/dsdmix/web/BasicDSDMixServlet.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.injection.dsdmix.web;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.logging.Logger;
+
+import javax.servlet.annotation.WebServlet;
+
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import com.ibm.ws.injection.dsdmix.ejb.DSDMixedBean;
+
+@SuppressWarnings("serial")
+@WebServlet("/BasicDSDMixServlet")
+public class BasicDSDMixServlet extends FATServlet {
+    private static final String CLASSNAME = BasicDSDMixServlet.class.getName();
+    private static final Logger svLogger = Logger.getLogger(CLASSNAME);
+
+    /**
+     * Lookup the bean and call the testDS method with the jndi name provided by
+     * the test method and verify it returns the expected loginTimeout value,
+     * isolation level, and user of the defined DataSource
+     *
+     * @param jndi
+     * @param expectedLTO
+     * @param expectedIso
+     * @param expectedUser
+     * @throws Exception
+     */
+    public void getAndVerifyResult(String jndi, int expectedLTO, int expectedIso, String expectedUser) throws Exception {
+        svLogger.info("--> Looking up bean...");
+        DSDMixedBean bean = (DSDMixedBean) FATHelper.lookupDefaultBindingEJBJavaApp(DSDMixedBean.class.getName(), "DSDMixEJB", "DSDMixedBean");
+
+        svLogger.info("--> Calling test method on the SLSB that defines the DS...");
+        boolean result = bean.testDS(jndi, expectedLTO, expectedIso, expectedUser);
+        svLogger.info("--> result = " + result);
+
+        assertTrue("--> Expecting the returned result to be true. " + "Actual value = " + result, result);
+    }
+
+    /**
+     * Verify that a DS defined with some attributes defined via annotation and
+     * other attributes defined via XML will be successfully created with a
+     * merged set of attributes.
+     *
+     * @throws Exception
+     *
+     */
+	@Test
+    public void testDSDMerge() throws Exception {
+        getAndVerifyResult("java:module/mix_MergeSLSBModLevelDS", 126, 1, "dsdTesterMerge");
+    }
+
+    /**
+     * Verify that a DS defined via both annotation and XML, where some of the
+     * same attributes defined using the annotation are also defined via XML with
+     * different values, result in the annotation attributes being overridden by
+     * the values used in XML.
+     *
+     * @throws Exception
+     *
+     */
+	@Test
+    public void testDSDOverride() throws Exception {
+        getAndVerifyResult("java:module/mix_XMLOverrideSLSBModLevelDS", 128, 4, "dsdTesterXMLKing");
+    }
+
+    /**
+     * Verify that a DS defined via annotation only is successfully created even
+     * if there are other DataSources defined in combination of annotation and
+     * XML and one only defined in XML.
+     *
+     * @throws Exception
+     *
+     */
+	@Test
+    public void testDSDAnnOnly() throws Exception {
+        getAndVerifyResult("java:module/mix_AnnOnlySLSBModLevelDS", 129, 8, "dsdTesterAnn");
+    }
+
+    /**
+     * Verify that a DS defined via XML only is successfully created even if
+     * there are other DataSources defined in combination of annotation and XML
+     * and one only defined in annotation.
+     *
+     * @throws Exception
+     *
+     */
+	@Test
+    public void testDSDXMLOnly() throws Exception {
+        getAndVerifyResult("java:module/mix_XMLOnlySLSBModLevelDS", 130, 2, "dsdTesterXML");
+    }
+}

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLEJB.jar/resources/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLEJB.jar/resources/META-INF/ejb-jar.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar id="ejb-jar_ID" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd" metadata-complete="true" version="3.1">
+  <display-name>DSDXMLEJB</display-name>
+  <enterprise-beans>
+    <session>
+      <ejb-name>DSDStatelessBean</ejb-name>
+      <local-bean/>
+      <ejb-class>com.ibm.ws.injection.dsdxml.ejb.DSDStatelessBean</ejb-class>
+      <session-type>Stateless</session-type>
+      <data-source>
+        <description>Basic Data Source Definition in an SLSB - module level</description>
+        <name>java:module/BasicModLevelDS</name>
+        <class-name>org.apache.derby.jdbc.EmbeddedXADataSource40</class-name>
+        <database-name>dsdTest</database-name>
+        <user>dsdTester</user>
+        <password>dsdPassword</password>
+        <property>
+          <name>createDatabase</name>
+          <value>create</value>
+        </property>
+        <login-timeout>142</login-timeout>
+        <isolation-level>TRANSACTION_SERIALIZABLE</isolation-level>
+      </data-source>
+      <data-source>
+        <description>Basic Data Source Definition in an SLSB - application level</description>
+        <name>java:app/BasicAppLevelDS</name>
+        <class-name>org.apache.derby.jdbc.EmbeddedXADataSource40</class-name>
+        <database-name>dsdTest</database-name>
+        <user>dsdTester</user>
+        <password>dsdPassword</password>
+        <property>
+          <name>createDatabase</name>
+          <value>create</value>
+        </property>
+        <login-timeout>122</login-timeout>
+        <isolation-level>TRANSACTION_SERIALIZABLE</isolation-level>
+      </data-source>
+      <data-source>
+        <description>Basic Data Source Definition in an SLSB - global level</description>
+        <name>java:global/BasicGlobalLevelDS</name>
+        <class-name>org.apache.derby.jdbc.EmbeddedXADataSource40</class-name>
+        <database-name>dsdTest</database-name>
+        <user>dsdTester</user>
+        <password>dsdPassword</password>
+        <property>
+          <name>createDatabase</name>
+          <value>create</value>
+        </property>
+        <login-timeout>132</login-timeout>
+        <isolation-level>TRANSACTION_SERIALIZABLE</isolation-level>
+      </data-source>
+      <data-source>
+        <description>Basic Data Source Definition in an SLSB - comp level</description>
+        <name>BasicCompLevelDS</name>
+        <class-name>org.apache.derby.jdbc.EmbeddedXADataSource40</class-name>
+        <database-name>dsdTest</database-name>
+        <user>dsdTester</user>
+        <password>dsdPassword</password>
+        <property>
+          <name>createDatabase</name>
+          <value>create</value>
+        </property>
+        <login-timeout>113</login-timeout>
+        <isolation-level>TRANSACTION_SERIALIZABLE</isolation-level>
+      </data-source>
+      <data-source>
+        <description>Verify that since metadata-complete=true the values defined via annotation are ignored and defaults will be taken for loginTimeout and Isolation Level.</description>
+        <name>java:module/MetaDataCompleteValidDS</name>
+        <class-name>org.apache.derby.jdbc.EmbeddedXADataSource40</class-name>
+        <database-name>dsdTestMetadataComplete</database-name>
+        <property>
+          <name>createDatabase</name>
+          <value>create</value>
+        </property>
+      </data-source>
+    </session>
+  </enterprise-beans>
+</ejb-jar>

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLEJB.jar/src/com/ibm/ws/injection/dsdxml/ejb/DSDStatelessBean.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLEJB.jar/src/com/ibm/ws/injection/dsdxml/ejb/DSDStatelessBean.java
@@ -23,20 +23,20 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 
-// NOTE: this is an XML only test and the following DS's are here 
-// to validate that when metadata-complete=true these annotations 
+// NOTE: this is an XML only test and the following DS's are here
+// to validate that when metadata-complete=true these annotations
 // are ignored.
 @DataSourceDefinitions({
-                        @DataSourceDefinition(name = "java:module/MetaDataCompleteValidDS",
-                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
-                                              loginTimeout = 29,
-                                              isolationLevel = TRANSACTION_SERIALIZABLE),
-                        @DataSourceDefinition(name = "java:module/AnnotationOnlyToBeIgnored",
-                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
-                                              databaseName = "dsdXMLTestMDCAnnOnly",
-                                              loginTimeout = 86,
-                                              isolationLevel = TRANSACTION_SERIALIZABLE,
-                                              properties = { "createDatabase=create" })
+                         @DataSourceDefinition(name = "java:module/MetaDataCompleteValidDS",
+                                               className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                               loginTimeout = 29,
+                                               isolationLevel = TRANSACTION_SERIALIZABLE),
+                         @DataSourceDefinition(name = "java:module/AnnotationOnlyToBeIgnored",
+                                               className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                               databaseName = "dsdXMLTestMDCAnnOnly",
+                                               loginTimeout = 86,
+                                               isolationLevel = TRANSACTION_SERIALIZABLE,
+                                               properties = { "createDatabase=create" })
 })
 public class DSDStatelessBean {
     private static String CLASSNAME = DSDStatelessBean.class.getName();

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLEJB.jar/src/com/ibm/ws/injection/dsdxml/ejb/DSDStatelessBean.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLEJB.jar/src/com/ibm/ws/injection/dsdxml/ejb/DSDStatelessBean.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.injection.dsdxml.ejb;
+
+import static java.sql.Connection.TRANSACTION_SERIALIZABLE;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.sql.DataSourceDefinition;
+import javax.annotation.sql.DataSourceDefinitions;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
+// NOTE: this is an XML only test and the following DS's are here 
+// to validate that when metadata-complete=true these annotations 
+// are ignored.
+@DataSourceDefinitions({
+                        @DataSourceDefinition(name = "java:module/MetaDataCompleteValidDS",
+                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                              loginTimeout = 29,
+                                              isolationLevel = TRANSACTION_SERIALIZABLE),
+                        @DataSourceDefinition(name = "java:module/AnnotationOnlyToBeIgnored",
+                                              className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
+                                              databaseName = "dsdXMLTestMDCAnnOnly",
+                                              loginTimeout = 86,
+                                              isolationLevel = TRANSACTION_SERIALIZABLE,
+                                              properties = { "createDatabase=create" })
+})
+public class DSDStatelessBean {
+    private static String CLASSNAME = DSDStatelessBean.class.getName();
+    private static Logger svLogger = Logger.getLogger(CLASSNAME);
+
+    public boolean testDS(String jndi, int expectedLTO, int expectedIso) throws NamingException, SQLException {
+        boolean result = true;
+        Connection dsCon = null;
+        try {
+            svLogger.info("--> Attempting to lookup the DS defined in XML using: '" + jndi + "' ");
+            InitialContext ctx = new InitialContext();
+            DataSource ds = (DataSource) ctx.lookup(jndi);
+
+            svLogger.info("--> Get connection...");
+            dsCon = ds.getConnection();
+
+            svLogger.info("--> Verify the loginTimeout value...");
+            int loginTO = ds.getLoginTimeout();
+            svLogger.info("--> The expected loginTimeout is: " + expectedLTO + ". The returned loginTimeout is: " + loginTO);
+            if (expectedLTO != loginTO) {
+                result = false;
+            }
+            svLogger.info("--> Verify the isolation level value...");
+            int isoLevel = dsCon.getTransactionIsolation();
+            svLogger.info("--> The expected isolation level is: " + expectedIso + ". The returned isolation level is: " + isoLevel);
+            if (expectedIso != isoLevel) {
+                result = false;
+            }
+
+            return result;
+        } finally {
+            if (dsCon != null) {
+                try {
+                    dsCon.close();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    svLogger.log(Level.INFO, "--> Caught unexpected exception in the finally block", e);
+                }
+            }
+        }
+    }
+
+    public boolean testInvalidDS() {
+        boolean result = false;
+        try {
+            svLogger.info("--> Attempting to lookup the invalid DS defined via annotation using: 'java:module/AnnotationOnlyToBeIgnored' ");
+            InitialContext ctx = new InitialContext();
+            ctx.lookup("java:module/AnnotationOnlyToBeIgnored");
+        } catch (NamingException ne) {
+            svLogger.log(Level.INFO, "--> Caught expected NamingException.", ne);
+            svLogger.info("--> Setting result = true...");
+            result = true;
+        }
+        return result;
+    }
+}

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLWeb.war/resources/WEB-INF/ibm-web-ext.xml
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLWeb.war/resources/WEB-INF/ibm-web-ext.xml
@@ -1,0 +1,8 @@
+<web-ext
+  xmlns="http://websphere.ibm.com/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+  version="1.0"
+>
+  <context-root uri="DSDXMLWeb"/>
+</web-ext>

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLWeb.war/src/com/ibm/ws/injection/dsdxml/web/BasicDSDXMLServlet.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLWeb.war/src/com/ibm/ws/injection/dsdxml/web/BasicDSDXMLServlet.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2010, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.injection.dsdxml.web;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.logging.Logger;
+
+import javax.servlet.annotation.WebServlet;
+
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import com.ibm.ws.injection.dsdxml.ejb.DSDStatelessBean;
+
+@SuppressWarnings("serial")
+@WebServlet("/BasicDSDXMLServlet")
+public class BasicDSDXMLServlet extends FATServlet {
+    private static final String CLASSNAME = BasicDSDXMLServlet.class.getName();
+    private static final Logger svLogger = Logger.getLogger(CLASSNAME);
+
+    /**
+     * Lookup the bean and call the testDS method with the jndi name provided by
+     * the test method and verify it returns the expected loginTimeout value and
+     * isolation level of the defined DataSource
+     *
+     * @param jndi
+     * @param expectedLTO
+     * @param expectedIso
+     * @throws Exception
+     */
+    public void getAndVerifyResult(String jndi, int expectedLTO, int expectedIso) throws Exception {
+        svLogger.info("--> Looking up bean...");
+        DSDStatelessBean bean = (DSDStatelessBean) FATHelper.lookupDefaultBindingEJBJavaApp(DSDStatelessBean.class.getName(), "DSDXMLEJB", "DSDStatelessBean");
+        svLogger.info("--> Calling test method on the bean that defines the DS...");
+        boolean result = bean.testDS(jndi, expectedLTO, expectedIso);
+        svLogger.info("--> result = " + result);
+
+        assertTrue("--> Expecting the returned result to be true. " + "Actual value = " + result, result);
+    }
+
+    /**
+     * Verify that a DS defined in a SLSB using the XML data-source element can
+     * be successfully looked up from the SLSB using the java:module namespace
+     *
+     * @throws Exception
+     *
+     */
+	@Test
+    public void testDSDModLevel() throws Exception {
+        getAndVerifyResult("java:module/BasicModLevelDS", 142, 8);
+    }
+
+    /**
+     * Verify that a DS defined in a SLSB using the XML data-source element can
+     * be successfully looked up from the SLSB using the java:app namespace
+     *
+     * @throws Exception
+     *
+     */
+	@Test
+    public void testDSDAppLevel() throws Exception {
+        getAndVerifyResult("java:app/BasicAppLevelDS", 122, 8);
+    }
+
+    /**
+     * Verify that a DS defined in a SLSB using the XML data-source element can
+     * be successfully looked up from the SLSB using the java:global namespace
+     *
+     * @throws Exception
+     *
+     */
+	@Test
+    public void testDSDGlobalLevel() throws Exception {
+        getAndVerifyResult("java:global/BasicGlobalLevelDS", 132, 8);
+    }
+
+    /**
+     * Verify that a DS defined in a SLSB using the XML data-source element can
+     * be successfully looked up from the SLSB using the java:comp namespace
+     *
+     * @throws Exception
+     */
+	@Test
+    public void testDSDCompLevel() throws Exception {
+        getAndVerifyResult("java:comp/env/BasicCompLevelDS", 113, 8);
+    }
+
+    /**
+     * Verify that a DS defined in a SLSB using both XML and annotations will
+     * ignore anything set in via annotations when metadata-complete = true.
+     * We expect to get the default values for the loginTimeout and Isolation
+     * level properties which are 0 and 4 respectively.
+     *
+     */
+	@Test
+    public void testDSDMetaDataCompleteValid() throws Exception {
+        getAndVerifyResult("java:module/MetaDataCompleteValidDS", 0, 4);
+    }
+
+    /**
+     * Verify that a DS defined ONLY via annotation will not be created when
+     * metadata-complete = true.
+     */
+	@Test
+    public void testDSMetaDataCompleteAnnOnly() throws Exception {
+        svLogger.info("--> Looking up bean...");
+        DSDStatelessBean bean = (DSDStatelessBean) FATHelper.lookupDefaultBindingEJBJavaApp(DSDStatelessBean.class.getName(), "DSDXMLEJB", "DSDStatelessBean");
+        assertTrue("--> Expected to receive result = true, actual value of result = " + bean.testInvalidDS(), bean.testInvalidDS());
+    }
+}

--- a/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLWeb.war/src/com/ibm/ws/injection/dsdxml/web/BasicDSDXMLServlet.java
+++ b/dev/com.ibm.ws.injection_fat/test-applications/DSDXMLWeb.war/src/com/ibm/ws/injection/dsdxml/web/BasicDSDXMLServlet.java
@@ -16,12 +16,12 @@ import java.util.logging.Logger;
 
 import javax.servlet.annotation.WebServlet;
 
-import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
-
 import org.junit.Test;
 
-import componenttest.app.FATServlet;
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
 import com.ibm.ws.injection.dsdxml.ejb.DSDStatelessBean;
+
+import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
 @WebServlet("/BasicDSDXMLServlet")
@@ -56,7 +56,7 @@ public class BasicDSDXMLServlet extends FATServlet {
      * @throws Exception
      *
      */
-	@Test
+    @Test
     public void testDSDModLevel() throws Exception {
         getAndVerifyResult("java:module/BasicModLevelDS", 142, 8);
     }
@@ -68,7 +68,7 @@ public class BasicDSDXMLServlet extends FATServlet {
      * @throws Exception
      *
      */
-	@Test
+    @Test
     public void testDSDAppLevel() throws Exception {
         getAndVerifyResult("java:app/BasicAppLevelDS", 122, 8);
     }
@@ -80,7 +80,7 @@ public class BasicDSDXMLServlet extends FATServlet {
      * @throws Exception
      *
      */
-	@Test
+    @Test
     public void testDSDGlobalLevel() throws Exception {
         getAndVerifyResult("java:global/BasicGlobalLevelDS", 132, 8);
     }
@@ -91,7 +91,7 @@ public class BasicDSDXMLServlet extends FATServlet {
      *
      * @throws Exception
      */
-	@Test
+    @Test
     public void testDSDCompLevel() throws Exception {
         getAndVerifyResult("java:comp/env/BasicCompLevelDS", 113, 8);
     }
@@ -103,7 +103,7 @@ public class BasicDSDXMLServlet extends FATServlet {
      * level properties which are 0 and 4 respectively.
      *
      */
-	@Test
+    @Test
     public void testDSDMetaDataCompleteValid() throws Exception {
         getAndVerifyResult("java:module/MetaDataCompleteValidDS", 0, 4);
     }
@@ -112,7 +112,7 @@ public class BasicDSDXMLServlet extends FATServlet {
      * Verify that a DS defined ONLY via annotation will not be created when
      * metadata-complete = true.
      */
-	@Test
+    @Test
     public void testDSMetaDataCompleteAnnOnly() throws Exception {
         svLogger.info("--> Looking up bean...");
         DSDStatelessBean bean = (DSDStatelessBean) FATHelper.lookupDefaultBindingEJBJavaApp(DSDStatelessBean.class.getName(), "DSDXMLEJB", "DSDStatelessBean");


### PR DESCRIPTION
Moving DataSourceDefinition testing to the com.ibm.ws.injection_fat bucket.