### PR TITLE
Fix FaultToleranceCDIExtension and downgrade warning

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceCDIExtension.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceCDIExtension.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance.cdi;
 
+import static com.ibm.websphere.ras.TraceComponent.isAnyTracingEnabled;
 import static com.ibm.ws.microprofile.faulttolerance.cdi.config.FTGlobalConfig.ALL_ANNOTATIONS;
 
 import java.lang.annotation.Annotation;
@@ -105,8 +106,8 @@ public class FaultToleranceCDIExtension implements Extension, WebSphereCDIExtens
                         bulkhead.validate();
                     }
                 } else {
-                    if (tc.isWarningEnabled()) {
-                        Tr.warning(tc, "Annotation {0} on {1} was disabled and will be ignored", annotation.annotationType().getSimpleName(), clazz.getCanonicalName());
+                    if (isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Annotation {0} on {1} was disabled and will be ignored", annotation.annotationType().getSimpleName(), clazz.getCanonicalName());
                     }
                 }
             }
@@ -183,9 +184,9 @@ public class FaultToleranceCDIExtension implements Extension, WebSphereCDIExtens
                         bulkhead.validate();
                     }
                 } else {
-                    if (tc.isWarningEnabled()) {
-                        Tr.warning(tc, "Annotation {0} on {1} was disabled and will be ignored", annotation.annotationType().getSimpleName(),
-                                   clazz.getCanonicalName() + "." + method.getJavaMember().getName());
+                    if (isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Annotation {0} on {1} was disabled and will be ignored", annotation.annotationType().getSimpleName(),
+                                 clazz.getCanonicalName() + "." + method.getJavaMember().getName());
                     }
                 }
             }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
