### PR TITLE
Issue 4364: Allow filling existing messages.log/trace.log files before rolling

### DIFF
--- a/dev/com.ibm.ws.logging/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.logging/resources/OSGI-INF/l10n/metatype.properties
@@ -87,3 +87,6 @@ console.source.desc=The list of sources to route to console.log / console
 
 console.format=Console format
 console.format.desc=The format to use for console.log / console
+
+fillExistingFile=Fill an existing file before rolling
+fillExistingFile.desc=When starting a messages.log or trace.log file, if one already exists, fill it first if there's space.

--- a/dev/com.ibm.ws.logging/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.logging/resources/OSGI-INF/metatype/metatype.xml
@@ -99,6 +99,10 @@
             <Option value="INFO" label="INFO"/>
             <Option value="NONE" label="NONE"/>
         </AD>
+
+        <AD name="%fillExistingFile" description="%fillExistingFile.desc" 
+            ibm:variable="com.ibm.ws.logging.fillExistingFile"
+            id="fillExistingFile" required="false" type="Boolean" default="true" />  
     </OCD>
   
     <Designate pid="com.ibm.ws.logging">

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -944,7 +944,8 @@ public class BaseTraceService implements TrService {
                                                         config.getLogDirectory(),
                                                         config.getMessageFileName(),
                                                         config.getMaxFiles(),
-                                                        config.getMaxFileBytes());
+                                                        config.getMaxFileBytes(),
+                                                        config.fillExistingFile());
 
         // Always create a traceLog when using Tr -- this file won't actually be
         // created until something is logged to it...
@@ -959,7 +960,8 @@ public class BaseTraceService implements TrService {
                                                          config.getLogDirectory(),
                                                          config.getTraceFileName(),
                                                          config.getMaxFiles(),
-                                                         config.getMaxFileBytes());
+                                                         config.getMaxFileBytes(),
+                                                         config.fillExistingFile());
             if (!TraceComponent.isAnyTracingEnabled()) {
                 ((FileLogHolder) traceLog).releaseFile();
             }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/CountingOutputStream.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/CountingOutputStream.java
