### PR TITLE
Adding extra mvn profile to exclude time sensitive tests from running on the mac build

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -108,23 +108,67 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
-				<configuration>
-					<systemPropertyVariables>
-						<wlp>${wlp}</wlp>
-						<tck_server>${tck_server}</tck_server>
-                        <tck_port>${tck_port}</tck_port>
-					</systemPropertyVariables>
-                    <dependenciesToScan>
-                        <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck</dependency>
-                        <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
-                    </dependenciesToScan>
-               </configuration>
-			</plugin>
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>default</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>2.17</version>
+						<configuration>
+							<systemPropertyVariables>
+								<wlp>${wlp}</wlp>
+								<tck_server>${tck_server}</tck_server>
+								<tck_port>${tck_port}</tck_port>
+							</systemPropertyVariables>
+							<dependenciesToScan>
+								<dependency>org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck</dependency>
+								<dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
+							</dependenciesToScan>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>mac</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>2.17</version>
+						<configuration>
+							<systemPropertyVariables>
+								<wlp>${wlp}</wlp>
+								<tck_server>${tck_server}</tck_server>
+								<tck_port>${tck_port}</tck_port>
+							</systemPropertyVariables>
+							<dependenciesToScan>
+								<dependency>org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck</dependency>
+								<dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
+							</dependenciesToScan>
+							<excludes>
+								<exclude>**/TimerTest.java</exclude>
+								<exclude>**/MeterTest.java</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Fixes #3311 

Further enhancements to the TimerTest and MeterTest will be added for MP Metrics 2.0.