### PR TITLE
Ignore CWWKZ0131W for MP Metrics tck. Fixes #2768

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
@@ -46,7 +46,8 @@ public class MetricsTCKLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E");
+        // Ignore CWWKZ0131W - In windows, some jars are being locked during the test. Issue #2768
+        server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E", "CWWKZ0131W");
     }
 
     @Test

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsTCKLauncher.java
@@ -46,7 +46,8 @@ public class MetricsTCKLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E");
+        // Ignore CWWKZ0131W - In windows, some jars are being locked during the test. Issue #2768
+        server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E", "CWWKZ0131W");
     }
 
     @Test


### PR DESCRIPTION
The error occurs only on Windows builds running the TCK. It does not affect the actual test cases from passing.
