### PR TITLE
Add units for bulkhead.waiting.duration metric

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.metrics/src/com/ibm/ws/microprofile/faulttolerance/metrics/integration/MetricRecorderImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.metrics/src/com/ibm/ws/microprofile/faulttolerance/metrics/integration/MetricRecorderImpl.java
@@ -149,7 +149,7 @@ public class MetricRecorderImpl implements MetricRecorder {
 
         if (bulkheadPolicy != null && isAsync == AsyncType.ASYNC) {
             bulkheadQueuePopulation = gauge(registry, metricPrefix + ".bulkhead.waitingQueue.population", MetricUnits.NONE, this::getQueuePopulation);
-            bulkheadQueueWaitTimeHistogram = registry.histogram(metricPrefix + ".bulkhead.waiting.duration");
+            bulkheadQueueWaitTimeHistogram = registry.histogram(new Metadata(metricPrefix + ".bulkhead.waiting.duration", MetricType.HISTOGRAM, MetricUnits.NANOSECONDS));
         } else {
             bulkheadQueuePopulation = null;
             bulkheadQueueWaitTimeHistogram = null;


### PR DESCRIPTION
This metric is reported in nanoseconds. Not supplying the unit meant
that the metric name was wrong and the value was not converted to
seconds in the prometheus output format.

Fixes #4378 