### PR TITLE
Perf improvements in webcontainer and JSF functions

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2/bnd.bnd
+++ b/dev/com.ibm.ws.jsf.2.2/bnd.bnd
@@ -137,7 +137,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 instrument.ffdc: false
 instrument.classesExcludes: \
     com/ibm/ws/jsf/resources/*.class, \
-    **/org/**
+    org/**/*.class
 
 -buildpath: \
 	org.apache.myfaces.buildtools:myfaces-builder-annotations;version=1.0.9,\

--- a/dev/com.ibm.ws.org.apache.myfaces.2.3/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.myfaces.2.3/bnd.bnd
@@ -72,7 +72,7 @@ com.ibm.ws.jsf.23.dd; \
 
 instrument.ffdc: false
 instrument.classesExcludes: \
-    **/org/**
+    org/**/*.class
 
 Include-Resource: \
   @${repo;org.apache.myfaces.core.impl;2.3.1;EXACT}!/META-INF/**, \

--- a/dev/com.ibm.ws.org.apache.myfaces.2.3/src/com/ibm/ws/jsf/config/WASApplicationImpl.java
+++ b/dev/com.ibm.ws.org.apache.myfaces.2.3/src/com/ibm/ws/jsf/config/WASApplicationImpl.java
@@ -23,6 +23,7 @@ import org.apache.myfaces.util.ExternalSpecifications;
 import org.apache.myfaces.application.ApplicationFactoryImpl;
 import org.apache.myfaces.cdi.util.CDIUtils;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jsf.extprocessor.JSFExtensionFactory;
 
 /**
@@ -45,6 +46,7 @@ public class WASApplicationImpl extends ApplicationWrapper
     }
     
     @Override
+    @Trivial
     public Application getWrapped()
     {
         return application;

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/GenericUtils.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/GenericUtils.java
@@ -875,10 +875,10 @@ public class GenericUtils {
     static public byte[] getBytes(String input) {
 
         if (null != input) {
-            char[] chars = input.toCharArray();
-            byte[] output = new byte[chars.length];
-            for (int i = 0; i < chars.length; i++) {
-                output[i] = (byte) chars[i];
+            int length = input.length();
+            byte[] output = new byte[length];
+            for (int i = 0; i < length; i++) {
+                output[i] = (byte) input.charAt(i);
             }
             return output;
         }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/KeyMatcher.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/KeyMatcher.java
@@ -19,12 +19,12 @@ public class KeyMatcher {
     /** Is this matcher case-sensitive */
     private boolean isCaseSensitive = false;
     /** List of buckets, one per allowed leading character */
