### PR TITLE
Enable the jaxb-2.2 feature when java 2 security is enabled on the JP…

### DIFF
--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPABootstrapTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPABootstrapTest.java
@@ -35,7 +35,7 @@ import jpabootstrap.web.TestJPABootstrapServlet;
  *
  */
 @RunWith(FATRunner.class)
-public class JPABootstrapTest extends FATServletClient {
+public class JPABootstrapTest extends JPAFATServletClient {
     public static final String APP_NAME = "jpabootstrap";
     public static final String SERVLET = "TestJPABootstrap";
 
@@ -54,6 +54,8 @@ public class JPABootstrapTest extends FATServletClient {
         createApplication("2.0");
         createApplication("2.1");
         createApplication("2.2");
+
+        handleJava2SecurityWorkaround(server1);
 
         server1.startServer();
     }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -1,0 +1,32 @@
+/**
+ *
+ */
+package com.ibm.ws.jpa;
+
+import java.util.Set;
+
+import com.ibm.websphere.simplicity.config.FeatureManager;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.PrivHelper;
+
+/**
+ *
+ */
+public class JPAFATServletClient extends FATServletClient {
+    protected static void handleJava2SecurityWorkaround(LibertyServer server) throws Exception {
+        if (Boolean.parseBoolean(PrivHelper.getProperty("global.java2.sec", "true"))) {
+            System.out.println("JAG: True");
+            ServerConfiguration sc = server.getServerConfiguration();
+            FeatureManager fm = sc.getFeatureManager();
+            Set<String> features = fm.getFeatures();
+            features.add("jaxb-2.2");
+            server.updateServerConfiguration(sc);
+            server.saveServerConfiguration();
+        } else {
+            System.out.println("JAG: False");
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/CallbackTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/CallbackTest.java
@@ -24,13 +24,13 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.jpa.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.FATServletClient;
 import jpa10callback.web.CallbackOrderOfInvocationTestServlet;
 import jpa10callback.web.CallbackRuntimeExceptionTestServlet;
 import jpa10callback.web.CallbackTestServlet;
@@ -38,7 +38,7 @@ import jpa10callback.web.DefaultListenerCallbackRuntimeExceptionTestServlet;
 import jpa10callback.web.DefaultListenerCallbackTestServlet;
 
 @RunWith(FATRunner.class)
-public class CallbackTest extends FATServletClient {
+public class CallbackTest extends JPAFATServletClient {
     public static final String APP_NAME = "callback";
     public static final String SERVLET = "TestCallback";
     public static final String SERVLET2 = "DefaultTestCallback";
@@ -84,6 +84,8 @@ public class CallbackTest extends FATServletClient {
         sc.getApplications().add(appRecord);
         server1.updateServerConfiguration(sc);
         server1.saveServerConfiguration();
+
+        handleJava2SecurityWorkaround(server1);
 
         server1.startServer();
     }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22BeanValidation.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22BeanValidation.java
@@ -18,16 +18,16 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jpa.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.FATServletClient;
 import jpa22bval.web.JPABeanValTestServlet;
 
 @RunWith(FATRunner.class)
-public class JPA22BeanValidation extends FATServletClient {
+public class JPA22BeanValidation extends JPAFATServletClient {
     public static final String APP_NAME = "bval";
     public static final String SERVLET = "TestJPA22BeanValidation";
 
@@ -45,6 +45,8 @@ public class JPA22BeanValidation extends FATServletClient {
         ShrinkHelper.addDirectory(app, resPath);
         ShrinkHelper.exportAppToServer(server1, app);
         server1.addInstalledAppForValidation(APP_NAME);
+
+        handleJava2SecurityWorkaround(server1);
 
         server1.startServer();
     }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22Injection.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22Injection.java
@@ -18,12 +18,12 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jpa.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.FATServletClient;
 import jpa22injection.web.JPAInjectionTestServlet;
 
 /**
@@ -31,7 +31,7 @@ import jpa22injection.web.JPAInjectionTestServlet;
  *
  */
 @RunWith(FATRunner.class)
-public class JPA22Injection extends FATServletClient {
+public class JPA22Injection extends JPAFATServletClient {
     public static final String APP_NAME = "jpa22injection";
     public static final String SERVLET = "TestJPA22Injection";
 
@@ -49,6 +49,8 @@ public class JPA22Injection extends FATServletClient {
         ShrinkHelper.addDirectory(app, resPath);
         ShrinkHelper.exportAppToServer(server1, app);
         server1.addInstalledAppForValidation(APP_NAME);
+
+        handleJava2SecurityWorkaround(server1);
 
         server1.startServer();
     }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22QueryTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22QueryTest.java
@@ -18,12 +18,12 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jpa.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.FATServletClient;
 import jpa22query.web.JPAQueryTestServlet;
 
 /**
@@ -31,7 +31,7 @@ import jpa22query.web.JPAQueryTestServlet;
  *
  */
 @RunWith(FATRunner.class)
-public class JPA22QueryTest extends FATServletClient {
+public class JPA22QueryTest extends JPAFATServletClient {
     public static final String APP_NAME = "jpa22query";
     public static final String SERVLET = "TestJPA22Query";
 
@@ -49,6 +49,8 @@ public class JPA22QueryTest extends FATServletClient {
         ShrinkHelper.addDirectory(app, resPath);
         ShrinkHelper.exportAppToServer(server1, app);
         server1.addInstalledAppForValidation(APP_NAME);
+
+        handleJava2SecurityWorkaround(server1);
 
         server1.startServer();
     }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22TimeAPITest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22TimeAPITest.java
@@ -18,12 +18,12 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jpa.JPAFATServletClient;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.FATServletClient;
 import jpa22timeapi.web.JPATimeAPITestServlet;
 
 /**
@@ -31,7 +31,7 @@ import jpa22timeapi.web.JPATimeAPITestServlet;
  *
  */
 @RunWith(FATRunner.class)
-public class JPA22TimeAPITest extends FATServletClient {
+public class JPA22TimeAPITest extends JPAFATServletClient {
     public static final String APP_NAME = "jpa22timeapi";
     public static final String SERVLET = "TestJPAAPI";
 
@@ -49,6 +49,8 @@ public class JPA22TimeAPITest extends FATServletClient {
         ShrinkHelper.addDirectory(app, resPath);
         ShrinkHelper.exportAppToServer(server1, app);
         server1.addInstalledAppForValidation(APP_NAME);
+
+        handleJava2SecurityWorkaround(server1);
 
         server1.startServer();
     }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPACDIIntegrationTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPACDIIntegrationTest.java
@@ -18,6 +18,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jpa.JPAFATServletClient;
 
 import cdi.web.ELIServlet;
 import componenttest.annotation.Server;
@@ -31,7 +32,7 @@ import componenttest.topology.impl.LibertyServer;
  *
  */
 @RunWith(FATRunner.class)
-public class JPACDIIntegrationTest {
+public class JPACDIIntegrationTest extends JPAFATServletClient {
     public static final String APP_NAME = "cdi";
     public static final String SERVLET = "eli";
 
@@ -49,6 +50,8 @@ public class JPACDIIntegrationTest {
         ShrinkHelper.addDirectory(app, resPath);
         ShrinkHelper.exportAppToServer(server1, app);
         server1.addInstalledAppForValidation(APP_NAME);
+
+        handleJava2SecurityWorkaround(server1);
 
         server1.startServer();
     }


### PR DESCRIPTION
Enable the jaxb-2.2 feature when java 2 security is enabled on the JPA 2.2 fats.  Workaround for ACE in java-provided JAXB until resolved.

Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>

