### PR TITLE
Add Maven coordinates for Java specs

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.cdi1.2-servlet3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.cdi1.2-servlet3.1.feature
@@ -5,7 +5,7 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.servlet-3.1))"
 -bundles=com.ibm.ws.cdi.1.2.web, \
  com.ibm.ws.cdi.web, \
- com.ibm.websphere.javaee.jsp.2.3; location:="dev/api/spec/,lib/"
+ com.ibm.websphere.javaee.jsp.2.3; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet.jsp:javax.servlet.jsp-api:2.3.1"
 IBM-Install-Policy: when-satisfied
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.cdi2.0-servlet4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.cdi2.0-servlet4.0.feature
@@ -5,7 +5,7 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.servlet-4.0))"
 -bundles=com.ibm.ws.cdi.2.0.web, \
  com.ibm.ws.cdi.web, \
- com.ibm.websphere.javaee.jsp.2.3; location:="dev/api/spec/,lib/"
+ com.ibm.websphere.javaee.jsp.2.3; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet.jsp:javax.servlet.jsp-api:2.3.1"
 IBM-Install-Policy: when-satisfied
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaccEjb-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaccEjb-1.5.feature
@@ -4,6 +4,6 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jacc-1.5))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.security.authorization.jacc.ejb, \
- com.ibm.websphere.javaee.jacc.1.5; location:="dev/api/spec/,lib"
+ com.ibm.websphere.javaee.jacc.1.5; location:="dev/api/spec/,lib"; mavenCoordinates="javax.security.jacc:javax.security.jacc-api:1.5"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaccWeb-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaccWeb-1.5.feature
@@ -4,6 +4,6 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jacc-1.5))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.security.authorization.jacc.web, \
- com.ibm.websphere.javaee.jacc.1.5; location:="dev/api/spec/,lib"
+ com.ibm.websphere.javaee.jacc.1.5; location:="dev/api/spec/,lib"; mavenCoordinates="javax.security.jacc:javax.security.jacc-api:1.5"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.webservicesee-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.webservicesee-1.3.feature
@@ -7,6 +7,6 @@ IBM-Provision-Capability: osgi.identity;filter:="(&(type=osgi.subsystem.feature)
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.javaee.ddmodel.ws, \
  com.ibm.ws.webservices.javaee.common, \
- com.ibm.websphere.javaee.jaxws.2.2; location:="dev/api/spec/,lib/"
+ com.ibm.websphere.javaee.jaxws.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.ws:jaxws-api:2.2.12"
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxb-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxb-2.2.feature
@@ -9,7 +9,7 @@ Subsystem-Name: Internal Java XML Bindings 2.2
 -features=\
   com.ibm.websphere.appserver.classloading-1.0
 -bundles=\
-  com.ibm.websphere.javaee.jaxb.2.2; location:="dev/api/spec/,lib/", \
+  com.ibm.websphere.javaee.jaxb.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.bind:jaxb-api:2.2.12", \
   com.ibm.ws.org.apache.geronimo.osgi.registry.1.1, \
   com.ibm.ws.jaxb.tools.2.2.10
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.0.feature
@@ -20,7 +20,7 @@ Subsystem-Name: Internal Java RESTful Services 2.0
  com.ibm.ws.jaxrs.2.0.common, \
  com.ibm.ws.jaxrs.2.x.config, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
- com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0.1", \
  com.ibm.ws.jaxrs.2.0.tools, \
  com.ibm.ws.jaxrs.2.0.web, \
  com.ibm.ws.jaxrs.2.0.server, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.1.feature
@@ -28,7 +28,7 @@ Subsystem-Name: Internal Java RESTful Services 2.1
  com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
- com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.1", \
  com.ibm.ws.jaxrs.2.0.tools, \
  com.ibm.ws.jaxrs.2.0.web, \
  com.ibm.ws.jaxrs.2.0.server, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jms-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jms-2.0.feature
