### PR TITLE
remove nonship guards for datasource backed by driver feature

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
@@ -220,9 +220,6 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
         if (vendorProps.containsKey(DataSourceDef.databaseName.name()) || vendorProps.containsKey(DataSourceDef.portNumber.name()))
             url = null;
 
-        if ((className == null || className.length() == 0) && !vendorProps.containsKey("internal.nonship.function")) // TODO remove nonship check once ready for GA
-            throw new IllegalArgumentException("className");
-
         // libraryRef - scan shared libraries from the application
         className = updateWithLibraries(bundleContext, application, declaringApplication, className, url, driverProps, dsSvcProps);
 

--- a/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
@@ -70,7 +70,6 @@ public class JDBCDriverManagerTest extends FATServletClient {
     public static void tearDown() throws Exception {
         server.stopServer("CWWKE0701E", // ResourceFactoryTrackerData error for data source that intentionally lacks ConnectionPoolDataSource class
                           "J2CA0030E", // Test intentionally makes illegal attempt to enlist multiple one-phase resources
-                          "WTRN0062E", // Test intentionally makes illegal attempt to enlist multiple one-phase resources
-                          "DSRA8020E.*internal.nonship.function"); // TODO remove once the capability becomes GA
+                          "WTRN0062E"); // Test intentionally makes illegal attempt to enlist multiple one-phase resources
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -30,44 +30,44 @@
     </library>
 
     <dataSource id="DefaultDataSource">
-      <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <jdbcDriver libraryRef="FATDriverLib"/>
       <properties databaseName="memory:jdbcdriver1" autoCreate="true" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="derby" jndiName="jdbc/derby" type="java.sql.Driver">
-      <jdbcDriver libraryRef="DerbyLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <jdbcDriver libraryRef="DerbyLib"/>
       <properties.derby.embedded url="jdbc:derby:" databaseName="memory:derbydb" create="true" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <!-- the following is unusable because no ConnectionPoolDataSource implementation is provided by the driver -->
     <dataSource id="fatConnectionPoolDataSource" jndiName="jdbc/fatConnectionPoolDataSource" type="javax.sql.ConnectionPoolDataSource">
-      <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <jdbcDriver libraryRef="FATDriverLib"/>
       <properties databaseName="memory:jdbcdriver1" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
     <dataSource id="fatDataSource" jndiName="jdbc/fatDataSource">
-      <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <jdbcDriver libraryRef="FATDriverLib"/>
       <properties databaseName="memory:jdbcdriver1" autoCreate="true" user="dbuser1" password="{xor}Oz0vKDtu" loginTimeout="660"/>
     </dataSource>
 
     <dataSource id="fatDriver" jndiName="jdbc/fatDriver">
-      <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <jdbcDriver libraryRef="FATDriverLib"/>
       <properties url="jdbc:fatdriver:memory:jdbcdriver1;create=true;loginTimeout=0" user="dbuser2" password="{xor}Oz0vKDtt"/>
       <containerAuthData user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <dataSource id="fatDriverInvalidURLLoginTimeout" jndiName="jdbc/fatDriverInvalidURLLoginTimeout">
-      <jdbcDriver libraryRef="FATDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <jdbcDriver libraryRef="FATDriverLib"/>
       <properties url="jdbc:fatdriver:memory:jdbcdriver1;create=true;LoginTimeout=10"/>
     </dataSource>
 
     <dataSource id="proxydriver" jndiName="jdbc/proxydriver">
-      <jdbcDriver libraryRef="ProxyDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <jdbcDriver libraryRef="ProxyDriverLib"/>
       <properties URL="jdbc:proxydriver:proxydb" Catalog="proxydb" Schema="pxschema1"/>
     </dataSource>
 
     <dataSource id="proxypoolds" jndiName="jdbc/proxypoolds">
-      <jdbcDriver libraryRef="ProxyDriverLib" internal.nonship.function="This is for internal development only. Never use this in production"/>
+      <jdbcDriver libraryRef="ProxyDriverLib"/>
       <properties catalog="proxydb" loginTimeout="200" schema="pxschema2"/>
     </dataSource>
 

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/resources/WEB-INF/web.xml
@@ -16,9 +16,6 @@
       <value>create</value>
     </property>
     <property>
-      <name>internal.nonship.function</name>
-      <value>This is for internal development only. Never use this in production</value></property>
-    <property>
       <name>onConnect</name>
       <value>insert into address values ('Rochester International Airport', 7600, 'Helgerson Dr SW', 'Rochester', 'MN', 55902)</value>
     </property>

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -52,48 +52,30 @@ import componenttest.app.FATServlet;
                                                url = "jdbc:derby:memory:jdbcdriver1",
                                                user = "dbuser1",
                                                password = "{xor}Oz0vKDtu",
-                                               properties = {
-                                                              "internal.nonship.function=This is for internal development only. Never use this in production",
-                                                              "createDatabase=create",
-                                               }),
+                                               properties = "createDatabase=create"),
                          @DataSourceDefinition(name = "java:comp/env/jdbc/dsd-driver-interface",
                                                className = "java.sql.Driver",
                                                url = "jdbc:fatdriver:memory:jdbcdriver1",
                                                user = "dbuser1",
                                                password = "{xor}Oz0vKDtu",
-                                               properties = {
-                                                              "internal.nonship.function=This is for internal development only. Never use this in production",
-                                                              "createDatabase=create",
-                                               }),
+                                               properties = "createDatabase=create"),
                          @DataSourceDefinition(name = "java:module/env/jdbc/dsd-infer-datasource-class",
                                                className = "",
                                                databaseName = "memory:jdbcdriver1;create=true",
-                                               properties = {
-                                                              "internal.nonship.function=This is for internal development only. Never use this in production",
-                                               },
                                                user = "dbuser1",
                                                password = "{xor}Oz0vKDtu"),
                          @DataSourceDefinition(name = "java:app/env/jdbc/dsd-with-login-timeout",
                                                className = "",
                                                loginTimeout = 76,
-                                               url = "jdbc:fatdriver:memory:jdbcdriver1",
-                                               properties = {
-                                                              "internal.nonship.function=This is for internal development only. Never use this in production"
-                                               }),
+                                               url = "jdbc:fatdriver:memory:jdbcdriver1"),
                          @DataSourceDefinition(name = "java:app/env/jdbc/dsd-with-datasource-interface",
                                                className = "javax.sql.DataSource",
                                                databaseName = "memory:jdbcdriver1;create=true",
-                                               properties = {
-                                                              "internal.nonship.function=This is for internal development only. Never use this in production",
-                                               },
                                                user = "dbuser1",
                                                password = "{xor}Oz0vKDtu"),
                          @DataSourceDefinition(name = "java:app/env/jdbc/dsd-with-xadatasource-interface",
                                                className = "javax.sql.XADataSource",
                                                databaseName = "memory:jdbcdriver1;create=true",
-                                               properties = {
-                                                              "internal.nonship.function=This is for internal development only. Never use this in production",
-                                               },
                                                user = "dbuser1",
                                                password = "{xor}Oz0vKDtu")
 })

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -24,12 +24,12 @@
     </dataSource>
 
     <dataSource id="MiniDataSource" jndiName="jdbc/miniDataSource" ibm.internal.nonship.function="true">
