### PR TITLE
Revert "2476 z fs log fails permanently"

### DIFF
--- a/dev/com.ibm.ws.logging/resources/com/ibm/ws/logging/internal/resources/LoggingMessages.nlsprops
+++ b/dev/com.ibm.ws.logging/resources/com/ibm/ws/logging/internal/resources/LoggingMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2018 IBM Corporation and others.
+# Copyright (c) 2011, 2016 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -123,15 +123,6 @@ MESSAGE_FORMAT_UPDATED.useraction=No action is required.
 CONSOLE_FORMAT_UPDATED=TRAS3003I: The console output format has now been updated to '{0}'.
 CONSOLE_FORMAT_UPDATED.explanation=The output format for console has now been updated.
 CONSOLE_FORMAT_UPDATED.useraction=No action is required.
-
-FAILED_TO_WRITE_LOG=TRAS3004E: Failed to write messages to the {0} file.
-FAILED_TO_WRITE_LOG.explanation=An error occurred when trying to write message to the file. 
-FAILED_TO_WRITE_LOG.useraction=Ensure that the directory exists, is writable, and has sufficient disk space.
-
-LOG_FILE_RESUMED=TRAS3005I: Logging messages to the {0} file has resumed.
-LOG_FILE_RESUMED.explanation=Messages can be written to the file.
-LOG_FILE_RESUMED.useraction=No action is required.
-
 # Note: no 9999 message kept here because saving footprint space is more important
 
 # End of file

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/FileLogSet.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/FileLogSet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corporation and others.
+ * Copyright (c) 2013 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,7 +63,7 @@ public class FileLogSet {
 
     /**
      * A pattern that matches a log with date and id.
-     *
+     * 
      * @see LoggingFileUtils#compileLogFileRegex
      */
     private Pattern filePattern;
@@ -116,7 +116,7 @@ public class FileLogSet {
 
     /**
      * Updates the configuration for this set of logs.
-     *
+     * 
      * @param directory the log directory
      * @param fileName the file base name (e.g., "messages")
      * @param fileExtension the file extension (e.g., ".log")
@@ -180,39 +180,25 @@ public class FileLogSet {
      * Creates a new file for this log set. If this is a rolling log, this will
      * rename the existing file and then return it on success. Otherwise, this
      * will return a new unique file.
-     *
+     * 
      * @return the file on success, or null on failure
      * @throws IOException
      */
     public File createNewFile() throws IOException {
-        return createNewFile(true);
-    }
-
-    /**
-     * Creates a new file for this log set. If this is a rolling log, this will
-     * rename the existing file and then return it on success. Otherwise, this
-     * will return a new unique file.
-     *
-     * @param show error message if showError is true
-     * @return the file on success, or null on failure
-     * @throws IOException
-     */
-    public File createNewFile(boolean showError) throws IOException {
-        if (LoggingFileUtils.validateDirectory(directory, showError) == null) {
+        if (LoggingFileUtils.validateDirectory(directory) == null) {
             return null;
         }
 
-        return rolling ? rollFile(showError) : createNewUniqueFile(null, showError);
+        return rolling ? rollFile() : createNewUniqueFile(null);
     }
 
     /**
      * Attempt to rename the base log file to a new log file, and then recreate
      * the base log file.
-     *
-     * @param show error message if showError is true
+     * 
      * @return the base log file
      */
-    private File rollFile(boolean showError) throws IOException {
+    private File rollFile() throws IOException {
         // If the base file exists, rename it and recreate it.
         File file = new File(directory, fileName + fileExtension);
         if (file.isFile()) {
@@ -222,18 +208,18 @@ public class FileLogSet {
             }
 
             if (maxFiles == 1) {
-                if (!LoggingFileUtils.deleteFile(file, showError)) {
+                if (!LoggingFileUtils.deleteFile(file)) {
                     // We failed to delete the file and issued a message.
                     return file;
                 }
-            } else if (createNewUniqueFile(file, showError) == null) {
+            } else if (createNewUniqueFile(file) == null) {
                 // We failed to rename (or copy + delete) the base file to a new
                 // file, and we already issued a message.
                 return file;
             }
         }
 
-        if (!file.createNewFile() && showError) {
+        if (!file.createNewFile()) {
             // Unsafe to use FFDC or ras: log to raw stderr
             String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_CREATE_RESOURCE_NOEX", file);
             BaseTraceService.rawSystemErr.println(msg);
@@ -245,13 +231,12 @@ public class FileLogSet {
     /**
      * Create a new unique file name. If the source file is specified, the new
      * file should be created by renaming the source file as the unique file.
-     *
+     * 
      * @param srcFile the file to rename, or null to create a new file
-     * @param show error message if showError is true
      * @return the newly created file, or null if the could not be created
      * @throws IOException if an unexpected I/O error occurs
      */
-    private File createNewUniqueFile(File srcFile, boolean showError) throws IOException {
+    private File createNewUniqueFile(File srcFile) throws IOException {
         String dateString = getDateString();
         int index = findFileIndexAndUpdateCounter(dateString);
 
@@ -285,14 +270,12 @@ public class FileLogSet {
 
         if (srcFile != null && copyFileTo(srcFile, destFile)) {
             addFile(index, destFileName);
-            return LoggingFileUtils.deleteFile(srcFile, showError) ? destFile : null;
+            return LoggingFileUtils.deleteFile(srcFile) ? destFile : null;
         }
 
         // Unsafe to use FFDC or ras: log to raw stderr
-        if (showError) {
-            String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_CREATE_RESOURCE_NOEX", destFile);
-            BaseTraceService.rawSystemErr.println(msg);
-        }
+        String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_CREATE_RESOURCE_NOEX", destFile);
+        BaseTraceService.rawSystemErr.println(msg);
         return null;
     }
 
@@ -310,7 +293,7 @@ public class FileLogSet {
     /**
      * Find the index in the files list where a new file should be inserted,
      * and ensure {@link #lastDataString} and {@link #lastCounter} are accurate.
-     *
+     * 
      * @param dateString the date string for the new file
      * @return the position in the files list where a new file should be inserted
      */
@@ -380,7 +363,7 @@ public class FileLogSet {
      * this file would cause the number of files to exceed the maximum, remove
      * all files after the specified index, and then remove the oldest files
      * until the number is reduced to the maximum.
-     *
+     * 
      * @param index the index in the files list to insert the file
      * @param file the file name
      */
@@ -412,7 +395,7 @@ public class FileLogSet {
 
     /**
      * Remove and delete a file from the file list.
-     *
+     * 
      * @param index the file index
      */
     private void removeFile(int index) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LoggingFileUtils.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LoggingFileUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 IBM Corporation and others.
+ * Copyright (c) 2012, 2013 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -80,18 +80,6 @@ public class LoggingFileUtils {
      * @return A valid/accessible/created directory or null
      */
     static File validateDirectory(final File directory) {
-        return validateDirectory(directory, true);
-    }
-
-    /**
-     * This method will create the directory if it does not exist,
-     * ensuring the specified location is writable.
-     *
-     * @param The new directory location
-     * @param show error message if showError is true
-     * @return A valid/accessible/created directory or null
-     */
-    static File validateDirectory(final File directory, final boolean showError) {
 
         File newDirectory = null;
 
@@ -106,7 +94,8 @@ public class LoggingFileUtils {
 
                     if (!ok) {
                         // Unsafe to use FFDC or ras: log to raw stderr
-                        showErrorMsg(showError, "UNABLE_TO_CREATE_RESOURCE_NOEX", new Object[] { directory.getAbsolutePath() });
+                        String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_CREATE_RESOURCE_NOEX", directory.getAbsolutePath());
+                        BaseTraceService.rawSystemErr.println(msg);
                         return null;
                     }
                     return directory;
@@ -114,24 +103,11 @@ public class LoggingFileUtils {
             });
         } catch (PrivilegedActionException e) {
             // Unsafe to use FFDC or ras: log to raw stderr
-            showErrorMsg(showError, "UNABLE_TO_CREATE_RESOURCE", new Object[] { directory.getAbsolutePath(), e });
+            String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_CREATE_RESOURCE", directory.getAbsolutePath(), e);
+            BaseTraceService.rawSystemErr.println(msg);
         }
 
         return newDirectory;
-    }
-
-    /**
-     * Show the error message if showError is true
-     *
-     * @param showError
-     * @param msgKey
-     * @param objs
-     */
-    private static void showErrorMsg(boolean showError, String msgKey, Object[] objs) {
-        if (showError) {
-            String msg = Tr.formatMessage(TraceSpecification.getTc(), msgKey, objs);
-            BaseTraceService.rawSystemErr.println(msg);
-        }
     }
 
     /**
@@ -142,17 +118,6 @@ public class LoggingFileUtils {
      * @see #getUniqueFile(File, String, String)
      */
     public static File createNewFile(final FileLogSet fileLogSet) {
-        return createNewFile(fileLogSet, true);
-    }
-
-    /**
-     * This method will create a new file with the specified name and extension in the specified directory. If a unique file is required then it will add a timestamp to the file
-     * and if necessary a unqiue identifier to the file name.
-     *
-     * @return The file or <code>null</code> if an error occurs
-     * @see #getUniqueFile(File, String, String)
-     */
-    public static File createNewFile(final FileLogSet fileLogSet, final boolean showError) {
         final File directory = fileLogSet.getDirectory();
         final String fileName = fileLogSet.getFileName();
         final String fileExtension = fileLogSet.getFileExtension();
@@ -162,14 +127,15 @@ public class LoggingFileUtils {
             f = AccessController.doPrivileged(new java.security.PrivilegedExceptionAction<File>() {
                 @Override
                 public File run() throws Exception {
-                    return fileLogSet.createNewFile(showError);
+                    return fileLogSet.createNewFile();
                 }
             });
         } catch (PrivilegedActionException e) {
             File exf = new File(directory, fileName + fileExtension);
 
             // Unsafe to use FFDC or ras: log to raw stderr
-            showErrorMsg(showError, "UNABLE_TO_CREATE_RESOURCE", new Object[] { exf.getAbsolutePath(), e });
+            String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_CREATE_RESOURCE", exf.getAbsolutePath(), e);
+            BaseTraceService.rawSystemErr.println(msg);
         }
 
         return f;
@@ -217,21 +183,14 @@ public class LoggingFileUtils {
      * @param file
      */
     public static boolean deleteFile(final File f) {
-        return deleteFile(f, true);
-    }
-
-    /**
-     * @param file
-     * @param show error message if showError is true
-     */
-    public static boolean deleteFile(final File f, final boolean showError) {
         try {
             return AccessController.doPrivileged(new java.security.PrivilegedExceptionAction<Boolean>() {
                 @Override
                 public Boolean run() {
                     if (!f.delete()) {
                         // Unsafe to use FFDC or ras: log to raw stderr
-                        showErrorMsg(showError, "UNABLE_TO_DELETE_RESOURCE_NOEX", new Object[] { f });
+                        String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_DELETE_RESOURCE_NOEX", f);
+                        BaseTraceService.rawSystemErr.println(msg);
                         return false;
                     }
 
@@ -240,7 +199,8 @@ public class LoggingFileUtils {
             });
         } catch (PrivilegedActionException e) {
             // Unsafe to use FFDC or ras: log to raw stderr
-            showErrorMsg(showError, "UNABLE_TO_DELETE_RESOURCE", new Object[] { f, e });
+            String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_DELETE_RESOURCE", f, e);
+            BaseTraceService.rawSystemErr.println(msg);
             return false;
         }
     }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corporation and others.
+ * Copyright (c) 2011, 2013 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,18 +15,16 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.util.Calendar;
 
-import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TrConfigurator;
-import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
-import com.ibm.ws.logging.internal.impl.BaseTraceService.TraceWriter;
+import com.ibm.ws.logging.internal.impl.BaseTraceService;
 import com.ibm.ws.logging.internal.impl.CountingOutputStream;
 import com.ibm.ws.logging.internal.impl.FileLogHeader;
 import com.ibm.ws.logging.internal.impl.FileLogSet;
 import com.ibm.ws.logging.internal.impl.LoggingConstants;
 import com.ibm.ws.logging.internal.impl.LoggingFileUtils;
+import com.ibm.ws.logging.internal.impl.BaseTraceService.TraceWriter;
 import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
 
 /**
@@ -39,8 +37,6 @@ import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
  * a non-unique name. It will be renamed when the log is rolled.
  */
 public class FileLogHolder implements TraceWriter {
-
-    private static TraceComponent tc = null;
 
     enum StreamStatus {
         INIT, ACTIVE, CLOSED
@@ -79,31 +75,9 @@ public class FileLogHolder implements TraceWriter {
     protected long maxFileSizeBytes;
 
     /**
-     * Capture when checked the existence of the log directory
-     */
-    private Long checkTime = null;
-
-    /**
-     * Capture when tempted to check the existence of the log directory
-     */
-    private Long retryTime = null;
-
-    /**
-     * This method will get an instance of TraceComponent
-     *
-     * @return
-     */
-    private static TraceComponent getTc() {
-        if (tc == null) {
-            tc = Tr.register(FileLogHolder.class, null, "com.ibm.ws.logging.internal.resources.LoggingMessages");
-        }
-        return tc;
-    }
-
-    /**
      * This method will check to see if the supplied parameters match the settings on the <code>oldLog</code>,
      * if they do then the <code>oldLog</code> is returned, otherwise a new FileLogHolder will be created.
-     *
+     * 
      * @param oldLog The previous FileLogHolder that may or may not be replaced by a new one, may
      *            be <code>null</code> (will cause a new instance to be created)
      * @param logHeader
@@ -124,7 +98,7 @@ public class FileLogHolder implements TraceWriter {
 
         final FileLogHolder logHolder;
 
-        // We're only supporting names in the log directory
+        // We're only supporting names in the log directory 
         // Our configurations encourage use of forward slash on all platforms
         int lio = newFileName.lastIndexOf("/");
         if (lio > 0) {
@@ -151,7 +125,7 @@ public class FileLogHolder implements TraceWriter {
             fileExtension = "";
         }
 
-        // IF there are changes to the rolling behavior, it will show up in a change to either
+        // IF there are changes to the rolling behavior, it will show up in a change to either 
         // maxFiles or maxBytes
         if (oldLog != null && oldLog instanceof FileLogHolder) {
             logHolder = (FileLogHolder) oldLog;
@@ -173,7 +147,7 @@ public class FileLogHolder implements TraceWriter {
 
     /**
      * Private constructor for this class as a lot of conversion needs to take place on the parameters prior to the object being constructed.
-     *
+     * 
      * @param logHeader The header to write at the beginning of all new log files
      * @param dirName The fully qualified name of the directory to put the logs into
      * @param fileName The name of the file without an extension to put the logs into
@@ -200,7 +174,7 @@ public class FileLogHolder implements TraceWriter {
         }
 
         if (updateLocation) {
-            // If the file name/extension/directory has changed,
+            // If the file name/extension/directory has changed, 
             // change status to "INIT" to force it to be replaced
             setStreamStatus(StreamStatus.INIT, currentFileStream, currentCountingStream, currentPrintStream);
         }
@@ -230,7 +204,7 @@ public class FileLogHolder implements TraceWriter {
 
     /**
      * Write a pre-formated record
-     *
+     * 
      * @param record
      */
     @Override
@@ -238,23 +212,18 @@ public class FileLogHolder implements TraceWriter {
         long length = record.length() + LoggingConstants.nlen;
         PrintStream ps = getPrintStream(length);
         ps.println(record);
-        if (ps.checkError()) {
-            setStreamStatus(StreamStatus.CLOSED, null, null, DummyOutputStream.psInstance);
-            File exf = new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
-            System.err.println(Tr.formatMessage(getTc(), "FAILED_TO_WRITE_LOG", new Object[] { exf.getAbsolutePath() }));
-        }
     }
 
     /**
      * Obtain the current printstream: called from synchronized methods
-     *
+     * 
      * @param requiredLength
      * @return
      */
     private synchronized PrintStream getPrintStream(long numNewChars) {
         switch (currentStatus) {
             case INIT:
-                return createStream(true);
+                return createStream();
             case ACTIVE:
                 if (maxFileSizeBytes > 0) {
                     long bytesWritten = currentCountingStream.count();
@@ -266,32 +235,9 @@ public class FileLogHolder implements TraceWriter {
                     // we underestimate the number of bytes that will be
                     // written, we'll roll the log next time.
                     if (bytesWritten + numNewChars > maxFileSizeBytes)
-                        return createStream(true);
+                        return createStream();
                 }
                 break;
-            case CLOSED:
-                if (checkTime == null) {
-                    checkTime = Long.valueOf(Calendar.getInstance().getTimeInMillis());
-                } else {
-                    long currentTime = Calendar.getInstance().getTimeInMillis();
-                    // try to create stream again for every 5 seconds
-                    if (currentTime - checkTime.longValue() > 5000L) {
-                        checkTime = Long.valueOf(currentTime);
-                        // show error for every 10 minutes
-                        boolean showError = (retryTime == null) || (currentTime - retryTime.longValue() > 600000L);
-                        if (showError)
-                            retryTime = Long.valueOf(currentTime);
-                        PrintStream ps = createStream(showError);
-                        if (this.currentStatus == StreamStatus.ACTIVE) {
-                            // stream successfully created
-                            File exf = new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
-                            Tr.audit(getTc(), "LOG_FILE_RESUMED", new Object[] { exf.getAbsolutePath() });
-                            this.checkTime = null;
-                            this.retryTime = null;
-                        }
-                        return ps;
-                    }
-                }
         }
 
         return currentPrintStream;
@@ -300,7 +246,7 @@ public class FileLogHolder implements TraceWriter {
     /**
      * @return a new print stream
      */
-    private synchronized PrintStream createStream(boolean showError) {
+    private synchronized PrintStream createStream() {
         FileOutputStream newFileStream = null;
         CountingOutputStream newCountingStream = null;
         PrintStream newPrintStream = null;
@@ -309,20 +255,20 @@ public class FileLogHolder implements TraceWriter {
         long realMaxFileSizeBytes = maxFileSizeBytes;
 
         // Store the value, and temporarily "disable" log rolling to avoid
-        // re-trying to roll the log if the ThreadIdentityManager creates
+        // re-trying to roll the log if the ThreadIdentityManager creates 
         // log or trace records. This value is reset in the finally block
         maxFileSizeBytes = 0;
 
         Object token = ThreadIdentityManager.runAsServer();
         try {
-            // Close the existing file
+            // Close the existing file  
             currentPrintStream.flush();
             if (currentFileStream != null) {
                 LoggingFileUtils.tryToClose(currentFileStream);
             }
 
             // Get the non-unique file (e.g. trace.log)
-            targetLogFile = LoggingFileUtils.createNewFile(fileLogSet, showError);
+            targetLogFile = LoggingFileUtils.createNewFile(fileLogSet);
 
             if (targetLogFile != null) {
                 try {


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#3775
This needs to be reverted because it breaks the unit test com.ibm.ws.logging.internal.hpel.HpelBaseTraceServiceTest