### PR TITLE
Refactor features to avoid MP Rest API features depending on impls

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.0.feature
@@ -5,28 +5,25 @@ singleton=true
 IBM-App-ForceRestart: uninstall, \
  install
 Subsystem-Name: Internal Java RESTful Services 2.0
--features=com.ibm.websphere.appserver.injection-1.0, \
+-features=com.ibm.websphere.appserver.javax.jaxrs-2.0, \
+ com.ibm.websphere.appserver.injection-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.servlet-3.1, \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.javax.mail-1.5, \
  com.ibm.websphere.appserver.globalhandler-1.0, \
- com.ibm.websphere.appserver.javax.annotation-1.2; apiJar=false, \
  com.ibm.websphere.appserver.json-1.0, \
  com.ibm.websphere.appserver.javaeeCompatible-7.0
--bundles=com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
- com.ibm.ws.org.apache.xml.resolver.1.2, \
+-bundles=com.ibm.ws.org.apache.xml.resolver.1.2, \
  com.ibm.ws.org.apache.neethi.3.0.2, \
  com.ibm.ws.jaxrs.2.0.common, \
  com.ibm.ws.jaxrs.2.x.config, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
- com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0.1", \
  com.ibm.ws.jaxrs.2.0.tools, \
  com.ibm.ws.jaxrs.2.0.web, \
  com.ibm.ws.jaxrs.2.0.server, \
  com.ibm.ws.jaxrs.2.0.client
--files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip, \
- bin/jaxrs/wadl2java, \
+-files=bin/jaxrs/wadl2java, \
  bin/jaxrs/wadl2java.bat, \
  bin/jaxrs/tools/wadl2java.jar
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.1.feature
@@ -5,16 +5,15 @@ singleton=true
 IBM-App-ForceRestart: uninstall, \
  install
 Subsystem-Name: Internal Java RESTful Services 2.1
--features=com.ibm.websphere.appserver.injection-1.0, \
+-features=com.ibm.websphere.appserver.javax.jaxrs-2.1, \
+ com.ibm.websphere.appserver.injection-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.servlet-4.0, \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.javax.mail-1.6, \
  com.ibm.websphere.appserver.globalhandler-1.0, \
- com.ibm.websphere.appserver.javax.annotation-1.3; apiJar=false, \
  com.ibm.websphere.appserver.javaeeCompatible-8.0
--bundles=com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
- com.ibm.ws.org.apache.xml.resolver.1.2, \
+-bundles=com.ibm.ws.org.apache.xml.resolver.1.2, \
  com.ibm.ws.org.apache.neethi.3.0.2, \
  com.ibm.ws.jaxrs.2.1.common, \
  com.ibm.ws.jaxrs.2.x.config, \
@@ -27,13 +26,11 @@ Subsystem-Name: Internal Java RESTful Services 2.1
  com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
- com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.1", \
  com.ibm.ws.jaxrs.2.0.tools, \
  com.ibm.ws.jaxrs.2.0.web, \
  com.ibm.ws.jaxrs.2.0.server, \
  com.ibm.ws.jaxrs.2.0.client
--files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip, \
- bin/jaxrs/wadl2java, \
+-files=bin/jaxrs/wadl2java, \
  bin/jaxrs/wadl2java.bat, \
  bin/jaxrs/tools/wadl2java.jar
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.0.feature
@@ -7,7 +7,6 @@ IBM-App-ForceRestart: uninstall, \
 Subsystem-Name: Java RESTful Services API 2.0
 -features=com.ibm.websphere.appserver.javax.servlet-3.1, \
  com.ibm.websphere.appserver.javax.annotation-1.2; apiJar=false, \
- com.ibm.websphere.appserver.json-1.0, \
  com.ibm.websphere.appserver.javaeeCompatible-7.0
 -bundles=com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
  com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0.1"

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.0.feature
@@ -1,0 +1,16 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.javax.jaxrs-2.0
+visibility=private
+singleton=true
+IBM-App-ForceRestart: uninstall, \
+ install
+Subsystem-Name: Java RESTful Services API 2.0
+-features=com.ibm.websphere.appserver.javax.servlet-3.1, \
+ com.ibm.websphere.appserver.javax.annotation-1.2; apiJar=false, \
+ com.ibm.websphere.appserver.json-1.0, \
+ com.ibm.websphere.appserver.javaeeCompatible-7.0
+-bundles=com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
+ com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0.1"
+-files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.1.feature
@@ -1,0 +1,15 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.javax.jaxrs-2.1
+visibility=private
+singleton=true
+IBM-App-ForceRestart: uninstall, \
+ install
+Subsystem-Name: Java RESTful Services API 2.1
+-features=com.ibm.websphere.appserver.javax.servlet-4.0, \
+ com.ibm.websphere.appserver.javax.annotation-1.3; apiJar=false, \
+ com.ibm.websphere.appserver.javaeeCompatible-8.0
+-bundles=com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
+ com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.1"
+-files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
@@ -11,24 +11,21 @@ IBM-API-Package: javax.ws.rs; type="spec", \
  com.ibm.websphere.jaxrs20.multipart; type="ibm-api", \
  com.ibm.websphere.jaxrs.providers.json4j; type="ibm-api"
 IBM-SPI-Package: com.ibm.wsspi.webservices.handler
--features=com.ibm.websphere.appserver.injection-1.0, \
+-features=com.ibm.websphere.appserver.javax.jaxrs-2.0, \
+ com.ibm.websphere.appserver.injection-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.servlet-3.1, \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.javax.mail-1.5, \
  com.ibm.websphere.appserver.globalhandler-1.0, \
