### PR TITLE
Performance update for getting beanmanager.

### DIFF
--- a/dev/com.ibm.ws.org.apache.myfaces.2.3/src/org/apache/myfaces/cdi/model/DataModelBuilderProxy.java
+++ b/dev/com.ibm.ws.org.apache.myfaces.2.3/src/org/apache/myfaces/cdi/model/DataModelBuilderProxy.java
@@ -20,7 +20,6 @@
 package org.apache.myfaces.cdi.model;
 
 import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
 import javax.faces.context.FacesContext;
 import javax.faces.model.DataModel;
 import org.apache.myfaces.cdi.util.CDIUtils;
@@ -34,7 +33,7 @@ public class DataModelBuilderProxy extends DataModelBuilder
     @Override
     public DataModel createDataModel(FacesContext facesContext, Class<?> forClass, Object value)
     {
-        BeanManager beanManager = CDI.current().getBeanManager();
+        BeanManager beanManager = CDIUtils.getBeanManager(facesContext.getExternalContext());
         FacesDataModelClassBeanHolder holder = CDIUtils.lookup(beanManager, FacesDataModelClassBeanHolder.class);
         return holder.createDataModel(facesContext, forClass, value);
     }

--- a/dev/com.ibm.ws.org.apache.myfaces.2.3/src/org/apache/myfaces/cdi/model/DataModelBuilderProxy.java
+++ b/dev/com.ibm.ws.org.apache.myfaces.2.3/src/org/apache/myfaces/cdi/model/DataModelBuilderProxy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.myfaces.cdi.model;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
+import javax.faces.context.FacesContext;
+import javax.faces.model.DataModel;
+import org.apache.myfaces.cdi.util.CDIUtils;
+
+/**
+ *
+ */
+public class DataModelBuilderProxy extends DataModelBuilder
+{
+    
+    @Override
+    public DataModel createDataModel(FacesContext facesContext, Class<?> forClass, Object value)
+    {
+        BeanManager beanManager = CDI.current().getBeanManager();
+        FacesDataModelClassBeanHolder holder = CDIUtils.lookup(beanManager, FacesDataModelClassBeanHolder.class);
+        return holder.createDataModel(facesContext, forClass, value);
+    }
+    
+}


### PR DESCRIPTION
Get the bean manager from CDIUtils, which is cached, instead of from CDI.current.
