### PR TITLE
Ignore SSLError on FAT that purposely misconfigures SSL

### DIFF
--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/SSLMutualAuthTests15.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/SSLMutualAuthTests15.java
@@ -39,7 +39,13 @@ public class SSLMutualAuthTests15 extends SSLCommonTests {
 
     @After
     public void stopTestServer() throws Exception {
-        super.stopServer(true);
+        String methodName = testName.getMethodName();
+
+        if ("testClientAuthNeedWithoutClientSideKeyStoreFor15".equals(methodName)) {
+            super.stopServer(true, "CWWKO0801E");
+        } else {
+            super.stopServer(true);
+        }
     }
 
     /* Passes when application property server.ssl.client-auth=NEED and if client side keystore and truststore are provided for authentication. */

--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/SSLMutualAuthTests20.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/SSLMutualAuthTests20.java
@@ -43,7 +43,13 @@ public class SSLMutualAuthTests20 extends SSLCommonTests {
 
     @After
     public void stopTestServer() throws Exception {
-        super.stopServer(true);
+        String methodName = testName.getMethodName();
+
+        if ("testClientAuthNeedWithoutClientSideKeyStoreFor20".equals(methodName)) {
+            super.stopServer(true, "CWWKO0801E");
+        } else {
+            super.stopServer(true);
+        }
     }
 
     /* Passes when application property server.ssl.client-auth=NEED and if client side keystore and truststore are provided for authentication. */


### PR DESCRIPTION
Ignore logged error "CWWKO0801E: Unable to initialize SSL connection" for a FAT where SSL is misconfigured as part of the test.
