### PR TITLE
add + or - to api types for easier usage

### DIFF
--- a/dev/com.ibm.ws.classloading/resources/OSGI-INF/l10n/classloader.properties
+++ b/dev/com.ibm.ws.classloading/resources/OSGI-INF/l10n/classloader.properties
@@ -33,7 +33,7 @@ classloader.common.library.ref$Ref=Shared library references
 classloader.common.library.ref.desc=List of library references. Library class instances are shared with other classloaders.  
 # allowed api types
 classloader.apis=Allowed API types
-classloader.apis.desc=The types of API packages that this class loader supports. This value is a comma-separated list of any combination of the following API packages: spec, ibm-api, api, stable, third-party.  If a prefix of + or - is added to API types, they will be added or removed, respectively, from the default set of API types.  Common usage for prefix "+third-party" results in "spec, ibm-api, api, stable, third-party" and "-api" results in "spec, ibm-api, stable" 
+classloader.apis.desc=The types of API packages that this class loader supports. This value is a comma-separated list of any combination of the following API packages: spec, ibm-api, api, stable, third-party.  If a prefix of + or - is added to API types, those API types are added or removed, respectively, from the default set of API types. Common usage for the prefix, +third-party, results in "spec, ibm-api, api, stable, third-party". The prefix, -api, results in "spec, ibm-api, stable". 
 classloader.api.spec=Spec interfaces
 classloader.api.spec.desc=Interfaces from formal specifications implemented or supported by the runtime, e.g. Java EE. 
 classloader.api.ibmapi=IBM APIs

--- a/dev/com.ibm.ws.classloading/resources/OSGI-INF/l10n/classloader.properties
+++ b/dev/com.ibm.ws.classloading/resources/OSGI-INF/l10n/classloader.properties
@@ -33,7 +33,7 @@ classloader.common.library.ref$Ref=Shared library references
 classloader.common.library.ref.desc=List of library references. Library class instances are shared with other classloaders.  
 # allowed api types
 classloader.apis=Allowed API types
-classloader.apis.desc=The types of API packages that this class loader supports. This value is a comma-separated list of any combination of the following API packages: spec, ibm-api, api, stable, third-party.  If a prefix of + or - is added to any API id, the default API package will be added.  Common usage for prefix "+third-party" results in "spec, ibm-api, api, stable, third-party" and "-api" results in "spec, ibm-api, stable" 
+classloader.apis.desc=The types of API packages that this class loader supports. This value is a comma-separated list of any combination of the following API packages: spec, ibm-api, api, stable, third-party.  If a prefix of + or - is added to API types, they will be added or removed, respectively, from the default set of API types.  Common usage for prefix "+third-party" results in "spec, ibm-api, api, stable, third-party" and "-api" results in "spec, ibm-api, stable" 
 classloader.api.spec=Spec interfaces
 classloader.api.spec.desc=Interfaces from formal specifications implemented or supported by the runtime, e.g. Java EE. 
 classloader.api.ibmapi=IBM APIs

--- a/dev/com.ibm.ws.classloading/resources/OSGI-INF/l10n/classloader.properties
+++ b/dev/com.ibm.ws.classloading/resources/OSGI-INF/l10n/classloader.properties
@@ -33,7 +33,7 @@ classloader.common.library.ref$Ref=Shared library references
 classloader.common.library.ref.desc=List of library references. Library class instances are shared with other classloaders.  
 # allowed api types
 classloader.apis=Allowed API types
-classloader.apis.desc=The types of API packages that this class loader supports. This value is a comma-separated list of any combination of the following API packages: spec, ibm-api, api, stable, third-party.
+classloader.apis.desc=The types of API packages that this class loader supports. This value is a comma-separated list of any combination of the following API packages: spec, ibm-api, api, stable, third-party.  If a prefix of + or - is added to any API id, the default API package will be added.  Common usage for prefix "+third-party" results in "spec, ibm-api, api, stable, third-party" and "-api" results in "spec, ibm-api, stable" 
 classloader.api.spec=Spec interfaces
 classloader.api.spec.desc=Interfaces from formal specifications implemented or supported by the runtime, e.g. Java EE. 
 classloader.api.ibmapi=IBM APIs

--- a/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
+++ b/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
@@ -142,13 +142,13 @@ slf.failed.delete.useraction=Verify that the cache file is not in a locked state
 
 cls.classloader.config.duplicate=CWWKL0080E: API id [{0}] was already used in this list [{1}], remove the duplicate API id.
 cls.classloader.config.duplicate.explanation=Remove the duplicate API id.
-cls.classloader.config.duplicate.useraction=Check the server configuration to ensure that the class loader has been defined and that the ID is correct.
+cls.classloader.config.duplicate.useraction=Check the server configuration for duplicate API id to ensure that the API id are correct.
 
 cls.classloader.config.not.allowed=CWWKL0081E: API id [{0}] is already added to the list when using prefix + or -, remove [{0}] from the list [{1}].
 cls.classloader.config.not.allowed.explanation=All default API ids are added, remove duplicates.
