### PR TITLE
Fix packaging of security FAT test applications

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/build.gradle
+++ b/dev/com.ibm.ws.security.fat.common/build.gradle
@@ -14,31 +14,41 @@ dependencies {
   requiredLibs 'commons-logging:commons-logging:1.1.3'
 }
 
-apply plugin: 'war'
+/*
+ * This is where all application ZIP and WARs will be built.
+ */
+def appBuildDir = "${buildDir}/test-application"
 
-/* build testmarker war for all FATs to use (this is a small test app that 
-     records testcase start/end message in the server side logs.
-*/
-war {
-  from "test-applications/testmarker/resources"
-  archiveName "test-application/testmarker.war"
+task formlogin(type: War, dependsOn: classes) {
+  def appName = "formlogin"
+  destinationDir file("${appBuildDir}")
+  archiveName "${appName}.war"
 
-  /*
-   * Don't include the dependency JARs in the testmarker WAR.
-   */
-  classpath = classpath.filter{ file -> !file.name.endsWith('jar') }
-}
- 
-/* build formlogin war for all FATs to use (this is a test app that 
-     prints credentials/subject/... .
-*/
-war {
-  from "test-applications/formlogin/resources"
-  archiveName "test-application/formlogin.war"
-
-  /*
-   * Don't include the dependency JARs in the formlogin WAR.
-   */
-  classpath = classpath.filter{ file -> !file.name.endsWith('jar') }
+  from("test-applications/${appName}/resources") {
+    include "**/*"
+  }
+  from ("build/classes/java/main") {
+    include "com/ibm/ws/security/fat/common/apps/${appName}/**/*.class"
+    into "WEB-INF/classes"
+  }
 }
 
+task testmarker(type: War, dependsOn: classes) {
+  def appName = "testmarker"
+  destinationDir file("${appBuildDir}")
+  archiveName "${appName}.war"
+
+  from("test-applications/${appName}/resources") {
+    include "**/*"
+  }
+  from ('build/classes/java/main') {
+    include "com/ibm/ws/security/fat/common/apps/${appName}/**/*.class"
+    into "WEB-INF/classes"
+  }
+}
+
+assemble {
+  dependsOn \
+    formlogin,
+    testmarker
+}


### PR DESCRIPTION
The `war` stanza in a `build.gradle` file appears to only be able to be used once; a project cannot package multiple WARs using the `war` plugin (as far as I'm aware). This will modify the `build.gradle` file to use separate tasks for zipping up the different test applications into their respective WAR files.