### PR TITLE
Add testSettingFrameBadSize test to the trace bucket.

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullModeTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullModeTests.java
@@ -1047,18 +1047,6 @@ public class Http2FullModeTests extends FATServletClient {
     }
 
     /**
-     * Test Coverage: Send a SETTINGS frame of the wrong size (other than a multiple of 6 octets)
-     * Test Outcome: Return a connection error of type FRAME_SIZE_ERROR and close the connection.
-     * Spec Section: 6.5
-     *
-     * @throws Exception
-     */
-    @Test
-    public void testSettingFrameBadSize() throws Exception {
-        runTest(defaultServletPath, testName.getMethodName());
-    }
-
-    /**
      * Test Coverage: Send a PING frame with ACK set
      * Test Outcome: Verify that a PING response is not returned.
      * Spec Section: 6.7

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullTracingTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullTracingTests.java
@@ -91,4 +91,17 @@ public class Http2FullTracingTests extends FATServletClient {
         runTest(dataServletPath, testName.getMethodName());
     }
 
+    /**
+     * Test Coverage: Send a SETTINGS frame of the wrong size (other than a multiple of 6 octets)
+     * Test Outcome: Return a connection error of type FRAME_SIZE_ERROR and close the connection.
+     * Spec Section: 6.5
+     *
+     * @throws Exception
+     */
+    // moved for debug - build break 255616
+    @Test
+    public void testSettingFrameBadSize() throws Exception {
+        runTest(defaultServletPath, testName.getMethodName());
+    }
+
 }


### PR DESCRIPTION
Fixes #3988 