-cls.classloader.config.not.allowed.useraction=Check the server configuration to ensure that the class loader has been defined and that the ID is correct.
+cls.classloader.config.not.allowed.useraction=Check the server configuration and remove default API id to ensure that the API id are correct.
 
 cls.classloader.config.typo=CWWKL0082E: API id [{0}] is not valid in this list [{1}] and needs to be changed to one of the valid API ids {2}.
 cls.classloader.config.typo.explanation=Change the invalid API id to a valid API id.
-cls.classloader.config.typo.useraction=Check the server configuration to ensure that the class loader has been defined and that the ID is correct.
+cls.classloader.config.typo.useraction=Check the server configuration for invalid API id to ensure that the API id are correct.
 

--- a/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
+++ b/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
@@ -140,18 +140,18 @@ slf.failed.delete=CWWKL0072W: The [{0}] cache file cannot be deleted. This resul
 slf.failed.delete.explanation=The system failed to delete the cache file. Because the file still exists in the system, this might cause corruption in nested archives.
 slf.failed.delete.useraction=Verify that the cache file is not in a locked state, which can cause the file deletion to fail.
 
-cls.classloader.config.duplicate=CWWKL0080E: API type [{0}] was already used in this list [{1}], remove the duplicate API type.
+cls.classloader.config.duplicate=CWWKL0080E: [{0}] API type was already used in this [{1}] list.  Remove the duplicate API type.
 cls.classloader.config.duplicate.explanation=Each API type can be specified a maximum of one time.
 cls.classloader.config.duplicate.useraction=Check the server configuration for duplicate API type to ensure that the API type are correct.
 
-cls.classloader.config.not.allowed=CWWKL0081E: API type [{0}] is already added to the list when using prefix + or -, remove [{0}] from the list [{1}].
+cls.classloader.config.not.allowed=CWWKL0081E: [{0}] API type is already added to the list when using prefix + or -.  Remove [{0}] from the [{1}] list.
 cls.classloader.config.not.allowed.explanation=All default API types are added, remove duplicates.
 cls.classloader.config.not.allowed.useraction=Check the server configuration and remove default API type to ensure that the API type are correct.
 
-cls.classloader.config.typo=CWWKL0082E: API type [{0}] is not valid in this list [{1}] and needs to be changed to one of the valid API types {2}.
+cls.classloader.config.typo=CWWKL0082E: [{0}] API type is not valid in this [{1}] list and needs to be changed to one of the valid {2} API types.
 cls.classloader.config.typo.explanation=Change the invalid API type to a valid API type.
 cls.classloader.config.typo.useraction=Check the server configuration for invalid API type to ensure that the API type are correct.
 
-cls.classloader.config.typo2=CWWKL0083E: When using prefix + or -, API type [{0}] is not valid in this list [{1}].  All API type must have a prefix of + or -
+cls.classloader.config.typo2=CWWKL0083E: When using prefix + or -, [{0}] API type is not valid in this [{1}] list.  All API type must have a prefix of + or -
 cls.classloader.config.typo2.explanation=Change the invalid API type to a valid API type with + or -.
 cls.classloader.config.typo2.useraction=Check the server configuration for invalid API type to ensure that the API type are correct.

--- a/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
+++ b/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
@@ -140,18 +140,18 @@ slf.failed.delete=CWWKL0072W: The [{0}] cache file cannot be deleted. This resul
 slf.failed.delete.explanation=The system failed to delete the cache file. Because the file still exists in the system, this might cause corruption in nested archives.
 slf.failed.delete.useraction=Verify that the cache file is not in a locked state, which can cause the file deletion to fail.
 
-cls.classloader.config.duplicate=CWWKL0080E: API id [{0}] was already used in this list [{1}], remove the duplicate API id.
-cls.classloader.config.duplicate.explanation=Remove the duplicate API id.
-cls.classloader.config.duplicate.useraction=Check the server configuration for duplicate API id to ensure that the API id are correct.
+cls.classloader.config.duplicate=CWWKL0080E: API type [{0}] was already used in this list [{1}], remove the duplicate API type.
+cls.classloader.config.duplicate.explanation=Each API type can be specified a maximum of one time.
+cls.classloader.config.duplicate.useraction=Check the server configuration for duplicate API type to ensure that the API type are correct.
 
