### PR TITLE
detect driver class based on DataSourceDefinition url

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,18 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc;
 
+import java.sql.Driver;
+import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
 import java.util.Collection;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.logging.Level;
 
 import javax.sql.ConnectionPoolDataSource;
@@ -41,6 +45,7 @@ import com.ibm.ws.jca.cm.ConnectionManagerService;
 import com.ibm.ws.jca.cm.ConnectorService;
 import com.ibm.ws.jdbc.internal.DataSourceDef;
 import com.ibm.ws.jdbc.internal.JDBCDriverService;
+import com.ibm.ws.jdbc.internal.JDBCDrivers;
 import com.ibm.ws.jdbc.internal.PropertyService;
 import com.ibm.ws.resource.ResourceFactory;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
@@ -199,8 +204,16 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
         // className
         String className = (String) vendorProps.remove(DataSourceDef.className.name());
 
+        // url should be used if properties like serverName/portNumber/databaseName are unspecified
+        String url = (String) vendorProps.remove(DataSourceDef.url.name());
+        if (vendorProps.containsKey(DataSourceDef.databaseName.name()) || vendorProps.containsKey(DataSourceDef.portNumber.name()))
+            url = null;
+
+        if ((className == null || className.length() == 0) && !vendorProps.containsKey("internal.nonship.function")) // TODO remove nonship check once ready for GA
+            throw new IllegalArgumentException("className");
+
         // libraryRef - scan shared libraries from the application
-        updateWithLibraries(bundleContext, application, declaringApplication, className, driverProps, dsSvcProps);
+        updateWithLibraries(bundleContext, application, declaringApplication, className, url, driverProps, dsSvcProps);
 
         // initialPoolSize > 0 not supported
         value = vendorProps.remove(DataSourceDef.initialPoolSize.name());
@@ -214,11 +227,6 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
             int stmtCacheSize = maxPoolSize == null || maxPoolSize <= 0 ? 0 : ((Integer) value / maxPoolSize);
             dsSvcProps.put(DSConfig.STATEMENT_CACHE_SIZE, stmtCacheSize);
         }
-
-        // url should be used if properties like serverName/portNumber/databaseName are unspecified
-        String url = (String) vendorProps.remove(DataSourceDef.url.name());
-        if (vendorProps.containsKey(DataSourceDef.databaseName.name()) || vendorProps.containsKey(DataSourceDef.portNumber.name()))
-            url = null;
 
         // serverName defaults to "localhost" (unless it's Derby Embedded, which doesn't have serverName)
         if (!vendorProps.containsKey(DataSourceDef.serverName.name()))
@@ -391,7 +399,8 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
      * 
      * @param applicationName name of the application with the DataSourceDefinition. Is set to null when java:global is specified
      * @param declaringApplication name of the application with the DataSourceDefinition.
-     * @param className data source implementation class name, including package.
+     * @param className data source or driver implementation class name, including package. NULL means infer the implementation class.
+     * @param url URL with which the Driver will connect to the database. NULL if data source should be used instead of Driver.
      * @param driverProps properties for the jdbcDriver.
      * @param dsSvcProps properties for the dataSource.
      * @throws Exception if an error occurs.
@@ -400,6 +409,7 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
                                            String applicationName,
                                            String declaringApplication,
                                            String className,
+                                           String url,
                                            Hashtable<String, Object> driverProps,
                                            Hashtable<String, Object> dsSvcProps) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -447,7 +457,7 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
                     Object privateLibraryRef = classloaderProps.get("privateLibraryRef");
                     if (privateLibraryRef != null && privateLibraryRef instanceof String[])
                         for (String pid : (String[]) privateLibraryRef)
-                                libraryFilter.append(FilterUtils.createPropertyFilter(Constants.SERVICE_PID, pid));
+                            libraryFilter.append(FilterUtils.createPropertyFilter(Constants.SERVICE_PID, pid));
                 }
 
                 Object commonLibraryRef = classloaderProps.get("commonLibraryRef");
@@ -479,7 +489,7 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
             Collection<ServiceReference<Library>> globalLib = DataSourceService.priv.getServiceReferences(bundleContext, Library.class, globalLibFilter.toString());
             libraryRefs.addAll(globalLib);
         }
