### PR TITLE
Enable Gradle daemon by default

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -40,4 +40,3 @@ bnd_defaultTask=build
 bnd_preCompileRefresh=false
 
 systemProp.com.ibm.jsse2.overrideDefaultTLS=true
-org.gradle.daemon=false


### PR DESCRIPTION
Since #4008 is delivered, the daemon can be used again.