### PR TITLE
test coverage for data source backed by java.sql.Driver in loadfromapp bucket

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -134,15 +134,6 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
     static final String DECLARING_APPLICATION = "declaringApplication";
 
     /**
-     * Privileged action to obtain the thread context class loader.
-     */
-    private static final PrivilegedAction<ClassLoader> getContextClassLoader = new PrivilegedAction<ClassLoader>() {
-        public ClassLoader run() {
-            return Thread.currentThread().getContextClassLoader();
-        }
-    };
-
-    /**
      * Properties to skip when parsing configuration.
      */
     private static final HashSet<String> WPROPS_TO_SKIP = new HashSet<String>(Arrays.asList
@@ -417,7 +408,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
 
             // data source class is loaded from thread context class loader
             if (identifier == null) {
-                ClassLoader tccl = AccessController.doPrivileged(getContextClassLoader);
+                ClassLoader tccl = priv.getContextClassLoader();
                 identifier = connectorSvc.getClassLoaderIdentifierService().getClassLoaderIdentifier(tccl);
                 // TODO better error handling when thread context class loader does not have an identifier
             }
@@ -518,7 +509,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
 
             // data source class is loaded from thread context class loader
             if (identifier == null) {
-                ClassLoader tccl = AccessController.doPrivileged(getContextClassLoader);
+                ClassLoader tccl = priv.getContextClassLoader();
                 identifier = connectorSvc.getClassLoaderIdentifierService().getClassLoaderIdentifier(tccl);
                 // TODO better error handling when thread context class loader does not have an identifier
             }
@@ -656,7 +647,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                 // data source class loaded from thread context class loader
                 mcf = null;
                 mcfPerClassLoader = new ConcurrentHashMap<String, WSManagedConnectionFactoryImpl>();
-                ClassLoader tccl = AccessController.doPrivileged(getContextClassLoader);
+                ClassLoader tccl = priv.getContextClassLoader();
                 String identifier = connectorSvc.getClassLoaderIdentifierService().getClassLoaderIdentifier(tccl);
                 mcfPerClassLoader.put(identifier, mcfImpl);
             } else {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -756,7 +756,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
      *
      * @param className pre-computed Driver implementation class name to load. This will only ever be available on the DataSourceDefinition path.
      * @param url the JDBC driver URL.
-     * @param classloader class loader from which to load JDBC drivers.
+     * @param classloader class loader from which to load JDBC drivers. NULL to load from the application's thread context class loader.
      * @return Driver instance that accepts the URL. NULL if no such Driver can be loaded.
      * @throws Exception if an error occurs.
      */
@@ -786,7 +786,10 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
 
         Iterable<Driver> drivers;
         if (className == null) {
-            drivers = ServiceLoader.load(Driver.class, classloader);
+            if (classloader == null)
+                drivers = ServiceLoader.load(Driver.class); // use thread context class loader of application
+            else
+                drivers = ServiceLoader.load(Driver.class, classloader);
         } else { // load explicitly specified class
             Driver driver = AccessController.doPrivileged(new PrivilegedExceptionAction<Driver>() {
                 public Driver run() throws Exception {

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -54,7 +54,10 @@ public class JDBCLoadFromAppTest extends FATServletClient {
         WebArchive otherApp = ShrinkWrap.create(WebArchive.class, "otherApp.war")
                         .addPackage("web.other") //
                         .addPackage("jdbc.driver.mini") // barely usable, fake jdbc driver included in app
+                        .addPackage("jdbc.driver.mini.jse") // java.sql.Driver implementation for the above
+                        .addAsServiceProvider(java.sql.Driver.class, jdbc.driver.mini.jse.DriverImpl.class)
                         .addPackage("jdbc.driver.proxy"); // delegates to the "mini" JDBC driver
+
         ShrinkHelper.exportAppToServer(server, otherApp);
 
         server.addInstalledAppForValidation("derbyApp");

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/jdbc-drivers/mini/src/jdbc/driver/mini/MiniConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/jdbc-drivers/mini/src/jdbc/driver/mini/MiniConnection.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLNonTransientConnectionException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 // A barely usable, fake connection (and database metadata) that we include in the application.
@@ -27,9 +28,9 @@ import java.util.Map;
 // our fake JDBC driver is being used.
 public class MiniConnection implements InvocationHandler {
     private boolean closed;
-    private Map<String, Object> map;
+    private Map<String, Object> map = new HashMap<String, Object>();
 
-    MiniConnection(String databaseName, String user, String password) {
+    public MiniConnection(String databaseName, String user, String password) {
         map.put("AutoCommit", true);
         map.put("Catalog", databaseName);
         map.put("DatabaseProductName", "MiniDatabase");
@@ -89,6 +90,10 @@ public class MiniConnection implements InvocationHandler {
                 return null;
             }
         }
+
+        Class<?> returnType = method.getReturnType();
+        if (void.class.equals(returnType))
+            return null;
 
         for (Class<?> c : method.getExceptionTypes())
             if (c.isAssignableFrom(SQLFeatureNotSupportedException.class))

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/jdbc-drivers/mini/src/jdbc/driver/mini/jse/DriverImpl.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/jdbc-drivers/mini/src/jdbc/driver/mini/jse/DriverImpl.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.driver.mini.jse;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import jdbc.driver.mini.MiniConnection;
+
+// A barely usable, fake driver that we include in the application
+public class DriverImpl implements Driver {
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        return url.startsWith("jdbc:mini:");
+    }
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        if (!acceptsURL(url))
+            return null;
+
+        // parse database name from url: jdbc:mini://localhost:1234/dbname?...
+        int start = url.lastIndexOf('/') + 1;
+        int end = url.indexOf('?', start);
+        if (end < 0)
+            end = url.length();
+        String databaseName = start > 0 ? url.substring(start, end) : null;
+
+        return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(),
+                                                   new Class<?>[] { Connection.class },
+                                                   new MiniConnection(databaseName, info.getProperty("user"), info.getProperty("password")));
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 1;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -23,10 +23,31 @@
       <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
     </dataSource>
 
+    <dataSource id="MiniDataSource" jndiName="jdbc/miniDataSource" ibm.internal.nonship.function="true">
+      <jdbcDriver libraryRef="ibm.internal.simulate.no.library.do.not.ship" ibm.internal.nonship.function="true" internal.nonship.function="This is for internal development only. Never use this in production"/> <!-- TODO remove libraryRef -->
+      <properties databaseName="minidb" loginTimeout="330"/>
+    </dataSource>
+
+    <dataSource id="MiniDriver" jndiName="jdbc/miniDriver" ibm.internal.nonship.function="true">
+      <jdbcDriver libraryRef="ibm.internal.simulate.no.library.do.not.ship" ibm.internal.nonship.function="true" internal.nonship.function="This is for internal development only. Never use this in production"/> <!-- TODO remove libraryRef -->
+      <properties url="jdbc:mini://localhost:3456/driverdb"/>
+    </dataSource>
+
     <library id="ibm.internal.simulate.no.library.do.not.ship"/>
 
     <!-- permissions for Derby -->
-    <javaPermission className="java.util.PropertyPermission" name="user.dir" actions="read"/>
+    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.io.FilePermission" name="derby.log" actions="read,write"/>
+    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.io.FilePermission" name="derby.properties" actions="read"/>
+    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.lang.RuntimePermission" name="getProtectionDomain"/>
+    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="javax.management.MBeanPermission" name="*" actions="registerMBean"/>
+    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
+    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="javax.management.MBeanTrustPermission" name="register"/>
+
+    <!-- permissions for Mini driver to utilize dynamic proxy -->
+    <javaPermission codeBase="${server.config.dir}apps/otherApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
 
     <variable name="onError" value="FAIL"/>
 </server>


### PR DESCRIPTION
The loadfromapp test bucket is a convenient place to gain some test coverage for data sources backed by (or inferred from) java.sql.Driver because it has a couple of mock JDBC drivers, of which one can easily be extended to also provide a Driver implementation.  In addition to enhancing coverage of our feature, this will also demonstrate its compatibility with the loadfromapp feature for which that bucket was originally written.