### PR TITLE
Remove beta restriction from "useJandex" configuration attributes.

### DIFF
--- a/dev/com.ibm.ws.app.manager/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.app.manager/resources/OSGI-INF/metatype/metatype.xml
@@ -16,7 +16,7 @@
 
 	<OCD description="%appmgmt.desc" name="%appmgmt.name" id="com.ibm.ws.app.management" ibm:alias="applicationManager">
 		<AD id="autoExpand" name="%appmgmt.autoExpand" description="%appmgmt.autoExpand.desc" required="false" type="Boolean" default="false"/>
-		<AD id="useJandex" ibm:beta="true" name="%appmgmt.useJandex" description="%appmgmt.useJandex.desc" required="false" type="Boolean"/>
+		<AD id="useJandex" name="%appmgmt.useJandex" description="%appmgmt.useJandex.desc" required="false" type="Boolean"/>
 		<AD id="startTimeout" name="%appmgmt.startTimeout" description="%appmgmt.startTimeout.desc" required="false" type="String" default="30s" ibm:type="duration(s)" />
 		<AD id="stopTimeout" name="%appmgmt.stopTimeout" description="%appmgmt.stopTimeout.desc" required="false" type="String" default="30s" ibm:type="duration(s)" />
 	</OCD>
@@ -30,7 +30,7 @@
         <AD id="type" name="%appmgr.type.name" description="%appmgr.type.desc" type="String" required="false"/>
         <AD id="context-root" name="%appmgr.contextRoot.name" description="%appmgr.contextRoot.desc" type="String" required="false"/>
         <AD id="autoStart" name="%appmgr.autoStart.name" description="%appmgr.autoStart.desc" type="Boolean" required="false" default="true"/>
-        <AD id="useJandex" ibm:beta="true" name="%appmgr.useJandex.name" description="%appmgr.useJandex.desc" type="Boolean" required="false"/>
+        <AD id="useJandex" name="%appmgr.useJandex.name" description="%appmgr.useJandex.desc" type="Boolean" required="false"/>
    </OCD>
     <Designate factoryPid="com.ibm.ws.app.manager">
         <Object ocdref="com.ibm.ws.app.manager"/>


### PR DESCRIPTION
Removes 'ibm:beta="true"' from the two 'useJandex' attributes, from metatype.xml.