-cls.classloader.config.not.allowed=CWWKL0081E: API id [{0}] is already added to the list when using prefix + or -, remove [{0}] from the list [{1}].
-cls.classloader.config.not.allowed.explanation=All default API ids are added, remove duplicates.
-cls.classloader.config.not.allowed.useraction=Check the server configuration and remove default API id to ensure that the API id are correct.
+cls.classloader.config.not.allowed=CWWKL0081E: API type [{0}] is already added to the list when using prefix + or -, remove [{0}] from the list [{1}].
+cls.classloader.config.not.allowed.explanation=All default API types are added, remove duplicates.
+cls.classloader.config.not.allowed.useraction=Check the server configuration and remove default API type to ensure that the API type are correct.
 
-cls.classloader.config.typo=CWWKL0082E: API id [{0}] is not valid in this list [{1}] and needs to be changed to one of the valid API ids {2}.
-cls.classloader.config.typo.explanation=Change the invalid API id to a valid API id.
-cls.classloader.config.typo.useraction=Check the server configuration for invalid API id to ensure that the API id are correct.
+cls.classloader.config.typo=CWWKL0082E: API type [{0}] is not valid in this list [{1}] and needs to be changed to one of the valid API types {2}.
+cls.classloader.config.typo.explanation=Change the invalid API type to a valid API type.
+cls.classloader.config.typo.useraction=Check the server configuration for invalid API type to ensure that the API type are correct.
 
-cls.classloader.config.typo2=CWWKL0083E: When using prefix + or -, API id [{0}] is not valid in this list [{1}].  All API id must have a prefix of + or -
-cls.classloader.config.typo2.explanation=Change the invalid API id to a valid API id with + or -.
-cls.classloader.config.typo2.useraction=Check the server configuration for invalid API id to ensure that the API id are correct.
+cls.classloader.config.typo2=CWWKL0083E: When using prefix + or -, API type [{0}] is not valid in this list [{1}].  All API type must have a prefix of + or -
+cls.classloader.config.typo2.explanation=Change the invalid API type to a valid API type with + or -.
+cls.classloader.config.typo2.useraction=Check the server configuration for invalid API type to ensure that the API type are correct.

