### PR TITLE
move jdbc init code towards tolerance of driver class

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -14,6 +14,7 @@ import java.io.Serializable;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLNonTransientException;
@@ -164,9 +165,9 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
     private final AtomicReference<DSConfig> dsConfigRef = new AtomicReference<DSConfig>();
 
     /**
-     * Data source implementation class name. Only rely on this value when initialized.
+     * Data source or driver implementation class name. Only rely on this value when initialized.
      */
-    private String dsImplClassName;
+    private String vendorImplClassName;
 
     /**
      * Indicates that we deferred the destroying that would normally happen because of configuration changes.
@@ -439,28 +440,30 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "create new data source", id, jndiName, type);
 
-                CommonDataSource ds;
+                Object vendorImpl;
                 Class<?> ifc;
 
                 if (type == null){
-                    ds = id != null && id.contains("dataSource[DefaultDataSource]") ? jdbcDriverSvc.createDefaultDataSource(vProps)
-                                    :jdbcDriverSvc.createAnyDataSource(vProps);
-                    ifc = ds instanceof XADataSource ? XADataSource.class
-                                    : ds instanceof ConnectionPoolDataSource ? ConnectionPoolDataSource.class
-                                                    : DataSource.class;
+                    vendorImpl = id != null && id.contains("dataSource[DefaultDataSource]")
+                               ? jdbcDriverSvc.createDefaultDataSourceOrDriver(vProps)
+                               : jdbcDriverSvc.createAnyDataSourceOrDriver(vProps);
+                    ifc = vendorImpl instanceof XADataSource ? XADataSource.class
+                        : vendorImpl instanceof ConnectionPoolDataSource ? ConnectionPoolDataSource.class
+                        : vendorImpl instanceof DataSource ? DataSource.class
+                        : Driver.class;
                 } else if (ConnectionPoolDataSource.class.getName().equals(type)) {
                     ifc = ConnectionPoolDataSource.class;
-                    ds = jdbcDriverSvc.createConnectionPoolDataSource(vProps);
+                    vendorImpl = jdbcDriverSvc.createConnectionPoolDataSource(vProps);
                 } else if (XADataSource.class.getName().equals(type)) {
                     ifc = XADataSource.class;
-                    ds = jdbcDriverSvc.createXADataSource(vProps);
+                    vendorImpl = jdbcDriverSvc.createXADataSource(vProps);
                 } else if (DataSource.class.getName().equals(type)) {
                     ifc = DataSource.class;
-                    ds = jdbcDriverSvc.createDataSource(vProps);
+                    vendorImpl = jdbcDriverSvc.createDataSource(vProps);
                 } else
                     throw new SQLNonTransientException(ConnectorService.getMessage("MISSING_RESOURCE_J2CA8030", DSConfig.TYPE, type, DATASOURCE, jndiName == null ? id : jndiName));
 
-                mcf1 = new WSManagedConnectionFactoryImpl(dsConfigRef, ifc, ds, jdbcRuntime);
+                mcf1 = new WSManagedConnectionFactoryImpl(dsConfigRef, ifc, vendorImpl, jdbcRuntime);
                 WSManagedConnectionFactoryImpl mcf0 = mcfPerClassLoader.putIfAbsent(identifier, mcf1);
                 mcf1 = mcf0 == null ? mcf1 : mcf0;
 
@@ -584,33 +587,35 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
             }
             jdbcDriverSvc.addObserver(this);
 
-            CommonDataSource ds;
+            Object vendorImpl;
             Class<?> ifc;
 
             if(type == null){
-                ds = id != null && id.contains("dataSource[DefaultDataSource]") ? jdbcDriverSvc.createDefaultDataSource(vProps)
-                                :jdbcDriverSvc.createAnyDataSource(vProps);
-                ifc = ds instanceof XADataSource ? XADataSource.class
-                                : ds instanceof ConnectionPoolDataSource ? ConnectionPoolDataSource.class
-                                                : DataSource.class;
+                vendorImpl = id != null && id.contains("dataSource[DefaultDataSource]")
+                                ? jdbcDriverSvc.createDefaultDataSourceOrDriver(vProps)
+                                : jdbcDriverSvc.createAnyDataSourceOrDriver(vProps);
+                ifc = vendorImpl instanceof XADataSource ? XADataSource.class
+                    : vendorImpl instanceof ConnectionPoolDataSource ? ConnectionPoolDataSource.class
+                    : vendorImpl instanceof DataSource ? DataSource.class
+                    : Driver.class;
             } else if (ConnectionPoolDataSource.class.getName().equals(type)) {
                 ifc = ConnectionPoolDataSource.class;
-                ds = jdbcDriverSvc.createConnectionPoolDataSource(vProps);
+                vendorImpl = jdbcDriverSvc.createConnectionPoolDataSource(vProps);
             } else if (XADataSource.class.getName().equals(type)) {
                 ifc = XADataSource.class;
-                ds = jdbcDriverSvc.createXADataSource(vProps);
+                vendorImpl = jdbcDriverSvc.createXADataSource(vProps);
             } else if (DataSource.class.getName().equals(type)) {
                 ifc = DataSource.class;
-                ds = jdbcDriverSvc.createDataSource(vProps);
+                vendorImpl = jdbcDriverSvc.createDataSource(vProps);
             } else
                 throw new SQLNonTransientException(ConnectorService.getMessage("MISSING_RESOURCE_J2CA8030", DSConfig.TYPE, type, DATASOURCE, jndiName == null ? id : jndiName));
 
             // Convert isolationLevel constant name to integer
-            dsImplClassName = ds.getClass().getName();
-            parseIsolationLevel(wProps, dsImplClassName);
+            vendorImplClassName = vendorImpl.getClass().getName();
+            parseIsolationLevel(wProps, vendorImplClassName);
 
             // Derby Embedded needs a reference count so that we can shutdown databases when no longer used.
-            isDerbyEmbedded = dsImplClassName.startsWith("org.apache.derby.jdbc.Embedded");
+            isDerbyEmbedded = vendorImplClassName.startsWith("org.apache.derby.jdbc.Embedded");
             if (isDerbyEmbedded) {
                 String dbName = (String) vProps.get(DataSourceDef.databaseName.name());
                 if (dbName != null) {
@@ -625,7 +630,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
 
             dsConfigRef.set(new DSConfig(id, jndiName, wProps, vProps, connectorSvc));
 
-            WSManagedConnectionFactoryImpl mcfImpl = new WSManagedConnectionFactoryImpl(dsConfigRef, ifc, ds, jdbcRuntime);
+            WSManagedConnectionFactoryImpl mcfImpl = new WSManagedConnectionFactoryImpl(dsConfigRef, ifc, vendorImpl, jdbcRuntime);
 
             if (jdbcDriverSvc.loadFromApp()) {
                 // data source class loaded from thread context class loader
@@ -718,7 +723,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                     // to issue a shutdown of the Derby database in order to free it up for other class loaders.
                     destroyConnectionFactories(isDerbyEmbedded);
                 } else {
-                    parseIsolationLevel(wProps, dsImplClassName);
+                    parseIsolationLevel(wProps, vendorImplClassName);
 
                     // Swap the reference to the configuration - the WAS data source will start honoring it
                     dsConfigRef.set(new DSConfig(config, wProps));
@@ -796,11 +801,11 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
      * Utility method that converts transaction isolation level constant names
      * to the corresponding int value.
      *
-     * @param isolationLevel the value to parse.
-     * @param ds the data source.
+     * @param wProps WAS data source properties, including the configured isolationLevel property.
+     * @param vendorImplClassName name of the vendor data source or driver implementation class.
      * @return Integer transaction isolation level constant value. If unknown, then the original String value.
      */
