### PR TITLE
Change @MinimumJavaLevel to use int instead of double for java level

### DIFF
--- a/dev/com.ibm.ws.beanvalidation.v11_fat/fat/src/com/ibm/ws/beanvalidation/fat/basic/BasicValidation20Test.java
+++ b/dev/com.ibm.ws.beanvalidation.v11_fat/fat/src/com/ibm/ws/beanvalidation/fat/basic/BasicValidation20Test.java
@@ -23,7 +23,7 @@ import componenttest.topology.impl.LibertyServer;
  * All Bean Validation tests for the 2.0 feature level.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class BasicValidation20Test extends BasicValidation_Common {
 
     @Server("com.ibm.ws.beanvalidation_2.0.fat")

--- a/dev/com.ibm.ws.beanvalidation.v11_fat/fat/src/com/ibm/ws/beanvalidation/fat/cdi/BeanValidation20CDITest.java
+++ b/dev/com.ibm.ws.beanvalidation.v11_fat/fat/src/com/ibm/ws/beanvalidation/fat/cdi/BeanValidation20CDITest.java
@@ -31,7 +31,7 @@ import componenttest.topology.impl.LibertyServer;
  * that everything that worked without CDI works with it as well.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class BeanValidation20CDITest extends BeanValidationCDI_Common {
 
     @Server("com.ibm.ws.beanvalidation.cdi_2.0.fat")

--- a/dev/com.ibm.ws.beanvalidation.v11_fat/fat/src/com/ibm/ws/beanvalidation/fat/ejb/EJBModule20Test.java
+++ b/dev/com.ibm.ws.beanvalidation.v11_fat/fat/src/com/ibm/ws/beanvalidation/fat/ejb/EJBModule20Test.java
@@ -28,7 +28,7 @@ import componenttest.topology.impl.LibertyServer;
  * container and provider and needs to be common between bval-1.0 and bval-1.1.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class EJBModule20Test extends EJBModule_Common {
 
     @Server("com.ibm.ws.beanvalidation.ejb_2.0.fat")

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_20.java
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_20.java
@@ -20,7 +20,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyClientFactory;
 
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class BvalAppClientTest_20 extends AbstractAppClientTest {
 	
 	@Test

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BasicSseTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BasicSseTest.java
@@ -31,7 +31,7 @@ import jaxrs21sse.basic.BasicSseTestServlet;
  * This test of basic SSE function.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class BasicSseTest extends FATServletClient {
     private static final String SERVLET_PATH = "BasicSseApp/BasicSseTestServlet";
 

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/DelaySseTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/DelaySseTest.java
@@ -35,7 +35,7 @@ import jaxrs21sse.delay.DelaySseTestServlet;
  * 4. The SSE event flows resetting the reconnect delay.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class DelaySseTest extends FATServletClient {
     private static final String SERVLET_PATH = "DelaySseApp/DelaySseTestServlet";
 

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/SseJaxbTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/SseJaxbTest.java
@@ -31,7 +31,7 @@ import jaxrs21sse.jaxb.SseJaxbTestServlet;
  * This test of jaxb SSE function.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class SseJaxbTest extends FATServletClient {
     private static final String SERVLET_PATH = "SseJaxbApp/SseJaxbTestServlet";
 

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/SseJsonbTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/SseJsonbTest.java
@@ -31,7 +31,7 @@ import jaxrs21sse.jsonb.SseJsonbTestServlet;
  * This test of jsonb SSE function.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class SseJsonbTest extends FATServletClient {
     private static final String SERVLET_PATH = "SseJsonbApp/SseJsonbTestServlet";
 

--- a/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/BatchInjectionTest.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/BatchInjectionTest.java
@@ -48,7 +48,7 @@ import componenttest.topology.utils.FATServletClient;
  * servlet referenced by the annotation, and will be run whenever this test class runs.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.7)
+@MinimumJavaLevel(javaLevel = 7)
 public class BatchInjectionTest extends FATServletClient {
 
     // Using the RepeatTests @ClassRule in FATSuite will cause all tests in the FAT to be run twice.

--- a/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/TranTimeoutCleanupTest.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/TranTimeoutCleanupTest.java
@@ -47,7 +47,7 @@ import componenttest.topology.utils.FATServletClient;
  * servlet referenced by the annotation, and will be run whenever this test class runs.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.7)
+@MinimumJavaLevel(javaLevel = 7)
 @Mode(TestMode.FULL)
 public class TranTimeoutCleanupTest extends FATServletClient {
 

--- a/dev/com.ibm.ws.jdbc_fat_v41/test-applications/basicfat/src/jdbc/fat/v41/web/BasicTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/test-applications/basicfat/src/jdbc/fat/v41/web/BasicTestServlet.java
@@ -1116,7 +1116,7 @@ public class BasicTestServlet extends FATDatabaseServlet {
 
     // Ensure that we preserve the behavior that DatabaseMetaData.supportsRefCursors always returns false prior to jdbc-4.1 feature
     @Test
-    @MinimumJavaLevel(javaLevel = 1.8) // supportsRefCursor only available in Java 8 or higher
+    @MinimumJavaLevel(javaLevel = 8) // supportsRefCursor only available in Java 8 or higher
     public void testSupportsRefCursors() throws Exception {
         Connection con = xads.getConnection();
         try {
@@ -1172,7 +1172,7 @@ public class BasicTestServlet extends FATDatabaseServlet {
 
     // Ensure that we preserve the behavior that DatabaseMetaData.getMaxLogicalLobSize always returns 0 prior to jdbc-4.2 feature
     @Test
-    @MinimumJavaLevel(javaLevel = 1.8) // getMaxLogicalLobSize only available in Java 8 or higher
+    @MinimumJavaLevel(javaLevel = 8) // getMaxLogicalLobSize only available in Java 8 or higher
     public void testGetMaxLogicalLobSize() throws Exception {
         Connection con = xads.getConnection();
         try {

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/CDIConfigByACPTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/CDIConfigByACPTests.java
@@ -35,7 +35,7 @@ import componenttest.topology.impl.LibertyServer;
  * We're extending CDITestBase, which has common test code.
  */
 @Mode(TestMode.FULL)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 public class CDIConfigByACPTests extends CDITestBase {
 

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/CDIFacesInMetaInfTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/CDIFacesInMetaInfTests.java
@@ -32,7 +32,7 @@ import componenttest.topology.impl.LibertyServer;
  * We're extending CDITestBase, which has common test code.
  */
 @Mode(TestMode.FULL)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 public class CDIFacesInMetaInfTests extends CDITestBase {
 

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/CDIFacesInWebXMLTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/CDIFacesInWebXMLTests.java
@@ -32,7 +32,7 @@ import componenttest.topology.impl.LibertyServer;
  * We're extending CDITestBase, which has common test code.
  */
 @Mode(TestMode.FULL)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 public class CDIFacesInWebXMLTests extends CDITestBase {
 

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/CDIInjectionTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/CDIInjectionTests.java
@@ -40,7 +40,7 @@ import junit.framework.Assert;
  *
  * We're extending CDITestBase, which has common test code.
  */
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 public class CDIInjectionTests extends CDITestBase {
     private static final Logger LOG = Logger.getLogger(CDIInjectionTests.class.getName());

--- a/dev/com.ibm.ws.jsonp.1.1_fat/fat/src/com/ibm/ws/jsonp11/fat/JSONP11Test.java
+++ b/dev/com.ibm.ws.jsonp.1.1_fat/fat/src/com/ibm/ws/jsonp11/fat/JSONP11Test.java
@@ -27,7 +27,7 @@ import componenttest.topology.utils.FATServletClient;
 import web.JSONP11Servlet;
 
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class JSONP11Test extends FATServletClient {
 
     private static final String appName = "JSONP11fat";

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerClasspathTest.java
@@ -29,7 +29,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Tests what can and cannot be loaded by the server's JVM classpath.
  */
-@MinimumJavaLevel(javaLevel = 1.7)
+@MinimumJavaLevel(javaLevel = 7)
 public class ServerClasspathTest {
 
     private static final String SERVER_NAME = "com.ibm.ws.kernel.boot.classpath.fat";

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATMPOpenTracing.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATMPOpenTracing.java
@@ -38,7 +38,7 @@ import junit.framework.Assert;
  * </ul>
  */
 @Mode(TestMode.FULL)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class FATMPOpenTracing {
     /**
      * For tracing.

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracing.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracing.java
@@ -76,7 +76,7 @@ import componenttest.topology.impl.LibertyServerFactory;
  * <p>Search for "***" within comments for specific tested conditions.</p>
  */
 @Mode(TestMode.FULL)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class FATOpentracing implements FATOpentracingConstants {
     private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.30.mf";
     private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock.jar";

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracingHelloWorld.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracingHelloWorld.java
@@ -32,7 +32,7 @@ import componenttest.topology.impl.LibertyServerFactory;
  * </ul>
  */
 @Mode(TestMode.FULL)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class FATOpentracingHelloWorld extends FATTestBase {
     /**
      * Set to the generated server before any tests are run.

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
@@ -28,7 +28,7 @@ import junit.framework.Assert;
  * Various utility methods.
  */
 @Mode(TestMode.FULL)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class FATTestBase {
     /**
      * Deploy jaxrsHelloWorld.war.

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/MicroProfile13NoTracer.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/MicroProfile13NoTracer.java
@@ -35,7 +35,7 @@ import componenttest.topology.impl.LibertyServerFactory;
  * </ul>
  */
 @Mode(TestMode.FULL)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class MicroProfile13NoTracer extends FATTestBase {
     /**
      * Set to the generated server before any tests are run.

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/TestSpanUtils.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/TestSpanUtils.java
@@ -27,7 +27,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
  * {@link FATUtilsSpans} will need to be updated to match.</p>
  */
 @Mode(TestMode.FULL)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class TestSpanUtils {
     /**
      * <p>Completed spans for span print string and parse verification.</p>

--- a/dev/com.ibm.ws.persistence_fat/fat/src/com/ibm/ws/persistence/fat/ConsumerTest_JPA22.java
+++ b/dev/com.ibm.ws.persistence_fat/fat/src/com/ibm/ws/persistence/fat/ConsumerTest_JPA22.java
@@ -27,7 +27,7 @@ import componenttest.topology.utils.FATServletClient;
 import persistence_fat.consumer.web.ConsumerServlet;
 
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 public class ConsumerTest_JPA22 extends FATServletClient {
     private static final String APP_NAME = "consumer";
 

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/AutoApplySessionTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/AutoApplySessionTest.java
@@ -45,7 +45,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Test Description:
  */
-@MinimumJavaLevel(javaLevel = 1.7, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 7, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 public class AutoApplySessionTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/BasicAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/BasicAuthenticationMechanismTest.java
@@ -44,7 +44,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class BasicAuthenticationMechanismTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/CustomIdentityStoreHandlerTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/CustomIdentityStoreHandlerTest.java
@@ -36,7 +36,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class CustomIdentityStoreHandlerTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/DatabaseIdentityStoreDeferredSettingsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/DatabaseIdentityStoreDeferredSettingsTest.java
@@ -63,7 +63,7 @@ import web.war.database.deferred.DatabaseSettingsBean;
 /**
  * Test for {@link LdapIdentityStore} configured with deferred EL expressions.
  */
-@MinimumJavaLevel(javaLevel = 1.7)
+@MinimumJavaLevel(javaLevel = 7)
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 public class DatabaseIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/DatabaseIdentityStoreImmediateSettingsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/DatabaseIdentityStoreImmediateSettingsTest.java
@@ -53,7 +53,7 @@ import web.war.database.deferred.DatabaseSettingsBean;
 /**
  * Test for {@link DatabaseIdentityStore} configured with immediate EL expressions.
  */
-@MinimumJavaLevel(javaLevel = 1.7)
+@MinimumJavaLevel(javaLevel = 7)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class DatabaseIdentityStoreImmediateSettingsTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
@@ -43,7 +43,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  *
  */
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class EJBModuleRealmTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestProtectedServlet.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestProtectedServlet.java
@@ -42,7 +42,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestUnprotectedServlet.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestUnprotectedServlet.java
@@ -41,7 +41,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FeatureTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FeatureTest.java
@@ -46,7 +46,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  *
  */
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class FeatureTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
@@ -58,7 +58,7 @@ import componenttest.topology.impl.LibertyServerFactory;
  * values for getAuthType, getUserPrincipal and getRemoteUser after JASPI authentication.
  *
  */
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class FormHttpAuthenticationMechanismTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBAnnotationTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBAnnotationTest.java
@@ -43,7 +43,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Test Description: Test with a datasource configured as an annotation
  */
-@MinimumJavaLevel(javaLevel = 1.7, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 7, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class HttpAuthenticationMechanismDBAnnotationTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBAuthAliasTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBAuthAliasTest.java
@@ -43,7 +43,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Test Description: Test with a containerAuthData defined in the server.xml.
  */
-@MinimumJavaLevel(javaLevel = 1.7, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 7, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class HttpAuthenticationMechanismDBAuthAliasTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBHashBeanTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBHashBeanTest.java
@@ -42,7 +42,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Test Description: Test with a custom hash implementation that uses a beans.xml to discover the hash class.
  */
-@MinimumJavaLevel(javaLevel = 1.7, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 7, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class HttpAuthenticationMechanismDBHashBeanTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBHashNoConfigTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBHashNoConfigTest.java
@@ -43,7 +43,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Test Description: Test that looking up a user fails because the custom hash class is not discovered
  */
-@MinimumJavaLevel(javaLevel = 1.7, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 7, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class HttpAuthenticationMechanismDBHashNoConfigTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBHashTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBHashTest.java
@@ -42,7 +42,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Test Description: Test with a custom hash implementation that uses an annotation to discover the hash class.
  */
-@MinimumJavaLevel(javaLevel = 1.7, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 7, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class HttpAuthenticationMechanismDBHashTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBNoUserTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBNoUserTest.java
@@ -43,7 +43,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Test Description: Check that no user/group defined in the access-id works.
  */
-@MinimumJavaLevel(javaLevel = 1.7, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 7, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class HttpAuthenticationMechanismDBNoUserTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBShortNameTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBShortNameTest.java
@@ -43,7 +43,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Test Description: Check that only a short name defined in the access-id works.
  */
-@MinimumJavaLevel(javaLevel = 1.7, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 7, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class HttpAuthenticationMechanismDBShortNameTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/HttpAuthenticationMechanismDBTest.java
@@ -47,7 +47,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Test Description:
  */
-@MinimumJavaLevel(javaLevel = 1.7, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 7, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class HttpAuthenticationMechanismDBTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LdapIdentityStoreDeferredSettingsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LdapIdentityStoreDeferredSettingsTest.java
@@ -62,7 +62,7 @@ import web.war.database.deferred.DatabaseSettingsBean;
 /**
  * Test for {@link LdapIdentityStore} configured with deferred EL expressions.
  */
-@MinimumJavaLevel(javaLevel = 1.7)
+@MinimumJavaLevel(javaLevel = 7)
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LoginToContinueELTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LoginToContinueELTest.java
@@ -38,7 +38,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class LoginToContinueELTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplCustomTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplCustomTest.java
@@ -36,7 +36,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleIdentityStoreApplCustomTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplLoginToContinueTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplLoginToContinueTest.java
@@ -40,7 +40,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleIdentityStoreApplLoginToContinueTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreBasicTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreBasicTest.java
@@ -36,7 +36,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleIdentityStoreBasicTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormPostTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormPostTest.java
@@ -50,7 +50,7 @@ import com.ibm.ws.security.javaeesec.fat_helper.JavaEESecTestBase;
 import com.ibm.ws.security.javaeesec.fat_helper.LocalLdapServer;
 import com.ibm.ws.security.javaeesec.fat_helper.WCApplicationHelper;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleIdentityStoreCustomFormPostTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormTest.java
@@ -42,7 +42,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormPostTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormPostTest.java
@@ -50,7 +50,7 @@ import com.ibm.ws.security.javaeesec.fat_helper.JavaEESecTestBase;
 import com.ibm.ws.security.javaeesec.fat_helper.LocalLdapServer;
 import com.ibm.ws.security.javaeesec.fat_helper.WCApplicationHelper;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleIdentityStoreFormPostTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormTest.java
@@ -39,7 +39,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleDBRunAsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleDBRunAsTest.java
@@ -43,7 +43,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleModuleDBRunAsTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleExpandTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleExpandTest.java
@@ -42,7 +42,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleModuleExpandTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertFailOverTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertFailOverTest.java
@@ -43,7 +43,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertTest.java
@@ -45,7 +45,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleModuleGlobalClientCertTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalLoginTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalLoginTest.java
@@ -41,7 +41,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleNoExpandTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleNoExpandTest.java
@@ -42,7 +42,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleModuleNoExpandTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleRunAsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleRunAsTest.java
@@ -43,7 +43,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class MultipleModuleRunAsTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/NoIdentityStoreTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/NoIdentityStoreTest.java
@@ -36,7 +36,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class NoIdentityStoreTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/NoJavaEESecFormTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/NoJavaEESecFormTest.java
@@ -44,7 +44,7 @@ import com.ibm.ws.security.javaeesec.fat_helper.JavaEESecTestBase;
 import com.ibm.ws.security.javaeesec.fat_helper.LocalLdapServer;
 import com.ibm.ws.security.javaeesec.fat_helper.WCApplicationHelper;
 
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class NoJavaEESecFormTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/ProgrammaticTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/ProgrammaticTest.java
@@ -40,7 +40,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  * Test Description:
  */
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 public class ProgrammaticTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/RememberMeTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/RememberMeTest.java
@@ -42,7 +42,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 public class RememberMeTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/ScopedTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/ScopedTest.java
@@ -34,7 +34,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-@MinimumJavaLevel(javaLevel = 1.8)
+@MinimumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 public class ScopedTest extends JavaEESecTestBase {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/SecurityContextEJBTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/SecurityContextEJBTest.java
@@ -39,7 +39,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 /**
  *
  */
-@MinimumJavaLevel(javaLevel = 1.8, runSyntheticTest = false)
+@MinimumJavaLevel(javaLevel = 8, runSyntheticTest = false)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class SecurityContextEJBTest extends JavaEESecTestBase {

--- a/dev/fattest.simplicity/src/componenttest/annotation/MaximumJavaLevel.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/MaximumJavaLevel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,15 +17,11 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation for expressing tests should only run when the java level is at or below the given level.
- * The argument is a double, such as 1.6 or 1.7.
- * Example:
- * 
- * @MaximumJavaLevel(javaLevel=1.7)
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MaximumJavaLevel {
 
-    double javaLevel();
+    int javaLevel();
 
 }

--- a/dev/fattest.simplicity/src/componenttest/annotation/MinimumJavaLevel.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/MinimumJavaLevel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,18 +17,12 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation for expressing tests should only run when the java level is above the given level.
- * The argument is a double, such as 1.6 or 1.7.<br>
- * <b>Note: If you want to skip an entire FAT on a certain java level, you can specify the following
- * property in your build-test.xml instead of using this annotation on every single test class:</b><br>
- * <code>
- * &lt;property name="minimum.java.level.for.test.execution" value="1.7"/>
- * </code>
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MinimumJavaLevel {
 
-    double javaLevel();
+    int javaLevel();
 
     /**
      * Deprecated: The synthetic test is no longer necessary.

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/AlwaysPassesTest.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/AlwaysPassesTest.java
@@ -27,7 +27,7 @@ public class AlwaysPassesTest {
 
     @Test
     @Mode(TestMode.LITE)
-    @MinimumJavaLevel(javaLevel = 1.6)
+    @MinimumJavaLevel(javaLevel = 6)
     public void testThatWillAlwaysPass() throws Exception {}
 
 }

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/JavaLevelFilter.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/JavaLevelFilter.java
@@ -24,13 +24,9 @@ public class JavaLevelFilter extends Filter {
 
     public static final String FEATURE_UNDER_TEST;
 
-    private static double JAVA_VERSION;
-
     static {
         FEATURE_UNDER_TEST = System.getProperty(FeatureFilter.FEATURE_UNDER_TEST_PROPERTY_NAME);
         Log.info(JavaLevelFilter.class, "<clinit>", "System property: " + FeatureFilter.FEATURE_UNDER_TEST_PROPERTY_NAME + " is " + FEATURE_UNDER_TEST);
-        JAVA_VERSION = Double.valueOf("1." + JavaInfo.JAVA_VERSION);
-        Log.info(JavaLevelFilter.class, "<clinit>", "Parsed java version: " + JAVA_VERSION);
     }
 
     private static Class<?> getMyClass() {
@@ -64,10 +60,10 @@ public class JavaLevelFilter extends Filter {
             maximumJavaLevelAnnotation = getTestClass(desc).getAnnotation(MaximumJavaLevel.class);
         }
         if (maximumJavaLevelAnnotation != null) {
-            if (JAVA_VERSION > maximumJavaLevelAnnotation.javaLevel()) {
+            if (JavaInfo.JAVA_VERSION > maximumJavaLevelAnnotation.javaLevel()) {
                 Log.debug(getMyClass(), "Removing test " + desc.getMethodName()
                                         + " from list to run, because its maximum java level is " + maximumJavaLevelAnnotation.javaLevel()
-                                        + " and we are running with " + JAVA_VERSION);
+                                        + " and we are running with " + JavaInfo.JAVA_VERSION);
                 return false;
             }
         }
@@ -89,11 +85,11 @@ public class JavaLevelFilter extends Filter {
         }
 
         // If there's a minimum java level annotaton, that sets a global minimum level, so if we don't meet that, don't run tests
-        boolean javaLevelTooLowForAllFeatures = minimumJavaLevelAnnotation != null && JAVA_VERSION < minimumJavaLevelAnnotation.javaLevel();
+        boolean javaLevelTooLowForAllFeatures = minimumJavaLevelAnnotation != null && JavaInfo.JAVA_VERSION < minimumJavaLevelAnnotation.javaLevel();
         if (javaLevelTooLowForAllFeatures) {
             Log.debug(getMyClass(), "Removing test " + desc.getMethodName() + " with minimum java level " + minimumJavaLevelAnnotation.javaLevel()
                                     + " from list to run, because it is too high for current java level "
-                                    + JAVA_VERSION);
+                                    + JavaInfo.JAVA_VERSION);
             return false;
         } else {
             // Check if this is testing the feature with the minimum level
@@ -101,11 +97,11 @@ public class JavaLevelFilter extends Filter {
             if (applicableFeaturePresent) {
                 // This feature has a minimum java level, do we meet it?
 
-                if (JAVA_VERSION < featureRequiresLevelAnnotation.javaLevel()) {
+                if (JavaInfo.JAVA_VERSION < featureRequiresLevelAnnotation.javaLevel()) {
                     Log.debug(getMyClass(), "Removing test " + desc.getMethodName() + " because feature " + featureRequiresLevelAnnotation.feature()
                                             + " from list to run, because it requires java level " + featureRequiresLevelAnnotation.javaLevel()
                                             + " and we are running with "
-                                            + JAVA_VERSION);
+                                            + JavaInfo.JAVA_VERSION);
                     return false;
                 }
             }


### PR DESCRIPTION
The key change here is in JavaLevelFilter.java and the MinimumJavaLevel annotation itself.  On Java 10, the annotation was not working because the java level was being parsed as a double and prepending "1.".  On Java 10 this gave us a double value of `1.10`, so comparisons like `if( 1.7 <= 1.10 )` were returning false.