### PR TITLE
Update JPA Container features to include internal JAXB-2.2 feature.

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.1/com.ibm.websphere.appserver.jpaContainer-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.1/com.ibm.websphere.appserver.jpaContainer-2.1.feature
@@ -16,6 +16,7 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.javax.persistence-2.1, \
  com.ibm.websphere.appserver.javax.annotation-1.2; apiJar=false, \
+ com.ibm.websphere.appserver.internal.jaxb-2.2, \
  com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.2", \
  com.ibm.websphere.appserver.transaction-1.2, \
  com.ibm.websphere.appserver.javaeeCompatible-7.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.2/com.ibm.websphere.appserver.jpaContainer-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-2.2/com.ibm.websphere.appserver.jpaContainer-2.2.feature
@@ -16,6 +16,7 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.javax.persistence-2.2, \
  com.ibm.websphere.appserver.javax.annotation-1.3; apiJar=false, \
+ com.ibm.websphere.appserver.internal.jaxb-2.2, \
  com.ibm.websphere.appserver.jdbc-4.2, \
  com.ibm.websphere.appserver.transaction-1.2, \
  com.ibm.websphere.appserver.javaeeCompatible-8.0

--- a/dev/com.ibm.ws.jpa.container/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.container/bnd.bnd
@@ -60,19 +60,13 @@ Import-Package: \
  javax.persistence.criteria;version="[1.1.0, 2.3.0)", \
  javax.persistence.metamodel;version="[1.1.0, 2.3.0)", \
  javax.persistence.spi;version="[1.1.0, 2.3.0)", \
- !javax.xml.bind.*, \
+ javax.xml.bind;version="[2.2, 3.0)", \
+ javax.xml.bind.annotation;version="[2.2, 3.0)", \
+ javax.xml.bind.annotation.adapters;version="[2.2, 3.0)", \
+ javax.xml.bind.attachment;version="[2.2, 3.0)", \
+ javax.xml.bind.helpers;version="[2.2, 3.0)", \
+ javax.xml.bind.util;version="[2.2, 3.0)", \
  *
- 
-# Use dynamicImport-Package for JAXB APIs, with this, Equonix will have a chance to wire
-# those packages to the JAXB-2.2 API if the target bundle is started, or the one from system
-# bundle will be always used due to JAXB 2.2 API is not resolved
-DynamicImport-Package: \
- javax.xml.bind, \
- javax.xml.bind.annotation, \
- javax.xml.bind.annotation.adapters, \
- javax.xml.bind.attachment, \
- javax.xml.bind.helpers, \
- javax.xml.bind.util
 
 instrument.classesIncludes: com/ibm/ws/jpa/container/osgi/**/*.class
 instrument.classesExcludes: com/ibm/ws/jpa/container/osgi/internal/url/FilterZipFileInputStream*.class


### PR DESCRIPTION
Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>

Reason as per ST discussion with @aguibert:

Andrew: at one point I found out that we don't trust the JDK's copy of jaxb in terms of j2sec, but we do trust our own copy from the jaxb-2.2 feature | 2:03:28 PM
so I'd prefer that we refactor our features to use our internal jaxb-2.2 feature (com.ibm.websphere.appserver.internal.jaxb-2.2) instead of the JDK copy. | 2:04:08 PM
this will also help us out in JDK 11 when JAX-B is removed from the JDK entirely | 2:04:23 PM

Updated to remove dynamic import in jpa container bnd.bnd file.