### PR TITLE
Improve performance of adding providers to ProviderFactories.

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -44,8 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.json.bind.spi.JsonbProvider;
 import javax.json.spi.JsonProvider;
@@ -123,14 +123,16 @@ public abstract class ProviderFactory {
     protected Map<NameKey, ProviderInfo<ReaderInterceptor>> readerInterceptors = new NameKeyMap<ProviderInfo<ReaderInterceptor>>(true);
     protected Map<NameKey, ProviderInfo<WriterInterceptor>> writerInterceptors = new NameKeyMap<ProviderInfo<WriterInterceptor>>(true);
 
-    private final List<ProviderInfo<MessageBodyReader<?>>> messageReaders =
-        new CopyOnWriteArrayList<ProviderInfo<MessageBodyReader<?>>>();
-    private final List<ProviderInfo<MessageBodyWriter<?>>> messageWriters =
-        new CopyOnWriteArrayList<ProviderInfo<MessageBodyWriter<?>>>();
-    private final List<ProviderInfo<ContextResolver<?>>> contextResolvers =
-        new CopyOnWriteArrayList<ProviderInfo<ContextResolver<?>>>();
-    private final List<ProviderInfo<ContextProvider<?>>> contextProviders =
-        new CopyOnWriteArrayList<ProviderInfo<ContextProvider<?>>>();
+    //Liberty code change start
+    private final AtomicReferenceProviderList<MessageBodyReader<?>> messageReaders =
+        new AtomicReferenceProviderList<>();
+    private final AtomicReferenceProviderList<MessageBodyWriter<?>> messageWriters =
+        new AtomicReferenceProviderList<>();
+    private final AtomicReferenceProviderList<ContextResolver<?>> contextResolvers =
+        new AtomicReferenceProviderList<>();
+    private final AtomicReferenceProviderList<ContextProvider<?>> contextProviders =
+        new AtomicReferenceProviderList<>();
+    //Liberty code change end
 
     private final List<ProviderInfo<ParamConverterProvider>> paramConverters = new ArrayList<ProviderInfo<ParamConverterProvider>>(1);
     private boolean paramConverterContextsAvailable;
@@ -733,6 +735,13 @@ public abstract class ProviderFactory {
 
     @SuppressWarnings("unchecked")
     protected void setCommonProviders(List<ProviderInfo<? extends Object>> theProviders) {
+        //Liberty code change start
+        List<ProviderInfo<MessageBodyReader<?>>> newReaders = new ArrayList<ProviderInfo<MessageBodyReader<?>>>();
+        List<ProviderInfo<MessageBodyWriter<?>>> newWriters = new ArrayList<ProviderInfo<MessageBodyWriter<?>>>();
+        List<ProviderInfo<ContextResolver<?>>> newResolvers = new ArrayList<ProviderInfo<ContextResolver<?>>>();
+        List<ProviderInfo<ContextProvider<?>>> newContextProviders = new ArrayList<ProviderInfo<ContextProvider<?>>>();
+        //Liberty code change end
+
         List<ProviderInfo<ReaderInterceptor>> readInts =
             new LinkedList<ProviderInfo<ReaderInterceptor>>();
         List<ProviderInfo<WriterInterceptor>> writeInts =
@@ -741,19 +750,27 @@ public abstract class ProviderFactory {
             Class<?> providerCls = ClassHelper.getRealClass(bus, provider.getProvider());
 
             if (filterContractSupported(provider, providerCls, MessageBodyReader.class)) {
-                addProviderToList(messageReaders, provider);
+                //Liberty code change start
+                addProviderToList(newReaders, provider);
+                //Liberty code change end
             }
 
             if (filterContractSupported(provider, providerCls, MessageBodyWriter.class)) {
-                addProviderToList(messageWriters, provider);
+                //Liberty code change start
+                addProviderToList(newWriters, provider);
+                //Liberty code change end
             }
 
             if (filterContractSupported(provider, providerCls, ContextResolver.class)) {
-                addProviderToList(contextResolvers, provider);
+                //Liberty code change start
+                addProviderToList(newResolvers, provider);
+                //Liberty code change end
             }
 
             if (ContextProvider.class.isAssignableFrom(providerCls)) {
-                addProviderToList(contextProviders, provider);
+                //Liberty code change start
+                addProviderToList(newContextProviders, provider);
+                //Liberty code change end
             }
 
             if (filterContractSupported(provider, providerCls, ReaderInterceptor.class)) {
@@ -768,15 +785,28 @@ public abstract class ProviderFactory {
                 paramConverters.add((ProviderInfo<ParamConverterProvider>) provider);
             }
         }
-        sortReaders();
-        sortWriters();
-        sortContextResolvers();
+        //Liberty code change start
+        if (newReaders.size() > 0) {
+            addAndSortReaders(newReaders);
+        }
+        if (newWriters.size() > 0) {
+            addAndSortWriters(newWriters);
+        }
+        if (newResolvers.size() > 0) {
+            contextResolvers.addAndSortProviders(newResolvers, new ContextResolverComparator());
+        }
+        if (newContextProviders.size() > 0) {
+            contextProviders.addProviders(newContextProviders);
+        }
+        //Liberty code change end
         sortParamConverters();
 
         mapInterceptorFilters(readerInterceptors, readInts, ReaderInterceptor.class, true);
         mapInterceptorFilters(writerInterceptors, writeInts, WriterInterceptor.class, true);
 
-        injectContextProxies(messageReaders, messageWriters, contextResolvers, paramConverters,
+        //Liberty code change start
+        injectContextProxies(messageReaders.get(), messageWriters.get(), contextResolvers.get(), paramConverters,
+        //Liberty code change end
                              readerInterceptors.values(), writerInterceptors.values());
         checkParamConverterContexts();
     }
@@ -830,36 +860,100 @@ public abstract class ProviderFactory {
         }
     }
 
-    /*
-     * sorts the available providers according to the media types they declare
-     * support for. Sorting of media types follows the general rule: x/y < * x < *,
-     * i.e. a provider that explicitly lists a media types is sorted before a
-     * provider that lists *. Quality parameter values are also used such that
-     * x/y;q=1.0 < x/y;q=0.7.
-     */
-    private void sortReaders() {
+    //Liberty code change start
+    private void addAndSortReaders(List<ProviderInfo<MessageBodyReader<?>>> newReaders) {
+        Comparator<ProviderInfo<MessageBodyReader<?>>> comparator = null;
         if (!customComparatorAvailable(MessageBodyReader.class)) {
-            messageReaders.sort(new MessageBodyReaderComparator(readerMediaTypesMap));
-        } else {
-            doCustomSort(messageReaders);
+            comparator = new MessageBodyReaderComparator(readerMediaTypesMap);
         }
+
+        messageReaders.addAndSortProviders(newReaders, comparator);
     }
 
-    private <T> void sortWriters() {
+    private void addAndSortWriters(List<ProviderInfo<MessageBodyWriter<?>>> newWriters) {
+        Comparator<ProviderInfo<MessageBodyWriter<?>>> comparator = null;
         if (!customComparatorAvailable(MessageBodyWriter.class)) {
-            messageWriters.sort(new MessageBodyWriterComparator(writerMediaTypesMap));
-        } else {
-            doCustomSort(messageWriters);
+            comparator = new MessageBodyWriterComparator(writerMediaTypesMap);
         }
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            StringBuilder msg = new StringBuilder("sortWriters - sorted list:");
-            for (int i = 0; i < messageWriters.size(); i++) {
-                msg.append(" (" + i + ") " + messageWriters.get(i).getProvider());
-            }
-            Tr.debug(tc, msg.toString());
-        }
+
+        messageWriters.addAndSortProviders(newWriters, comparator);
     }
 
+    protected class AtomicReferenceProviderList<T> implements Iterable<ProviderInfo<T>> {
+        private final AtomicReference<List<ProviderInfo<T>>> referent;
+
+        public AtomicReferenceProviderList() {
+            referent = new AtomicReference<>(Collections.emptyList());
+        }
+
+        /*
+         * sorts the available providers according to the media types they declare
+         * support for. Sorting of media types follows the general rule: x/y < * x < *,
+         * i.e. a provider that explicitly lists a media types is sorted before a
+         * provider that lists *. Quality parameter values are also used such that
+         * x/y;q=1.0 < x/y;q=0.7.
+         */
+        public void addAndSortProviders(List<ProviderInfo<T>> providers, 
+                                           Comparator<ProviderInfo<T>> comparator) {
+            List<ProviderInfo<T>> currentProviders = null;
+            List<ProviderInfo<T>> newProviders = null;
+            do {
+                currentProviders = referent.get();
+                if (currentProviders.isEmpty()) {
+                    newProviders = providers;
+                } else {
+                    newProviders = new ArrayList<ProviderInfo<T>>(currentProviders);
+                    for (ProviderInfo<T> provider : providers) {
+                        addProviderToList(newProviders, provider);
+                    }
+                }
+                if (comparator != null) {
+                    newProviders.sort(comparator);
+                } else {
+                    doCustomSort(newProviders);
+                }
+            } while (!referent.compareAndSet(currentProviders, newProviders));
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                StringBuilder msg = new StringBuilder("sortProviders - sorted list:");
+                for (int i = 0; i < newProviders.size(); i++) {
+                    msg.append(" (" + i + ") " + newProviders.get(i).getProvider());
+                }
+                Tr.debug(tc, msg.toString());
+            }
+        }
+
+        public void addProviders(List<ProviderInfo<T>> providers) {
+            List<ProviderInfo<T>> currentProviders = null;
+            List<ProviderInfo<T>> newProviders = null;
+            do {
+                currentProviders = referent.get();
+                if (currentProviders.isEmpty()) {
+                    newProviders = providers;
+                } else {
+                    newProviders = new ArrayList<ProviderInfo<T>>(currentProviders);
+                    for (ProviderInfo<T> provider : providers) {
+                        addProviderToList(newProviders, provider);
+                    }
+                }
+            } while (!referent.compareAndSet(currentProviders, newProviders));
+        }
+
+        @Override
+        public Iterator<ProviderInfo<T>> iterator() {
+            return referent.get().iterator();
+        }
+
+        public List<ProviderInfo<T>> get() {
+            return referent.get();
+        }
+
+        public void clear() {
+            referent.set(Collections.emptyList());
+        }
+    }
+    //Liberty code change end
+    
     private <T> void sortParamConverters() {
         if (!customComparatorAvailable(ParamConverter.class)) {
             paramConverters.sort(new ParamConverterProviderComparator());
@@ -909,10 +1003,6 @@ public abstract class ProviderFactory {
         List<T> theProviders = (List<T>) listOfProviders;
         Comparator<? super T> theComparator = (Comparator<? super T>) theProviderComparator;
         theProviders.sort(theComparator);
-    }
-
-    private void sortContextResolvers() {
-        contextResolvers.sort(new ContextResolverComparator());
     }
 
     private final Map<MessageBodyReader<?>, List<MediaType>> readerMediaTypesMap = new HashMap<>();
@@ -1008,15 +1098,21 @@ public abstract class ProviderFactory {
     }
 
     List<ProviderInfo<MessageBodyReader<?>>> getMessageReaders() {
-        return Collections.unmodifiableList(messageReaders);
+        //Liberty code change start
+        return Collections.unmodifiableList(messageReaders.get());
+        //Liberty code change end
     }
 
     List<ProviderInfo<MessageBodyWriter<?>>> getMessageWriters() {
-        return Collections.unmodifiableList(messageWriters);
+        //Liberty code change start
+        return Collections.unmodifiableList(messageWriters.get());
+        //Liberty code change end
     }
 
     List<ProviderInfo<ContextResolver<?>>> getContextResolvers() {
-        return Collections.unmodifiableList(contextResolvers);
+        //Liberty code change start
+        return Collections.unmodifiableList(contextResolvers.get());
+        //Liberty code change end
     }
 
     public void registerUserProvider(Object provider) {
@@ -1087,9 +1183,13 @@ public abstract class ProviderFactory {
                 return result;
             }
             List<MediaType> types1 =
-                JAXRSUtils.sortMediaTypes(JAXRSUtils.getProviderProduceTypes(e1), JAXRSUtils.MEDIA_TYPE_QS_PARAM);
+                //Liberty code change start
+                JAXRSUtils.sortMediaTypes(getProviderProduceTypes(e1, cache), JAXRSUtils.MEDIA_TYPE_QS_PARAM);
+                //Liberty code change end
             List<MediaType> types2 =
-                JAXRSUtils.sortMediaTypes(JAXRSUtils.getProviderProduceTypes(e2), JAXRSUtils.MEDIA_TYPE_QS_PARAM);
+                //Liberty code change start
+                JAXRSUtils.sortMediaTypes(getProviderProduceTypes(e2, cache), JAXRSUtils.MEDIA_TYPE_QS_PARAM);
+                //Liberty code change end
 
             result = JAXRSUtils.compareSortedMediaTypes(types1, types2, JAXRSUtils.MEDIA_TYPE_QS_PARAM);
             if (result != 0) {
@@ -1257,8 +1357,10 @@ public abstract class ProviderFactory {
 
     Set<Object> getReadersWriters() {
         Set<Object> set = new HashSet<>();
-        set.addAll(messageReaders);
-        set.addAll(messageWriters);
+        //Liberty code change start
+        set.addAll(messageReaders.get());
+        set.addAll(messageWriters.get());
+        //Liberty code change end
         return set;
     }
 
@@ -1419,22 +1521,24 @@ public abstract class ProviderFactory {
 
     }
 
-    protected static class BindingPriorityComparator extends AbstractPriorityComparator
-        implements Comparator<ProviderInfo<?>> {
-        private final Class<?> providerCls;
+    //Liberty code change start
+    protected static class BindingPriorityComparator<T> extends AbstractPriorityComparator
+        implements Comparator<ProviderInfo<T>> {
+        private final Class<T> providerCls;
 
-        public BindingPriorityComparator(Class<?> providerCls, boolean ascending) {
+        public BindingPriorityComparator(Class<T> providerCls, boolean ascending) {
             super(ascending);
             this.providerCls = providerCls;
         }
 
         @Override
-        public int compare(ProviderInfo<?> p1, ProviderInfo<?> p2) {
+        public int compare(ProviderInfo<T> p1, ProviderInfo<T> p2) {
             return compare(getFilterPriority(p1, providerCls),
                            getFilterPriority(p2, providerCls));
         }
 
     }
+    //Liberty code change end
 
     static class ContextResolverProxy<T> implements ContextResolver<T> {
         private final List<ContextResolver<T>> candidates;
@@ -1704,8 +1808,10 @@ public abstract class ProviderFactory {
 
     public void setProviderComparator(Comparator<?> providerComparator) {
         this.providerComparator = providerComparator;
-        sortReaders();
-        sortWriters();
+        //Liberty code change start
+        addAndSortReaders(Collections.emptyList());
+        addAndSortWriters(Collections.emptyList());
+        //Liberty code change end
         sortParamConverters();
     }
 


### PR DESCRIPTION
Change from using CopyOnWriteArrayList to using an AtomicReference and
creating a new List each time we need to add new Providers to the list.
Also update the 2.1 CXF JAXRS code to use the
ProviderFactory.getProviderProduceTypes method like is done in the 2.0
JAXRS code.
With the changes to not use CopyOnWriteArrayList, now the concurrent
issues that were resolved only with Java 8 will now also be resolved
with Java 7.