-      <jdbcDriver libraryRef="ibm.internal.simulate.no.library.do.not.ship" ibm.internal.nonship.function="true" internal.nonship.function="This is for internal development only. Never use this in production"/> <!-- TODO remove libraryRef -->
+      <jdbcDriver libraryRef="ibm.internal.simulate.no.library.do.not.ship" ibm.internal.nonship.function="true"/> <!-- TODO remove libraryRef -->
       <properties databaseName="minidb" loginTimeout="330"/>
     </dataSource>
 
     <dataSource id="MiniDriver" jndiName="jdbc/miniDriver" ibm.internal.nonship.function="true">
-      <jdbcDriver libraryRef="ibm.internal.simulate.no.library.do.not.ship" ibm.internal.nonship.function="true" internal.nonship.function="This is for internal development only. Never use this in production"/> <!-- TODO remove libraryRef -->
+      <jdbcDriver libraryRef="ibm.internal.simulate.no.library.do.not.ship" ibm.internal.nonship.function="true"/> <!-- TODO remove libraryRef -->
       <properties url="jdbc:mini://localhost:3456/driverdb"/>
     </dataSource>
 


### PR DESCRIPTION
Code path for the feature to have data sources backed by driver
is currently guarded with a hidden nonship property.
This pull removes the hidden property so that the function can be usable
and updates our test cases accordingly such that they no longer specify the hidden property.