### PR TITLE
Stop converting connection manager properties

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
@@ -169,45 +169,6 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
     }
 
     /**
-     * Convert a value to be understood by traditional WAS J2C,
-     * according to the specified rules.
-     *
-     * @param value value to convert
-     * @param defaultValue default to use if the value isn't supported
-     * @param tWAS_immediate value used by tWAS for immediate. Null if not supported.
-     * @param tWAS_infinite value used by tWAS for infinite or never time out. Null if not supported.
-     * @param propName name of the property (in case we need to raise an error).
-     * @param connectorSvc connector service
-     * @return configured value as understood by traditional WAS J2C code.
-     * @throws ResourceException if the value isn't supported and the ignore/warn/fail setting is configured to fail.
-     */
-    private static final int convert(int value, int defaultValue, Integer tWAS_immediate, Integer tWAS_infinite, String propName,
-                                     ConnectorService connectorSvc) throws ResourceException {
-        boolean supported = true;
-        if (value == 0)
-            if (tWAS_immediate == null) // immediate not supported
-                supported = false;
-            else
-                return tWAS_immediate;
-        else if (value < 0)
-            if (tWAS_infinite == null) // infinite not supported
-                supported = false;
-            else
-                return tWAS_infinite;
-
-        if (supported)
-            return value;
-        else {
-            ResourceException failure = connectorSvc.ignoreWarnOrFail(tc, null, ResourceException.class, "UNSUPPORTED_VALUE_J2CA8011",
-                                                                      value, propName, CONNECTION_MANAGER);
-            if (failure == null)
-                return defaultValue;
-            else
-                throw failure;
-        }
-    }
-
-    /**
      * Create and initialize the connection manager/pool configuration
      * based on the connection factory configuration.
      * Precondition: invoker must have the write lock for this connection manager service.
@@ -216,7 +177,7 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
      * @throws ResourceException if an error occurs
      */
     private void createPoolManager(AbstractConnectionFactoryService svc) throws ResourceException {
-
+        //change something
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "createPoolManager", svc, properties);
@@ -488,22 +449,21 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
         @SuppressWarnings("unchecked")
         Map<String, Object> map = properties == null ? Collections.EMPTY_MAP : new HashMap<String, Object>(properties);
 
-        // Set configured values or initial default values.
-        int agedTimeout = validateProperty(map, J2CConstants.POOL_AgedTimeout, -1, TimeUnit.SECONDS, -1, Integer.MAX_VALUE, -1, 0, connectorSvc);
-        int connectionTimeout = validateProperty(map, J2CConstants.POOL_ConnectionTimeout, 30, TimeUnit.SECONDS, -1, Integer.MAX_VALUE, -1, 0, connectorSvc);
-        int maxIdleTime = validateProperty(map, MAX_IDLE_TIME, ConnectionPoolProperties.DEFAULT_UNUSED_TIMEOUT, TimeUnit.SECONDS, -1, Integer.MAX_VALUE, null, 0, connectorSvc);
-        int maxNumberOfMCsAllowableInThread = validateProperty(map, MAX_CONNECTIONS_PER_THREAD, 0, null, 0, Integer.MAX_VALUE, connectorSvc);
-        int maxPoolSize = validateProperty(map, MAX_POOL_SIZE, 50, null, 0, Integer.MAX_VALUE, connectorSvc);
+        int agedTimeout = validateProperty(map, J2CConstants.POOL_AgedTimeout, -1, TimeUnit.SECONDS, -1, Integer.MAX_VALUE, true, connectorSvc);
+        int connectionTimeout = validateProperty(map, J2CConstants.POOL_ConnectionTimeout, 30, TimeUnit.SECONDS, -1, Integer.MAX_VALUE, true, connectorSvc);
+        int maxIdleTime = validateProperty(map, MAX_IDLE_TIME, ConnectionPoolProperties.DEFAULT_UNUSED_TIMEOUT, TimeUnit.SECONDS, -1, Integer.MAX_VALUE, false, connectorSvc);
+        int maxNumberOfMCsAllowableInThread = validateProperty(map, MAX_CONNECTIONS_PER_THREAD, 0, null, 0, Integer.MAX_VALUE, true, connectorSvc);
+        int maxPoolSize = validateProperty(map, MAX_POOL_SIZE, 50, null, 0, Integer.MAX_VALUE, true, connectorSvc);
         int minPoolSize = 0;
         if (maxPoolSize == 0)
