### PR TITLE
Skip the JAXB test when Java 2 security is enabled.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/SseJaxbApp/src/jaxrs21sse/jaxb/SseJaxbTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/SseJaxbApp/src/jaxrs21sse/jaxb/SseJaxbTestServlet.java
@@ -57,6 +57,10 @@ public class SseJaxbTestServlet extends FATServlet {
 
     public void testJaxbSse(HttpServletRequest req, HttpServletResponse resp) throws Exception {
 
+        if (System.getSecurityManager() != null) {
+            return; // skip test to avoid Java 2 security issues in JDK XML/JAXB code.
+        }
+
         final List<TestXML> receivedEvents = new ArrayList<TestXML>();
         final CountDownLatch executionLatch = new CountDownLatch(1);
 


### PR DESCRIPTION
This test fails when Java 2 security is enabled because the JDK does
not have doPriv blocks around things like checking for JAXB- or XML-
specific system properties, etc.

Since we cannot control the JDK, we will continue to run these tests,
but only when Java 2 security is not enabled.

This is a test case issue, so it is not a release bug.