### PR TITLE
Fix for issue #3483: Refactor JAX-RS 2.1

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaxrsAppSecurity-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaxrsAppSecurity-2.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.jaxrsAppSecurity-2.0
 visibility=private
 IBM-App-ForceRestart: uninstall, \
  install
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.jaxrsClient-2.0)(osgi.identity=com.ibm.websphere.appserver.jaxrsClient-2.1)))", \
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jaxrsClient-2.0))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.ssl-1.0))"
 IBM-Install-Policy: when-satisfied
 -features=com.ibm.websphere.appserver.appSecurity-2.0; ibm.tolerates:=3.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaxrsAppSecurity-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaxrsAppSecurity-2.1.feature
@@ -6,7 +6,6 @@ IBM-App-ForceRestart: uninstall, \
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jaxrsClient-2.1))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.ssl-1.0))"
 IBM-Install-Policy: when-satisfied
--features=com.ibm.websphere.appserver.appSecurity-2.0; ibm.tolerates:=3.0
 -bundles=com.ibm.ws.jaxrs.2.0.security
 kind=ga
 edition=core

--- a/dev/com.ibm.ws.jaxrs.2.0.client/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/bnd.bnd
@@ -27,6 +27,7 @@ Export-Package: \
 Import-Package: \
    org.apache.cxf.*;version=3.1.14, \
    com.ibm.websphere.security.saml2;resolution:=optional, \
+   com.ibm.ws.jaxrs20.appsecurity.security;resolution:=optional, \
    *
    
 Private-Package:\

--- a/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/security/LibertyJaxRsClientSSLOutInterceptor.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/security/LibertyJaxRsClientSSLOutInterceptor.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs20.client.security;
 
+import java.lang.reflect.Method;
+import java.util.Map;
+
 import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.cxf.common.util.PropertyUtils;
@@ -25,7 +28,6 @@ import org.apache.cxf.transport.http.HTTPConduit;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.jaxrs20.client.JAXRSClientConstants;
-import com.ibm.ws.jaxrs20.client.component.JaxRsAppSecurity;
 
 /**
  *
@@ -62,10 +64,11 @@ public class LibertyJaxRsClientSSLOutInterceptor extends AbstractPhaseIntercepto
             sslRef = (String) sslRefObj;
         }
 
-        //Allow a null sslRef to be used,  Liberty will resolve it to the default // getSSLSocketFactory will return null if either the ssl feature is not enabled
+        //Allow a null sslRef to be used,  Liberty will resolve it to the default
+        // getSocketFactory will return null if either the ssl feature is not enabled
         // or if it is enabled but there is no SSL configuration defined.  A null here
         // means to use the JDK's SSL implementation.
-        if (isSecured && JaxRsAppSecurity.getSSLSocketFactory(sslRef, null) != null) {
+        if (isSecured && getSocketFactory(sslRef) != null) {
             Object disableCNCheckObj = message.get(JAXRSClientConstants.DISABLE_CN_CHECK);
             Conduit cd = message.getExchange().getConduit(message);
             configClientSSL(cd, sslRef, PropertyUtils.isTrue(disableCNCheckObj));
@@ -104,7 +107,7 @@ public class LibertyJaxRsClientSSLOutInterceptor extends AbstractPhaseIntercepto
                 Tr.debug(tc, "Get Liberty default SSLSocketFactory.");
             }
         }
-        sslSocketFactory = JaxRsAppSecurity.getSSLSocketFactory(sslRef, null);
+        sslSocketFactory = getSocketFactory(sslRef);
 
         if (null != sslSocketFactory) {
             if (null == tlsClientParams) {
@@ -124,4 +127,25 @@ public class LibertyJaxRsClientSSLOutInterceptor extends AbstractPhaseIntercepto
         this.secConfig = secConfig;
     }
 
+    private SSLSocketFactory getSocketFactory(String sslRef) {
+        try {
+            Class<?> jaxrsSslMgrClass = Class.forName("com.ibm.ws.jaxrs20.appsecurity.security.JaxRsSSLManager");
+            if (jaxrsSslMgrClass == null) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "getSocketFactory could not find JaxRsSSLManager class");
+                }
+                return null;
+            }
+            Object classObject = jaxrsSslMgrClass.newInstance();
+            Method m = jaxrsSslMgrClass.getDeclaredMethod("getSSLSocketFactoryBySSLRef", String.class, Map.class, boolean.class);
+            Object[] parameters = { sslRef, null, false }; //getSSLSocketFactoryBySSLRef ignores the third (boolean) parameter
+            SSLSocketFactory ssLSocketFactory = (SSLSocketFactory) m.invoke(classObject, parameters);
+            return ssLSocketFactory;
+        } catch (Exception e) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "getSocketFactory reflection failed with exception " + e.toString());
+            }
+            return null;
+        }
+    }
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.security/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.security/bnd.bnd
@@ -20,9 +20,12 @@ WS-TraceGroup: JAXRS
 # jaxrs-2.0-appSecurity is part of EE7 and therefore requires java 1.7 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))" 
 
+Export-Package: \
+  com.ibm.ws.jaxrs20.appsecurity.security
+
 Import-Package: \
   javax.ws.rs.*; version="[2.0,3)", \
-  com.ibm.websphere.security.web, \
+  com.ibm.websphere.security.web;resolution:=optional, \
   com.ibm.websphere.*, \
   javax.servlet.http, \
   javax.net.ssl.*, \

--- a/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/providers/security/SecurityAnnoProviderRegister.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/src/com/ibm/ws/jaxrs20/providers/security/SecurityAnnoProviderRegister.java
@@ -27,7 +27,7 @@ public class SecurityAnnoProviderRegister implements JaxRsProviderRegister {
     public void installProvider(boolean clientSide, List<Object> providers, Set<String> features) {
 
         if (!clientSide) {
-            if (features.contains("appSecurity-2.0") || features.contains("appSecurity-1.0")) {
+            if (features.contains("appSecurity-2.0") || features.contains("appSecurity-1.0") || features.contains("appSecurity-3.0")) {
                 //add one built-in ContainerRequestFilter to handle basic security
                 LibertyAuthFilter laf = new LibertyAuthFilter();
                 LibertySimpleAuthorizingInterceptor in = new LibertySimpleAuthorizingInterceptor();


### PR DESCRIPTION
We've had some complaints in JAX-RS 2.1 that when a customer enables the jaxrs-2.1 and ssl-1.0 features together, they also get the appSecurity-2.0 feature. These users would prefer not to have appSecurity-2.0 enabled.

