### PR TITLE
Remove now-unused interface methods

### DIFF
--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/BatchStatusValidator.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/BatchStatusValidator.java
@@ -75,14 +75,10 @@ public class BatchStatusValidator {
 
     /**
      * Validates that the JobExecution is the latest and greatest
-     * 
+     *
      * @param previousExecutionId
      * @return
      */
-    public static boolean isJobExecutionMostRecentOnPartitionRestart(long previousExecutionId) {
-        return isJobExecutionMostRecentImpl(previousExecutionId);
-    }
-
     public static boolean isJobExecutionMostRecent(long previousExecutionId) {
         return isJobExecutionMostRecentImpl(previousExecutionId);
     }
@@ -260,10 +256,10 @@ public class BatchStatusValidator {
 
         /*
          * @param status The BatchStatus that needs to be checked
-         * 
+         *
          * @param listAcceptable The list of BatchStatus that should be acceptable
          * match
-         * 
+         *
          * @returns boolean true if status is one of the list
          */
         private boolean checkIfStatusMatchesFromList(BatchStatus status,
@@ -279,10 +275,10 @@ public class BatchStatusValidator {
 
         /*
          * @param state The InstanceState that needs to be checked
-         * 
+         *
          * @param listAcceptable The list of InstanceStates that should be acceptable
          * match
-         * 
+         *
          * @returns boolean true if state is one of the list
          */
         private boolean checkIfStateMatchesFromList(InstanceState state,

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/WSJobRepository.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/WSJobRepository.java
@@ -157,15 +157,6 @@ public interface WSJobRepository {
      */
     public abstract WSJobInstance updateJobInstanceState(long instanceId, InstanceState state);
 
-    // DELETE ME
-    /**
-     * Update the instanceState of this job instance if state is currently STOPPED or FAILED
-     *
-     * @param instanceId
-     * @param state
-     */
-    public abstract WSJobInstance updateJobInstanceStateUponRestart(long instanceId, InstanceState state);
-
     /**
      * Update the instanceState to SUBMITTED for this job instance if state is currently STOPPED or FAILED
      *

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSJobRepositoryImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSJobRepositoryImpl.java
@@ -239,13 +239,6 @@ public class WSJobRepositoryImpl implements WSJobRepository {
         return persistenceManagerService.updateJobInstanceWithInstanceState(instanceId, state, new Date());
     }
 
-    // DELETE ME
-    @Override
-    public WSJobInstance updateJobInstanceStateUponRestart(long instanceId, InstanceState state) {
-        // Switch to use new internal interface
-        return (WSJobInstance) persistenceManagerService.updateJobInstanceOnRestart(instanceId, new Date());
-    }
-
     @Override
     public WSJobInstance updateJobInstanceStateOnRestart(long instanceId) {
         return (WSJobInstance) persistenceManagerService.updateJobInstanceOnRestart(instanceId, new Date());


### PR DESCRIPTION
This will perform some additional cleanup for issue #3578.  It follows-up  on PR #3597 and deletes some older interface methods.

E.g. `BatchStatusValidator#isJobExecutionMostRecentOnPartitionRestart`  and `WSJobRepository#updateJobInstanceStateUponRestart(long, InstanceState)`
