### PR TITLE
Issue 4364: Fill existing messages.log/trace.log files before rolling

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -945,7 +945,7 @@ public class BaseTraceService implements TrService {
                                                         config.getMessageFileName(),
                                                         config.getMaxFiles(),
                                                         config.getMaxFileBytes(),
-                                                        config.fillExistingFile());
+                                                        config.newLogsOnStart());
 
         // Always create a traceLog when using Tr -- this file won't actually be
         // created until something is logged to it...
@@ -961,7 +961,7 @@ public class BaseTraceService implements TrService {
                                                          config.getTraceFileName(),
                                                          config.getMaxFiles(),
                                                          config.getMaxFileBytes(),
-                                                         config.fillExistingFile());
+                                                         config.newLogsOnStart());
             if (!TraceComponent.isAnyTracingEnabled()) {
                 ((FileLogHolder) traceLog).releaseFile();
             }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -944,7 +944,8 @@ public class BaseTraceService implements TrService {
                                                         config.getLogDirectory(),
                                                         config.getMessageFileName(),
                                                         config.getMaxFiles(),
-                                                        config.getMaxFileBytes());
+                                                        config.getMaxFileBytes(),
+                                                        config.fillExistingFile());
 
         // Always create a traceLog when using Tr -- this file won't actually be
         // created until something is logged to it...
@@ -959,7 +960,8 @@ public class BaseTraceService implements TrService {
                                                          config.getLogDirectory(),
                                                          config.getTraceFileName(),
                                                          config.getMaxFiles(),
-                                                         config.getMaxFileBytes());
+                                                         config.getMaxFileBytes(),
+                                                         config.fillExistingFile());
             if (!TraceComponent.isAnyTracingEnabled()) {
                 ((FileLogHolder) traceLog).releaseFile();
             }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -945,7 +945,7 @@ public class BaseTraceService implements TrService {
                                                         config.getMessageFileName(),
                                                         config.getMaxFiles(),
                                                         config.getMaxFileBytes(),
-                                                        config.newLogsOnStart());
+                                                        config.getNewLogsOnStart());
 
         // Always create a traceLog when using Tr -- this file won't actually be
         // created until something is logged to it...
@@ -961,7 +961,7 @@ public class BaseTraceService implements TrService {
                                                          config.getTraceFileName(),
                                                          config.getMaxFiles(),
                                                          config.getMaxFileBytes(),
-                                                         config.newLogsOnStart());
+                                                         config.getNewLogsOnStart());
             if (!TraceComponent.isAnyTracingEnabled()) {
                 ((FileLogHolder) traceLog).releaseFile();
             }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/CountingOutputStream.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/CountingOutputStream.java
@@ -18,7 +18,12 @@ public class CountingOutputStream extends OutputStream {
     private long count;
 
     public CountingOutputStream(OutputStream out) {
+        this(out, 0);
+    }
+
+    public CountingOutputStream(OutputStream out, long startOffset) {
         this.out = out;
+        this.count = startOffset;
     }
 
     public long count() {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/FileLogHeader.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/FileLogHeader.java
@@ -25,19 +25,72 @@ public class FileLogHeader {
         this.javaLangInstrument = javaLangInstrument;
     }
 
-    public void print(PrintStream ps) {
-        ps.println(BaseTraceFormatter.banner);
+    private void process(Processor processor) {
+        processor.println(BaseTraceFormatter.banner);
 
-        ps.print(header);
+        processor.print(header);
 
         if (trace) {
-            ps.println("trace.specification = " + TrConfigurator.getEffectiveTraceSpec());
+            processor.println("trace.specification = " + TrConfigurator.getEffectiveTraceSpec());
 
             if (!javaLangInstrument) {
-                ps.println("java.lang.instrument = " + javaLangInstrument);
+                processor.println("java.lang.instrument = " + javaLangInstrument);
             }
         }
 
-        ps.println(BaseTraceFormatter.banner);
+        processor.println(BaseTraceFormatter.banner);
+    }
+
+    public void print(PrintStream ps) {
+        process(new PrintProcessor(ps));
+    }
+
+    public long length() {
+        LengthProcessor lengthProcessor = new LengthProcessor();
+        process(lengthProcessor);
+        return lengthProcessor.getLength();
+    }
+
+    interface Processor {
+        void print(String str);
+
+        void println(String str);
+    }
+
+    class PrintProcessor implements Processor {
+
+        final PrintStream ps;
+
+        public PrintProcessor(final PrintStream ps) {
+            this.ps = ps;
+        }
+
+        @Override
+        public void println(String str) {
+            ps.println(str);
+        }
+
+        @Override
+        public void print(String str) {
+            ps.print(str);
+        }
+    }
+
+    class LengthProcessor implements Processor {
+        long length;
+
+        @Override
+        public void print(String str) {
+            length += str.getBytes().length;
+        }
+
+        @Override
+        public void println(String str) {
+            length += str.getBytes().length + LoggingConstants.nlen;
+        }
+
+        long getLength() {
+            return length;
+        }
     }
 }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/Jsr47TraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/Jsr47TraceService.java
@@ -62,7 +62,7 @@ public class Jsr47TraceService extends BaseTraceService {
                                                             config.getMessageFileName(),
                                                             config.getMaxFiles(),
                                                             config.getMaxFileBytes(),
-                                                            config.fillExistingFile());
+                                                            config.newLogsOnStart());
 
             // Always create a traceLog when using Tr -- this file won't actually be
             // created until something is logged to it...

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/Jsr47TraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/Jsr47TraceService.java
@@ -61,10 +61,11 @@ public class Jsr47TraceService extends BaseTraceService {
                                                             config.getLogDirectory(),
                                                             config.getMessageFileName(),
                                                             config.getMaxFiles(),
-                                                            config.getMaxFileBytes());
+                                                            config.getMaxFileBytes(),
+                                                            config.fillExistingFile());
 
             // Always create a traceLog when using Tr -- this file won't actually be
