### PR TITLE
Add missing javaPermissions for jdbc_fat_v41

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41/server.xml
@@ -10,32 +10,32 @@
  -->
 <server>
     <featureManager>
-      <feature>componenttest-1.0</feature>
-      <feature>servlet-3.1</feature>
-      <feature>localConnector-1.0</feature>
-      <feature>jdbc-4.1</feature>
-      <feature>jndi-1.0</feature>
-      <feature>jsp-2.2</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>servlet-3.1</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>jdbc-4.1</feature>
+        <feature>jndi-1.0</feature>
+        <feature>jsp-2.2</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>
 
     <application location="basicfat.war" >
-      <classloader commonLibraryRef="DerbyLib"/>
+        <classloader commonLibraryRef="DerbyLib"/>
     </application>
     
     <dataSource id="DefaultDataSource" fat.modify="true">
-    	<jdbcDriver libraryRef="DerbyLib"/>
-    	<properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+        <jdbcDriver libraryRef="DerbyLib"/>
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
     <library id="DerbyLib" fat.modify="true">
-    	<fileset dir="${server.config.dir}/derby" includes="derby.jar,slowdriver.jar"/>
+        <fileset dir="${server.config.dir}/derby" includes="derby.jar,slowdriver.jar"/>
     </library>
     
     <dataSource id="ds1" jndiName="jdbc/${id}" fat.modify="true">
         <jdbcDriver libraryRef="DerbyLib" fat.modify="true"/>
-    	<properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
     <dataSource id="ds2" jndiName="jdbc/${id}" fat.modify="true">
@@ -55,12 +55,16 @@
     </dataSource>
     
     <dataSource id="slowDS" jndiName="jdbc/${id}" type="javax.sql.DataSource">
-    	<!-- The TimeoutDataSourceImpl class is found inside DerbyLib, but we need to specify it as the desired javax.sql.DataSource impl -->
-    	<jdbcDriver id="SlowDriver" libraryRef="DerbyLib" javax.sql.DataSource="jdbc.fat.v41.slowdriver.TimeoutDataSourceImpl"/>
-    	<properties.derby.embedded databaseName="memory:ds1" createDatabase="create" />
+        <!-- The TimeoutDataSourceImpl class is found inside DerbyLib, but we need to specify it as the desired javax.sql.DataSource impl -->
+        <jdbcDriver id="SlowDriver" libraryRef="DerbyLib" javax.sql.DataSource="jdbc.fat.v41.slowdriver.TimeoutDataSourceImpl"/>
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" />
     </dataSource>
     
     <javaPermission codebase="${server.config.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission className="java.sql.SQLPermission" name="callAbort"/>
+    <javaPermission codebase="${server.config.dir}/apps/basicfat.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission codebase="${server.config.dir}/apps/basicfat.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/basicfat.war" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
 
     <!--  Permissions for application to access mbeans -->
     <javaPermission codebase="${server.config.dir}/apps/basicfat.war" className="javax.management.MBeanPermission" actions="queryNames"/>


### PR DESCRIPTION
```
testAbortedConnectionDestroyed:junit.framework.AssertionFailedError: 2018-04-27-07:53:33:884 The response did not contain [SUCCESS].  Full output is:
ERROR: Caught exception attempting to call test method testAbortedConnectionDestroyed on servlet jdbc.fat.v41.web.BasicTestServlet
java.security.AccessControlException: Access denied (java.sql.SQLPermission callAbort)
at java.security.AccessController.throwACE(AccessController.java:157)
at java.security.AccessController.checkPermissionHelper(AccessController.java:217)
at java.security.AccessController.checkPermission(AccessController.java:349)
at java.lang.SecurityManager.checkPermission(SecurityManager.java:562)
at org.apache.derby.impl.jdbc.EmbedConnection.abort(Unknown Source)
at org.apache.derby.iapi.jdbc.BrokeredConnection.abort(Unknown Source)
at com.ibm.ws.rsadapter.jdbc.v41.WSJdbc41Connection.abort(WSJdbc41Connection.java:163)
at jdbc.fat.v41.web.BasicTestServlet.testAbortedConnectionDestroyed(BasicTestServlet.java:889)
at componenttest.app.FATServlet.doGet(FATServlet.java:71)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1255)
at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:743)
at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:440)
at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1154)
at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:4962)
at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:996)
at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1011)
...
```