### PR TITLE
tests for driver not accessible to application classloader

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
@@ -29,6 +29,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jdbc.fat.driver.derby.FATDriver;
 import jdbc.fat.driver.web.JDBCDriverManagerServlet;
+import jdbc.fat.proxy.driver.ProxyDrivr;
 
 @RunWith(FATRunner.class)
 public class JDBCDriverManagerTest extends FATServletClient {
@@ -55,7 +56,12 @@ public class JDBCDriverManagerTest extends FATServletClient {
                         .merge(derbyJar)
                         .addAsServiceProvider(java.sql.Driver.class, FATDriver.class);
 
+        JavaArchive proxyDriver = ShrinkWrap.create(JavaArchive.class, "ProxyDriver.jar")
+                        .addPackage("jdbc.fat.proxy.driver")
+                        .addAsServiceProvider(java.sql.Driver.class, ProxyDrivr.class);
+
         ShrinkHelper.exportToServer(server, "derby", fatDriver);
+        ShrinkHelper.exportToServer(server, "proxydriver", proxyDriver);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -25,6 +25,10 @@
         <file name="${server.config.dir}/derby/FATDriver.jar"/>
     </library>
 
+    <library id="ProxyDriverLib">
+        <file name="${server.config.dir}/proxydriver/ProxyDriver.jar"/>
+    </library>
+
     <dataSource id="DefaultDataSource">
       <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
       <properties databaseName="memory:jdbcdriver1" autoCreate="true" user="dbuser1" password="{xor}Oz0vKDtu"/>
@@ -55,6 +59,16 @@
     <dataSource id="fatDriverInvalidURLLoginTimeout" jndiName="jdbc/fatDriverInvalidURLLoginTimeout">
       <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
       <properties url="jdbc:fatdriver:memory:jdbcdriver1;create=true;LoginTimeout=10"/>
+    </dataSource>
+
+    <dataSource id="proxydriver" jndiName="jdbc/proxydriver">
+      <jdbcDriver libraryRef="ProxyDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <properties URL="jdbc:proxydriver:proxydb" Catalog="proxydb" Schema="pxschema1"/>
+    </dataSource>
+
+    <dataSource id="proxypoolds" jndiName="jdbc/proxypoolds">
+      <jdbcDriver libraryRef="ProxyDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <properties catalog="proxydb" loginTimeout="200" schema="pxschema2"/>
     </dataSource>
 
     <javaPermission codeBase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/proxy/driver/Handler.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/proxy/driver/Handler.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.proxy.driver;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Properties;
+
+public class Handler implements InvocationHandler {
+    private Properties props;
+    private final Class<?> type;
+
+    Handler(Class<?> type, Properties props) {
+        this.type = type;
+        this.props = props;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        String methodName = method.getName();
+        Class<?> returnType = method.getReturnType();
+        if ("hashCode".equals(methodName))
+            return System.identityHashCode(proxy);
+        if ("toString".equals(methodName))
+            return "jdbc.fat.proxy.driver." + type.getSimpleName() + '@' + Integer.toHexString(System.identityHashCode(proxy));
+        String s = methodName.startsWith("get") ? props.getProperty(methodName.substring(3)) : null;
+        if (boolean.class.equals(returnType))
+            return s == null ? true : Boolean.parseBoolean(s);
+        if (long.class.equals(returnType))
+            return s == null ? 0 : Long.parseLong(s);
+        if (int.class.equals(returnType))
+            return s == null ? 0 : Integer.parseInt(s);
+        if (short.class.equals(returnType))
+            return s == null ? 0 : Short.parseShort(s);
+        if (String.class.equals(returnType))
+            return s == null ? null : s;
+        if (returnType.isInterface())
+            return Proxy.newProxyInstance(Handler.class.getClassLoader(), new Class[] { returnType }, new Handler(returnType, props));
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/proxy/driver/ProxyDrivr.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/proxy/driver/ProxyDrivr.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.proxy.driver;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+// 'e' is intentionally omitted from this class name to prevent Liberty from discovering the
+// corresponding data source classes by swapping out "Driver" in the class name
+public class ProxyDrivr implements Driver {
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        if (!acceptsURL(url))
+            return null;
+
+        info.setProperty("DatabaseProductName", "Proxy Database");
+        info.setProperty("DatabaseProductVersion", "1.0.0");
+        info.setProperty("DriverName", "Proxy Driver");
+        info.setProperty("DriverVersion", "1.0");
+        info.setProperty("DatabaseMajorVersion", "1");
+        info.setProperty("DatabaseMinorVersion", "0");
+        info.setProperty("JDBCMajorVersion", "4");
+        info.setProperty("JDBCMinorVersion", "2");
+        info.setProperty("URL", url);
+        String user = info.getProperty("user");
+        if (user != null)
+            info.setProperty("UserName", user);
+
+        return (Connection) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] { Connection.class }, new Handler(Connection.class, info));
+    }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        return url.startsWith("jdbc:proxydriver:");
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 1;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/proxy/driver/ProxyPoolDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/proxy/driver/ProxyPoolDataSource.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.proxy.driver;
+
+import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.PooledConnection;
+
+public class ProxyPoolDataSource implements ConnectionPoolDataSource {
+    private final Properties props = new Properties();
+
+    public String getCatalog() {
+        return props.getProperty("Catalog");
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return Integer.parseInt(props.getProperty("LoginTimeout", "0"));
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public PooledConnection getPooledConnection() throws SQLException {
+        return getPooledConnection(null, null);
+    }
+
+    @Override
+    public PooledConnection getPooledConnection(String user, String password) throws SQLException {
+        Properties info = (Properties) props.clone();
+        info.setProperty("DatabaseProductName", "Proxy Database");
+        info.setProperty("DatabaseProductVersion", "1.0.0");
+        info.setProperty("DriverName", "Proxy Pool Driver");
+        info.setProperty("DriverVersion", "1.0");
+        info.setProperty("DatabaseMajorVersion", "1");
+        info.setProperty("DatabaseMinorVersion", "0");
+        info.setProperty("JDBCMajorVersion", "4");
+        info.setProperty("JDBCMinorVersion", "2");
+        if (user != null)
+            info.setProperty("UserName", user);
+
+        return (PooledConnection) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] { PooledConnection.class }, new Handler(PooledConnection.class, info));
+    }
+
+    public String getSchema() {
+        return props.getProperty("Schema");
+    }
+
+    public void setCatalog(String value) {
+        props.put("Catalog", value);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) {
+        props.put("LoginTimeout", Integer.toString(seconds));
+    }
+
+    public void setSchema(String value) {
+        props.put("Schema", value);
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) {}
+}


### PR DESCRIPTION
Add test cases to cover scenarios where the JDBC driver library is only available to the dataSource/jdbcDriver and not on the application class loader, so that we can be sure that the added code to detect JDBC driver and data source classes based on it does not require the classes to be available on the thread context class loader.