### PR TITLE
JPA 2.2 Container Feature needs JNDI feature dependency

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jpa-2.1/com.ibm.websphere.appserver.jpa-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jpa-2.1/com.ibm.websphere.appserver.jpa-2.1.feature
@@ -223,8 +223,7 @@ IBM-API-Package: org.eclipse.persistence.descriptors.changetracking; type="inter
  org.eclipse.persistence; type="third-party"
 IBM-ShortName: jpa-2.1
 Subsystem-Name: Java Persistence API 2.1
--features=com.ibm.websphere.appserver.jndi-1.0, \
- com.ibm.websphere.appserver.transaction-1.2, \
+-features=com.ibm.websphere.appserver.transaction-1.2, \
  com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.2", \
  com.ibm.websphere.appserver.jpaContainer-2.1, \
  com.ibm.websphere.appserver.org.eclipse.persistence-2.6

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jpa-2.2/com.ibm.websphere.appserver.jpa-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jpa-2.2/com.ibm.websphere.appserver.jpa-2.2.feature
@@ -223,8 +223,7 @@ IBM-API-Package: org.eclipse.persistence.descriptors.changetracking; type="inter
  org.eclipse.persistence; type="third-party"
 IBM-ShortName: jpa-2.2
 Subsystem-Name: Java Persistence API 2.2
--features=com.ibm.websphere.appserver.jndi-1.0, \
- com.ibm.websphere.appserver.transaction-1.2, \
+-features=com.ibm.websphere.appserver.transaction-1.2, \
  com.ibm.websphere.appserver.jdbc-4.2, \
  com.ibm.websphere.appserver.jpaContainer-2.2,\
  com.ibm.websphere.appserver.org.eclipse.persistence-2.7

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.1/com.ibm.websphere.appserver.jpaContainer-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.1/com.ibm.websphere.appserver.jpaContainer-2.1.feature
@@ -12,7 +12,8 @@ IBM-API-Package: javax.persistence; type="spec", \
  javax.persistence.metamodel; type="spec"
 IBM-App-ForceRestart: uninstall, \
  install
--features=com.ibm.websphere.appserver.classloading-1.0, \
+-features=com.ibm.websphere.appserver.jndi-1.0, \
+ com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.javax.persistence-2.1, \
  com.ibm.websphere.appserver.javax.annotation-1.2; apiJar=false, \
  com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.2", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.2/com.ibm.websphere.appserver.jpaContainer-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.2/com.ibm.websphere.appserver.jpaContainer-2.2.feature
@@ -12,7 +12,8 @@ IBM-API-Package: javax.persistence; type="spec", \
  javax.persistence.metamodel; type="spec"
 IBM-App-ForceRestart: uninstall, \
  install
--features=com.ibm.websphere.appserver.classloading-1.0, \
+-features=com.ibm.websphere.appserver.jndi-1.0, \
+ com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.javax.persistence-2.2, \
  com.ibm.websphere.appserver.javax.annotation-1.3; apiJar=false, \
  com.ibm.websphere.appserver.jdbc-4.2, \


### PR DESCRIPTION
Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>

When testing the JPA 2.2 Container feature against HIbernate, I noticed that datasource lookup was failing due to in-availability of JNDI.  The JPA 2.2 feature declares a dependency on the JNDI feature, but the JPA 2.2 Container (which JPA 2.2 extends) did not.  This corrects that oversight.
