### PR TITLE
i4310-SpringBoot app fails with ClassCastException on startup

### DIFF
--- a/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootApplicationImpl.java
+++ b/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootApplicationImpl.java
@@ -950,4 +950,7 @@ public class SpringBootApplicationImpl extends DeployedAppInfoBase implements Sp
         this.applicationActivated = applicationActivated;
     }
 
+    protected final ClassLoadingService getClassLoadingService() {
+    	return this.classLoadingService;
+    }
 }

--- a/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootModuleInfo.java
+++ b/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootModuleInfo.java
@@ -20,22 +20,35 @@ import com.ibm.ws.container.service.app.deploy.WebModuleInfo;
 import com.ibm.wsspi.adaptable.module.Container;
 import com.ibm.wsspi.adaptable.module.Entry;
 import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
+import com.ibm.wsspi.classloading.ClassLoadingService;
 
 /**
  *
  */
 public class SpringBootModuleInfo extends ExtendedModuleInfoImpl {
     private final SpringBootApplicationImpl springBootApplication;
+    private final ClassLoader threadContextClassLoader;
 
     public SpringBootModuleInfo(ApplicationInfo appInfo, String moduleName, String path,
                                 Container moduleContainer, Entry altDDEntry, List<ContainerInfo> moduleClassesContainers,
                                 ModuleClassLoaderFactory classLoaderFactory,
                                 SpringBootApplicationImpl springBootApplication) throws UnableToAdaptException {
-        super(appInfo, moduleName, path, moduleContainer, altDDEntry, moduleClassesContainers, classLoaderFactory, ContainerInfo.Type.WEB_MODULE, WebModuleInfo.class);
+        super(appInfo, moduleName, path, moduleContainer, altDDEntry, moduleClassesContainers, classLoaderFactory, ContainerInfo.Type.WEB_MODULE, SpringBootModuleInfo.class);
         this.springBootApplication = springBootApplication;
+        this.threadContextClassLoader = springBootApplication.getClassLoadingService().createThreadContextClassLoader(this.getClassLoader());        
     }
 
     SpringBootApplicationImpl getSpringBootApplication() {
         return springBootApplication;
+    }
+
+    ClassLoader getThreadContextClassLoader() {
+        return threadContextClassLoader;
+    }
+
+    void destroyThreadContextClassLoader() {
+        if (null != threadContextClassLoader) {
+        	springBootApplication.getClassLoadingService().destroyThreadContextClassLoader(threadContextClassLoader);
+        }
     }
 }

