### PR TITLE
Fix NPE when checking for skipping

### DIFF
--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingClientFilter.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingClientFilter.java
@@ -155,7 +155,8 @@ public class OpentracingClientFilter implements ClientRequestFilter, ClientRespo
                        ClientResponseContext clientResponseContext) throws IOException {
         String methodName = "filter(incoming)";
 
-        if ((Boolean) clientRequestContext.getProperty(CLIENT_SPAN_SKIPPED_ID)) {
+        Boolean skip = (Boolean) clientRequestContext.getProperty(CLIENT_SPAN_SKIPPED_ID);
+        if ((skip != null) && skip) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, methodName, "skipped");
             }


### PR DESCRIPTION
Check for null in `clientRequestContext.getProperty(CLIENT_SPAN_SKIPPED_ID)`

fixes #4275