@@ -7,7 +7,7 @@ IBM-API-Package: javax.jms; version="2.0"; type="spec"
  com.ibm.websphere.appserver.javaeePlatform-7.0, \
  com.ibm.websphere.appserver.internal.jca-1.6, \
  com.ibm.websphere.appserver.transaction-1.2
--bundles=com.ibm.websphere.javaee.jms.2.0; location:="dev/api/spec/,lib/", \
+-bundles=com.ibm.websphere.javaee.jms.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.jms:javax.jms-api:2.0", \
  com.ibm.ws.messaging.jmsspec.common
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.j2eeManagementClient-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.j2eeManagementClient-1.1.feature
@@ -5,6 +5,6 @@ IBM-API-Package: javax.management.j2ee; type="spec", \
  javax.management.j2ee.statistics; type="spec", \
  org.omg.stub.javax.management.j2ee; type="spec"
 Subsystem-Version: 1.1
--bundles=com.ibm.websphere.javaee.management.j2ee.1.1; location:=dev/api/spec/
+-bundles=com.ibm.websphere.javaee.management.j2ee.1.1; location:=dev/api/spec/; mavenCoordinates="javax.management.j2ee:management-api:1.1-rev-1"
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.1.feature
@@ -3,6 +3,6 @@ symbolicName=com.ibm.websphere.appserver.javax.annotation-1.1
 singleton=true
 IBM-Process-Types: server, \
  client
--bundles=com.ibm.websphere.javaee.annotation.1.1; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.annotation.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.2.feature
@@ -3,6 +3,6 @@ symbolicName=com.ibm.websphere.appserver.javax.annotation-1.2
 singleton=true
 IBM-Process-Types: server, \
  client
--bundles=com.ibm.websphere.javaee.annotation.1.2; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.annotation.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.3.feature
@@ -3,6 +3,6 @@ symbolicName=com.ibm.websphere.appserver.javax.annotation-1.3
 singleton=true
 IBM-Process-Types: server, \
  client
--bundles=com.ibm.websphere.javaee.annotation.1.3; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.annotation.1.3; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.3.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.cdi-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.cdi-1.2.feature
@@ -3,6 +3,6 @@ symbolicName=com.ibm.websphere.appserver.javax.cdi-1.2
 singleton=true
 -features=com.ibm.websphere.appserver.javax.el-3.0; apiJar=false, \
  com.ibm.websphere.appserver.javax.interceptor-1.2
--bundles=com.ibm.websphere.javaee.cdi.1.2; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.cdi.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise:cdi-api:1.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.cdi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.cdi-2.0.feature
@@ -3,6 +3,6 @@ symbolicName=com.ibm.websphere.appserver.javax.cdi-2.0
 singleton=true
 -features=com.ibm.websphere.appserver.javax.el-3.0; apiJar=false, \
  com.ibm.websphere.appserver.javax.interceptor-1.2
--bundles=com.ibm.websphere.javaee.cdi.2.0; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.cdi.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise:cdi-api:2.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.connector.internal-1.6.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.connector.internal-1.6.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.connector.internal-1.6
 singleton=true
--bundles=com.ibm.websphere.javaee.connector.1.6; apiJar=false; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.connector.1.6; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.resource:javax.resource-api:1.7"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.connector.internal-1.7.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.connector.internal-1.7.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.connector.internal-1.7
 singleton=true
--bundles=com.ibm.websphere.javaee.connector.1.7; apiJar=false; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.connector.1.7; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.resource:javax.resource-api:1.7"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.ejb-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.ejb-3.1.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.ejb-3.1
 singleton=true
--bundles=com.ibm.websphere.javaee.ejb.3.1; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.ejb.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="org.glassfish:javax.ejb:3.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.ejb-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.ejb-3.2.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.ejb-3.2
 singleton=true
--bundles=com.ibm.websphere.javaee.ejb.3.2; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.ejb.3.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ejb:javax.ejb-api:3.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.el-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.el-2.2.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.el-2.2
 singleton=true
