### PR TITLE
JWT SSO FAT: Update to compile and run on Java 8

### DIFF
--- a/dev/com.ibm.ws.security.jwtsso_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwtsso_fat/bnd.bnd
@@ -19,9 +19,8 @@ src: \
 
 test.project: true
 
-# To define a global minimum java level for the FAT, use the following property.
-# If unspecified, the default value is ${javac.source}
-# fat.minimum.java.level: 1.8
+javac.source: 1.8
+javac.target: 1.8
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)


### PR DESCRIPTION
Some builds that run on Java 7 fail to find some of the classes we're using in the `com.ibm.ws.security.jwtsso_fat` bucket. With the focus on Java 8, I'm updating the FAT to run on at least Java 8.