-            // created until something is logged to it... 
+            // created until something is logged to it...
             traceLog = new TraceWriter() {
 
                 @Override

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/Jsr47TraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/Jsr47TraceService.java
@@ -62,7 +62,7 @@ public class Jsr47TraceService extends BaseTraceService {
                                                             config.getMessageFileName(),
                                                             config.getMaxFiles(),
                                                             config.getMaxFileBytes(),
-                                                            config.newLogsOnStart());
+                                                            config.getNewLogsOnStart());
 
             // Always create a traceLog when using Tr -- this file won't actually be
             // created until something is logged to it...

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
@@ -108,6 +108,9 @@ public class LogProviderConfigImpl implements LogProviderConfig {
     /** Format to use for console.log / console */
     protected volatile String consoleFormat = LoggingConstants.DEFAULT_CONSOLE_FORMAT;
 
+    /** Whether to fill up any existing primary file instead of immediately rolling it. */
+    protected volatile boolean fillExistingFile = true;
+
     /** The header written at the beginning of all log files. */
     private final String logHeader;
 
@@ -222,6 +225,8 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         messageFormat = InitConfgAttribute.MESSAGE_FORMAT.getStringValueAndSaveInit(c, messageFormat, isInit);
         consoleSource = InitConfgAttribute.CONSOLE_SOURCE.getStringCollectionValueAndSaveInit("consoleSource", c, consoleSource, isInit);
         consoleFormat = InitConfgAttribute.CONSOLE_FORMAT.getStringValueAndSaveInit(c, consoleFormat, isInit);
+
+        fillExistingFile = InitConfgAttribute.FILL_EXISTING_FILE.getBooleanValue(c, fillExistingFile, isInit);
     }
 
     /**
@@ -373,6 +378,10 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         return consoleFormat;
     }
 
+    public boolean fillExistingFile() {
+        return fillExistingFile;
+    }
+
     /**
      * @return true if we should use the logger -> tr handler
      */
@@ -392,6 +401,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         sb.append(",traceFormat=").append(traceFormat);
         sb.append(",isoDateFormat=").append(isoDateFormat);
         sb.append(",traceFileName=").append(traceFileName);
+        sb.append(",fillExistingFile=").append(fillExistingFile);
         sb.append("]");
 
         return sb.toString();
@@ -414,7 +424,8 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         MESSAGE_SOURCE("messageSource", "com.ibm.ws.logging.message.source"),
         MESSAGE_FORMAT("messageFormat", "com.ibm.ws.logging.message.format"),
         CONSOLE_SOURCE("consoleSource", "com.ibm.ws.logging.console.source"),
-        CONSOLE_FORMAT("consoleFormat", "com.ibm.ws.logging.console.format");
+        CONSOLE_FORMAT("consoleFormat", "com.ibm.ws.logging.console.format"),
+        FILL_EXISTING_FILE("fillExistingFile", "com.ibm.ws.logging.fillExistingFile");
 
         final String configKey;
         final String propertyKey;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
@@ -110,7 +110,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
     protected volatile String consoleFormat = LoggingConstants.DEFAULT_CONSOLE_FORMAT;
 
     /** Whether to fill up any existing primary file instead of immediately rolling it. */
-    protected volatile boolean fillExistingFile = !FileLogHolder.NEW_LOGS_ON_START_DEFAULT;
+    protected volatile boolean newLogsOnStart = FileLogHolder.NEW_LOGS_ON_START_DEFAULT;
 
     /** The header written at the beginning of all log files. */
     private final String logHeader;
@@ -227,7 +227,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         consoleSource = InitConfgAttribute.CONSOLE_SOURCE.getStringCollectionValueAndSaveInit("consoleSource", c, consoleSource, isInit);
         consoleFormat = InitConfgAttribute.CONSOLE_FORMAT.getStringValueAndSaveInit(c, consoleFormat, isInit);
 
-        fillExistingFile = InitConfgAttribute.FILL_EXISTING_FILE.getBooleanValue(c, fillExistingFile, isInit);
+        newLogsOnStart = InitConfgAttribute.NEW_LOGS_ON_START.getBooleanValue(c, newLogsOnStart, isInit);
     }
 
     /**
@@ -379,8 +379,8 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         return consoleFormat;
     }
 
-    public boolean fillExistingFile() {
-        return fillExistingFile;
+    public boolean newLogsOnStart() {
+        return newLogsOnStart;
     }
 
     /**
@@ -402,7 +402,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         sb.append(",traceFormat=").append(traceFormat);
         sb.append(",isoDateFormat=").append(isoDateFormat);
         sb.append(",traceFileName=").append(traceFileName);
-        sb.append(",newLogsOnStart=").append(!fillExistingFile);
+        sb.append(",newLogsOnStart=").append(newLogsOnStart);
         sb.append("]");
 
         return sb.toString();
@@ -426,7 +426,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         MESSAGE_FORMAT("messageFormat", "com.ibm.ws.logging.message.format"),
         CONSOLE_SOURCE("consoleSource", "com.ibm.ws.logging.console.source"),
         CONSOLE_FORMAT("consoleFormat", "com.ibm.ws.logging.console.format"),
-        FILL_EXISTING_FILE("newLogsOnStart", "com.ibm.ws.logging.newLogsOnStart");
+        NEW_LOGS_ON_START("newLogsOnStart", "com.ibm.ws.logging.newLogsOnStart");
 
         final String configKey;
         final String propertyKey;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
@@ -25,6 +25,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.logging.internal.impl.LoggingConstants.FFDCSummaryPolicy;
 import com.ibm.ws.logging.internal.impl.LoggingConstants.TraceFormat;
+import com.ibm.ws.logging.utils.FileLogHolder;
 import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
 import com.ibm.wsspi.logprovider.FFDCFilterService;
 import com.ibm.wsspi.logprovider.LogProviderConfig;
@@ -109,7 +110,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
     protected volatile String consoleFormat = LoggingConstants.DEFAULT_CONSOLE_FORMAT;
 
     /** Whether to fill up any existing primary file instead of immediately rolling it. */
-    protected volatile boolean fillExistingFile = true;
+    protected volatile boolean fillExistingFile = !FileLogHolder.NEW_LOGS_ON_START_DEFAULT;
 
     /** The header written at the beginning of all log files. */
     private final String logHeader;
@@ -401,7 +402,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         sb.append(",traceFormat=").append(traceFormat);
         sb.append(",isoDateFormat=").append(isoDateFormat);
         sb.append(",traceFileName=").append(traceFileName);
-        sb.append(",fillExistingFile=").append(fillExistingFile);
+        sb.append(",newLogsOnStart=").append(!fillExistingFile);
         sb.append("]");
 
         return sb.toString();
