### PR TITLE
use driver package to identify known data source class

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -17,8 +17,10 @@ import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Dictionary;
@@ -29,6 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Observable;
 import java.util.Properties;
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -147,6 +150,9 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
      */
     private String name;
 
+    // TODO remove once function is ready to GA
+    private boolean nonshipFunction;
+
     /**
      * JDBC driver configuration.
      */
@@ -176,6 +182,8 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
         } finally {
             lock.writeLock().unlock();
         }
+
+        nonshipFunction = props.get("internal.nonship.function") != null;
 
         if ("file".equals(props.get("config.source"))) {
             if (name.startsWith(AppDefinedResource.PREFIX)) // avoid conflicts with application defined data sources
@@ -217,7 +225,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
      * @return the data source
      * @throws SQLException if an error occurs
      */
-    private <T extends CommonDataSource> T create(final Class<T> type, final String className, final Hashtable<?, ?> props) throws SQLException {
+    private <T extends CommonDataSource> T create(final String className, final Hashtable<?, ?> props) throws SQLException {
         if (className == null)
             throw classNotFound(null);
 
@@ -229,7 +237,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(tc, "create", type, className, classloader, PropertyService.hidePasswords(props));
+            Tr.entry(tc, "create", className, classloader, PropertyService.hidePasswords(props));
         try {
             T ds = AccessController.doPrivileged(new PrivilegedExceptionAction<T>() {
                 public T run() throws Exception {
@@ -352,18 +360,21 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
 
             if (null != (className = (String) properties.get(ConnectionPoolDataSource.class.getName()))
              || null != (className = JDBCDrivers.getConnectionPoolDataSourceClassName(vendorPropertiesPID))
-             || null != (className = JDBCDrivers.getConnectionPoolDataSourceClassName(getClasspath(sharedLib, true))))
-                return create(ConnectionPoolDataSource.class, className, props);
+             || null != (className = JDBCDrivers.getConnectionPoolDataSourceClassName(getClasspath(sharedLib, true)))
 
-            if (null != (className = (String) properties.get(DataSource.class.getName()))
+             || null != (className = (String) properties.get(DataSource.class.getName()))
              || null != (className = JDBCDrivers.getDataSourceClassName(vendorPropertiesPID))
-             || null != (className = JDBCDrivers.getDataSourceClassName(getClasspath(sharedLib, true))))
-                return create(DataSource.class, className, props);
+             || null != (className = JDBCDrivers.getDataSourceClassName(getClasspath(sharedLib, true)))
 
-            if (null != (className = (String) properties.get(XADataSource.class.getName()))
+             || null != (className = (String) properties.get(XADataSource.class.getName()))
              || null != (className = JDBCDrivers.getXADataSourceClassName(vendorPropertiesPID))
-             || null != (className = JDBCDrivers.getXADataSourceClassName(getClasspath(sharedLib, true))))
-                return create(XADataSource.class, className, props);
+             || null != (className = JDBCDrivers.getXADataSourceClassName(getClasspath(sharedLib, true)))
+
+             || nonshipFunction && null != (className = JDBCDrivers.inferDataSourceClassFromDriver(classloader,
+                                                                                JDBCDrivers.CONNECTION_POOL_DATA_SOURCE,
+                                                                                JDBCDrivers.DATA_SOURCE,
+                                                                                JDBCDrivers.XA_DATA_SOURCE)))
+                 return create(className, props);
 
             throw classNotFound(null);
         } finally {
@@ -409,18 +420,21 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
             
             if (null != (className = (String) properties.get(XADataSource.class.getName()))
              || null != (className = JDBCDrivers.getXADataSourceClassName(vendorPropertiesPID))
-             || null != (className = JDBCDrivers.getXADataSourceClassName(getClasspath(sharedLib, true))))
-                return create(XADataSource.class, className, props);
+             || null != (className = JDBCDrivers.getXADataSourceClassName(getClasspath(sharedLib, true)))
 
-            if (null != (className = (String) properties.get(ConnectionPoolDataSource.class.getName()))
+             || null != (className = (String) properties.get(ConnectionPoolDataSource.class.getName()))
              || null != (className = JDBCDrivers.getConnectionPoolDataSourceClassName(vendorPropertiesPID))
-             || null != (className = JDBCDrivers.getConnectionPoolDataSourceClassName(getClasspath(sharedLib, true))))
-                return create(ConnectionPoolDataSource.class, className, props);
+             || null != (className = JDBCDrivers.getConnectionPoolDataSourceClassName(getClasspath(sharedLib, true)))
 
-            if (null != (className = (String) properties.get(DataSource.class.getName()))
+             || null != (className = (String) properties.get(DataSource.class.getName()))
              || null != (className = JDBCDrivers.getDataSourceClassName(vendorPropertiesPID))
-             || null != (className = JDBCDrivers.getDataSourceClassName(getClasspath(sharedLib, true))))
-                return create(DataSource.class, className, props);
+             || null != (className = JDBCDrivers.getDataSourceClassName(getClasspath(sharedLib, true)))
+
+             || nonshipFunction && null != (className = JDBCDrivers.inferDataSourceClassFromDriver(classloader,
+                                                                                JDBCDrivers.XA_DATA_SOURCE,
+                                                                                JDBCDrivers.CONNECTION_POOL_DATA_SOURCE,
+                                                                                JDBCDrivers.DATA_SOURCE)))
+                return create(className, props);
 
             throw classNotFound(null);
         } finally {
@@ -459,11 +473,14 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
             if (className == null) {
                 String vendorPropertiesPID = props instanceof PropertyService ? ((PropertyService) props).getFactoryPID() : PropertyService.FACTORY_PID;
                 className = JDBCDrivers.getConnectionPoolDataSourceClassName(vendorPropertiesPID);
-                if (className == null)
+                if (className == null) {
                     className = JDBCDrivers.getConnectionPoolDataSourceClassName(getClasspath(sharedLib, true));
+                    if (className == null && nonshipFunction)
+                        className = JDBCDrivers.inferDataSourceClassFromDriver(classloader, JDBCDrivers.CONNECTION_POOL_DATA_SOURCE);
+                }
             }
 
-            return create(ConnectionPoolDataSource.class, className, props);
+            return create(className, props);
         } finally {
             lock.readLock().unlock();
         }
@@ -500,11 +517,14 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
             if (className == null) {
                 String vendorPropertiesPID = props instanceof PropertyService ? ((PropertyService) props).getFactoryPID() : PropertyService.FACTORY_PID;
                 className = JDBCDrivers.getDataSourceClassName(vendorPropertiesPID);
-                if (className == null)
+                if (className == null) {
                     className = JDBCDrivers.getDataSourceClassName(getClasspath(sharedLib, true));
+                    if (className == null && nonshipFunction)
+                        className = JDBCDrivers.inferDataSourceClassFromDriver(classloader, JDBCDrivers.DATA_SOURCE);
+                }
             }
 
-            return create(DataSource.class, className, props);
+            return create(className, props);
         } finally {
             lock.readLock().unlock();
         }
@@ -541,11 +561,14 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
             if (className == null) {
                 String vendorPropertiesPID = props instanceof PropertyService ? ((PropertyService) props).getFactoryPID() : PropertyService.FACTORY_PID;
                 className = JDBCDrivers.getXADataSourceClassName(vendorPropertiesPID);
-                if (className == null)
+                if (className == null) {
                     className = JDBCDrivers.getXADataSourceClassName(getClasspath(sharedLib, true));
+                    if (className == null && nonshipFunction)
+                        className = JDBCDrivers.inferDataSourceClassFromDriver(classloader, JDBCDrivers.XA_DATA_SOURCE);
+                }
             }
 
-            return create(XADataSource.class, className, props);
+            return create(className, props);
         } finally {
             lock.readLock().unlock();
         }


### PR DESCRIPTION
When the existing mechanism to infer data source impl class names based upon the properties element type and the driver jar names don't match anything, we can load the JDBC vendor's java.sql.Driver and use its package name to help identify which data source impl class should be used.

This capability will be gated for internal testing only until it is determined that the feature is ready to GA.