### PR TITLE
Fix bug which didn't allow for infinite conn timeout

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
@@ -190,7 +190,11 @@ public final class FreePool implements JCAPMIHelper {
                 pm.displayInfiniteWaitMessage = false; // only display this message once per PM.
             }
             pm.activeRequest.decrementAndGet();
-            pm.waiterFreePoolLock.wait(waitTimeout);
+            if (waitTimeout < 0) {
+                pm.waiterFreePoolLock.wait(0); //wait an infinite amount of time
+            } else {
+                pm.waiterFreePoolLock.wait(waitTimeout); //wait the specified amount of time
+            }
             pm.requestingAccessToPool();
         } catch (InterruptedException ie) {
             if (tc.isDebugEnabled()) {


### PR DESCRIPTION
For for issue #4120. The change in pull #3840 introduced a bug where an exception is thrown for a connection with a connectionTimeout value of -1 (infinite). This is not a release bug as the pull introducing this bug has not be GA'd.