-            
+
         if (trace && tc.isDebugEnabled())
             Tr.debug(tc, "libraries", libraryRefs.toArray());
 
@@ -494,18 +504,53 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
                 } else {
                     try {
                         ClassLoader loader = AdapterUtil.getClassLoaderWithPriv(library);
-                        Class<?> cl = DataSourceService.priv.loadClass(loader, className);
-                        String type = XADataSource.class.isAssignableFrom(cl) ? XADataSource.class.getName()
-                                        : ConnectionPoolDataSource.class.isAssignableFrom(cl) ? ConnectionPoolDataSource.class.getName()
-                                                        : DataSource.class.getName();
-                        driverProps.put(JDBCDriverService.LIBRARY_REF, new String[] { libraryPid });
-                        driverProps.put(JDBCDriverService.TARGET_LIBRARY, FilterUtils.createPropertyFilter("service.pid", libraryPid));
-                        driverProps.put(type, className);
-                        dsSvcProps.put(DSConfig.TYPE, type);
-    
-                        if (trace && tc.isEntryEnabled())
-                            Tr.exit(tc, "updateWithLibraries", driverProps);
-                        return;
+
+                        String type;
+                        if (className == null || className.length() == 0) {
+                            if (url == null) {
+                                if (trace && tc.isDebugEnabled())
+                                    Tr.debug(this, tc, "path where url is lacking has not been implemented");
+                                break; // TODO implement this path : JDBCDriverService.inferDataSourceClass[es]FromDriver & combine ?
+                            } else {
+                                type = Driver.class.getName();
+                                for (Iterator<Driver> it = ServiceLoader.load(Driver.class, loader).iterator(); it.hasNext(); ) {
+                                    Driver driver = it.next();
+                                    if (trace && tc.isDebugEnabled())
+                                        Tr.debug(this, tc, "trying driver", driver);
+                                    try {
+                                        if (driver.acceptsURL(url)) {
+                                            if (trace && tc.isDebugEnabled())
+                                                Tr.debug(this, tc, driver + " accepts " + url);
+                                            className = driver.getClass().getName();
+                                            break;
+                                        } else {
+                                            if (trace && tc.isDebugEnabled())
+                                                Tr.debug(this, tc, driver + " does not accept " + url);
+                                        }
+                                    } catch (SQLException x) {
+                                        if (trace && tc.isDebugEnabled())
+                                            Tr.debug(this, tc, driver + " does not accept " + url, x);
+                                    }
+                                }
+                            }
+                        } else {
+                            Class<?> cl = DataSourceService.priv.loadClass(loader, className);
+                            type = XADataSource.class.isAssignableFrom(cl) ? XADataSource.class.getName()
+                                 : ConnectionPoolDataSource.class.isAssignableFrom(cl) ? ConnectionPoolDataSource.class.getName()
+                                 : DataSource.class.isAssignableFrom(cl) ? DataSource.class.getName()
+                                 : Driver.class.getName();
+                        }
+
+                        if (className != null) {
+                            driverProps.put(JDBCDriverService.LIBRARY_REF, new String[] { libraryPid });
+                            driverProps.put(JDBCDriverService.TARGET_LIBRARY, FilterUtils.createPropertyFilter("service.pid", libraryPid));
+                            driverProps.put(type, className);
+                            dsSvcProps.put(DSConfig.TYPE, type);
+
+                            if (trace && tc.isEntryEnabled())
+                                Tr.exit(tc, "updateWithLibraries", driverProps);
+                            return;
+                        }
                     } catch (ClassNotFoundException x) {
                         if (trace && tc.isDebugEnabled())
                             Tr.debug(tc, className + " not found in", libraryPid);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -460,9 +460,10 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                 } else if (DataSource.class.getName().equals(type)) {
                     ifc = DataSource.class;
                     vendorImpl = jdbcDriverSvc.createDataSource(vProps);
-//                } else if (Driver.class.getName().equals(type)) { //TODO uncomment when we add support for type=java.sql.Driver
-//                    ifc = Driver.class;
-//                    vendorImpl = jdbcDriverSvc.createDriver(vProps);
+                } else if (Driver.class.getName().equals(type)) {
+                    ifc = Driver.class;
+                    String url = vProps.getProperty("URL", vProps.getProperty("url"));
+                    vendorImpl = jdbcDriverSvc.getDriver(url);
                 } else
                     throw new SQLNonTransientException(ConnectorService.getMessage("MISSING_RESOURCE_J2CA8030", DSConfig.TYPE, type, DATASOURCE, jndiName == null ? id : jndiName));
 
@@ -610,9 +611,10 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
             } else if (DataSource.class.getName().equals(type)) {
                 ifc = DataSource.class;
                 vendorImpl = jdbcDriverSvc.createDataSource(vProps);
-//            } else if (Driver.class.getName().equals(type)) { //TODO uncomment when we add support for type=java.sql.Driver
-//                ifc = Driver.class;
-//                vendorImpl = jdbcDriverSvc.createDriver(vProps);
+            } else if (Driver.class.getName().equals(type)) {
+                ifc = Driver.class;
+                String url = vProps.getProperty("URL", vProps.getProperty("url"));
+                vendorImpl = jdbcDriverSvc.getDriver(url);
             } else
                 throw new SQLNonTransientException(ConnectorService.getMessage("MISSING_RESOURCE_J2CA8030", DSConfig.TYPE, type, DATASOURCE, jndiName == null ? id : jndiName));
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -605,7 +605,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
      * @return the driver
      * @throws SQLException if an error occurs
      */
