### PR TITLE
Add FAT JDBC driver

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_driver/.classpath
+++ b/dev/com.ibm.ws.jdbc_fat_driver/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/jdbcapp/src"/>
+	<classpathentry kind="src" path="test-applications/fatdriver/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jdbc_fat_driver/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_driver/bnd.bnd
@@ -13,7 +13,8 @@ bVersion=1.0
 
 src: \
 	fat/src,\
-	test-applications/jdbcapp/src
+	test-applications/jdbcapp/src,\
+	test-applications/fatdriver/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -17,19 +17,34 @@
       <feature>jndi-1.0</feature>
     </featureManager>
  
-    <dataSource id="jdbc/derby" jndiName="jdbc/derby">
-      <jdbcDriver>
-        <library>
-          <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
-        </library>
-      </jdbcDriver>    
+ 
+    <library id="DerbyLib">
+        <file name="${shared.resource.dir}/derby/derby.jar"/>
+    </library>
+    
+    <library id="FATDriverLib">
+        <file name="${server.config.dir}/derby/FATDriver.jar"/>
+    </library>
+    
+    <dataSource id="derby" jndiName="jdbc/derby">
+      <jdbcDriver libraryRef="DerbyLib" />
       <properties databaseName="memory:jdbcdriver1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
+    <dataSource id="fatDriver" jndiName="jdbc/fatDriver">
+ 	  <jdbcDriver libraryRef="FATDriverLib" />  
+      <properties url="jdbc:derby:memory:wrappedDerby;create=true" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
     <javaPermission codeBase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codeBase="${server.config.dir}derby/FATDriver.jar" className="java.security.AllPermission"/>
+    
+    <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>
     
     <include location="../fatTestPorts.xml"/>
     
-    <application location="jdbcapp.war" />
+    <application location="jdbcapp.war" >
+        <classloader commonLibraryRef="FATDriverLib"/>
+    </application>
 
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/FATDriver.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/FATDriver.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.driver.derby;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class FATDriver implements Driver {
+    private static Driver fatDriver = new FATDriver();
+
+    static {
+        try {
+            DriverManager.registerDriver(fatDriver);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        System.out.println("[FATDriver]   ->  connect");
+        try {
+            Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+        } catch (ClassNotFoundException e) {
+            throw new SQLException(e);
+        }
+        Enumeration<Driver> drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            Driver nextElement = drivers.nextElement();
+            if (nextElement.getClass().getName().contains("org.apache.derby.jdbc")) {
+                return nextElement.connect(url, info);
+            }
+        }
+        throw new SQLException("Unable to find Derby driver");
+    }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -185,5 +186,19 @@ public class JDBCDriverManagerServlet extends FATServlet {
             }
             con.close();
         }
+    }
+
+    //TODO this test can be removed once other tests are updated to use the custom FAT driver
+    @Test
+    public void testFATDriver() throws Exception {
+        Class.forName("jdbc.fat.driver.derby.FATDriver");
+        Connection conn = DriverManager.getConnection("jdbc:derby:memory:wrappedDerby;create=true");
+        try {
+            System.out.println("Connected to " + conn.getMetaData().getDatabaseProductName());
+            conn.createStatement().executeQuery("VALUES 1");
+        } finally {
+            conn.close();
+        }
+
     }
 }


### PR DESCRIPTION
Add a custom FAT JDBC driver to the jdbc_fat_driver bucket.  This driver will be used for testing a JDBC driver which is completely unknown to Liberty and does not support datasource.