### PR TITLE
Update to bndPlugin version 4.0.0

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -13,7 +13,7 @@ bnd_cnf=cnf
 
 # bnd_plugin is the dependency declaration for the bnd gradle plugin
 #bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:+
-bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:3.5.0
+bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:4.0.0
 
 # The URL to the bnd build repo.
 # DO NOT check in changes to this. This can be overridden on the gradle command line with


### PR DESCRIPTION
Upgrade bndPlugin from version 3.5.0 to 4.0.0 to save time when re-running already built workspace. I ran tests using v4.1.0, but the time improvements are in 4.0.0 as well.


Before, bnd v3.5.0:
- 9:46 (Clean --parallel release) + 8:03 (Re-run --parallel release)

After, bnd v4.1.0:
- 9:29 (Clean --parallel release) + 5:57 (Re-run --parallel release)
- 4699 actionable tasks: 2037 executed, 2662 up-to-date


Before, bnd v3.5.0:
- 5:11 (Clean --parallel assemble) + 3:12 (Re-run --parallel assemble)

After, bnd v4.1.0:
- 5:34 (Clean --parallel assemble) + 1:48 (Re-run --parallel assemble)
- 2150 actionable tasks: 21 executed, 2129 up-to-date


Before, bnd v3.5.0:
- 0:55 (Clean --parallel com.ibm.ws.webcontainer.security:assemble) + 0:45 (Re-run --parallel com.ibm.ws.webcontainer.security:assemble)

After, bnd v4.1.0:
- 1:03 (Clean --parallel com.ibm.ws.webcontainer.security:assemble) + 0:25 (Re-run --parallel com.ibm.ws.webcontainer.security:assemble)
- 216 actionable tasks: 216 up-to-date