### PR TITLE
avoid modifications to vendor properties so as to allow subsequent connections via Driver

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -374,9 +374,12 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 return create(className, props);
 
             if (nonshipFunction) {
-                Driver driver = loadDriver(props, classloader);
-                if (driver != null)
-                    return driver;
+                String url = props.getProperty("URL", props.getProperty("url"));
+                if (url != null) {
+                    Driver driver = loadDriver(url, classloader);
+                    if (driver != null)
+                        return driver;
+                }
 
                 className = JDBCDrivers.inferDataSourceClassFromDriver(classloader,
                                                                        JDBCDrivers.CONNECTION_POOL_DATA_SOURCE,
@@ -442,9 +445,12 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 return create(className, props);
 
             if (nonshipFunction) {
-                Driver driver = loadDriver(props, classloader);
-                if (driver != null)
-                    return driver;
+                String url = props.getProperty("URL", props.getProperty("url"));
+                if (url != null) {
+                    Driver driver = loadDriver(url, classloader);
+                    if (driver != null)
+                        return driver;
+                }
 
                 className = JDBCDrivers.inferDataSourceClassFromDriver(classloader,
                                                                        JDBCDrivers.XA_DATA_SOURCE,
@@ -593,13 +599,13 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
     }
     
     /**
-     * Create a Driver
+     * Load the Driver instance for the specified URL.
      * 
-     * @param props typed data source properties
+     * @param url JDBC driver URL.
      * @return the driver
      * @throws SQLException if an error occurs
      */
-    public Object createDriver(PropertyService props) throws SQLException {
+    public Object createDriver(String url) throws SQLException {
         lock.readLock().lock();
         try {
             if (!isInitialized)
@@ -618,8 +624,8 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                     lock.readLock().lock();
                     lock.writeLock().unlock();
                 }
-            
-            return loadDriver(props, classloader);
+
+            return loadDriver(url, classloader);
         } finally {
             lock.readLock().unlock();
         }
@@ -699,70 +705,43 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
 
     /**
      * Load java.sql.Driver implementations available to the specific class loader and return
-     * the first that accepts the URL (if any) that is specified in the vendor properties.
+     * the first that accepts the URL that is specified in the vendor properties.
      *
-     * @param vProps configured JDBC vendor properties.
+     * @param url the JDBC driver URL.
      * @param classloader class loader from which to load JDBC drivers.
      * @return Driver instance that accepts the URL. NULL if no such Driver can be loaded.
      * @throws SQLException if an error occurs.
      */
-    private Driver loadDriver(Properties vProps, ClassLoader classloader) throws SQLException {
-        String url = vProps.getProperty("URL", vProps.getProperty("url"));
-
+    private Driver loadDriver(String url, ClassLoader classloader) throws SQLException {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isDebugEnabled())
             Tr.entry(this, tc, "loadDriver", url, classloader);
 
         SQLException failure = null;
-        if (url != null)
-            for (Driver driver : ServiceLoader.load(Driver.class, classloader)) {
-                boolean acceptsURL;
-                try {
-                    acceptsURL = driver.acceptsURL(url);
-                } catch (SQLException x) {
-                    if (failure == null)
-                        failure = x;
-                    acceptsURL = false;
-                }
-                if (acceptsURL) {
-                    // TODO When it does matching, DataSourceService.modified method will dislike that we have stringified the values. Need to allow for this.
-                    // convert property values to String and decode passwords 
-                    for (Map.Entry<Object, Object> prop : vProps.entrySet()) {
-                        Object value = prop.getValue();
-                        if (value instanceof String) {
-                            String str = (String) value;
-                            // Decode passwords
-                            if (PropertyService.isPassword((String) prop.getKey()) && PasswordUtil.getCryptoAlgorithm(str) != null)
-                                try {
-                                    prop.setValue(PasswordUtil.decode(str));
-                                } catch (Exception x) {
-                                    if (trace && tc.isEntryEnabled())
-                                        Tr.exit(this, tc, "loadDriver", x);
-                                    if (x instanceof SQLException)
-                                        throw (SQLException) x;
-                                    else
-                                        throw new SQLNonTransientException(x);
-                                }
-                        } else {
-                            // Convert to String value
-                            prop.setValue(value.toString());
-                        }
-                    }
-
-                    if (classloader != null && url.startsWith("jdbc:derby:") && isDerbyEmbedded.compareAndSet(false, true)) {
-                        embDerbyRefCount.add(classloader);
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                            Tr.debug(this, tc, "ref count for shutdown", classloader, embDerbyRefCount);
-                    }
-
-                    if (trace && tc.isEntryEnabled())
-                        Tr.exit(this, tc, "loadDriver", driver);
-                    return driver;
-                } else {
-                    if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, driver + " does not accept url");
-                }
+        for (Driver driver : ServiceLoader.load(Driver.class, classloader)) {
+            boolean acceptsURL;
+            try {
+                acceptsURL = driver.acceptsURL(url);
+            } catch (SQLException x) {
+                if (failure == null)
+                    failure = x;
+                acceptsURL = false;
             }
+            if (acceptsURL) {
+                if (classloader != null && url.startsWith("jdbc:derby:") && isDerbyEmbedded.compareAndSet(false, true)) {
+                    embDerbyRefCount.add(classloader);
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "ref count for shutdown", classloader, embDerbyRefCount);
+                }
+
+                if (trace && tc.isEntryEnabled())
+                    Tr.exit(this, tc, "loadDriver", driver);
+                return driver;
+            } else {
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, driver + " does not accept url");
+            }
+        }
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "loadDriver", failure);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -868,8 +868,8 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
                             if ("URL".equals(name) || "url".equals(name)) {
                                 url = str;
                                 if (isTraceOn && tc.isDebugEnabled())
-                                    Tr.debug(this, tc, name + '=' + str);
-                            } else if ((user == null || !"user".equals(name) && (pwd == null || !"password".equals(name)))) {
+                                    Tr.debug(this, tc, name + '=' + str); // TODO obscure values of any possible passwords in URL value?
+                            } else if ((user == null || !"user".equals(name)) && (pwd == null || !"password".equals(name))) {
                                 // Decode passwords
                                 if (PropertyService.isPassword(name) && PasswordUtil.getCryptoAlgorithm(str) != null) {
                                     if (isTraceOn && tc.isDebugEnabled())

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -33,7 +33,8 @@
 
     <dataSource id="fatDriver" jndiName="jdbc/fatDriver">
       <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
-      <properties url="jdbc:fatdriver:memory:jdbcdriver1;create=true" user="dbuser1" password="{xor}Oz0vKDtu" />
+      <properties url="jdbc:fatdriver:memory:jdbcdriver1;create=true" user="dbuser2" password="{xor}Oz0vKDtt"/>
+      <containerAuthData user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <javaPermission codeBase="${server.config.dir}derby/FATDriver.jar" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -72,7 +72,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
      * Verify that it is possible to establish a second connection to a data source that is backed by a Driver,
      * which demonstrates that the URL and other properties are not lost upon the initial connection.
      * Also verifies that the user/password from the data source vendor properties are supplied to the driver
-     * in the case of application authentication (which is default when looked up with a resource reference).
+     * in the case of application authentication (which is default when looked up without a resource reference).
      */
     @Test
     public void testAnotherConnection() throws Exception {
@@ -245,7 +245,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
      * This test validates that the user name from the container authentication data is used for resource reference lookup with
      * auth=CONTAINER rather than the default user/password that are specified in the data source vendor properties.
      * It also verifies that we can read an entry that was previously written by the same data source when accessed via
-     * a direct lookup, which equates to auth=APPLICATION where the same same user/password as the container auth data were
+     * a direct lookup, which equates to auth=APPLICATION where the same user/password as the container auth data were
      * explicitly requested.
      */
     @Test


### PR DESCRIPTION
Always make a new copy of the properties supplied to the JDBC driver when establishing a new connection so as to avoid modifying the master copy.  This enables subsequent connections to be established also based on the master copy of vendor properties and avoids interference with matching performed by the DataSourceService.modified method.