--- a/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
+++ b/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
@@ -152,3 +152,6 @@ cls.classloader.config.typo=CWWKL0082E: API id [{0}] is not valid in this list [
 cls.classloader.config.typo.explanation=Change the invalid API id to a valid API id.
 cls.classloader.config.typo.useraction=Check the server configuration for invalid API id to ensure that the API id are correct.
 
+cls.classloader.config.typo=CWWKL0083E: When using prefix + or -, API id [{0}] is not valid in this list [{1}].  All API id must have a prefix of + or -
+cls.classloader.config.typo.explanation=Change the invalid API id to a valid API id with + or -.
+cls.classloader.config.typo.useraction=Check the server configuration for invalid API id to ensure that the API id are correct.

--- a/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
+++ b/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
@@ -152,6 +152,6 @@ cls.classloader.config.typo=CWWKL0082E: API id [{0}] is not valid in this list [
 cls.classloader.config.typo.explanation=Change the invalid API id to a valid API id.
 cls.classloader.config.typo.useraction=Check the server configuration for invalid API id to ensure that the API id are correct.
 
-cls.classloader.config.typo=CWWKL0083E: When using prefix + or -, API id [{0}] is not valid in this list [{1}].  All API id must have a prefix of + or -
-cls.classloader.config.typo.explanation=Change the invalid API id to a valid API id with + or -.
-cls.classloader.config.typo.useraction=Check the server configuration for invalid API id to ensure that the API id are correct.
+cls.classloader.config.typo2=CWWKL0083E: When using prefix + or -, API id [{0}] is not valid in this list [{1}].  All API id must have a prefix of + or -
+cls.classloader.config.typo2.explanation=Change the invalid API id to a valid API id with + or -.
+cls.classloader.config.typo2.useraction=Check the server configuration for invalid API id to ensure that the API id are correct.

--- a/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
+++ b/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
@@ -139,3 +139,16 @@ slf.no.acf.useraction=See the problem determination information on the WebSphere
 slf.failed.delete=CWWKL0072W: The [{0}] cache file cannot be deleted. This result can lead to the corruption of nested archives.
 slf.failed.delete.explanation=The system failed to delete the cache file. Because the file still exists in the system, this might cause corruption in nested archives.
 slf.failed.delete.useraction=Verify that the cache file is not in a locked state, which can cause the file deletion to fail.
+
+cls.classloader.config.duplicate=CWWKL0080E: API id [{0}] was already used in this list [{1}], remove the duplicate API id.
+cls.classloader.config.duplicate.explanation=Remove the duplicate API id.
+cls.classloader.config.duplicate.useraction=Check the server configuration to ensure that the class loader has been defined and that the ID is correct.
+
+cls.classloader.config.not.allowed=CWWKL0081E: API id [{0}] is already added to the list when using prefix + or -, remove [{0}] from the list [{1}].
+cls.classloader.config.not.allowed.explanation=All default API ids are added, remove duplicates.
+cls.classloader.config.not.allowed.useraction=Check the server configuration to ensure that the class loader has been defined and that the ID is correct.
+
+cls.classloader.config.typo=CWWKL0082E: API id [{0}] is not valid in this list [{1}] and needs to be changed to one of the valid API ids {2}.
+cls.classloader.config.typo.explanation=Change the invalid API id to a valid API id.
+cls.classloader.config.typo.useraction=Check the server configuration to ensure that the class loader has been defined and that the ID is correct.
+

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/ClassLoaderConfigHelper.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/ClassLoaderConfigHelper.java
@@ -15,10 +15,6 @@ import static com.ibm.ws.classloading.ClassLoaderConfigHelper.Attribute.classPro
 import static com.ibm.ws.classloading.ClassLoaderConfigHelper.Attribute.commonLibraryRef;
 import static com.ibm.ws.classloading.ClassLoaderConfigHelper.Attribute.delegation;
 import static com.ibm.ws.classloading.ClassLoaderConfigHelper.Attribute.privateLibraryRef;
-import static com.ibm.wsspi.classloading.ApiType.API;
-import static com.ibm.wsspi.classloading.ApiType.IBMAPI;
-import static com.ibm.wsspi.classloading.ApiType.SPEC;
-import static com.ibm.wsspi.classloading.ApiType.STABLE;
 
 import java.io.File;
 import java.io.IOException;
@@ -75,8 +71,6 @@ public class ClassLoaderConfigHelper {
         }
     }
 
-    private static final EnumSet<ApiType> DEFAULT_API_TYPES = EnumSet.of(SPEC, IBMAPI, API, STABLE);
-
     private final List<String> sharedLibraries;
     private final List<String> commonLibraries;
     private final List<String> classProviders;
@@ -101,7 +95,7 @@ public class ClassLoaderConfigHelper {
             if (tc.isDebugEnabled())
                 Tr.debug(tc, methodName + reason.getMessage());
             this.classLoaderConfigProps = null;
-            this.apiTypes = DEFAULT_API_TYPES;
+            this.apiTypes = ApiType.DEFAULT_API_TYPES;
             this.isDelegateLast = false;
             this.sharedLibraries = Collections.emptyList();
             this.commonLibraries = Collections.emptyList();

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/ClassLoaderConfigHelper.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/ClassLoaderConfigHelper.java
@@ -15,6 +15,10 @@ import static com.ibm.ws.classloading.ClassLoaderConfigHelper.Attribute.classPro
 import static com.ibm.ws.classloading.ClassLoaderConfigHelper.Attribute.commonLibraryRef;
 import static com.ibm.ws.classloading.ClassLoaderConfigHelper.Attribute.delegation;
 import static com.ibm.ws.classloading.ClassLoaderConfigHelper.Attribute.privateLibraryRef;
+import static com.ibm.wsspi.classloading.ApiType.API;
+import static com.ibm.wsspi.classloading.ApiType.IBMAPI;
+import static com.ibm.wsspi.classloading.ApiType.SPEC;
+import static com.ibm.wsspi.classloading.ApiType.STABLE;
 
 import java.io.File;
 import java.io.IOException;
@@ -71,6 +75,8 @@ public class ClassLoaderConfigHelper {
         }
     }
 
+    private static final EnumSet<ApiType> DEFAULT_API_TYPES = EnumSet.of(SPEC, IBMAPI, API, STABLE);
+
     private final List<String> sharedLibraries;
     private final List<String> commonLibraries;
     private final List<String> classProviders;
@@ -95,7 +101,7 @@ public class ClassLoaderConfigHelper {
             if (tc.isDebugEnabled())
                 Tr.debug(tc, methodName + reason.getMessage());
             this.classLoaderConfigProps = null;
-            this.apiTypes = ApiType.DEFAULT_API_TYPES;
+            this.apiTypes = DEFAULT_API_TYPES;
             this.isDelegateLast = false;
             this.sharedLibraries = Collections.emptyList();
             this.commonLibraries = Collections.emptyList();

--- a/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ApiType.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ApiType.java
@@ -10,8 +10,11 @@
  *******************************************************************************/
 package com.ibm.wsspi.classloading;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 /**
@@ -36,6 +39,7 @@ public enum ApiType {
 
     // OSGi APIs are marked spec:api, which is obviously not in this enum.
     // This means that OSGi application API will not be visible to EE applications.
+    private static final TraceComponent tc = Tr.register(ApiType.class);
 
     private final String attributeName;
 
@@ -64,42 +68,114 @@ public enum ApiType {
     public static EnumSet<ApiType> createApiTypeSet(String... apiTypes) {
         EnumSet<ApiType> set = EnumSet.noneOf(ApiType.class);
         EnumSet<ApiType> removeSet = EnumSet.noneOf(ApiType.class);
-        boolean addDefaults = false;
-        boolean removeType = false;
+        EnumSet<ApiType> addSet = EnumSet.noneOf(ApiType.class);
+        ArrayList<String> notFoundSet = new ArrayList<String>();
+        StringBuffer initialtypes = new StringBuffer();
         if (apiTypes != null)
-            for (String types : apiTypes)
+            for (String types : apiTypes) {
+                if (initialtypes.length() == 0)
+                    initialtypes.append("\"" + types + "\"");
+                else
+                    initialtypes.append(" \"" + types + "\"");
                 if (types != null)
                     for (String stype : types.split("[ ,]+")) {
                         if (stype.indexOf("+") == 0) {
                             stype = stype.replaceFirst("\\+", "");
-                            addDefaults = true;
+                            ApiType type = ApiType.fromString(stype);
+                            if (type != null) {
+                                if (!addSet.add(type)) {
+                                    if (tc.isErrorEnabled())
+                                        Tr.error(tc, "cls.classloader.config.duplicate", stype, initialtypes);
+                                    set.clear();
+                                    return set;
+                                }
+                            } else {
+                                if (tc.isErrorEnabled())
+                                    Tr.error(tc, "cls.classloader.config.typo", stype, initialtypes, EnumSet.allOf(ApiType.class));
+                                set.clear();
+                                return set;
+                            }
                         } else if (stype.indexOf("-") == 0) {
                             stype = stype.replaceFirst("-", "");
-                            removeType = true;
-                        }
-                        ApiType type = ApiType.fromString(stype);
-                        if (type != null) {
-                            if (removeType) {
-                                removeSet.add(type);
-                                removeType = false;
-                            } else {
-                                set.add(type);
-                                if (addDefaults) {
-                                    for (ApiType apiType : DEFAULT_API_TYPES)
-                                        set.add(apiType);
-                                    addDefaults = false;
+                            ApiType type = ApiType.fromString(stype);
+                            if (type != null) {
+                                if (!removeSet.add(type)) {
+                                    if (tc.isErrorEnabled())
+                                        Tr.error(tc, "cls.classloader.config.duplicate", stype, initialtypes);
+                                    set.clear();
+                                    return set;
                                 }
+                            } else {
+                                if (tc.isErrorEnabled())
+                                    Tr.error(tc, "cls.classloader.config.typo", stype, initialtypes, EnumSet.allOf(ApiType.class));
+                                set.clear();
+                                return set;
                             }
+                        } else {
+                            ApiType type = ApiType.fromString(stype);
+                            if (type != null)
+                                set.add(type);
+                            else
+                                notFoundSet.add(stype);
+
                         }
                     }
+            }
 
-        if (!removeSet.isEmpty()) {
-            for (ApiType apiType1 : DEFAULT_API_TYPES)
-                set.add(apiType1);
-            for (ApiType apiType2 : removeSet)
-                set.remove(apiType2);
+        if (!removeSet.isEmpty() || !addSet.isEmpty()) {
+            // processing +/- api types
+            if (set.isEmpty() && notFoundSet.isEmpty()) {
+                for (ApiType apiType : addSet) {
+                    if (removeSet.contains(apiType)) {
+                        if (tc.isErrorEnabled())
+                            Tr.error(tc, "cls.classloader.config.duplicate", apiType, initialtypes);
+                        set.clear();
+                        return set;
+                    }
+                }
+            } else {
+                EnumSet<ApiType> invalidSet = EnumSet.noneOf(ApiType.class);
+                for (ApiType apiType1 : DEFAULT_API_TYPES)
+                    for (ApiType set1 : set)
+                        if (set1.equals(apiType1))
+                            invalidSet.add(set1);
+                if (!invalidSet.isEmpty() || !notFoundSet.isEmpty() || !set.isEmpty()) {
+                    if (tc.isErrorEnabled()) {
+                        if (!notFoundSet.isEmpty())
+                            Tr.error(tc, "cls.classloader.config.typo", notFoundSet, initialtypes, EnumSet.allOf(ApiType.class));
+                        if (!invalidSet.isEmpty())
+                            Tr.error(tc, "cls.classloader.config.not.allowed", invalidSet, initialtypes);
+                        if (!set.isEmpty())
+                            Tr.error(tc, "cls.classloader.config.typo2", set, initialtypes);
+
+                    }
+                    set.clear();
+                    return set;
+                }
+            }
+            for (ApiType apiType : addSet) {
+                if (removeSet.contains(apiType) || set.contains(apiType)) {
+                    if (tc.isErrorEnabled())
+                        Tr.error(tc, "cls.classloader.config.duplicate", apiType, initialtypes);
+                    set.clear();
+                    return set;
+                }
+            }
+            for (ApiType apiType : removeSet) {
+                if (set.contains(apiType)) {
+                    if (tc.isErrorEnabled())
+                        Tr.error(tc, "cls.classloader.config.duplicate", apiType, initialtypes);
+                    set.clear();
+                    return set;
+                }
+            }
+            for (ApiType apiType : DEFAULT_API_TYPES)
+                set.add(apiType);
+            for (ApiType apiType : addSet)
+                set.add(apiType);
+            for (ApiType apiType : removeSet)
+                set.remove(apiType);
         }
-
         return set;
     }
 

--- a/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ApiType.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ApiType.java
@@ -39,16 +39,10 @@ public enum ApiType {
 
     private final String attributeName;
 
+    public static final EnumSet<ApiType> DEFAULT_API_TYPES = EnumSet.of(SPEC, IBMAPI, API, STABLE);
+
     private ApiType(String attributeName) {
         this.attributeName = attributeName;
-    }
-
-    private static boolean addDefaults(EnumSet<ApiType> set) {
-        set.add(SPEC);
-        set.add(IBMAPI);
-        set.add(API);
-        set.add(STABLE);
-        return true;
     }
 
     public static ApiType fromString(String value) {
@@ -70,16 +64,15 @@ public enum ApiType {
     public static EnumSet<ApiType> createApiTypeSet(String... apiTypes) {
         EnumSet<ApiType> set = EnumSet.noneOf(ApiType.class);
         EnumSet<ApiType> removeSet = EnumSet.noneOf(ApiType.class);
-        boolean addType = false;
+        boolean addDefaults = false;
         boolean removeType = false;
-        boolean defaultsAdded = false;
         if (apiTypes != null)
             for (String types : apiTypes)
                 if (types != null)
                     for (String stype : types.split("[ ,]+")) {
                         if (stype.indexOf("+") == 0) {
                             stype = stype.replaceFirst("\\+", "");
-                            addType = true;
+                            addDefaults = true;
                         } else if (stype.indexOf("-") == 0) {
                             stype = stype.replaceFirst("-", "");
                             removeType = true;
@@ -91,19 +84,20 @@ public enum ApiType {
                                 removeType = false;
                             } else {
                                 set.add(type);
-                                if (!defaultsAdded && addType) {
-                                    defaultsAdded = addDefaults(set);
+                                if (addDefaults) {
+                                    for (ApiType apiType : DEFAULT_API_TYPES)
+                                        set.add(apiType);
+                                    addDefaults = false;
                                 }
                             }
                         }
                     }
 
         if (!removeSet.isEmpty()) {
-            if (!defaultsAdded)
-                addDefaults(set);
-            for (ApiType apiType : removeSet) {
-                set.remove(apiType);
-            }
+            for (ApiType apiType1 : DEFAULT_API_TYPES)
+                set.add(apiType1);
+            for (ApiType apiType2 : removeSet)
+                set.remove(apiType2);
         }
 
         return set;

--- a/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ApiType.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ApiType.java
@@ -43,7 +43,7 @@ public enum ApiType {
 
     private final String attributeName;
 
-    public static final EnumSet<ApiType> DEFAULT_API_TYPES = EnumSet.of(SPEC, IBMAPI, API, STABLE);
+    private static final EnumSet<ApiType> DEFAULT_API_TYPES = EnumSet.of(SPEC, IBMAPI, API, STABLE);
 
     private ApiType(String attributeName) {
         this.attributeName = attributeName;

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/ApiTypeTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/ApiTypeTest.java
@@ -51,24 +51,11 @@ public class ApiTypeTest {
         assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, third-party"));
     }
 
-    /**
-     * This test assumes a default set of api types will be
-     * provided when a + or - prefix is used.
-     *
-     * The current default is set(SPEC, IBMAPI, API, STABLE). The type set is not
-     * order dependent and a prefix of - overrides a prefix of +
-     *
-     * A common use will be +third-party that will result in api type
-     * set(SPEC, IBMAPI, API, THIRDPARTY, STABLE)
-     */
     @Test
-    public void testApiTypePlusMinusSetParsing() {
-        // normal usage of + and -
+    public void testApiTypePlusMinusSetParsingValid() {
         assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("+third-party"));
         assertEquals(set(SPEC, IBMAPI, THIRDPARTY, STABLE), ApiType.createApiTypeSet("+third-party, -api"));
         assertEquals(set(SPEC, IBMAPI, THIRDPARTY, STABLE), ApiType.createApiTypeSet("-api, +third-party"));
-        assertEquals(set(SPEC, IBMAPI, THIRDPARTY, STABLE), ApiType.createApiTypeSet("-api, third-party"));
-        assertEquals(set(SPEC, IBMAPI, THIRDPARTY, STABLE), ApiType.createApiTypeSet("third-party, -api"));
         assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec"));
         assertEquals(set(SPEC, API, STABLE), ApiType.createApiTypeSet("-ibm-api"));
         assertEquals(set(SPEC, IBMAPI, STABLE), ApiType.createApiTypeSet("-api"));
@@ -77,27 +64,53 @@ public class ApiTypeTest {
         assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+ibm-api"));
         assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+api"));
         assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+stable"));
-
-        // could be used
         assertEquals(set(IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("-spec,+third-party"));
         assertEquals(set(IBMAPI, API, THIRDPARTY), ApiType.createApiTypeSet("-spec,+third-party, -stable"));
         assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec"));
         assertEquals(set(API, STABLE), ApiType.createApiTypeSet("-spec,-ibm-api"));
         assertEquals(set(STABLE), ApiType.createApiTypeSet("-spec,-ibm-api,-api"));
         assertEquals(set(), ApiType.createApiTypeSet("-spec,-ibm-api,-api,-stable"));
-
-        // could be errors or warning, but are current not logged and - overrides a prefix of +
-        // more code and a message will need to be added to this code to detect errors
-        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec,+spec"));
-        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("+spec,-spec"));
+        assertEquals(set(), ApiType.createApiTypeSet("-spec,-ibm-api,-api,-stable,-third-party"));
         assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("-third-party"));
-        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+third-party,-third-party"));
-        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("-third-party,+third-party"));
-        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, third-party"));
-        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, third-party -third-party"));
-        assertEquals(set(SPEC, IBMAPI, API), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, +third-parttttty"));
-        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, +third-party"));
-        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("spec +ibm-api,random", "junk,api, third-party"));
+    }
+
+    @Test
+    public void testApiTypePlusMinusSetParsingInValid() {
+        assertEquals(set(), ApiType.createApiTypeSet("-spec,-spec"));
+        assertEquals(set(), ApiType.createApiTypeSet("+spec,+spec"));
+        assertEquals(set(), ApiType.createApiTypeSet("+api, third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("third-party, +api"));
+        assertEquals(set(), ApiType.createApiTypeSet("-api, third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("third-party, -api"));
+        assertEquals(set(), ApiType.createApiTypeSet("-api, spec"));
+        assertEquals(set(), ApiType.createApiTypeSet("spec, -api"));
+        assertEquals(set(), ApiType.createApiTypeSet("+third-party,-third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("-third-party,+third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("third-party,+third-party,-third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("third-party,-third-party,+third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("api,+third-party,-third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("api,-third-party,+third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("api,+third-party,-spec"));
+        assertEquals(set(), ApiType.createApiTypeSet("api,-third-party,+spec"));
+        assertEquals(set(), ApiType.createApiTypeSet("+third-partttty"));
+        assertEquals(set(), ApiType.createApiTypeSet("-third-partttty"));
+        assertEquals(set(), ApiType.createApiTypeSet("third-party,+third-party,-api"));
+        assertEquals(set(), ApiType.createApiTypeSet("third-party,-third-party,+api"));
+        assertEquals(set(), ApiType.createApiTypeSet("third-party,-api,+third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("-api,third-party,+third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("-third-partttty"));
+        assertEquals(set(), ApiType.createApiTypeSet("+third-partttty"));
+        assertEquals(set(), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, third-party -third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, third-party +third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("+api, third-partty"));
+        assertEquals(set(), ApiType.createApiTypeSet("-api, third-partty"));
+        assertEquals(set(), ApiType.createApiTypeSet("+third-party, -api, -ibm-api, fun"));
+        assertEquals(set(), ApiType.createApiTypeSet("+api, third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("-api, third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("+api, +third-party", "+api, third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("-api, +third-party", "-api, third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, +third-party"));
+        assertEquals(set(), ApiType.createApiTypeSet("spec +ibm-api,random", "junk,api, third-party"));
     }
 
     private static Set<ApiType> set(ApiType... types) {

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/ApiTypeTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/ApiTypeTest.java
@@ -51,6 +51,45 @@ public class ApiTypeTest {
         assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, third-party"));
     }
 
+    /**
+     * This test assumes a default set of api types will be
+     * provided when a + or - prefix is used.
+     *
+     * The current default is set(SPEC, IBMAPI, API, STABLE). The type set is not
+     * order dependent and a prefix of - overrides a prefix of +
+     *
+     * A common use will be +third-party that will result in api type
+     * set(SPEC, IBMAPI, API, THIRDPARTY, STABLE)
+     */
+    @Test
+    public void testApiTypePlusMinusSetParsing() {
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+spec"));
+        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec"));
+        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec,+spec"));
+        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("+spec,-spec"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+ibm-api"));
+        assertEquals(set(SPEC, API, STABLE), ApiType.createApiTypeSet("-ibm-api"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+api"));
+        assertEquals(set(SPEC, IBMAPI, STABLE), ApiType.createApiTypeSet("-api"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+stable"));
+        assertEquals(set(SPEC, IBMAPI, API), ApiType.createApiTypeSet("-stable"));
+        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("+third-party"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("-third-party"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+third-party,-third-party"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("-third-party,+third-party"));
+        assertEquals(set(IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("-spec,+third-party"));
+        assertEquals(set(IBMAPI, API, THIRDPARTY), ApiType.createApiTypeSet("-spec,+third-party, -stable"));
+        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec"));
+        assertEquals(set(API, STABLE), ApiType.createApiTypeSet("-spec,-ibm-api"));
+        assertEquals(set(STABLE), ApiType.createApiTypeSet("-spec,-ibm-api,-api"));
+        assertEquals(set(), ApiType.createApiTypeSet("-spec,-ibm-api,-api,-stable"));
+        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, third-party"));
+        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, +third-party"));
+        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("spec +ibm-api,random", "junk,api, third-party"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, third-party -third-party"));
+        assertEquals(set(SPEC, IBMAPI, API), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, +third-parttttty"));
+    }
+
     private static Set<ApiType> set(ApiType... types) {
         return new HashSet<ApiType>(Arrays.asList(types));
     }

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/ApiTypeTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/ApiTypeTest.java
@@ -63,31 +63,41 @@ public class ApiTypeTest {
      */
     @Test
     public void testApiTypePlusMinusSetParsing() {
-        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+spec"));
-        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec"));
-        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec,+spec"));
-        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("+spec,-spec"));
-        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+ibm-api"));
-        assertEquals(set(SPEC, API, STABLE), ApiType.createApiTypeSet("-ibm-api"));
-        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+api"));
-        assertEquals(set(SPEC, IBMAPI, STABLE), ApiType.createApiTypeSet("-api"));
-        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+stable"));
-        assertEquals(set(SPEC, IBMAPI, API), ApiType.createApiTypeSet("-stable"));
+        // normal usage of + and -
         assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("+third-party"));
-        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("-third-party"));
-        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+third-party,-third-party"));
-        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("-third-party,+third-party"));
+        assertEquals(set(SPEC, IBMAPI, THIRDPARTY, STABLE), ApiType.createApiTypeSet("+third-party, -api"));
+        assertEquals(set(SPEC, IBMAPI, THIRDPARTY, STABLE), ApiType.createApiTypeSet("-api, +third-party"));
+        assertEquals(set(SPEC, IBMAPI, THIRDPARTY, STABLE), ApiType.createApiTypeSet("-api, third-party"));
+        assertEquals(set(SPEC, IBMAPI, THIRDPARTY, STABLE), ApiType.createApiTypeSet("third-party, -api"));
+        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec"));
+        assertEquals(set(SPEC, API, STABLE), ApiType.createApiTypeSet("-ibm-api"));
+        assertEquals(set(SPEC, IBMAPI, STABLE), ApiType.createApiTypeSet("-api"));
+        assertEquals(set(SPEC, IBMAPI, API), ApiType.createApiTypeSet("-stable"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+spec"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+ibm-api"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+api"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+stable"));
+
+        // could be used
         assertEquals(set(IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("-spec,+third-party"));
         assertEquals(set(IBMAPI, API, THIRDPARTY), ApiType.createApiTypeSet("-spec,+third-party, -stable"));
         assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec"));
         assertEquals(set(API, STABLE), ApiType.createApiTypeSet("-spec,-ibm-api"));
         assertEquals(set(STABLE), ApiType.createApiTypeSet("-spec,-ibm-api,-api"));
         assertEquals(set(), ApiType.createApiTypeSet("-spec,-ibm-api,-api,-stable"));
+
+        // could be errors or warning, but are current not logged and - overrides a prefix of +
+        // more code and a message will need to be added to this code to detect errors
+        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("-spec,+spec"));
+        assertEquals(set(IBMAPI, API, STABLE), ApiType.createApiTypeSet("+spec,-spec"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("-third-party"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("+third-party,-third-party"));
+        assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("-third-party,+third-party"));
         assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, third-party"));
-        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, +third-party"));
-        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("spec +ibm-api,random", "junk,api, third-party"));
         assertEquals(set(SPEC, IBMAPI, API, STABLE), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, third-party -third-party"));
         assertEquals(set(SPEC, IBMAPI, API), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, +third-parttttty"));
+        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("spec ibm-api,random", "junk,api, +third-party"));
+        assertEquals(set(SPEC, IBMAPI, API, THIRDPARTY, STABLE), ApiType.createApiTypeSet("spec +ibm-api,random", "junk,api, third-party"));
     }
 
     private static Set<ApiType> set(ApiType... types) {


### PR DESCRIPTION
This story will assumes a default set of api types will be used when a + or - prefix is used.

The current default set is SPEC, IBMAPI, API, STABLE

A common use will be +third-party that will result in api type set SPEC, IBMAPI, API, THIRDPARTY, STABLE

Example,
  <classloader apiTypeVisibility="+third-party"/>