### PR TITLE
Filter URL for tracing when using Driver

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
@@ -574,16 +574,16 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
                                     try {
                                         if (driver.acceptsURL(url)) {
                                             if (trace && tc.isDebugEnabled())
-                                                Tr.debug(this, tc, driver + " accepts " + url);
+                                                Tr.debug(this, tc, driver + " accepts " + PropertyService.filterURL(url));
                                             className = driver.getClass().getName();
                                             break;
                                         } else {
                                             if (trace && tc.isDebugEnabled())
-                                                Tr.debug(this, tc, driver + " does not accept " + url);
+                                                Tr.debug(this, tc, driver + " does not accept " + PropertyService.filterURL(url));
                                         }
                                     } catch (SQLException x) {
                                         if (trace && tc.isDebugEnabled())
-                                            Tr.debug(this, tc, driver + " does not accept " + url, x);
+                                            Tr.debug(this, tc, driver + " does not accept " + PropertyService.filterURL(url), x);
                                     }
                                 }
                             } else {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -225,7 +225,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
     protected void activate(ComponentContext context, Map<String, Object> properties) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "activate", AdapterUtil.toString(properties));
+            Tr.entry(this, tc, "activate", PropertyService.hidePasswords(properties));
 
         String jndiName = (String) properties.get(JNDI_NAME);
         id = (String) properties.get("config.displayId");
@@ -792,8 +792,14 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                         }
                         if (DataSourceDef.password.name().equals(key))
                             ConnectorService.logMessage(Level.INFO, "RECOMMEND_AUTH_ALIAS_J2CA8050", id);
-                    } else if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "Found vendor property: " + key + '=' + value);
+                    } else if (trace && tc.isDebugEnabled()) {
+                        if(key.toLowerCase().equals("url")) {
+                            if(value instanceof String)
+                                Tr.debug(this, tc, "Found vendor property: " + key + '=' + PropertyService.filterURL((String) value));
+                        } else {
+                            Tr.debug(this, tc, "Found vendor property: " + key + '=' + value);
+                        }
+                    }
 
                     vProps.put(key, value);
                 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -869,13 +869,15 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
                             if ("URL".equals(name) || "url".equals(name)) {
                                 url = str;
                                 if (isTraceOn && tc.isDebugEnabled())
-                                    Tr.debug(this, tc, name + '=' + str); // TODO obscure values of any possible passwords in URL value?
+                                    Tr.debug(this, tc, name + '=' + PropertyService.filterURL(str));
                             } else if ((user == null || !"user".equals(name)) && (pwd == null || !"password".equals(name))) {
                                 // Decode passwords
-                                if (PropertyService.isPassword(name) && PasswordUtil.getCryptoAlgorithm(str) != null) {
+                                if (PropertyService.isPassword(name)) {
                                     if (isTraceOn && tc.isDebugEnabled())
                                         Tr.debug(this, tc, "prop " + name + '=' + (str == null ? null : "***"));
-                                    str = PasswordUtil.decode(str);
+                                    if (PasswordUtil.getCryptoAlgorithm(str) != null) {
+                                        str = PasswordUtil.decode(str);
+                                    }
                                 } else {
                                     if (isTraceOn && tc.isDebugEnabled())
                                         Tr.debug(this, tc, "prop " + name + '=' + str);
@@ -907,10 +909,9 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
                         int first = url.indexOf(":");
                         int second = url.indexOf(":", first+1);
                         if(first < 0 || second < 0) {
-                            //TODO URL format with doesn't follow JDBC spec, return URL with stripped passwords after that logic has been added
+                            urlPrefix = url.substring(0, 10);
                         } else {
                             urlPrefix = url.substring(0, second);
-                            //TODO run the URL stub through the URL password detection logic just in case there is an uncomplient driver that has two colons
                         }
                         throw new ResourceException(AdapterUtil.getNLSMessage("DSRA4006.null.connection", dsConfig.get().id, vendorImplClass.getName(), urlPrefix));
                     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcTracer.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcTracer.java
@@ -44,6 +44,7 @@ import javax.sql.XADataSource;
 import javax.transaction.xa.XAResource;
 
 import com.ibm.ejs.ras.TraceComponent;
+import com.ibm.ws.jdbc.internal.PropertyService;
 
 /**
  * This class provides generic JDBC method level tracing for JDBC drivers (like the
@@ -147,7 +148,7 @@ public class WSJdbcTracer implements InvocationHandler
         // Trace entry
 
         if (TraceComponent.isAnyTracingEnabled() && tracer.isDebugEnabled()) {
-            boolean hasPassword = methName.equals("getPooledConnection") || methName.equals("getXAConnection");
+            boolean hasPassword = methName.equals("getPooledConnection") || methName.equals("getXAConnection") || methName.equals("connect");
 
             StringBuilder buffer = new StringBuilder(120);
 
@@ -155,6 +156,11 @@ public class WSJdbcTracer implements InvocationHandler
 
             if (tracer.getLevel() <= 1 /* LevelConstants.LEVEL_ALL */&& args != null)
                 for (int i = 0; i < args.length; i++) {
+                    if(methName.equals("connect") && i == 0) {
+                        buffer.append(PropertyService.filterURL(toString(args[i])));
+                        continue;
+                    }
+                    
                     if (i != 0)
                         buffer.append(", ");
                     buffer.append(hasPassword && i == 1 ? "***" : toString(args[i]));

--- a/dev/com.ibm.ws.jdbc/test/com/ibm/ws/jdbc/internal/InternalTest.java
+++ b/dev/com.ibm.ws.jdbc/test/com/ibm/ws/jdbc/internal/InternalTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.internal;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
@@ -164,5 +165,36 @@ public class InternalTest {
         } catch (Throwable t) {
             outputMgr.failWithThrowable(m, t);
         }
+    }
+    
+    @Test
+    public void testURLFiltering() {
+        //URL with descriptor beyond vendor
+        assertEquals("Test1", "jdbc:oracle:thin:****", 
+                     PropertyService.filterURL("jdbc:oracle:thin:username/pass123!@localhost:1521:oracle"));
+
+        //URL with no descriptor beyond vendor, no properties
+        assertEquals("Test2", "jdbc:vendor:****", 
+                     PropertyService.filterURL("jdbc:vendor:username/pass123!@localhost:1521:oracle"));
+
+        //Test with password in URL, with qualifier following, using semicolon
+        assertEquals("Test4", "jdbc:sqlserver:****", 
+                     PropertyService.filterURL("jdbc:sqlserver:!@pass://localhost;user=username;password=ab9&*&^*#(*;"));
+
+        //Test with password at very end of URL, using semicolon
+        assertEquals("Test5", "jdbc:sqlserver:****", 
+                     PropertyService.filterURL("jdbc:sqlserver://localhost/;user=username;password=ab9&*&^*#(*"));
+        
+        //Driver using mutliple tokens
+        assertEquals("Test15", "jdbc:driver:****", 
+                     PropertyService.filterURL("jdbc:driver:database5,host=localhost:user=bob,foo=bar,test=2"));
+        
+        //Uncompliant driver without property
+        assertEquals("Test16", "****", 
+                     PropertyService.filterURL("this_is_a_very_non_complient_jdbc_url"));
+        
+        //Uncompliant driver with property
+        assertEquals("Test17", "****", 
+                     PropertyService.filterURL("this_is_a_very_non_complient_jdbc_url;password=12jsadf")); 
     }
 }


### PR DESCRIPTION
When using a datasource backed by driver filter URL to ensure that no passwords are traced.