### PR TITLE
Remove test dependencies between microprofile.config tests.

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.2/.classpath
+++ b/dev/com.ibm.ws.microprofile.config.1.2/.classpath
@@ -6,6 +6,5 @@
 	<classpathentry kind="src" output="bin_test" path="test/resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/com.ibm.ws.microprofile.config"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.microprofile.config.1.2/test/src/com/ibm/ws/microprofile/config/converter/test/ClassC.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2/test/src/com/ibm/ws/microprofile/config/converter/test/ClassC.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config.converter.test;
+
+public class ClassC {
+
+    private String value;
+
+    public static ClassC newClassC(String value) {
+        ClassC classC = new ClassC();
+        classC.value = value;
+        return classC;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "ClassC: " + getValue();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config.1.2/test/src/com/ibm/ws/microprofile/config/converter/test/ConverterC.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2/test/src/com/ibm/ws/microprofile/config/converter/test/ConverterC.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config.converter.test;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+public class ConverterC implements Converter<ClassC> {
+
+    /** {@inheritDoc} */
+    @Override
+    public ClassC convert(String value) {
+        return (ClassC) ClassC.newClassC(value);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config.1.2/test/src/com/ibm/ws/microprofile/config/loader/test/ServiceLoaderConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2/test/src/com/ibm/ws/microprofile/config/loader/test/ServiceLoaderConfigSource.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config.loader.test;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+@SuppressWarnings("serial")
+public class ServiceLoaderConfigSource extends ConcurrentHashMap<String, String> implements ConfigSource {
+
+    public ServiceLoaderConfigSource() {
+        put("SLKey1", "SLValue1");
+        put("SLKey2", "SLValue2");
+        put("SLKey3", "SLValue3");
+        put("SLKey4", "SLValue4");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ConcurrentMap<String, String> getProperties() {
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getOrdinal() {
+        return 100;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getValue(String propertyName) {
+        return get(propertyName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getName() {
+        return "ServiceLoaderConfigSource";
+    }
+}

--- a/dev/com.ibm.ws.microprofile.config.1.3/.classpath
+++ b/dev/com.ibm.ws.microprofile.config.1.3/.classpath
@@ -6,6 +6,5 @@
 	<classpathentry kind="src" output="bin_test" path="test/resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/com.ibm.ws.microprofile.config.1.2"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.microprofile.config.1.3/test/src/com/ibm/ws/microprofile/config/converter/test/ClassC.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/test/src/com/ibm/ws/microprofile/config/converter/test/ClassC.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config.converter.test;
+
+public class ClassC {
+
+    private String value;
+
+    public static ClassC newClassC(String value) {
+        ClassC classC = new ClassC();
+        classC.value = value;
+        return classC;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "ClassC: " + getValue();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config.1.3/test/src/com/ibm/ws/microprofile/config/converter/test/ConverterC.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/test/src/com/ibm/ws/microprofile/config/converter/test/ConverterC.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config.converter.test;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+public class ConverterC implements Converter<ClassC> {
+
+    /** {@inheritDoc} */
+    @Override
+    public ClassC convert(String value) {
+        return (ClassC) ClassC.newClassC(value);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config.1.3/test/src/com/ibm/ws/microprofile/config/loader/test/ServiceLoaderConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/test/src/com/ibm/ws/microprofile/config/loader/test/ServiceLoaderConfigSource.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config.loader.test;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+@SuppressWarnings("serial")
+public class ServiceLoaderConfigSource extends ConcurrentHashMap<String, String> implements ConfigSource {
+
+    public ServiceLoaderConfigSource() {
+        put("SLKey1", "SLValue1");
+        put("SLKey2", "SLValue2");
+        put("SLKey3", "SLValue3");
+        put("SLKey4", "SLValue4");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ConcurrentMap<String, String> getProperties() {
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getOrdinal() {
+        return 100;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getValue(String propertyName) {
+        return get(propertyName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getName() {
+        return "ServiceLoaderConfigSource";
+    }
+}


### PR DESCRIPTION
Add necessary classes from com.ibm.ws.microprofile.config/test directory
to the config.1.2/test and config.1.3/test directory to make tests pass
with having a runtime dependency on the test output from the config
component.