--bundles=com.ibm.websphere.javaee.el.2.2; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.el.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.el:el-api:2.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.el-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.el-3.0.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.el-3.0
 singleton=true
--bundles=com.ibm.websphere.javaee.el.3.0; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.el.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.el:javax.el-api:3.0.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.interceptor-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.interceptor-1.1.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.interceptor-1.1
 singleton=true
--bundles=com.ibm.websphere.javaee.interceptor.1.1; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.interceptor.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="org.apache.geronimo.specs:geronimo-interceptor_1.1_spec:1.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.interceptor-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.interceptor-1.2.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.interceptor-1.2
 singleton=true
--bundles=com.ibm.websphere.javaee.interceptor.1.2; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.interceptor.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.interceptor:javax.interceptor-api:1.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsf-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsf-2.2.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.jsf-2.2
 singleton=true
--bundles=com.ibm.websphere.javaee.jsf.2.2; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.jsf.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="org.apache.myfaces.core:myfaces-api:2.2.12"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsf-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsf-2.3.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.jsf-2.3
 singleton=true
--bundles=com.ibm.websphere.javaee.jsf.2.3; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.jsf.2.3; location:="dev/api/spec/,lib/"; mavenCoordinates="org.apache.myfaces.core:myfaces-api:2.3.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsp-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsp-2.2.feature
@@ -3,6 +3,6 @@ symbolicName=com.ibm.websphere.appserver.javax.jsp-2.2
 singleton=true
 -features=com.ibm.websphere.appserver.javax.servlet-3.0; ibm.tolerates:=3.1; apiJar=false, \
  com.ibm.websphere.appserver.javax.el-2.2; apiJar=false
--bundles=com.ibm.websphere.javaee.jsp.2.2; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.jsp.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet.jsp:javax.servlet.jsp-api:2.2.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsp-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsp-2.3.feature
@@ -3,6 +3,6 @@ symbolicName=com.ibm.websphere.appserver.javax.jsp-2.3
 singleton=true
 -features=com.ibm.websphere.appserver.javax.el-3.0; apiJar=false, \
  com.ibm.websphere.appserver.javax.servlet-3.1; ibm.tolerates:=4.0; apiJar=false
--bundles=com.ibm.websphere.javaee.jsp.2.3; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.jsp.2.3; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet.jsp:javax.servlet.jsp-api:2.3.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.persistence-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.persistence-2.1.feature
@@ -5,6 +5,6 @@ IBM-Process-Types: server, \
  client
 -features=com.ibm.websphere.appserver.javax.persistence.base-2.1
 -bundles=com.ibm.ws.javaee.persistence.api.2.1
--jars=com.ibm.websphere.javaee.persistence.2.1; location:=dev/api/spec/
+-jars=com.ibm.websphere.javaee.persistence.2.1; location:=dev/api/spec/; mavenCoordinates="org.eclipse.persistence:javax.persistence:2.1.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.persistence-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.persistence-2.2.feature
@@ -5,6 +5,6 @@ IBM-Process-Types: server, \
  client
 -features=com.ibm.websphere.appserver.javax.persistence.base-2.2
 -bundles=com.ibm.ws.javaee.persistence.api.2.2
--jars=com.ibm.websphere.javaee.persistence.2.2; location:=dev/api/spec/
+-jars=com.ibm.websphere.javaee.persistence.2.2; location:=dev/api/spec/; mavenCoordinates="javax.persistence:javax.persistence-api:2.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-3.0.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.servlet-3.0
 singleton=true
--bundles=com.ibm.websphere.javaee.servlet.3.0; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.servlet.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:3.0.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-3.1.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.servlet-3.1
 singleton=true
--bundles=com.ibm.websphere.javaee.servlet.3.1; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.servlet.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:3.1.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-4.0.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.servlet-4.0
 singleton=true
--bundles=com.ibm.websphere.javaee.servlet.4.0; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.servlet.4.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:4.0.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.validation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.validation-1.1.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.validation-1.1
 singleton=true
