### PR TITLE
Revert "Use incubating parallel builds"

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -30,23 +30,14 @@ bnd_repourl=https://repo1.maven.org/maven2
 # bnd_build can be set to the name of a "master" project whose dependencies will seed the set of projects to build.
 bnd_build=
 
+# our current build and test seems to max out at around 1.5GB of memory. I'm a little worried this isn't sustainable.
+org.gradle.jvmargs=-Xmx2560M -XX:+HeapDumpOnOutOfMemoryError
+
 # Default gradle task to build
 bnd_defaultTask=build
 
 # This should be false. It only needs to be true in rare cases.
 bnd_preCompileRefresh=false
 
-# Daemon improves the startup and execution time of Gradle.
-# Since the first daemon requires some additional startup time, the daemon shouldn't run on CI servers since they
-# are containerized or VMs. CI servers override this property by running Gradle with --no-daemon.
-org.gradle.daemon=false
 systemProp.com.ibm.jsse2.overrideDefaultTLS=true
-
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2560M -XX:+HeapDumpOnOutOfMemoryError
-
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-org.gradle.parallel=true
+org.gradle.daemon=false


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#4063

buildfat and runfat tasks are not correctly configured for the parallel feature yet. I need to resolve the inputs/outputs for the tasks before enabling parallel by default.