### PR TITLE
prepare for driver class instead of data source class

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -440,7 +440,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                     Tr.debug(this, tc, "create new data source", id, jndiName, type);
 
                 CommonDataSource ds;
-                Class<? extends CommonDataSource> ifc;
+                Class<?> ifc;
 
                 if (type == null){
                     ds = id != null && id.contains("dataSource[DefaultDataSource]") ? jdbcDriverSvc.createDefaultDataSource(vProps)
@@ -585,7 +585,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
             jdbcDriverSvc.addObserver(this);
 
             CommonDataSource ds;
-            Class<? extends CommonDataSource> ifc;
+            Class<?> ifc;
 
             if(type == null){
                 ds = id != null && id.contains("dataSource[DefaultDataSource]") ? jdbcDriverSvc.createDefaultDataSource(vProps)

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
@@ -156,7 +156,7 @@ public class DB2JCCHelper extends DB2Helper {
         //  we need to check whether the impl class has the  correct configuration for zOS. we can't do
         // this checking in the constructor since we don't have the properties at that time.
         if (localZOS && driverType == 2) {
-            String dsClassName = mcf.getDataSourceClass().getName();
+            String dsClassName = mcf.vendorImplClass.getName();
             if (dsClassName.equals("com.ibm.db2.jcc.DB2XADataSource")) {
                 throw new ResourceException(AdapterUtil.getNLSMessage("DB2ZOS_TYPE2_ERROR"));
             } else if (dsClassName.equals("com.ibm.db2.jcc.DB2ConnectionPoolDataSource")) {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
@@ -140,13 +140,13 @@ public class DB2iNativeHelper extends DB2Helper {
             if (c == null) { 
                 if(System.getSecurityManager() == null)
                     com_ibm_db2_jdbc_app_DB2ConnectionHandle_class.set(
-                        c = mc.mcf.dataSourceImplClass.getClassLoader().loadClass("com.ibm.db2.jdbc.app.DB2ConnectionHandle"));
+                        c = mc.mcf.jdbcDriverLoader.loadClass("com.ibm.db2.jdbc.app.DB2ConnectionHandle"));
                 else 
                     com_ibm_db2_jdbc_app_DB2ConnectionHandle_class.set( 
                         c = AccessController.doPrivileged(new PrivilegedExceptionAction<Class<?>>() {
                             @Override
                             public Class<?> run() throws ClassNotFoundException {
-                                return mc.mcf.dataSourceImplClass.getClassLoader().loadClass("com.ibm.db2.jdbc.app.DB2ConnectionHandle");
+                                return mc.mcf.jdbcDriverLoader.loadClass("com.ibm.db2.jdbc.app.DB2ConnectionHandle");
                             }
                         }));
             }
@@ -162,13 +162,13 @@ public class DB2iNativeHelper extends DB2Helper {
             if (c == null) { 
                 if(System.getSecurityManager() == null)
                     com_ibm_db2_jdbc_app_UDBConnectionHandle_class.set(
-                        c = mc.mcf.dataSourceImplClass.getClassLoader().loadClass("com.ibm.db2.jdbc.app.UDBConnectionHandle"));               
+                        c = mc.mcf.jdbcDriverLoader.loadClass("com.ibm.db2.jdbc.app.UDBConnectionHandle"));               
                 else 
                     com_ibm_db2_jdbc_app_DB2ConnectionHandle_class.set( 
                         c = AccessController.doPrivileged(new PrivilegedExceptionAction<Class<?>>() {
                             @Override
                             public Class<?> run() throws ClassNotFoundException {
-                                return mc.mcf.dataSourceImplClass.getClassLoader().loadClass("com.ibm.db2.jdbc.app.UDBConnectionHandle");
+                                return mc.mcf.jdbcDriverLoader.loadClass("com.ibm.db2.jdbc.app.UDBConnectionHandle");
                             }
                         }));
             }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
@@ -143,13 +143,13 @@ public class DB2iToolboxHelper extends DB2Helper {
             if (c == null) {
                 if(System.getSecurityManager() == null)
                     com_ibm_as400_access_AS400JDBCConnectionHandle_class.set(
-                        c = mc.mcf.dataSourceImplClass.getClassLoader().loadClass("com.ibm.as400.access.AS400JDBCConnectionHandle"));
+                        c = mc.mcf.jdbcDriverLoader.loadClass("com.ibm.as400.access.AS400JDBCConnectionHandle"));
                 else 
                     com_ibm_as400_access_AS400JDBCConnectionHandle_class.set(
                         c = AccessController.doPrivileged(new PrivilegedExceptionAction<Class<?>>() {
                             @Override
                             public Class<?> run() throws ClassNotFoundException {
-                                return mc.mcf.dataSourceImplClass.getClassLoader().loadClass("com.ibm.as400.access.AS400JDBCConnectionHandle");
+                                return mc.mcf.jdbcDriverLoader.loadClass("com.ibm.as400.access.AS400JDBCConnectionHandle");
                             }
                         }));
             }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
@@ -57,7 +57,7 @@ public class SybaseHelper extends DatabaseHelper
     public boolean doConnectionCleanup(Connection conn) throws SQLException {
         boolean standardPropModified = false;
 
-        if (XADataSource.class.isAssignableFrom(mcf.dataSourceImplClass)) {
+        if (XADataSource.class.isAssignableFrom(mcf.vendorImplClass)) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "doConnectionCleanup(): calling setAutoCommit(true) and returning true from this method"); 
             conn.setAutoCommit(true);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -410,11 +410,11 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         {
             if (isTraceOn && tc.isDebugEnabled()) 
             {
-                if (!DataSource.class.equals(mcf.dataSourceInterface) && !mcf.isUCP)
+                if (!DataSource.class.equals(mcf.type) && !mcf.isUCP)
                     Tr.debug(this, tc, "##### poolConn is null which will cause is2Phase to always be false and that will cause XA to break");
             }
         }
-        else if (!DataSource.class.equals(mcf.dataSourceInterface) && !mcf.isUCP)
+        else if (!DataSource.class.equals(mcf.type) && !mcf.isUCP)
         {
             poolConn1.addConnectionEventListener(this); 
 


### PR DESCRIPTION
Updates to prepare for supporting java.sql.Driver in addition to data source.

This includes updating reflective code to use the 'jdbcDriverLoader' based of either the data source or java.sql.Driver implementation class from the JDBC vendor when loading JDBC vendor classes.

Ensure that DatabaseHelper selection of the built-in known types can be done correctly when java.sql.Driver implementation class name is used rather than data source implementation class name.   This applies to the following list of driver classes, 
   oracle.jdbc.driver.OracleDriver
   com.ibm.as400.access.AS400JDBCDriver
   com.ibm.db2.jdbc.app.DB2Driver
   com.microsoft.sqlserver.jdbc.SQLServerDriver
   com.ddtek.jdbc.sqlserver.SQLServerDriver
   com.informix.jdbc.IfxDriver
   com.sybase.jdbc#.jdbc.SybDriver
   org.apache.derby.jdbc.ClientDriver
   org.apache.derby.jdbc.EmbeddedDriver
   com.ibm.db2.jcc.DB2Driver
which corresponds to the JDBC vendors for which Liberty has customized DatabaseHelper implementations.

There is also some renaming of fields/updating comments to indicate that interface/implementation types can also be java.sql.Driver.