### PR TITLE
test for discovering datasource class from JAR

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
@@ -51,6 +51,7 @@ public class JDBCDriverManagerTest extends FATServletClient {
 
         JavaArchive fatDriver = ShrinkWrap.create(JavaArchive.class, "FATDriver.jar")
                         .addPackage("jdbc.fat.driver.derby")
+                        .addPackage("jdbc.fat.driver.derby.xa")
                         .merge(derbyJar)
                         .addAsServiceProvider(java.sql.Driver.class, FATDriver.class);
 

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -17,26 +17,20 @@
       <feature>jndi-1.0</feature>
     </featureManager>
  
- 
-    <library id="DerbyLib">
-        <file name="${shared.resource.dir}/derby/derby.jar"/>
-    </library>
-    
     <library id="FATDriverLib">
         <file name="${server.config.dir}/derby/FATDriver.jar"/>
     </library>
     
-    <dataSource id="derby" jndiName="jdbc/derby">
-      <jdbcDriver libraryRef="DerbyLib" />
-      <properties databaseName="memory:jdbcdriver1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    <dataSource id="fatDataSource" jndiName="jdbc/fatDataSource">
+      <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <properties databaseName="memory:jdbcdriver1" autoCreate="true" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
     <dataSource id="fatDriver" jndiName="jdbc/fatDriver">
- 	  <jdbcDriver libraryRef="FATDriverLib" />  
+ 	  <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
       <properties url="jdbc:derby:memory:wrappedDerby;create=true" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
-    <javaPermission codeBase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}derby/FATDriver.jar" className="java.security.AllPermission"/>
     
     <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -20,14 +20,20 @@
     <library id="FATDriverLib">
         <file name="${server.config.dir}/derby/FATDriver.jar"/>
     </library>
+
+    <dataSource id="DefaultDataSource">
+      <jdbcDriver libraryRef="FATDriverLib"
+                  javax.sql.XADataSource="jdbc.fat.driver.derby.xa.FAT2PCDataSource"/> <!-- TODO automatically locate this data source class -->
+      <properties databaseName="memory:jdbcdriver1" autoCreate="true" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
     
     <dataSource id="fatDataSource" jndiName="jdbc/fatDataSource">
       <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
       <properties databaseName="memory:jdbcdriver1" autoCreate="true" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
-    
+
     <dataSource id="fatDriver" jndiName="jdbc/fatDriver">
- 	  <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
       <properties url="jdbc:derby:memory:wrappedDerby;create=true" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/FATDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/FATDataSource.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.driver.derby;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
+
+public class FATDataSource implements DataSource {
+    private final DataSource derbyds;
+
+    public FATDataSource() throws Exception {
+        derbyds = (DataSource) Class.forName("org.apache.derby.jdbc.EmbeddedDataSource").newInstance();
+    }
+
+    public boolean getAutoCreate() throws Exception {
+        return "create".equals(derbyds.getClass().getMethod("getCreateDatabase").invoke(derbyds));
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return derbyds.getConnection();
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return derbyds.getConnection(username, password);
+    }
+
+    public String getDatabaseName() throws Exception {
+        return (String) derbyds.getClass().getMethod("getDatabaseName").invoke(derbyds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return derbyds.getLoginTimeout();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return derbyds.getLogWriter();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return derbyds.getParentLogger();
+    }
+
+    public void setAutoCreate(boolean value) throws Exception {
+        derbyds.getClass().getMethod("setCreateDatabase", String.class).invoke(derbyds, value ? "create" : "false");
+    }
+
+    public void setDatabaseName(String value) throws Exception {
+        derbyds.getClass().getMethod("setDatabaseName", String.class).invoke(derbyds, value);
+    }
+
+    @Override
+    public void setLoginTimeout(int value) throws SQLException {
+        derbyds.setLoginTimeout(value);
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        derbyds.setLogWriter(out);
+    }
+
+    public void setPassword(String value) throws Exception {
+        derbyds.getClass().getMethod("setPassword", String.class).invoke(derbyds, value);
+    }
+
+    public void setUser(String value) throws Exception {
+        derbyds.getClass().getMethod("setUser", String.class).invoke(derbyds, value);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (isWrapperFor(iface))
+            return iface.cast(this);
+        else
+            throw new SQLException(this + " does not wrap " + iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return iface.isInterface() && iface.isAssignableFrom(getClass());
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/xa/FAT2PCDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/xa/FAT2PCDataSource.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.driver.derby.xa;
+
+import java.sql.SQLException;
+
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+
+import jdbc.fat.driver.derby.FATDataSource;
+
+/**
+ * This data source class name will be difficult to guess because it doesn't match the pattern
+ * of the Driver class name. It also intentionally inherits from a javax.sql.DataSource implementation
+ * so as to be an implementation of multiple data source types, which is valid for a JDBC driver to do.
+ */
+public class FAT2PCDataSource extends FATDataSource implements XADataSource {
+    public FAT2PCDataSource() throws Exception {
+        super((XADataSource) Class.forName("org.apache.derby.jdbc.EmbeddedXADataSource").newInstance());
+    }
+
+    @Override
+    public XAConnection getXAConnection() throws SQLException {
+        return ((XADataSource) derbyds).getXAConnection();
+    }
+
+    @Override
+    public XAConnection getXAConnection(String user, String password) throws SQLException {
+        return ((XADataSource) derbyds).getXAConnection(user, password);
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -37,7 +37,7 @@ import componenttest.app.FATServlet;
 @WebServlet("/JDBCDriverManagerServlet")
 public class JDBCDriverManagerServlet extends FATServlet {
 
-    @Resource(name = "jdbc/derby", shareable = false, authenticationType = AuthenticationType.APPLICATION)
+    @Resource(name = "jdbc/fatDataSource", shareable = false, authenticationType = AuthenticationType.APPLICATION)
     DataSource ds;
 
     /**

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -40,6 +40,9 @@ public class JDBCDriverManagerServlet extends FATServlet {
     @Resource(name = "jdbc/fatDataSource", shareable = false, authenticationType = AuthenticationType.APPLICATION)
     DataSource ds;
 
+    @Resource
+    DataSource xads;
+
     /**
      * Test of basic database connectivity
      */
@@ -137,6 +140,11 @@ public class JDBCDriverManagerServlet extends FATServlet {
             tran.begin();
             try {
                 stmt.executeUpdate("update drivertable set col2='uno' where col1=1");
+
+                // Enlist second resource (must be two-phase capable)
+                Connection con2 = xads.getConnection();
+                Statement stmt2 = con2.createStatement();
+                stmt2.executeUpdate("insert into drivertable values (5, 'five')");
             } finally {
                 tran.commit();
             }


### PR DESCRIPTION
Write a test case including a test XADataSource implementation based on Derby which is named/packaged in a way that cannot be easily inferred based upon the driver name.  The test will be disabled for now because the capability hasn't been implemented in the Liberty data source.