### PR TITLE
PR for Issue 3711: JWT SSO FAT for JWK enabled

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jwtSso-1.0/com.ibm.websphere.appserver.jwtSso-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jwtSso-1.0/com.ibm.websphere.appserver.jwtSso-1.0.feature
@@ -9,10 +9,13 @@ Subsystem-Name: JwtSso
  -features=com.ibm.websphere.appserver.jwt-1.0, \
   com.ibm.websphere.appserver.appSecurity-2.0, \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:=4.0, \
-  com.ibm.websphere.appserver.jsonp-1.0; ibm.tolerates:=1.1
+  com.ibm.websphere.appserver.jsonp-1.0; ibm.tolerates:=1.1, \
+  com.ibm.websphere.appserver.httpcommons-1.0
 -bundles= com.ibm.ws.security.jwtsso, \
   com.ibm.ws.security.common, \
   com.ibm.websphere.org.eclipse.microprofile.jwt.1.0; location:="dev/api/stable/,lib/",\
-  com.ibm.ws.security.mp.jwt
+  com.ibm.ws.security.mp.jwt,\
+  com.ibm.ws.org.apache.commons.codec.1.4, \
+  com.ibm.ws.org.apache.commons.logging.1.0.3
 kind=ga
 edition=core

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/TestActions.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/actions/TestActions.java
@@ -54,7 +54,7 @@ public class TestActions {
             throw new Exception("An error occurred invoking the URL [" + url + "]: " + e);
         }
     }
-    
+
     /**
      * Invoke the specified URL, adding a basic auth header first
      */
@@ -63,14 +63,14 @@ public class TestActions {
         loggingUtils.printMethodName(thisMethod);
         try {
             WebRequest request = createGetRequest(url);
-            String encodedIdPw= Base64.encode(user + ":" + password);
-            request.setAdditionalHeader("Authorization", "Basic "+ encodedIdPw);
+            String encodedIdPw = Base64.encode(user + ":" + password);
+            request.setAdditionalHeader("Authorization", "Basic " + encodedIdPw);
             return submitRequest(currentTest, wc, request);
         } catch (Exception e) {
             throw new Exception("An error occurred invoking the URL [" + url + "]: " + e);
         }
     }
-    
+
     /**
      * Invoke the specified URL, adding a bearer token header first.
      */
