### PR TITLE
update basic annotations test to drive code path

### DIFF
--- a/dev/com.ibm.ws.jcache_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jcache_fat/bnd.bnd
@@ -21,5 +21,6 @@ javac.source: 1.8
 javac.target: 1.8
 
 -buildpath: \
+	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.jcache.1.1;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest

--- a/dev/com.ibm.ws.jcache_fat/publish/servers/jcacheContainerServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jcache_fat/publish/servers/jcacheContainerServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jcache.container.*=all

--- a/dev/com.ibm.ws.jcache_fat/publish/servers/jcacheContainerServer/server.xml
+++ b/dev/com.ibm.ws.jcache_fat/publish/servers/jcacheContainerServer/server.xml
@@ -11,6 +11,7 @@
 <server>
 
     <featureManager>
+        <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componenttest-1.0</feature>
         <feature>jcacheContainer-1.1</feature>

--- a/dev/com.ibm.ws.jcache_fat/publish/servers/jcacheContainerServerBell/server.xml
+++ b/dev/com.ibm.ws.jcache_fat/publish/servers/jcacheContainerServerBell/server.xml
@@ -12,6 +12,7 @@
 
     <featureManager>
         <feature>bells-1.0</feature>
+        <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componenttest-1.0</feature>
         <feature>jcacheContainer-1.1</feature>

--- a/dev/com.ibm.ws.jcache_fat/test-applications/jcacheApp/src/jcache/web/JCacheTestServlet.java
+++ b/dev/com.ibm.ws.jcache_fat/test-applications/jcacheApp/src/jcache/web/JCacheTestServlet.java
@@ -25,6 +25,7 @@ import javax.cache.configuration.MutableConfiguration;
 import javax.cache.expiry.AccessedExpiryPolicy;
 import javax.cache.expiry.Duration;
 import javax.cache.spi.CachingProvider;
+import javax.inject.Inject;
 import javax.servlet.annotation.WebServlet;
 
 import org.junit.Test;
@@ -34,6 +35,8 @@ import componenttest.app.FATServlet;
 @SuppressWarnings("serial")
 @WebServlet("/JCacheTestServlet")
 public class JCacheTestServlet extends FATServlet {
+    @Inject
+    ZombiePod zp;
 	
 	//TODO: Disabling all tests until the hazelcast config for the bucket is fixed and Annotations are addressed.
 	@Test
@@ -139,22 +142,23 @@ public class JCacheTestServlet extends FATServlet {
     /**
      * Test that we can use annotations
      */
-    //@Test
+    @Test
     public void testAnnotations() throws Exception {
-    		ZombiePod zp = new ZombiePod();
-    		String name = zp.getZombie(2);
-    		int zid = zp.addZombie("Nathan");
-    		zp.emptyPod();
-    		
-    		CachingProvider provider = Caching.getCachingProvider();
-        URI hazelcastXML = new URI("../hazelcast/hazelcast-localhost-only.xml");
-        CacheManager manager = provider.getCacheManager(hazelcastXML, Caching.getDefaultClassLoader());
-        //Cache zom = manager.getCache("zombies");
-        //System.out.println(zom.iterator().hasNext());
-    
-            
-    		assertEquals("Should have received cached name",name,zp.getZombie(2));		
-    		
-    		//TODO remove cache
+        zp.emptyPod();
+
+        zp.addOrReplaceZombie(1, "Alex");
+        assertEquals("Andy", zp.getZombie(2, "Andy"));
+        //TODO assertEquals("Andy", zp.getZombie(2, "should-ignore-this-value"));
+        //TODO assertEquals("Alex", zp.getZombie(1, "should-ignore-this-value"));
+
+        zp.removeZombie(1);
+        assertEquals("Jim", zp.getZombie(1, "Jim"));
+
+        zp.addOrReplaceZombie(2, "Joe");
+        // TODO assertEquals("Joe", zp.getZombie(2, "should-ignore-this-value"));
+
+        zp.emptyPod();
+        assertEquals("Mark", zp.getZombie(1, "Mark"));
+        assertEquals("Nathan", zp.getZombie(2, "Nathan"));
     }
 }

--- a/dev/com.ibm.ws.jcache_fat/test-applications/jcacheApp/src/jcache/web/ZombiePod.java
+++ b/dev/com.ibm.ws.jcache_fat/test-applications/jcacheApp/src/jcache/web/ZombiePod.java
@@ -1,6 +1,5 @@
 package jcache.web;
 
-import java.util.ArrayList;
 import javax.cache.annotation.CacheDefaults;
 import javax.cache.annotation.CacheKey;
 import javax.cache.annotation.CachePut;
@@ -8,53 +7,25 @@ import javax.cache.annotation.CacheRemove;
 import javax.cache.annotation.CacheRemoveAll;
 import javax.cache.annotation.CacheResult;
 import javax.cache.annotation.CacheValue;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 @CacheDefaults(cacheName="zombies")
 public class ZombiePod {
-	
-	private ArrayList<String> zombies = new ArrayList<String>();
-	
-	
-	public ZombiePod() {	
-		zombies.add("Alex");
-		zombies.add("Mark");
-		zombies.add("Andy");
-		zombies.add("Jim");
-		System.out.println("init - ArraySize: " + zombies.size());
-	}
-	
-	
-	@CacheResult
-	public String getZombie(@CacheKey Integer z) {
-		System.out.println("get - ArraySize: " + zombies.size());
-		return zombies.get(z);
-	}
-	
-	@CachePut
-	public int addZombie(@CacheValue String name) {
-		zombies.add(name);
-		return zombies.lastIndexOf(name); 
-	}
-	
-	@CacheRemove
-	public boolean removeZombie(@CacheKey Integer z, String name) {
-		if (zombies.get(z).equals(name)) {
-			zombies.remove(z);
-			return true;
-		} else {
-			//Cache is out of sync
-			apocalypse();
-		}
-		return false;
-	}
-	
-	@CacheRemoveAll
-	public void apocalypse() {		
-	}
-	
-	public void emptyPod() {
-		zombies.clear();
-	}
-	
+    @CacheResult
+    public String getZombie(@CacheKey Integer z, String defaultName) {
+        return defaultName; // only returned if not found in cache
+    }
 
+    @CachePut
+    public void addOrReplaceZombie(@CacheKey Integer z, @CacheValue String name) {
+    }
+
+    @CacheRemove
+    public void removeZombie(@CacheKey Integer z) {
+    }
+
+    @CacheRemoveAll
+    public void emptyPod() {        
+    }
 }


### PR DESCRIPTION
Update the annotations test to get it to attempt to drive the codepath where CDI would process JCache annotations if our extensions implemented them.