@@ -425,7 +426,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         MESSAGE_FORMAT("messageFormat", "com.ibm.ws.logging.message.format"),
         CONSOLE_SOURCE("consoleSource", "com.ibm.ws.logging.console.source"),
         CONSOLE_FORMAT("consoleFormat", "com.ibm.ws.logging.console.format"),
-        FILL_EXISTING_FILE("fillExistingFile", "com.ibm.ws.logging.fillExistingFile");
+        FILL_EXISTING_FILE("newLogsOnStart", "com.ibm.ws.logging.newLogsOnStart");
 
         final String configKey;
         final String propertyKey;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
@@ -426,7 +426,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         MESSAGE_FORMAT("messageFormat", "com.ibm.ws.logging.message.format"),
         CONSOLE_SOURCE("consoleSource", "com.ibm.ws.logging.console.source"),
         CONSOLE_FORMAT("consoleFormat", "com.ibm.ws.logging.console.format"),
-        NEW_LOGS_ON_START("newLogsOnStart", "com.ibm.ws.logging.newLogsOnStart");
+        NEW_LOGS_ON_START("newLogsOnStart", FileLogHolder.NEW_LOGS_ON_START_PROPERTY);
 
         final String configKey;
         final String propertyKey;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
@@ -379,7 +379,7 @@ public class LogProviderConfigImpl implements LogProviderConfig {
         return consoleFormat;
     }
 
-    public boolean newLogsOnStart() {
+    public boolean getNewLogsOnStart() {
         return newLogsOnStart;
     }
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
@@ -15,6 +15,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Calendar;
 
 import com.ibm.websphere.ras.Tr;
@@ -39,6 +41,17 @@ import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
  * a non-unique name. It will be renamed when the log is rolled.
  */
 public class FileLogHolder implements TraceWriter {
+
+    /**
+     * The default of whether to fill existing messages.log/trace.log files or not before rolling.
+     * By default, we do. This can be reverted with -Dcom.ibm.ws.logging.doNotFillExistingFile=true
+     */
+    public static final boolean FILL_EXISTING_FILE_DEFAULT = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+        @Override
+        public Boolean run() {
+            return !Boolean.getBoolean("com.ibm.ws.logging.doNotFillExistingFile");
+        }
+    });
 
     private static TraceComponent tc = null;
 