--bundles=com.ibm.websphere.javaee.validation.1.1; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.validation.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.validation:validation-api:1.1.0.Final"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.validation-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.validation-2.0.feature
@@ -1,6 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.validation-2.0
 singleton=true
--bundles=com.ibm.websphere.javaee.validation.2.0; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.validation.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.validation:validation-api:2.0.1.Final"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
@@ -25,7 +25,7 @@ IBM-SPI-Package: com.ibm.wsspi.webservices.handler
  com.ibm.ws.jaxrs.2.0.common, \
  com.ibm.ws.jaxrs.2.x.config, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
- com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0.1", \
  com.ibm.ws.jaxrs.2.0.tools
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip, \
  bin/jaxrs/wadl2java, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
@@ -28,7 +28,7 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
- com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.1", \
  com.ibm.ws.jaxrs.2.0.tools
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip, \
  bin/jaxrs/wadl2java, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxwsClient-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxwsClient-2.2.feature
@@ -19,11 +19,11 @@ IBM-Process-Types: client
  com.ibm.ws.org.apache.cxf-rt-databinding-jaxb.2.6.2, \
  com.ibm.ws.org.apache.cxf-rt-management.2.6.2, \
  com.ibm.ws.org.apache.cxf-rt-ws-addr.2.6.2, \
- com.ibm.websphere.javaee.jaxws.2.2; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jaxws.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.ws:jaxws-api:2.2.12", \
  com.ibm.ws.org.apache.cxf-rt-frontend-simple.2.6.2, \
  com.ibm.websphere.prereq.wsdl4j.api; location:="dev/api/spec/,lib/", \
  com.ibm.ws.jaxws.clientcontainer, \
- com.ibm.websphere.javaee.wsdl4j.1.2; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.wsdl4j.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="wsdl4j:wsdl4j:1.6.3", \
  com.ibm.ws.prereq.wsdl4j.1.6.2, \
  com.ibm.ws.org.apache.cxf-rt-frontend-jaxws.2.6.2, \
  com.ibm.ws.org.apache.cxf-rt-ws-policy.2.6.2, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonbImpl-1.0.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonbImpl-1.0.0.feature
@@ -8,6 +8,6 @@ visibility=private
  com.ibm.websphere.appserver.jsonp-1.1,\
  com.ibm.websphere.appserver.javax.cdi-2.0,\
  com.ibm.websphere.appserver.javaeeCompatible-8.0
--bundles=com.ibm.websphere.javaee.jsonb.1.0; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.jsonb.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json.bind:javax.json.bind-api:1.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonbImpl-1.0.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonbImpl-1.0.1.feature
@@ -8,6 +8,6 @@ visibility=private
   com.ibm.websphere.appserver.javax.cdi-2.0,\
   com.ibm.websphere.appserver.javaeeCompatible-8.0
 -bundles=com.ibm.ws.org.eclipse.yasson.1.0, \
-  com.ibm.websphere.javaee.jsonb.1.0; location:="dev/api/spec/,lib/"
+  com.ibm.websphere.javaee.jsonb.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json.bind:javax.json.bind-api:1.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.1.0.feature
@@ -6,6 +6,6 @@ singleton=true
 visibility=private
 -features=com.ibm.websphere.appserver.bells-1.0,\
   com.ibm.websphere.appserver.javaeeCompatible-8.0
--bundles=com.ibm.websphere.javaee.jsonp.1.1; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.jsonp.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.1.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.1.1.feature
@@ -4,7 +4,7 @@ symbolicName=com.ibm.websphere.appserver.jsonpImpl-1.1.1
 singleton=true
 visibility=private
 -features=com.ibm.websphere.appserver.javaeeCompatible-8.0
