### PR TITLE
Do not add bnd.gradle dependency since it isn't needed.

### DIFF
--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     binaries "org.jmockit:jmockit:1.25"
     binaries "biz.aQute.bnd:biz.aQute.bnd:4.0.0"
     binaries "biz.aQute.bnd:biz.aQute.bnd.annotation:4.0.0"
-    binaries "biz.aQute.bnd:biz.aQute.bnd.gradle:4.0.0"
     binaries "org.apache.maven:maven-model:3.5.0"
     binaries "javax.json:javax.json-api:1.1.2"
     binaries "org.glassfish:javax.json:1.1.2"
@@ -257,7 +256,7 @@ import aQute.bnd.gradle.Index
 task ('index', type: Index) {
     description 'Index the release repository. (Does not depend on releaseNeeded)'
     group 'release'
-    repositoryName = "Bnd ${version}"
+    repositoryName = "OpenLiberty ${version}"
     destinationDir = releaserepo
     gzip = true
     /* Bundles to index. */

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -4,7 +4,6 @@
 #org.apache.geronimo.specs:geronimo-validation_1.1_spec:1.0
 biz.aQute.bnd:biz.aQute.bnd:4.0.0
 biz.aQute.bnd:biz.aQute.bnd.annotation:4.0.0
-biz.aQute.bnd:biz.aQute.bnd.gradle:4.0.0
 com.fasterxml:classmate:1.3.1
 com.fasterxml.jackson.core:jackson-annotations:2.2.3
 com.fasterxml.jackson.core:jackson-annotations:2.9.1


### PR DESCRIPTION
Also change the index name to be OpenLiberty instead of Bnd.

These changes are in response to review comments in PR #4015 