### PR TITLE
More support for Driver

### DIFF
--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -250,6 +250,11 @@ DSRA4005.invalid.logintimeout=DSRA4005E: The server does not support the loginTi
 DSRA4005.invalid.logintimeout.explanation=The loginTimeout property is not supported when it is specified for a DataSource that is backed by a java.sql.Driver implementation because the server is unable to call getLoginTimeout on the java.sql.Driver class.
 DSRA4005.invalid.logintimeout.useraction=Modify the DataSource configuration to use a DataSource implementation instead of a java.sql.Driver implementation, or remove the loginTimeout property.
 
+# {0} name of the DataSource, {1} the vendor class name, {2} the start of the JDBC URL
+DSRA4006.null.connection=DSRA4006E: DataSource {0} is unable to connect to the database because {1} returned a null connection for the URL beginning with {2}.
+DSRA4006.null.connection.explanation=Although the java.sql.Driver indicated it accepted the supplied URL, it returned a null connection.
+DSRA4006.null.connection.useraction=This indicates a bug in the JDBC driver. Report the error to the JDBC driver vendor. Also ensure the JDBC driver and DataSource configuration are correct.
+
 DSRA4008.tran.none.unsupported=DSRA4008E: The JDBC driver does not support an isolation level of TRANSACTION_NONE, which is configured on data source {0}.
 DSRA4008.tran.none.unsupported.explanation=The TRANSACTION_NONE isolation level that is configured on the data source is not supported by the JDBC driver.
 DSRA4008.tran.none.unsupported.useraction=Either update the data source configuration to use an isolation level that is supported by the driver, or use a driver that supports an isolation level of TRANSACTION_NONE. 

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -252,8 +252,8 @@ DSRA4005.invalid.logintimeout.useraction=Modify the DataSource configuration to 
 
 # {0} name of the DataSource, {1} the vendor class name, {2} the start of the JDBC URL
 DSRA4006.null.connection=DSRA4006E: DataSource {0} is unable to connect to the database because {1} returned a null connection for the URL beginning with {2}.
-DSRA4006.null.connection.explanation=Although the java.sql.Driver indicated it accepted the supplied URL, it returned a null connection.
-DSRA4006.null.connection.useraction=This indicates a bug in the JDBC driver. Report the error to the JDBC driver vendor. Also ensure the JDBC driver and DataSource configuration are correct.
+DSRA4006.null.connection.explanation=Although the java.sql.Driver indicated that it accepted the supplied URL, it returned a null connection. This error indicates a bug in the JDBC driver.
+DSRA4006.null.connection.useraction=Report the error to the JDBC driver vendor and ensure that the JDBC driver and DataSource configuration are correct.
 
 DSRA4008.tran.none.unsupported=DSRA4008E: The JDBC driver does not support an isolation level of TRANSACTION_NONE, which is configured on data source {0}.
 DSRA4008.tran.none.unsupported.explanation=The TRANSACTION_NONE isolation level that is configured on the data source is not supported by the JDBC driver.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcDataSource.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcDataSource.java
@@ -246,7 +246,11 @@ public class WSJdbcDataSource extends WSJdbcWrapper implements DataSource, FFDCS
     @Override
     @SuppressWarnings("unchecked")
     protected <T> T getJDBCImplObject(Class<T> interfaceClass) throws SQLException {
-        Object impl = WSJdbcTracer.getImpl(getJDBCImplObject());
+        Object jdbcImplObject = getJDBCImplObject();
+        if(jdbcImplObject == null) {
+            return null;
+        }
+        Object impl = WSJdbcTracer.getImpl(jdbcImplObject);
         return interfaceClass.isInstance(impl) ? (T) impl : null;
     }
 

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jdbc.*=all:com.ibm.ejs.j2c.*=all:com.ibm.ws.rsadapter.*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jdbc.*=all:com.ibm.ejs.j2c.*=all:com.ibm.ws.rsadapter.*=all:com.ibm.ws.database.logwriter=all

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -13,6 +13,7 @@ package jdbc.fat.driver.web;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -588,7 +589,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
         //It should however still be able to be unwrapped to an interface impl'd by WsJdbcDataSource
         assertTrue("fatDriverDS should wrap CommonDataSource", fatDriverDS.isWrapperFor(CommonDataSource.class));
         CommonDataSource ds = fatDriverDS.unwrap(CommonDataSource.class);
-        assertEquals("The WSJdbcDataSource instance should have been returned by the call to unwrap", fatDriverDS, ds);
+        assertSame("The WSJdbcDataSource instance should have been returned by the call to unwrap", fatDriverDS, ds);
     }
 
 }

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -12,15 +12,19 @@ package jdbc.fat.driver.web;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 
 import javax.annotation.Resource;
@@ -31,6 +35,7 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
+import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 import javax.transaction.Status;
 import javax.transaction.UserTransaction;
@@ -534,6 +539,7 @@ public class JDBCDriverManagerServlet extends FATServlet {
         }
     }
 
+    //Test that setting the LoginTimeout via URL or properties for DataSources using Driver is rejected and that getLoginTimeout always returns 0.
     @Test
     @ExpectedFFDC({ "java.sql.SQLNonTransientException" })
     public void testGetSetLoginTimeout() throws Exception {
@@ -554,6 +560,35 @@ public class JDBCDriverManagerServlet extends FATServlet {
         DriverManager.setLoginTimeout(10 * 60); //10 minutes
 
         assertEquals("Login timeout should be 0 regardless of what is done to DriverManager", 0, fatDriverDS.getLoginTimeout());
+    }
+
+    //Test that you are unable to set the logwriter on the DataSource and that the getLogWriter method returns null
+    @Test
+    public void testGetSetLogWriter() throws Exception {
+        try {
+            fatDriverDS.setLogWriter(new PrintWriter(System.out));
+        } catch (SQLFeatureNotSupportedException ex) {
+        } //expected
+        assertNull("The getLogWriter method should always return null when using Driver", fatDriverDS.getLogWriter());
+    }
+
+    //Test that ensures unwrapping a DataSource backed by Driver to the underlying Driver interface is not possible
+    @Test
+    @ExpectedFFDC({ "java.sql.SQLException" })
+    public void testUnwrapDriver() throws Exception {
+        assertFalse("fatDriverDS should not wrap Driver", fatDriverDS.isWrapperFor(Driver.class));
+        try {
+            fatDriverDS.unwrap(Driver.class);
+            fail("Should not be able to unwrap to the Driver interface");
+        } catch (SQLException ex) {
+            if (!ex.getMessage().contains("DSRA9122E"))
+                throw ex;
+        }
+
+        //It should however still be able to be unwrapped to an interface impl'd by WsJdbcDataSource
+        assertTrue("fatDriverDS should wrap CommonDataSource", fatDriverDS.isWrapperFor(CommonDataSource.class));
+        CommonDataSource ds = fatDriverDS.unwrap(CommonDataSource.class);
+        assertEquals("The WSJdbcDataSource instance should have been returned by the call to unwrap", fatDriverDS, ds);
     }
 
 }


### PR DESCRIPTION
Additional support for using the a Driver as the underlying Datasource class.  This PR adds functionality and testing to ensure the correct behavior for calls to get/setLogWriter, unwrap, and a null connection being returned from the driver.