### PR TITLE
Issue 4399: Ensure GW bundle is started before allowing classloads

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderFactory.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderFactory.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import org.eclipse.equinox.region.RegionDigraph;
 import org.osgi.framework.Bundle;
@@ -60,8 +61,9 @@ class ClassLoaderFactory extends GatewayBundleFactory {
 
     ClassLoaderFactory(BundleContext bundleContext, RegionDigraph digraph, Map<Bundle, Set<GatewayClassLoader>> classloaders,
                        CanonicalStore<ClassLoaderIdentity, AppClassLoader> store,
-                       CompositeResourceProvider resourceProviders, ClassRedefiner redefiner, ClassGenerator generator) {
-        super(bundleContext, digraph, classloaders);
+                       CompositeResourceProvider resourceProviders, ClassRedefiner redefiner, ClassGenerator generator,
+                       ExecutorService executor) {
+        super(bundleContext, digraph, classloaders, executor);
         this.store = store;
         this.resourceProviders = resourceProviders;
         this.redefiner = redefiner;
@@ -124,9 +126,7 @@ class ClassLoaderFactory extends GatewayBundleFactory {
     private AppClassLoader createClassLoader() {
         validate();
         inferParentLoader();
-        AppClassLoader result = config.getDelegateToParentAfterCheckingLocalClasspath()
-                        ? new ParentLastClassLoader(parentClassLoader, config, classPath, access, redefiner, generator)
-                        : new AppClassLoader(parentClassLoader, config, classPath, access, redefiner, generator);
+        AppClassLoader result = config.getDelegateToParentAfterCheckingLocalClasspath() ? new ParentLastClassLoader(parentClassLoader, config, classPath, access, redefiner, generator) : new AppClassLoader(parentClassLoader, config, classPath, access, redefiner, generator);
         addSharedLibPaths(result);
         runPostCreateAction(result);
         return result;

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/TestUtil.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/TestUtil.java
@@ -24,6 +24,7 @@ import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.concurrent.ForkJoinPool;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -60,7 +61,9 @@ final class TestUtil {
     }
 
     static synchronized ClassLoadingServiceImpl getClassLoadingService(ClassLoader parentClassLoader) throws BundleException, InvalidSyntaxException {
-        return getClassLoadingService(parentClassLoader, null, false, null);
+        ClassLoadingServiceImpl service = getClassLoadingService(parentClassLoader, null, false, null);
+        service.setExecutorService(ForkJoinPool.commonPool());
+        return service;
     }
 
     static synchronized ClassLoadingServiceImpl getClassLoadingService(ClassLoader parentClassLoader, boolean failResolve) throws BundleException, InvalidSyntaxException {


### PR DESCRIPTION
This root problem of this issue appears to be that the gateway bundle
is not activated until after the application has attempted to use it's
classloader to load classes. This fix resolves the issue by preventing
the createGatewayBundleClassLoader method from exiting until the bundle
is started or a timeout (default 10 seconds) has expired.

This pull request should resolve issue #4399. 