### PR TITLE
Issue #3540: Add missing servelet-4.0 dependency to EJB FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.tx_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.tx_fat/bnd.bnd
@@ -19,7 +19,7 @@ src: \
 fat.project: true
 
 tested.features: \
-	servlet-3.1, ejbLite-3.2
+	servlet-3.1, servlet-4.0, ejbLite-3.2
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\


### PR DESCRIPTION
servlet-4.0 dependency is missing from bnd.bnd of ejbcontainer.tx fat
Added.

fixes #3540 