### PR TITLE
JWT SSO FAT: Update JWK test to use different keystore

### DIFF
--- a/dev/com.ibm.ws.security.jwtsso_fat/publish/files/configs/server_noBuilder_jwksUriConfigured.xml
+++ b/dev/com.ibm.ws.security.jwtsso_fat/publish/files/configs/server_noBuilder_jwksUriConfigured.xml
@@ -18,6 +18,13 @@
 
     <authentication cacheEnabled="false"/>
 
-    <mpJwt id="mpJwt_trustAllIssuers" issuer="ALL_ISSUERS" jwksUri="https://localhost:${bvt.prop.HTTP_default.secure}/jwt/ibm/api/defaultJWT/jwk" />
+    <!-- Configure the mpJwt consumer's sslRef to use a different keystore than the server default. However, configuring the jwksUri
+         attribute should result in the JWK URI being used to validate the JWT cookie instead of the keystore used by the sslRef. -->
+    <mpJwt id="mpJwt_trustAllIssuers" issuer="ALL_ISSUERS" jwksUri="https://localhost:${bvt.prop.HTTP_default.secure}/jwt/ibm/api/defaultJWT/jwk"
+        sslRef="otherSsl" />
+
+    <ssl id="otherSsl" keyStoreRef="separateKeyStore" trustStoreRef="defaultKeyStore" />
+
+    <keyStore id="separateKeyStore" password="Liberty" type="jks" location="${server.config.dir}/separateKeyStore.jks" />/>
 
 </server>

--- a/dev/com.ibm.ws.security.jwtsso_fat/publish/shared/config/ssl.xml
+++ b/dev/com.ibm.ws.security.jwtsso_fat/publish/shared/config/ssl.xml
@@ -10,6 +10,8 @@
  -->
 <server>
 
+    <sslDefault sslRef="defaultSSLConfig" />
+    <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultKeyStore" />
     <keyStore id="defaultKeyStore" password="Liberty" />
 
 </server>


### PR DESCRIPTION
Ensure that the JWK test for the `jwtSso-1.0` feature sets the `mpJwt` configuration to use a keystore with a certificate that can't be used to validate the JWT cookie, but also configures the `jwksUri` attribute. This should make sure we're testing that if the `jwksUri` attribute is configured, we should use the JWK endpoint to get the right key to verify the JWT cookie instead of looking in the configured keystore.