### PR TITLE
Revert "update weld to 3.0.4"

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -210,7 +210,7 @@ org.jacoco:org.jacoco.ant:0.7.9
 org.jacoco:org.jacoco.core:0.7.9
 org.jacoco:org.jacoco.report:0.7.9
 org.javassist:javassist:3.17.1-GA
-org.jboss.classfilewriter:jboss-classfilewriter:1.2.3.Final
+org.jboss.classfilewriter:jboss-classfilewriter:1.1.2.Final
 org.jboss:jandex:2.0.3.Final
 org.jboss.jdeparser:jdeparser:1.0.0.Final
 org.jboss.logging:jboss-logging:3.3.0.Final
@@ -218,7 +218,7 @@ org.jboss.shrinkwrap:shrinkwrap-api:1.2.3
 org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.3
 org.jboss.shrinkwrap:shrinkwrap-spi:1.2.3
 org.jboss.weld:weld-osgi-bundle:2.4.7.Final
-org.jboss.weld:weld-osgi-bundle:3.0.4.Final
+org.jboss.weld:weld-osgi-bundle:3.0.3.Final
 org.jmock:jmock:2.5.1
 org.jmock:jmock-junit4:2.5.1
 org.jsoup:jsoup:1.7.2

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-1.2/com.ibm.websphere.appserver.cdi-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-1.2/com.ibm.websphere.appserver.cdi-1.2.feature
@@ -52,7 +52,7 @@ Subsystem-Name: Contexts and Dependency Injection 1.2
  com.ibm.ws.org.jboss.jdeparser.1.0.0, \
  com.ibm.ws.managedobject, \
  com.ibm.ws.org.jboss.logging.3.3.0, \
- com.ibm.ws.org.jboss.classfilewriter.1.2.3, \
+ com.ibm.ws.org.jboss.classfilewriter.1.1.2, \
  com.ibm.ws.cdi.weld, \
  com.ibm.ws.cdi.internal, \
  com.ibm.ws.cdi.1.2.weld, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
@@ -53,11 +53,11 @@ Subsystem-Name: Contexts and Dependency Injection 2.0
  com.ibm.websphere.appserver.javax.jsf-2.3, \
  com.ibm.websphere.appserver.internal.slf4j-1.7.7, \
  com.ibm.websphere.appserver.contextService-1.0
--bundles=com.ibm.ws.org.jboss.weld.3.0.4, \
+-bundles=com.ibm.ws.org.jboss.weld.3.0.3, \
  com.ibm.ws.org.jboss.jdeparser.1.0.0, \
  com.ibm.ws.managedobject, \
  com.ibm.ws.org.jboss.logging.3.3.0, \
- com.ibm.ws.org.jboss.classfilewriter.1.2.3, \
+ com.ibm.ws.org.jboss.classfilewriter.1.1.2, \
  com.ibm.ws.cdi.weld, \
  com.ibm.ws.cdi.internal, \
  com.ibm.ws.cdi.2.0.weld, \

--- a/dev/com.ibm.websphere.appserver.thirdparty.cdi-2.0/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.cdi-2.0/bnd.bnd
@@ -13,15 +13,15 @@ bVersion=1.0
 
 Bundle-Name: WebSphere CDI Weld Third Party API
 Bundle-SymbolicName: com.ibm.websphere.appserver.thirdparty.cdi-2.0
-Bundle-Description: WebSphere CDI 2.0 Weld Third Party API, version 3.0.4.Final
+Bundle-Description: WebSphere CDI 2.0 Weld Third Party API, version 3.0.3.Final
 
 Export-Package:\
- org.jboss.weld.context;version=3.0.4.Final, \
- org.jboss.weld.context.*;version=3.0.4.Final
+ org.jboss.weld.context;version=3.0.3.Final, \
+ org.jboss.weld.context.*;version=3.0.3.Final
 
 Import-Package:*
 
 publish.wlp.jar.suffix: dev/api/third-party
 
 -buildpath: \
-	com.ibm.ws.org.jboss.weld.3.0.4;version=latest
+	com.ibm.ws.org.jboss.weld.3.0.3;version=latest

--- a/dev/com.ibm.ws.cdi.2.0.ejb/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.2.0.ejb/bnd.bnd
@@ -61,7 +61,7 @@ WS-TraceGroup: JCDI
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	com.ibm.ws.org.jboss.weld.3.0.4;version=latest,\
+	com.ibm.ws.org.jboss.weld.3.0.3;version=latest,\
 	com.ibm.ws.cdi.interfaces;version=latest, \
 	com.ibm.ws.cdi.ejb.common;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.cdi.2.0.jsf/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.2.0.jsf/bnd.bnd
