### PR TITLE
Issue 4480: Allow user to specify root folder in package command

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/LaunchArguments.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/LaunchArguments.java
@@ -31,7 +31,7 @@ public class LaunchArguments {
     private static final List<String> KNOWN_OPTIONS = Collections.unmodifiableList(Arrays.asList(new String[] { "archive", "include",
                                                                                                                 "os", "pid", "pid-file",
                                                                                                                 "script", "template", "force",
-                                                                                                                "target", "no-password" }));
+                                                                                                                "target", "no-password", "server-root" }));
 
     /**
      * Script argument: set by both batch and shell scripts to record the

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapConstants.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapConstants.java
@@ -33,6 +33,8 @@ public final class BootstrapConstants {
 
     public static final String CLI_PACKAGE_INCLUDE_VALUE = "include";
 
+    public static final String CLI_ROOT_PACKAGE_NAME = "server-root";
+
     /** Store command line arguments for the CommandLine service */
     public static final String INTERNAL_COMMAND_LINE_ARG_LIST = "commandline.args";
 

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommand.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommand.java
@@ -229,23 +229,16 @@ public class PackageCommand {
             List<Pair<PackageOption, String>> options = new ArrayList<Pair<PackageOption, String>>();
             options.add(new Pair<PackageOption, String>(PackageOption.INCLUDE, includeValue));
             processor = new PackageProcessor(serverName, packageFile, bootProps, options, libertyFiles);
-            if (rootOption != null) {
-                if (processor.hasProductExtentions() && rootOption.trim().equalsIgnoreCase("")) {
-                    System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("warning.package.root.invalid"),
-                                                            serverName));
-                } else {
-                    processor.setArchivePrefix(rootOption);
-                }
-            }
         } else {
             processor = new PackageProcessor(serverName, packageFile, bootProps, null, libertyFiles);
-            if (rootOption != null) {
-                if (processor.hasProductExtentions() && rootOption.trim().equalsIgnoreCase("")) {
-                    System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("warning.package.root.invalid"),
-                                                            serverName));
-                } else {
-                    processor.setArchivePrefix(rootOption);
-                }
+        }
+
+        if (rootOption != null) {
+            if (processor.hasProductExtentions() && rootOption.trim().equalsIgnoreCase("")) {
+                System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("warning.package.root.invalid"),
+                                                        serverName));
+            } else {
+                processor.setArchivePrefix(rootOption);
             }
         }
 

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommand.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommand.java
@@ -56,6 +56,7 @@ public class PackageCommand {
     final BootstrapConfig bootProps;
     final String includeOption;
     final String archiveOption;
+    final String rootOption;
 
     public PackageCommand(BootstrapConfig bootProps, LaunchArguments launchArgs) {
         this.serverName = bootProps.getProcessName();
@@ -69,11 +70,13 @@ public class PackageCommand {
         osRequest = launchArgs.getOption("os");
         includeOption = launchArgs.getOption(BootstrapConstants.CLI_PACKAGE_INCLUDE_VALUE);
         archiveOption = launchArgs.getOption(BootstrapConstants.CLI_ARG_ARCHIVE_TARGET);
+        rootOption = launchArgs.getOption(BootstrapConstants.CLI_ROOT_PACKAGE_NAME);
+
     }
 
     /**
      * Package the server
-     * 
+     *
      * @return
      */
     public ReturnCode doPackage() {
@@ -154,7 +157,7 @@ public class PackageCommand {
 
     /**
      * Package the server
-     * 
+     *
      * @return
      */
     public ReturnCode doPackageRuntimeOnly() {
@@ -177,7 +180,7 @@ public class PackageCommand {
      * Return true for include values of:
      * include=minify
      * include=minify,runnable
-     * 
+     *
      * Otherwise return false.
      */
     private boolean includeMinifyorMinifyRunnable(String val) {
@@ -221,12 +224,29 @@ public class PackageCommand {
         }
 
         PackageProcessor processor;
+
         if (null != includeValue) {
             List<Pair<PackageOption, String>> options = new ArrayList<Pair<PackageOption, String>>();
             options.add(new Pair<PackageOption, String>(PackageOption.INCLUDE, includeValue));
             processor = new PackageProcessor(serverName, packageFile, bootProps, options, libertyFiles);
+            if (rootOption != null) {
+                if (processor.hasProductExtentions() && rootOption.trim().equalsIgnoreCase("")) {
+                    System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("warning.package.root.invalid"),
+                                                            serverName));
+                } else {
+                    processor.setArchivePrefix(rootOption);
+                }
+            }
         } else {
             processor = new PackageProcessor(serverName, packageFile, bootProps, null, libertyFiles);
+            if (rootOption != null) {
+                if (processor.hasProductExtentions() && rootOption.trim().equalsIgnoreCase("")) {
+                    System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("warning.package.root.invalid"),
+                                                            serverName));
+                } else {
+                    processor.setArchivePrefix(rootOption);
+                }
+            }
         }
 
         //this will now go onto do the package, libertyFiles will be non-null in the minify case only.
@@ -258,7 +278,7 @@ public class PackageCommand {
 
     /**
      * Determine the default package format for the current operating system.
-     * 
+     *
      * @return "pax" on z/OS and "zip" for all others
      */
     private String getDefaultPackageFormat() {
@@ -271,13 +291,13 @@ public class PackageCommand {
         if (PackageProcessor.IncludeOption.RUNNABLE.matches(includeOption)) {
             return "jar";
         }
-        
+
         return "zip";
     }
 
     /**
      * Normalize the packageTarget ext Name if the user specify a wrong one.
-     * 
+     *
      * @param packageTarget
      * @return
      */
@@ -290,10 +310,10 @@ public class PackageCommand {
             //FIXME we need improve this to print message when we auto modify the extension name as following
             if (ext.equalsIgnoreCase(".zip") || ext.equalsIgnoreCase(".pax")) {
                 return packageTarget.substring(0, poz) + "." + defaultExt;
-            } else if (ext.equalsIgnoreCase(".jar") && 
-                        ("zip".equals(defaultExt) || "jar".equals(defaultExt))) {
+            } else if (ext.equalsIgnoreCase(".jar") &&
+                       ("zip".equals(defaultExt) || "jar".equals(defaultExt))) {
                 //allow jar format packaging for zip defaulting platforms.
-                //this method overall currently prevents creation of zip on non-zip platforms, 
+                //this method overall currently prevents creation of zip on non-zip platforms,
                 //prevents pax on non-pax platforms, this may be an error, but if we wish to create
                 //jar on a pax platform, there will be codepage issues to resolve for the scripts
                 return packageTarget;
@@ -321,10 +341,7 @@ public class PackageCommand {
         //tell user we are collecting.
         System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("info.serverPackagingCollectingInformation"),
                                                 serverName));
-        EmbeddedServerImpl server = (EmbeddedServerImpl) (new ServerBuilder())
-                        .setName(serverName)
-                        .setOutputDir(new File(serverOutputDir).getParentFile())
-                        .setUserDir(bootProps.getUserRoot())
+        EmbeddedServerImpl server = (EmbeddedServerImpl) (new ServerBuilder()).setName(serverName).setOutputDir(new File(serverOutputDir).getParentFile()).setUserDir(bootProps.getUserRoot())
                         //.setServerEventListener(this)
                         .build();
 

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageProcessor.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageProcessor.java
@@ -73,7 +73,7 @@ public class PackageProcessor implements ArchiveProcessor {
     final String wlpPropertyBackup = "WebSphereApplicationServer.properties.bak";
 
     private static final String PACKAGE_ARCHIVE_PREFIX = "wlp/";
-    public static String packageArchiveEntryPrefix = PACKAGE_ARCHIVE_PREFIX;
+    public String packageArchiveEntryPrefix = PACKAGE_ARCHIVE_PREFIX;
 
     public PackageProcessor(String processName, File packageFile, BootstrapConfig bootProps, List<Pair<PackageOption, String>> options, Set<String> processContent) {
         this.processName = processName;
@@ -571,7 +571,7 @@ public class PackageProcessor implements ArchiveProcessor {
                 looseConfig = ProcessorUtils.convertToLooseConfig(lf);
                 if (looseConfig != null) {
                     try {
-                        ArchiveEntryConfig looseArchiveEntryConfig = ProcessorUtils.createLooseArchiveEntryConfig(looseConfig, lf, bootProps);
+                        ArchiveEntryConfig looseArchiveEntryConfig = ProcessorUtils.createLooseArchiveEntryConfig(looseConfig, lf, bootProps, packageArchiveEntryPrefix);
                         entryConfigs.add(looseArchiveEntryConfig);
                     } catch (FileNotFoundException e) {
                         // If any exception occurs when creating loose file archive, just skip it and create the next one.

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageProcessor.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageProcessor.java
@@ -56,8 +56,6 @@ public class PackageProcessor implements ArchiveProcessor {
 
     private final Map<PackageOption, String> options;
 
-    public static final String PACKAGE_ARCHIVE_ENTRY_PREFIX = "wlp/";
-
     protected static final String DEFAULT_CONFIG_LOCATION_KEY = "configLocation";
 
     private final File wlpUserDir;
@@ -73,6 +71,8 @@ public class PackageProcessor implements ArchiveProcessor {
     final File installRoot;
     final String wlpProperty = "/lib/versions/WebSphereApplicationServer.properties";
     final String wlpPropertyBackup = "WebSphereApplicationServer.properties.bak";
+
+    public static String packageArchiveEntryPrefix = "wlp/";
 
     public PackageProcessor(String processName, File packageFile, BootstrapConfig bootProps, List<Pair<PackageOption, String>> options, Set<String> processContent) {
         this.processName = processName;
@@ -300,7 +300,7 @@ public class PackageProcessor implements ArchiveProcessor {
         /*
          * Create an empty (includeByDefault==false) config for the root dir of liberty
          */
-        DirEntryConfig rootDirConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX, bootProps.getInstallRoot(), false, PatternStrategy.ExcludePreference);
+        DirEntryConfig rootDirConfig = new DirEntryConfig(packageArchiveEntryPrefix, bootProps.getInstallRoot(), false, PatternStrategy.ExcludePreference);
         entryConfigs.add(rootDirConfig);
 
         List<DirEntryConfig> extensionDirConfigs = new ArrayList<DirEntryConfig>();
@@ -334,7 +334,7 @@ public class PackageProcessor implements ArchiveProcessor {
          */
         File lafilesDir = new File(bootProps.getInstallRoot(), "lafiles");
         if (lafilesDir.exists()) {
-            DirEntryConfig lafilesDirConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX + "lafiles", lafilesDir, true, PatternStrategy.IncludePreference);
+            DirEntryConfig lafilesDirConfig = new DirEntryConfig(packageArchiveEntryPrefix + "lafiles", lafilesDir, true, PatternStrategy.IncludePreference);
             entryConfigs.add(lafilesDirConfig);
         }
 
@@ -343,7 +343,7 @@ public class PackageProcessor implements ArchiveProcessor {
          * (these are orphans that need resolution still)
          */
         File templatesDir = new File(bootProps.getInstallRoot(), "templates");
-        DirEntryConfig templatesDirConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX + "templates", templatesDir, true, PatternStrategy.IncludePreference);
+        DirEntryConfig templatesDirConfig = new DirEntryConfig(packageArchiveEntryPrefix + "templates", templatesDir, true, PatternStrategy.IncludePreference);
         entryConfigs.add(templatesDirConfig);
 
         /*
@@ -368,7 +368,7 @@ public class PackageProcessor implements ArchiveProcessor {
     private void addLibExtractDir(List<ArchiveEntryConfig> entryConfigs) throws IOException {
         try {
             File libExtractDir = new File(bootProps.getInstallRoot(), "lib/extract");
-            DirEntryConfig libExtractDirConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX + "lib/extract", libExtractDir, true, PatternStrategy.IncludePreference);
+            DirEntryConfig libExtractDirConfig = new DirEntryConfig(packageArchiveEntryPrefix + "lib/extract", libExtractDir, true, PatternStrategy.IncludePreference);
             entryConfigs.add(libExtractDirConfig);
         } catch (FileNotFoundException ex) {
             System.out.println(BootstrapConstants.messages.getString("error.package.missingLibExtractDir"));
@@ -385,7 +385,7 @@ public class PackageProcessor implements ArchiveProcessor {
         /*
          * Add wlp's root directory
          */
-        DirEntryConfig rootDirConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX, bootProps.getInstallRoot(), true, PatternStrategy.IncludePreference);
+        DirEntryConfig rootDirConfig = new DirEntryConfig(packageArchiveEntryPrefix, bootProps.getInstallRoot(), true, PatternStrategy.IncludePreference);
         entryConfigs.add(rootDirConfig);
 
         // include all underneath install-root except usr directory
@@ -421,7 +421,7 @@ public class PackageProcessor implements ArchiveProcessor {
         // Add product extensions
         File prodExtDir = ProcessorUtils.getFileFromDirectory(wlpUserDir.getParentFile(), "/etc/extensions");
         if (prodExtDir.exists()) {
-            DirEntryConfig prodExtDirConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX + "etc/extensions", prodExtDir, true, PatternStrategy.IncludePreference);
+            DirEntryConfig prodExtDirConfig = new DirEntryConfig(packageArchiveEntryPrefix + "etc/extensions", prodExtDir, true, PatternStrategy.IncludePreference);
             entryConfigs.add(prodExtDirConfig);
         }
         for (ProductExtensionInfo info : ProductExtension.getProductExtensions()) {
@@ -453,7 +453,7 @@ public class PackageProcessor implements ArchiveProcessor {
         if (bootProps.getProcessType() == BootstrapConstants.LOC_PROCESS_TYPE_CLIENT) {
             locAreaName = BootstrapConstants.LOC_AREA_NAME_CLIENTS;
         }
-        DirEntryConfig processConfigDirConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX
+        DirEntryConfig processConfigDirConfig = new DirEntryConfig(packageArchiveEntryPrefix
                                                                    + BootstrapConstants.LOC_AREA_NAME_USR + "/"
                                                                    + locAreaName + "/"
                                                                    + processName + "/", processConfigDir, true, PatternStrategy.IncludePreference);
@@ -493,7 +493,7 @@ public class PackageProcessor implements ArchiveProcessor {
          */
         File sharedDir = ProcessorUtils.getFileFromDirectory(wlpUserDir, "shared");
         if (sharedDir.exists()) {
-            DirEntryConfig serverSharedDirConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX
+            DirEntryConfig serverSharedDirConfig = new DirEntryConfig(packageArchiveEntryPrefix
                                                                       + BootstrapConstants.LOC_AREA_NAME_USR + "/"
                                                                       + BootstrapConstants.LOC_AREA_NAME_SHARED + "/", sharedDir, true, PatternStrategy.IncludePreference);
             entryConfigs.add(serverSharedDirConfig);
@@ -517,7 +517,7 @@ public class PackageProcessor implements ArchiveProcessor {
         if (addUsrExtension) {
             File extensionDir = ProcessorUtils.getFileFromDirectory(wlpUserDir, BootstrapConstants.LOC_AREA_NAME_EXTENSION);
             if (extensionDir.exists()) {
-                DirEntryConfig serverExtensionDirConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX
+                DirEntryConfig serverExtensionDirConfig = new DirEntryConfig(packageArchiveEntryPrefix
                                                                              + BootstrapConstants.LOC_AREA_NAME_USR + "/"
                                                                              + BootstrapConstants.LOC_AREA_NAME_EXTENSION
                                                                              + "/", extensionDir, true, PatternStrategy.IncludePreference);
@@ -535,7 +535,7 @@ public class PackageProcessor implements ArchiveProcessor {
         // avoid any special characters in processName when construct patterns
         String regexProcessName = Pattern.quote(processName);
         // Include the package_<timestamp>.txt that generated in server output dir, and must be move into lib/versions
-        DirEntryConfig processPkgInfoConfig = new DirEntryConfig(PACKAGE_ARCHIVE_ENTRY_PREFIX
+        DirEntryConfig processPkgInfoConfig = new DirEntryConfig(packageArchiveEntryPrefix
                                                                  + BootstrapConstants.LOC_AREA_NAME_LIB + "/"
                                                                  + "versions" + "/", bootProps.getOutputFile(null), false, PatternStrategy.IncludePreference);
         entryConfigs.add(processPkgInfoConfig);
@@ -702,5 +702,18 @@ public class PackageProcessor implements ArchiveProcessor {
             }
             return false;
         }
+    }
+
+    public boolean hasProductExtentions() {
+        File prodExtDir = ProcessorUtils.getFileFromDirectory(wlpUserDir.getParentFile(), "/etc/extension");
+        if (prodExtDir.exists()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public void setArchivePrefix(String prefix) {
+        packageArchiveEntryPrefix = prefix + "/";
     }
 }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageProcessor.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageProcessor.java
@@ -72,7 +72,8 @@ public class PackageProcessor implements ArchiveProcessor {
     final String wlpProperty = "/lib/versions/WebSphereApplicationServer.properties";
     final String wlpPropertyBackup = "WebSphereApplicationServer.properties.bak";
 
-    public static String packageArchiveEntryPrefix = "wlp/";
+    private static final String PACKAGE_ARCHIVE_PREFIX = "wlp/";
+    public static String packageArchiveEntryPrefix = PACKAGE_ARCHIVE_PREFIX;
 
     public PackageProcessor(String processName, File packageFile, BootstrapConfig bootProps, List<Pair<PackageOption, String>> options, Set<String> processContent) {
         this.processName = processName;
@@ -453,10 +454,18 @@ public class PackageProcessor implements ArchiveProcessor {
         if (bootProps.getProcessType() == BootstrapConstants.LOC_PROCESS_TYPE_CLIENT) {
             locAreaName = BootstrapConstants.LOC_AREA_NAME_CLIENTS;
         }
-        DirEntryConfig processConfigDirConfig = new DirEntryConfig(packageArchiveEntryPrefix
-                                                                   + BootstrapConstants.LOC_AREA_NAME_USR + "/"
-                                                                   + locAreaName + "/"
-                                                                   + processName + "/", processConfigDir, true, PatternStrategy.IncludePreference);
+        DirEntryConfig processConfigDirConfig = null;
+        if (packageArchiveEntryPrefix.equalsIgnoreCase(PACKAGE_ARCHIVE_PREFIX)) {
+            processConfigDirConfig = new DirEntryConfig(packageArchiveEntryPrefix
+                                                        + BootstrapConstants.LOC_AREA_NAME_USR + "/"
+                                                        + locAreaName + "/"
+                                                        + processName + "/", processConfigDir, true, PatternStrategy.IncludePreference);
+        } else {
+            // if --server-root set, then don't add /usr/ in path
+            processConfigDirConfig = new DirEntryConfig(packageArchiveEntryPrefix
+                                                        + locAreaName + "/"
+                                                        + processName + "/", processConfigDir, true, PatternStrategy.IncludePreference);
+        }
         entryConfigs.add(processConfigDirConfig);
         // avoid any special characters in processName when construct patterns
         String regexProcessName = Pattern.quote(processName);

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessorUtils.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessorUtils.java
@@ -185,11 +185,12 @@ public class ProcessorUtils {
      * @return
      * @throws IOException
      */
-    public static ArchiveEntryConfig createLooseArchiveEntryConfig(LooseConfig looseConfig, File looseFile, BootstrapConfig bootProps) throws IOException {
+    public static ArchiveEntryConfig createLooseArchiveEntryConfig(LooseConfig looseConfig, File looseFile, BootstrapConfig bootProps,
+                                                                   String archiveEntryPrefix) throws IOException {
         File usrRoot = bootProps.getUserRoot();
         int len = usrRoot.getAbsolutePath().length();
 
-        String entryPath = PackageProcessor.packageArchiveEntryPrefix + "usr" + looseFile.getAbsolutePath().substring(len);
+        String entryPath = archiveEntryPrefix + "usr" + looseFile.getAbsolutePath().substring(len);
         entryPath = entryPath.replace("\\", "/");
         entryPath = entryPath.substring(0, entryPath.length() - 4); // trim the .xml
 

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessorUtils.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessorUtils.java
@@ -50,7 +50,7 @@ public class ProcessorUtils {
 
     /**
      * Get the loose config files from ${server.config.dir}/apps, ${server.config.dir}/dropins or ${shared.app.dir}
-     * 
+     *
      * @param bootProps
      * @return
      */
@@ -80,7 +80,7 @@ public class ProcessorUtils {
     /**
      * Refer to the com.ibm.ws.artifact.api.loose.internal.LooseContainerFactoryHelper.createContainer.
      * Parse the loose config file and create the looseConfig object which contains the file's content.
-     * 
+     *
      * @param looseFile
      * @return
      * @throws Exception
@@ -178,7 +178,7 @@ public class ProcessorUtils {
 
     /**
      * Using the method to create Loose config's Archive entry config
-     * 
+     *
      * @param looseConfig
      * @param looseFile
      * @param bootProps
@@ -189,7 +189,7 @@ public class ProcessorUtils {
         File usrRoot = bootProps.getUserRoot();
         int len = usrRoot.getAbsolutePath().length();
 
-        String entryPath = PackageProcessor.PACKAGE_ARCHIVE_ENTRY_PREFIX + "usr" + looseFile.getAbsolutePath().substring(len);
+        String entryPath = PackageProcessor.packageArchiveEntryPrefix + "usr" + looseFile.getAbsolutePath().substring(len);
         entryPath = entryPath.replace("\\", "/");
         entryPath = entryPath.substring(0, entryPath.length() - 4); // trim the .xml
 
@@ -259,7 +259,7 @@ public class ProcessorUtils {
 
     /**
      * Copy from com.ibm.ws.artifact.api.loose.internal.LooseArchive
-     * 
+     *
      * @param excludeStr
      * @return
      */

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ServerHelpActions.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ServerHelpActions.java
@@ -20,7 +20,7 @@ public class ServerHelpActions implements HelpActions {
         helpCmd(Category.help),
         javadumpCmd(Category.service, "include"),
         listCmd(Category.help),
-        packageCmd(Category.misc, "archive", "include", "os"),
+        packageCmd(Category.misc, "archive", "include", "os", "server-root"),
         pauseCmd(Category.misc, "target"),
         registerWinServiceCmd(Category.win),
         resumeCmd(Category.misc, "target"),

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -684,7 +684,7 @@ warning.server.status.invalid.targets=CWWKE0946W: A status request was received 
 warning.server.status.invalid.targets.explanation=A user issued a status request with an empty target list on the target option. The request completed but no action was taken.
 warning.server.status.invalid.targets.useraction=Specify on the target option a list of components to check their status. To check the cumulative status of all pause capable components in the server, issue status request without the target option.
 
-warning.package.root.invalid=CWWKE0947W: A --server-root option with empty argument is not allowed when Product Extensions are installed. The default argument of wlp will be used.
+warning.package.root.invalid=CWWKE0947W: A --server-root option with an empty argument is not allowed when Product Extensions are installed. The default argument of wlp will be used.
 warning.package.root.invalid.explanation=The user performed a package request with a --server-root option specifying an empty argument and Product Extensions were detected. The default server root of wlp will be used.
 warning.package.root.invalid.useraction=No action is required.
 

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -684,6 +684,10 @@ warning.server.status.invalid.targets=CWWKE0946W: A status request was received 
 warning.server.status.invalid.targets.explanation=A user issued a status request with an empty target list on the target option. The request completed but no action was taken.
 warning.server.status.invalid.targets.useraction=Specify on the target option a list of components to check their status. To check the cumulative status of all pause capable components in the server, issue status request without the target option.
 
+warning.package.root.invalid=CWWKE0947W: A --server-root option with empty argument is not allowed when Product Extensions are installed. The default argument of wlp will be used.
+warning.package.root.invalid.explanation=The user performed a package request with a --server-root option specifying an empty argument and Product Extensions were detected. The default server root of wlp will be used.
+warning.package.root.invalid.useraction=No action is required.
+
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.
 info.serverStartedWithPID=Server {0} started with process ID {1}.

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherOptions.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherOptions.nlsprops
@@ -104,7 +104,8 @@ action-desc.package=\
 \tThe --include option can be used with values "all", "usr", "minify", \n\
 \t"wlp", "runnable", "all,runnable", and "minify,runnable". The values \n\
 \t"runnable" and "all,runnable" are equivalent. The "runnable" value   \n\
-\tworks with "jar" type archives only.
+\tworks with "jar" type archives only. The --server-root option can be \n\
+\tused to specify the root folder in the package archive.
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
 action-key.dump=\
 \ \ \ \ --dump
@@ -233,3 +234,8 @@ option-key.no-password=\
 \ \ \ \ --no-password
 option-desc.no-password=\
 \tDisable generation of default keystore password
+#------------------------------\n at 72 chars -- leading tab-----------\n\#
+option-key.server-root=\
+\ \ \ \ --server-root="root server folder in archive"
+option-desc.package.server-root=\
+\tSpecifies the root server folder name in the archive file.           \n\

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommandTest.java
@@ -15,11 +15,15 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.junit.Test;
 
@@ -27,9 +31,13 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 /**
- * 
+ *
  */
 public class PackageCommandTest {
+    private static final Class<?> c = PackageCommandTest.class;
+
+    private static String serverName = "com.ibm.ws.kernel.boot.root.fat";
+    private static String archivePackage = "MyPackage.zip";
 
     /**
      * The package command requires that the lib/extract directory exists, as this directory
@@ -44,13 +52,13 @@ public class PackageCommandTest {
      * FAT environment's installation of WLP does not include this directory. If we end up creating that
      * directory in the FAT environment, then we'll need to find another way to run this test - as we
      * probably don't want to delete a directory in the FAT environment's installation.
-     * 
+     *
      * @throws Exception
      */
     @Test
     public void testCorrectErrorMessageWhenLibExtractDirIsMissing() throws Exception {
         // Pick any server, doesn't matter.
-        LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.bootstrap.fat");
+        LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.boot.fat");
         // Only run the test if the lib/extract directory does not exist
         try {
             server.getFileFromLibertyInstallRoot("lib/extract");
@@ -69,7 +77,7 @@ public class PackageCommandTest {
      * This test is not run if:
      * 1) platform is z/OS (jar archive not supported)
      * 2) wlp/lib/extract directory does not exist
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -98,7 +106,7 @@ public class PackageCommandTest {
             Manifest mf = jarFile.getManifest();
             assertNotNull("There should be a manifest in the jar file", mf);
 
-            // make sure it'a a runnable jar 
+            // make sure it'a a runnable jar
             assertEquals(mainClass, mf.getMainAttributes().getValue("Main-Class"));
 
             // Check that the self-extract and the server's entries are in the jar
@@ -139,7 +147,7 @@ public class PackageCommandTest {
 
         String stdout = server.executeServerScript("package",
                                                    new String[] { "--archive=" + jarFileName,
-                                                                 "--include=usr" }).getStdout();
+                                                                  "--include=usr" }).getStdout();
 
         JarFile jarFile = new JarFile(server.getFileFromLibertyServerRoot(jarFileName).getAbsolutePath());
 
@@ -165,6 +173,61 @@ public class PackageCommandTest {
 
         assertTrue(foundServerEntry);
         assertTrue(foundSelfExtractEntry);
+    }
+
+    @Test
+    public void testCorrectErrorMessageWhenProductExtensionsInstalledAndServerRootSpecified() throws Exception {
+
+        LibertyServer server = LibertyServerFactory.getLibertyServer(serverName);
+
+        // Make sure we have the /wlp/etc/extension directory which indicates Product Extensions are installed
+        File prodExtensionDir = null;
+        try {
+            server.getFileFromLibertyInstallRoot("etc/extension/");
+        } catch (FileNotFoundException ex) {
+            // The /etc/extension directory does not exist - so create it for this test.
+            String pathToProdExt = server.getInstallRoot() + "/etc" + "/extension/";
+            prodExtensionDir = new File(pathToProdExt);
+            prodExtensionDir.mkdirs();
+        }
+
+        String[] cmd = new String[] { "--archive=" + archivePackage,
+                                      "--include=minify",
+                                      "--server-root= " };
+        String stdout = server.executeServerScript("package", cmd).getStdout();
+
+        assertTrue("Did not find expected failure message, CWWKE0947W", stdout.contains("CWWKE0947W"));
+    }
+
+    @Test
+    public void testServerRootSpecified() throws Exception {
+
+        LibertyServer server = LibertyServerFactory.getLibertyServer(serverName);
+
+        String[] cmd = new String[] { "--archive=" + archivePackage,
+                                      "--include=minify",
+                                      "--server-root=MyRoot" };
+        // Ensure package completes
+        String stdout = server.executeServerScript("package", cmd).getStdout();
+        assertTrue("The package command did not complete as expected", stdout.contains("package complete"));
+
+        // Ensure root is correct in the .zip
+        ZipFile zipFile = new ZipFile(server.getServerRoot() + "/" + archivePackage);
+        try {
+
+            for (Enumeration<? extends ZipEntry> en = zipFile.entries(); en.hasMoreElements();) {
+                ZipEntry entry = en.nextElement();
+                String entryName = entry.getName();
+                assertTrue("The package did not contain MyRoot as expected", entryName.contains("MyRoot"));
+            }
+
+        } finally {
+            try {
+                zipFile.close();
+            } catch (IOException ex) {
+            }
+        }
+
     }
 
 }

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommandTest.java
@@ -58,7 +58,7 @@ public class PackageCommandTest {
     @Test
     public void testCorrectErrorMessageWhenLibExtractDirIsMissing() throws Exception {
         // Pick any server, doesn't matter.
-        LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.boot.fat");
+        LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.bootstrap.fat");
         // Only run the test if the lib/extract directory does not exist
         try {
             server.getFileFromLibertyInstallRoot("lib/extract");
@@ -179,8 +179,9 @@ public class PackageCommandTest {
     public void testCorrectErrorMessageWhenProductExtensionsInstalledAndServerRootSpecified() throws Exception {
 
         LibertyServer server = LibertyServerFactory.getLibertyServer(serverName);
-        server.getFileFromLibertyInstallRoot("lib/extract");
+
         try {
+            server.getFileFromLibertyInstallRoot("lib/extract");
 
             // Make sure we have the /wlp/etc/extension directory which indicates Product Extensions are installed
             File prodExtensionDir = null;

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommandTest.java
@@ -196,7 +196,7 @@ public class PackageCommandTest {
                                       "--server-root= " };
         String stdout = server.executeServerScript("package", cmd).getStdout();
 
-        assertTrue("Did not find expected failure message, CWWKE0947W", stdout.contains("CWWKE0947W"));
+        assertTrue("Did not find expected failure message, CWWKE0947W.  STDOUT = " + stdout, stdout.contains("CWWKE0947W"));
     }
 
     @Test
@@ -209,7 +209,7 @@ public class PackageCommandTest {
                                       "--server-root=MyRoot" };
         // Ensure package completes
         String stdout = server.executeServerScript("package", cmd).getStdout();
-        assertTrue("The package command did not complete as expected", stdout.contains("package complete"));
+        assertTrue("The package command did not complete as expected. STDOUT = " + stdout, stdout.contains("package complete"));
 
         // Ensure root is correct in the .zip
         ZipFile zipFile = new ZipFile(server.getServerRoot() + "/" + archivePackage);
@@ -218,7 +218,7 @@ public class PackageCommandTest {
             for (Enumeration<? extends ZipEntry> en = zipFile.entries(); en.hasMoreElements();) {
                 ZipEntry entry = en.nextElement();
                 String entryName = entry.getName();
-                assertTrue("The package did not contain MyRoot as expected", entryName.contains("MyRoot"));
+                assertTrue("The package did not contain MyRoot as expected. Entry Name is = " + entryName, entryName.contains("MyRoot"));
             }
 
         } finally {

--- a/dev/com.ibm.ws.kernel.boot_fat/publish/servers/com.ibm.ws.kernel.boot.root.fat/server.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/publish/servers/com.ibm.ws.kernel.boot.root.fat/server.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <include optional="true" location="${shared.config.dir}/bvtTestPorts.xml"/>
+    <config monitorInterval="1s" />
+    
+<!--     <featureManager> -->
+<!--         <feature>httpservice-2.2</feature> -->
+<!--     </featureManager> -->
+    
+</server>


### PR DESCRIPTION
Users need to be allowed to specify the root folder name within the output archive whenever the server package command is executed.  