### PR TITLE
Update Maven coordinates for j2ee management api

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.j2eeManagementClient-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.j2eeManagementClient-1.1.feature
@@ -5,6 +5,6 @@ IBM-API-Package: javax.management.j2ee; type="spec", \
  javax.management.j2ee.statistics; type="spec", \
  org.omg.stub.javax.management.j2ee; type="spec"
 Subsystem-Version: 1.1
--bundles=com.ibm.websphere.javaee.management.j2ee.1.1; location:=dev/api/spec/; mavenCoordinates="javax.management.j2ee:management-api:1.1-rev-1"
+-bundles=com.ibm.websphere.javaee.management.j2ee.1.1; location:=dev/api/spec/; mavenCoordinates="javax.management.j2ee:javax.management.j2ee-api:1.1.1"
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/j2eeManagement-1.1/com.ibm.websphere.appserver.j2eeManagement-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/j2eeManagement-1.1/com.ibm.websphere.appserver.j2eeManagement-1.1.feature
@@ -13,7 +13,7 @@ Subsystem-Name: J2EE Management 1.1
  com.ibm.websphere.appserver.transaction-1.2
 -bundles=com.ibm.ws.management.j2ee, \
  com.ibm.ws.management.j2ee.mbeans; location:=lib/, \
- com.ibm.websphere.javaee.management.j2ee.1.1; location:=dev/api/spec/; mavenCoordinates="javax.management.j2ee:management-api:1.1-rev-1"
+ com.ibm.websphere.javaee.management.j2ee.1.1; location:=dev/api/spec/; mavenCoordinates="javax.management.j2ee:javax.management.j2ee-api:1.1.1"
 -jars=com.ibm.websphere.appserver.api.j2eemanagement; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.j2eemanagement_1.1-javadoc.zip
 kind=ga


### PR DESCRIPTION
The Maven coordinates for j2ee management api in the following features should be updated to use a newer version:
com.ibm.websphere.appserver.j2eeManagementClient-1.1.feature
com.ibm.websphere.appserver.j2eeManagement-1.1.feature