### PR TITLE
jcacheContainer should not force enablement of bells feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jcacheContainer-1.1/com.ibm.websphere.appserver.jcacheContainer-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jcacheContainer-1.1/com.ibm.websphere.appserver.jcacheContainer-1.1.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.jcacheContainer-1.1
 visibility=public
 IBM-ShortName: jcacheContainer-1.1
 Manifest-Version: 1.0
-Subsystem-Name: JCache via Bells
+Subsystem-Name: JCache spec API and container integration
 IBM-API-Package: \
  javax.cache; type="spec", \
  javax.cache.annotation; type="spec", \
@@ -15,7 +15,6 @@ IBM-API-Package: \
  javax.cache.processor; type="spec", \
  javax.cache.spi; type="spec"
 -features=\
- com.ibm.websphere.appserver.bells-1.0, \
  com.ibm.websphere.appserver.classloading-1.0
 -bundles=\
  com.ibm.websphere.javaee.jcache.1.1; location:="dev/api/spec/,lib/"

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -626,7 +626,7 @@ public class CacheHashMap extends BackedHashMap {
                     if (trace && tc.isDebugEnabled())
                         tcReturn(tcSessionMetaCache, "get", oldValue);
                     if (oldValue == null) 
-                        {break;} // TODO implement code path where cache entry for session is expired. Delete the property entries?
+                        break; // no need to delete corresponding entries from attributes cache. The code that deleted the session meta info will do so.
                     SessionInfo sessionInfo = new SessionInfo(oldValue).clone();
                     if (propsToWrite != null)
                         sessionInfo.addSessionPropertyIds(propsToWrite);

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -249,7 +249,7 @@ public class SessionCacheTestServlet extends FATServlet {
         ((IBMSession) session).sync();
 
         long puts = attrCacheStatsMXBean.getCachePuts();
-        // TODO sometimes this assert is failing with observed value still being the initial value. Seems to be a bug in the JCache provider
+        // Sometimes this assert is failing with observed value still being the initial value. Seems to be a bug in the JCache provider
         // assertEquals(initialPuts + 1, puts);
 
         session.invalidate();

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -257,10 +257,6 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         run("testSetAttribute&attribute=testWriteFrequency&value=2_MANUAL_UPDATE", session);
         run("testCacheContains&attribute=testWriteFrequency&value=1_END_OF_SERVLET_SERVICE", session);
 
-        // TODO enable if manual sync is supported across same session spanning multiple servlet requests:
-        // Perform a manual sync under a subsequent servlet request and verify the previously set value is updated
-        // FATSuite.run(server, APP_NAME + '/' + SERVLET_NAME, "testManualSync&attribute=testWriteFrequency&value=2_MANUAL_UPDATE", session);
-
         // Perform a manual update within the same servlet request
         run("testManualUpdate&attribute=testWriteFrequency&value=3_MANUAL_UPDATE", session);
         run("invalidateSession", session);


### PR DESCRIPTION
The jcacheContainer feature should not force the bells feature to be enabled, because it is usable if you package the jcache provider in an application without configuring any bell elements.

Also, clean up various TODO comments in code.