### PR TITLE
When FFDC checking is disabled for one server, continue checking other servers

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
@@ -470,7 +470,7 @@ public class FATRunner extends BlockJUnit4ClassRunner {
                 // If the server has the FFDC checking flag set to false, skip it.
                 if (server.getFFDCChecking() == false) {
                     Log.info(c, "retrieveFFDCCounts", "FFDC log collection for server: " + server.getServerName() + " is skipped. FFDC Checking is disabled for this server.");
-                    break;
+                    continue;
                 }
 
                 int readAttempts = 0;


### PR DESCRIPTION
When `componenttest.topology.impl.LibertyServer.setFFDCChecking(false)` is called the FAT framework will avoid checking this server's FFDCs against the expected/allowed set.

However the logic in `componenttest.custom.junit.runner.FATRunner` is written to immediately abandon checking when any single server has FFDC checking disabled.   

This can prevent unexpected FFDCs from being detected and also prevent expected FFDCs from being matched.

The fix is to simply continue checking FFDCs with the next server, after seeing a server with checking disabled.