-            minPoolSize = validateProperty(map, MIN_POOL_SIZE, 0, null, 0, Integer.MAX_VALUE, connectorSvc);
+            minPoolSize = validateProperty(map, MIN_POOL_SIZE, 0, null, 0, Integer.MAX_VALUE, true, connectorSvc);
         else
-            minPoolSize = validateProperty(map, MIN_POOL_SIZE, 0, null, 0, maxPoolSize, connectorSvc);
+            minPoolSize = validateProperty(map, MIN_POOL_SIZE, 0, null, 0, maxPoolSize, true, connectorSvc);
 
         int numConnectionsPerThreadLocal = validateProperty(map, NUM_CONNECTIONS_PER_THREAD_LOCAL, ConnectionPoolProperties.DEFAULT_numConnectionsPerThreadLocal,
-                                                            null, 0, Integer.MAX_VALUE, connectorSvc);
-        int reapTime = validateProperty(map, J2CConstants.POOL_ReapTime, ConnectionPoolProperties.DEFAULT_REAP_TIME, TimeUnit.SECONDS, -1, Integer.MAX_VALUE, null,
-                                        0, connectorSvc);
+                                                            null, 0, Integer.MAX_VALUE, true, connectorSvc);
+        int reapTime = validateProperty(map, J2CConstants.POOL_ReapTime, ConnectionPoolProperties.DEFAULT_REAP_TIME, TimeUnit.SECONDS, -1, Integer.MAX_VALUE, false, connectorSvc);
+
         boolean throwExceptionOnMCThreadCheck = false;
 
         /*
@@ -595,14 +555,16 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
      * @param units units for duration type. Null if not a duration type.
      * @param minVal the minimum value
      * @param maxVal the maximum value
+     * @param immediateSupported weather or not property supports immediate action
      * @param connectorSvc connector service
      * @return the configured value if the value is valid, else the default value
      * @throws ResourceException
      */
-    private int validateProperty(Map<String, Object> map, String propName, int defaultVal, TimeUnit units, Integer minVal, Integer maxVal,
+    private int validateProperty(Map<String, Object> map, String propName, int defaultVal, TimeUnit units, Integer minVal, Integer maxVal, Boolean immediateSupported,
                                  ConnectorService connectorSvc) throws ResourceException {
         Object value = map.remove(propName);
 
+        //Get property value and check if it is a number and convert it to long
         long val;
         if (value == null)
             return defaultVal;
@@ -619,6 +581,15 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
                     throw resX;
             }
 
+        //Check if immediate is supported.  If not default value?
+        if (!immediateSupported && val == 0) {
+            ResourceException immediateFailure = connectorSvc.ignoreWarnOrFail(tc, null, ResourceException.class, "UNSUPPORTED_VALUE_J2CA8011",
+                                                                               val, propName, CONNECTION_MANAGER);
+            if (immediateFailure != null)
+                throw immediateFailure;
+        }
+
+        //Finally check if value is within tolerance
         if (val < minVal || val > maxVal) {
             ResourceException failure = connectorSvc.ignoreWarnOrFail(tc, null, ResourceException.class, "UNSUPPORTED_VALUE_J2CA8011",
                                                                       val, propName, CONNECTION_MANAGER);
@@ -627,32 +598,6 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
             return defaultVal;
         }
         return (int) val;
-    }
-
-    /**
-     * Method tests whether a property's value is valid or not.<p>
-     * Specify the range the value must fall in
-     * with <code>minVal</code> and <code>maxVal</code>. <p>
-     *
-     * This method will also handle raising an exception or Tr message if the
-     * property is invalid.
-     *
-     * @param map map of configured properties
-     * @param propName the name of the property being tested
-     * @param defaultVal the default value
-     * @param units units for duration type. Null if not a duration type.
-     * @param minVal the minimum value
-     * @param maxVal the maximum value
-     * @param tWAS_immediate value used by tWAS for immediate. Null if not supported.
-     * @param tWAS_infinite value used by tWAS for infinite or never time out. Null if not supported.
-     * @param connectorSvc connector service
-     * @return the configured value if the value is valid, else the default value
-     * @throws ResourceException
-     */
-    private final int validateProperty(Map<String, Object> map, String propName, int defaultVal, TimeUnit units, Integer minVal, Integer maxVal, Integer tWAS_immediate,
-                                       Integer tWAS_infinite, ConnectorService connectorSvc) throws ResourceException {
-        int val = validateProperty(map, propName, defaultVal, units, minVal, maxVal, connectorSvc);
-        return convert(val, defaultVal, tWAS_immediate, tWAS_infinite, propName, connectorSvc);
     }
 
     /**

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
@@ -177,7 +177,6 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
      * @throws ResourceException if an error occurs
      */
     private void createPoolManager(AbstractConnectionFactoryService svc) throws ResourceException {
-        //change something
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "createPoolManager", svc, properties);
@@ -581,7 +580,7 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
                     throw resX;
             }
 
