### PR TITLE
Issue #4465: Fix EJB Timer Create Timing Issue

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent/src/com/ibm/ws/ejbcontainer/timer/persistent/osgi/internal/PersistentTimerTaskHandlerImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent/src/com/ibm/ws/ejbcontainer/timer/persistent/osgi/internal/PersistentTimerTaskHandlerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2015 IBM Corporation and others.
+ * Copyright (c) 2003, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -147,6 +147,13 @@ class PersistentTimerTaskHandlerImpl extends PersistentTimerTaskHandler implemen
             nextTimeout = parsedSchedule.getNextTimeout(lastExecution.getTime());
         } else {
             nextTimeout = parsedSchedule.getFirstTimeout();
+
+            // A timer would never be scheduled if getFirstTimeout() had originally returned
+            // -1, therefore the first (and only) timeout has passed while creating the timer.
+            // In this scenario, run the timer immediately by returning the creation time.
+            if (nextTimeout == -1) {
+                return timerCreationTime;
+            }
         }
         if (nextTimeout == -1) {
             return null;


### PR DESCRIPTION
This error may occur when creating a persistent Calendar based EJB timer, which only has one
scheduled time, and that time expires while the timer is being created.

Specifically, the EJB Container checked the scheduled expression to ensure it has at least
one expiration in the future. If there is at least one timeout, then the timer is created
and scheduled to run. When scheduled, the first timeout is calculated again. However, if
the one timeout for the timer has passed between the time the EJB Container checked and
the timer is scheduled, then the RejectedExcecutionException occurs and timer creation fails.

The EJB specification indicates an EJB timer should determine timeouts based on the time
the EJB timer is created, not when the transaction commits, so the timer should be valid
and should run immediately.

The fix will be to detect the small timing window, and schedule to run the timer immediately,
avoiding the failed timer creation.

fixes #4465 