--bundles=com.ibm.websphere.javaee.jsonp.1.1; location:="dev/api/spec/,lib/", \
+-bundles=com.ibm.websphere.javaee.jsonp.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.1.2", \
  com.ibm.ws.org.glassfish.json.1.1
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.persistentExecutorSubset-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.persistentExecutorSubset-1.0.feature
@@ -8,7 +8,7 @@ visibility=private
  com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.2", \
  com.ibm.websphere.appserver.transaction-1.2
 -bundles=com.ibm.ws.javaee.platform.defaultresource, \
- com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.0", \
  com.ibm.ws.resource, \
  com.ibm.ws.concurrent.persistent
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.javax.connector-1.6.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.javax.connector-1.6.feature
@@ -10,6 +10,6 @@ IBM-API-Package: javax.resource; type="spec", \
  javax.resource.spi.work; type="spec"
 -features=com.ibm.websphere.appserver.javax.connector.internal-1.6, \
  com.ibm.websphere.appserver.javaeeCompatible-6.0
--bundles=com.ibm.websphere.javaee.connector.1.6; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.connector.1.6; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.resource:javax.resource-api:1.7"
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.javax.connector-1.7.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.javax.connector-1.7.feature
@@ -10,6 +10,6 @@ IBM-API-Package: javax.resource; type="spec", \
  javax.resource.spi.work; type="spec"
 -features=com.ibm.websphere.appserver.javax.connector.internal-1.7, \
  com.ibm.websphere.appserver.javaeeCompatible-7.0; ibm.tolerates:=8.0
--bundles=com.ibm.websphere.javaee.connector.1.7; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.connector.1.7; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.resource:javax.resource-api:1.7"
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.jta-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.jta-1.1.feature
@@ -4,7 +4,7 @@ visibility=protected
 singleton=true
 IBM-API-Package: javax.transaction;  type="spec", \
  javax.transaction.xa;  type="spec"
--bundles=com.ibm.websphere.javaee.transaction.1.1; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.transaction.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.transaction:jta:1.1"
 -jars=com.ibm.websphere.appserver.api.transaction; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.transaction_1.1-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.jta-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.jta-1.2.feature
@@ -5,7 +5,7 @@ singleton=true
 IBM-API-Package: javax.transaction;  type="spec", \
  javax.transaction.xa;  type="spec"
 -features=com.ibm.websphere.appserver.javax.cdi-1.2; ibm.tolerates:=2.0
--bundles=com.ibm.websphere.javaee.transaction.1.2; location:="dev/api/spec/,lib/"
+-bundles=com.ibm.websphere.javaee.transaction.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.transaction:javax.transaction-api:1.2"
 -jars=com.ibm.websphere.appserver.api.transaction; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.transaction_1.1-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
@@ -12,7 +12,7 @@ Subsystem-Name: Application Security 3.0
  com.ibm.websphere.appserver.el-3.0, \
  com.ibm.websphere.appserver.jaspic-1.1, \
  com.ibm.websphere.appserver.servlet-4.0
--bundles=com.ibm.websphere.javaee.security.1.0; location:=dev/api/spec/, \
+-bundles=com.ibm.websphere.javaee.security.1.0; location:=dev/api/spec/; mavenCoordinates="javax.security.enterprise:javax.security.enterprise-api:1.0", \
  com.ibm.ws.security.javaeesec.1.0, \
  com.ibm.ws.security.javaeesec.cdi
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/batch-1.0/com.ibm.websphere.appserver.batch-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/batch-1.0/com.ibm.websphere.appserver.batch-1.0.feature
@@ -27,6 +27,6 @@ Subsystem-Name: Batch API 1.0
  com.ibm.ws.security.credentials, \
  com.ibm.websphere.security, \
  com.ibm.jbatch.container, \
- com.ibm.websphere.javaee.batch.1.0; location:="dev/api/spec/,lib/"
+ com.ibm.websphere.javaee.batch.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.batch:javax.batch-api:1.0.1"
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-1.2/com.ibm.websphere.appserver.cdi-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-1.2/com.ibm.websphere.appserver.cdi-1.2.feature
@@ -56,7 +56,7 @@ Subsystem-Name: Contexts and Dependency Injection 1.2
  com.ibm.ws.cdi.weld, \
  com.ibm.ws.cdi.internal, \
  com.ibm.ws.cdi.1.2.weld, \
