### PR TITLE
Make the RC for Starting Liberty as a Windows Service consistent with

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -358,6 +358,8 @@ goto:eof
     )
   ) else (
      "!WLP_INSTALL_DIR!\bin\tools\win\prunsrv.exe" //ES//%SERVER_NAME%
+      call:serverRunning
+      call:javaCmdResult
   )   
 goto:eof
 


### PR DESCRIPTION
the RC for when Liberty is started successfully when not as a Windows Service