@@ -78,13 +78,13 @@ public class TestActions {
         String thisMethod = "invokeUrlWithBearerToken";
         loggingUtils.printMethodName(thisMethod);
         try {
-            WebRequest request = createGetRequest(url);            
-            request.setAdditionalHeader("Authorization", "Bearer "+ token);
+            WebRequest request = createGetRequest(url);
+            request.setAdditionalHeader("Authorization", "Bearer " + token);
             return submitRequest(currentTest, wc, request);
         } catch (Exception e) {
             throw new Exception("An error occurred invoking the URL [" + url + "]: " + e);
         }
-}
+    }
 
     /**
      * Invokes the specified URL, including the specified cookie in the request, and returns the Page object that represents the
@@ -200,6 +200,7 @@ public class TestActions {
     WebClient createWebClient() {
         WebClient webClient = new WebClient();
         webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions().setUseInsecureSSL(true);
         return webClient;
     }
 

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/BuilderTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/BuilderTests.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.jwtsso.fat;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.util.Cookie;
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.fat.common.actions.TestActions;
+import com.ibm.ws.security.fat.common.expectations.Expectations;
+import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
+import com.ibm.ws.security.jwtsso.fat.utils.CommonExpectations;
+import com.ibm.ws.security.jwtsso.fat.utils.JwtFatActions;
+import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class BuilderTests extends CommonJwtFat {
+
+    protected static Class<?> thisClass = BuilderTests.class;
+
+    @Server("com.ibm.ws.security.jwtsso.fat")
+    public static LibertyServer server;
+
+    private JwtFatActions actions = new JwtFatActions();
+    private TestValidationUtils validationUtils = new TestValidationUtils();
+
+    String protectedUrl = "https://" + server.getHostname() + ":" + server.getHttpDefaultSecurePort() + JwtFatConstants.SIMPLE_SERVLET_PATH;
+    String defaultUser = JwtFatConstants.TESTUSER;
+    String defaultPassword = JwtFatConstants.TESTUSERPWD;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        setUpAndStartServer(server, JwtFatConstants.COMMON_CONFIG_DIR + "/server_withFeature.xml");
+    }
+
+    /**
+     * Tests:
+     * - Log into a protected resource with the jwtSso element pointing to a jwtBuilder that has JWK enabled
+     * Expects:
+     * - Should successfully reach protected resource
+     * - JWT cookie header should include a "kid" entry for the JWK ID
+     */
+    @Test
+    public void test_jwkEnabled() throws Exception {
+        server.reconfigureServer(JwtFatConstants.COMMON_CONFIG_DIR + "/server_builder_jwkEnabled.xml");
+
+        WebClient webClient = getHtmlUnitWebClient();
+
+        String builderId = "builder_jwkEnabled";
+
+        String currentAction = TestActions.ACTION_INVOKE_PROTECTED_RESOURCE;
+
+        Expectations expectations = new Expectations();
+        expectations.addExpectations(CommonExpectations.successfullyReachedLoginPage(currentAction));
+
+        Page response = actions.invokeUrl(testName.getMethodName(), webClient, protectedUrl);
+        validationUtils.validateResult(response, currentAction, expectations);
+
+        currentAction = TestActions.ACTION_SUBMIT_LOGIN_CREDENTIALS;
+
+        String expectedIssuer = "https://[^/]+/jwt/" + builderId;
+        expectations.addExpectations(CommonExpectations.successfullyReachedProtectedResourceWithJwtCookie(currentAction, protectedUrl, defaultUser, expectedIssuer));
+        expectations.addExpectations(CommonExpectations.responseTextMissingCookie(currentAction, JwtFatConstants.LTPA_COOKIE_NAME));
+        expectations.addExpectations(CommonExpectations.jwtCookieExists(currentAction, webClient, JwtFatConstants.JWT_COOKIE_NAME, JwtFatConstants.SECURE,
+                                                                        JwtFatConstants.HTTPONLY));
+
+        response = actions.doFormLogin(response, defaultUser, defaultPassword);
+        validationUtils.validateResult(response, currentAction, expectations);
+
+        Cookie jwtCookie = webClient.getCookieManager().getCookie(JwtFatConstants.JWT_COOKIE_NAME);
+        verifyJwtHeaderContainsKey(jwtCookie.getValue(), "kid");
+    }
+
+    /**
+     * Tests:
+     * - Log into a protected resource with the jwtSso element not pointing to a jwtBuilder
+     * - MP JWT consumer configuration specifies the jwksUri attribute
+     * Expects:
+     * - Should successfully reach protected resource
+     * - JWT cookie should be signed by a certificate from the keystore, and its header should NOT include a "kid" entry
+     */
+    @Test
+    public void test_noBuilderRef_mpJwtJwksUriConfigured() throws Exception {
+        server.reconfigureServer(JwtFatConstants.COMMON_CONFIG_DIR + "/server_noBuilder_jwksUriConfigured.xml");
+
+        WebClient webClient = getHtmlUnitWebClient();
+
+        String currentAction = TestActions.ACTION_INVOKE_PROTECTED_RESOURCE;
+
+        Expectations expectations = new Expectations();
+        expectations.addExpectations(CommonExpectations.successfullyReachedLoginPage(currentAction));
+
+        Page response = actions.invokeUrl(testName.getMethodName(), webClient, protectedUrl);
+        validationUtils.validateResult(response, currentAction, expectations);
+
+        currentAction = TestActions.ACTION_SUBMIT_LOGIN_CREDENTIALS;
+
+        expectations.addExpectations(CommonExpectations.successfullyReachedProtectedResourceWithJwtCookie(currentAction, protectedUrl, defaultUser));
+        expectations.addExpectations(CommonExpectations.responseTextMissingCookie(currentAction, JwtFatConstants.LTPA_COOKIE_NAME));
+
+        response = actions.doFormLogin(response, defaultUser, defaultPassword);
+        validationUtils.validateResult(response, currentAction, expectations);
+
+        Cookie jwtCookie = webClient.getCookieManager().getCookie(JwtFatConstants.JWT_COOKIE_NAME);
+        verifyJwtHeaderDoesNotContainKey(jwtCookie.getValue(), "kid");
+    }
+
+    private void verifyJwtHeaderContainsKey(String jwt, String key) throws UnsupportedEncodingException {
+        Log.info(thisClass, "verifyJwtHeaderContainsKey", "Verifying that JWT header contains key \"" + key + "\". JWT: " + jwt);
+        String jwtHeader = extractAndDecodeJwtHeader(jwt);
+        JsonObject header = convertStringToJsonObject(jwtHeader);
+        assertTrue("JWT cookie header should have included a \"" + key + "\" entry but did not. Header was: " + header, header.containsKey(key));
+    }
+
+    private void verifyJwtHeaderDoesNotContainKey(String jwt, String key) throws UnsupportedEncodingException {
+        Log.info(thisClass, "verifyJwtHeaderDoesNotContainKey", "Verifying that JWT header does not contain key \"" + key + "\". JWT: " + jwt);
+        String jwtHeader = extractAndDecodeJwtHeader(jwt);
+        JsonObject header = convertStringToJsonObject(jwtHeader);
+        assertFalse("JWT cookie header should NOT have included a \"" + key + "\" entry but did. Header was: " + header, header.containsKey(key));
+    }
+
+    private String extractAndDecodeJwtHeader(String jwt) throws UnsupportedEncodingException {
+        String encodedJwtHeader = jwt.substring(0, jwt.indexOf("."));
+        return new String(Base64.getDecoder().decode(encodedJwtHeader), "UTF-8");
+    }
+
+    private JsonObject convertStringToJsonObject(String jsonObjectString) {
+        JsonReader reader = Json.createReader(new StringReader(jsonObjectString));
+        return reader.readObject();
+    }
+
+}

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/CommonJwtFat.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/CommonJwtFat.java
@@ -12,6 +12,7 @@ package com.ibm.ws.security.jwtsso.fat;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.security.fat.common.CommonSecurityFat;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
@@ -58,6 +59,13 @@ public class CommonJwtFat extends CommonSecurityFat {
 
     private static WebArchive getFormLoginApp() throws Exception {
         return ShrinkHelper.buildDefaultApp(JwtFatConstants.APP_FORMLOGIN, "com.ibm.ws.security.fat.common.apps.formlogin.*");
+    }
+
+    protected static WebClient getHtmlUnitWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions().setUseInsecureSSL(true);
+        return webClient;
     }
 
 }

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/FATSuite.java
@@ -21,5 +21,6 @@ import org.junit.runners.Suite.SuiteClasses;
                 CookieProcessingTests.class,
                 ReplayCookieTests.class,
                 CookieExpirationTests.class,
