### PR TITLE
Update arquillian container to 1.0.2

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version> 
+            <version>1.0.2</version> 
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version> 
+            <version>1.0.2</version> 
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.config_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat_tck/publish/tckRunner/tck/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version> 
+            <version>1.0.2</version> 
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.config_git_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config_git_fat_tck/publish/tckRunner/tck/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version> 
+            <version>1.0.2</version> 
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version> 
+            <version>1.0.2</version> 
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/publish/tckRunner/tck/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
@@ -192,7 +192,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.2-20180716.130746-3</version>
+	    <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.2-20180716.130746-3</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
 <!-- 

--- a/dev/com.ibm.ws.opentracing.1.1_fat/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/publish/tckRunner/tck/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.opentracing_fat/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.opentracing_fat/publish/tckRunner/tck/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Should fix some of the app deployment errors we've been seeing
occasionally in TCK test buckets.