### PR TITLE
locate driver and stringify properties

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -14,6 +14,7 @@ import java.io.Serializable;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLNonTransientException;
@@ -164,9 +165,9 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
     private final AtomicReference<DSConfig> dsConfigRef = new AtomicReference<DSConfig>();
 
     /**
-     * Data source implementation class name. Only rely on this value when initialized.
+     * Data source or driver implementation class name. Only rely on this value when initialized.
      */
-    private String dsImplClassName;
+    private String vendorImplClassName;
 
     /**
      * Indicates that we deferred the destroying that would normally happen because of configuration changes.
@@ -439,28 +440,30 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "create new data source", id, jndiName, type);
 
-                CommonDataSource ds;
+                Object vendorImpl;
                 Class<?> ifc;
 
                 if (type == null){
-                    ds = id != null && id.contains("dataSource[DefaultDataSource]") ? jdbcDriverSvc.createDefaultDataSource(vProps)
-                                    :jdbcDriverSvc.createAnyDataSource(vProps);
-                    ifc = ds instanceof XADataSource ? XADataSource.class
-                                    : ds instanceof ConnectionPoolDataSource ? ConnectionPoolDataSource.class
-                                                    : DataSource.class;
+                    vendorImpl = id != null && id.contains("dataSource[DefaultDataSource]")
+                               ? jdbcDriverSvc.createDefaultDataSourceOrDriver(vProps)
+                               : jdbcDriverSvc.createAnyDataSourceOrDriver(vProps);
+                    ifc = vendorImpl instanceof XADataSource ? XADataSource.class
+                        : vendorImpl instanceof ConnectionPoolDataSource ? ConnectionPoolDataSource.class
+                        : vendorImpl instanceof DataSource ? DataSource.class
+                        : Driver.class;
                 } else if (ConnectionPoolDataSource.class.getName().equals(type)) {
                     ifc = ConnectionPoolDataSource.class;
-                    ds = jdbcDriverSvc.createConnectionPoolDataSource(vProps);
+                    vendorImpl = jdbcDriverSvc.createConnectionPoolDataSource(vProps);
                 } else if (XADataSource.class.getName().equals(type)) {
                     ifc = XADataSource.class;
-                    ds = jdbcDriverSvc.createXADataSource(vProps);
+                    vendorImpl = jdbcDriverSvc.createXADataSource(vProps);
                 } else if (DataSource.class.getName().equals(type)) {
                     ifc = DataSource.class;
-                    ds = jdbcDriverSvc.createDataSource(vProps);
+                    vendorImpl = jdbcDriverSvc.createDataSource(vProps);
                 } else
                     throw new SQLNonTransientException(ConnectorService.getMessage("MISSING_RESOURCE_J2CA8030", DSConfig.TYPE, type, DATASOURCE, jndiName == null ? id : jndiName));
 
-                mcf1 = new WSManagedConnectionFactoryImpl(dsConfigRef, ifc, ds, jdbcRuntime);
+                mcf1 = new WSManagedConnectionFactoryImpl(dsConfigRef, ifc, vendorImpl, jdbcRuntime);
                 WSManagedConnectionFactoryImpl mcf0 = mcfPerClassLoader.putIfAbsent(identifier, mcf1);
                 mcf1 = mcf0 == null ? mcf1 : mcf0;
 
@@ -584,33 +587,35 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
             }
             jdbcDriverSvc.addObserver(this);
 
-            CommonDataSource ds;
+            Object vendorImpl;
             Class<?> ifc;
 
             if(type == null){
-                ds = id != null && id.contains("dataSource[DefaultDataSource]") ? jdbcDriverSvc.createDefaultDataSource(vProps)
-                                :jdbcDriverSvc.createAnyDataSource(vProps);
-                ifc = ds instanceof XADataSource ? XADataSource.class
-                                : ds instanceof ConnectionPoolDataSource ? ConnectionPoolDataSource.class
-                                                : DataSource.class;
+                vendorImpl = id != null && id.contains("dataSource[DefaultDataSource]")
+                                ? jdbcDriverSvc.createDefaultDataSourceOrDriver(vProps)
+                                : jdbcDriverSvc.createAnyDataSourceOrDriver(vProps);
+                ifc = vendorImpl instanceof XADataSource ? XADataSource.class
+                    : vendorImpl instanceof ConnectionPoolDataSource ? ConnectionPoolDataSource.class
+                    : vendorImpl instanceof DataSource ? DataSource.class
+                    : Driver.class;
             } else if (ConnectionPoolDataSource.class.getName().equals(type)) {
                 ifc = ConnectionPoolDataSource.class;
-                ds = jdbcDriverSvc.createConnectionPoolDataSource(vProps);
+                vendorImpl = jdbcDriverSvc.createConnectionPoolDataSource(vProps);
             } else if (XADataSource.class.getName().equals(type)) {
                 ifc = XADataSource.class;
-                ds = jdbcDriverSvc.createXADataSource(vProps);
+                vendorImpl = jdbcDriverSvc.createXADataSource(vProps);
             } else if (DataSource.class.getName().equals(type)) {
                 ifc = DataSource.class;
-                ds = jdbcDriverSvc.createDataSource(vProps);
+                vendorImpl = jdbcDriverSvc.createDataSource(vProps);
             } else
                 throw new SQLNonTransientException(ConnectorService.getMessage("MISSING_RESOURCE_J2CA8030", DSConfig.TYPE, type, DATASOURCE, jndiName == null ? id : jndiName));
 
             // Convert isolationLevel constant name to integer
-            dsImplClassName = ds.getClass().getName();
-            parseIsolationLevel(wProps, dsImplClassName);
+            vendorImplClassName = vendorImpl.getClass().getName();
+            parseIsolationLevel(wProps, vendorImplClassName);
 
             // Derby Embedded needs a reference count so that we can shutdown databases when no longer used.
-            isDerbyEmbedded = dsImplClassName.startsWith("org.apache.derby.jdbc.Embedded");
+            isDerbyEmbedded = vendorImplClassName.startsWith("org.apache.derby.jdbc.Embedded");
             if (isDerbyEmbedded) {
                 String dbName = (String) vProps.get(DataSourceDef.databaseName.name());
                 if (dbName != null) {
@@ -625,7 +630,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
 
             dsConfigRef.set(new DSConfig(id, jndiName, wProps, vProps, connectorSvc));
 
-            WSManagedConnectionFactoryImpl mcfImpl = new WSManagedConnectionFactoryImpl(dsConfigRef, ifc, ds, jdbcRuntime);
+            WSManagedConnectionFactoryImpl mcfImpl = new WSManagedConnectionFactoryImpl(dsConfigRef, ifc, vendorImpl, jdbcRuntime);
 
             if (jdbcDriverSvc.loadFromApp()) {
                 // data source class loaded from thread context class loader
@@ -718,7 +723,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                     // to issue a shutdown of the Derby database in order to free it up for other class loaders.
                     destroyConnectionFactories(isDerbyEmbedded);
                 } else {
-                    parseIsolationLevel(wProps, dsImplClassName);
+                    parseIsolationLevel(wProps, vendorImplClassName);
 
                     // Swap the reference to the configuration - the WAS data source will start honoring it
                     dsConfigRef.set(new DSConfig(config, wProps));
@@ -796,11 +801,11 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
      * Utility method that converts transaction isolation level constant names
      * to the corresponding int value.
      *
-     * @param isolationLevel the value to parse.
-     * @param ds the data source.
+     * @param wProps WAS data source properties, including the configured isolationLevel property.
+     * @param vendorImplClassName name of the vendor data source or driver implementation class.
      * @return Integer transaction isolation level constant value. If unknown, then the original String value.
      */
