### PR TITLE
only match CachingProvider instances from bells

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/DefaultCachingProviderSupport.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/DefaultCachingProviderSupport.java
@@ -59,7 +59,7 @@ public class DefaultCachingProviderSupport {
         registration.unregister();
     }
 
-    @Reference(service = CachingProvider.class)
+    @Reference(service = CachingProvider.class, target="(exported.from=*)")
     protected void setCachingProvider(ServiceReference<CachingProvider> ref) {
         libraryId = (String) ref.getProperty("exported.from");
     }


### PR DESCRIPTION
DefaultCachingProviderSupport is accepting any CachingProvider from the service registry and ought to only access those which were put there by bells, specifically, which have the exported.from attribute that it requires to hook the CachingProvider up to the CacheStoreService.