### PR TITLE
Revert "force the use of tls 1.2"

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -38,6 +38,3 @@ bnd_defaultTask=build
 
 # This should be false. It only needs to be true in rare cases.
 bnd_preCompileRefresh=false
-
-systemProp.com.ibm.jsse2.overrideDefaultTLS=true
-org.gradle.daemon=false


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#4009

Since #4009 changes are delivered, there is no longer a need for this workaround.