### PR TITLE
infer data source class for DataSourceDefinition

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -20,6 +20,7 @@ import java.security.PrivilegedExceptionAction;
 import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -381,12 +382,12 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                         return driver;
                 }
 
-                className = JDBCDrivers.inferDataSourceClassFromDriver(classloader,
+                SimpleEntry<Integer, String> dsEntry = JDBCDrivers.inferDataSourceClassFromDriver(classloader,
                                                                        JDBCDrivers.CONNECTION_POOL_DATA_SOURCE,
                                                                        JDBCDrivers.DATA_SOURCE,
                                                                        JDBCDrivers.XA_DATA_SOURCE);
-                if (className != null)
-                    return create(className, props);
+                if (dsEntry != null)
+                    return create(className = dsEntry.getValue(), props);
             }
 
             throw classNotFound(null);
@@ -452,12 +453,12 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                         return driver;
                 }
 
-                className = JDBCDrivers.inferDataSourceClassFromDriver(classloader,
+                SimpleEntry<Integer, String> dsEntry = JDBCDrivers.inferDataSourceClassFromDriver(classloader,
                                                                        JDBCDrivers.XA_DATA_SOURCE,
                                                                        JDBCDrivers.CONNECTION_POOL_DATA_SOURCE,
                                                                        JDBCDrivers.DATA_SOURCE);
-                if (className != null)
-                    return create(className, props);
+                if (dsEntry != null)
+                    return create(className = dsEntry.getValue(), props);
             }
 
             throw classNotFound(null);
@@ -499,8 +500,10 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 className = JDBCDrivers.getConnectionPoolDataSourceClassName(vendorPropertiesPID);
                 if (className == null) {
                     className = JDBCDrivers.getConnectionPoolDataSourceClassName(getClasspath(sharedLib, true));
-                    if (className == null && nonshipFunction)
-                        className = JDBCDrivers.inferDataSourceClassFromDriver(classloader, JDBCDrivers.CONNECTION_POOL_DATA_SOURCE);
+                    if (className == null && nonshipFunction) {
+                        SimpleEntry<Integer, String> dsEntry = JDBCDrivers.inferDataSourceClassFromDriver(classloader, JDBCDrivers.CONNECTION_POOL_DATA_SOURCE); 
+                        className = dsEntry == null ? null : dsEntry.getValue();
+                    }
                 }
             }
 
@@ -543,8 +546,10 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 className = JDBCDrivers.getDataSourceClassName(vendorPropertiesPID);
                 if (className == null) {
                     className = JDBCDrivers.getDataSourceClassName(getClasspath(sharedLib, true));
-                    if (className == null && nonshipFunction)
-                        className = JDBCDrivers.inferDataSourceClassFromDriver(classloader, JDBCDrivers.DATA_SOURCE);
+                    if (className == null && nonshipFunction) {
+                        SimpleEntry<Integer, String> dsEntry = JDBCDrivers.inferDataSourceClassFromDriver(classloader, JDBCDrivers.DATA_SOURCE);
+                        className = dsEntry == null ? null : dsEntry.getValue();
+                    }
                 }
             }
 
@@ -587,8 +592,10 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 className = JDBCDrivers.getXADataSourceClassName(vendorPropertiesPID);
                 if (className == null) {
                     className = JDBCDrivers.getXADataSourceClassName(getClasspath(sharedLib, true));
-                    if (className == null && nonshipFunction)
-                        className = JDBCDrivers.inferDataSourceClassFromDriver(classloader, JDBCDrivers.XA_DATA_SOURCE);
+                    if (className == null && nonshipFunction) {
+                        SimpleEntry<Integer, String> dsEntry = JDBCDrivers.inferDataSourceClassFromDriver(classloader, JDBCDrivers.XA_DATA_SOURCE);
+                        className = dsEntry == null ? null : dsEntry.getValue();
+                    }
                 }
             }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDrivers.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDrivers.java
@@ -15,6 +15,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.sql.Driver;
+import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,7 +49,7 @@ public class JDBCDrivers {
     /**
      * Constants for the positions of each type of data source within the classNames arrays.
      */
-    static final int DATA_SOURCE = 0, CONNECTION_POOL_DATA_SOURCE = 1, XA_DATA_SOURCE = 2, NUM_TYPES = 3;
+    public static final int DATA_SOURCE = 0, CONNECTION_POOL_DATA_SOURCE = 1, XA_DATA_SOURCE = 2, NUM_DATA_SOURCE_INTERFACES = 3;
 
     /**
      * Ordered map of upper-case key to data source implementation class names.
@@ -350,14 +352,14 @@ public class JDBCDrivers {
      * 
      * @param loader class loader from which to load JDBC driver classes 
      * @param ordered list of data source types (see type constants in this class) indicating precedence
-     * @return name of vendor data source implementation class. Null if unknown.
+     * @return pair of data source type constant and name of vendor data source implementation class. Null if unknown.
      */
-    static String inferDataSourceClassFromDriver(ClassLoader loader, int... types) {
+    public static SimpleEntry<Integer, String> inferDataSourceClassFromDriver(ClassLoader loader, int... types) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isDebugEnabled())
             Tr.debug(tc, "infer from driver", loader, Arrays.toString(types));
 
-        String[] found = new String[NUM_TYPES];
+        String[] found = new String[NUM_DATA_SOURCE_INTERFACES];
         int preferredType = types[0];
 
         // Load JDBC driver class from service registry and use the package to infer the data source class
@@ -477,9 +479,15 @@ public class JDBCDrivers {
         if (trace && tc.isDebugEnabled())
             Tr.debug(tc, "found data sources", found);
 
+        // skip over JDK's built-in driver on first pass
+        for (int type : types)
+            if (found[type] != null && !found[type].startsWith("sun."))
+                return new SimpleEntry<Integer, String>(type, found[type]);
+
         for (int type : types)
             if (found[type] != null)
-                return found[type];
+                return new SimpleEntry<Integer, String>(type, found[type]);
+
         return null;
     }
 

--- a/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
@@ -62,6 +62,6 @@ public class JDBCDriverManagerTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("DSRA8020E.*internal.nonship.function"); // TODO remove once the capability becomes GA
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/FATDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/driver/derby/FATDataSource.java
@@ -63,6 +63,10 @@ public class FATDataSource implements DataSource {
         return derbyds.getParentLogger();
     }
 
+    public String getServerName() {
+        return "localhost";
+    }
+
     public void setAutoCreate(boolean value) throws Exception {
         derbyds.getClass().getMethod("setCreateDatabase", String.class).invoke(derbyds, value ? "create" : "false");
     }
@@ -83,6 +87,13 @@ public class FATDataSource implements DataSource {
 
     public void setPassword(String value) throws Exception {
         derbyds.getClass().getMethod("setPassword", String.class).invoke(derbyds, value);
+    }
+
+    // @DataSourceDefinition supplies default value of 'localhost' for serverName.
+    // Accept this value so that warnings are not generated in the logs.
+    public void setServerName(String value) throws Exception {
+        if (!"localhost".equals(value))
+            throw new IllegalArgumentException(value);
     }
 
     public void setUser(String value) throws Exception {


### PR DESCRIPTION
When DataSourceDefinition lacks a className and url, we can discover available JDBC drivers and infer/discover available data source implementations.  This will make it unnecessary for the user to know the implementation class name in many cases.