### PR TITLE
Issue #3683: Add app validation to exportDropins

### DIFF
--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/DSDTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/DSDTest.java
@@ -67,6 +67,10 @@ public class DSDTest extends FATServletClient {
         ShrinkHelper.exportAppToServer(server, DSDMixTest);
         ShrinkHelper.exportAppToServer(server, DSDXMLTest);
 
+        server.addInstalledAppForValidation("DSDAnnTest");
+        server.addInstalledAppForValidation("DSDMixTest");
+        server.addInstalledAppForValidation("DSDXMLTest");
+
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/RepeatableDSDTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/RepeatableDSDTest.java
@@ -66,6 +66,10 @@ public class RepeatableDSDTest extends FATServletClient {
         ShrinkHelper.exportAppToServer(server, RepeatableDSDMixTest);
         ShrinkHelper.exportAppToServer(server, RepeatableDSDXMLTest);
 
+        server.addInstalledAppForValidation("RepeatableDSDAnnTest");
+        server.addInstalledAppForValidation("RepeatableDSDMixTest");
+        server.addInstalledAppForValidation("RepeatableDSDXMLTest");
+
         server.startServer();
     }
 

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/ShrinkHelper.java
@@ -91,6 +91,11 @@ public class ShrinkHelper {
      */
     public static void exportDropinAppToServer(LibertyServer server, Archive<?> a) throws Exception {
         exportToServer(server, "dropins", a);
+
+        String appName = a.getName();
+        String installedAppName = (appName.endsWith(".war") || appName.endsWith(".ear"))//
+                        ? appName.substring(0, appName.length() - 4) : appName;
+        server.addInstalledAppForValidation(installedAppName);
     }
 
     /**
@@ -234,9 +239,7 @@ public class ShrinkHelper {
     public static WebArchive defaultDropinApp(LibertyServer server, String appName, String... packages) throws Exception {
         WebArchive app = buildDefaultApp(appName, packages);
         exportDropinAppToServer(server, app);
-        String installedAppName = (appName.endsWith(".war") || appName.endsWith(".ear"))//
-                        ? appName.substring(0, appName.length() - 4) : appName;
-        server.addInstalledAppForValidation(installedAppName);
+
         return app;
     }
 


### PR DESCRIPTION
Also, add explicit validation to a couple injection_fat tests that are
not using exportDropins.