- com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
  com.ibm.ws.cdi.interfaces
 -jars=com.ibm.websphere.appserver.thirdparty.cdi; location:="dev/api/third-party/,lib/"
 -files=dev/api/ibm/schema/ibm-managed-bean-bnd_1_0.xsd, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
@@ -60,8 +60,8 @@ Subsystem-Name: Contexts and Dependency Injection 2.0
  com.ibm.ws.cdi.weld, \
  com.ibm.ws.cdi.internal, \
  com.ibm.ws.cdi.2.0.weld, \
- com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/", \
- com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
+ com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.websocket:javax.websocket-api:1.1", \
  com.ibm.ws.cdi.interfaces
 -jars=com.ibm.websphere.appserver.thirdparty.cdi-2.0; location:="dev/api/third-party/,lib/"
 -files=dev/api/ibm/schema/ibm-managed-bean-bnd_1_0.xsd, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
@@ -12,7 +12,7 @@ Subsystem-Name: Concurrency Utilities for Java EE 1.0
  com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
  com.ibm.websphere.appserver.contextService-1.0
 -bundles=com.ibm.ws.javaee.platform.defaultresource, \
- com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.0", \
  com.ibm.ws.resource, \
  com.ibm.ws.concurrent
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/j2eeManagement-1.1/com.ibm.websphere.appserver.j2eeManagement-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/j2eeManagement-1.1/com.ibm.websphere.appserver.j2eeManagement-1.1.feature
@@ -13,7 +13,7 @@ Subsystem-Name: J2EE Management 1.1
  com.ibm.websphere.appserver.transaction-1.2
 -bundles=com.ibm.ws.management.j2ee, \
  com.ibm.ws.management.j2ee.mbeans; location:=lib/, \
- com.ibm.websphere.javaee.management.j2ee.1.1; location:=dev/api/spec/
+ com.ibm.websphere.javaee.management.j2ee.1.1; location:=dev/api/spec/; mavenCoordinates="javax.management.j2ee:management-api:1.1-rev-1"
 -jars=com.ibm.websphere.appserver.api.j2eemanagement; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.j2eemanagement_1.1-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jacc-1.5/com.ibm.websphere.appserver.jacc-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jacc-1.5/com.ibm.websphere.appserver.jacc-1.5.feature
@@ -12,7 +12,7 @@ IBM-Install-Policy: when-satisfied
  com.ibm.websphere.appserver.appSecurity-2.0; ibm.tolerates:=3.0, \
  com.ibm.websphere.appserver.javaeedd-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0
--bundles=com.ibm.websphere.javaee.jacc.1.5; location:=dev/api/spec/, \
+-bundles=com.ibm.websphere.javaee.jacc.1.5; location:=dev/api/spec/; mavenCoordinates="javax.security.jacc:javax.security.jacc-api:1.5", \
  com.ibm.ws.security.authorization.jacc, \
  com.ibm.ws.security.audit.utils
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaspic-1.1/com.ibm.websphere.appserver.jaspic-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaspic-1.1/com.ibm.websphere.appserver.jaspic-1.1.feature
@@ -10,7 +10,7 @@ IBM-SPI-Package: com.ibm.wsspi.security.jaspi; type="ibm-spi"
 Subsystem-Name: Java Authentication SPI for Containers 1.1
 -features=com.ibm.websphere.appserver.appSecurity-2.0; ibm.tolerates:=3.0, \
  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1, 4.0"
