### PR TITLE
Update EclipseLink logging logic to avoid calling Map.get so often.

### DIFF
--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/eclipselink/Log.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/eclipselink/Log.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package com.ibm.wsspi.persistence.internal.eclipselink;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.logging.SessionLogEntry;
@@ -28,18 +28,22 @@ public class Log extends ServerLog {
 
     public final static String LOG_PREFIX = "eclipselink.ps";
     private final static String EMPTY_CHANNEL = LOG_PREFIX;
+    private final static LogChannel EMPTY_LOG_CHANNEL = new LogChannel(EMPTY_CHANNEL);
 
     private static final TraceComponent _tc = Tr.register(Log.class, PersistenceServiceConstants.TRACE_GROUP);
-    private final Map<String, LogChannel> _channels;
+    private static final Map<String, LogChannel> _channels = new HashMap<String, LogChannel>();
 
-    public Log() {
-        _channels = new ConcurrentHashMap<String, LogChannel>();
+    static {
 
         // Register each category with eclipselink prefix as a WebSphere log channel
         for (String category : SessionLog.loggerCatagories) {
             _channels.put(category, new LogChannel(LOG_PREFIX + "." + category));
         }
-        _channels.put(EMPTY_CHANNEL, new LogChannel(EMPTY_CHANNEL));
+        _channels.put(EMPTY_CHANNEL, EMPTY_LOG_CHANNEL);
+    }
+
+    public Log() {
+        // nothing to do.
     }
 
     @Override
@@ -63,16 +67,15 @@ public class Log extends ServerLog {
     @Trivial
     private LogChannel getLogChannel(String category) {
         if (category == null) {
-            category = EMPTY_CHANNEL;
+            return EMPTY_LOG_CHANNEL;
         }
         LogChannel channel = _channels.get(category);
         if (channel == null) {
             if (_tc.isDebugEnabled()) {
                 Tr.debug(_tc, "Found an unmapped logging channel (" + category
                               + ") in log(...). Possibly something wrong in EclipseLink, remapping to base channel.");
-                channel = _channels.get(EMPTY_CHANNEL);
             }
-            channel = _channels.get(EMPTY_CHANNEL);
+            channel = EMPTY_LOG_CHANNEL;
         }
         return channel;
     }


### PR DESCRIPTION
Change from a ConcurrentHashMap to a normal HashMap since there is no
concurrency.  The map is created initially and then never updated. 
Made the Map of LogChannel's static instead of instance scoped in case
there are multiple Logger objects created.  No need to create multiple
Maps since they all have the same data.
Changed the getLogChannel logic to do at most 1 Map.get call instead of
possibly 2 or 3 depending on if trace is enabled.