--- a/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootRuntimeContainer.java
+++ b/dev/com.ibm.ws.app.manager.springboot/src/com/ibm/ws/app/manager/springboot/internal/SpringBootRuntimeContainer.java
@@ -94,7 +94,7 @@ public class SpringBootRuntimeContainer implements ModuleRuntimeContainer {
     private void invokeSpringMain(Future<Boolean> mainInvokeResult, SpringBootModuleInfo springBootModuleInfo) {
         final SpringBootApplicationImpl springBootApplication = springBootModuleInfo.getSpringBootApplication();
         final Method main;
-        ClassLoader newTccl = springBootModuleInfo.getClassLoader();
+        ClassLoader newTccl = springBootModuleInfo.getThreadContextClassLoader();
         ClassLoader previousTccl = AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> Thread.currentThread().getContextClassLoader());
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             Thread.currentThread().setContextClassLoader(newTccl);
@@ -179,6 +179,7 @@ public class SpringBootRuntimeContainer implements ModuleRuntimeContainer {
         SpringBootModuleInfo springBootModuleInfo = (SpringBootModuleInfo) moduleInfo;
         springBootModuleInfo.getSpringBootApplication().unregisterSpringConfigFactory();
         springBootModuleInfo.getSpringBootApplication().callShutdownHooks();
+        springBootModuleInfo.destroyThreadContextClassLoader();
     }
 
 }

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBContainerImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBContainerImpl.java
@@ -141,7 +141,7 @@ public class EJBContainerImpl implements EJBContainer {
             // This adapt should always succeed because ModuleInitDataAdapter
             // should always find WebModuleInfo.
             ModuleInitDataImpl mid = container.adapt(ModuleInitDataImpl.class);
-            if (mid.ivBeans.isEmpty()) {
+            if (null == mid || mid.ivBeans.isEmpty()) {
                 // Do nothing if there are no EJBs.
                 return null;
             }

--- a/dev/com.ibm.ws.springboot.support_fat/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support_fat/bnd.bnd
@@ -19,7 +19,7 @@ javac.target: 1.8
 
 fat.project: true
 
-tested.features: springBoot-1.5, springBoot-2.0, servlet-3.1, servlet-4.0, transportSecurity-1.0, jsp-2.3, websocket-1.1, appSecurity-2.0, cdi-1.2
+tested.features: springBoot-1.5, springBoot-2.0, servlet-3.1, servlet-4.0, transportSecurity-1.0, jsp-2.3, websocket-1.1, appSecurity-2.0, cdi-1.2, javaee-7.0, javaee-8.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/FATSuite.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/FATSuite.java
@@ -60,7 +60,9 @@ import com.ibm.ws.springboot.support.fat.utility.SpringBootUtilityThinTest;
                 ErrorPage20Test.class,
                 WebFluxApplicationNotSupportedTest.class,
                 EnableSpringBootTraceTests.class,
-                ExceptionOccuredAfterAppIsAvailableTest15.class
+                ExceptionOccuredAfterAppIsAvailableTest15.class,
+                JavaeeFeatureTests15.class,
+                JavaeeFeatureTests20.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/JavaeeFeatureTests15.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/JavaeeFeatureTests15.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.springboot.support.fat;
+
+import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.topology.utils.HttpUtils;
+
+
+@RunWith(FATRunner.class)
+public class JavaeeFeatureTests15 extends AbstractSpringTests {
+
+    /**
+     * Export JavaEE feature API to basic Spring Boot application. 
+     */
+    @Test
+    public void testBasicAppEnableJavaee70() throws Exception {
+        HttpUtils.findStringInUrl(server, "", "HELLO SPRING BOOT!!");
+    }
+
+    @Override
+    public Set<String> getFeatures() {
+        return new HashSet<>(Arrays.asList("springBoot-1.5", "javaee-7.0"));
+    }
+
+    @Override
+    public String getApplication() {
+        return SPRING_BOOT_15_APP_BASE;
+    }
+
+}

--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/JavaeeFeatureTests20.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/JavaeeFeatureTests20.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.springboot.support.fat;
+
+import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.topology.utils.HttpUtils;
+
+
+@RunWith(FATRunner.class)
+public class JavaeeFeatureTests20 extends AbstractSpringTests {
+
+    /**
+     * Export JavaEE feature API to basic Spring Boot application.  
+     */
+    @Test
+    public void testEnableJavaee80() throws Exception {
+        HttpUtils.findStringInUrl(server, "", "HELLO SPRING BOOT!!");
+    }
+
+    @Override
+    public Set<String> getFeatures() {
+        return new HashSet<>(Arrays.asList("springBoot-2.0", "javaee-8.0"));
+    }
+
+    @Override
+    public String getApplication() {
+        return SPRING_BOOT_20_APP_BASE;
+    }
+
+}


### PR DESCRIPTION
fixes #4310 

Resolves the problem where a Spring Boot application fails to start whenever an Enterprise JavaBean feature is directly or indirectly enabled in a server configuration.  For example: when starting a Spring Boot application on a server configured with the following features:

`    <featureManager>` 
`        <feature>javaee-8.0</feature>`
`        <feature>springBoot-2.0</feature>`
`    </featureManager>`

The server will fail to start the application and emit an FFDC event indicating a ClassCastException:

`java.lang.ClassCastException: com.ibm.ws.app.manager.springboot.internal.SpringBootModuleInfo cannot be cast to com.ibm.ws.container.service.app.deploy.WebModuleInfo
        at com.ibm.ws.ejbcontainer.osgi.internal.ModuleInitDataAdapter.adapt(ModuleInitDataAdapter.java:100)
        at com.ibm.ws.ejbcontainer.osgi.internal.ModuleInitDataAdapter.adapt(ModuleInitDataAdapter.java:40)
        at com.ibm.ws.adaptable.module.internal.AdapterFactoryServiceImpl.adapt(AdapterFactoryServiceImpl.java:196)
        at com.ibm.ws.adaptable.module.internal.AdaptableContainerImpl.adapt(AdaptableContainerImpl.java:170)
        at com.ibm.ws.ejbcontainer.osgi.internal.EJBContainerImpl.createEJBInWARModuleMetaData(EJBContainerImpl.java:143)
        at com.ibm.ws.ejbcontainer.war.internal.EJBWARMetaDataRuntime.createdNestedModuleMetaData(EJBWARMetaDataRuntime.java:63)
        at com.ibm.ws.app.manager.module.internal.SimpleDeployedAppInfoBase$ModuleContainerInfoBase.createModuleMetaData(SimpleDeployedAppInfoBase.java:173)
        at com.ibm.ws.app.manager.module.internal.DeployedAppInfoBase.preDeployApp(DeployedAppInfoBase.java:368)
        at com.ibm.ws.app.manager.module.internal.DeployedAppInfoBase.deployApp(DeployedAppInfoBase.java:412)
        at com.ibm.ws.app.manager.springboot.internal.SpringBootHandler.install(SpringBootHandler.java:135)
        at com.ibm.ws.app.manager.internal.statemachine.StartAction.execute(StartAction.java:140)
        at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.enterState(ApplicationStateMachineImpl.java:1258)
        at com.ibm.ws.app.manager.internal.statemachine.ApplicationStateMachineImpl.run(ApplicationStateMachineImpl.java:873)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)`