--bundles=com.ibm.websphere.javaee.jaspic.1.1; location:=dev/api/spec/, \
+-bundles=com.ibm.websphere.javaee.jaspic.1.1; location:=dev/api/spec/; mavenCoordinates="javax.security.auth.message:javax.security.auth.message-api:1.1", \
  com.ibm.ws.security.jaspic.1.1
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.5/com.ibm.websphere.appserver.javaMail-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.5/com.ibm.websphere.appserver.javaMail-1.5.feature
@@ -27,7 +27,7 @@ Subsystem-Name: JavaMail 1.5
 -bundles=\
   com.ibm.ws.javamail,\
   com.ibm.ws.javamail.config
--jars=com.ibm.websphere.javaee.mail.1.5; location:=dev/api/spec/, \
+-jars=com.ibm.websphere.javaee.mail.1.5; location:=dev/api/spec/; mavenCoordinates="javax.mail:javax.mail-api:1.5.6", \
  com.ibm.websphere.appserver.thirdparty.mail; location:=dev/api/third-party/
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.6/com.ibm.websphere.appserver.javaMail-1.6.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.6/com.ibm.websphere.appserver.javaMail-1.6.feature
@@ -29,7 +29,7 @@ IBM-API-Package: \
 -bundles=\
   com.ibm.ws.javamail.1.6,\
   com.ibm.ws.javamail.config
--jars=com.ibm.websphere.javaee.mail.1.6; location:=dev/api/spec/, \
+-jars=com.ibm.websphere.javaee.mail.1.6; location:=dev/api/spec/; mavenCoordinates="javax.mail:javax.mail-api:1.6.1", \
  com.ibm.websphere.appserver.thirdparty.mail-1.6; location:=dev/api/third-party/
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxws-2.2/com.ibm.websphere.appserver.jaxws-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxws-2.2/com.ibm.websphere.appserver.jaxws-2.2.feature
@@ -44,11 +44,11 @@ Subsystem-Name: Java Web Services 2.2
  com.ibm.ws.org.apache.cxf-rt-management.2.6.2, \
  com.ibm.ws.org.apache.cxf-rt-ws-addr.2.6.2, \
  com.ibm.ws.jaxws.common, \
- com.ibm.websphere.javaee.jaxws.2.2; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jaxws.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.ws:jaxws-api:2.2.12", \
  com.ibm.ws.jaxws.tools.2.2.10, \
  com.ibm.ws.org.apache.cxf-rt-frontend-simple.2.6.2, \
  com.ibm.websphere.prereq.wsdl4j.api; location:="dev/api/spec/,lib/", \
- com.ibm.websphere.javaee.wsdl4j.1.2; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.wsdl4j.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="wsdl4j:wsdl4j:1.6.3", \
  com.ibm.ws.prereq.wsdl4j.1.6.2, \
  com.ibm.ws.org.apache.cxf-rt-frontend-jaxws.2.6.2, \
  com.ibm.ws.org.apache.cxf-rt-ws-policy.2.6.2, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jcaInboundSecurity-1.0/com.ibm.websphere.appserver.jcaInboundSecurity-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jcaInboundSecurity-1.0/com.ibm.websphere.appserver.jcaInboundSecurity-1.0.feature
@@ -8,6 +8,6 @@ Subsystem-Name: Java Connector Architecture Security Inflow
  com.ibm.websphere.appserver.security-1.0, \
  com.ibm.websphere.appserver.jca-1.6; ibm.tolerates:=1.7
 -bundles=com.ibm.ws.jca.inbound.security, \
- com.ibm.websphere.javaee.jaspic.1.1; location:=dev/api/spec/
+ com.ibm.websphere.javaee.jaspic.1.1; location:=dev/api/spec/; mavenCoordinates="javax.security.auth.message:javax.security.auth.message-api:1.1"
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jcacheContainer-1.1/com.ibm.websphere.appserver.jcacheContainer-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jcacheContainer-1.1/com.ibm.websphere.appserver.jcacheContainer-1.1.feature
@@ -18,6 +18,6 @@ IBM-API-Package: \
  com.ibm.websphere.appserver.bells-1.0, \
  com.ibm.websphere.appserver.classloading-1.0
 -bundles=\