@@ -46,6 +46,6 @@ WS-TraceGroup: JCDI
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.wsspi.org.osgi.service.component.annotations,\
 	com.ibm.ws.jsf.shared;version=latest,\
-	com.ibm.ws.org.jboss.weld.3.0.4;version=latest,\
+	com.ibm.ws.org.jboss.weld.3.0.3;version=latest,\
 	com.ibm.ws.cdi.interfaces;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.cdi.2.0.web/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.2.0.web/bnd.bnd
@@ -25,7 +25,7 @@ Export-Package: com.ibm.ws.cdi.web.factories
 WS-TraceGroup: JCDI
 
 -buildpath: \
-        com.ibm.ws.org.jboss.weld.3.0.4;version=latest,\
+        com.ibm.ws.org.jboss.weld.3.0.3;version=latest,\
         com.ibm.websphere.javaee.servlet.4.0;version=latest,\
         com.ibm.websphere.javaee.el.3.0;version=latest,\
         com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/com.ibm.ws.cdi.2.0.weld/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.2.0.weld/bnd.bnd
@@ -35,7 +35,7 @@ javac.target: 1.8
 
 -buildpath: \
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
-	com.ibm.ws.org.jboss.weld.3.0.4;version=latest, \
+	com.ibm.ws.org.jboss.weld.3.0.3;version=latest, \
 	com.ibm.websphere.appserver.spi.kernel.service,\
 	com.ibm.websphere.org.osgi.core,\
         com.ibm.websphere.org.osgi.service.component,\

--- a/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/EnablingBeansXmlValidationTest.java
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/fat/src/com/ibm/ws/cdi12/fat/tests/EnablingBeansXmlValidationTest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePaths;
@@ -36,15 +35,12 @@ import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.LoggingTest;
 
 import componenttest.annotation.ExpectedFFDC;