-    private static final void parseIsolationLevel(NavigableMap<String, Object> wProps, String dsImplClassName) {
+    private static final void parseIsolationLevel(NavigableMap<String, Object> wProps, String vendorImplClassName) {
         // Convert isolationLevel constant name to integer
         Object isolationLevel = wProps.get(DataSourceDef.isolationLevel.name());
         if (isolationLevel instanceof String) {
@@ -808,7 +813,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                             : "TRANSACTION_REPEATABLE_READ".equals(isolationLevel) ? Connection.TRANSACTION_REPEATABLE_READ
                                             : "TRANSACTION_SERIALIZABLE".equals(isolationLevel) ? Connection.TRANSACTION_SERIALIZABLE
                                                             : "TRANSACTION_READ_UNCOMMITTED".equals(isolationLevel) ? Connection.TRANSACTION_READ_UNCOMMITTED
-                                                                            : "TRANSACTION_SNAPSHOT".equals(isolationLevel) ? (dsImplClassName.startsWith("com.microsoft.") ? 4096 : 16)
+                                                                            : "TRANSACTION_SNAPSHOT".equals(isolationLevel) ? (vendorImplClassName.startsWith("com.microsoft.") ? 4096 : 16)
                                                                                             : isolationLevel;
 
             wProps.put(DataSourceDef.isolationLevel.name(), isolationLevel);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -324,18 +324,19 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
     }
 
     /**
-     * Create any type of data source - whichever is available, in the following order,
+     * Create any type of data source or java.sql.Driver - whichever is available, looking for known data source impl classes in the following order,
      * <ul>
      * <li>javax.sql.ConnectionPoolDataSource
      * <li>javax.sql.DataSource
      * <li>javax.sql.XADataSource
+     * <li>java.sql.Driver // TODO
      * </ul>
      * 
      * @param props typed data source properties
-     * @return the data source
+     * @return the data source or driver instance
      * @throws SQLException if an error occurs
      */
-    public CommonDataSource createAnyDataSource(Properties props) throws SQLException {
+    public Object createAnyDataSourceOrDriver(Properties props) throws SQLException {
         lock.readLock().lock();
         try {
             if (!isInitialized)
@@ -383,19 +384,19 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
     }
     
     /**
-     * Create any type of data source - whichever is available, in the following order,
+     * Create any type of data source or java.sql.Driver - whichever is available, looking for known data source impl classes in the following order,
      * <ul>
      * <li>javax.sql.XADataSource
      * <li>javax.sql.ConnectionPoolDataSource
      * <li>javax.sql.DataSource
      * </ul>
-     * This order is different than the standard priority, which prioritizes javax.sql.XADataSource last.
+     * This order is different than the standard priority, which prioritizes javax.sql.XADataSource after ConnectionPoolDataSource and DataSource.
      * 
      * @param props typed data source properties
-     * @return the data source
+     * @return the data source or driver instance
      * @throws SQLException if an error occurs
      */
-    public CommonDataSource createDefaultDataSource(Properties props) throws SQLException {
+    public Object createDefaultDataSourceOrDriver(Properties props) throws SQLException {
         lock.readLock().lock();
         try {
             if (!isInitialized)


### PR DESCRIPTION
The updates under this pull are still very early on and form some basic steps to start moving the JDBC code in the directly of accepting a java.sql.Driver instead of a data source impl class.  No new capability is made available here - many more steps are necessary before that can happen - but we can at least demonstrate that we are maintaining non-breakage of existing code path as we head in this direction.