-    private static final void parseIsolationLevel(NavigableMap<String, Object> wProps, String dsImplClassName) {
+    private static final void parseIsolationLevel(NavigableMap<String, Object> wProps, String vendorImplClassName) {
         // Convert isolationLevel constant name to integer
         Object isolationLevel = wProps.get(DataSourceDef.isolationLevel.name());
         if (isolationLevel instanceof String) {
@@ -808,7 +813,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                             : "TRANSACTION_REPEATABLE_READ".equals(isolationLevel) ? Connection.TRANSACTION_REPEATABLE_READ
                                             : "TRANSACTION_SERIALIZABLE".equals(isolationLevel) ? Connection.TRANSACTION_SERIALIZABLE
                                                             : "TRANSACTION_READ_UNCOMMITTED".equals(isolationLevel) ? Connection.TRANSACTION_READ_UNCOMMITTED
-                                                                            : "TRANSACTION_SNAPSHOT".equals(isolationLevel) ? (dsImplClassName.startsWith("com.microsoft.") ? 4096 : 16)
+                                                                            : "TRANSACTION_SNAPSHOT".equals(isolationLevel) ? (vendorImplClassName.startsWith("com.microsoft.") ? 4096 : 16)
                                                                                             : isolationLevel;
 
             wProps.put(DataSourceDef.isolationLevel.name(), isolationLevel);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -688,7 +688,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 try {
                     acceptsURL = driver.acceptsURL(url);
                 } catch (SQLException x) {
-                    if (failure != null)
+                    if (failure == null)
                         failure = x;
                     acceptsURL = false;
                 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -324,18 +324,19 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
     }
 
     /**
-     * Create any type of data source - whichever is available, in the following order,
+     * Create any type of data source or java.sql.Driver - whichever is available, looking for known data source impl classes in the following order,
      * <ul>
      * <li>javax.sql.ConnectionPoolDataSource
      * <li>javax.sql.DataSource
      * <li>javax.sql.XADataSource
+     * <li>java.sql.Driver // TODO
      * </ul>
      * 
      * @param props typed data source properties
-     * @return the data source
+     * @return the data source or driver instance
      * @throws SQLException if an error occurs
      */
-    public CommonDataSource createAnyDataSource(Properties props) throws SQLException {
+    public Object createAnyDataSourceOrDriver(Properties props) throws SQLException {
         lock.readLock().lock();
         try {
             if (!isInitialized)
@@ -383,19 +384,19 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
     }
     
     /**
-     * Create any type of data source - whichever is available, in the following order,
+     * Create any type of data source or java.sql.Driver - whichever is available, looking for known data source impl classes in the following order,
      * <ul>
      * <li>javax.sql.XADataSource
      * <li>javax.sql.ConnectionPoolDataSource
      * <li>javax.sql.DataSource
      * </ul>
-     * This order is different than the standard priority, which prioritizes javax.sql.XADataSource last.
+     * This order is different than the standard priority, which prioritizes javax.sql.XADataSource after ConnectionPoolDataSource and DataSource.
      * 
      * @param props typed data source properties
-     * @return the data source
+     * @return the data source or driver instance
      * @throws SQLException if an error occurs
      */
-    public CommonDataSource createDefaultDataSource(Properties props) throws SQLException {
+    public Object createDefaultDataSourceOrDriver(Properties props) throws SQLException {
         lock.readLock().lock();
         try {
             if (!isInitialized)

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -33,7 +33,7 @@
 
     <dataSource id="fatDriver" jndiName="jdbc/fatDriver">
       <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
-      <properties url="jdbc:derby:memory:wrappedDerby;create=true" user="dbuser1" password="{xor}Oz0vKDtu" />
+      <properties url="jdbc:fatdriver:memory:jdbcdriver1;create=true" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
     <javaPermission codeBase="${server.config.dir}derby/FATDriver.jar" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/FATDriver.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/FATDriver.java
@@ -33,6 +33,11 @@ public class FATDriver implements Driver {
 
     @Override
     public Connection connect(String url, Properties info) throws SQLException {
+        if (!acceptsURL(url))
+            return null;
+
+        url = url.replace(":fatdriver:", ":derby:");
+
         System.out.println("[FATDriver]   ->  connect");
         try {
             Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
@@ -51,7 +56,7 @@ public class FATDriver implements Driver {
 
     @Override
     public boolean acceptsURL(String url) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        return url.startsWith("jdbc:fatdriver:");
     }
 
     @Override
@@ -61,7 +66,7 @@ public class FATDriver implements Driver {
 
     @Override
     public int getMajorVersion() {
-        return 0;
+        return 1;
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -200,7 +200,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
     @Test
     public void testFATDriver() throws Exception {
         Class.forName("jdbc.fat.driver.derby.FATDriver");
-        Connection conn = DriverManager.getConnection("jdbc:derby:memory:wrappedDerby;create=true");
+        Connection conn = DriverManager.getConnection("jdbc:fatdriver:memory:jdbcdriver1;create=true");
         try {
             System.out.println("Connected to " + conn.getMetaData().getDatabaseProductName());
             conn.createStatement().executeQuery("VALUES 1");


### PR DESCRIPTION
When URL is specified and the built-in logic for inferring data source classes doesn't find any, locate the Driver implementation that accepts the configured URL.  Make adjustments to the configured properties (stringify values and decode passwords) such that they can be supplied to the JDBC driver.  This gets us up to the point where there data source can be used to attempt a connection, which will fail indicating that the JDBC driver impl class isn't a data source because we haven't implemented code path beyond that point yet.