### PR TITLE
Updates to support URBridge audit testing

### DIFF
--- a/dev/com.ibm.ws.security.wim.core/resources/com/ibm/ws/security/wim/util/resources/WimUtilMessages.nlsprops
+++ b/dev/com.ibm.ws.security.wim.core/resources/com/ibm/ws/security/wim/util/resources/WimUtilMessages.nlsprops
@@ -248,7 +248,7 @@ MALFORMED_SEARCH_EXPRESSION=CWIML3006W: The user registry operation could not be
 MALFORMED_SEARCH_EXPRESSION.explanation=The search operation cannot be performed because the search expression is not valid.
 MALFORMED_SEARCH_EXPRESSION.useraction=Provide a valid search expression.
 
-ENTITY_SEARCH_FAILED=CWIML4506E: The user registry operation could not be completed because the user registry encountered the underlying error : {1}
+ENTITY_SEARCH_FAILED=CWIML4506E: The user registry operation could not be completed because the user registry encountered the underlying error : {0}
 ENTITY_SEARCH_FAILED.explanation=The entity cannot be searched because of the reason specified by the underlying registry.
 ENTITY_SEARCH_FAILED.useraction=Review the reason message and the trace file to determine the cause of the failure. Fix the error and try again.
 

--- a/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/ProfileManager.java
+++ b/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/ProfileManager.java
@@ -38,6 +38,7 @@ import com.ibm.websphere.security.wim.util.PasswordUtil;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.audit.Audit;
 import com.ibm.ws.security.wim.env.ICacheUtil;
+import com.ibm.ws.security.wim.util.AuditConstants;
 import com.ibm.ws.security.wim.util.ControlsHelper;
 import com.ibm.ws.security.wim.util.SchemaConstantsInternal;
 import com.ibm.ws.security.wim.util.SortHandler;
