### PR TITLE
3422 updates to schema gen for default config ignore

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/SchemaWriter.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/SchemaWriter.java
@@ -1030,7 +1030,6 @@ class SchemaWriter {
         writer.writeEndElement();
 
         if (type.getHasFactoryReference()) {
-            System.out.println("schemaWriter :: " + type.getTypeName());
             writer.writeStartElement(XSD, "complexType");
             writer.writeAttribute("name", type.getTypeName() + "-factory");
             writer.writeStartElement(XSD, "complexContent");

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/SchemaWriter.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/SchemaWriter.java
@@ -452,7 +452,7 @@ class SchemaWriter {
                 String extension = currOcd.getExtends();
                 // Check that we've got extensions and ensure we're a Factory Pid. If so, add the definition to the list, and get the parent type
                 // to check on the next loop.
-                if (extension != null && currOcdType.getHasFactoryReference()) {
+                if (extension != null && (currOcdType.getHasFactoryReference() || currOcdType.getHasIBMFinalWithDefault())) {
                     ocdDefs.add(0, currOcd);
                     TypeBuilder.OCDTypeReference ocdSuperType = builder.getPidType(extension);
                     if (ocdSuperType != null) {
@@ -1030,6 +1030,7 @@ class SchemaWriter {
         writer.writeEndElement();
 
         if (type.getHasFactoryReference()) {
+            System.out.println("schemaWriter :: " + type.getTypeName());
             writer.writeStartElement(XSD, "complexType");
             writer.writeAttribute("name", type.getTypeName() + "-factory");
             writer.writeStartElement(XSD, "complexContent");

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/TypeBuilder.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/TypeBuilder.java
@@ -37,6 +37,7 @@ import com.ibm.websphere.metatype.MetaTypeFactory;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.config.xml.internal.metatype.ExtendedAttributeDefinition;
+import com.ibm.ws.config.xml.internal.metatype.ExtendedAttributeDefinitionImpl;
 import com.ibm.ws.config.xml.internal.metatype.ExtendedObjectClassDefinition;
 import com.ibm.ws.config.xml.internal.metatype.ExtendedObjectClassDefinitionImpl;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
@@ -104,6 +105,12 @@ class TypeBuilder {
 
                 if (factoryPids) {
                     type.setHasFactoryReference(true);
+                }
+
+                boolean isIBMFinalSetForIdField = processAttributes(ocd);
+                if (isIBMFinalSetForIdField) {
+                    type.setHasFactoryReference(false);
+                    type.setHasIBMFinalWithDefault(true);
                 }
 
                 if ("internal".equalsIgnoreCase(ocd.getName())) {
@@ -241,6 +248,22 @@ class TypeBuilder {
                 }
             }
         }
+    }
+
+    public boolean processAttributes(ObjectClassDefinition ocd) {
+        boolean response = false;
+
+        AttributeDefinition[] attributeList = ocd.getAttributeDefinitions(ObjectClassDefinition.ALL);
+        for (AttributeDefinition ad : attributeList) {
+            String[] defaultValue = ad.getDefaultValue();
+            ExtendedAttributeDefinition ead = new ExtendedAttributeDefinitionImpl(ad);
+
+            if (ad.getID().equalsIgnoreCase("id") && ead.isFinal() && (defaultValue != null && defaultValue.length > 0)) {
+                response = true;
+            }
+
+        }
+        return response;
     }
 
     private void processPidReferences() {
@@ -423,6 +446,7 @@ class TypeBuilder {
         private ResourceBundle resourceBundle;
         private final String pid;
         private final List<String> excludedChildren;
+        private boolean hasIBMFinalWithDefault;
 
         public OCDType(MetaTypeInformation metatype, String pid, ExtendedObjectClassDefinition ocd) {
             this.metatype = metatype;
@@ -469,6 +493,14 @@ class TypeBuilder {
 
         public void setHasFactoryReference(boolean hasFactoryReference) {
             this.hasFactoryReference = hasFactoryReference;
+        }
+
+        public boolean getHasIBMFinalWithDefault() {
+            return hasIBMFinalWithDefault;
+        }
+
+        public void setHasIBMFinalWithDefault(boolean hasIBMFinalWithDefault) {
+            this.hasIBMFinalWithDefault = hasIBMFinalWithDefault;
         }
 
         public String getAliasName() {
@@ -594,12 +626,12 @@ class TypeBuilder {
 
         public String[] getLabelKeys(String prefix) {
             return new String[] { prefix + "." + ocd.getID() + ".name",
-                                 prefix + ".name" };
+                                  prefix + ".name" };
         }
 
         public String[] getDescriptionKeys(String prefix) {
             return new String[] { prefix + "." + ocd.getID() + ".description",
-                                 prefix + ".description" };
+                                  prefix + ".description" };
         }
 
         @FFDCIgnore(MissingResourceException.class)


### PR DESCRIPTION
This change keeps any 'id' fields marked as ibm:final='true' out of the generated schema.  These are values the user should not configure.