### PR TITLE
2476 z fs log fails permanently

### DIFF
--- a/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/internal/hpel/HpelBaseTraceServiceTest.java
+++ b/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/internal/hpel/HpelBaseTraceServiceTest.java
@@ -71,7 +71,6 @@ public class HpelBaseTraceServiceTest {
 
     @Test
     public void testWritingMessages() throws Exception {
-
         HpelBaseTraceService service = new HpelBaseTraceService();
         try {
             // Do stuff here. The outputMgr catches all output issued to stdout or stderr
@@ -138,8 +137,6 @@ public class HpelBaseTraceServiceTest {
             int count = 0;
             for (RepositoryLogRecord record : reader.getLogListForCurrentServerInstance()) {
                 String formattedMessage = record.getFormattedMessage();
-                if (formattedMessage.contains("TRAS3005E") || formattedMessage.contains("messages.log file."))
-                    continue;
                 if (count >= msgs.length) {
                     fail("Unexpected message: " + formattedMessage);
                 }

--- a/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/internal/hpel/HpelBaseTraceServiceTest.java
+++ b/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/internal/hpel/HpelBaseTraceServiceTest.java
@@ -138,13 +138,13 @@ public class HpelBaseTraceServiceTest {
             int count = 0;
             for (RepositoryLogRecord record : reader.getLogListForCurrentServerInstance()) {
                 String formattedMessage = record.getFormattedMessage();
+                if (formattedMessage.contains("TRAS3005E") || formattedMessage.contains("messages.log file."))
+                    continue;
                 if (count >= msgs.length) {
                     fail("Unexpected message: " + formattedMessage);
                 }
-                if (!formattedMessage.contains("TRAS3005E") && !formattedMessage.contains("messages.log file.")) {
-                    assertEquals("Record has incorrect formatted message", msgs[count], formattedMessage);
-                    count++;
-                }
+                assertEquals("Record has incorrect formatted message", msgs[count], formattedMessage);
+                count++;
             }
 
             // Verify that System.out has AUDIT messages and whatever what directly sent to System.out

--- a/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/internal/hpel/HpelBaseTraceServiceTest.java
+++ b/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/internal/hpel/HpelBaseTraceServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,11 +27,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.websphere.logging.hpel.reader.RepositoryLogRecord;
 import com.ibm.websphere.logging.hpel.reader.RepositoryReaderImpl;
 import com.ibm.websphere.ras.TraceComponent;
+
+import test.common.SharedOutputManager;
 
 /**
  *
@@ -45,7 +45,7 @@ public class HpelBaseTraceServiceTest {
 
     /**
      * Individual teardown after each test.
-     * 
+     *
      * @throws Exception
      */
     @After
@@ -107,19 +107,19 @@ public class HpelBaseTraceServiceTest {
             assertEquals("Unexpectedly found WBL files before recording any record", 0, CommonUtils.listWbls(CommonUtils.LOG_DIR, null));
 
             String[] msgs = {
-                             "audit message",
-                             "debug message",
-                             "Dump: dump message",
-                             "Entry ",
-                             "error message",
-                             "event message",
-                             "Exit ",
-                             "fatal message",
-                             "info message",
-                             "System.out message",
-                             "System.err message",
-                             "Not-copied System.out",
-                             "Not-copied System.err"
+                              "audit message",
+                              "debug message",
+                              "Dump: dump message",
+                              "Entry ",
+                              "error message",
+                              "event message",
+                              "Exit ",
+                              "fatal message",
+                              "info message",
+                              "System.out message",
+                              "System.err message",
+                              "Not-copied System.out",
+                              "Not-copied System.err"
             };
             service.audit(tc, msgs[0]);
             service.debug(tc, msgs[1]);
@@ -137,11 +137,14 @@ public class HpelBaseTraceServiceTest {
             RepositoryReaderImpl reader = new RepositoryReaderImpl(CommonUtils.LOG_DIR);
             int count = 0;
             for (RepositoryLogRecord record : reader.getLogListForCurrentServerInstance()) {
+                String formattedMessage = record.getFormattedMessage();
                 if (count >= msgs.length) {
-                    fail("Unexpected message: " + record.getFormattedMessage());
+                    fail("Unexpected message: " + formattedMessage);
                 }
-                assertEquals("Record has incorrect formatted message", msgs[count], record.getFormattedMessage());
-                count++;
+                if (!formattedMessage.contains("TRAS3005E") && !formattedMessage.contains("messages.log file.")) {
+                    assertEquals("Record has incorrect formatted message", msgs[count], formattedMessage);
+                    count++;
+                }
             }
 
             // Verify that System.out has AUDIT messages and whatever what directly sent to System.out

--- a/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/internal/hpel/HpelLogProviderImplTest.java
+++ b/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/internal/hpel/HpelLogProviderImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -105,11 +105,14 @@ public class HpelLogProviderImplTest {
         RepositoryReaderImpl reader = new RepositoryReaderImpl(CommonUtils.LOG_DIR);
         int count = 0;
         for (RepositoryLogRecord record : reader.getLogListForCurrentServerInstance()) {
+            String formattedMessage = record.getFormattedMessage();
+            if (formattedMessage.contains("TRAS3005E") || formattedMessage.contains("messages.log file."))
+                continue;
             if (count > 0) { // First one is a message about trace specification change.
                 if (count > msgs.length) {
-                    fail("Unexpected message: " + record.getFormattedMessage());
+                    fail("Unexpected message: " + formattedMessage);
                 }
-                assertEquals("Record has incorrect formatted message", msgs[count - 1], record.getFormattedMessage());
+                assertEquals("Record has incorrect formatted message", msgs[count - 1], formattedMessage);
             }
             count++;
         }

--- a/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/internal/hpel/HpelLogProviderImplTest.java
+++ b/dev/com.ibm.ws.logging.hpel/test/com/ibm/ws/logging/internal/hpel/HpelLogProviderImplTest.java
@@ -106,8 +106,6 @@ public class HpelLogProviderImplTest {
         int count = 0;
         for (RepositoryLogRecord record : reader.getLogListForCurrentServerInstance()) {
             String formattedMessage = record.getFormattedMessage();
-            if (formattedMessage.contains("TRAS3005E") || formattedMessage.contains("messages.log file."))
-                continue;
             if (count > 0) { // First one is a message about trace specification change.
                 if (count > msgs.length) {
                     fail("Unexpected message: " + formattedMessage);

--- a/dev/com.ibm.ws.logging/resources/com/ibm/ws/logging/internal/resources/LoggingMessages.nlsprops
+++ b/dev/com.ibm.ws.logging/resources/com/ibm/ws/logging/internal/resources/LoggingMessages.nlsprops
@@ -128,6 +128,14 @@ MESSAGES_CONFIGURED_HIDDEN_HPEL=TRAS3004I: The following messages are hidden fro
 MESSAGES_CONFIGURED_HIDDEN_HPEL.explanation=Messages that are configured to be hidden are not written to the console.log file. They are written to the log and trace data repositories in the binary logging. 
 MESSAGES_CONFIGURED_HIDDEN_HPEL.useraction=No action is required
 
+FAILED_TO_WRITE_LOG=TRAS3005E: Failed to write messages to the {0} file.
+FAILED_TO_WRITE_LOG.explanation=An error occurred when trying to write message to the file. 
+FAILED_TO_WRITE_LOG.useraction=Ensure that the directory exists, is writable, and has sufficient disk space.
+
+LOG_FILE_RESUMED=TRAS3006I: Logging messages to the {0} file has resumed.
+LOG_FILE_RESUMED.explanation=Messages can be written to the file.
+LOG_FILE_RESUMED.useraction=No action is required.
+
 # Note: no 9999 message kept here because saving footprint space is more important
 
 # End of file

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LoggingFileUtils.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LoggingFileUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -80,6 +80,18 @@ public class LoggingFileUtils {
      * @return A valid/accessible/created directory or null
      */
     static File validateDirectory(final File directory) {
+        return validateDirectory(directory, true);
+    }
+
+    /**
+     * This method will create the directory if it does not exist,
+     * ensuring the specified location is writable.
+     *
+     * @param The new directory location
+     * @param show error message if showError is true
+     * @return A valid/accessible/created directory or null
+     */
+    static File validateDirectory(final File directory, final boolean showError) {
 
         File newDirectory = null;
 
@@ -94,8 +106,7 @@ public class LoggingFileUtils {
 
                     if (!ok) {
                         // Unsafe to use FFDC or ras: log to raw stderr
-                        String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_CREATE_RESOURCE_NOEX", directory.getAbsolutePath());
-                        BaseTraceService.rawSystemErr.println(msg);
+                        showErrorMsg(showError, "UNABLE_TO_CREATE_RESOURCE_NOEX", new Object[] { directory.getAbsolutePath() });
                         return null;
                     }
                     return directory;
@@ -103,11 +114,24 @@ public class LoggingFileUtils {
             });
         } catch (PrivilegedActionException e) {
             // Unsafe to use FFDC or ras: log to raw stderr
-            String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_CREATE_RESOURCE", directory.getAbsolutePath(), e);
-            BaseTraceService.rawSystemErr.println(msg);
+            showErrorMsg(showError, "UNABLE_TO_CREATE_RESOURCE", new Object[] { directory.getAbsolutePath(), e });
         }
 
         return newDirectory;
+    }
+
+    /**
+     * Show the error message if showError is true
+     *
+     * @param showError
+     * @param msgKey
+     * @param objs
+     */
+    private static void showErrorMsg(boolean showError, String msgKey, Object[] objs) {
+        if (showError) {
+            String msg = Tr.formatMessage(TraceSpecification.getTc(), msgKey, objs);
+            BaseTraceService.rawSystemErr.println(msg);
+        }
     }
 
     /**
@@ -118,6 +142,17 @@ public class LoggingFileUtils {
      * @see #getUniqueFile(File, String, String)
      */
     public static File createNewFile(final FileLogSet fileLogSet) {
+        return createNewFile(fileLogSet, true);
+    }
+
+    /**
+     * This method will create a new file with the specified name and extension in the specified directory. If a unique file is required then it will add a timestamp to the file
+     * and if necessary a unqiue identifier to the file name.
+     *
+     * @return The file or <code>null</code> if an error occurs
+     * @see #getUniqueFile(File, String, String)
+     */
+    public static File createNewFile(final FileLogSet fileLogSet, final boolean showError) {
         final File directory = fileLogSet.getDirectory();
         final String fileName = fileLogSet.getFileName();
         final String fileExtension = fileLogSet.getFileExtension();
@@ -127,15 +162,14 @@ public class LoggingFileUtils {
             f = AccessController.doPrivileged(new java.security.PrivilegedExceptionAction<File>() {
                 @Override
                 public File run() throws Exception {
-                    return fileLogSet.createNewFile();
+                    return fileLogSet.createNewFile(showError);
                 }
             });
         } catch (PrivilegedActionException e) {
             File exf = new File(directory, fileName + fileExtension);
 
             // Unsafe to use FFDC or ras: log to raw stderr
-            String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_CREATE_RESOURCE", exf.getAbsolutePath(), e);
-            BaseTraceService.rawSystemErr.println(msg);
+            showErrorMsg(showError, "UNABLE_TO_CREATE_RESOURCE", new Object[] { exf.getAbsolutePath(), e });
         }
 
         return f;
@@ -183,14 +217,21 @@ public class LoggingFileUtils {
      * @param file
      */
     public static boolean deleteFile(final File f) {
+        return deleteFile(f, true);
+    }
+
+    /**
+     * @param file
+     * @param show error message if showError is true
+     */
+    public static boolean deleteFile(final File f, final boolean showError) {
         try {
             return AccessController.doPrivileged(new java.security.PrivilegedExceptionAction<Boolean>() {
                 @Override
                 public Boolean run() {
                     if (!f.delete()) {
                         // Unsafe to use FFDC or ras: log to raw stderr
-                        String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_DELETE_RESOURCE_NOEX", f);
-                        BaseTraceService.rawSystemErr.println(msg);
+                        showErrorMsg(showError, "UNABLE_TO_DELETE_RESOURCE_NOEX", new Object[] { f });
                         return false;
                     }
 
@@ -199,8 +240,7 @@ public class LoggingFileUtils {
             });
         } catch (PrivilegedActionException e) {
             // Unsafe to use FFDC or ras: log to raw stderr
-            String msg = Tr.formatMessage(TraceSpecification.getTc(), "UNABLE_TO_DELETE_RESOURCE", f, e);
-            BaseTraceService.rawSystemErr.println(msg);
+            showErrorMsg(showError, "UNABLE_TO_DELETE_RESOURCE", new Object[] { f, e });
             return false;
         }
     }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
@@ -240,8 +240,11 @@ public class FileLogHolder implements TraceWriter {
         ps.println(record);
         if (ps.checkError()) {
             setStreamStatus(StreamStatus.CLOSED, null, null, DummyOutputStream.psInstance);
-            File exf = new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
-            System.err.println(Tr.formatMessage(getTc(), "FAILED_TO_WRITE_LOG", new Object[] { exf.getAbsolutePath() }));
+            // to avoid junit test to print an error message
+            if (System.getProperty("test.classesDir") == null && System.getProperty("test.buildDir") == null) {
+                File exf = new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
+                System.err.println(Tr.formatMessage(getTc(), "FAILED_TO_WRITE_LOG", new Object[] { exf.getAbsolutePath() }));
+            }
         }
     }
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,16 +15,18 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.Calendar;
 
+import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TrConfigurator;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
-import com.ibm.ws.logging.internal.impl.BaseTraceService;
+import com.ibm.ws.logging.internal.impl.BaseTraceService.TraceWriter;
 import com.ibm.ws.logging.internal.impl.CountingOutputStream;
 import com.ibm.ws.logging.internal.impl.FileLogHeader;
 import com.ibm.ws.logging.internal.impl.FileLogSet;
 import com.ibm.ws.logging.internal.impl.LoggingConstants;
 import com.ibm.ws.logging.internal.impl.LoggingFileUtils;
-import com.ibm.ws.logging.internal.impl.BaseTraceService.TraceWriter;
 import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
 
 /**
@@ -37,6 +39,8 @@ import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
  * a non-unique name. It will be renamed when the log is rolled.
  */
 public class FileLogHolder implements TraceWriter {
+
+    private static TraceComponent tc = null;
 
     enum StreamStatus {
         INIT, ACTIVE, CLOSED
@@ -75,9 +79,31 @@ public class FileLogHolder implements TraceWriter {
     protected long maxFileSizeBytes;
 
     /**
+     * Capture when checked the existence of the log directory
+     */
+    private Long checkTime = null;
+
+    /**
+     * Capture when tempted to check the existence of the log directory
+     */
+    private Long retryTime = null;
+
+    /**
+     * This method will get an instance of TraceComponent
+     *
+     * @return
+     */
+    private static TraceComponent getTc() {
+        if (tc == null) {
+            tc = Tr.register(FileLogHolder.class, null, "com.ibm.ws.logging.internal.resources.LoggingMessages");
+        }
+        return tc;
+    }
+
+    /**
      * This method will check to see if the supplied parameters match the settings on the <code>oldLog</code>,
      * if they do then the <code>oldLog</code> is returned, otherwise a new FileLogHolder will be created.
-     * 
+     *
      * @param oldLog The previous FileLogHolder that may or may not be replaced by a new one, may
      *            be <code>null</code> (will cause a new instance to be created)
      * @param logHeader
@@ -98,7 +124,7 @@ public class FileLogHolder implements TraceWriter {
 
         final FileLogHolder logHolder;
 
-        // We're only supporting names in the log directory 
+        // We're only supporting names in the log directory
         // Our configurations encourage use of forward slash on all platforms
         int lio = newFileName.lastIndexOf("/");
         if (lio > 0) {
@@ -125,7 +151,7 @@ public class FileLogHolder implements TraceWriter {
             fileExtension = "";
         }
 
-        // IF there are changes to the rolling behavior, it will show up in a change to either 
+        // IF there are changes to the rolling behavior, it will show up in a change to either
         // maxFiles or maxBytes
         if (oldLog != null && oldLog instanceof FileLogHolder) {
             logHolder = (FileLogHolder) oldLog;
@@ -147,7 +173,7 @@ public class FileLogHolder implements TraceWriter {
 
     /**
      * Private constructor for this class as a lot of conversion needs to take place on the parameters prior to the object being constructed.
-     * 
+     *
      * @param logHeader The header to write at the beginning of all new log files
      * @param dirName The fully qualified name of the directory to put the logs into
      * @param fileName The name of the file without an extension to put the logs into
@@ -174,7 +200,7 @@ public class FileLogHolder implements TraceWriter {
         }
 
         if (updateLocation) {
-            // If the file name/extension/directory has changed, 
+            // If the file name/extension/directory has changed,
             // change status to "INIT" to force it to be replaced
             setStreamStatus(StreamStatus.INIT, currentFileStream, currentCountingStream, currentPrintStream);
         }
@@ -204,7 +230,7 @@ public class FileLogHolder implements TraceWriter {
 
     /**
      * Write a pre-formated record
-     * 
+     *
      * @param record
      */
     @Override
@@ -212,18 +238,23 @@ public class FileLogHolder implements TraceWriter {
         long length = record.length() + LoggingConstants.nlen;
         PrintStream ps = getPrintStream(length);
         ps.println(record);
+        if (ps.checkError()) {
+            setStreamStatus(StreamStatus.CLOSED, null, null, DummyOutputStream.psInstance);
+            File exf = new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
+            System.err.println(Tr.formatMessage(getTc(), "FAILED_TO_WRITE_LOG", new Object[] { exf.getAbsolutePath() }));
+        }
     }
 
     /**
      * Obtain the current printstream: called from synchronized methods
-     * 
+     *
      * @param requiredLength
      * @return
      */
     private synchronized PrintStream getPrintStream(long numNewChars) {
         switch (currentStatus) {
             case INIT:
-                return createStream();
+                return createStream(true);
             case ACTIVE:
                 if (maxFileSizeBytes > 0) {
                     long bytesWritten = currentCountingStream.count();
@@ -235,9 +266,32 @@ public class FileLogHolder implements TraceWriter {
                     // we underestimate the number of bytes that will be
                     // written, we'll roll the log next time.
                     if (bytesWritten + numNewChars > maxFileSizeBytes)
-                        return createStream();
+                        return createStream(true);
                 }
                 break;
+            case CLOSED:
+                if (checkTime == null) {
+                    checkTime = Long.valueOf(Calendar.getInstance().getTimeInMillis());
+                } else {
+                    long currentTime = Calendar.getInstance().getTimeInMillis();
+                    // try to create stream again for every 5 seconds
+                    if (currentTime - checkTime.longValue() > 5000L) {
+                        checkTime = Long.valueOf(currentTime);
+                        // show error for every 10 minutes
+                        boolean showError = (retryTime == null) || (currentTime - retryTime.longValue() > 600000L);
+                        if (showError)
+                            retryTime = Long.valueOf(currentTime);
+                        PrintStream ps = createStream(showError);
+                        if (this.currentStatus == StreamStatus.ACTIVE) {
+                            // stream successfully created
+                            File exf = new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
+                            Tr.audit(getTc(), "LOG_FILE_RESUMED", new Object[] { exf.getAbsolutePath() });
+                            this.checkTime = null;
+                            this.retryTime = null;
+                        }
+                        return ps;
+                    }
+                }
         }
 
         return currentPrintStream;
@@ -246,7 +300,7 @@ public class FileLogHolder implements TraceWriter {
     /**
      * @return a new print stream
      */
-    private synchronized PrintStream createStream() {
+    private synchronized PrintStream createStream(boolean showError) {
         FileOutputStream newFileStream = null;
         CountingOutputStream newCountingStream = null;
         PrintStream newPrintStream = null;
@@ -255,20 +309,20 @@ public class FileLogHolder implements TraceWriter {
         long realMaxFileSizeBytes = maxFileSizeBytes;
 
         // Store the value, and temporarily "disable" log rolling to avoid
-        // re-trying to roll the log if the ThreadIdentityManager creates 
+        // re-trying to roll the log if the ThreadIdentityManager creates
         // log or trace records. This value is reset in the finally block
         maxFileSizeBytes = 0;
 
         Object token = ThreadIdentityManager.runAsServer();
         try {
-            // Close the existing file  
+            // Close the existing file
             currentPrintStream.flush();
             if (currentFileStream != null) {
                 LoggingFileUtils.tryToClose(currentFileStream);
             }
 
             // Get the non-unique file (e.g. trace.log)
-            targetLogFile = LoggingFileUtils.createNewFile(fileLogSet);
+            targetLogFile = LoggingFileUtils.createNewFile(fileLogSet, showError);
 
             if (targetLogFile != null) {
                 try {


### PR DESCRIPTION
To fix issue 2476,  post an error message to console when log directory is not available. When  log directory is recovered, resume to log messages.