@@ -164,15 +165,6 @@ public class ProfileManager implements ProfileServiceLite {
     //TODO For now it doesn't make any diff. Could be be implemented as service only LA comes in picture
     PropertyManager propMgr = new PropertyManager();
 
-    /*
-     * Contants for populating the audit records
-     */
-    private static final String CREATE_AUDIT = "create";
-    private static final String GET_AUDIT = "get";
-    private static final String UPDATE_AUDIT = "update";
-    private static final String DELETE_AUDIT = "delete";
-    private static final String SEARCH_AUDIT = "search";
-
     /**
      * @param repositoryManager
      */
@@ -290,7 +282,7 @@ public class ProfileManager implements ProfileServiceLite {
             Tr.debug(tc, "targetReposID = ", targetReposId);
         }
         auditManager.setRepositoryId(targetReposId);
-        auditManager.setRequestType(GET_AUDIT);
+        auditManager.setRequestType(AuditConstants.GET_AUDIT);
 
         String realmName = getRealmName(inRoot);
 
@@ -330,7 +322,8 @@ public class ProfileManager implements ProfileServiceLite {
             IdentifierType identifier = entity.getIdentifier();
 
             if (identifier == null) {
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), GET_AUDIT, targetReposId, null, getRealmName(inRoot), inRoot,
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.GET_AUDIT, targetReposId, null, getRealmName(inRoot),
+                            inRoot,
                             Integer.valueOf("203"));
 
                 throw new EntityIdentifierNotSpecifiedException(WIMMessageKey.ENTITY_IDENTIFIER_NOT_SPECIFIED, Tr.formatMessage(
@@ -375,7 +368,8 @@ public class ProfileManager implements ProfileServiceLite {
                         }
                         continue;
                     }
-                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), GET_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.GET_AUDIT, targetReposId, uniqueName, realmName,
+                                inRoot,
                                 Integer.valueOf("210"));
 
                     throw new WIMApplicationException(WIMMessageKey.EXTERNAL_NAME_CONTROL_NOT_FOUND, Tr.formatMessage(
@@ -384,7 +378,8 @@ public class ProfileManager implements ProfileServiceLite {
                                                                                                                       WIMMessageHelper.generateMsgParms(externalName)));
                 }
 
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), GET_AUDIT, targetReposId, uniqueName, realmName, inRoot, Integer.valueOf("211"));
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.GET_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                            Integer.valueOf("211"));
 
                 throw new InvalidIdentifierException(WIMMessageKey.INVALID_IDENTIFIER, Tr.formatMessage(
                                                                                                         tc,
@@ -432,7 +427,8 @@ public class ProfileManager implements ProfileServiceLite {
             realmName = getRealmName(inRoot);
             if (realmName != null && !getConfigManager().isUniqueNameInRealm(uniqueName, realmName) &&
                 UniqueNameHelper.isDN(uniqueName) != null) {
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), GET_AUDIT, repositoryId, uniqueName, realmName, inRoot, Integer.valueOf("204"));
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.GET_AUDIT, repositoryId, uniqueName, realmName, inRoot,
+                            Integer.valueOf("204"));
 
                 throw new EntityNotInRealmScopeException(WIMMessageKey.ENTITY_NOT_IN_REALM_SCOPE, Tr.formatMessage(
                                                                                                                    tc,
@@ -523,7 +519,8 @@ public class ProfileManager implements ProfileServiceLite {
                     }
                 }
                 if (retSRoot == null) {
-                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), GET_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.GET_AUDIT, targetReposId, uniqueName, realmName,
+                                inRoot,
                                 Integer.valueOf("212"));
 
                     throw new EntityNotFoundException(WIMMessageKey.ENTITY_NOT_FOUND, Tr.formatMessage(
@@ -618,7 +615,8 @@ public class ProfileManager implements ProfileServiceLite {
             }
 
             if (sortKeys == null || sortKeys.size() == 0) {
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), GET_AUDIT, targetReposId, uniqueName, realmName, inRoot, Integer.valueOf("213"));
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.GET_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                            Integer.valueOf("213"));
 
                 throw new SortControlException(WIMMessageKey.MISSING_SORT_KEY, Tr.formatMessage(
                                                                                                 tc,
@@ -642,7 +640,7 @@ public class ProfileManager implements ProfileServiceLite {
             context.setValue(failureRepositoryIds);
         }
 
-        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), GET_AUDIT, targetReposId, uniqueName,
+        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.GET_AUDIT, targetReposId, uniqueName,
                     realmName = (realmName != null) ? realmName : auditManager.getRealm(), retRoot, Integer.valueOf("200"));
 
         return retRoot;
@@ -700,7 +698,7 @@ public class ProfileManager implements ProfileServiceLite {
             Tr.debug(tc, "targetReposID = ", targetReposId);
         }
         auditManager.setRepositoryId(targetReposId);
-        auditManager.setRequestType(SEARCH_AUDIT);
+        auditManager.setRequestType(AuditConstants.SEARCH_AUDIT);
 
         List<Entity> entitys = inRoot.getEntities();
         if (entitys != null && !entitys.isEmpty()) {
@@ -757,7 +755,8 @@ public class ProfileManager implements ProfileServiceLite {
             cacheKey = getPageCacheKey(searchControl, sortControl);
 
         if (searchControl == null && pageControl == null) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot, Integer.valueOf("214"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                        Integer.valueOf("214"));
 
             throw new MissingSearchControlException(WIMMessageKey.MISSING_SEARCH_CONTROL, Tr.formatMessage(
                                                                                                            tc,
@@ -861,7 +860,8 @@ public class ProfileManager implements ProfileServiceLite {
             }
             searchLimit = searchControl.getSearchLimit();
             if (searchLimit < 0) {
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.SEARCH_AUDIT, targetReposId, uniqueName, realmName,
+                            inRoot,
                             Integer.valueOf("215"));
 
                 throw new SearchControlException(WIMMessageKey.INCORRECT_SEARCH_LIMIT, Tr.formatMessage(
@@ -872,7 +872,8 @@ public class ProfileManager implements ProfileServiceLite {
             long timeLimit = searchControl.getTimeLimit();
 
             if (searchCountLimit > 0 && pageControl != null) {
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.SEARCH_AUDIT, targetReposId, uniqueName, realmName,
+                            inRoot,
                             Integer.valueOf("216"));
 
                 throw new SearchControlException(WIMMessageKey.CANNOT_SPECIFY_COUNT_LIMIT, Tr.formatMessage(
@@ -909,7 +910,8 @@ public class ProfileManager implements ProfileServiceLite {
                 String searchExpr = searchControl.getExpression();
                 if (!bFirstChangeSearchCall) {
                     if (searchExpr == null || searchExpr.length() == 0) {
-                        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.SEARCH_AUDIT, targetReposId, uniqueName,
+                                    realmName, inRoot,
                                     Integer.valueOf("217"));
 
                         throw new SearchControlException(WIMMessageKey.MISSING_SEARCH_EXPRESSION, Tr.formatMessage(
@@ -966,7 +968,8 @@ public class ProfileManager implements ProfileServiceLite {
                             exceptionMessage = anse.getMessage();
                             continue;
                         } catch (ParseException pe) {
-                            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.SEARCH_AUDIT, targetReposId, uniqueName,
+                                        realmName, inRoot,
                                         Integer.valueOf("218"));
 
                             throw new SearchControlException(WIMMessageKey.SEARCH_EXPRESSION_ERROR, Tr.formatMessage(
@@ -974,7 +977,8 @@ public class ProfileManager implements ProfileServiceLite {
                                                                                                                      WIMMessageKey.SEARCH_EXPRESSION_ERROR,
                                                                                                                      WIMMessageHelper.generateMsgParms(pe.getMessage())));
                         } catch (TokenMgrError e) {
-                            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.SEARCH_AUDIT, targetReposId, uniqueName,
+                                        realmName, inRoot,
                                         Integer.valueOf("219"));
 
                             throw new SearchControlException(WIMMessageKey.INVALID_SEARCH_EXPRESSION, Tr.formatMessage(
@@ -1004,7 +1008,8 @@ public class ProfileManager implements ProfileServiceLite {
                 //If the attribute in the search expression is not supported by any repository where search is to be performed,then
                 // SearhControlException is thrown.
                 if (!propFound) {
-                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.SEARCH_AUDIT, targetReposId, uniqueName, realmName,
+                                inRoot,
                                 Integer.valueOf("218"));
 
                     throw new SearchControlException(WIMMessageKey.SEARCH_EXPRESSION_ERROR, Tr.formatMessage(
@@ -1081,7 +1086,8 @@ public class ProfileManager implements ProfileServiceLite {
             searchLimit = (getConfigManager().getMaxSearchResults() > searchLimit ? searchLimit : getConfigManager().getMaxSearchResults());
         }
         if (searchLimit > 0 && reEntitySize > searchLimit) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot, Integer.valueOf("220"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                        Integer.valueOf("220"));
 
             throw new MaxResultsExceededException(WIMMessageKey.EXCEED_MAX_TOTAL_SEARCH_LIMIT, Tr.formatMessage(
                                                                                                                 tc,
@@ -1130,7 +1136,8 @@ public class ProfileManager implements ProfileServiceLite {
                 }));
             }
             if (sortKeys == null || sortKeys.size() == 0) {
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), SEARCH_AUDIT, targetReposId, uniqueName, realmName, inRoot,
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.SEARCH_AUDIT, targetReposId, uniqueName, realmName,
+                            inRoot,
                             Integer.valueOf("213"));
 
                 throw new SortControlException(WIMMessageKey.MISSING_SORT_KEY, Tr.formatMessage(
@@ -1224,7 +1231,7 @@ public class ProfileManager implements ProfileServiceLite {
             }
         }
 
-        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), SEARCH_AUDIT, targetReposId, uniqueName,
+        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.SEARCH_AUDIT, targetReposId, uniqueName,
                     realmName = (realmName != null) ? realmName : auditManager.getRealm(), retRootDO,
                     Integer.valueOf("200"));
 
@@ -2677,7 +2684,7 @@ public class ProfileManager implements ProfileServiceLite {
             return null;
 
         AuditManager auditManager = new AuditManager();
-        auditManager.setRequestType(DELETE_AUDIT);
+        auditManager.setRequestType(AuditConstants.DELETE_AUDIT);
         if (repositoryManager.getNumberOfRepositories() == 1) {
             auditManager.setRepositoryId(repositoryManager.getRepoIds().get(0));
         }
@@ -2692,13 +2699,15 @@ public class ProfileManager implements ProfileServiceLite {
         List<Entity> entities = root.getEntities();
 
         if (entities.size() == 0) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), DELETE_AUDIT, null, null, getRealmName(root), root, Integer.valueOf("201"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.DELETE_AUDIT, null, null, getRealmName(root), root,
+                        Integer.valueOf("201"));
 
             throw new EntityNotFoundException(WIMMessageKey.MISSING_ENTITY_DATA_OBJECT, Tr.formatMessage(tc,
                                                                                                          WIMMessageKey.MISSING_ENTITY_DATA_OBJECT,
                                                                                                          WIMMessageHelper.generateMsgParms(DELETE_EMITTER)));
         } else if (entities.size() > 1) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), DELETE_AUDIT, null, null, getRealmName(root), root, Integer.valueOf("202"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.DELETE_AUDIT, null, null, getRealmName(root), root,
+                        Integer.valueOf("202"));
 
             throw new OperationNotSupportedException(WIMMessageKey.ACTION_MULTIPLE_ENTITIES_SPECIFIED, Tr.formatMessage(tc,
                                                                                                                         WIMMessageKey.ACTION_MULTIPLE_ENTITIES_SPECIFIED,
@@ -2720,7 +2729,8 @@ public class ProfileManager implements ProfileServiceLite {
 
         IdentifierType identifier = entity.getIdentifier();
         if (identifier == null) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), DELETE_AUDIT, null, null, getRealmName(root), root, Integer.valueOf("203"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.DELETE_AUDIT, null, null, getRealmName(root), root,
+                        Integer.valueOf("203"));
 
             throw new EntityIdentifierNotSpecifiedException(WIMMessageKey.ENTITY_IDENTIFIER_NOT_SPECIFIED, Tr.formatMessage(tc, WIMMessageKey.ENTITY_IDENTIFIER_NOT_SPECIFIED));
         }
@@ -2735,7 +2745,8 @@ public class ProfileManager implements ProfileServiceLite {
         // check realm
         String realmName = getRealmName(root);
         if (realmName != null && !getConfigManager().isUniqueNameInRealm(uniqueName, realmName)) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), DELETE_AUDIT, repositoryId, uniqueName, realmName, root, Integer.valueOf("204"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.DELETE_AUDIT, repositoryId, uniqueName, realmName, root,
+                        Integer.valueOf("204"));
 
             throw new EntityNotInRealmScopeException(WIMMessageKey.ENTITY_NOT_IN_REALM_SCOPE, Tr.formatMessage(tc, WIMMessageKey.ENTITY_NOT_IN_REALM_SCOPE,
                                                                                                                WIMMessageHelper.generateMsgParms(uniqueName, realmName)));
@@ -2752,7 +2763,8 @@ public class ProfileManager implements ProfileServiceLite {
         try {
             retRoot = repositoryManager.getRepository(repositoryId).delete(root);
         } catch (EntityNotFoundException ex) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), DELETE_AUDIT, repositoryId, uniqueName, realmName, root, Integer.valueOf("212"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.DELETE_AUDIT, repositoryId, uniqueName, realmName, root,
+                        Integer.valueOf("212"));
             throw ex;
         }
 
@@ -2760,7 +2772,8 @@ public class ProfileManager implements ProfileServiceLite {
             retRoot = postDelete(retRoot, repositoryId, returnDeleted);
         }
 
-        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), DELETE_AUDIT, repositoryId, uniqueName, realmName, retRoot, Integer.valueOf("200"));
+        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.DELETE_AUDIT, repositoryId, uniqueName, realmName, retRoot,
+                    Integer.valueOf("200"));
 
         return retRoot;
     }
@@ -2808,15 +2821,17 @@ public class ProfileManager implements ProfileServiceLite {
         }
         auditManager.setRepositoryId(targetReposId);
         auditManager.setRepositoryRealm(realmName);
-        auditManager.setRequestType(CREATE_AUDIT);
+        auditManager.setRequestType(AuditConstants.CREATE_AUDIT);
 
         if (entities.size() == 0) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, null, getRealmName(root), root, Integer.valueOf("201"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId, null, getRealmName(root), root,
+                        Integer.valueOf("201"));
 
             throw new EntityNotFoundException(WIMMessageKey.MISSING_ENTITY_DATA_OBJECT, Tr.formatMessage(tc, WIMMessageKey.MISSING_ENTITY_DATA_OBJECT,
                                                                                                          WIMMessageHelper.generateMsgParms(RepositoryManager.ACTION_CREATE)));
         } else if (entities.size() > 1) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, null, getRealmName(root), root, Integer.valueOf("202"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId, null, getRealmName(root), root,
+                        Integer.valueOf("202"));
 
             throw new OperationNotSupportedException(WIMMessageKey.ACTION_MULTIPLE_ENTITIES_SPECIFIED, Tr.formatMessage(tc, WIMMessageKey.ACTION_MULTIPLE_ENTITIES_SPECIFIED,
                                                                                                                         WIMMessageHelper.generateMsgParms(RepositoryManager.ACTION_CREATE)));
@@ -2852,14 +2867,15 @@ public class ProfileManager implements ProfileServiceLite {
                             if (entity != null && entity.getIdentifier() != null) {
                                 if (tc.isDebugEnabled())
                                     Tr.debug(tc, "entity not null, parentDN null");
-                                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId,
+                                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId,
                                             entity.getIdentifier().getUniqueName(),
                                             realmName, root,
                                             Integer.valueOf("205"));
                             } else {
                                 if (tc.isDebugEnabled())
                                     Tr.debug(tc, "entity null, parentDN null");
-                                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, null, realmName, root,
+                                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId, null,
+                                            realmName, root,
                                             Integer.valueOf("205"));
                             }
                             throw new InvalidUniqueIdException(WIMMessageKey.INVALID_PARENT_UNIQUE_ID, Tr.formatMessage(tc, WIMMessageKey.INVALID_PARENT_UNIQUE_ID,
@@ -2871,13 +2887,15 @@ public class ProfileManager implements ProfileServiceLite {
                 if (entity != null && entity.getIdentifier() != null) {
                     if (tc.isDebugEnabled())
                         Tr.debug(tc, "parent.isSetIdentifier null, entity not null");
-                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, entity.getIdentifier().getUniqueName(),
+                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId,
+                                entity.getIdentifier().getUniqueName(),
                                 realmName,
                                 inRoot, Integer.valueOf("205"));
                 } else {
                     if (tc.isDebugEnabled())
                         Tr.debug(tc, "parent.isSetIdentifier null, entity null");
-                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, null, realmName, inRoot, Integer.valueOf("205"));
+                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId, null, realmName, inRoot,
+                                Integer.valueOf("205"));
                 }
                 throw new InvalidUniqueIdException(WIMMessageKey.INVALID_PARENT_UNIQUE_ID, Tr.formatMessage(tc, WIMMessageKey.INVALID_PARENT_UNIQUE_ID,
                                                                                                             WIMMessageHelper.generateMsgParms(null)));
@@ -2901,10 +2919,12 @@ public class ProfileManager implements ProfileServiceLite {
 
         if (parentDN == null) {
             if (entity != null && entity.getIdentifier() != null)
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, entity.getIdentifier().getUniqueName(), realmName,
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId,
+                            entity.getIdentifier().getUniqueName(), realmName,
                             root, Integer.valueOf("206"));
             else
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, null, realmName, root, Integer.valueOf("206"));
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId, null, realmName, root,
+                            Integer.valueOf("206"));
 
             throw new DefaultParentNotFoundException(WIMMessageKey.DEFAULT_PARENT_NOT_FOUND, Tr.formatMessage(tc, WIMMessageKey.DEFAULT_PARENT_NOT_FOUND,
                                                                                                               WIMMessageHelper.generateMsgParms(qualifiedEntityType, realmName)));
@@ -2912,10 +2932,12 @@ public class ProfileManager implements ProfileServiceLite {
 
         if (!getConfigManager().isUniqueNameInRealm(parentDN, realmName)) {
             if (entity != null && entity.getIdentifier() != null)
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, entity.getIdentifier().getUniqueName(), realmName,
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId,
+                            entity.getIdentifier().getUniqueName(), realmName,
                             root, Integer.valueOf("204"));
             else
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, null, realmName, root, Integer.valueOf("204"));
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId, null, realmName, root,
+                            Integer.valueOf("204"));
 
             throw new EntityNotInRealmScopeException(WIMMessageKey.ENTITY_NOT_IN_REALM_SCOPE, Tr.formatMessage(tc, WIMMessageKey.ENTITY_NOT_IN_REALM_SCOPE,
                                                                                                                WIMMessageHelper.generateMsgParms(parentDN, realmName)));
@@ -2938,7 +2960,8 @@ public class ProfileManager implements ProfileServiceLite {
                     || !entityUniqueName.endsWith(parentDN)) {
                     if (tc.isDebugEnabled())
                         Tr.debug(tc, "entity not being created under the right parent");
-                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, entity.getIdentifier().getUniqueName(),
+                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId,
+                                entity.getIdentifier().getUniqueName(),
                                 realmName,
                                 inRoot, Integer.valueOf("205"));
 
@@ -2975,7 +2998,8 @@ public class ProfileManager implements ProfileServiceLite {
                         String reposId = retrieveTargetRepository(memberId);
                         boolean crossRepos = repositoryManager.canGroupAcceptMember(targetReposId, reposId);
                         if (!(crossRepos || targetReposId.equalsIgnoreCase(reposId))) {
-                            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, entity.getIdentifier().getUniqueName(),
+                            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId,
+                                        entity.getIdentifier().getUniqueName(),
                                         realmName, root,
                                         Integer.valueOf("207"));
                             throw new OperationNotSupportedException(WIMMessageKey.MISSING_REPOSITORIES_FOR_GROUPS_CONFIGURATION, Tr.formatMessage(tc,
@@ -3018,10 +3042,12 @@ public class ProfileManager implements ProfileServiceLite {
 
         if (!SchemaConstants.DO_PERSON_ACCOUNT.equalsIgnoreCase(qualifiedEntityType) && !SchemaConstants.DO_GROUP.equalsIgnoreCase(qualifiedEntityType)) {
             if (entity != null && entity.getIdentifier() != null)
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, entity.getIdentifier().getUniqueName(), realmName,
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId,
+                            entity.getIdentifier().getUniqueName(), realmName,
                             root, Integer.valueOf("208"));
             else
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, null, realmName, root, Integer.valueOf("208"));
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId, null, realmName, root,
+                            Integer.valueOf("208"));
 
             throw new EntityTypeNotSupportedException(WIMMessageKey.ENTITY_TYPE_NOT_SUPPORTED, Tr.formatMessage(tc, WIMMessageKey.ENTITY_TYPE_NOT_SUPPORTED,
                                                                                                                 WIMMessageHelper.generateMsgParms(qualifiedEntityType)));
@@ -3029,10 +3055,12 @@ public class ProfileManager implements ProfileServiceLite {
 
         if (entity.getIdentifier() == null || entity.getIdentifier().getUniqueName() == null) {
             if (entity != null && entity.getIdentifier() != null)
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, entity.getIdentifier().getUniqueName(), realmName,
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId,
+                            entity.getIdentifier().getUniqueName(), realmName,
                             root, Integer.valueOf("203"));
             else
-                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, null, realmName, root, Integer.valueOf("203"));
+                Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId, null, realmName, root,
+                            Integer.valueOf("203"));
             throw new EntityIdentifierNotSpecifiedException(WIMMessageKey.ENTITY_IDENTIFIER_NOT_SPECIFIED, Tr.formatMessage(tc, WIMMessageKey.ENTITY_IDENTIFIER_NOT_SPECIFIED));
         }
 
@@ -3078,7 +3106,8 @@ public class ProfileManager implements ProfileServiceLite {
 
                         update(newRoot);
                     } else {
-                        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, entity.getIdentifier().getUniqueName(),
+                        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId,
+                                    entity.getIdentifier().getUniqueName(),
                                     realmName, created,
                                     Integer.valueOf("207"));
                         throw new OperationNotSupportedException(WIMMessageKey.MISSING_REPOSITORIES_FOR_GROUPS_CONFIGURATION, Tr.formatMessage(tc,
@@ -3094,7 +3123,8 @@ public class ProfileManager implements ProfileServiceLite {
 
         unsetExternalId(created);
 
-        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), CREATE_AUDIT, targetReposId, uniqueName, realmName, created, Integer.valueOf("200"));
+        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.CREATE_AUDIT, targetReposId, uniqueName, realmName, created,
+                    Integer.valueOf("200"));
 
         return created;
     }
@@ -3325,7 +3355,7 @@ public class ProfileManager implements ProfileServiceLite {
         }
 
         AuditManager auditManager = new AuditManager();
-        auditManager.setRequestType(UPDATE_AUDIT);
+        auditManager.setRequestType(AuditConstants.UPDATE_AUDIT);
         if (repositoryManager.getNumberOfRepositories() == 1) {
             auditManager.setRepositoryId(repositoryManager.getRepoIds().get(0));
         }
@@ -3396,7 +3426,8 @@ public class ProfileManager implements ProfileServiceLite {
                                 String messageKey = e.getMessageKey();
                                 // If this message is thrown by a read only adapter i.e. UR Bridge, then consume this exception.
                                 if (WIMMessageKey.CANNOT_WRITE_TO_READ_ONLY_REPOSITORY.equalsIgnoreCase(messageKey)) {
-                                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), UPDATE_AUDIT, repositoryId, id.getUniqueName(),
+                                    Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.UPDATE_AUDIT, repositoryId,
+                                                id.getUniqueName(),
                                                 getRealmName(root), root,
                                                 Integer.valueOf("209"));
                                     // Consuming this exception
@@ -3463,11 +3494,13 @@ public class ProfileManager implements ProfileServiceLite {
         List<Entity> entities = root.getEntities();
 
         if (entities.size() == 0) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), UPDATE_AUDIT, repositoryId, null, getRealmName(root), root, Integer.valueOf("201"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.UPDATE_AUDIT, repositoryId, null, getRealmName(root), root,
+                        Integer.valueOf("201"));
             throw new EntityNotFoundException(WIMMessageKey.MISSING_ENTITY_DATA_OBJECT, Tr.formatMessage(tc, WIMMessageKey.MISSING_ENTITY_DATA_OBJECT,
                                                                                                          WIMMessageHelper.generateMsgParms(RepositoryManager.ACTION_DELETE)));
         } else if (entities.size() > 1) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), UPDATE_AUDIT, repositoryId, null, getRealmName(root), root, Integer.valueOf("202"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.UPDATE_AUDIT, repositoryId, null, getRealmName(root), root,
+                        Integer.valueOf("202"));
             throw new OperationNotSupportedException(WIMMessageKey.ACTION_MULTIPLE_ENTITIES_SPECIFIED, Tr.formatMessage(tc, WIMMessageKey.ACTION_MULTIPLE_ENTITIES_SPECIFIED,
                                                                                                                         WIMMessageHelper.generateMsgParms(RepositoryManager.ACTION_DELETE)));
         }
@@ -3480,7 +3513,8 @@ public class ProfileManager implements ProfileServiceLite {
 
         IdentifierType identifier = entity.getIdentifier();
         if (identifier == null) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), UPDATE_AUDIT, repositoryId, null, getRealmName(root), root, Integer.valueOf("203"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.UPDATE_AUDIT, repositoryId, null, getRealmName(root), root,
+                        Integer.valueOf("203"));
             throw new EntityIdentifierNotSpecifiedException(WIMMessageKey.ENTITY_IDENTIFIER_NOT_SPECIFIED, Tr.formatMessage(tc, WIMMessageKey.ENTITY_IDENTIFIER_NOT_SPECIFIED));
         }
 
@@ -3499,7 +3533,8 @@ public class ProfileManager implements ProfileServiceLite {
 
         String realmName = getRealmName(root);
         if (realmName != null && !getConfigManager().isUniqueNameInRealm(uniqueName, realmName)) {
-            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), UPDATE_AUDIT, repositoryId, uniqueName, realmName, root, Integer.valueOf("204"));
+            Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.UPDATE_AUDIT, repositoryId, uniqueName, realmName, root,
+                        Integer.valueOf("204"));
             throw new EntityNotInRealmScopeException(WIMMessageKey.ENTITY_NOT_IN_REALM_SCOPE, Tr.formatMessage(tc, WIMMessageKey.ENTITY_NOT_IN_REALM_SCOPE,
                                                                                                                WIMMessageHelper.generateMsgParms(uniqueName, realmName)));
         }
