### PR TITLE
Use exact version 0.30.0

### DIFF
--- a/dev/com.ibm.ws.io.opentracing.opentracing-api/bnd.bnd
+++ b/dev/com.ibm.ws.io.opentracing.opentracing-api/bnd.bnd
@@ -16,7 +16,7 @@ Bundle-SymbolicName: com.ibm.ws.io.opentracing.opentracing-api
 Bundle-Description: OpenTracing Java API, version 0.30.0
 
 -includeresource: \
-  @${repo;io.opentracing:opentracing-api;0.30.0}!/!(OSGI-OPT/src|META-INF/maven)/*
+  @${repo;io.opentracing:opentracing-api;0.30.0;EXACT}!/!(OSGI-OPT/src|META-INF/maven)/*
 
 Export-Package: io.opentracing;version=0.30.0, \
   io.opentracing.propagation;version=0.30.0, \
@@ -28,5 +28,4 @@ Include-Resource: \
 
 instrument.disabled: true
 
--buildpath: \
-  io.opentracing:opentracing-api;version=0.30.0
+

--- a/dev/com.ibm.ws.opentracing/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing/bnd.bnd
@@ -16,7 +16,7 @@ javac.target: 1.8
 
 Bundle-Name: com.ibm.ws.opentracing
 Bundle-SymbolicName: com.ibm.ws.opentracing
-Bundle-Description:Opentracing 1.0, version ${bVersion}
+Bundle-Description:Opentracing, version 1.0
 
 WS-TraceGroup: OPENTRACING
 
@@ -24,12 +24,16 @@ WS-TraceGroup: OPENTRACING
                 com.ibm.ws.opentracing.OpentracingJaxRsProviderRegister, \
                 com.ibm.ws.opentracing.OpentracingService
                 
-Import-Package: *
+Import-Package: \
+    io.opentracing;version=0.30.0, \
+    io.opentracing.propagation;version=0.30.0, \
+    io.opentracing.tag;version=0.30.0, \
+    *
 
 Export-Package: \
-	com.ibm.ws.opentracing,\
-	com.ibm.ws.opentracing.filters,\
-	com.ibm.ws.opentracing.tracer;provide=true,\
+	com.ibm.ws.opentracing;version=1.0,\
+	com.ibm.ws.opentracing.filters;version=1.0,\
+	com.ibm.ws.opentracing.tracer;version=1.0;provide=true,\
 	io.opentracing;version=0.30.0,\
 	io.opentracing.propagation;version=0.30.0,\
 	io.opentracing.tag;version=0.30.0
@@ -39,12 +43,12 @@ Private-Package: com.ibm.ws.opentracing.resources
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 -buildpath: \
-        com.ibm.websphere.javaee.jaxrs.2.0;version=latest, \
-        com.ibm.ws.logging;version=latest, \
-        com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
-        com.ibm.ws.jaxrs.2.0.common;version=latest, \
-        com.ibm.wsspi.org.osgi.service.component;version=latest, \
-        com.ibm.wsspi.org.osgi.core;version=latest, \
-        com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
-        com.ibm.websphere.org.osgi.service.cm;version=latest, \
-        com.ibm.ws.io.opentracing.opentracing-api;version=latest
+	com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
+	com.ibm.ws.logging;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.jaxrs.2.0.common;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component;version=latest,\
+	com.ibm.wsspi.org.osgi.core;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.websphere.org.osgi.service.cm;version=latest,\
+	com.ibm.ws.io.opentracing.opentracing-api;version=latest

--- a/dev/com.ibm.ws.opentracing_fat/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.opentracing_fat/opentracing.mock.bnd
@@ -31,8 +31,8 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"
 
 -includeresource: \
-   @${repo;io.opentracing:opentracing-mock;0.30.0}!/!(OSGI-OPT/src|META-INF/maven)/*, \
-   @${repo;io.opentracing:opentracing-util;0.30.0}!/!(OSGI-OPT/src|META-INF/maven)/*
+   @${repo;io.opentracing:opentracing-mock;0.30.0;EXACT}!/!(OSGI-OPT/src|META-INF/maven)/*, \
+   @${repo;io.opentracing:opentracing-util;0.30.0;EXACT}!/!(OSGI-OPT/src|META-INF/maven)/*
    
 -buildpath: \
         io.opentracing:opentracing-mock;version=0.30.0, \


### PR DESCRIPTION
Add the EXACT to the includeresource line so that only io.opentracing:opentracing-api 0.30.0 will be used.

Fixes #4366 