-    private KeyBucket[] buckets = new KeyBucket[255];
+    private final KeyBucket[] buckets = new KeyBucket[255];
 
     /**
      * Constructor for a key matcher that uses the input case-sensitive flag
      * for comparisons.
-     * 
+     *
      * @param caseSensitive
      */
     public KeyMatcher(boolean caseSensitive) {
@@ -36,7 +36,7 @@ public class KeyMatcher {
 
     /**
      * Access the bucket for this specific character.
-     * 
+     *
      * @param c
      * @return HeaderBucket
      */
@@ -55,7 +55,7 @@ public class KeyMatcher {
 
     /**
      * Access the bucket for this specific character.
-     * 
+     *
      * @param c
      * @return HeaderBucket
      */
@@ -77,7 +77,7 @@ public class KeyMatcher {
 
     /**
      * Query whether this matcher is case-sensitive during comparisons.
-     * 
+     *
      * @return boolean
      */
     protected boolean isCaseSensitive() {
@@ -86,7 +86,7 @@ public class KeyMatcher {
 
     /**
      * Add a new enumerated object to the matcher.
-     * 
+     *
      * @param key
      */
     public synchronized void add(GenericKeys key) {
@@ -99,7 +99,7 @@ public class KeyMatcher {
     /**
      * Compare the input value against the stored list of objects and return a
      * match if found.
-     * 
+     *
      * @param name
      * @param start
      * @param length
@@ -111,7 +111,7 @@ public class KeyMatcher {
         }
         KeyBucket bucket = getBucket(name.charAt(start));
         if (null != bucket) {
-            return bucket.match(name.toCharArray(), start, length);
+            return bucket.match(name, start, length);
         }
         return null;
     }
@@ -119,7 +119,7 @@ public class KeyMatcher {
     /**
      * Compare the input value against the stored list of objects and return a
      * match if found.
-     * 
+     *
      * @param name
      * @param start
      * @param length
@@ -158,7 +158,7 @@ public class KeyMatcher {
 
         /**
          * Add the input key to this bucket.
-         * 
+         *
          * @param key
          */
         protected void add(GenericKeys key) {
@@ -180,7 +180,7 @@ public class KeyMatcher {
         /**
          * Compare the input value against the stored list of objects and return a
          * match if found.
-         * 
+         *
          * @param data
          * @param start
          * @param length
@@ -215,13 +215,13 @@ public class KeyMatcher {
         /**
          * Compare the input value against the stored list of objects and return a
          * match if found.
-         * 
+         *
          * @param data
          * @param start
          * @param length
          * @return GenericKeys, null if not found
          */
-        protected GenericKeys match(char[] data, int start, int length) {
+        protected GenericKeys match(String data, int start, int length) {
             int end = start + length - 1;
             int x, y;
             // save local refs to avoid problems with concurrent add() calls
@@ -234,7 +234,7 @@ public class KeyMatcher {
                     // potential match, scan backwards because most things vary
                     // later on... Content-Length vs Content-Language for example
                     for (x = end, y = temp.length - 1; x >= start; x--, y--) {
-                        if (!isEqual(data[x], temp[y])) {
+                        if (!isEqual(data.charAt(x), temp[y])) {
                             break; // out of the inner for loop
                         }
                     }
@@ -249,7 +249,7 @@ public class KeyMatcher {
 
         /**
          * Query whether these two characters are equal.
-         * 
+         *
          * @param c1
          * @param c2
          * @return true if equal, false otherwise

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/BufferedWriter.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/BufferedWriter.java
@@ -342,6 +342,7 @@ public class BufferedWriter extends Writer implements ResponseBuffer
      *          the number of chars to write
      * @exception IOException
      *              if an I/O error has occurred
+     * @Override
      */
     public void write(@Sensitive String str, int off, int len) throws IOException {
         if (len < 0) { throw new IndexOutOfBoundsException(); }
@@ -413,6 +414,7 @@ public class BufferedWriter extends Writer implements ResponseBuffer
      *          the number of chars to write
      * @exception IOException
      *              if an I/O error has occurred
+     * @Override
      */
     public void write(@Sensitive char[] b, int off, int len) throws IOException
     {

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/BufferedWriter.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/BufferedWriter.java
@@ -329,9 +329,82 @@ public class BufferedWriter extends Writer implements ResponseBuffer
     }
 
     /**
+     * Writes a String. This method will block until the String
+     * is actually written.
+     * 
+     * Any changes to this method should also be made to the write(char[], int, int) method
+     * 
+     * @param str
+     *          the data to be written
+     * @param off
+     *          the start offset of the data
+     * @param len
+     *          the number of chars to write
+     * @exception IOException
+     *              if an I/O error has occurred
+     */
+    public void write(@Sensitive String str, int off, int len) throws IOException {
+        if (len < 0) { throw new IndexOutOfBoundsException(); }
+        synchronized (lock) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            { // 306998.15
+                Tr.debug(tc, "write(String) total: " + total + " len: " + len + " limit: " + limit + " buf.length: " + buf.length + " count: " + count);
+            }
+            if (!_hasWritten && obs != null)
+            {
+                _hasWritten = true;
+                obs.alertFirstWrite();
+            }
+
+            if (limit > -1)
+            {
+                if (total + len > limit)
+                {
+                    len = (int)(limit - total);
+                    except = new WriteBeyondContentLengthException();
+                }
+            }
+
+            if (len >= buf.length)
+            {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                { // 306998.15
+                    Tr.debug(tc, "write(String), len >= buf.length");
+                }
+                response.setFlushMode(false);
+                flushChars();
+                total += len;
+                writeOut(str, off, len);
+                // out.flush(); moved to writeOut 277717 SVT:Mixed information shown on
+                // the Admin Console WAS.webcontainer
+                response.setFlushMode(true);
+                check();
+                return;
+            }
+            int avail = buf.length - count;
+            if (len > avail)
+            {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                { // 306998.15
+                    Tr.debug(tc, "write(String), len >= avail");
+                }
+                response.setFlushMode(false);
+                flushChars();
+                response.setFlushMode(true);
+            }
+            str.getChars(off, off+len, buf, count);
+            count += len;
+            total += len;
+            check();
+        }
+    }
+
+    /**
      * Writes an array of chars. This method will block until all the chars
      * are actually written.
      * 
+     * Any changes to this method should also be made to the write(String, int, int) method
+     *
      * @param b
      *          the data to be written
      * @param off
@@ -345,7 +418,7 @@ public class BufferedWriter extends Writer implements ResponseBuffer
     {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
         { // 306998.15
-            Tr.debug(tc, "write total: " + total + " len: " + len + " limit: " + limit + " buf.length: " + buf.length + " count: " + count);
+            Tr.debug(tc, "write(char[]) total: " + total + " len: " + len + " limit: " + limit + " buf.length: " + buf.length + " count: " + count);
         }
         if (len < 0)
         {
@@ -373,7 +446,7 @@ public class BufferedWriter extends Writer implements ResponseBuffer
         {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             { // 306998.15
-                Tr.debug(tc, "write, len >= buf.length");
+                Tr.debug(tc, "write(char[]), len >= buf.length");
             }
             response.setFlushMode(false);
             flushChars();
@@ -390,7 +463,7 @@ public class BufferedWriter extends Writer implements ResponseBuffer
         {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             { // 306998.15
-                Tr.debug(tc, "write, len >= avail");
+                Tr.debug(tc, "write(char[]), len >= avail");
             }
             response.setFlushMode(false);
             flushChars();
@@ -566,12 +639,54 @@ public class BufferedWriter extends Writer implements ResponseBuffer
 
     /*
      * Writes to the underlying stream
+     * 
+     * Any changes to this method should also be made to the writeOut(char[], int, int) method
+     */
+    protected void writeOut(String str, int offset, int len) throws IOException
+    {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+        { // 306998.15
+            Tr.debug(tc, "writeOut(String) --> " + len);
+        }
+        try
+        {
+            out.write(str, offset, len);
+            out.flush(); // 277717 SVT:Mixed information shown on the Admin Console
+            // WAS.webcontainer
+        }
+        catch (IOException ioe)
+        {
+            // No FFDC -- promote debug to event
+            //com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(ioe, "com.ibm.ws.webcontainer.srt.BufferedWriter.writeOut", "416", this);
+            count = 0;
+
+            // begin pq54943
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+            { // 306998.15
+                Tr.event(tc, "IOException occurred in writeOut(String) method, observer alerting close.", ioe);
+            }
+            // IOException occurred possibly due to SocketError from early browser
+            // closure...alert observer to close writer
+            obs.alertClose();
+            // end pq54943
+
+            // let the observer know that an exception has occurred...
+            obs.alertException();
+
+            throw ioe;
+        }
+    }
+
+    /*
+     * Writes to the underlying stream
+     * 
+     * Any changes to this method should also be made to the writeOut(String, int, int) method
      */
     protected void writeOut(char[] buf, int offset, int len) throws IOException
     {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
         { // 306998.15
-            Tr.debug(tc, "writeOut --> " + len);
+            Tr.debug(tc, "writeOut(char[]) --> " + len);
         }
         try
         {
@@ -588,7 +703,7 @@ public class BufferedWriter extends Writer implements ResponseBuffer
             // begin pq54943
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
             { // 306998.15
-                Tr.event(tc, "IOException occurred in writeOut method, observer alerting close.", ioe);
+                Tr.event(tc, "IOException occurred in writeOut(char[]) method, observer alerting close.", ioe);
             }
             // IOException occurred possibly due to SocketError from early browser
             // closure...alert observer to close writer


### PR DESCRIPTION
Several updates are being made to web container and JSF functions for performance reasons.

Avoid calling String.toCharArray() in favor of using String.getChars().  This reduces the creation of multiple char[]s during a request that goes through the web container. 
Turn off trace injection of org.apache.myfaces classes.  It appears that it wasn't working with the previous values in the bnd file.
Add @Trivial to a hot get method in the JSF code.