@@ -112,8 +112,8 @@ public class FaultToleranceInterceptor {
         Annotation[] annotations = targetClass.getAnnotations();
         for (Annotation annotation : annotations) {
 
-            //Check that the annotation has not been disabled for this specific class. 
-            if (FTGlobalConfig.isAnnotationEnabled(annotation, targetClass)) { 
+            //Check that the annotation has not been disabled for this specific class.
+            if (FTGlobalConfig.ALL_ANNOTATIONS.contains(annotation.annotationType()) && FTGlobalConfig.isAnnotationEnabled(annotation, targetClass)) {
 
                 if (annotation.annotationType().equals(Asynchronous.class)) {
                     asynchronous = new AsynchronousConfig(targetClass, (Asynchronous) annotation);
@@ -140,8 +140,8 @@ public class FaultToleranceInterceptor {
         annotations = method.getAnnotations();
         for (Annotation annotation : annotations) {
 
-            //Check that the annotation has not been disabled for this specific method. 
-            if (FTGlobalConfig.isAnnotationEnabled(annotation, targetClass, method)) { 
+            //Check that the annotation has not been disabled for this specific method.
+            if (FTGlobalConfig.ALL_ANNOTATIONS.contains(annotation.annotationType()) && FTGlobalConfig.isAnnotationEnabled(annotation, targetClass, method)) {
 
                 if (annotation.annotationType().equals(Asynchronous.class)) {
                     asynchronous = new AsynchronousConfig(method, targetClass, (Asynchronous) annotation);

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/config/FTGlobalConfig.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/config/FTGlobalConfig.java
@@ -64,7 +64,7 @@ public class FTGlobalConfig {
     }
 
     /**
-     * Checks if an annotation is enabled or disabled via configuration options. Annotations can be disabled with the following syntax:
+     * Checks if an fault tolerance annotation is enabled or disabled via configuration options. Annotations can be disabled with the following syntax:
      *
      * <ul>
      * <li>Disable at the method-level: com.acme.test.MyClient/serviceA/methodA/CircuitBreaker/enabled=false</li>
@@ -77,9 +77,14 @@ public class FTGlobalConfig {
      * @param ann The annotation
      * @param clazz The class containing the annotation.
      * @param method The method annotated with the annotation. If {@code null} only class and global scope properties will be checked.
+     * @throws IllegalArgumentException If passed a non-fault-tolerance annotation
      * @return Is the annotation enabled
      */
     public static boolean isAnnotationEnabled(Annotation ann, Class<?> clazz, Method method) {
+        if (!ALL_ANNOTATIONS.contains(ann.annotationType())) {
+            throw new IllegalArgumentException(ann + " is not a fault tolerance annotation");
+        }
+
         // Find the real class since we probably have a Weld proxy
         clazz = FTUtils.getRealClass(clazz);
         ClassLoader cl = FTUtils.getClassLoader(clazz);

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/config/FTGlobalConfig.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/config/FTGlobalConfig.java
@@ -42,8 +42,8 @@ public class FTGlobalConfig {
     private final static ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     private final static Set<Class<?>> ONLY_FALLBACK = Collections.singleton(Fallback.class);
-    private final static Set<Class<?>> ALL_ANNOTATIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Asynchronous.class, CircuitBreaker.class,
-                                                                                                                 Retry.class, Timeout.class, Bulkhead.class, Fallback.class)));
+    public final static Set<Class<?>> ALL_ANNOTATIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Asynchronous.class, CircuitBreaker.class,
+                                                                                                                Retry.class, Timeout.class, Bulkhead.class, Fallback.class)));
     private final static String CONFIG_NONFALLBACK_ENABLED = "MP_Fault_Tolerance_NonFallback_Enabled";
 
     /**
@@ -112,7 +112,7 @@ public class FTGlobalConfig {
         }
 
         //The lowest priority is a global disabling of all fault tolerence annotations. (Only check FT annotations. Fallback is exempt from this global configuration)
-        if (enabled == null && ALL_ANNOTATIONS.contains(ann.annotationType()) && !getActiveAnnotations(clazz).contains(ann.annotationType())){
+        if (enabled == null && !getActiveAnnotations(clazz).contains(ann.annotationType())) {
             enabled = false;
         }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/FATSuite.java
@@ -31,6 +31,7 @@ import com.ibm.websphere.microprofile.faulttolerance_fat.tests.CDIRetryTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.tests.CDITimeoutTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.tests.TxRetryReorderedTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.tests.TxRetryTest;
+import com.ibm.websphere.microprofile.faulttolerance_fat.tests.enablement.DisableEnableTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.validation.ValidationTest;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
@@ -48,6 +49,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
                 TestMultiModuleConfigLoad.class,
                 TestMultiModuleClassLoading.class,
                 ValidationTest.class,
+                DisableEnableTest.class,
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/enablement/DisableEnableClient.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/enablement/DisableEnableClient.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.enablement;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
+
+// Important: no annotation on the class
+// Empty beans.xml will make this a dependent bean
+public class DisableEnableClient {
+
+    private int failWithOneRetryCounter = 0;
+    private int failWithOneRetryAgainCounter = 0;
+
+    /**
+     * If Retry is enabled, this method will run twice, otherwise it will run once
+     */
+    @Retry(maxRetries = 1)
+    public void failWithOneRetry() throws ConnectException {
+        failWithOneRetryCounter++;
+        throw new ConnectException("Test Exception");
+    }
+
+    public int getFailWithOneRetryCounter() {
+        return failWithOneRetryCounter;
+    }
+
+    /**
+     * If Retry is enabled, this method will run twice, otherwise it will run once
+     */
+    @Retry(maxRetries = 1)
+    public void failWithOneRetryAgain() throws ConnectException {
+        failWithOneRetryAgainCounter++;
+        throw new ConnectException("Test Exception");
+    }
+
+    public int getFailWithOneRetryAgainCounter() {
+        return failWithOneRetryAgainCounter;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/enablement/DisableEnableServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/enablement/DisableEnableServlet.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.enablement;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/DisableEnableTest")
+public class DisableEnableServlet extends FATServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    DisableEnableClient client;
+
+    @Test
+    public void testDisableAtClassLevel() {
+        // Note, Retry is disabled for DisableEnableClient using config
+        // so we expect no retries here
+        assertThrows(ConnectException.class, client::failWithOneRetryAgain);
+        assertThat(client.getFailWithOneRetryAgainCounter(), is(1));
+    }
+
+    @Test
+    public void testDisableAtClassLevelEnableAtMethodLevel() {
+        // Note, Retry is disabled for DisableEnableClient but explicitly enabled for the failWithOneRetry method using config
+        // so we do expect a retry here
+        assertThrows(ConnectException.class, client::failWithOneRetry);
+        assertThat(client.getFailWithOneRetryCounter(), is(2));
+    }
+
+    private void assertThrows(Class<? extends Exception> expected, ThrowingRunnable runnable) {
+        try {
+            runnable.run();
+            fail("Exception not thrown, expected " + expected.getClass().getSimpleName());
+        } catch (Exception e) {
+            assertThat("Wrong exception type thrown", e, instanceOf(expected));
+        }
+    }
+
+    @FunctionalInterface
+    private static interface ThrowingRunnable {
+        public void run() throws Exception;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/enablement/DisableEnableTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/enablement/DisableEnableTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.enablement;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * These tests supplement the (fairly exhaustive) annotation enablement tests in the TCK
+ *
+ * They pick out specific liberty behaviour (like log messages) and also some specific edge cases we've tripped over in our implementation
+ */
+@RunWith(FATRunner.class)
+public class DisableEnableTest extends FATServletClient {
+
+    private static final String APP_NAME = "DisableEnable";
+    private static final String SERVER_NAME = "CDIFaultTolerance";
+
+    @Server(SERVER_NAME)
+    @TestServlet(servlet = DisableEnableServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .with(new FeatureReplacementAction("mpFaultTolerance-1.1").removeFeature("mpFaultTolerance-1.0").forServers(SERVER_NAME))
+                    .andWith(new FeatureReplacementAction("mpFaultTolerance-1.0").removeFeature("mpFaultTolerance-1.1").forServers(SERVER_NAME));
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        StringBuilder config = new StringBuilder();
+        config.append("com.ibm.websphere.microprofile.faulttolerance_fat.tests.enablement.DisableEnableClient/Retry/enabled=false\n");
+        config.append("com.ibm.websphere.microprofile.faulttolerance_fat.tests.enablement.DisableEnableClient/failWithOneRetry/Retry/enabled=true\n");
+        config.append("com.ibm.websphere.microprofile.faulttolerance_fat.tests.enablement.DisableEnableClassAnnotatedClient/Retry/enabled=false\n");
+
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addClasses(DisableEnableServlet.class, DisableEnableClient.class, ConnectException.class)
+                        .addAsResource(new StringAsset(config.toString()), "META-INF/microprofile-config.properties")
+                        .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ShrinkHelper.exportDropinAppToServer(server, app);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        server.stopServer();
+        server.removeDropinsApplications(APP_NAME + ".war");
+    }
+
+}

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
@@ -56,7 +56,7 @@ public class FeatureReplacementAction implements RepeatTestAction {
 
     private boolean forceAddFeatures = true;
     private int minJavaLevel = 7;
-    protected String currentID = toString();
+    protected String currentID = null;
     private final Set<String> servers = new HashSet<>(Arrays.asList(ALL_SERVERS));
     private final Set<String> clients = new HashSet<>(Arrays.asList(ALL_CLIENTS));
     private final Set<String> removeFeatures = new HashSet<>();
@@ -368,6 +368,10 @@ public class FeatureReplacementAction implements RepeatTestAction {
 
     @Override
     public String getID() {
-        return currentID;
+        if (currentID != null) {
+            return currentID;
+        } else {
+            return toString();
+        }
     }
 }


### PR DESCRIPTION
* Fix the logic that determines when to add the FaultToleranceInterceptor
* Add a test to demonstrate the edge case where the interceptor was not added correctly
* Downgrade warnings in FaultToleranceCDIExtension to debug
* Fix default ID for FeatureReplacementAction