### PR TITLE
explicitly configure to use driver class

### DIFF
--- a/dev/com.ibm.ws.jdbc/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc/resources/OSGI-INF/metatype/metatype.xml
@@ -48,6 +48,7 @@
    <Option value="javax.sql.XADataSource"             label="javax.sql.XADataSource"/>
    <Option value="javax.sql.ConnectionPoolDataSource" label="javax.sql.ConnectionPoolDataSource"/>
    <Option value="javax.sql.DataSource"               label="javax.sql.DataSource"/>
+   <Option value="java.sql.Driver"                    label="java.sql.Driver"/>
   </AD>
   <AD id="connectionSharing"                      name="%conSharing"   description="%conSharing.desc"   required="false" type="String"  default="MatchOriginalRequest" >
    <Option value="MatchOriginalRequest"           label="%conSharing.MatchOriginalRequest.desc"/>

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
@@ -589,7 +589,7 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
                             }
                         }
 
-                        if (className != null) {
+                        if (className != null && type != null) {
                             driverProps.put(JDBCDriverService.LIBRARY_REF, new String[] { libraryPid });
                             driverProps.put(JDBCDriverService.TARGET_LIBRARY, FilterUtils.createPropertyFilter("service.pid", libraryPid));
                             driverProps.put(type, className);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -342,9 +342,9 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
      * 
      * @param props typed data source properties
      * @return the data source or driver instance
-     * @throws SQLException if an error occurs
+     * @throws Exception if an error occurs
      */
-    public Object createAnyDataSourceOrDriver(Properties props, String dataSourceID) throws SQLException {
+    public Object createAnyDataSourceOrDriver(Properties props, String dataSourceID) throws Exception {
         lock.readLock().lock();
         try {
             if (!isInitialized)
@@ -385,7 +385,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
             if (nonshipFunction) {
                 String url = props.getProperty("URL", props.getProperty("url"));
                 if (url != null) {
-                    Driver driver = loadDriver(url, classloader, props, dataSourceID);
+                    Driver driver = loadDriver(null, url, classloader, props, dataSourceID);
                     if (driver != null)
                         return driver;
                 }
@@ -420,9 +420,9 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
      * 
      * @param props typed data source properties
      * @return the data source or driver instance
-     * @throws SQLException if an error occurs
+     * @throws Exception if an error occurs
      */
-    public Object createDefaultDataSourceOrDriver(Properties props) throws SQLException {
+    public Object createDefaultDataSourceOrDriver(Properties props) throws Exception {
         lock.readLock().lock();
         try {
             if (!isInitialized)
@@ -463,7 +463,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
             if (nonshipFunction) {
                 String url = props.getProperty("URL", props.getProperty("url"));
                 if (url != null) {
-                    Driver driver = loadDriver(url, classloader, props, "dataSource[DefaultDataSource]");
+                    Driver driver = loadDriver(null, url, classloader, props, "dataSource[DefaultDataSource]");
                     if (driver != null)
                         return driver;
                 }
@@ -645,9 +645,9 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
      * 
      * @param url JDBC driver URL.
      * @return the driver
-     * @throws SQLException if an error occurs
+     * @throws Exception if an error occurs
      */
-    public Object getDriver(String url, Properties props, String dataSourceID) throws SQLException {
+    public Object getDriver(String url, Properties props, String dataSourceID) throws Exception {
         lock.readLock().lock();
         try {
             if (!isInitialized)
@@ -666,8 +666,12 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                     lock.readLock().lock();
                     lock.writeLock().unlock();
                 }
-            
-            return loadDriver(url, classloader, props, dataSourceID);
+
+            final String className = (String) properties.get(Driver.class.getName());
+            Driver driver = loadDriver(className, url, classloader, props, dataSourceID);
+            if (driver == null)
+               throw classNotFound(Driver.class.getName(), Collections.singleton("META-INF/services/java.sql.Driver"), null);
+            return driver;
         } finally {
             lock.readLock().unlock();
         }
@@ -746,15 +750,17 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
     }
 
     /**
-     * Load java.sql.Driver implementations available to the specific class loader and return
-     * the first that accepts the URL that is specified in the vendor properties.
+     * Load java.sql.Driver implementations available to the specific class loader.
+     * If className is specified, return an instance of that class.
+     * Otherwise return the first that accepts the URL.
      *
+     * @param className pre-computed Driver implementation class name to load. This will only ever be available on the DataSourceDefinition path.
      * @param url the JDBC driver URL.
      * @param classloader class loader from which to load JDBC drivers.
      * @return Driver instance that accepts the URL. NULL if no such Driver can be loaded.
-     * @throws SQLException if an error occurs.
+     * @throws Exception if an error occurs.
      */
-    private Driver loadDriver(String url, ClassLoader classloader, Properties props, String dataSourceID) throws SQLException {
+    private Driver loadDriver(final String className, String url, final ClassLoader classloader, Properties props, String dataSourceID) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isDebugEnabled())
             Tr.entry(this, tc, "loadDriver", url, classloader);
@@ -773,14 +779,28 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 Tr.debug(this, tc, "Allowing value of 0 for loginTimeout in URL");
         }
         
-        
         Object loginTimeout = props.get("loginTimeout");
         if(loginTimeout != null && !loginTimeout.toString().equals("0")) {
             throw new SQLNonTransientException(AdapterUtil.getNLSMessage("DSRA4005.invalid.logintimeout", dataSourceID));
         }
 
+        Iterator<Driver> drivers;
+        if (className == null) {
+            drivers = ServiceLoader.load(Driver.class, classloader).iterator();
+        } else { // load explicitly specified class
+            Driver driver = AccessController.doPrivileged(new PrivilegedExceptionAction<Driver>() {
+                public Driver run() throws Exception {
+                    ClassLoader loader = classloader == null ? null : Thread.currentThread().getContextClassLoader();
+                    Class<Driver> driverClass = (Class<Driver>) loader.loadClass(className);
+                    return driverClass.newInstance();
+                }
+            });
+            drivers = Collections.singleton(driver).iterator();
+        }
+
         SQLException failure = null;
-        for (Driver driver : ServiceLoader.load(Driver.class, classloader)) {
+        while (drivers.hasNext()) {
+            Driver driver = drivers.next();
             boolean acceptsURL;
             try {
                 acceptsURL = driver.acceptsURL(url);

--- a/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
@@ -63,6 +63,8 @@ public class JDBCDriverManagerTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer("CWWKE0701E", // ResourceFactoryTrackerData error for data source that intentionally lacks ConnectionPoolDataSource class
+                          "J2CA0030E", // Test intentionally makes illegal attempt to enlist multiple one-phase resources
+                          "WTRN0062E", // Test intentionally makes illegal attempt to enlist multiple one-phase resources
                           "DSRA8020E.*internal.nonship.function"); // TODO remove once the capability becomes GA
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -17,13 +17,22 @@
       <feature>jndi-1.0</feature>
     </featureManager>
  
+    <library id="DerbyLib">
+        <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+    </library>
+ 
     <library id="FATDriverLib">
         <file name="${server.config.dir}/derby/FATDriver.jar"/>
     </library>
 
     <dataSource id="DefaultDataSource">
       <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
-      <properties databaseName="memory:jdbcdriver1" autoCreate="true" user="dbuser1" password="{xor}Oz0vKDtu" />
+      <properties databaseName="memory:jdbcdriver1" autoCreate="true" user="dbuser1" password="{xor}Oz0vKDtu"/>
+    </dataSource>
+
+    <dataSource id="derby" jndiName="jdbc/derby" type="java.sql.Driver">
+      <jdbcDriver libraryRef="DerbyLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <properties.derby.embedded url="jdbc:derby:" databaseName="memory:derbydb" create="true" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <!-- the following is unusable because no ConnectionPoolDataSource implementation is provided by the driver -->
@@ -47,7 +56,9 @@
       <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
       <properties url="jdbc:fatdriver:memory:jdbcdriver1;create=true;LoginTimeout=10"/>
     </dataSource>
-    
+
+    <javaPermission codeBase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
+
     <javaPermission codeBase="${server.config.dir}derby/FATDriver.jar" className="java.security.AllPermission"/>
     
     <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>


### PR DESCRIPTION
User should be able to explicitly configure to use type=java.sql.Driver in server.xml.
And they should be able to explicitly specify the desired Driver impl class name on DataSourceDefinition.

Additionally, users for DataSourceDefinition should be able to specify className=java.sql.Driver or any of the data source interfaces, similar to how they can select the type in server.xml