@@ -17,8 +17,9 @@ public class CountingOutputStream extends OutputStream {
     private final OutputStream out;
     private long count;
 
-    public CountingOutputStream(OutputStream out) {
+    public CountingOutputStream(OutputStream out, long startOffset) {
         this.out = out;
+        this.count = startOffset;
     }
 
     public long count() {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/CountingOutputStream.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/CountingOutputStream.java
@@ -17,6 +17,10 @@ public class CountingOutputStream extends OutputStream {
     private final OutputStream out;
     private long count;
 
+    public CountingOutputStream(OutputStream out) {
+        this(out, 0);
+    }
+
     public CountingOutputStream(OutputStream out, long startOffset) {
         this.out = out;
         this.count = startOffset;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/FileLogHeader.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/FileLogHeader.java
@@ -25,19 +25,72 @@ public class FileLogHeader {
         this.javaLangInstrument = javaLangInstrument;
     }
 
-    public void print(PrintStream ps) {
-        ps.println(BaseTraceFormatter.banner);
+    private void process(Processor processor) {
+        processor.println(BaseTraceFormatter.banner);
 
-        ps.print(header);
+        processor.print(header);
 
         if (trace) {
-            ps.println("trace.specification = " + TrConfigurator.getEffectiveTraceSpec());
+            processor.println("trace.specification = " + TrConfigurator.getEffectiveTraceSpec());
 
             if (!javaLangInstrument) {
-                ps.println("java.lang.instrument = " + javaLangInstrument);
+                processor.println("java.lang.instrument = " + javaLangInstrument);
             }
         }
 
-        ps.println(BaseTraceFormatter.banner);
+        processor.println(BaseTraceFormatter.banner);
+    }
+
+    public void print(PrintStream ps) {
+        process(new PrintProcessor(ps));
+    }
+
+    public long length() {
+        LengthProcessor lengthProcessor = new LengthProcessor();
+        process(lengthProcessor);
+        return lengthProcessor.getLength();
+    }
+
+    interface Processor {
+        void print(String str);
+
+        void println(String str);
+    }
+
+    class PrintProcessor implements Processor {
+
+        final PrintStream ps;
+
+        public PrintProcessor(final PrintStream ps) {
+            this.ps = ps;
+        }
+
+        @Override
+        public void println(String str) {
+            ps.println(str);
+        }
+
+        @Override
+        public void print(String str) {
+            ps.print(str);
+        }
+    }
+
+    class LengthProcessor implements Processor {
+        long length;
+
+        @Override
+        public void print(String str) {
+            length += str.getBytes().length;
+        }
+
+        @Override
+        public void println(String str) {
+            length += str.getBytes().length + LoggingConstants.nlen;
+        }
+
+        long getLength() {
+            return length;
+        }
     }
 }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/Jsr47TraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/Jsr47TraceService.java
@@ -61,10 +61,11 @@ public class Jsr47TraceService extends BaseTraceService {
                                                             config.getLogDirectory(),
                                                             config.getMessageFileName(),
                                                             config.getMaxFiles(),
-                                                            config.getMaxFileBytes());
+                                                            config.getMaxFileBytes(),
+                                                            config.fillExistingFile());
 
             // Always create a traceLog when using Tr -- this file won't actually be
-            // created until something is logged to it... 
+            // created until something is logged to it...
             traceLog = new TraceWriter() {
 
                 @Override

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
@@ -108,6 +108,9 @@ public class LogProviderConfigImpl implements LogProviderConfig {
     /** Format to use for console.log / console */
     protected volatile String consoleFormat = LoggingConstants.DEFAULT_CONSOLE_FORMAT;
 
+    /** Whether to fill up any existing primary file instead of immediately rolling it. */
+    protected volatile boolean fillExistingFile = true;
+
     /** The header written at the beginning of all log files. */
     private final String logHeader;
 
@@ -222,6 +225,8 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         messageFormat = InitConfgAttribute.MESSAGE_FORMAT.getStringValueAndSaveInit(c, messageFormat, isInit);
         consoleSource = InitConfgAttribute.CONSOLE_SOURCE.getStringCollectionValueAndSaveInit("consoleSource", c, consoleSource, isInit);
         consoleFormat = InitConfgAttribute.CONSOLE_FORMAT.getStringValueAndSaveInit(c, consoleFormat, isInit);
+
+        fillExistingFile = InitConfgAttribute.FILL_EXISTING_FILE.getBooleanValue(c, fillExistingFile, isInit);
     }
 
     /**
@@ -373,6 +378,10 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         return consoleFormat;
     }
 
+    public boolean fillExistingFile() {
+        return fillExistingFile;
+    }
+
     /**
      * @return true if we should use the logger -> tr handler
      */
@@ -392,6 +401,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         sb.append(",traceFormat=").append(traceFormat);
         sb.append(",isoDateFormat=").append(isoDateFormat);
         sb.append(",traceFileName=").append(traceFileName);
+        sb.append(",fillExistingFile=").append(fillExistingFile);
         sb.append("]");
 
         return sb.toString();
@@ -414,7 +424,9 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         MESSAGE_SOURCE("messageSource", "com.ibm.ws.logging.message.source"),
         MESSAGE_FORMAT("messageFormat", "com.ibm.ws.logging.message.format"),
         CONSOLE_SOURCE("consoleSource", "com.ibm.ws.logging.console.source"),
-        CONSOLE_FORMAT("consoleFormat", "com.ibm.ws.logging.console.format");
+        CONSOLE_FORMAT("consoleFormat", "com.ibm.ws.logging.console.format"),
+
+        FILL_EXISTING_FILE("fillExistingFile", "com.ibm.ws.logging.fillExistingFile");
 
         final String configKey;
         final String propertyKey;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/EmergencyLog.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/EmergencyLog.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.utils;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+
+/**
+ * This should only be used by something that doesn't have access to normal logging.
+ * By default, this will write to elog.txt in the JVM's current working directory.
+ */
+public class EmergencyLog {
+    /**
+     * Activate debug* methods if -Dcom.ibm.ws.logging.edebug=true is set on the JVM.
+     */
+    public static final boolean EDEBUG = Boolean.getBoolean("com.ibm.ws.logging.edebug");
+
+    /**
+     * Set this to blank to send to System.err instead.
+     */
+    public static final String EFILE = System.getProperty("com.ibm.ws.logging.efile", "elog.txt");
+
+    private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    private static PrintStream out;
+
+    private static synchronized void ensureStream() {
+        if (out == null) {
+            if (EFILE != null && EFILE.length() > 0) {
+                try {
+                    out = new PrintStream(new FileOutputStream(EFILE, true), true);
+                } catch (FileNotFoundException e) {
+                    throw new Error(e);
+                }
+            } else {
+                out = System.err;
+            }
+        }
+    }
+
+    /**
+     * Print specified data to the emergency log.
+     *
+     * @param clazz The class source.
+     * @param method The method source.
+     * @param objects A list of objects to trace.
+     */
+    public static void print(final Class<?> clazz, final String method, final Object... objects) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("ELOG: [");
+        sb.append(dateFormat.format(new Date()));
+        sb.append("] ");
+        sb.append(clazz.getSimpleName());
+        sb.append('.');
+        sb.append(method);
+        if (objects != null && objects.length > 0) {
+            sb.append(": ");
+            for (int i = 0; i < objects.length; i++) {
+                if (i > 0) {
+                    sb.append("; ");
+                }
+                sb.append(objects[i]);
+            }
+        }
+
+        ensureStream();
+        out.println(sb);
+        out.flush();
+    }
+
+    /**
+     * Print specified data with an Entry prefix to the emergency log.
+     *
+     * @param clazz The class source.
+     * @param method The method source.
+     * @param objects A list of objects to trace.
+     */
+    public static void printEntry(final Class<?> clazz, final String method, final Object... objects) {
+        printPrefixed(clazz, method, "> Entry", objects);
+    }
+
+    /**
+     * Print specified data with an Exit prefix to the emergency log.
+     *
+     * @param clazz The class source.
+     * @param method The method source.
+     * @param objects A list of objects to trace.
+     */
+    public static void printExit(final Class<?> clazz, final String method, final Object... objects) {
+        printPrefixed(clazz, method, "< Exit", objects);
+    }
+
+    private static void printPrefixed(final Class<?> clazz, final String method, final String prefix, final Object... objects) {
+        if (objects != null && objects.length > 0) {
+            final Object[] allObjects = new Object[objects.length + 1];
+            allObjects[0] = prefix;
+            for (int i = 0; i < objects.length; i++) {
+                allObjects[i + 1] = objects[i];
+            }
+            print(clazz, method, allObjects);
+        } else {
+            print(clazz, method, prefix);
+        }
+    }
+
+    /**
+     * Print specified data to the emergency log if -Dcom.ibm.ws.logging.edebug=true.
+     *
+     * @param clazz The class source.
+     * @param method The method source.
+     * @param objects A list of objects to trace.
+     */
+    public static void debug(final Class<?> clazz, final String method, final Object... objects) {
+        if (EDEBUG) {
+            print(clazz, method, objects);
+        }
+    }
+
+    /**
+     * Print specified data with an Entry prefix to the emergency log if -Dcom.ibm.ws.logging.edebug=true.
+     *
+     * @param clazz The class source.
+     * @param method The method source.
+     * @param objects A list of objects to trace.
+     */
+    public static void debugEntry(final Class<?> clazz, final String method, final Object... objects) {
+        if (EDEBUG) {
+            printEntry(clazz, method, objects);
+        }
+    }
+
+    /**
+     * Print specified data with an Exit prefix to the emergency log if -Dcom.ibm.ws.logging.edebug=true.
+     *
+     * @param clazz The class source.
+     * @param method The method source.
+     * @param objects A list of objects to trace.
+     */
+    public static void debugExit(final Class<?> clazz, final String method, final Object... objects) {
+        if (EDEBUG) {
+            printExit(clazz, method, objects);
+        }
+    }
+
+    /**
+     * Get the current thread stack as a String.
+     *
+     * @return Current thread stack.
+     */
+    public static String getCurrentStack() {
+        return Arrays.toString(Thread.currentThread().getStackTrace());
+    }
+}

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
@@ -79,6 +79,11 @@ public class FileLogHolder implements TraceWriter {
     protected long maxFileSizeBytes;
 
     /**
+     * Whether to fill up an existing primary file instead of rolling it.
+     */
+    protected final boolean fillExistingFile;
+
+    /**
      * Capture when checked the existence of the log directory
      */
     private Long checkTime = null;
@@ -120,7 +125,8 @@ public class FileLogHolder implements TraceWriter {
      */
     public static FileLogHolder createFileLogHolder(TraceWriter oldLog, FileLogHeader logHeader,
                                                     File logDirectory, String newFileName,
-                                                    int maxFiles, long maxSizeBytes) {
+                                                    int maxFiles, long maxSizeBytes,
+                                                    boolean fillExistingFile) {
 
         final FileLogHolder logHolder;
 
@@ -165,7 +171,7 @@ public class FileLogHolder implements TraceWriter {
             }
 
             // Send to bit bucket until the file is created (true -- create/replace if needed).
-            logHolder = new FileLogHolder(logHeader, logDirectory, fileName, fileExtension, maxFiles, maxSizeBytes);
+            logHolder = new FileLogHolder(logHeader, logDirectory, fileName, fileExtension, maxFiles, maxSizeBytes, fillExistingFile);
         }
 
         return logHolder;
@@ -182,8 +188,9 @@ public class FileLogHolder implements TraceWriter {
      *            <code>maxSizeBytes</code> is greater than 0)
      * @param maxFileSizeBytes The maximum file size a single file should create when this is a rolling log (i.e. when <code>alwaysCreateNewFile</code> is <code>false</code>)
      */
-    private FileLogHolder(FileLogHeader logHeader, File directory, String fileName, String fileExtension, int maxNumFiles, long maxFileSizeBytes) {
+    private FileLogHolder(FileLogHeader logHeader, File directory, String fileName, String fileExtension, int maxNumFiles, long maxFileSizeBytes, boolean fillExistingFile) {
         this.logHeader = logHeader;
+        this.fillExistingFile = fillExistingFile;
 
         currentPrintStream = DummyOutputStream.psInstance;
         update(directory, fileName, fileExtension, maxNumFiles, maxFileSizeBytes);
@@ -204,6 +211,8 @@ public class FileLogHolder implements TraceWriter {
             // change status to "INIT" to force it to be replaced
             setStreamStatus(StreamStatus.INIT, currentFileStream, currentCountingStream, currentPrintStream);
         }
+
+        EmergencyLog.debug(FileLogHolder.class, "update", newMaxSizeBytes);
 
         maxFileSizeBytes = newMaxSizeBytes;
     }
@@ -242,10 +251,18 @@ public class FileLogHolder implements TraceWriter {
             setStreamStatus(StreamStatus.CLOSED, null, null, DummyOutputStream.psInstance);
             // to avoid junit test to print an error message
             if (System.getProperty("test.classesDir") == null && System.getProperty("test.buildDir") == null) {
-                File exf = new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
-                System.err.println(Tr.formatMessage(getTc(), "FAILED_TO_WRITE_LOG", new Object[] { exf.getAbsolutePath() }));
+                System.err.println(Tr.formatMessage(getTc(), "FAILED_TO_WRITE_LOG", new Object[] { getPrimaryFile().getAbsolutePath() }));
             }
         }
+    }
+
+    /**
+     * Return the primary (non-unique) file for this logset.
+     *
+     * @return File for the primary file of this logset.
+     */
+    private File getPrimaryFile() {
+        return new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
     }
 
     /**
@@ -257,6 +274,29 @@ public class FileLogHolder implements TraceWriter {
     private synchronized PrintStream getPrintStream(long numNewChars) {
         switch (currentStatus) {
             case INIT:
+
+                EmergencyLog.debug(FileLogHolder.class, "getPrintStream", fillExistingFile, EmergencyLog.getCurrentStack());
+
+                if (fillExistingFile) {
+                    // Check if we can fill into an existing file (including
+                    // a new log header).
+                    File primaryFile = getPrimaryFile();
+                    if (primaryFile.exists()) {
+
+                        EmergencyLog.debug(FileLogHolder.class, "getPrintStream", primaryFile.getAbsolutePath(), primaryFile.length(), logHeader.length(), numNewChars,
+                                           maxFileSizeBytes);
+
+                        if (maxFileSizeBytes <= 0 || primaryFile.length() + logHeader.length() + numNewChars <= maxFileSizeBytes) {
+                            // There's space, so print the header and return
+                            // the stream.
+
+                            EmergencyLog.debug(FileLogHolder.class, "getPrintStream", "Getting primary stream");
+
+                            return getPrimaryStream(true);
+                        }
+                    }
+                }
+
                 return createStream(true);
             case ACTIVE:
                 if (maxFileSizeBytes > 0) {
@@ -287,8 +327,7 @@ public class FileLogHolder implements TraceWriter {
                         PrintStream ps = createStream(showError);
                         if (this.currentStatus == StreamStatus.ACTIVE) {
                             // stream successfully created
-                            File exf = new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
-                            Tr.audit(getTc(), "LOG_FILE_RESUMED", new Object[] { exf.getAbsolutePath() });
+                            Tr.audit(getTc(), "LOG_FILE_RESUMED", new Object[] { getPrimaryFile().getAbsolutePath() });
                             this.checkTime = null;
                             this.retryTime = null;
                         }
@@ -304,11 +343,25 @@ public class FileLogHolder implements TraceWriter {
      * @return a new print stream
      */
     private synchronized PrintStream createStream(boolean showError) {
-        FileOutputStream newFileStream = null;
-        CountingOutputStream newCountingStream = null;
-        PrintStream newPrintStream = null;
 
-        File targetLogFile = null;
+        // Create the non-unique file (e.g. trace.log)
+        File targetLogFile = LoggingFileUtils.createNewFile(fileLogSet, showError);
+
+        setStreamFromFile(targetLogFile, true, 0);
+
+        return currentPrintStream;
+    }
+
+    /**
+     * This has a side effect of calling
+     * {@link #setStreamStatus(StreamStatus, FileOutputStream, CountingOutputStream, PrintStream)}
+     * with the new stream, thus setting various member variables.
+     *
+     * @param targetLogFile The file to create the stream from.
+     * @param closeExisting Whether to close the existing streams.
+     * @param startOffset The start of the file.
+     */
+    private void setStreamFromFile(File targetLogFile, boolean closeExisting, long startOffset) {
         long realMaxFileSizeBytes = maxFileSizeBytes;
 
         // Store the value, and temporarily "disable" log rolling to avoid
@@ -318,16 +371,18 @@ public class FileLogHolder implements TraceWriter {
 
         Object token = ThreadIdentityManager.runAsServer();
         try {
-            // Close the existing file
-            currentPrintStream.flush();
-            if (currentFileStream != null) {
-                LoggingFileUtils.tryToClose(currentFileStream);
+            if (closeExisting) {
+                // Close the existing file
+                currentPrintStream.flush();
+                if (currentFileStream != null) {
+                    LoggingFileUtils.tryToClose(currentFileStream);
+                }
             }
 
-            // Get the non-unique file (e.g. trace.log)
-            targetLogFile = LoggingFileUtils.createNewFile(fileLogSet, showError);
-
             if (targetLogFile != null) {
+                FileOutputStream newFileStream = null;
+                CountingOutputStream newCountingStream = null;
+                PrintStream newPrintStream = null;
                 try {
                     // create the new file stream -- never append
                     // When asking Erin about the above comment, she could not find a reason for why we would
@@ -336,7 +391,7 @@ public class FileLogHolder implements TraceWriter {
                     // switch to using append = true is being made to address APAR PI57488
                     TextFileOutputStreamFactory fileStreamFactory = TrConfigurator.getFileOutputStreamFactory();
                     newFileStream = fileStreamFactory.createOutputStream(targetLogFile, true);
-                    newCountingStream = new CountingOutputStream(newFileStream);
+                    newCountingStream = new CountingOutputStream(newFileStream, startOffset);
                     newPrintStream = new PrintStream(newCountingStream);
                 } catch (IOException e) {
                     // should not happen: we created the new file in createNewFile
@@ -366,7 +421,17 @@ public class FileLogHolder implements TraceWriter {
             ThreadIdentityManager.reset(token);
             maxFileSizeBytes = realMaxFileSizeBytes;
         }
+    }
 
+    /**
+     * This assume that the primary file exists.
+     *
+     * @param showError
+     * @return
+     */
+    private PrintStream getPrimaryStream(boolean showError) {
+        File primaryFile = getPrimaryFile();
+        setStreamFromFile(primaryFile, false, primaryFile.length());
         return currentPrintStream;
     }
 

--- a/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/utils/FileLogHolderTest.java
+++ b/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/utils/FileLogHolderTest.java
@@ -82,7 +82,7 @@ public class FileLogHolderTest {
 
         // Create a log file with 50byte limit that will keep at most 2 files.
         FileLogHolder a1 = FileLogHolder.createFileLogHolder(null, new FileLogHeader(headerLine, false, false),
-                                                             testLogDir, "a.log", 2, headerLen + aRecordLen + (rolledRecordLen / 2));
+                                                             testLogDir, "a.log", 2, headerLen + aRecordLen + (rolledRecordLen / 2), true);
         a1.writeRecord(aRecord);
 
         assertEquals("fileName should match expected", "a", a1.fileLogSet.getFileName());
@@ -117,7 +117,7 @@ public class FileLogHolderTest {
         // Now lets change the maxNumFiles and maxFileSizeBytes and repeat.
         // a1 and a2 should be the same instance (updates applied)
         FileLogHolder a2 = FileLogHolder.createFileLogHolder(a1, new FileLogHeader(headerLine, false, false),
-                                                             testLogDir, "a.log", 1, headerLen + 20);
+                                                             testLogDir, "a.log", 1, headerLen + 20, true);
         assertSame("a1 and a2 should be the same instance", a1, a2);
         assertEquals("maxNumFiles should have changed to new value", 1, a2.fileLogSet.getMaxFiles());
         assertEquals("maxFileSizeBytes should have changed to new value", headerLen + 20, a2.maxFileSizeBytes);
@@ -132,7 +132,7 @@ public class FileLogHolderTest {
         // Now, let's change the log name to b*. Nothing should happen to the a* log file.
         // a1 and b1 should still be the same log holder instance
         // It should have a new regex pattern for the new filename
-        FileLogHolder b1 = FileLogHolder.createFileLogHolder(a1, null, testLogDir, "b.log", 1, headerLen + 20);
+        FileLogHolder b1 = FileLogHolder.createFileLogHolder(a1, null, testLogDir, "b.log", 1, headerLen + 20, true);
         assertSame("a1 and b1 should be the same instance", a1, b1);
         assertEquals("fileName should match expected", "b", b1.fileLogSet.getFileName());
         assertEquals("fileExtension should match expected", ".log", b1.fileLogSet.getFileExtension());
@@ -148,7 +148,7 @@ public class FileLogHolderTest {
         assertEquals("Only one b* file should exist", 1, getLogFiles(bLogFilter).length);
 
         // Turn off log-rolling
-        FileLogHolder b2 = FileLogHolder.createFileLogHolder(b1, null, testLogDir, "b.log", 1, 0);
+        FileLogHolder b2 = FileLogHolder.createFileLogHolder(b1, null, testLogDir, "b.log", 1, 0, true);
         assertSame("b1 and b2 should be the same instance", b1, b2);
         assertEquals("maxFileSizeBytes should have changed to new value", 0, b2.maxFileSizeBytes);
         assertEquals("maxFiles should be preserved", 1, b2.fileLogSet.getMaxFiles());
@@ -196,7 +196,7 @@ public class FileLogHolderTest {
 
         // Now let's create a new c.log. the previous a and b logs should stay present.
         // Purpose is to test whether or not lock on file can be released.
-        FileLogHolder c1 = FileLogHolder.createFileLogHolder(null, null, testLogDir, "c.log", 1, 0);
+        FileLogHolder c1 = FileLogHolder.createFileLogHolder(null, null, testLogDir, "c.log", 1, 0, true);
 
         // Verify that c.log does not exist, write text to log, and check that file exists
         File cLog = new File(testLogDir, "c.log");


### PR DESCRIPTION
This changes the default behavior of `messages.log` and `trace.log` (but **not** `console.log`) processing so that, if said file already exists, then append to it before rolling (taking into account [maxFileSize](https://openliberty.io/config/rwlp_config_logging.html)).

This behavior may be reverted by specifying `com.ibm.ws.logging.fillExistingFile=false` in `bootstrap.properties` (although reverting does **not** work by setting `fillExistingFile="false"` in the `logging` element of `server.xml`).