### PR TITLE
 Remove readOnly from DatabaseIdentityStore

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStore.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStore.java
@@ -386,7 +386,6 @@ public class DatabaseIdentityStore implements IdentityStore {
         }
 
         Connection conn = localDataSource.getConnection();
-        conn.setReadOnly(true);
         return conn;
     }
 }


### PR DESCRIPTION
Fixes #3397

Removes the readOnly set to true on the data source in DatabaseIdentityStore