- com.ibm.websphere.appserver.javax.annotation-1.2; apiJar=false, \
  com.ibm.websphere.appserver.json-1.0
--bundles=com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
- com.ibm.ws.org.apache.xml.resolver.1.2, \
+-bundles=com.ibm.ws.org.apache.xml.resolver.1.2, \
  com.ibm.ws.org.apache.neethi.3.0.2, \
  com.ibm.ws.jaxrs.2.0.common, \
  com.ibm.ws.jaxrs.2.x.config, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
- com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0.1", \
  com.ibm.ws.jaxrs.2.0.tools
--files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip, \
- bin/jaxrs/wadl2java, \
+-files=bin/jaxrs/wadl2java, \
  bin/jaxrs/wadl2java.bat, \
  bin/jaxrs/tools/wadl2java.jar
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
@@ -3,18 +3,17 @@ symbolicName=com.ibm.websphere.appserver.jaxrs.common-2.1
 visibility=private
 IBM-App-ForceRestart: uninstall, \
  install
--features=com.ibm.websphere.appserver.injection-1.0, \
+-features=com.ibm.websphere.appserver.javax.jaxrs-2.1, \
+ com.ibm.websphere.appserver.injection-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.servlet-4.0, \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.javax.mail-1.6, \
  com.ibm.websphere.appserver.globalhandler-1.0, \
- com.ibm.websphere.appserver.javax.annotation-1.3; apiJar=false, \
  com.ibm.websphere.appserver.jsonpInternal-1.1, \
  com.ibm.websphere.appserver.jsonbInternal-1.0, \
  com.ibm.websphere.appserver.internal.slf4j-1.7.7
--bundles=com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
- com.ibm.ws.org.apache.xml.resolver.1.2, \
+-bundles=com.ibm.ws.org.apache.xml.resolver.1.2, \
  com.ibm.ws.org.apache.neethi.3.0.2, \
  com.ibm.ws.jaxrs.2.1.common, \
  com.ibm.ws.jaxrs.2.x.config, \
@@ -27,10 +26,8 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
- com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.1", \
  com.ibm.ws.jaxrs.2.0.tools
--files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip, \
- bin/jaxrs/wadl2java, \
+-files=bin/jaxrs/wadl2java, \
  bin/jaxrs/wadl2java.bat, \
  bin/jaxrs/tools/wadl2java.jar
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.0.feature
@@ -3,8 +3,7 @@ symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.
 singleton=true
 -features=com.ibm.websphere.appserver.javax.cdi-1.2; ibm.tolerates:=2.0, \
  com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3, \
- com.ibm.websphere.appserver.javax.jaxrs-2.0; ibm.tolerates:=2.1, \
- com.ibm.websphere.appserver.jsonp-1.0; ibm.tolerates:=1.1
+ com.ibm.websphere.appserver.javax.jaxrs-2.0; ibm.tolerates:=2.1
 -bundles=com.ibm.websphere.org.eclipse.microprofile.rest.client.1.0; location:="dev/api/stable/,lib/"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.
 singleton=true
 -features=com.ibm.websphere.appserver.javax.cdi-1.2; ibm.tolerates:=2.0, \
  com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3, \
- com.ibm.websphere.appserver.jaxrsClient-2.0; ibm.tolerates:=2.1, \
+ com.ibm.websphere.appserver.javax.jaxrs-2.0; ibm.tolerates:=2.1, \
  com.ibm.websphere.appserver.jsonp-1.0; ibm.tolerates:=1.1
 -bundles=com.ibm.websphere.org.eclipse.microprofile.rest.client.1.0; location:="dev/api/stable/,lib/"
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.1.feature
@@ -3,8 +3,7 @@ symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.
 singleton=true
 -features=com.ibm.websphere.appserver.javax.cdi-1.2; ibm.tolerates:=2.0, \
  com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3, \
- com.ibm.websphere.appserver.javax.jaxrs-2.0; ibm.tolerates:=2.1, \
- com.ibm.websphere.appserver.jsonp-1.0; ibm.tolerates:=1.1
+ com.ibm.websphere.appserver.javax.jaxrs-2.0; ibm.tolerates:=2.1
 -bundles=com.ibm.websphere.org.eclipse.microprofile.rest.client.1.1; location:="dev/api/stable/,lib/"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.1.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.rest.client-1.
 singleton=true
 -features=com.ibm.websphere.appserver.javax.cdi-1.2; ibm.tolerates:=2.0, \
  com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3, \
- com.ibm.websphere.appserver.jaxrsClient-2.0; ibm.tolerates:=2.1, \
+ com.ibm.websphere.appserver.javax.jaxrs-2.0; ibm.tolerates:=2.1, \
  com.ibm.websphere.appserver.jsonp-1.0; ibm.tolerates:=1.1
 -bundles=com.ibm.websphere.org.eclipse.microprofile.rest.client.1.1; location:="dev/api/stable/,lib/"
 kind=ga


### PR DESCRIPTION
Involves creating a new private JAX-RS API feature that is included by the existing common/internal JAX-RS features.  This allows the MP Rest Client API features to depend on the same API feature.

This was suggested during yesterday's externals review - to lighten the footprint of the MP Rest Client API feature.  The same changes are applied to the MP Rest Client 1.0 API feature, but I do not view this as a release bug, since from the external users' perspective, nothing has changed - only the internal/private API feature has changed, and no Liberty feature currently depends on the MP Rest Client feature.