### PR TITLE
Also handle UnsupportedOperationException in getCompatibleUpdateCount

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.2/src/com/ibm/ws/rsadapter/jdbc/v42/WSJdbc42PreparedStatement.java
+++ b/dev/com.ibm.ws.jdbc.4.2/src/com/ibm/ws/rsadapter/jdbc/v42/WSJdbc42PreparedStatement.java
@@ -52,7 +52,7 @@ public class WSJdbc42PreparedStatement extends WSJdbc41PreparedStatement impleme
         if (mcf.jdbcDriverSpecVersion >= 42 && mcf.supportsGetLargeUpdateCount) {
             try {
                 return stmtImpl.getLargeUpdateCount();
-            } catch (SQLFeatureNotSupportedException notSupp) {
+            } catch (SQLFeatureNotSupportedException | UnsupportedOperationException notSupp) {
                 mcf.supportsGetLargeUpdateCount = false;
             }
         }


### PR DESCRIPTION
Fixes #3703 

Need to also handle the JDK default implementation of `java.sql.Statement.getLargeUpdateCount()` which throws an `UnsupportedOperationException` instead of a `SQLFeatureNotSupportedException`

@eweitlaner FYI