### PR TITLE
Change from the TwoTierObjectPool to a new ConcurrentObjectPool.

### DIFF
--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/PooledWsByteBufferImpl.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/PooledWsByteBufferImpl.java
@@ -44,7 +44,7 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
     protected int actionState = COPY_ALL_INIT;
     protected final Object actionAccess = new Object();
 
-    private Object identifier = null;
+    private final Object identifier;
     /** number of references to this pool entry */
     transient public int intReferenceCount = 1;
 
@@ -66,6 +66,16 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
     public PooledWsByteBufferImpl() {
         super();
         this.wsBBRoot = this;
+        this.identifier = null;
+        // if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+        // Tr.event(tc, "Created " + this);
+        // }
+    }
+
+    public PooledWsByteBufferImpl(Object id) {
+        super();
+        this.wsBBRoot = this;
+        this.identifier = id;
         // if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
         // Tr.event(tc, "Created " + this);
         // }
@@ -73,7 +83,7 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
 
     /**
      * Access the ID for this buffer.
-     * 
+     *
      * @return Object
      */
     public Object getID() {
@@ -81,18 +91,9 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
     }
 
     /**
-     * Set the ID of this buffer to the input value.
-     * 
-     * @param id
-     */
-    public void setID(Object id) {
-        this.identifier = id;
-    }
-
-    /**
      * If leak detection is enabled, this is the table that keeps track of
      * buffers related to this one (itself plus dupes and slices).
-     * 
+     *
      * @return Hashtable<WsByteBuffer,WsByteBuffer>
      */
     public Hashtable<WsByteBuffer, WsByteBuffer> getallBuffers() {
@@ -101,7 +102,7 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
 
     /**
      * Add a related buffer to the stored list for this instance.
-     * 
+     *
      * @param buffer
      */
     public void addWsByteBuffer(WsByteBuffer buffer) {
@@ -113,7 +114,7 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
 
     /**
      * Remove a buffer from the stored list for this instance.
-     * 
+     *
      * @param buffer
      */
     public void removeWsByteBuffer(WsByteBuffer buffer) {
@@ -122,7 +123,7 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
 
     /**
      * Add the following owner to the list for this buffer.
-     * 
+     *
      * @param owner
      */
     public void addOwner(String owner) {
@@ -134,7 +135,7 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
 
     /**
      * Remove the input ID from the stored owners of this buffer.
-     * 
+     *
      * @param owner
      */
     public void removeOwner(String owner) {
@@ -152,7 +153,7 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
     /**
      * Return the debug information for this buffer, as it related to the input
      * owner.
-     * 
+     *
      * @param ownerID
      * @return String
      */

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/WsByteBufferPool.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/WsByteBufferPool.java
@@ -10,24 +10,31 @@
  *******************************************************************************/
 package com.ibm.ws.bytebuffer.internal;
 
+import java.util.Hashtable;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.wsspi.channelfw.objectpool.ObjectDestroyer;
-import com.ibm.wsspi.channelfw.objectpool.ObjectFactory;
-import com.ibm.wsspi.channelfw.objectpool.TwoTierObjectPool;
+import com.ibm.ws.kernel.service.util.ConcurrentObjectPool;
 
 /**
  * A Pool of WsByteBuffers. The size of the entries and the pool depth are
  * configurable.
  */
 public class WsByteBufferPool {
-    private int intEntrySize;
-    private int globalPoolSize;
-    private int localThreadPoolSize;
-    private TwoTierObjectPool pool = null;
-    private WsByteBufferFactory wsbbFactory = null;
+    private final int intEntrySize;
+    private final int globalPoolSize;
+    private final boolean isDirectPool;
+    private final ConcurrentObjectPool<PooledWsByteBufferImpl> pool;
 
-    int intUniqueCounter = 0;
+    /**
+     * When {@link #inUseTracking} is enabled, this table records poolable objects that were previously created, but
+     * are currently not in the pool. An entry is placed in this table for a {@link #get()} and removed for a
+     * {@link #put(Object)}. An entry's key and value are identical, and are the poolable object itself.
+     */
+    private final Hashtable<PooledWsByteBufferImpl, PooledWsByteBufferImpl> inUseTable;
+
+    private final AtomicInteger intUniqueCounter = new AtomicInteger(0);
 
     private static final TraceComponent tc = Tr.register(WsByteBufferPool.class,
                                                          MessageConstants.WSBB_TRACE_NAME,
@@ -36,123 +43,118 @@ public class WsByteBufferPool {
     /**
      * Create the pool and obtain the values for the size of the pool
      * entries and the pool depth.
-     * 
+     *
      * @param entrySizeIn
-     * @param _localPoolSize
      * @param _globalPoolSize
      * @param tracking
      * @param isDirectPool
-     * @param cleanUpOld
      */
-    public WsByteBufferPool(int entrySizeIn, int _localPoolSize, int _globalPoolSize, boolean tracking, boolean isDirectPool, boolean cleanUpOld) { // @427758C
+    public WsByteBufferPool(int entrySizeIn, int _globalPoolSize, boolean tracking, boolean isDirectPool) { // @427758C
 
         this.intEntrySize = entrySizeIn;
         this.globalPoolSize = _globalPoolSize;
-        this.localThreadPoolSize = _localPoolSize;
+        this.isDirectPool = isDirectPool;
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, "Creating : " +
                          this.toString() +
                          " direct=" + isDirectPool +
-                         " backing pool size: " + this.globalPoolSize +
-                         " local thread pool size: " + this.localThreadPoolSize);
-        }
-        this.wsbbFactory = new WsByteBufferFactory();
-
-        if (isDirectPool) {
-            this.pool = new TwoTierObjectPool(localThreadPoolSize, globalPoolSize, wsbbFactory, wsbbFactory, tracking);
-        } else {
-            this.pool = new TwoTierObjectPool(localThreadPoolSize, globalPoolSize, wsbbFactory, null, tracking);
+                         " backing pool size: " + this.globalPoolSize);
         }
 
-        if (!cleanUpOld) {
-            this.pool.doNotCleanUpOld();
-        }
+        this.pool = new ConcurrentObjectPool<>(globalPoolSize);
+        this.inUseTable = tracking ? new Hashtable<PooledWsByteBufferImpl, PooledWsByteBufferImpl>(globalPoolSize * 2) : null;
     }
 
-    /**
-     * inner class for creating the object which will be pooled.
-     */
-    public class WsByteBufferFactory implements ObjectFactory, ObjectDestroyer {
-        private WsByteBufferPoolManagerImpl wsbbPoolManager = null;
+    private WsByteBufferPoolManagerImpl wsbbPoolManager = null;
 
-        public Object create() {
-            int intUniqueId;
-
-            PooledWsByteBufferImpl pooledWSBB = new PooledWsByteBufferImpl();
-
-            // The factory has the responsibility of supplying the unique identifier,
-            // so set it into the WsByteBuffer at this time.
-            synchronized (this) {
-                intUniqueId = intUniqueCounter++;
-                if (intUniqueCounter == -1) {
-                    // if counter has rolled over to -1, then increment it because
-                    // -1 is the ID of all WsByteBuffers which have been created
-                    // with the wrap method
-                    intUniqueCounter++;
-                }
-
-            }
-            pooledWSBB.setID(Integer.valueOf(intUniqueId));
-            return pooledWSBB;
+    public PooledWsByteBufferImpl create() {
+        // The factory has the responsibility of supplying the unique identifier,
+        // so set it into the WsByteBuffer at this time.
+        int intUniqueId = intUniqueCounter.getAndIncrement();
+        if (intUniqueId == -1) {
+            // if counter has rolled over to -1, then increment it because
+            // -1 is the ID of all WsByteBuffers which have been created
+            // with the wrap method
+            intUniqueId = intUniqueCounter.getAndIncrement();
         }
 
-        public void destroy(Object obj) {
+        return new PooledWsByteBufferImpl(Integer.valueOf(intUniqueId));
+    }
 
-            // If we try to set this on the initialization of the class,
-            // we end up in an infinite loop calling WsByteBufferPoolManager.getRef
-            if (this.wsbbPoolManager == null) {
-                this.wsbbPoolManager = (WsByteBufferPoolManagerImpl) WsByteBufferPoolManagerImpl.getRef();
-            }
-            if (this.wsbbPoolManager != null) {
-                this.wsbbPoolManager.releasing(((WsByteBufferImpl) obj).oByteBuffer);
-            }
+    public void destroy(PooledWsByteBufferImpl obj) {
+
+        // If we try to set this on the initialization of the class,
+        // we end up in an infinite loop calling WsByteBufferPoolManager.getRef
+        if (this.wsbbPoolManager == null) {
+            this.wsbbPoolManager = (WsByteBufferPoolManagerImpl) WsByteBufferPoolManagerImpl.getRef();
         }
-
+        if (this.wsbbPoolManager != null) {
+            this.wsbbPoolManager.releasing(((WsByteBufferImpl) obj).oByteBuffer);
+        }
     }
 
     /**
      * Return a buffer from the pool, or allocate a new buffer is the pool
      * is full.
-     * 
+     *
      * @return PooledWsByteBufferImpl
      */
     public PooledWsByteBufferImpl getEntry() {
-        return (PooledWsByteBufferImpl) this.pool.get();
+        PooledWsByteBufferImpl returnValue = pool.get();
+        if (returnValue == null) {
+            returnValue = create();
+        }
+        if (inUseTable != null) {
+            inUseTable.put(returnValue, returnValue);
+        }
+        return returnValue;
     }
 
     /**
      * Return a buffer to the pool or free the buffer to be garbage
      * collected if the pool is full.
-     * 
+     *
      * @param buffer to be released.
      * @param entryID
      */
-    public void release(Object buffer, Object entryID) {
-        this.pool.put(buffer);
+    public void release(PooledWsByteBufferImpl buffer) {
+        if (inUseTable != null) {
+            inUseTable.remove(buffer);
+        }
+        boolean pooled = pool.put(buffer);
+        if (isDirectPool && !pooled) {
+            destroy(buffer);
+        }
     }
 
     /**
      * Return the inUse table.
-     * 
+     *
      * @return Object[] an array of Objects representing the inUse table
      */
+    @SuppressWarnings("unchecked")
     public Object[] getInUse() {
-        return (this.pool.getInUseTable());
+        return inUseTable != null ? (((Hashtable<PooledWsByteBufferImpl, PooledWsByteBufferImpl>) inUseTable.clone()).keySet().toArray()) : new Object[0];
     }
 
     /**
      * Remove a buffer from the InUse pool. To be used when the buffer
      * should be removed without waiting for the release logic to remove it.
-     * 
+     *
      * @param buffer to be released.
      */
     public void removeFromInUse(Object buffer) {
-        this.pool.removeFromInUse(buffer);
+        if (inUseTable != null) {
+            if (null == buffer) {
+                throw new NullPointerException();
+            }
+            inUseTable.remove(buffer);
+        }
     }
 
     /**
      * Return a customized toString.
-     * 
+     *
      * @return String
      */
     @Override
@@ -165,14 +167,5 @@ public class WsByteBufferPool {
         sb.append('/').append(this.intEntrySize);
         sb.append(']');
         return sb.toString();
-    }
-
-    /**
-     * Caller is requesting that this pool purge it's thread local
-     * information back to the main group pool.
-     * 
-     */
-    public void purgeThreadLocal() {
-        this.pool.purgeThreadLocal();
     }
 }

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/WsByteBufferPoolManagerImpl.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/WsByteBufferPoolManagerImpl.java
@@ -94,12 +94,11 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
     private String leakDetectionOutput = null;
     private final Object leakDetectionSyncObject = new Object() {};
 
-    protected boolean cleanUpOld = false;
-
     /**
      * Create the one WsByteBufferPool Manager that is to be used.
-     * @param directByteBufferHelper 
-     * 
+     *
+     * @param directByteBufferHelper
+     *
      * @param properties
      * @throws WsBBConfigException
      */
@@ -171,7 +170,6 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
                 }
 
                 if (key.equalsIgnoreCase(CLEAN_UP)) {
-                    cleanUpOld = MetatypeUtils.parseBoolean(CONFIG_ALIAS, CLEAN_UP, value, cleanUpOld);
                     continue;
                 }
 
@@ -180,17 +178,15 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
         } catch (NumberFormatException x) {
             Tr.error(tc, MessageConstants.CONFIG_VALUE_NUMBER_EXCEPTION,
                      new Object[] { key, value });
-            WsBBConfigException e = new WsBBConfigException(
-                            "NumberFormatException processing name: "
-                                            + key + " value: " + value, x);
+            WsBBConfigException e = new WsBBConfigException("NumberFormatException processing name: "
+                                                            + key + " value: " + value, x);
             FFDCFilter.processException(e, getClass().getName(), "102", this);
             throw e;
         }
 
         if (result != VALIDATE_OK) {
             Tr.error(tc, MessageConstants.NOT_VALID_CUSTOM_PROPERTY, new Object[] { key, value });
-            WsBBConfigException e = new WsBBConfigException(
-                            "Property has a value that is not valid, name: " + key + " value: [" + value + "]");
+            WsBBConfigException e = new WsBBConfigException("Property has a value that is not valid, name: " + key + " value: [" + value + "]");
             FFDCFilter.processException(e, getClass().getName(), "103", this);
             throw e;
         }
@@ -202,8 +198,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
                 } catch (IOException x) {
                     Tr.error(tc, MessageConstants.NOT_VALID_CUSTOM_PROPERTY,
                              new Object[] { MEM_LEAK_FILE, leakFile });
-                    WsBBConfigException e = new WsBBConfigException(
-                                    "Error with leak detection file, " + MEM_LEAK_FILE + "=[" + leakFile + "]", x);
+                    WsBBConfigException e = new WsBBConfigException("Error with leak detection file, " + MEM_LEAK_FILE + "=[" + leakFile + "]", x);
                     FFDCFilter.processException(e,
                                                 getClass().getName(), "104", this);
                     throw e;
@@ -211,8 +206,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
             } else {
                 Tr.error(tc, MessageConstants.NOT_VALID_CUSTOM_PROPERTY,
                          new Object[] { MEM_LEAK_FILE, "null" });
-                WsBBConfigException e = new WsBBConfigException(
-                                "Leak interval set without an output file");
+                WsBBConfigException e = new WsBBConfigException("Leak interval set without an output file");
                 FFDCFilter.processException(e, getClass().getName(), "105", this);
                 throw e;
             }
@@ -223,8 +217,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
             initialize(defaultPoolSizes, defaultPoolDepths);
         } else if (sizes.length != depths.length) {
             Tr.error(tc, MessageConstants.POOL_MISMATCH, new Object[] { sizes, depths });
-            WsBBConfigException e = new WsBBConfigException(
-                            "Mismatch in pool sizes (" + sizes.length + ") and depths(" + depths.length + ")");
+            WsBBConfigException e = new WsBBConfigException("Mismatch in pool sizes (" + sizes.length + ") and depths(" + depths.length + ")");
             FFDCFilter.processException(e, getClass().getName(), "106", this);
             throw e;
         } else {
@@ -236,7 +229,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
 
     /**
      * Create a pool manager with the default configuration.
-     * 
+     *
      * @throws WsBBConfigException
      */
     public WsByteBufferPoolManagerImpl(AtomicReference<DirectByteBufferHelper> directByteBufferHelper) throws WsBBConfigException {
@@ -246,7 +239,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
     /**
      * This class implements the singleton pattern. This method is provided
      * to return a reference to the single instance of this class in existence.
-     * 
+     *
      * @return WsByteBufferPoolManager
      */
     public static WsByteBufferPoolManager getRef() {
@@ -260,7 +253,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
     /**
      * Initialize the pool manager with the number of pools, the entry sizes for each
      * pool, and the maximum depth of the free pool.
-     * 
+     *
      * @param bufferEntrySizes the memory sizes of each entry in the pools
      * @param bufferEntryDepths the maximum number of entries in the free pool
      */
@@ -308,10 +301,8 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
         this.poolSizes = new int[len];
         for (int i = 0; i < len; i++) {
             // make backing pool 10 times larger than local pools
-            this.pools[i] = new WsByteBufferPool(
-                            bSizes[i], bDepths[i], bDepths[i] * 10, tracking, false, cleanUpOld);
-            this.poolsDirect[i] = new WsByteBufferPool(
-                            bSizes[i], bDepths[i], bDepths[i] * 10, tracking, true, cleanUpOld);
+            this.pools[i] = new WsByteBufferPool(bSizes[i], bDepths[i] * 10, tracking, false);
+            this.poolsDirect[i] = new WsByteBufferPool(bSizes[i], bDepths[i] * 10, tracking, true);
             this.poolSizes[i] = bSizes[i];
         }
 
@@ -327,7 +318,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
     /**
      * Set the memory leak detection parameters. If the interval is 0 or
      * greater, then the detection code will enabled.
-     * 
+     *
      * @param interval the minimum amount of time between leak detection code
      *            will be ran. Also the minimum amount of time that a buffer can go without
      *            being accessed before it will be flagged as a possible memory leak.
@@ -360,7 +351,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
 
     /**
      * Check whether the buffer leak detection code is enabled or not.
-     * 
+     *
      * @return boolean
      */
     private boolean trackingBuffers() {
@@ -369,7 +360,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
 
     /**
      * Query the interval used for leak detection.
-     * 
+     *
      * @return int
      */
     public int getLeakDetectionInterval() {
@@ -378,7 +369,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
 
     /**
      * Access the sync lock object for the leak detection.
-     * 
+     *
      * @return Object
      */
     public Object getLeakDetectionSyncObject() {
@@ -398,7 +389,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
     /**
      * Allocate a buffer which will use tha FileChannel until the buffer needs
      * to be used in a "non-FileChannel" way.
-     * 
+     *
      * @param fc FileChannel to use for this buffer
      * @return FCWsByteBuffer buffer which can now be used.
      */
@@ -413,7 +404,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
     /**
      * Allocate a buffer from a buffer pool. Choose the buffer pool which
      * is closest to the desired size, but not less than the desired size.
-     * 
+     *
      * @param entrySize the amount of memory be requested for this allocation
      * @param direct
      * @return WsByteBuffer buffer which can now be used.
@@ -497,7 +488,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
                 pooledWSBB.limit(entrySize);
 
                 if ((TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                        || trackingBuffers()) {
+                    || trackingBuffers()) {
 
                     Throwable t = new Throwable();
                     StackTraceElement[] ste = t.getStackTrace();
@@ -551,7 +542,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
     /**
      * Allocate the direct ByteBuffer that will be wrapped by the
      * input WsByteBuffer object.
-     * 
+     *
      * @param buffer
      * @param size
      * @param overrideRefCount
@@ -612,19 +603,19 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
 
     /**
      * Release a buffer from being in use.
-     * 
+     *
      * @param buffer
      * @param isDirectPool
      * @param pool
      */
     public void release(PooledWsByteBufferImpl buffer, boolean isDirectPool, WsByteBufferPool pool) {
-        pool.release(buffer, buffer.getID());
+        pool.release(buffer);
     }
 
     /**
      * Method called when a buffer is being destroyed to allow any
      * additional cleanup that might be required.
-     * 
+     *
      * @param buffer
      */
     protected void releasing(ByteBuffer buffer) {
@@ -643,7 +634,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
      * the duplicate() method of the ByteBuffer wrapped by the passed
      * WsByteBuffer
      * 3. Updating variables of the new WsByteBuffer
-     * 
+     *
      * @param buffer to duplicate
      * @return WsByteBuffer duplicated buffer
      */
@@ -685,7 +676,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
         srcBuffer.updateDuplicate(newBuffer);
 
         if ((TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                || (trackingBuffers())) {
+            || (trackingBuffers())) {
 
             Throwable t = new Throwable();
             StackTraceElement[] ste = t.getStackTrace();
@@ -724,7 +715,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
      * WsByteBuffer
      * 3. Updating the control variables of the new WsByteBuffer (such
      * setting the ID to be the same as that of the passed WsByteBuffer)
-     * 
+     *
      * @param buffer to slice
      * @return WsByteBuffer sliced buffer
      */
@@ -766,7 +757,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
         srcBuffer.updateSlice(newBuffer);
 
         if ((TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                || (trackingBuffers())) {
+            || (trackingBuffers())) {
 
             Throwable t = new Throwable();
             StackTraceElement[] ste = t.getStackTrace();
@@ -805,11 +796,11 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
      * out to a file. The name of this file is also configurable. If the
      * force parameter is set, then look for leaks even if less time has
      * elapsed than is specified by the time interval.
-     * 
+     *
      * @param force if this method is to look for leaks without regard to
      *            the last time leaks were looked for, false if leaks are only to be
      *            looked for if a specified (configuable) amount of time has elapsed.
-     * 
+     *
      */
     public void lookForLeaks(boolean force) {
         if (this.leakDetectionInterval < -1) {
@@ -956,7 +947,7 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
 
     /**
      * Check whether the pool-user trust flag is enabled or not.
-     * 
+     *
      * @return boolean
      */
     protected boolean isTrustedUsers() {
@@ -997,20 +988,5 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
             Tr.exit(tc, methodName, oWsByteBuffer);
         }
         return (oWsByteBuffer);
-    }
-
-    /**
-     * When a thread is being destroyed, this api will trigger each of the
-     * buffer pools to purge their respective threadlocal levels.
-     * 
-     */
-    public void purgeThreadLocals() {
-        for (int i = 0; i < this.poolSizes.length; i++) {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Purging the " + this.poolSizes[i] + " sized pools");
-            }
-            this.pools[i].purgeThreadLocal();
-            this.poolsDirect[i].purgeThreadLocal();
-        }
     }
 }

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/ConcurrentObjectPool.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/ConcurrentObjectPool.java
@@ -1,0 +1,202 @@
+/*******************************************************************************
+ * Copyright (c) 2014,2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.service.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A pool of objects, which is thread-safe, and never blocks the callers.
+ * Null objects are not allowed.
+ *
+ * The state of the pool consists of two indexes - a get index and a put
+ * index. The get index points to the position of the next element to fetch.
+ * The put index points to an empty cell that will accommodate the next object
+ * to be returned to the pool.
+ * The pool is empty if the two indexes point to the same cell. The actual pool
+ * capacity is one less than the capacity parameter passed in the constructor.
+ * The index values are not limited to the array boundary. When accessing the
+ * array, the index is normalized using (index % array_size). This provides
+ * easier comparison between the two indexes, as the put index is always
+ * larger than or equal to the get index. In order to prevent negative indexes
+ * in the (rare) case where an index value exceeds the 32-bit integer limit,
+ * indexes are always truncated to 31 bits. This implies that the next index
+ * after 2**31-1 is 0. The only case when the value of the put index can be
+ * smaller than the get index is when the put index completes a full cycle and
+ * rolls back to 0. In such a case, to make it simple, the pool is drained
+ * (returned objects are discarded and garbage-collected) until all pooled
+ * items are removed, and both indexes return to the initial state of 0, ready
+ * for a new cycle.
+ *
+ * The two indexes are atomic integers. A thread that wishes to access a cell
+ * (for either get or put) first conquers the cell by incrementing the index.
+ * If the thread succeeded in incrementing the index without interference, it
+ * owns the cell exclusively, and can then modify the cell contents with no
+ * need for locking.
+ *
+ * Note that each call to get() or put() is executed in two steps:
+ * 1. incrementing the index to conquer a cell
+ * 2. modifying the contents of the cell
+ *
+ * There is no way to guarantee that a single call performs the 2 steps
+ * atomically. It is possible that step 1 wins the race and step 2 loses
+ * the race. This causes the operation to change the index without changing
+ * a reference in the array. When this happens, the operation is re-iterated,
+ * incrementing the index again. The call only returns after both steps have
+ * completed successfully.
+ */
+public class ConcurrentObjectPool<T> {
+    /** array of pooled objects */
+    private final AtomicReference<T>[] m_array;
+
+    /** index of the next object to take from the pool */
+    private final AtomicInteger m_get;
+
+    /** index of the free cell to accommodate the next object to put back */
+    private final AtomicInteger m_put;
+
+    /** cached value of m_array.length() */
+    private final int m_arraySize;
+
+    /** largest get/put index */
+    private static final int LIMIT = Integer.MAX_VALUE;
+
+    /**
+     * constructor
+     *
+     * @param poolSize
+     *            max amount allowed in the pool
+     */
+    @SuppressWarnings("unchecked")
+    public ConcurrentObjectPool(int poolSize) {
+        if (poolSize < 1) {
+            throw new IllegalArgumentException("pool size is too small");
+        }
+        m_get = new AtomicInteger(0);
+        m_put = new AtomicInteger(0);
+        m_arraySize = poolSize + 1;
+
+        m_array = new AtomicReference[m_arraySize];
+        for (int i = 0; i < m_arraySize; i++) {
+            m_array[i] = new AtomicReference<T>(null);
+        }
+    }
+
+    /**
+     * gets an object from the pool
+     *
+     * @return the pooled object
+     */
+    public T get() {
+        T object;
+
+        while (true) {
+            // 1. get the next free object
+            int p = m_put.get();
+            int g = m_get.get();
+            if (g >= p) {
+                // get index hits the put index, implying empty pool
+                if (p >= LIMIT) {
+                    // put pointer wrapped around. rewind both indexes.
+                    m_get.set(0);
+                    m_put.set(0);
+                }
+                return null;
+            }
+
+            // 2. conquer this cell by incrementing the get index
+            if (!m_get.compareAndSet(g, g + 1)) {
+                // some other thread got here first. try again.
+                continue;
+            }
+
+            // 3. retrieve the object at the get index
+            int index = g % m_arraySize;
+            AtomicReference<T> reference = m_array[index];
+            object = reference.get();
+            if (object == null) {
+                // getting here is rare. it happens when:
+                // 1. put() is called on an empty pool (p==g)
+                // 2. put() increments the put pointer (p==g+1)
+                // 3. get() is called and finds g < p
+                // 4. get() takes the object at g (which is null)
+                // 5. put() puts the object at g
+                continue;
+            }
+
+            // 4. change the reference to null so no other get() takes the
+            // same element, and no other put() replaces it with another.
+            if (reference.compareAndSet(object, null)) {
+                return object;
+            }
+
+            // getting here is rare. the object that was supposedly conquered
+            // locally was either replaced by a different object or replaced
+            // with null, in the same cell.
+        }
+    }
+
+    /**
+     * puts an object back into the pool for recycling
+     *
+     * @param object
+     *            the pooled object
+     * @return true on success, false if pool is full
+     */
+    public boolean put(T object) {
+        if (object == null) {
+            throw new IllegalArgumentException("returning null object to pool");
+        }
+
+        while (true) {
+            // 1. get the index of the next free cell
+            int g = m_get.get();
+            int p = m_put.get();
+            if (p >= LIMIT) {
+                // this happens very seldom - once every 1**31 calls, the put
+                // index completes a full cycle.
+                // to handle this simply, we just wait for the pool to
+                // drain, and start placing objects back in the pool only when
+                // the get index completes its cycle too.
+                return false;
+            }
+            if (p - g >= (m_arraySize - 1)) {
+                // put index is far from the get pointer, implying full pool.
+                // note that (p >= g + m_capacity) is a bug.
+                return false;
+            }
+
+            // 2. conquer this cell by incrementing the put index
+            if (!m_put.compareAndSet(p, p + 1)) {
+                // some other thread got here first. try again.
+                continue;
+            }
+
+            // 3. put the object in the cell
+            int index = p % m_arraySize;
+            AtomicReference<T> reference = m_array[index];
+            if (reference.compareAndSet(null, object)) {
+                return true;
+            }
+
+            // getting here is rare. the object that was supposedly conquered
+            // locally was replaced with a different object in the same cell.
+        }
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "ConcurrentObjectPool-" + System.identityHashCode(this);
+    }
+}


### PR DESCRIPTION
Change to use an ObjectPool that doesn't require synchronization and
doesn't use thread local pool and a global pool.
Also remove sync logic for creating a new identifier for a WsByteBuffer.