@@ -3522,7 +3557,8 @@ public class ProfileManager implements ProfileServiceLite {
                     if (crossRepos || repositoryId.equalsIgnoreCase(reposId)) {
                         updateCrossRepos = updateCrossRepos && false;
                     } else {
-                        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), UPDATE_AUDIT, repositoryId, uniqueName, realmName, root,
+                        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.UPDATE_AUDIT, repositoryId, uniqueName, realmName,
+                                    root,
                                     Integer.valueOf("207"));
                         throw new OperationNotSupportedException(WIMMessageKey.MISSING_REPOSITORIES_FOR_GROUPS_CONFIGURATION, Tr.formatMessage(tc,
                                                                                                                                                WIMMessageKey.MISSING_REPOSITORIES_FOR_GROUPS_CONFIGURATION,
@@ -3581,7 +3617,8 @@ public class ProfileManager implements ProfileServiceLite {
                     IdentifierType groupId = group.getIdentifier();
                     String reposId = retrieveTargetRepository(groupId);
                     if (!repositoryId.equalsIgnoreCase(reposId)) {
-                        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), UPDATE_AUDIT, repositoryId, uniqueName, realmName, root,
+                        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.UPDATE_AUDIT, repositoryId, uniqueName, realmName,
+                                    root,
                                     Integer.valueOf("207"));
                         throw new OperationNotSupportedException(WIMMessageKey.MISSING_REPOSITORIES_FOR_GROUPS_CONFIGURATION, Tr.formatMessage(tc,
                                                                                                                                                WIMMessageKey.MISSING_REPOSITORIES_FOR_GROUPS_CONFIGURATION,
@@ -3606,7 +3643,8 @@ public class ProfileManager implements ProfileServiceLite {
             retRoot = repositoryManager.getRepository(repositoryId).update(root);
         }
 
-        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), UPDATE_AUDIT, repositoryId, uniqueName, realmName, retRoot, Integer.valueOf("200"));
+        Audit.audit(Audit.EventID.SECURITY_MEMBER_MGMT_01, auditManager.getRESTRequest(), AuditConstants.UPDATE_AUDIT, repositoryId, uniqueName, realmName, retRoot,
+                    Integer.valueOf("200"));
 
         return retRoot;
     }

--- a/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/util/AuditConstants.java
+++ b/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/util/AuditConstants.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.wim.util;
+
+/**
+ * Constants related to logging audit records.
+ */
+public interface AuditConstants {
+
+    public static final String CREATE_AUDIT = "create";
+    public static final String GET_AUDIT = "get";
+    public static final String UPDATE_AUDIT = "update";
+    public static final String DELETE_AUDIT = "delete";
+    public static final String SEARCH_AUDIT = "search";
+
+    public static final String VMMSERVICE = "vmmservice";
+    public static final String URBRIDGE = "urbridge";
+
+}

--- a/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/util/package-info.java
+++ b/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/util/package-info.java
@@ -12,7 +12,7 @@
 /**
  * @version 1.0.16
  */
-@org.osgi.annotation.versioning.Version("1.0.16")
+@org.osgi.annotation.versioning.Version("1.0.17")
 @TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
 package com.ibm.ws.security.wim.util;
 


### PR DESCRIPTION
fixes #4326 

Changes included fixing the parameter on a message, swapped out the strings in URBridge audits to constants, removed the rest checks and added code to try and do a best guess on providing the user to the audit message.