-        //Check if immediate is supported.  If not default value?
+        //Check if immediate is supported.  If not throw exception
         if (!immediateSupported && val == 0) {
             ResourceException immediateFailure = connectorSvc.ignoreWarnOrFail(tc, null, ResourceException.class, "UNSUPPORTED_VALUE_J2CA8011",
                                                                                val, propName, CONNECTION_MANAGER);

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
@@ -160,15 +160,14 @@ public final class FreePool implements JCAPMIHelper {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.entry(this, tc, "queueRequest", waitTimeout);
         }
-
-        if (waitTimeout < 0) {
+        if (waitTimeout <= 0) {
             --pm.waiterCount;
             Tr.error(
                      tc,
                      "POOL_MANAGER_EXCP_CCF2_0001_J2CA0045",
                      new Object[] { "queueRequest", gConfigProps.cfName });
 
-            ConnectionWaitTimeoutException cwte = new ConnectionWaitTimeoutException("Connection not available, Timed out waiting. 0 used for wait timeout");
+            ConnectionWaitTimeoutException cwte = new ConnectionWaitTimeoutException("Connection not available, Timed out waiting. Negative value used for wait timeout");
             com.ibm.ws.ffdc.FFDCFilter.processException(cwte, J2CConstants.DMSID_MAX_CONNECTIONS_REACHED, "192", this.pm);
             pm.activeRequest.decrementAndGet();
 
@@ -209,7 +208,7 @@ public final class FreePool implements JCAPMIHelper {
                     Tr.debug(this, tc, "Waiters: total time waiter were in queue: " + (pm.waitersEndedTime - pm.waitersStartedTime));
                 }
             }
-            ResourceAllocationException throwMe = new ResourceAllocationException(ie.getMessage()); 
+            ResourceAllocationException throwMe = new ResourceAllocationException(ie.getMessage());
             throwMe.initCause(ie);
             if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
                 Tr.exit(this, tc, "queueRequest", throwMe);
@@ -231,7 +230,7 @@ public final class FreePool implements JCAPMIHelper {
             Tr.entry(this, tc, "returnToFreePool", gConfigProps.cfName);
         }
         if (mcWrapper.shouldBeDestroyed() || mcWrapper.hasFatalErrorNotificationOccurred(fatalErrorNotificationTime)
-            || ((pm.agedTimeout != 0)
+            || ((pm.agedTimeout != -1)
                 && (mcWrapper.hasAgedTimedOut(pm.agedTimeoutMillis)))) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 if (mcWrapper.shouldBeDestroyed()) {
@@ -240,7 +239,7 @@ public final class FreePool implements JCAPMIHelper {
                 if (mcWrapper.hasFatalErrorNotificationOccurred(fatalErrorNotificationTime)) {
                     Tr.debug(this, tc, "Fatal error occurred, removing connection " + mcWrapper);
                 }
-                if (((pm.agedTimeout != 0) && (mcWrapper.hasAgedTimedOut(pm.agedTimeoutMillis)))) {
+                if (((pm.agedTimeout != -1) && (mcWrapper.hasAgedTimedOut(pm.agedTimeoutMillis)))) {
                     Tr.debug(this, tc, "Aged timeout exceeded, removing connection " + mcWrapper);
                 }
                 if (mcWrapper.isDestroyState()) {
@@ -894,7 +893,7 @@ public final class FreePool implements JCAPMIHelper {
                          * will break out of the while(true)). For case 4, mcWrapperTemp is null and we will check for a tls matching connection.
                          */
                         if (mcWrapperTemp == null) {
-                            if (pm.isThreadLocalConnectionEnabled && waitTimeout >= 0) {
+                            if (pm.isThreadLocalConnectionEnabled && waitTimeout != 0) {
                                 mcWrapper = pm.searchTLSForMatchingConnection(managedConnectionFactory, subject, cri);
                                 if (mcWrapper != null)
                                     break;
@@ -927,7 +926,7 @@ public final class FreePool implements JCAPMIHelper {
                         }
                     } // end if (waitStartTime == 0)
 
-                    // NOTE:  When we get here, we either timedout or got notified.
+                    // NOTE:  When we get here, we either timed-out or got notified.
 
                     /*
                      * Look for a connection in the mcWrapperWaiterList
@@ -1110,7 +1109,7 @@ public final class FreePool implements JCAPMIHelper {
                     //      so we need to throw a connection waitTimeoutException
                     // b) This is the first waiter, in which case we need to wait and try again
                     // if there are not waiters, then we might have found a connection to return
-                    // or found a spot to create one.  This is the thrid way into this branch.
+                    // or found a spot to create one.  This is the third way into this branch.
 
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(this, tc, "We didn't find or are not going to create a connection.");
@@ -1150,7 +1149,7 @@ public final class FreePool implements JCAPMIHelper {
                                          " waitTimeout is " + waitTimeout + " total time waited is " + totalTimeWaited);
                         }
 
-                        // handle both waiting slighlty less than waitTimeout or waiting longer
+                        // handle both waiting slightly less than waitTimeout or waiting longer
                         //  than waitTimeout
 
                         if ((waitTimeout - timeWaited) <= kludge) {
@@ -1912,7 +1911,7 @@ public final class FreePool implements JCAPMIHelper {
         }
     }
 
-    //The Below two  methods are added to support PMI data for connection pools.This can be avoid if we expose com.ibm.ejs.jca,but currently as per JIM
+    //The Below two methods are added to support PMI data for connection pools.This can be avoid if we expose com.ibm.ejs.jca,but currently as per JIM
     //it should not be done as j2c code is partial implementation only for JDBC and JMS.In future when j2c code is fully implemented its better to
     //remove the interface JCAPMIHelper and implemented methods and update ConnectionPoolMonitor.java to use the exposed j2c code.
     @Override

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
@@ -160,14 +160,14 @@ public final class FreePool implements JCAPMIHelper {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.entry(this, tc, "queueRequest", waitTimeout);
         }
-        if (waitTimeout <= 0) {
+        if (waitTimeout == 0) {
             --pm.waiterCount;
             Tr.error(
                      tc,
                      "POOL_MANAGER_EXCP_CCF2_0001_J2CA0045",
                      new Object[] { "queueRequest", gConfigProps.cfName });
 
-            ConnectionWaitTimeoutException cwte = new ConnectionWaitTimeoutException("Connection not available, Timed out waiting. Negative value used for wait timeout");
+            ConnectionWaitTimeoutException cwte = new ConnectionWaitTimeoutException("Connection not available, Timed out waiting. Zero used for wait timeout");
             com.ibm.ws.ffdc.FFDCFilter.processException(cwte, J2CConstants.DMSID_MAX_CONNECTIONS_REACHED, "192", this.pm);
             pm.activeRequest.decrementAndGet();
 

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
@@ -39,7 +39,7 @@ import com.ibm.ws.jca.cm.AppDefinedResource;
  * the code can have fast (performance wise) access to them.
  * <li> <B>Immediately Dynamically Updateable properties </B> - those which can have
  * their values changed from the outside at any time without the need for
- * sychronization and without causeing errors to the running code.
+ * Synchronization and without causing errors to the running code.
  * <li> <B>Dynamically Updateable - requires Property Change processing. </B>
  * </ul>
  *
@@ -50,7 +50,6 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
     private static final TraceComponent tc = Tr.register(J2CGlobalConfigProperties.class, J2CConstants.traceSpec, J2CConstants.messageFile);
 
     // TODO: consider if this class really needs to be serializable
-    //
     private static final long serialVersionUID = 3666445884103132373L;
 
     // The following group of properties are read only and can only be set via
@@ -157,7 +156,7 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
      * ConnectionWaitTimeoutException is thrown. The wait may be necessary if
      * the maximum value of connections to a particular connection pool has been
      * reached (Max Connections) . This value has no meaning if Max Connections
-     * is set to 0 (infinite number of ManagedConnections). If Connection
+     * is set to -1 (infinite number of ManagedConnections). If Connection
      * Timeout is set to 0 or a negative number the Pool Manager waits until a
      * connection can be allocated (which happens when the number of connections
      * falls below Max Connections). The default value is 180.
@@ -201,7 +200,7 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
     private int maxConnections = 0;
     /**
      * Min Connections is the minimum number of ManagedConnections that should
-     * be maintained. Until this number is reached, the pool maintenence thread
+     * be maintained. Until this number is reached, the pool maintenance thread
      * will not discard any ManagedConnections. However no attempt will be made
      * to bring the number of connections up to this number. For example if Min
      * Connections is 3, and one managed connection has been created, that
@@ -231,21 +230,21 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
     /**
      * Reap Time (seconds - converted to milliseconds in TaskTimer)
      * <p><p> Reap time is
-     * the interval, in seconds, between runs of the pool maintenence thread.
-     * The default value is 0 which will disable the pool maintenence thread.
-     * Another way to disable the pool maintenence thread is to set Unused
-     * Timeout to 0 and Aged Timeout to 0.
+     * the interval, in seconds, between runs of the pool maintenance thread.
+     * The default value is -1 which will disable the pool maintenance thread.
+     * Another way to disable the pool maintenance thread is to set Unused
+     * Timeout to -1 and Aged Timeout to -1.
      * <p><p>
-     * When the pool maintenence thread runs
+     * When the pool maintenance thread runs
      * it discards any connections that have been unused longer than Unused
      * Timeout, down to Min Connections, and any connections that have been
-     * active longer than Aged Timeout. If pool maintenence is enabled, Reap Time
+     * active longer than Aged Timeout. If pool maintenance is enabled, Reap Time
      * should be less than Aged Timeout and Unused Timeout. For example if Reap
-     * Time is set to 60, the pool maintenence thread will run every minute. The
+     * Time is set to 60, the pool maintenance thread will run every minute. The
      * Reap Time interval will affect the accuracy of the Unused Timeout and
      * Aged Timeout. The smaller the interval, the greater the accuracy. The
      * Reap Time interval will also affect performance. Smaller intervals mean
-     * that the pool maintenence thread will run more often and degrade
+     * that the pool maintenance thread will run more often and degrade
      * performance.
      * <p><p>
      * MBeans: The reap time interval will be changed to the new value at the
@@ -259,16 +258,16 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
      * <p><p>
      * Unused Timeout is the approximate interval in
      * seconds after which an unused, or idle, connection is discarded. The
-     * default value is 1800. The recommended way to disable the pool maintenence
-     * thread is to set Reap Time to 0, in which case Unused Timeout and Aged
+     * default value is 1800. The recommended way to disable the pool maintenance
+     * thread is to set Reap Time to -1, in which case Unused Timeout and Aged
      * Timeout will be ignored. However if Unused Timeout and Aged Timeout are
-     * set to 0, the pool maintenence thread will run, but only
+     * set to -1, the pool maintenance thread will run, but only
      * ManagedConnections which timeout due to non-zero timeout values will be
      * discarded. Unused Timeout should be set higher than Reap Timeout for
      * optimal performance. In addition, unused ManagedConnections will only be
      * discarded if the current number of connection not in use exceeds the Min
      * Connections setting. For example if unused timeout is set to 120, and the
-     * pool maintenence thread is enabled (Reap Time is not 0), any managed
+     * pool maintenance thread is enabled (Reap Time is not -1), any managed
      * connection that has been unused for two minutes will be discarded
      * <p><p>
      * Note that accuracy of this timeout, as well as performance, is affect by
@@ -283,15 +282,15 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
      * <p><p>
      * Aged Timeout is the approximate interval (or age
      * of a ManagedConnection), in seconds, before a ManagedConnection is
-     * discarded. The default value is 0 which will allow active
+     * discarded. The default value is -1 which will allow active
      * ManagedConnections to remain in the pool indefinitely. The recommended
-     * way to disable the pool maintenence thread is to set Reap Time to 0, in
+     * way to disable the pool maintenance thread is to set Reap Time to -1, in
      * which case Aged Timeout and Unused Timeout will be ignored. However if
-     * Aged Timeout or Unused Timeout are set to 0, the pool maintenence thread
+     * Aged Timeout or Unused Timeout are set to -1, the pool maintenance thread
      * will run, but only ManagedConnections which timeout due to non-zero
      * Connection Timeout values will be discarded. Aged Timeout should be set
      * higher than Reap Timeout for optimal performance. For example if Aged
-     * Timeout is set to 1200, and Reap Time is not 0, any ManagedConnection
+     * Timeout is set to 1200, and Reap Time is not -1, any ManagedConnection
      * that has been in use for 20 minutes will be discarded from the pool.
      * <p><p>
      * Note that accuracy of this timeout, as well as performance, is affect by

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
@@ -2364,7 +2364,7 @@ public final class MCWrapper implements com.ibm.ws.j2c.MCWrapper, JCAPMIHelper {
             if (isTracingEnabled && tc.isDebugEnabled()) {
                 Tr.debug(this, tc, "hasAgedTimedOut is " + booleanValue);
                 Tr.debug(this, tc, "The created time was " + new Date(createdTimeStamp) + " and the current time is " + new Date(currentTime));
-                Tr.debug(this, tc, "Time difference " + timeDifference + " is greate then the aged timeout " + timeoutValue);
+                Tr.debug(this, tc, "Time difference " + timeDifference + " is greater then the aged timeout " + timeoutValue);
             }
 
         }

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManager.java
@@ -2820,7 +2820,6 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                             aBuffer.append("Connection marked for thread supported cleanup and destroy.  Waiting ");
                             aBuffer.append("for transaction end and connection close - ");
                         } else {
-                            //Changed 0 to -1
                             if (mcw.isStale() || mcw.hasFatalErrorNotificationOccurred(freePool[0].getFatalErrorNotificationTime())
                                 || ((this.agedTimeout != -1)
                                     && (mcw.hasAgedTimedOut(this.agedTimeoutMillis)))) {

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManager.java
@@ -821,7 +821,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
         if (localConnection_ != null) {
             if (mcWrapper.getPoolState() == MCWrapper.ConnectionState_sharedTLSPool || mcWrapper.getPoolState() == MCWrapper.ConnectionState_unsharedTLSPool) {
                 if (mcWrapper.isDestroyState() || mcWrapper.isStale() || mcWrapper.hasFatalErrorNotificationOccurred(freePool[0].getFatalErrorNotificationTime())
-                    || ((this.agedTimeout != 0)
+                    || ((this.agedTimeout != -1)
                         && (mcWrapper.hasAgedTimedOut(this.agedTimeoutMillis)))) {
                     // Need to remove it from TLS and decrease total connection count.
                     ArrayList<MCWrapper> mh = localConnection_.get();
@@ -2660,7 +2660,6 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
         synchronized (taskTimerLockObject) {
             if (!reaperThreadStarted) {
                 if (reapTime > 0) {
-
                     if ((this.unusedTimeout > 0)
                         || (this.agedTimeout > 0)) {
                         final PoolManager tempPM = this;
@@ -2821,8 +2820,9 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                             aBuffer.append("Connection marked for thread supported cleanup and destroy.  Waiting ");
                             aBuffer.append("for transaction end and connection close - ");
                         } else {
+                            //Changed 0 to -1
                             if (mcw.isStale() || mcw.hasFatalErrorNotificationOccurred(freePool[0].getFatalErrorNotificationTime())
-                                || ((this.agedTimeout != 0)
+                                || ((this.agedTimeout != -1)
                                     && (mcw.hasAgedTimedOut(this.agedTimeoutMillis)))) {
                                 aBuffer.append("Connection marked to be destroyed.  Waiting ");
                                 aBuffer.append("for transaction end and connection close - ");
@@ -2904,7 +2904,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                         aBuffer.append("    ");
                         if (mcw.isStale()
                             || mcw.hasFatalErrorNotificationOccurred(freePool[0].getFatalErrorNotificationTime())
-                            || ((this.agedTimeout != 0) && (mcw.hasAgedTimedOut(this.agedTimeoutMillis)))) {
+                            || ((this.agedTimeout != -1) && (mcw.hasAgedTimedOut(this.agedTimeoutMillis)))) {
                             aBuffer.append("Connection marked to be destroyed.  Waiting ");
                             aBuffer.append("for transaction end and connection close - ");
                         }
@@ -3009,7 +3009,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                         aBuffer.append("    ");
                         if (mcw.isStale()
                             || mcw.hasFatalErrorNotificationOccurred(freePool[0].getFatalErrorNotificationTime())
-                            || ((this.agedTimeout != 0) && (mcw.hasAgedTimedOut(this.agedTimeoutMillis)))) {
+                            || ((this.agedTimeout != -1) && (mcw.hasAgedTimedOut(this.agedTimeoutMillis)))) {
                             aBuffer.append("Connection marked to be destroyed.  Waiting ");
                             aBuffer.append("for transaction end and connection close - ");
                         }
@@ -3060,7 +3060,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                         aBuffer.append("    ");
                         if (mcw.isStale()
                             || mcw.hasFatalErrorNotificationOccurred(freePool[0].getFatalErrorNotificationTime())
-                            || ((this.agedTimeout != 0) && (mcw.hasAgedTimedOut(this.agedTimeoutMillis)))) {
+                            || ((this.agedTimeout != -1) && (mcw.hasAgedTimedOut(this.agedTimeoutMillis)))) {
                             aBuffer.append("Connection marked to be destroyed.  Waiting ");
                             aBuffer.append("for transaction end and connection close - ");
                         }
@@ -3109,7 +3109,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                         aBuffer.append("    ");
                         if (mcw.isStale()
                             || mcw.hasFatalErrorNotificationOccurred(freePool[0].getFatalErrorNotificationTime())
-                            || ((this.agedTimeout != 0) && (mcw.hasAgedTimedOut(this.agedTimeoutMillis)))) {
+                            || ((this.agedTimeout != -1) && (mcw.hasAgedTimedOut(this.agedTimeoutMillis)))) {
                             aBuffer.append("Connection marked to be destroyed.  Waiting ");
                             aBuffer.append("for transaction end and connection close - ");
                         }
@@ -3159,7 +3159,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                 Date startDateTime = new Date(startHoldTime);
                 long timeInUseInSeconds = holdTime / 1000;
                 /*
-                 * Add the new inuse information to the trace.
+                 * Add the new in-use information to the trace.
                  */
                 aBuffer.append(" Start time inuse " + startDateTime + " Time inuse " + timeInUseInSeconds + " (seconds)" + nl);
                 Throwable t = ((com.ibm.ejs.j2c.MCWrapper) mcw).getInitialRequestStackTrace();
@@ -3195,7 +3195,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
         // at a time.
         if (collectorCount > 1) {
             // This condition will happen if the reapTime is set to low. Example:
-            // The reapTime = 1 second and the reclaimconnections takes more than
+            // The reapTime = 1 second and the reclaim connections takes more than
             // 1 second to finish.
             collectorCount--;
             return;
@@ -3217,13 +3217,13 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
             while (i.hasNext()) {
                 MCWrapper mcw = i.next();
                 if (mcw.getPoolState() == MCWrapper.ConnectionState_freeTLSPool) {
-                    if (agedTimeout != 0) {
+                    if (agedTimeout != -1) {
                         if (mcw.hasAgedTimedOut(agedTimeoutMillis)) {
                             removemcw = true;
                             break;
                         }
                     }
-                    if (!removemcw && unusedTimeout != 0) {
+                    if (!removemcw && unusedTimeout != -1) {
                         if (mcw.hasIdleTimedOut(unusedTimeout * 1000)
                             && (totalConnectionCount.get() > minConnections)) {
                             removemcw = true;
@@ -3249,14 +3249,14 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                 int localtotalConnectionCount = totalConnectionCount.get();
                 int mcwlSize = freePool[j].mcWrapperList.size();
                 for (int k = 0; k < mcwlSize; ++k) {
-                    MCWrapper mcw = (MCWrapper) freePool[j].mcWrapperList.get(k);;
-                    if (agedTimeout != 0) {
+                    MCWrapper mcw = (MCWrapper) freePool[j].mcWrapperList.get(k);
+                    if (agedTimeout != -1) {
                         if (mcw.hasAgedTimedOut(agedTimeoutMillis)) {
                             removemcw = true;
                             break;
                         }
                     }
-                    if (!removemcw && unusedTimeout != 0) {
+                    if (!removemcw && unusedTimeout != -1) {
                         if (mcw.hasIdleTimedOut(unusedTimeout * 1000)
                             && (localtotalConnectionCount > minConnections)) {
                             removemcw = true;
@@ -3303,7 +3303,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                 int mcwlSize = freePool[j].mcWrapperList.size();
                 for (int k = 0; k < mcwlSize; ++k) {
                     MCWrapper mcw = (MCWrapper) freePool[j].mcWrapperList.get(k);
-                    if (!removemcw && agedTimeout != 0) {
+                    if (!removemcw && agedTimeout != -1) {
                         if (mcw.hasAgedTimedOut(agedTimeoutMillis)) {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                 Tr.debug(this, tc, "Aged timeout reclaim connection " + mcw);
@@ -3311,7 +3311,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                             removemcw = true;
                         }
                     }
-                    if (!removemcw && unusedTimeout != 0) {
+                    if (!removemcw && unusedTimeout != -1) {
                         if (mcw.hasIdleTimedOut(unusedTimeout * 1000)
                             && (this.totalConnectionCount.get() > minConnections)) {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -3376,7 +3376,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                             MCWrapper mcw = e.getKey();
                             if (mcw.getPoolState() == MCWrapper.ConnectionState_freeTLSPool) {
                                 ArrayList<MCWrapper> mh = e.getValue();
-                                if (agedTimeout != 0) {
+                                if (agedTimeout != -1) {
                                     if (mcw.hasAgedTimedOut(agedTimeoutMillis)) {
                                         mh.remove(mcw);
                                         tlsArrayLists.remove(mcw);
@@ -3390,7 +3390,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                                         continue;
                                     }
                                 }
-                                if (unusedTimeout != 0) {
+                                if (unusedTimeout != -1) {
                                     if (mcw.hasIdleTimedOut(unusedTimeout * 1000)
                                         && (this.totalConnectionCount.get() > minConnections)) {
                                         mh.remove(mcw);
@@ -3509,7 +3509,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
         }
         /*
          * Future improvement can be if we may
-         * wanna check subject a cri before
+         * want to check subject a cri before
          * computing hashcode again
          */
 
@@ -3517,7 +3517,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
 
         if (subject != null) {
 
-            // RRA currently returns false for reauthentication support
+            // RRA currently returns false for re-authentication support
             if (!gConfigProps.raSupportsReauthentication) {
                 /*
                  * If we are the rra or re-authentication is not supported,
@@ -4104,7 +4104,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                 logPropertyChangeMsg("connectionTimeout", connectionTimeout, value);
             }
             connectionTimeout = value;
-            displayInfiniteWaitMessage = (connectionTimeout == 0);
+            displayInfiniteWaitMessage = (connectionTimeout == -1);
             synchronized (waiterFreePoolLock) {
                 waiterFreePoolLock.notifyAll();
             }
@@ -4114,7 +4114,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
                 logPropertyChangeMsg("unusedTimeout", unusedTimeout, value);
             }
             unusedTimeout = value;
-            if (value > 0) {
+            if (value > -1) {
                 unusedTimeoutEnabled = true;
             } else {
                 unusedTimeoutEnabled = false;

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
@@ -256,7 +256,7 @@ public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionMan
                             if (mcw.isDestroyState()
                                 || mcw.isStale()
                                 || mcw.hasFatalErrorNotificationOccurred(_pm.freePool[0].getFatalErrorNotificationTime())
-                                || ((_pm.agedTimeout != 0) && (mcw.hasAgedTimedOut(_pm.agedTimeoutMillis)))) {
+                                || ((_pm.agedTimeout != -1) && (mcw.hasAgedTimedOut(_pm.agedTimeoutMillis)))) {
                                 sharedBuf.append("ToBePurged");
                             }
                             sharedBuf.append(" thread=");
@@ -276,7 +276,7 @@ public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionMan
                             // Check if connection is about to be purged
                             if (mcw.isStale()
                                 || mcw.hasFatalErrorNotificationOccurred(_pm.freePool[0].getFatalErrorNotificationTime())
-                                || ((_pm.agedTimeout != 0) && (mcw.hasAgedTimedOut(_pm.agedTimeoutMillis)))) {
+                                || ((_pm.agedTimeout != -1) && (mcw.hasAgedTimedOut(_pm.agedTimeoutMillis)))) {
                                 unsharedBuf.append("ToBePurged");
                             }
                             unsharedBuf.append(" thread=");

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/j2c/poolmanager/ConnectionPoolProperties.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/j2c/poolmanager/ConnectionPoolProperties.java
@@ -188,7 +188,7 @@ public interface ConnectionPoolProperties extends java.io.Serializable {
      * Currently Defined levels are as follows:
      * <ul>
      * <li>0 - information that can be gathered with no performance impact (default).
-     * <li>1 - information that can be gathered with minimun to moderate performance impact.
+     * <li>1 - information that can be gathered with minimum to moderate performance impact.
      * <li>2 - information that can be gather which has a moderate to significant performance impact.
      * </ul>
      */


### PR DESCRIPTION
Removed the convert/validateProperty methods in ConnectionManagerServiceImpl and then reconfigured the logic where converted values had been used