### PR TITLE
jcacheContainer-1.1 feature should be listed as non-ship

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jcacheContainer-1.1/com.ibm.websphere.appserver.jcacheContainer-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jcacheContainer-1.1/com.ibm.websphere.appserver.jcacheContainer-1.1.feature
@@ -18,5 +18,5 @@ IBM-API-Package: \
  com.ibm.websphere.appserver.classloading-1.0
 -bundles=\
  com.ibm.websphere.javaee.jcache.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.cache:cache-api:1.1.0"
-kind=beta
+kind=noship
 edition=core


### PR DESCRIPTION
Update the jcacheContainer-1.1 file to indicate that it is non-ship (needs some investment in jcache annotation support).