-    public Object createDriver(String url) throws SQLException {
+    public Object getDriver(String url) throws SQLException {
         lock.readLock().lock();
         try {
             if (!isInitialized)

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -374,9 +374,12 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 return create(className, props);
 
             if (nonshipFunction) {
-                Driver driver = loadDriver(props, classloader);
-                if (driver != null)
-                    return driver;
+                String url = props.getProperty("URL", props.getProperty("url"));
+                if (url != null) {
+                    Driver driver = loadDriver(url, classloader);
+                    if (driver != null)
+                        return driver;
+                }
 
                 className = JDBCDrivers.inferDataSourceClassFromDriver(classloader,
                                                                        JDBCDrivers.CONNECTION_POOL_DATA_SOURCE,
@@ -442,9 +445,12 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 return create(className, props);
 
             if (nonshipFunction) {
-                Driver driver = loadDriver(props, classloader);
-                if (driver != null)
-                    return driver;
+                String url = props.getProperty("URL", props.getProperty("url"));
+                if (url != null) {
+                    Driver driver = loadDriver(url, classloader);
+                    if (driver != null)
+                        return driver;
+                }
 
                 className = JDBCDrivers.inferDataSourceClassFromDriver(classloader,
                                                                        JDBCDrivers.XA_DATA_SOURCE,
@@ -593,13 +599,13 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
     }
     
     /**
-     * Create a Driver
+     * Load the Driver instance for the specified URL.
      * 
-     * @param props typed data source properties
+     * @param url JDBC driver URL.
      * @return the driver
      * @throws SQLException if an error occurs
      */
-    public Object createDriver(PropertyService props) throws SQLException {
+    public Object createDriver(String url) throws SQLException {
         lock.readLock().lock();
         try {
             if (!isInitialized)
@@ -618,8 +624,8 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                     lock.readLock().lock();
                     lock.writeLock().unlock();
                 }
-            
-            return loadDriver(props, classloader);
+
+            return loadDriver(url, classloader);
         } finally {
             lock.readLock().unlock();
         }
@@ -699,70 +705,43 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
 
     /**
      * Load java.sql.Driver implementations available to the specific class loader and return
-     * the first that accepts the URL (if any) that is specified in the vendor properties.
+     * the first that accepts the URL that is specified in the vendor properties.
      *
-     * @param vProps configured JDBC vendor properties.
+     * @param url the JDBC driver URL.
      * @param classloader class loader from which to load JDBC drivers.
      * @return Driver instance that accepts the URL. NULL if no such Driver can be loaded.
      * @throws SQLException if an error occurs.
      */
-    private Driver loadDriver(Properties vProps, ClassLoader classloader) throws SQLException {
-        String url = vProps.getProperty("URL", vProps.getProperty("url"));
-
+    private Driver loadDriver(String url, ClassLoader classloader) throws SQLException {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isDebugEnabled())
             Tr.entry(this, tc, "loadDriver", url, classloader);
 
         SQLException failure = null;
-        if (url != null)
-            for (Driver driver : ServiceLoader.load(Driver.class, classloader)) {
-                boolean acceptsURL;
-                try {
-                    acceptsURL = driver.acceptsURL(url);
-                } catch (SQLException x) {
-                    if (failure == null)
-                        failure = x;
-                    acceptsURL = false;
-                }
-                if (acceptsURL) {
-                    // TODO When it does matching, DataSourceService.modified method will dislike that we have stringified the values. Need to allow for this.
-                    // convert property values to String and decode passwords 
-                    for (Map.Entry<Object, Object> prop : vProps.entrySet()) {
-                        Object value = prop.getValue();
-                        if (value instanceof String) {
-                            String str = (String) value;
-                            // Decode passwords
-                            if (PropertyService.isPassword((String) prop.getKey()) && PasswordUtil.getCryptoAlgorithm(str) != null)
-                                try {
-                                    prop.setValue(PasswordUtil.decode(str));
-                                } catch (Exception x) {
-                                    if (trace && tc.isEntryEnabled())
-                                        Tr.exit(this, tc, "loadDriver", x);
-                                    if (x instanceof SQLException)
-                                        throw (SQLException) x;
-                                    else
-                                        throw new SQLNonTransientException(x);
-                                }
-                        } else {
-                            // Convert to String value
-                            prop.setValue(value.toString());
-                        }
-                    }
-
-                    if (classloader != null && url.startsWith("jdbc:derby:") && isDerbyEmbedded.compareAndSet(false, true)) {
-                        embDerbyRefCount.add(classloader);
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                            Tr.debug(this, tc, "ref count for shutdown", classloader, embDerbyRefCount);
-                    }
-
-                    if (trace && tc.isEntryEnabled())
-                        Tr.exit(this, tc, "loadDriver", driver);
-                    return driver;
-                } else {
-                    if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, driver + " does not accept url");
-                }
+        for (Driver driver : ServiceLoader.load(Driver.class, classloader)) {
+            boolean acceptsURL;
+            try {
+                acceptsURL = driver.acceptsURL(url);
+            } catch (SQLException x) {
+                if (failure == null)
+                    failure = x;
+                acceptsURL = false;
             }
+            if (acceptsURL) {
+                if (classloader != null && url.startsWith("jdbc:derby:") && isDerbyEmbedded.compareAndSet(false, true)) {
+                    embDerbyRefCount.add(classloader);
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "ref count for shutdown", classloader, embDerbyRefCount);
+                }
+
+                if (trace && tc.isEntryEnabled())
+                    Tr.exit(this, tc, "loadDriver", driver);
+                return driver;
+            } else {
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, driver + " does not accept url");
+            }
+        }
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "loadDriver", failure);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -868,8 +868,8 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
                             if ("URL".equals(name) || "url".equals(name)) {
                                 url = str;
                                 if (isTraceOn && tc.isDebugEnabled())
-                                    Tr.debug(this, tc, name + '=' + str);
-                            } else if ((user == null || !"user".equals(name) && (pwd == null || !"password".equals(name)))) {
+                                    Tr.debug(this, tc, name + '=' + str); // TODO obscure values of any possible passwords in URL value?
+                            } else if ((user == null || !"user".equals(name)) && (pwd == null || !"password".equals(name))) {
                                 // Decode passwords
                                 if (PropertyService.isPassword(name) && PasswordUtil.getCryptoAlgorithm(str) != null) {
                                     if (isTraceOn && tc.isDebugEnabled())

--- a/dev/com.ibm.ws.jdbc_fat_driver/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_driver/bnd.bnd
@@ -19,5 +19,6 @@ src: \
 fat.project: true
 
 -buildpath: \
+    com.ibm.websphere.javaee.annotation.1.3;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -33,7 +33,8 @@
 
     <dataSource id="fatDriver" jndiName="jdbc/fatDriver">
       <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
-      <properties url="jdbc:fatdriver:memory:jdbcdriver1;create=true" user="dbuser1" password="{xor}Oz0vKDtu" />
+      <properties url="jdbc:fatdriver:memory:jdbcdriver1;create=true" user="dbuser2" password="{xor}Oz0vKDtt"/>
+      <containerAuthData user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <javaPermission codeBase="${server.config.dir}derby/FATDriver.jar" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/FATDriver.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/FATDriver.java
@@ -16,9 +16,11 @@ import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.Enumeration;
+import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
+
+import javax.sql.DataSource;
 
 public class FATDriver implements Driver {
     private static Driver fatDriver = new FATDriver();
@@ -36,22 +38,46 @@ public class FATDriver implements Driver {
         if (!acceptsURL(url))
             return null;
 
-        url = url.replace(":fatdriver:", ":derby:");
+        String loginTimeout = (String) info.remove("loginTimeout");
 
-        System.out.println("[FATDriver]   ->  connect");
+        int dbNameStart = "jdbc:fatdriver:".length();
+        int firstSemicolon = url.indexOf(';', dbNameStart);
+
+        String databaseName = url.substring(dbNameStart, firstSemicolon > 0 ? firstSemicolon : url.length());
+
+        StringBuilder attributes = new StringBuilder();
+        if (firstSemicolon > 0)
+            attributes.append(url.substring(firstSemicolon + 1));
+
+        for (Map.Entry<?, ?> prop : info.entrySet()) {
+            if (attributes.length() > 0)
+                attributes.append(';');
+            attributes.append(prop.getKey()).append('=').append(prop.getValue());
+        }
+
+        System.out.println("[FATDriver]   ->  connect to " + databaseName + " using " + attributes);
+
         try {
-            Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
-        } catch (ClassNotFoundException e) {
-            throw new SQLException(e);
+            @SuppressWarnings("unchecked")
+            Class<? extends DataSource> EmbeddedDataSource = (Class<? extends DataSource>) Class.forName("org.apache.derby.jdbc.EmbeddedDataSource");
+            DataSource ds = EmbeddedDataSource.newInstance();
+
+            EmbeddedDataSource.getMethod("setDatabaseName", String.class).invoke(ds, databaseName);
+
+            if (attributes.length() > 0)
+                EmbeddedDataSource.getMethod("setConnectionAttributes", String.class).invoke(ds, attributes.toString());
+
+            if (loginTimeout != null)
+                ds.setLoginTimeout(Integer.parseInt(loginTimeout));
+
+            return ds.getConnection();
+        } catch (RuntimeException x) {
+            throw x;
+        } catch (SQLException x) {
+            throw x;
+        } catch (Exception x) {
+            throw new SQLException(x);
         }
-        Enumeration<Driver> drivers = DriverManager.getDrivers();
-        while (drivers.hasMoreElements()) {
-            Driver nextElement = drivers.nextElement();
-            if (nextElement.getClass().getName().contains("org.apache.derby.jdbc")) {
-                return nextElement.connect(url, info);
-            }
-        }
-        throw new SQLException("Unable to find Derby driver");
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -72,7 +72,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
      * Verify that it is possible to establish a second connection to a data source that is backed by a Driver,
      * which demonstrates that the URL and other properties are not lost upon the initial connection.
      * Also verifies that the user/password from the data source vendor properties are supplied to the driver
-     * in the case of application authentication (which is default when looked up with a resource reference).
+     * in the case of application authentication (which is default when looked up without a resource reference).
      */
     @Test
     public void testAnotherConnection() throws Exception {
@@ -245,7 +245,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
      * This test validates that the user name from the container authentication data is used for resource reference lookup with
      * auth=CONTAINER rather than the default user/password that are specified in the data source vendor properties.
      * It also verifies that we can read an entry that was previously written by the same data source when accessed via
-     * a direct lookup, which equates to auth=APPLICATION where the same same user/password as the container auth data were
+     * a direct lookup, which equates to auth=APPLICATION where the same user/password as the container auth data were
      * explicitly requested.
      */
     @Test


### PR DESCRIPTION
When DataSourceDefinition is specified without a className, we can infer the Driver class based on the URL by iterating through the Drivers available to the ServiceLoader and checking which one accepts the URL.