+                BuilderTests.class,
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.security.jwtsso_fat/publish/files/configs/server_builder_jwkEnabled.xml
+++ b/dev/com.ibm.ws.security.jwtsso_fat/publish/files/configs/server_builder_jwkEnabled.xml
@@ -1,0 +1,27 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <include location="${shared.config.dir}/jwtSsoFeatures.xml" />
+    <include location="${shared.config.dir}/basicRegistry.xml" />
+    <include location="${shared.config.dir}/ssl.xml" />
+    <include location="${shared.config.dir}/formloginApp.xml" />
+    <include location="../fatTestPorts.xml"/>
+
+    <authentication cacheEnabled="false"/>
+
+    <jwtSso jwtBuilderRef="builder_jwkEnabled" />
+
+    <jwtBuilder id="builder_jwkEnabled" jwkEnabled="true"/>
+
+    <mpJwt id="mpJwt_trustAllIssuers" issuer="ALL_ISSUERS" jwksUri="https://localhost:${bvt.prop.HTTP_default.secure}/jwt/ibm/api/builder_jwkEnabled/jwk" />
+
+</server>

--- a/dev/com.ibm.ws.security.jwtsso_fat/publish/files/configs/server_noBuilder_jwksUriConfigured.xml
+++ b/dev/com.ibm.ws.security.jwtsso_fat/publish/files/configs/server_noBuilder_jwksUriConfigured.xml
@@ -1,0 +1,23 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <include location="${shared.config.dir}/jwtSsoFeatures.xml" />
+    <include location="${shared.config.dir}/basicRegistry.xml" />
+    <include location="${shared.config.dir}/ssl.xml" />
+    <include location="${shared.config.dir}/formloginApp.xml" />
+    <include location="../fatTestPorts.xml"/>
+
+    <authentication cacheEnabled="false"/>
+
+    <mpJwt id="mpJwt_trustAllIssuers" issuer="ALL_ISSUERS" jwksUri="https://localhost:${bvt.prop.HTTP_default.secure}/jwt/ibm/api/defaultJWT/jwk" />
+
+</server>


### PR DESCRIPTION
Fixes #3711

Adds test for the following scenarios:
- `jwtSso` element uses the `jwtBuilderRef` attribute to point to a JWT builder with `jwkEnabled` set to `true`
- `jwtSso` element does not have a `jwtBuilderRef` configured, but the an `mpJwt` element is configured with the `jwksUri` attribute