### PR TITLE
Minor doc improvements to JMS & server cmd

### DIFF
--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherOptions.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherOptions.nlsprops
@@ -194,12 +194,13 @@ option-desc.javadump.include=\
 \tthread.
 option-desc.package.include=\
 \tA comma-delimited list of values. The valid values are: all*, usr,   \n\
-\tminify, runnable. If you specify runnable the resulting package will \n\
-\tbe an executable jar that runs the server. The minify option produces\n\
-\tthe smallest image possible for the server. The usr option creates a \n\
-\tpackage that contains the server and application, but not the        \n\
-\truntime. The default all option produces a server package that       \n\
-\tcontains everything.
+\tminify, runnable, wlp. If you specify runnable the resulting package \n\
+\twill be an executable jar that runs the server. The minify option    \n\
+\tproduces the smallest image possible for the server. The usr option  \n\
+\tcreates a package that contains the server and application, but not  \n\
+\tthe runtime. The wlp option produces a runtime that does not contain \n\
+\tthe server configuration. The default all option produces a server   \n\
+\tpackage that contains everything.
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
 option-key.template=\
 \ \ \ \ --template="templateName"

--- a/dev/com.ibm.ws.messaging.jms.common/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.messaging.jms.common/resources/OSGI-INF/l10n/metatype.properties
@@ -31,7 +31,7 @@ jms.qcf.properties.wasJms.QueueConnectionFactory=Embedded Messaging
 jms.qcf.properties.wasJms.QueueConnectionFactory.desc=A JMS queue connection factory is used to create connections to the associated JMS provider of JMS queues, for point-to-point messaging.
 
 jms.common.busName=Bus name
-jms.common.busName.desc=The name of a bus when connecting to the service integration bus in a full profile server.
+jms.common.busName.desc=The name of a bus when connecting to the service integration bus in WebSphere Application Server traditional.
 jms.common.userName=User name
 jms.common.userName.desc=It is recommended to use a container managed authentication alias instead of configuring this property.
 jms.common.password=Password
@@ -51,7 +51,7 @@ jms.common.temporaryTopicNamePrefix.desc=The prefix of up to twelve characters u
 jms.common.remoteServerAddress=Remote server address
 jms.common.remoteServerAddress.desc=The remote server address that has triplets separated by a comma, with the syntax hostName:portNumber:chainName, used to connect to a bootstrap server. For example, Merlin:7276:BootstrapBasicMessaging. If hostName is not specified, the default is localhost. If portNumber is not specified, the default is 7276. If chainName is not specified, the default is BootstrapBasicMessaging. Refer to the information center for more information.
 jms.common.targetTransportChain=Transport chain
-jms.common.targetTransportChain.desc=Transport chains specify the communication protocols that can be used to communicate with the service integration bus in a full profiles server.
+jms.common.targetTransportChain.desc=Transport chains specify the communication protocols that can be used to communicate with the service integration bus in WebSphere Application Server traditional.
 jms.common.shareDurableSubscription=Share durable subscription
 jms.common.shareDurableSubscription.desc=Controls whether or not durable subscription can be shared across connections.
 jms.common.durableSubscriptionHome= Durable subscription home


### PR DESCRIPTION
The online help for the server package tool doesn't list wlp as an option for
--include even though it is documented in the command description.

The WAS JMS configuration references 'full profile server' which is now referred
to as "WebSphere Application Server traditional"