-import componenttest.annotation.SkipForRepeat;
-import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 @Mode(TestMode.FULL)
-@RunWith(FATRunner.class)//Needed for SkipForRepeat
 public class EnablingBeansXmlValidationTest extends LoggingTest {
 
     //For reasons I do not know this test requires the app to be in the dropins folder before the test starts. Thus the app is built and exported in FATSuit.java
@@ -69,7 +65,6 @@ public class EnablingBeansXmlValidationTest extends LoggingTest {
     }        
 
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES)
     @ExpectedFFDC({ "org.jboss.weld.exceptions.IllegalStateException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testEnablingBeansXmlValidation() throws Exception {
         server = LibertyServerFactory.getLibertyServer("cdi12BeansXmlValidationServer");
@@ -99,35 +94,6 @@ public class EnablingBeansXmlValidationTest extends LoggingTest {
             }
         }
 
-    }
-
-    //In CDI 2.0 with weld 3.0.4 or later WELD-001210 is a warning not an error. 
-    @Test
-    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
-    public void testEnablingBeansXmlValidationCDITwo() throws Exception {
-        boolean foundNetworkError = false;
-        try {
-            server = LibertyServerFactory.getLibertyServer("cdi12BeansXmlValidationServer");
-            server.startServer(true);
-
-            if (server.waitForStringInLog("WELD-001210") != null) {
-                /*
-                 * WELD-001210 means that the server could not get the schema document from java.sun.com.
-                 * In this case the server defaults to saying the xml is valid.
-                 */
-                 foundNetworkError = true;
-            } else { 
-                if (server.waitForStringInLog("WELD-001210") == null) {
-                    assertNotNull("WELD-001208 Warning message not found", server.waitForStringInLog("WELD-001208"));
-                }
-            }
-        } catch (Exception e) {
-            //I saw a failure with WELD-001208 in the logs, but not CWWKZ0002E, so I'm adding a fallback WELD-001210 check.
-            //If we saw WELD-001210 before or we see it now skip the asserts. 
-            if (foundNetworkError == false && server.waitForStringInLog("WELD-001210") == null) {
-                assertNotNull("WELD-001208 Warning message not found", server.waitForStringInLog("WELD-001208"));
-            }
-        }
     }
 
     /*

--- a/dev/com.ibm.ws.jsfContainer.classloading.2.3/bnd.bnd
+++ b/dev/com.ibm.ws.jsfContainer.classloading.2.3/bnd.bnd
@@ -39,5 +39,5 @@ Private-Package: \
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.websphere.javaee.el.3.0;version=latest,\
-	com.ibm.ws.org.jboss.weld.3.0.4;version=latest
+	com.ibm.ws.org.jboss.weld.3.0.3;version=latest
 

--- a/dev/com.ibm.ws.org.jboss.classfilewriter/bnd.bnd
+++ b/dev/com.ibm.ws.org.jboss.classfilewriter/bnd.bnd
@@ -8,6 +8,6 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.jboss.classfilewriter:jboss-classfilewriter;1.2.3.Final}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.jboss.classfilewriter:jboss-classfilewriter;1.1.2.Final}}!/META-INF/MANIFEST.MF,bnd.overrides
 
--buildpath: org.jboss.classfilewriter:jboss-classfilewriter;version=1.2.3.Final
+-buildpath: org.jboss.classfilewriter:jboss-classfilewriter;version=1.1.2.Final

--- a/dev/com.ibm.ws.org.jboss.classfilewriter/bnd.overrides
+++ b/dev/com.ibm.ws.org.jboss.classfilewriter/bnd.overrides
@@ -2,25 +2,24 @@
 bVersion=1.0
 
 Bundle-Name: jboss-classfilewriter
-Bundle-SymbolicName: com.ibm.ws.org.jboss.classfilewriter.1.2.3
+Bundle-SymbolicName: com.ibm.ws.org.jboss.classfilewriter.1.1.2
 
-Bundle-Description: A bytecode writer that creates .class files at runtime, jboss-classfilewriter 1.2.3.Final
-Export-Package: org.jboss.classfilewriter;version="1.2.3.Final";uses:="o\
+Bundle-Description: A bytecode writer that creates .class files at runtime, jboss-classfilewriter 1.1.2.Final
+Export-Package: org.jboss.classfilewriter;version="1.1.2.Final";uses:="o\
  rg.jboss.classfilewriter.annotations,org.jboss.classfilewriter.code,org\
  .jboss.classfilewriter.constpool,org.jboss.classfilewriter.util",org.jb\
- oss.classfilewriter.annotations;version="1.2.3.Final";uses:="org.jboss.\
+ oss.classfilewriter.annotations;version="1.1.2.Final";uses:="org.jboss.\
  classfilewriter,org.jboss.classfilewriter.attributes,org.jboss.classfil\
  ewriter.constpool,org.jboss.classfilewriter.util",org.jboss.classfilewr\
- iter.attributes;version="1.2.3.Final";uses:="org.jboss.classfilewriter,\
+ iter.attributes;version="1.1.2.Final";uses:="org.jboss.classfilewriter,\
  org.jboss.classfilewriter.constpool,org.jboss.classfilewriter.util",org\
- .jboss.classfilewriter.code;version="1.2.3.Final";uses:="org.jboss.clas\
+ .jboss.classfilewriter.code;version="1.1.2.Final";uses:="org.jboss.clas\
  sfilewriter,org.jboss.classfilewriter.attributes,org.jboss.classfilewri\
  ter.constpool,org.jboss.classfilewriter.util",org.jboss.classfilewriter\
- .constpool;version="1.2.3.Final";uses:="org.jboss.classfilewriter,org.j\
- boss.classfilewriter.util",org.jboss.classfilewriter.util;version="1.2.\
- 3.Final";uses:="org.jboss.classfilewriter.code"
-Import-Package: !sun.misc,*
-Dynamic-Import: sun.misc
+ .constpool;version="1.1.2.Final";uses:="org.jboss.classfilewriter,org.j\
+ boss.classfilewriter.util",org.jboss.classfilewriter.util;version="1.1.\
+ 2.Final";uses:="org.jboss.classfilewriter.code"
+Import-Package: *
 
 Include-Resource: \
-  @${repo;org.jboss.classfilewriter:jboss-classfilewriter;1.2.3.Final}!/!META-INF/maven/*
+  @${repo;org.jboss.classfilewriter:jboss-classfilewriter;1.1.2.Final}!/!META-INF/maven/*

--- a/dev/com.ibm.ws.org.jboss.classfilewriter/build.xml
+++ b/dev/com.ibm.ws.org.jboss.classfilewriter/build.xml
@@ -13,6 +13,6 @@
     <import file="../ant_build/public_imports/rejar_imports.xml"/>
     
     <target name="package"> 
-    	<bndPackage version="1.0" original.jar.name="org.jboss.classfilewriter" original.jar.version="1.2.3" bnd.classpath="lib/jboss-classfilewriter-1.2.3.Final.jar" bnd.file="bnd.bnd"  />
+    	<bndPackage version="1.0" original.jar.name="org.jboss.classfilewriter" original.jar.version="1.1.2" bnd.classpath="lib/jboss-classfilewriter-1.1.2.Final.jar" bnd.file="bnd.bnd"  />
     </target>
 </project>

--- a/dev/com.ibm.ws.org.jboss.weld.3.0/bnd.bnd
+++ b/dev/com.ibm.ws.org.jboss.weld.3.0/bnd.bnd
@@ -14,5 +14,5 @@ javac.source: 1.8
 javac.target: 1.8
 
 -buildpath: \
-	org.jboss.weld:weld-osgi-bundle;version=3.0.4.Final, \
+	org.jboss.weld:weld-osgi-bundle;version=3.0.3.Final, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.org.jboss.weld.3.0/bnd.overrides
+++ b/dev/com.ibm.ws.org.jboss.weld.3.0/bnd.overrides
@@ -2,16 +2,16 @@
 bVersion=1.0
 
 Bundle-Name: weld OSGi bundle
-Bundle-SymbolicName: com.ibm.ws.org.jboss.weld.3.0.4
-Bundle-Description: Weld OSGi Bundle, version 3.0.4.Final
+Bundle-SymbolicName: com.ibm.ws.org.jboss.weld.3.0.3
+Bundle-Description: Weld OSGi Bundle, version 3.0.3.Final
 Implementation-Title: Weld OSGi Bundle
 Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.html
-Implementation-Version: 3.0.4.Final
+Implementation-Version: 3.0.3.Final
 Embed-Dependency: *; scope=compile; inline=true
 Specification-Title: JSR-365 Contexts and Dependency Injection for Java
 Specification-Version: 2.0
 DynamicImport-Package: *
-Export-Package: org.jboss.*;version="3.0.4.Final", \
+Export-Package: org.jboss.*;version="3.0.3.Final", \
  org.jboss.weldx.transaction;version="1.0.16"
 Import-Package: javax.annotation;version="1.1",javax.el;version="1.0";re\
  solution:=optional,javax.faces.application;resolution:=optional,javax.f\
@@ -27,8 +27,8 @@ Import-Package: javax.annotation;version="1.1",javax.el;version="1.0";re\
  ject.spi;version="[2.0,3)",javax.enterprise.inject.spi.configurator;ver\
  sion="[2.0,3)",javax.enterprise.util;version="[2.0,3)",javax.inject,jav\
  ax.management,javax.naming,javax.naming.spi,javax.xml.parsers,org.jboss\
- .classfilewriter;version="[1.2,2)",org.jboss.classfilewriter.code;versi\
- on="[1.2,2)",org.jboss.classfilewriter.util;version="[1.2,2)",\
+ .classfilewriter;version="[1.1,2)",org.jboss.classfilewriter.code;versi\
+ on="[1.1,2)",org.jboss.classfilewriter.util;version="[1.1,2)",\
  org.jboss.weld.bootstrap.api;version="[3.0,4\
  )",org.jboss.weld.bootstrap.api.helpers;version="[3.0,4)",org.jboss.wel\
  d.bootstrap.event;version="[3.0,4)",org.jboss.weld.bootstrap.spi;versio\

--- a/dev/com.ibm.ws.org.jboss.weld/bnd.overrides
+++ b/dev/com.ibm.ws.org.jboss.weld/bnd.overrides
@@ -26,9 +26,9 @@ Import-Package: javax.annotation;version="1.1",javax.el;version="1.0";\
  t;version="[1.1,2)",javax.enterprise.inject;version="[1.1,2)",javax.e\
  nterprise.inject.spi;version="[1.1,2)",javax.enterprise.util;version=\
  "[1.1,2)",javax.inject,javax.management,javax.naming,javax.naming.spi\
- ,javax.xml.parsers,org.jboss.classfilewriter;version="[1.2,2)",org.jb\
- oss.classfilewriter.code;version="[1.2,2)",org.jboss.classfilewriter.\
- util;version="[1.2,2)",org.jboss.\
+ ,javax.xml.parsers,org.jboss.classfilewriter;version="[1.1,2)",org.jb\
+ oss.classfilewriter.code;version="[1.1,2)",org.jboss.classfilewriter.\
+ util;version="[1.1,2)",org.jboss.\
  weld.bootstrap.api;version="[2.4,3)",org.jboss.weld.bootstrap.api.hel\
  pers;version="[2.4,3)",org.jboss.weld.bootstrap.spi;version="[2.4,3)"\
  ,org.jboss.weld.bootstrap.spi.helpers;version="[2.4,3)",org.jboss.wel\


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#4099

This change introduced a dependency on java 8.

Tests have started failing with messages like com.ibm.ws.container.service.state.StateChangeException: java.lang.UnsupportedClassVersionError: JVMCFRE003 bad major version; class=org/jboss/classfilewriter/DuplicateMemberException offset=6

Backing out this change as it caused the vast majority of buckets to fail on Java 7. Java 7 are pretty much untriagable until this change is removed.

See RTC Defect: https://wasrtc.hursley.ibm.com:9443/jazz/resource/itemName/com.ibm.team.workitem.WorkItem/257165 for more information