### PR TITLE
Add heuristic knowledge of H2 JDBC driver

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDrivers.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDrivers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -200,6 +200,11 @@ public class JDBCDrivers {
                                  "org.postgresql.ds.PGConnectionPoolDataSource", 
                                  "org.postgresql.xa.PGXADataSource" };
         classNamesByKey.put("POSTGRESQL", classes);
+        
+        // H2 Database JDBC driver
+        className = "org.h2.jdbcx.JdbcDataSource";
+        classes = new String[] { className, className, className };
+        classNamesByKey.put("H2-", classes);
     }
 
     /**


### PR DESCRIPTION
This resulted from the following StackOverflow question: https://stackoverflow.com/questions/51330870/how-to-use-h2-database-with-jpa-on-websphere-liberty

H2 database is a popular simple database, commonly used for testing because it offers an in-memory option, just like Derby.

Currently, to use H2 with Liberty one must explicitly state the DataSource class names in the `<jdbcDriver>` config like so:
```xml
<dataSource id="h2test" jndiName="jdbc/h2test">
    <jdbcDriver 
        javax.sql.XADataSource="org.h2.jdbcx.JdbcDataSource"
        javax.sql.ConnectionPoolDataSource="org.h2.jdbcx.JdbcDataSource"
        javax.sql.DataSource="org.h2.jdbcx.JdbcDataSource" 
        libraryRef="H2JDBCLib"/>
    <properties URL="jdbc:h2:mem:testdb"/>
</dataSource>
```

We should map these classes to the presence of `h2-` on the JDBC driver classpath, which simplifies the above configuration to the following:
```xml
<dataSource id="h2test" jndiName="jdbc/h2test">
    <jdbcDriver libraryRef="H2JDBCLib"/>
    <properties URL="jdbc:h2:mem:testdb"/>
</dataSource>
```