### PR TITLE
FAT test for FT metrics being removed

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/suite/FATSuite.java
@@ -21,11 +21,13 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.CDIFallbackTest;
+import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.MetricRemovalTest;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                CDIFallbackTest.class
+                CDIFallbackTest.class,
+                MetricRemovalTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/MetricRemovalTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/MetricRemovalTest.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal.MetricListServlet;
+import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal.RemovalBean;
+import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal.RemovalServlet;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+@RunWith(FATRunner.class)
+public class MetricRemovalTest {
+
+    @Server("CDIFaultToleranceMetricsRemoval")
+    public static LibertyServer server;
+
+    private final static String TEST_METRIC = "ft.com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal.RemovalBean.doWorkWithRetry.invocations.total";
+
+    @Test
+    public void metricRemovalTest() throws Exception {
+        WebArchive removalTest = ShrinkWrap.create(WebArchive.class, "removalTest.war")
+                        .addClasses(RemovalBean.class, RemovalServlet.class)
+                        .addAsManifestResource(MetricRemovalTest.class.getResource("removal/permissions.xml"), "permissions.xml");
+
+        WebArchive metricReporter = ShrinkWrap.create(WebArchive.class, "metricReporter.war")
+                        .addClass(MetricListServlet.class)
+                        .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                        .addAsManifestResource(MetricRemovalTest.class.getResource("removal/permissions.xml"), "permissions.xml");
+
+        server.startServer();
+
+        try {
+            deployApp(removalTest);
+
+            try {
+                deployApp(metricReporter);
+
+                // Call the test app
+                HttpUtils.findStringInUrl(server, "removalTest/removaltest", "OK");
+
+                // Check that metrics exist
+                assertThat(getMetricsPage(), containsString(TEST_METRIC));
+
+            } finally {
+                // Remove the test app
+                undeployApp(removalTest);
+            }
+
+            // Check that metrics do not exist
+            assertThat(getMetricsPage(), not(containsString(TEST_METRIC)));
+        } finally {
+            undeployApp(metricReporter);
+        }
+
+    }
+
+    /**
+     * Retrieve the list of registered metrics from the {@link MetricListServlet}
+     */
+    private String getMetricsPage() throws IOException {
+        HttpURLConnection con = HttpUtils.getHttpConnection(server, "metricReporter/metriclist");
+        BufferedReader reader = HttpUtils.getResponseBody(con, "UTF-8");
+
+        StringBuilder b = new StringBuilder();
+        char[] cbuf = new char[1024];
+        int charCount;
+
+        while ((charCount = reader.read(cbuf)) > 0) {
+            b.append(cbuf, 0, charCount);
+        }
+
+        return b.toString();
+    }
+
+    /**
+     * Deploy an app to a running server using dropins
+     * <p>
+     * {@link ShrinkHelper#exportDropinAppToServer(LibertyServer, Archive)} also copies the app to the server's publish directory, which isn't what we want when we're deploying and
+     * undeploying while the server is running.
+     */
+    private void deployApp(Archive<?> archive) throws Exception {
+        ShrinkHelper.exportArtifact(archive, ".");
+        System.out.println("I'm putting the archive here: " + new File(".").getAbsolutePath());
+        server.setMarkToEndOfLog();
+        server.copyFileToLibertyServerRoot(".", "dropins", archive.getName());
+        assertNotNull(archive.getName() + " started message not found", server.waitForStringInLog("CWWKZ000[13]I.*" + getAppName(archive)));
+    }
+
+    /**
+     * Remove an app from a running server using dropins
+     */
+    private void undeployApp(Archive<?> archive) throws Exception {
+        server.setMarkToEndOfLog();
+        server.deleteFileFromLibertyServerRoot("dropins/" + archive.getName());
+        assertNotNull(archive.getName() + " stopped message not found", server.waitForStringInLog("CWWKZ0009I.*" + getAppName(archive)));
+    }
+
+    private String getAppName(Archive<?> archive) throws Exception {
+        // Liberty uses the file name with the extension removed
+        String appName = archive.getName();
+        if (appName.contains(".")) {
+            appName = appName.substring(0, appName.lastIndexOf("."));
+        }
+        return appName;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/removal/MetricListServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/removal/MetricListServlet.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+
+/**
+ * Lists the metrics currently registered in the application registry
+ */
+@WebServlet("metriclist")
+public class MetricListServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    MetricRegistry reg;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        for (String metricName : reg.getNames()) {
+            resp.getWriter().println(metricName);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/removal/RemovalBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/removal/RemovalBean.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+/**
+ * Simple bean with Fault Tolerance annotation which should result in metrics being produced
+ */
+@ApplicationScoped
+public class RemovalBean {
+
+    @Retry
+    public void doWorkWithRetry() {
+        // Do nothing
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/removal/RemovalServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/removal/RemovalServlet.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet to drive the annotated method on {@link RemovalBean} so that its metrics get reported
+ */
+@WebServlet("/removaltest")
+public class RemovalServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    RemovalBean bean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        bean.doWorkWithRetry();
+        resp.getWriter().println("OK");
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/removal/permissions.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/removal/permissions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+	version="7">
+	<permission>
+		<class-name>java.lang.RuntimePermission</class-name>
+		<name>getenv.*</name>
+	</permission>
+	
+	<!-- Needed until #4155 is fixed -->
+	<permission>
+		<class-name>java.lang.RuntimePermission</class-name>
+		<name>getClassLoader</name>
+	</permission>
+</permissions>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetricsRemoval/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetricsRemoval/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=5471

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetricsRemoval/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetricsRemoval/server.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright (c) 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <include location="../fatTestPorts.xml"/>
+    
+	<featureManager>
+	    <feature>componenttest-1.0</feature>
+		<feature>osgiconsole-1.0</feature>
+		<feature>localConnector-1.0</feature>
+		<feature>appSecurity-2.0</feature>
+		<feature>cdi-1.2</feature>
+		<feature>servlet-3.1</feature>
+		<feature>mpFaultTolerance-1.1</feature>
+		<feature>mpMetrics-1.1</feature>
+	</featureManager>
+
+</server>


### PR DESCRIPTION
Ensure that FT metrics are removed when the app is undeployed

Related to #4034 - it turns out that liberty does behave as we want, this PR just adds a test to assert that behaviour and ensure we don't regress in the future.