@@ -77,6 +90,11 @@ public class FileLogHolder implements TraceWriter {
      * log will be rolled over into a new file.
      */
     protected long maxFileSizeBytes;
+
+    /**
+     * Whether to fill up an existing primary file instead of rolling it.
+     */
+    protected final boolean fillExistingFile;
 
     /**
      * Capture when checked the existence of the log directory
@@ -121,6 +139,33 @@ public class FileLogHolder implements TraceWriter {
     public static FileLogHolder createFileLogHolder(TraceWriter oldLog, FileLogHeader logHeader,
                                                     File logDirectory, String newFileName,
                                                     int maxFiles, long maxSizeBytes) {
+        return createFileLogHolder(oldLog, logHeader, logDirectory, newFileName, maxFiles, maxSizeBytes, FILL_EXISTING_FILE_DEFAULT);
+    }
+
+    /**
+     * This method will check to see if the supplied parameters match the settings on the <code>oldLog</code>,
+     * if they do then the <code>oldLog</code> is returned, otherwise a new FileLogHolder will be created.
+     *
+     * @param oldLog The previous FileLogHolder that may or may not be replaced by a new one, may
+     *            be <code>null</code> (will cause a new instance to be created)
+     * @param logHeader
+     *            Header to print at the top of new log files
+     * @param logDirectory
+     *            Directory in which to store created log files
+     * @param newFileName
+     *            File name for new log: this will be split into a name and extension
+     * @param maxFiles
+     *            New maximum number of log files. If 0, log files won't be pruned.
+     * @param maxSizeBytes
+     *            New maximum log file size in bytes. If 0, log files won't be rolled.
+     * @param fillExistingFile
+     *            Whether to fill an existing primary file if there's space (if it exists).
+     * @return a log holder. If all values are the same, the old one is returned, otherwise a new log holder is created.
+     */
+    public static FileLogHolder createFileLogHolder(TraceWriter oldLog, FileLogHeader logHeader,
+                                                    File logDirectory, String newFileName,
+                                                    int maxFiles, long maxSizeBytes,
+                                                    boolean fillExistingFile) {
 
         final FileLogHolder logHolder;
 
@@ -165,7 +210,7 @@ public class FileLogHolder implements TraceWriter {
             }
 
             // Send to bit bucket until the file is created (true -- create/replace if needed).
-            logHolder = new FileLogHolder(logHeader, logDirectory, fileName, fileExtension, maxFiles, maxSizeBytes);
+            logHolder = new FileLogHolder(logHeader, logDirectory, fileName, fileExtension, maxFiles, maxSizeBytes, fillExistingFile);
         }
 
         return logHolder;
@@ -182,8 +227,9 @@ public class FileLogHolder implements TraceWriter {
      *            <code>maxSizeBytes</code> is greater than 0)
      * @param maxFileSizeBytes The maximum file size a single file should create when this is a rolling log (i.e. when <code>alwaysCreateNewFile</code> is <code>false</code>)
      */
-    private FileLogHolder(FileLogHeader logHeader, File directory, String fileName, String fileExtension, int maxNumFiles, long maxFileSizeBytes) {
+    private FileLogHolder(FileLogHeader logHeader, File directory, String fileName, String fileExtension, int maxNumFiles, long maxFileSizeBytes, boolean fillExistingFile) {
         this.logHeader = logHeader;
+        this.fillExistingFile = fillExistingFile;
 
         currentPrintStream = DummyOutputStream.psInstance;
         update(directory, fileName, fileExtension, maxNumFiles, maxFileSizeBytes);
@@ -242,10 +288,18 @@ public class FileLogHolder implements TraceWriter {
             setStreamStatus(StreamStatus.CLOSED, null, null, DummyOutputStream.psInstance);
             // to avoid junit test to print an error message
             if (System.getProperty("test.classesDir") == null && System.getProperty("test.buildDir") == null) {
-                File exf = new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
-                System.err.println(Tr.formatMessage(getTc(), "FAILED_TO_WRITE_LOG", new Object[] { exf.getAbsolutePath() }));
+                System.err.println(Tr.formatMessage(getTc(), "FAILED_TO_WRITE_LOG", new Object[] { getPrimaryFile().getAbsolutePath() }));
             }
         }
+    }
+
+    /**
+     * Return the primary (non-unique) file for this logset.
+     *
+     * @return File for the primary file of this logset.
+     */
+    private File getPrimaryFile() {
+        return new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
     }
 
     /**
@@ -257,6 +311,31 @@ public class FileLogHolder implements TraceWriter {
     private synchronized PrintStream getPrintStream(long numNewChars) {
         switch (currentStatus) {
             case INIT:
+
+                if (fillExistingFile) {
+
+                    // Check if we can fill into an existing file (including a new log header).
+                    File primaryFile = getPrimaryFile();
+                    if (primaryFile.exists()) {
+
+                        // If maxFileSize is set in bootstrap.properties, then maxFileSizeBytes will have been
+                        // updated before this INIT check to that value; otherwise, if maxFileSize was not
+                        // set (i.e. default) or it was set in server.xml, then config processing hasn't run
+                        // yet, so maxFileSizeBytes will be 0 (there will be an `update` call later). In the
+                        // latter case, this means that we might add the logging header (about 1KB) plus
+                        // any other messages up until that size update, meaning that we could go
+                        // over the configured maxFileSize by a little bit, but this is okay. In that case,
+                        // maxFileSizeBytes will be 0, so we'll fill the existing file, and then later on,
+                        // it'll roll over if needed.
+
+                        if (maxFileSizeBytes <= 0 || primaryFile.length() + logHeader.length() + numNewChars <= maxFileSizeBytes) {
+                            // There's space, so print the header and return the stream.
+
+                            return getPrimaryStream(true);
+                        }
+                    }
+                }
+
                 return createStream(true);
             case ACTIVE:
                 if (maxFileSizeBytes > 0) {
@@ -287,8 +366,7 @@ public class FileLogHolder implements TraceWriter {
                         PrintStream ps = createStream(showError);
                         if (this.currentStatus == StreamStatus.ACTIVE) {
                             // stream successfully created
-                            File exf = new File(this.fileLogSet.getDirectory(), this.fileLogSet.getFileName() + this.fileLogSet.getFileExtension());
-                            Tr.audit(getTc(), "LOG_FILE_RESUMED", new Object[] { exf.getAbsolutePath() });
+                            Tr.audit(getTc(), "LOG_FILE_RESUMED", new Object[] { getPrimaryFile().getAbsolutePath() });
                             this.checkTime = null;
                             this.retryTime = null;
                         }
@@ -304,11 +382,25 @@ public class FileLogHolder implements TraceWriter {
      * @return a new print stream
      */
     private synchronized PrintStream createStream(boolean showError) {
-        FileOutputStream newFileStream = null;
-        CountingOutputStream newCountingStream = null;
-        PrintStream newPrintStream = null;
 
-        File targetLogFile = null;
+        // Create the non-unique file (e.g. trace.log)
+        File targetLogFile = LoggingFileUtils.createNewFile(fileLogSet, showError);
+
+        setStreamFromFile(targetLogFile, true, 0);
+
+        return currentPrintStream;
+    }
+
+    /**
+     * This has a side effect of calling
+     * {@link #setStreamStatus(StreamStatus, FileOutputStream, CountingOutputStream, PrintStream)}
+     * with the new stream, thus setting various member variables.
+     *
+     * @param targetLogFile The file to create the stream from.
+     * @param closeExisting Whether to close the existing streams.
+     * @param startOffset The start of the file.
+     */
+    private void setStreamFromFile(File targetLogFile, boolean closeExisting, long startOffset) {
         long realMaxFileSizeBytes = maxFileSizeBytes;
 
         // Store the value, and temporarily "disable" log rolling to avoid
@@ -318,16 +410,18 @@ public class FileLogHolder implements TraceWriter {
 
         Object token = ThreadIdentityManager.runAsServer();
         try {
-            // Close the existing file
-            currentPrintStream.flush();
-            if (currentFileStream != null) {
-                LoggingFileUtils.tryToClose(currentFileStream);
+            if (closeExisting) {
+                // Close the existing file
+                currentPrintStream.flush();
+                if (currentFileStream != null) {
+                    LoggingFileUtils.tryToClose(currentFileStream);
+                }
             }
 
-            // Get the non-unique file (e.g. trace.log)
-            targetLogFile = LoggingFileUtils.createNewFile(fileLogSet, showError);
-
             if (targetLogFile != null) {
+                FileOutputStream newFileStream = null;
+                CountingOutputStream newCountingStream = null;
+                PrintStream newPrintStream = null;
                 try {
                     // create the new file stream -- never append
                     // When asking Erin about the above comment, she could not find a reason for why we would
@@ -336,7 +430,7 @@ public class FileLogHolder implements TraceWriter {
                     // switch to using append = true is being made to address APAR PI57488
                     TextFileOutputStreamFactory fileStreamFactory = TrConfigurator.getFileOutputStreamFactory();
                     newFileStream = fileStreamFactory.createOutputStream(targetLogFile, true);
-                    newCountingStream = new CountingOutputStream(newFileStream);
+                    newCountingStream = new CountingOutputStream(newFileStream, startOffset);
                     newPrintStream = new PrintStream(newCountingStream);
                 } catch (IOException e) {
                     // should not happen: we created the new file in createNewFile
@@ -366,7 +460,17 @@ public class FileLogHolder implements TraceWriter {
             ThreadIdentityManager.reset(token);
             maxFileSizeBytes = realMaxFileSizeBytes;
         }
+    }
 
+    /**
+     * This assume that the primary file exists.
+     *
+     * @param showError
+     * @return
+     */
+    private PrintStream getPrimaryStream(boolean showError) {
+        File primaryFile = getPrimaryFile();
+        setStreamFromFile(primaryFile, false, primaryFile.length());
         return currentPrintStream;
     }
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
@@ -43,6 +43,9 @@ public class FileLogHolder implements TraceWriter {
     /** Whether to fill up any existing primary file instead of immediately rolling it. */
     public static final boolean NEW_LOGS_ON_START_DEFAULT = true;
 
+    /** The bootstrap property to change whether to fill up existing primary file instead of immediately rolling it. */
+    public static final String NEW_LOGS_ON_START_PROPERTY = "com.ibm.ws.logging.newLogsOnStart";
+
     private static TraceComponent tc = null;
 
     enum StreamStatus {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
@@ -84,7 +84,7 @@ public class FileLogHolder implements TraceWriter {
     /**
      * Whether to fill up an existing primary file instead of rolling it.
      */
-    protected final boolean fillExistingFile;
+    protected final boolean newLogsOnStart;
 
     /**
      * Capture when checked the existence of the log directory
@@ -148,14 +148,14 @@ public class FileLogHolder implements TraceWriter {
      *            New maximum number of log files. If 0, log files won't be pruned.
      * @param maxSizeBytes
      *            New maximum log file size in bytes. If 0, log files won't be rolled.
-     * @param fillExistingFile
+     * @param newLogsOnStart
      *            Whether to fill an existing primary file if there's space (if it exists).
      * @return a log holder. If all values are the same, the old one is returned, otherwise a new log holder is created.
      */
     public static FileLogHolder createFileLogHolder(TraceWriter oldLog, FileLogHeader logHeader,
                                                     File logDirectory, String newFileName,
                                                     int maxFiles, long maxSizeBytes,
-                                                    boolean fillExistingFile) {
+                                                    boolean newLogsOnStart) {
 
         final FileLogHolder logHolder;
 
@@ -200,7 +200,7 @@ public class FileLogHolder implements TraceWriter {
             }
 
             // Send to bit bucket until the file is created (true -- create/replace if needed).
-            logHolder = new FileLogHolder(logHeader, logDirectory, fileName, fileExtension, maxFiles, maxSizeBytes, fillExistingFile);
+            logHolder = new FileLogHolder(logHeader, logDirectory, fileName, fileExtension, maxFiles, maxSizeBytes, newLogsOnStart);
         }
 
         return logHolder;
@@ -216,10 +216,11 @@ public class FileLogHolder implements TraceWriter {
      * @param maxNumFiles The maximum number of files to create if this is a rolling log (i.e. when <code>alwaysCreateNewFile</code> is <code>false</code> and
      *            <code>maxSizeBytes</code> is greater than 0)
      * @param maxFileSizeBytes The maximum file size a single file should create when this is a rolling log (i.e. when <code>alwaysCreateNewFile</code> is <code>false</code>)
+     * @param newLogsOnStart Whether to fill an existing primary file if there's space (if it exists).
      */
-    private FileLogHolder(FileLogHeader logHeader, File directory, String fileName, String fileExtension, int maxNumFiles, long maxFileSizeBytes, boolean fillExistingFile) {
+    private FileLogHolder(FileLogHeader logHeader, File directory, String fileName, String fileExtension, int maxNumFiles, long maxFileSizeBytes, boolean newLogsOnStart) {
         this.logHeader = logHeader;
-        this.fillExistingFile = fillExistingFile;
+        this.newLogsOnStart = newLogsOnStart;
 
         currentPrintStream = DummyOutputStream.psInstance;
         update(directory, fileName, fileExtension, maxNumFiles, maxFileSizeBytes);
@@ -302,7 +303,7 @@ public class FileLogHolder implements TraceWriter {
         switch (currentStatus) {
             case INIT:
 
-                if (fillExistingFile) {
+                if (!newLogsOnStart) {
 
                     // Check if we can fill into an existing file (including a new log header).
                     File primaryFile = getPrimaryFile();

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
@@ -40,6 +40,9 @@ import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
  */
 public class FileLogHolder implements TraceWriter {
 
+    /** Whether to fill up any existing primary file instead of immediately rolling it. */
+    public static final boolean NEW_LOGS_ON_START_DEFAULT = true;
+
     private static TraceComponent tc = null;
 
     enum StreamStatus {
@@ -103,6 +106,30 @@ public class FileLogHolder implements TraceWriter {
             tc = Tr.register(FileLogHolder.class, null, "com.ibm.ws.logging.internal.resources.LoggingMessages");
         }
         return tc;
+    }
+
+    /**
+     * This method will check to see if the supplied parameters match the settings on the <code>oldLog</code>,
+     * if they do then the <code>oldLog</code> is returned, otherwise a new FileLogHolder will be created.
+     *
+     * @param oldLog The previous FileLogHolder that may or may not be replaced by a new one, may
+     *            be <code>null</code> (will cause a new instance to be created)
+     * @param logHeader
+     *            Header to print at the top of new log files
+     * @param logDirectory
+     *            Directory in which to store created log files
+     * @param newFileName
+     *            File name for new log: this will be split into a name and extension
+     * @param maxFiles
+     *            New maximum number of log files. If 0, log files won't be pruned.
+     * @param maxSizeBytes
+     *            New maximum log file size in bytes. If 0, log files won't be rolled.
+     * @return a log holder. If all values are the same, the old one is returned, otherwise a new log holder is created.
+     */
+    public static FileLogHolder createFileLogHolder(TraceWriter oldLog, FileLogHeader logHeader,
+                                                    File logDirectory, String newFileName,
+                                                    int maxFiles, long maxSizeBytes) {
+        return createFileLogHolder(oldLog, logHeader, logDirectory, newFileName, maxFiles, maxSizeBytes, !NEW_LOGS_ON_START_DEFAULT);
     }
 
     /**

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
@@ -129,7 +129,7 @@ public class FileLogHolder implements TraceWriter {
     public static FileLogHolder createFileLogHolder(TraceWriter oldLog, FileLogHeader logHeader,
                                                     File logDirectory, String newFileName,
                                                     int maxFiles, long maxSizeBytes) {
-        return createFileLogHolder(oldLog, logHeader, logDirectory, newFileName, maxFiles, maxSizeBytes, !NEW_LOGS_ON_START_DEFAULT);
+        return createFileLogHolder(oldLog, logHeader, logDirectory, newFileName, maxFiles, maxSizeBytes, NEW_LOGS_ON_START_DEFAULT);
     }
 
     /**

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/utils/FileLogHolder.java
@@ -15,8 +15,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Calendar;
 
 import com.ibm.websphere.ras.Tr;
@@ -41,17 +39,6 @@ import com.ibm.wsspi.logging.TextFileOutputStreamFactory;
  * a non-unique name. It will be renamed when the log is rolled.
  */
 public class FileLogHolder implements TraceWriter {
-
-    /**
-     * The default of whether to fill existing messages.log/trace.log files or not before rolling.
-     * By default, we do. This can be reverted with -Dcom.ibm.ws.logging.doNotFillExistingFile=true
-     */
-    public static final boolean FILL_EXISTING_FILE_DEFAULT = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-        @Override
-        public Boolean run() {
-            return !Boolean.getBoolean("com.ibm.ws.logging.doNotFillExistingFile");
-        }
-    });
 
     private static TraceComponent tc = null;
 
@@ -116,30 +103,6 @@ public class FileLogHolder implements TraceWriter {
             tc = Tr.register(FileLogHolder.class, null, "com.ibm.ws.logging.internal.resources.LoggingMessages");
         }
         return tc;
-    }
-
-    /**
-     * This method will check to see if the supplied parameters match the settings on the <code>oldLog</code>,
-     * if they do then the <code>oldLog</code> is returned, otherwise a new FileLogHolder will be created.
-     *
-     * @param oldLog The previous FileLogHolder that may or may not be replaced by a new one, may
-     *            be <code>null</code> (will cause a new instance to be created)
-     * @param logHeader
-     *            Header to print at the top of new log files
-     * @param logDirectory
-     *            Directory in which to store created log files
-     * @param newFileName
-     *            File name for new log: this will be split into a name and extension
-     * @param maxFiles
-     *            New maximum number of log files. If 0, log files won't be pruned.
-     * @param maxSizeBytes
-     *            New maximum log file size in bytes. If 0, log files won't be rolled.
-     * @return a log holder. If all values are the same, the old one is returned, otherwise a new log holder is created.
-     */
-    public static FileLogHolder createFileLogHolder(TraceWriter oldLog, FileLogHeader logHeader,
-                                                    File logDirectory, String newFileName,
-                                                    int maxFiles, long maxSizeBytes) {
-        return createFileLogHolder(oldLog, logHeader, logDirectory, newFileName, maxFiles, maxSizeBytes, FILL_EXISTING_FILE_DEFAULT);
     }
 
     /**

--- a/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/utils/FileLogHolderTest.java
+++ b/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/utils/FileLogHolderTest.java
@@ -10,11 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.logging.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -285,7 +280,7 @@ public class FileLogHolderTest {
 
         int expected = header.length() + record.length() + LoggingConstants.nlen;
 
-        if (newLogsOnStart) {
+        if (!newLogsOnStart) {
             expected <<= 1;
         }
 

--- a/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/utils/FileLogHolderTest.java
+++ b/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/utils/FileLogHolderTest.java
@@ -266,36 +266,35 @@ public class FileLogHolderTest {
      */
     @Test
     public void testFillingExistingFile() throws Exception {
+        // Test both rolling behaviors
         testFilling("d.log", true);
-
-        // Also check that the old behavior works:
         testFilling("e.log", false);
     }
 
-    private void testFilling(String logName, boolean refill) {
+    private void testFilling(String logName, boolean newLogsOnStart) {
         final String bannerLine = BaseTraceFormatter.banner + LoggingConstants.nl;
         String headerLine = "header line" + LoggingConstants.nl;
         String header = bannerLine + headerLine + bannerLine;
 
         String record = "record";
 
-        writeFileOnce(headerLine, record, logName, refill);
-        writeFileOnce(headerLine, record, logName, refill);
+        writeFileOnce(headerLine, record, logName, newLogsOnStart);
+        writeFileOnce(headerLine, record, logName, newLogsOnStart);
 
         File f = new File(testLogDir, logName);
 
         int expected = header.length() + record.length() + LoggingConstants.nlen;
 
-        if (refill) {
+        if (newLogsOnStart) {
             expected <<= 1;
         }
 
-        assertTrue("Incorrect file length for " + logName + ". Length: " + f.length() + ", Expected: " + expected + ", Refill: " + refill, f.length() == expected);
+        assertTrue("Incorrect file length for " + logName + ". Length: " + f.length() + ", Expected: " + expected + ", NewLogsOnStart: " + newLogsOnStart, f.length() == expected);
     }
 
-    private void writeFileOnce(String headerLine, String record, String logName, boolean refill) {
+    private void writeFileOnce(String headerLine, String record, String logName, boolean newLogsOnStart) {
         FileLogHolder d1 = FileLogHolder.createFileLogHolder(null, new FileLogHeader(headerLine, false, false),
-                                                             testLogDir, logName, 2, 0, refill);
+                                                             testLogDir, logName, 2, 0, newLogsOnStart);
 
         d1.writeRecord(record);
 

--- a/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/utils/FileLogHolderTest.java
+++ b/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/utils/FileLogHolderTest.java
@@ -10,6 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.logging.utils;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -81,4 +81,5 @@ test.project: true
 	org.apache.derby:derbynet;version=10.11.1.1,\
 	org.jmock:jmock;strategy=exact;version=2.5.1,\
 	org.hamcrest:hamcrest-all;version=1.3,\
-	com.ibm.ws.org.glassfish.json.1.0;version=latest
+	com.ibm.ws.org.glassfish.json.1.0;version=latest,\
+	com.ibm.ws.logging;version=latest

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1217,10 +1217,21 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     /**
+     * Clear any log marks and then set log marks to messages.log
+     * or trace.log if those exist. See issue 4364
+     *
      * @throws Exception
      */
     private void initializeAnyExistingMarks() throws Exception {
         final String method = "initializeAnyExistingMarks";
+
+        // First we clear any marks - it's possible this
+        // server was re-used, but stopped, so logs were taken
+        // away. So if we simply clear our cache of log marks,
+        // and then for any of the files that do exist, set the
+        // log marks, then we should be at a good initial state
+        clearLogMarks();
+
         if (defaultLogFileExists()) {
             Log.info(c, method, "Saving messages.log mark");
             setMarkToEndOfLog();

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -906,6 +906,7 @@ public class LibertyServer implements LogMonitorClient {
 
         if (preClean) {
             // Tidy up any pre-existing logs
+            Log.info(c, method, "Tidying logs");
             preStartServerLogsTidy();
             clearLogMarks();
         } else {
@@ -921,6 +922,7 @@ public class LibertyServer implements LogMonitorClient {
             if (traceLog != null && traceLog.exists()) {
                 setTraceMarkToEndOfDefaultTrace();
             }
+            Log.info(c, method, "Saving marks");
             logMonitor.setOriginLogMarks();
         }
 
@@ -4298,6 +4300,7 @@ public class LibertyServer implements LogMonitorClient {
      * @param log files to mark. If none are specified, the default log file is marked.
      */
     public void setMarkToEndOfLog(RemoteFile... logFiles) throws Exception {
+        Log.info(c, "setMarkToEndOfLog", "Setting mark to the end of logs (if null, messages.log): " + logFiles);
         logMonitor.setMarkToEndOfLog(logFiles);
     }
 
@@ -4307,6 +4310,7 @@ public class LibertyServer implements LogMonitorClient {
      * @throws Exception
      */
     public void setTraceMarkToEndOfDefaultTrace() throws Exception {
+        Log.info(c, "setTraceMarkToEndOfDefaultTrace", "Setting mark to the end of trace.log");
         setMarkToEndOfLog(getDefaultTraceFile());
     }
 
@@ -5669,7 +5673,7 @@ public class LibertyServer implements LogMonitorClient {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see componenttest.topology.impl.LogMonitorClient#lmcResetLogOffsets()
      */
     @Override
@@ -5679,7 +5683,7 @@ public class LibertyServer implements LogMonitorClient {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see componenttest.topology.impl.LogMonitorClient#lmcSetOriginLogOffsets()
      */
     @Override

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -282,7 +282,9 @@ public class LibertyServer implements LogMonitorClient {
     protected List<String> originalFeatureSet = null;
 
     //Used for keeping track of offset positions of log files
-    protected final HashMap<String, Long> logOffsets = new HashMap<String, Long>();
+    protected HashMap<String, Long> logOffsets = new HashMap<String, Long>();
+
+    protected HashMap<String, Long> originOffsets = new HashMap<String, Long>();
 
     protected boolean serverCleanupProblem = false;
 
@@ -5662,6 +5664,27 @@ public class LibertyServer implements LogMonitorClient {
     @Override
     public void lmcClearLogOffsets() {
         logOffsets.clear();
+        originOffsets.clear();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see componenttest.topology.impl.LogMonitorClient#lmcResetLogOffsets()
+     */
+    @Override
+    public void lmcResetLogOffsets() {
+        logOffsets = new HashMap<String, Long>(originOffsets);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see componenttest.topology.impl.LogMonitorClient#lmcSetOriginLogOffsets()
+     */
+    @Override
+    public void lmcSetOriginLogOffsets() {
+        originOffsets = new HashMap<String, Long>(logOffsets);
     }
 
     /*

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -900,8 +900,10 @@ public class LibertyServer implements LogMonitorClient {
         this.isTidy = false;
 
         //Tidy up any pre-existing logs
-        if (preClean)
+        if (preClean) {
+            resetLogMarks();
             preStartServerLogsTidy();
+        }
 
         final Properties envVars = new Properties();
 
@@ -2037,6 +2039,12 @@ public class LibertyServer implements LogMonitorClient {
 
             checkLogsForErrorsAndWarnings(expectedFailuresRegExps);
         } finally {
+            // Issue 4363: No longer reset the log offsets because if the
+            // server starts again, logs will roll into the existing logs.
+            // We also don't clear the message counters because the use
+            // of those counters uses searchForMessages which doesn't take
+            // into account marks.
+            /*-
             if (commandPortEnabled) {
                 // If the command port is enabled we should reset the log offsets
                 // as we will get new logs on the next start. However, if the
@@ -2045,6 +2053,8 @@ public class LibertyServer implements LogMonitorClient {
                 resetLogOffsets();
                 clearMessageCounters();
             }
+            */
+
             if (GLOBAL_JAVA2SECURITY || GLOBAL_DEBUG_JAVA2SECURITY) {
                 try {
                     new ACEScanner(this).run();

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3969,7 +3969,7 @@ public class LibertyServer implements LogMonitorClient {
         //Set path to server log assuming the default setting.
         // ALWAYS RETURN messages.log -- tests assume they can look for INFO+ messages.
         RemoteFile file = LibertyFileManager.getLibertyFile(machine, messageAbsPath);
-        if (file == null) {
+        if (file == null && throwIfMissing) {
             throw new IllegalStateException("Unable to find default log file, path=" + messageAbsPath);
         }
         return file;

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitor.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitor.java
@@ -58,7 +58,7 @@ public class LogMonitor {
     public void resetLogMarks() {
         client.lmcResetLogOffsets();
         logMarks = new HashMap<String, Long>(originMarks);
-        Log.info(c, "resetLogMarks", "reset log offsets " + logMarks);
+        Log.info(c, "resetLogMarks", "Reset log offsets " + logMarks);
     }
 
     /**
@@ -72,7 +72,7 @@ public class LogMonitor {
         logMarks.clear();
         originMarks.clear();
 
-        Log.info(c, "clearLogMarks", "cleared log marks");
+        Log.info(c, "clearLogMarks", "Cleared log marks");
     }
 
     /**
@@ -83,7 +83,7 @@ public class LogMonitor {
         client.lmcSetOriginLogOffsets();
         originMarks = new HashMap<String, Long>(logMarks);
 
-        Log.info(c, "setOriginLogMarks", "set origin log marks " + originMarks);
+        Log.info(c, "setOriginLogMarks", "Set origin log marks " + originMarks);
     }
 
     /**
@@ -128,7 +128,7 @@ public class LogMonitor {
             logMarks.put(logFile, 0L);
         }
 
-        Log.info(c, "getMarkOffset", "mark offset=" + logMarks.get(logFile) + " for " + logFile);
+        Log.info(c, "getMarkOffset", "Mark offset for " + logFile + "=" + logMarks.get(logFile) + " for " + logFile);
         return logMarks.get(logFile);
     }
 

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitor.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitor.java
@@ -56,6 +56,7 @@ public class LogMonitor {
      * Reset the mark and offset values for logs back to the start of the JVM's run.
      */
     public void resetLogMarks() {
+        client.lmcResetLogOffsets();
         logMarks = new HashMap<String, Long>(originMarks);
         Log.finer(c, "resetLogMarks", "reset log offsets");
     }
@@ -70,6 +71,8 @@ public class LogMonitor {
         client.lmcClearLogOffsets();
         logMarks.clear();
         originMarks.clear();
+
+        Log.finer(c, "clearLogMarks", "cleared marks");
     }
 
     /**
@@ -77,9 +80,10 @@ public class LogMonitor {
      */
     public void setOriginLogMarks() {
 
+        client.lmcSetOriginLogOffsets();
         originMarks = new HashMap<String, Long>(logMarks);
 
-        Log.finer(c, "setOriginMarks", "set origin marks");
+        Log.finer(c, "setOriginLogMarks", "set origin marks");
     }
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitor.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitor.java
@@ -40,7 +40,9 @@ public class LogMonitor {
     protected static final long LOG_SEARCH_TIMEOUT = FATRunner.FAT_TEST_LOCALRUN ? 12 * 1000 : 120 * 1000;
 
     //Used for keeping track of mark positions of log files
-    protected final HashMap<String, Long> logMarks = new HashMap<String, Long>();
+    protected HashMap<String, Long> logMarks = new HashMap<String, Long>();
+
+    protected HashMap<String, Long> originMarks = new HashMap<String, Long>();
 
     //The sole client for this LogMonitor instance.  The LogMonitorClient provides a means of hiding
     //the underlying server class for which this class providing log monitoring services.
@@ -51,17 +53,33 @@ public class LogMonitor {
     }
 
     /**
-     * Reset the mark and offset values for logs back to the start of the file.
-     * <p>
+     * Reset the mark and offset values for logs back to the start of the JVM's run.
+     */
+    public void resetLogMarks() {
+        logMarks = new HashMap<String, Long>(originMarks);
+        Log.finer(c, "resetLogMarks", "reset log offsets");
+    }
+
+    /**
      * Note: This method doesn't set the offset values to the beginning of the file per se,
      * rather this method sets the list of logs and their offset values to null. When one
      * of the findStringsInLogsAndTrace...(...) methods are called, it will recreate the
      * list of logs and set each offset value to 0L - the start of the file.
      */
-    public void resetLogMarks() {
-        client.lmcClearLogOffsets();//logOffsets.clear();
+    public void clearLogMarks() {
+        client.lmcClearLogOffsets();
         logMarks.clear();
-        Log.finer(c, "resetLogOffsets", "cleared log and mark offsets");
+        originMarks.clear();
+    }
+
+    /**
+     * Set the marks that we'll go back to when {@link #resetLogMarks()} is called.
+     */
+    public void setOriginLogMarks() {
+
+        originMarks = new HashMap<String, Long>(logMarks);
+
+        Log.finer(c, "setOriginMarks", "set origin marks");
     }
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitor.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitor.java
@@ -58,7 +58,7 @@ public class LogMonitor {
     public void resetLogMarks() {
         client.lmcResetLogOffsets();
         logMarks = new HashMap<String, Long>(originMarks);
-        Log.finer(c, "resetLogMarks", "reset log offsets");
+        Log.info(c, "resetLogMarks", "reset log offsets " + logMarks);
     }
 
     /**
@@ -72,7 +72,7 @@ public class LogMonitor {
         logMarks.clear();
         originMarks.clear();
 
-        Log.finer(c, "clearLogMarks", "cleared marks");
+        Log.info(c, "clearLogMarks", "cleared log marks");
     }
 
     /**
@@ -83,7 +83,7 @@ public class LogMonitor {
         client.lmcSetOriginLogOffsets();
         originMarks = new HashMap<String, Long>(logMarks);
 
-        Log.finer(c, "setOriginLogMarks", "set origin marks");
+        Log.info(c, "setOriginLogMarks", "set origin log marks " + originMarks);
     }
 
     /**
@@ -111,7 +111,7 @@ public class LogMonitor {
             }
 
             Long oldMarkOffset = logMarks.put(path, offset);
-            Log.finer(c, "setMarkToEndOfLog", path + ", old mark offset=" + oldMarkOffset + ", new mark offset=" + offset);
+            Log.info(c, "setMarkToEndOfLog", path + ", old mark offset=" + oldMarkOffset + ", new mark offset=" + offset + " for " + logFile);
         }
     }
 
@@ -128,7 +128,7 @@ public class LogMonitor {
             logMarks.put(logFile, 0L);
         }
 
-        Log.finer(c, "getMarkOffset", "mark offset=" + logMarks.get(logFile));
+        Log.info(c, "getMarkOffset", "mark offset=" + logMarks.get(logFile) + " for " + logFile);
         return logMarks.get(logFile);
     }
 

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitorClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitorClient.java
@@ -35,6 +35,16 @@ public interface LogMonitorClient {
     public void lmcClearLogOffsets();
 
     /**
+     * Reset the mark and offset values for logs back to the start of this process.
+     */
+    public void lmcResetLogOffsets();
+
+    /**
+     * Set the offsets that we'll go back to when {@link #lmcResetLogOffsets()} is called.
+     */
+    public void lmcSetOriginLogOffsets();
+
+    /**
      * This method updates the log offset for the server instance. Log offset style
      * tracking has been deprecated. This method has been provided to enable backward
      * compatibility with logic that was moved into the LogMonitor class. For new implementations,

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/WebServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/WebServer.java
@@ -416,6 +416,26 @@ public class WebServer extends Server implements LogMonitorClient {
         // Do nothing, the use of offsets is not supported in this server type
     }
 
+    /*
+     * (non-Javadoc)
+     * 
+     * @see componenttest.topology.impl.LogMonitorClient#lmcResetLogOffsets()
+     */
+    @Override
+    public void lmcResetLogOffsets() {
+        // Do nothing, the use of offsets is not supported in this server type
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see componenttest.topology.impl.LogMonitorClient#lmcSetOriginLogOffsets()
+     */
+    @Override
+    public void lmcSetOriginLogOffsets() {
+        // Do nothing, the use of offsets is not supported in this server type
+    }
+
     //*******************************************************************************************************
     //*** End of log monitoring methods
     //*******************************************************************************************************


### PR DESCRIPTION
See https://github.com/OpenLiberty/open-liberty/issues/4364

This adds an option to change the behavior of `messages.log` and `trace.log` (but not `console.log`) processing so that, if said file already exists when starting Liberty, then append to it before rolling (taking into account [`maxFileSize`](https://openliberty.io/config/rwlp_config_logging.html) and [`maxFiles`](https://openliberty.io/config/rwlp_config_logging.html)).

This behavior may be enabled by specifying `com.ibm.ws.logging.newLogsOnStart=false` in [`bootstrap.properties`](https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/twlp_inst_bootstrap.html).