- com.ibm.websphere.javaee.jcache.1.1; location:="dev/api/spec/,lib/"
+ com.ibm.websphere.javaee.jcache.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.cache:cache-api:1.1.0"
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.3/com.ibm.websphere.appserver.jsf-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.3/com.ibm.websphere.appserver.jsf-2.3.feature
@@ -44,6 +44,6 @@ Subsystem-Name: JavaServer Faces 2.3
  com.ibm.ws.jsf.shared, \
  com.ibm.ws.cdi.interfaces, \
  com.ibm.ws.org.apache.commons.digester.1.8, \
- com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/"
+ com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.websocket:javax.websocket-api:1.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonp-1.0/com.ibm.websphere.appserver.jsonp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonp-1.0/com.ibm.websphere.appserver.jsonp-1.0.feature
@@ -7,7 +7,7 @@ IBM-API-Package: javax.json; type="spec", \
  javax.json.spi; type="spec"
 IBM-ShortName: jsonp-1.0
 Subsystem-Name: JavaScript Object Notation Processing 1.0
--bundles=com.ibm.websphere.javaee.jsonp.1.0; location:="dev/api/spec/,lib/", \
+-bundles=com.ibm.websphere.javaee.jsonp.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.0", \
  com.ibm.ws.org.glassfish.json.1.0
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
@@ -39,7 +39,7 @@ Subsystem-Name: JavaServer Pages 2.2
  com.ibm.websphere.appserver.javaeeCompatible-6.0
 -bundles=com.ibm.ws.org.eclipse.jdt.core.3.10.2.v20160712-0000, \
  com.ibm.ws.jsp.factories, \
- com.ibm.websphere.javaee.jstl.1.2; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jstl.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
  com.ibm.ws.jsp.jasper, \
  com.ibm.ws.jsp, \
  com.ibm.ws.jsp.jstl.facade, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.3/com.ibm.websphere.appserver.jsp-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.3/com.ibm.websphere.appserver.jsp-2.3.feature
@@ -37,7 +37,7 @@ Subsystem-Name: JavaServer Pages 2.3
  com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:=4.0, \
  com.ibm.websphere.appserver.el-3.0
 -bundles=com.ibm.ws.org.eclipse.jdt.core.3.10.2.v20160712-0000, \
- com.ibm.websphere.javaee.jstl.1.2; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jstl.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
  com.ibm.ws.jsp.2.3, \
  com.ibm.ws.jsp, \
  com.ibm.ws.jsp.jstl.facade

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-1.0/com.ibm.websphere.appserver.websocket-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-1.0/com.ibm.websphere.appserver.websocket-1.0.feature
@@ -11,7 +11,7 @@ IBM-ShortName: websocket-1.0
 Subsystem-Name: Java WebSocket 1.0
 -features=com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:=4.0
 -bundles=com.ibm.ws.wsoc, \
- com.ibm.websphere.javaee.websocket.1.0; location:="dev/api/spec/,lib/"
+ com.ibm.websphere.javaee.websocket.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.websocket:javax.websocket-api:1.0"
 -jars=com.ibm.websphere.appserver.api.wsoc; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.wsoc_1.0-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-1.1/com.ibm.websphere.appserver.websocket-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/websocket-1.1/com.ibm.websphere.appserver.websocket-1.1.feature
@@ -11,7 +11,7 @@ IBM-ShortName: websocket-1.1
 Subsystem-Name: Java WebSocket 1.1
 -features=com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:=4.0
 -bundles=com.ibm.ws.wsoc, \
- com.ibm.websphere.javaee.websocket.1.1; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.websocket.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.websocket:javax.websocket-api:1.1", \
  com.ibm.ws.wsoc.1.1
 -jars=com.ibm.websphere.appserver.api.wsoc; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.wsoc_1.0-javadoc.zip


### PR DESCRIPTION
Add Maven coordinates for Java spec APIs, to be used as Maven compile dependencies