### PR TITLE
mpJwt issuer is no longer required in server.xml

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -29,7 +29,7 @@
         <AD id="sslRef" name="%sslRef" description="%sslRef.desc" 
             required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.repertoire" />
         <AD id="keyName" name="%trustAliasName" description="%trustAliasName.desc" required="false" type="String" />   
-        <AD id="issuer" name="%issuer" description="%issuer.desc" required="true" type="String" />               
+        <AD id="issuer" name="%issuer" description="%issuer.desc" required="false" type="String" />               
         <AD id="groupNameAttribute" name="%groupNameAttribute" description="%groupNameAttribute.desc"
             required="false"  type="String" default="groups" />
         <AD id="mapToUserRegistry" name="%mapToUserRegistry" description="%mapToUserRegistry.desc"


### PR DESCRIPTION
In prep for mpJwt 1.1 support, make the issuer in the mp_jwt config optional.

#build
