### PR TITLE
Ensure mpRestClient-1.0 works with Filters in JAX-RS 2.1

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/model/FilterProviderInfo.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/model/FilterProviderInfo.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxrs.model;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.jaxrs.provider.ProviderFactory;
+
+public class FilterProviderInfo<T> extends ProviderInfo<T> {
+
+    private Set<String> nameBinding;
+    private Map<Class<?>, Integer> supportedContracts;
+    private boolean dynamic;
+    
+    public FilterProviderInfo(T provider,
+                              Bus bus,
+                              Map<Class<?>, Integer> supportedContracts) {
+        this(provider, bus, ProviderFactory.DEFAULT_FILTER_NAME_BINDING, false, supportedContracts);        
+    }
+    
+    public FilterProviderInfo(T provider,
+                              Bus bus,
+                              String nameBinding,
+                              boolean dynamic,
+                              Map<Class<?>, Integer> supportedContracts) {
+        super(provider, bus, true);
+        this.nameBinding = Collections.singleton(nameBinding);
+        this.supportedContracts = supportedContracts;
+        this.dynamic = dynamic;
+    }
+
+    //Liberty change start -- this should be removed on next update of CXF 3.1.X stream
+    public FilterProviderInfo(Class<?> resourceClass, 
+                              Class<?> serviceClass,
+                              T provider,
+                              Bus bus,
+                              Map<Class<?>, Integer> supportedContracts) {
+        this(provider, bus, ProviderFactory.DEFAULT_FILTER_NAME_BINDING, false, supportedContracts);
+    }
+    //Liberty change end
+
+    public Set<String> getNameBinding() {
+        return nameBinding;
+    }
+
+    public int getPriority(Class<?> contract) {
+        return supportedContracts.get(contract);
+    }
+    
+    public boolean isDynamic() {
+        return dynamic;
+    }
+
+    public Set<Class<?>> getSupportedContracts() {
+        return supportedContracts.keySet();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/BasicClientTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/BasicClientTestServlet.java
@@ -84,4 +84,20 @@ public class BasicClientTestServlet extends FATServlet {
         }
     }
 
+    @Test
+    public void testFiltersInvoked(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        try {
+            MyFilter.requestFilterInvoked = false;
+            MyFilter.responseFilterInvoked = false;
+
+            client.createNewWidget(new Widget("Erasers", 10, 0.8));
+            assertTrue("Request filter was not invoked", MyFilter.requestFilterInvoked);
+            assertTrue("Response filter was not invoked", MyFilter.responseFilterInvoked);
+            assertTrue("POSTed widget does not show up in query", client.getWidgetNames().contains("Erasers"));
+
+        } finally {
+            //ensure we delete so as to not throw off other tests
+            client.removeWidget("Erasers");
+        }
+    }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/BasicServiceClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/BasicServiceClient.java
@@ -29,6 +29,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 @Produces(MediaType.APPLICATION_JSON)
 @RegisterProvider(DuplicateWidgetExceptionMapper.class)
 @RegisterProvider(UnknownWidgetExceptionMapper.class)
+@RegisterProvider(MyFilter.class)
 @RegisterRestClient
 @Path("/")
 public interface BasicServiceClient {

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/MyFilter.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/MyFilter.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient10.basicCdi;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+
+public class MyFilter implements ClientRequestFilter, ClientResponseFilter {
+
+    static boolean requestFilterInvoked;
+    static boolean responseFilterInvoked;
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.ws.rs.client.ClientResponseFilter#filter(javax.ws.rs.client.ClientRequestContext, javax.ws.rs.client.ClientResponseContext)
+     */
+    @Override
+    public void filter(ClientRequestContext arg0, ClientResponseContext arg1) throws IOException {
+        responseFilterInvoked = true;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.ws.rs.client.ClientRequestFilter#filter(javax.ws.rs.client.ClientRequestContext)
+     */
+    @Override
+    public void filter(ClientRequestContext arg0) throws IOException {
+        requestFilterInvoked = true;
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
@@ -112,7 +112,7 @@ public class MicroProfileClientFactoryBean extends JAXRSClientFactoryBean {
         for (Object provider : configuration.getInstances()) {
             Class<?> providerCls = ClassHelper.getRealClass(bus, provider);
             if (provider instanceof ClientRequestFilter || provider instanceof ClientResponseFilter) {
-                FilterProviderInfo<Object> filter = new FilterProviderInfo<Object>(//providerCls, providerCls,
+                FilterProviderInfo<Object> filter = new FilterProviderInfo<Object>(providerCls, providerCls,
                         provider, bus, configuration.getContracts(providerCls));
                 providers.add(filter);
             } else {


### PR DESCRIPTION
When we upgraded the jaxrs-2.1 feature to CXF 3.2.4, that pulled in some
changes to FilterProviderInfo that are incompatible with CXF's 3.1.16
version that we use with jaxrs-2.0.  When a MP Rest Client attempts to
register a filter (when using jaxrs-2.1), the user will see a 
NoSuchMethodError for FilterProviderInfo's constructor.  

This fix changes the MP Rest Client implementation to use the newer
constructor and adds a "Stub" constructor for the 2.0 version of
FilterProviderInfo - this stub constructor should be removed when we
move to the next version of CXF 3.1.X.

This fix also adds new tests that verify that the fix works.

This is not fixing a release bug because JAX-RS 2.1 has not shipped yet.