### PR TITLE
Modify the collectorjsonutils to accomodate the new threadid key value…

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
@@ -358,7 +358,7 @@ public class CollectorJsonUtils {
                      * Note: we'll expect any external/thirdparty/additional source to be using IBM_* keys.
                      * This method is to parse and format into logstash_1.0 expected formatting.
                      */
-                    if (key.equals("eventTime") || key.equals("eventSequenceNumber") || key.equals("eventThreadId")) {
+                    if (key.equals("eventTime") || key.equals("eventSequenceNumber")) {
                         continue;
                     } else if (key.equals(LogFieldConstants.IBM_DATETIME) || key.equals("loggingEventTime")) {
                         String datetime = CollectorJsonHelpers.dateFormatTL.get().format(kvp.getLongValue());

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
@@ -348,6 +348,8 @@ public class CollectorJsonUtils {
                      *
                      * Explicitly parse for ibm_sequence/loggingSequenceNumber for special processing.
                      *
+                     * Explicitly parse for ibm_threadid for special processing.
+                     *
                      * Audit is currently not using the logging constants for the datetime and sequence keys,
                      * we need to format the json output with the appropriate logging values for the keys.
                      *
@@ -356,13 +358,15 @@ public class CollectorJsonUtils {
                      * Note: we'll expect any external/thirdparty/additional source to be using IBM_* keys.
                      * This method is to parse and format into logstash_1.0 expected formatting.
                      */
-                    if (key.equals("eventTime") || key.equals("eventSequenceNumber")) {
+                    if (key.equals("eventTime") || key.equals("eventSequenceNumber") || key.equals("eventThreadId")) {
                         continue;
                     } else if (key.equals(LogFieldConstants.IBM_DATETIME) || key.equals("loggingEventTime")) {
                         String datetime = CollectorJsonHelpers.dateFormatTL.get().format(kvp.getLongValue());
                         CollectorJsonHelpers.addToJSON(sb, LogFieldConstants.DATETIME, datetime, false, true, false, false, false);
                     } else if (key.equals(LogFieldConstants.IBM_SEQUENCE) || key.equals("loggingSequenceNumber")) {
                         CollectorJsonHelpers.addToJSON(sb, LogFieldConstants.SEQUENCE, kvp.getStringValue(), false, false, false, false, !kvp.isString());
+                    } else if (key.equals(LogFieldConstants.IBM_THREADID)) {
+                        CollectorJsonHelpers.addToJSON(sb, LogFieldConstants.THREADID, DataFormatHelper.padHexString(kvp.getIntValue(), 8), false, true, false, false, false);
                     } else {
                         CollectorJsonHelpers.addToJSON(sb, key, kvp.getStringValue(), false, false, false, false, !kvp.isString());
                     }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils.java
@@ -341,9 +341,6 @@ public class CollectorJsonUtils {
                     key = kvp.getKey();
 
                     /*
-                     * Skip GDO KVP if the key is 'eventTime' or 'eventSequenceNumber' - this is not valid for our use.
-                     * This is reserved for AuditFileHandler.
-                     *
                      * Explicitly parse for ibm_datetime/loggingEventTime for special processing.
                      *
                      * Explicitly parse for ibm_sequence/loggingSequenceNumber for special processing.
@@ -358,9 +355,7 @@ public class CollectorJsonUtils {
                      * Note: we'll expect any external/thirdparty/additional source to be using IBM_* keys.
                      * This method is to parse and format into logstash_1.0 expected formatting.
                      */
-                    if (key.equals("eventTime") || key.equals("eventSequenceNumber")) {
-                        continue;
-                    } else if (key.equals(LogFieldConstants.IBM_DATETIME) || key.equals("loggingEventTime")) {
+                    if (key.equals(LogFieldConstants.IBM_DATETIME) || key.equals("loggingEventTime")) {
                         String datetime = CollectorJsonHelpers.dateFormatTL.get().format(kvp.getLongValue());
                         CollectorJsonHelpers.addToJSON(sb, LogFieldConstants.DATETIME, datetime, false, true, false, false, false);
                     } else if (key.equals(LogFieldConstants.IBM_SEQUENCE) || key.equals("loggingSequenceNumber")) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils1_1.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils1_1.java
@@ -344,7 +344,7 @@ public class CollectorJsonUtils1_1 {
                      *
                      * Parse the rest of audit GDO KVP - They are strings.
                      */
-                    if (key.equals("eventTime") || key.equals("eventSequenceNumber") || key.equals("eventThreadId")) {
+                    if (key.equals("eventTime") || key.equals("eventSequenceNumber")) {
                         continue;
                     } else if (key.equals(LogFieldConstants.IBM_DATETIME) || key.equals("loggingEventTime")) {
                         String datetime = CollectorJsonHelpers.dateFormatTL.get().format(kvp.getLongValue());

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils1_1.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils1_1.java
@@ -330,9 +330,6 @@ public class CollectorJsonUtils1_1 {
                     key = kvp.getKey();
 
                     /*
-                     * Skip GDO KVP if the key is 'eventTime' or 'eventSequenceNumber' - this is not valid for our use.
-                     * This is reserved for AuditFileHandler.
-                     *
                      * Explicitly parse for ibm_datetime/loggingEventTime for special processing.
                      *
                      * Explicitly parse for ibm_sequence/loggingSequenceNumber for special processing.
@@ -344,9 +341,7 @@ public class CollectorJsonUtils1_1 {
                      *
                      * Parse the rest of audit GDO KVP - They are strings.
                      */
-                    if (key.equals("eventTime") || key.equals("eventSequenceNumber")) {
-                        continue;
-                    } else if (key.equals(LogFieldConstants.IBM_DATETIME) || key.equals("loggingEventTime")) {
+                    if (key.equals(LogFieldConstants.IBM_DATETIME) || key.equals("loggingEventTime")) {
                         String datetime = CollectorJsonHelpers.dateFormatTL.get().format(kvp.getLongValue());
                         CollectorJsonHelpers.addToJSON(sb, LogFieldConstants.IBM_DATETIME, datetime, false, true, false, false, false);
                     } else if (key.equals(LogFieldConstants.IBM_SEQUENCE) || key.equals("loggingSequenceNumber")) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils1_1.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils1_1.java
@@ -337,18 +337,22 @@ public class CollectorJsonUtils1_1 {
                      *
                      * Explicitly parse for ibm_sequence/loggingSequenceNumber for special processing.
                      *
+                     * Explicitly parse for ibm_threadid for special processing.
+                     *
                      * Audit is currently not using the logging constants for the datetime and sequence keys,
                      * we need to format the json output with the appropriate logging values for the keys.
                      *
                      * Parse the rest of audit GDO KVP - They are strings.
                      */
-                    if (key.equals("eventTime") || key.equals("eventSequenceNumber")) {
+                    if (key.equals("eventTime") || key.equals("eventSequenceNumber") || key.equals("eventThreadId")) {
                         continue;
                     } else if (key.equals(LogFieldConstants.IBM_DATETIME) || key.equals("loggingEventTime")) {
                         String datetime = CollectorJsonHelpers.dateFormatTL.get().format(kvp.getLongValue());
                         CollectorJsonHelpers.addToJSON(sb, LogFieldConstants.IBM_DATETIME, datetime, false, true, false, false, false);
                     } else if (key.equals(LogFieldConstants.IBM_SEQUENCE) || key.equals("loggingSequenceNumber")) {
                         CollectorJsonHelpers.addToJSON(sb, LogFieldConstants.IBM_SEQUENCE, kvp.getStringValue(), false, false, false, false, !kvp.isString());
+                    } else if (key.equals(LogFieldConstants.IBM_THREADID)) {
+                        CollectorJsonHelpers.addToJSON(sb, LogFieldConstants.IBM_THREADID, DataFormatHelper.padHexString(kvp.getIntValue(), 8), false, true, false, false, false);
                     } else {
                         CollectorJsonHelpers.addToJSON(sb, key, kvp.getStringValue(), false, false, false, false, !kvp.isString());
                     }


### PR DESCRIPTION
fixes #4419 

Modify the collectorjsonutils to accommodate the new threadid/ibm_threadid keyValuePair as well as reincorporate the audit's eventTime and eventSequence KeyValuePairs to abide with the CADF format.