### PR TITLE
Add recursion counters to avoid infinite loop in trace for hpelbts

### DIFF
--- a/dev/com.ibm.ws.logging.hpel/src/com/ibm/ws/logging/internal/hpel/HpelBaseTraceService.java
+++ b/dev/com.ibm.ws.logging.hpel/src/com/ibm/ws/logging/internal/hpel/HpelBaseTraceService.java
@@ -119,8 +119,14 @@ public class HpelBaseTraceService extends BaseTraceService {
         //but the results of this call are not actually used anywhere (for traces), so it can be disabled for now
         //String traceDetail = formatter.traceLogFormat(logRecord, id, formattedMsg, formattedVerboseMsg);
         invokeTraceRouters(routedTrace);
-        if (traceSource != null) {
-            traceSource.publish(routedTrace, id);
+        try {
+            if (!(counterForTraceSource.incrementCount() > 2)) {
+                if (traceSource != null) {
+                    traceSource.publish(routedTrace, id);
+                }
+            }
+        } finally {
+            counterForTraceRouter.decrementCount();
         }
         trWriter.repositoryPublish(logRecord);
     }


### PR DESCRIPTION
 #build 
fix #3923 
The change is to add a recursion counter to the `publishTraceLogrecord()` in `HpelBaseTraceService` similar to `BaseTraceService`. The counter is lacking in `HpelBaseTraceService` due to the method having been overrode. 

The counter to is address any infinite traces that can occur if the `BufferManagerImpl` is traced.