### PR TITLE
Reset httpclient between user checks

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/DatabaseIdentityStoreDeferredSettingsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/DatabaseIdentityStoreDeferredSettingsTest.java
@@ -27,7 +27,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.http.client.params.ClientPNames;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpParams;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -100,12 +103,21 @@ public class DatabaseIdentityStoreDeferredSettingsTest extends JavaEESecTestBase
 
     @Before
     public void setupConnection() {
-        httpclient = new DefaultHttpClient();
+        // disable auto redirect.
+        HttpParams httpParams = new BasicHttpParams();
+        httpParams.setParameter(ClientPNames.HANDLE_REDIRECTS, Boolean.FALSE);
+
+        httpclient = new DefaultHttpClient(httpParams);
     }
 
     @After
     public void cleanupConnection() {
         httpclient.getConnectionManager().shutdown();
+    }
+
+    public void resetConnection() {
+        cleanupConnection();
+        setupConnection();
     }
 
     @Override
@@ -130,12 +142,16 @@ public class DatabaseIdentityStoreDeferredSettingsTest extends JavaEESecTestBase
         }
         passwordChecker.checkForPasswordInAnyFormat(Constants.DB_USER1_PWD);
 
+        resetConnection();
+
         /* DB_USER2 */
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase, Constants.DB_USER2, Constants.DB_USER2_PWD, code2);
         if (code2 == SC_OK) {
             verifyUserResponse(response, getUserPrincipalFound + Constants.DB_USER2, getRemoteUserFound + Constants.DB_USER2);
         }
         passwordChecker.checkForPasswordInAnyFormat(Constants.DB_USER2_PWD);
+
+        resetConnection();
 
         /* DB_USER3 */
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase, Constants.DB_USER3, Constants.DB_USER3_PWD, code3);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LdapIdentityStoreDeferredSettingsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LdapIdentityStoreDeferredSettingsTest.java
@@ -28,7 +28,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.http.client.params.ClientPNames;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpParams;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -210,12 +213,21 @@ public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {
 
     @Before
     public void setupConnection() {
-        httpclient = new DefaultHttpClient();
+        // disable auto redirect.
+        HttpParams httpParams = new BasicHttpParams();
+        httpParams.setParameter(ClientPNames.HANDLE_REDIRECTS, Boolean.FALSE);
+
+        httpclient = new DefaultHttpClient(httpParams);
     }
 
     @After
     public void cleanupConnection() {
         httpclient.getConnectionManager().shutdown();
+    }
+
+    public void resetConnection() {
+        cleanupConnection();
+        setupConnection();
     }
 
     @Override
@@ -241,12 +253,16 @@ public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {
         }
 //        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER1_PASSWORD); TODO Uncomment when ApacheDS logs are clean
 
+        resetConnection();
+
         /* ldapuser2 */
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER2_UID, LDAP_USER2_PASSWORD, code2);
         if (code2 == SC_OK) {
             verifyUserResponse(response, getUserPrincipalFound + LDAP_USER2_UID, getRemoteUserFound + LDAP_USER2_UID);
         }
 //        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER2_PASSWORD); TODO Uncomment when ApacheDS logs are clean
+
+        resetConnection();
 
         /* ldapuser3 */
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER3_UID, LDAP_USER3_PASSWORD, code3);
@@ -255,6 +271,7 @@ public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {
         }
 //        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER3_PASSWORD); TODO Uncomment when ApacheDS logs are clean
 
+        resetConnection();
         /* ldapuser4 */
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER4_UID, LDAP_USER4_PASSWORD, code4);
         if (code4 == SC_OK) {


### PR DESCRIPTION
Fixes #3666 

Update test to reset the httpClient when we're checking multiple users in one test method.