### PR TITLE
3917 Additional transaction none testing

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -707,7 +707,6 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
         lock.writeLock().lock();
         try {
             componentContext = context;
-
             if (!AdapterUtil.match(jndiName, properties.get(JNDI_NAME))) {
                 // To change JNDI name, must re-run the activate code
                 deactivate(context);
@@ -735,7 +734,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                     destroyConnectionFactories(isDerbyEmbedded);
                 } else {
                     parseIsolationLevel(wProps, vendorImplClassName);
-
+                    
                     // Swap the reference to the configuration - the WAS data source will start honoring it
                     dsConfigRef.set(new DSConfig(config, wProps));
                 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -3859,16 +3859,9 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
     public final void setTransactionIsolation(int isoLevel) throws SQLException 
     {
         if (currentTransactionIsolation != isoLevel) {            
-            // Reject switching to an isolation level of TRANSACTION_NONE unless 
-            // the driver is configured with an isolation level of TRANSACTION_NONE.
+            // Reject switching to an isolation level of TRANSACTION_NONE
             if (isoLevel == Connection.TRANSACTION_NONE) {
-                if(sqlConn.getTransactionIsolation() != Connection.TRANSACTION_NONE) {
                     throw new SQLException(AdapterUtil.getNLSMessage("DSRA4011.tran.none.iso.switch.unsupported", dsConfig.get().id));
-                } else {
-                    currentTransactionIsolation = isoLevel;
-                    isolationChanged = true;
-                    return;
-                }   
             }
             
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -356,12 +356,6 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
      * flag to keep track of isolation level switching on connection support or not
      **/
     boolean supportIsolvlSwitching = false; 
-    
-    /**
-     * Flag if datasource is configured with isolation level = TRANSACTION_NONE
-     * Used to ensure JDBC driver supports using a datasource with this isolation level 
-     */
-    boolean isDSTranNone = false;
 
     /**
      * The value of the fatal connection error counter of the parent ManagedConnectionFactory
@@ -495,10 +489,10 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         if(config.isolationLevel == Connection.TRANSACTION_NONE) {
             try {
                 if(conn.getTransactionIsolation() == Connection.TRANSACTION_NONE) {
+                    //Expected behavior
                     if(isTraceOn && tc.isDebugEnabled()) {
                         Tr.debug(this, tc, "DataSource configured with an isolation level of 'NONE (0)' and the driver's isolation level is already 'NONE (0)'."); 
                     }
-                    isDSTranNone = true; //Expected behavior
                 } else {
                     throw new SQLException(AdapterUtil.getNLSMessage("DSRA4008.tran.none.unsupported", config.id));
                 }
@@ -1182,8 +1176,6 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
     /**
      * This method checks if transaction enlistment is enabled on the MC
-     * and indicates whether or not this managed connection should enlist 
-     * in application server managed transactions.
      * 
      * @return true if transaction enlistment is enabled and supported, false otherwise.
      */
@@ -3843,7 +3835,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
     {
         if (value != currentAutoCommit || helper.alwaysSetAutoCommit()) 
         {
-            if(isDSTranNone && (value == false) )
+            if( (dsConfig.get().isolationLevel == Connection.TRANSACTION_NONE) && (value == false) )
                 throw new SQLException(AdapterUtil.getNLSMessage("DSRA4010.tran.none.autocommit.required", dsConfig.get().id));
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "Set AutoCommit to " + value); 
@@ -3866,15 +3858,17 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
     public final void setTransactionIsolation(int isoLevel) throws SQLException 
     {
-        if (currentTransactionIsolation != isoLevel) {
-            // TODO Determine behavior when switching from TRANSACTION_NONE to another isolation level
-//            if ( isDSTranNone && (isoLevel != Connection.TRANSACTION_NONE) ) {
-//                throw new SQLException(AdapterUtil.getNLSMessage("DSRA4011.tran.none.iso.switch.unsupported", dsConfig.get().id));
-//            } 
-            
-            // Reject switching to Transaction_None
+        if (currentTransactionIsolation != isoLevel) {            
+            // Reject switching to an isolation level of TRANSACTION_NONE unless 
+            // the driver is configured with an isolation level of TRANSACTION_NONE.
             if (isoLevel == Connection.TRANSACTION_NONE) {
-                throw new SQLException(AdapterUtil.getNLSMessage("DSRA4011.tran.none.iso.switch.unsupported", dsConfig.get().id));
+                if(sqlConn.getTransactionIsolation() != Connection.TRANSACTION_NONE) {
+                    throw new SQLException(AdapterUtil.getNLSMessage("DSRA4011.tran.none.iso.switch.unsupported", dsConfig.get().id));
+                } else {
+                    currentTransactionIsolation = isoLevel;
+                    isolationChanged = true;
+                    return;
+                }   
             }
             
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) 

--- a/dev/com.ibm.ws.jdbc_fat_derby/fat/src/com/ibm/ws/jdbc/fat/derby/JDBCDerbyTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_derby/fat/src/com/ibm/ws/jdbc/fat/derby/JDBCDerbyTest.java
@@ -10,14 +10,25 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.derby;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.TreeSet;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.DataSource;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -28,15 +39,18 @@ import jdbc.fat.derby.web.JDBCDerbyServlet;
 @RunWith(FATRunner.class)
 public class JDBCDerbyTest extends FATServletClient {
 
-    public static final String APP_NAME = "jdbcapp";
+    private static final Class<?> c = JDBCDerbyTest.class;
+
+    private static final String jdbcapp = "jdbcapp";
+    private static final String jdbcappfat = "jdbcapp/JDBCDerbyServlet";
 
     @Server("com.ibm.ws.jdbc.fat.derby")
-    @TestServlet(servlet = JDBCDerbyServlet.class, contextRoot = APP_NAME)
+    @TestServlet(servlet = JDBCDerbyServlet.class, contextRoot = jdbcapp)
     public static LibertyServer server;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        ShrinkHelper.defaultApp(server, APP_NAME, "jdbc.fat.derby.web");
+        ShrinkHelper.defaultApp(server, jdbcapp, "jdbc.fat.derby.web");
 
         JavaArchive tranNoneDriver = ShrinkWrap.create(JavaArchive.class, "trandriver.jar").addPackage("jdbc.tran.none.driver");
         ShrinkHelper.exportToServer(server, "../../shared/resources/derby", tranNoneDriver);
@@ -48,6 +62,147 @@ public class JDBCDerbyTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKE0701E"); //expected by testTransactionalSetting
+        server.stopServer("CWWKE0701E", //expected by testTransactionalSetting
+                          "DSRA4011E", //expected by testTNConfigIsoLvlReverse
+                          "SRVE0319E"); //expected by testTNConfigTnsl
+    }
+
+    /**
+     * Update the data source configuration while the server is running.
+     * Ensure that when using a data source with isolation level of TRANSACTION_NONE
+     * that when switching to a data source with Transactional = true the change is prevented
+     */
+    @Test
+    @ExpectedFFDC({ "com.ibm.wsspi.injectionengine.InjectionException", "javax.servlet.UnavailableException", "java.sql.SQLException" })
+    public void testTNConfigTnsl() throws Throwable {
+        String method = "testTNConfigTnsl";
+        Log.info(c, method, "Executing " + method);
+
+        //First check that we are not enlisting in transactions
+        runTest(server, jdbcappfat, "testTNTransationEnlistment");
+
+        ServerConfiguration config = server.getServerConfiguration();
+        DataSource ds12 = config.getDataSources().getBy("id", "dsfat12");
+
+        try {
+            ds12.setTransactional("true");
+
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(new TreeSet<String>(Arrays.asList(jdbcapp)));
+
+            //Ensure that updating the config resulted in server not being able to restart
+            int responseCode = runTestForResponseCode(server, jdbcappfat, "testTNTransationEnlistment");
+            assertEquals("Reponse from servlet should have been", 404, responseCode);
+        } catch (Exception e) {
+            fail("Exception should not have been thrown when switching transactional property.");
+        } finally {
+            //Attempt to switch back
+            ds12.setTransactional("false");
+
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(new TreeSet<String>(Arrays.asList(jdbcapp)));
+
+            //Ensure that we were able to switch back
+
+            assertEquals("ds12 should have transactional = false", "false", ds12.getTransactional());
+            runTest(server, jdbcappfat, "testTNTransationEnlistment");
+        }
+    }
+
+    /**
+     * Update the data source configuration while the server is running.
+     * Ensure that switching from a data source configured with an isolation level of TRANSACTION_NONE
+     * to a data source configured with a different isolation level does not fail.
+     * And, ensure that switching the other way is not prevented.
+     */
+    @Test
+    public void testTNConfigIsoLvl() throws Throwable {
+        String method = "testTNConfigIsoLvl";
+        Log.info(c, method, "Executing " + method);
+
+        //First ensure we are using a data source with an isolation level of TRANSACTION_NONE
+        runTest(server, jdbcappfat, "testTNOriginalIsoLvl");
+
+        ServerConfiguration config = server.getServerConfiguration();
+        DataSource ds11 = config.getDataSources().getBy("id", "dsfat11");
+
+        try {
+            ds11.setIsolationLevel("TRANSACTION_SERIALIZABLE");
+
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(new TreeSet<String>(Arrays.asList(jdbcapp)));
+
+            //Check update was successful and we are now using the updated transaction isolation level
+            runTest(server, jdbcappfat, "testTNModifiedIsoLvl");
+        } catch (Exception e) {
+            fail("Exception should not have been thrown when switching isolation level from TRANSACTION_NONE.");
+        }
+
+        try {
+            //Attempt to switch back
+            ds11.setIsolationLevel("TRANSACTION_NONE");
+
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(new TreeSet<String>(Arrays.asList(jdbcapp)));
+
+            //Ensure that we were able to switch back
+            runTest(server, jdbcappfat, "testTNOriginalIsoLvl");
+        } catch (Exception e) {
+            fail("Exception should not have been thrown when switching isolation level to TRANSACTION_NONE.");
+        }
+    }
+
+    /**
+     * Update the data source configuration while the server is running.
+     * Ensure that switching to a data source configured with an isolation level of TRANSACTION_NONE
+     * from a data source configured with a different isolation level fails to get an connection.
+     * And, ensure that switching the other way is not prevented.
+     */
+    @Test
+    @ExpectedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException", "java.sql.SQLException" })
+    public void testTNConfigIsoLvlReverse() throws Throwable {
+        String method = "testTNConfigIsoLvl";
+        Log.info(c, method, "Executing " + method);
+
+        //First ensure we are using a data source with an isolation level of TRANSACTION_SERIALIZABLE
+        runTest(server, jdbcappfat, "testTNOriginalIsoLvlReverse");
+
+        ServerConfiguration config = server.getServerConfiguration();
+        DataSource ds10 = config.getDataSources().getBy("id", "dsfat10");
+
+        try {
+            ds10.setIsolationLevel("TRANSACTION_NONE");
+
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(new TreeSet<String>(Arrays.asList(jdbcapp)));
+
+            //Check update was successful and getting a connection fails
+            runTest(server, jdbcappfat, "testTNModifiedIsoLvlReverse");
+        } catch (Exception e) {
+            fail("Exception should not have been thrown when switching isolation level to TRANSACTION_NONE.");
+        }
+
+        try {
+            //Attempt to switch back
+            ds10.setIsolationLevel("TRANSACTION_SERIALIZABLE");
+
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(new TreeSet<String>(Arrays.asList(jdbcapp)));
+
+            //Ensure that we were able to switch back
+            runTest(server, jdbcappfat, "testTNOriginalIsoLvlReverse");
+        } catch (Exception e) {
+            fail("Exception should not have been thrown when switching isolation level from TRANSACTION_NONE.");
+        }
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_derby/publish/servers/com.ibm.ws.jdbc.fat.derby/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_derby/publish/servers/com.ibm.ws.jdbc.fat.derby/server.xml
@@ -25,7 +25,8 @@
      
     <dataSource id="dsfat0" jndiName="jdbc/dsfat0" type="javax.sql.DataSource" isolationLevel="TRANSACTION_SERIALIZABLE">
       <jdbcDriver libraryRef="DerbyLib" />
-      <properties.derby.embedded databaseName="memory:ds0" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <authentication-alias name="derbyAuth"/>
+      <properties.derby.embedded databaseName="memory:ds0" createDatabase="create"/>
     </dataSource>
     
     <dataSource id="dsfat1" jndiName="jdbc/dsfat1" type="javax.sql.DataSource" isolationLevel="TRANSACTION_NONE" transactional="false">
@@ -35,7 +36,8 @@
     
     <dataSource id="dsfat2" jndiName="jdbc/dsfat2" type="javax.sql.DataSource">
       <jdbcDriver libraryRef="DerbyLib" />
-      <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <authentication-alias name="derbyAuth"/>
+      <properties.derby.embedded databaseName="memory:ds2" createDatabase="create"/>
     </dataSource>
     
     <dataSource id="dsfat3" jndiName="jdbc/dsfat3" type="javax.sql.DataSource" isolationLevel="TRANSACTION_NONE" transactional="false">
@@ -48,7 +50,33 @@
       <properties.derby.embedded databaseName="memory:ds4" createDatabase="create"/>
     </dataSource>
     
+    <dataSource id="dsfat5" jndiName="jdbc/dsfat5" type="javax.sql.DataSource" isolationLevel="TRANSACTION_NONE" transactional="false">
+      <jdbcDriver libraryRef="DerbyLib" />
+      <authentication-alias name="derbyAuth"/>
+      <properties.derby.embedded databaseName="memory:ds5" createDatabase="create"/>
+    </dataSource>
+    
+    <!-- dsfat6, dsfat7, dsfat8, dsfat9 are defined via @DataSourceDefinition in JDBCDerbyServlet -->
+    
+    <dataSource id="dsfat10" jndiName="jdbc/dsfat10" type="javax.sql.DataSource" isolationLevel="TRANSACTION_SERIALIZABLE" transactional="false">
+      <jdbcDriver libraryRef="DerbyLib" />
+      <authentication-alias name="derbyAuth"/>
+      <properties.derby.embedded databaseName="memory:ds10" createDatabase="create"/>
+    </dataSource>
+    
+    <dataSource id="dsfat11" jndiName="jdbc/dsfat11" type="javax.sql.DataSource" isolationLevel="TRANSACTION_NONE" transactional="false">
+      <jdbcDriver libraryRef="DerbyLib" javax.sql.DataSource="jdbc.tran.none.driver.TranNoneDataSource"/>
+      <properties.derby.embedded databaseName="memory:ds11" createDatabase="create"/>
+    </dataSource>
+    
+    <dataSource id="dsfat12" jndiName="jdbc/dsfat12" type="javax.sql.DataSource" isolationLevel="TRANSACTION_NONE" transactional="false">
+      <jdbcDriver libraryRef="DerbyLib" javax.sql.DataSource="jdbc.tran.none.driver.TranNoneDataSource"/>
+      <properties.derby.embedded databaseName="memory:ds11" createDatabase="create"/>
+    </dataSource>
+    
     <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    
+    <jdbcDriver id="Derby1" libraryRef="DerbyLib"/>
         
     <include location="../fatTestPorts.xml"/>
     

--- a/dev/com.ibm.ws.jdbc_fat_derby/publish/servers/com.ibm.ws.jdbc.fat.derby/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_derby/publish/servers/com.ibm.ws.jdbc.fat.derby/server.xml
@@ -58,12 +58,6 @@
     
     <!-- dsfat6, dsfat7, dsfat8, dsfat9 are defined via @DataSourceDefinition in JDBCDerbyServlet -->
     
-    <dataSource id="dsfat10" jndiName="jdbc/dsfat10" type="javax.sql.DataSource" isolationLevel="TRANSACTION_SERIALIZABLE" transactional="false">
-      <jdbcDriver libraryRef="DerbyLib" />
-      <authentication-alias name="derbyAuth"/>
-      <properties.derby.embedded databaseName="memory:ds10" createDatabase="create"/>
-    </dataSource>
-    
     <dataSource id="dsfat11" jndiName="jdbc/dsfat11" type="javax.sql.DataSource" isolationLevel="TRANSACTION_NONE" transactional="false">
       <jdbcDriver libraryRef="DerbyLib" javax.sql.DataSource="jdbc.tran.none.driver.TranNoneDataSource"/>
       <properties.derby.embedded databaseName="memory:ds11" createDatabase="create"/>

--- a/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/resources/WEB-INF/ibm-web-bnd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd" version="1.0">
+    
+  	<resource-ref name="jdbc/dsfat0ref" binding-name="jdbc/dsfat0">
+		<authentication-alias name="derbyAuth" />
+	</resource-ref>
+  
+	<resource-ref name="jdbc/dsfat2ref" binding-name="jdbc/dsfat2">
+		<authentication-alias name="derbyAuth" />
+	</resource-ref>
+	
+	<resource-ref name="jdbc/dsfat3ref" binding-name="jdbc/dsfat3">
+		<authentication-alias name="derbyAuth" />
+	</resource-ref>
+	
+	<resource-ref name="jdbc/dsfat7ref" binding-name="java:module/env/jdbc/dsfat7">
+		<authentication-alias name="derbyAuth" />
+	</resource-ref>
+	
+	<resource-ref name="jdbc/dsfat8ref" binding-name="java:module/env/jdbc/dsfat8">
+		<authentication-alias name="derbyAuth" />
+	</resource-ref>
+	
+	<resource-ref name="jdbc/dsfat9ref" binding-name="java:module/env/jdbc/dsfat9">
+		<authentication-alias name="derbyAuth" />
+	</resource-ref>
+</web-bnd>

--- a/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/resources/WEB-INF/ibm-web-ext.xml
+++ b/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/resources/WEB-INF/ibm-web-ext.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-ext xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd" version="1.0">
+  
+  <resource-ref name="jdbc/dsfat0ref" isolation-level="TRANSACTION_NONE" />
+  
+  <resource-ref name="jdbc/dsfat2ref" isolation-level="TRANSACTION_NONE" />
+  
+  <resource-ref name="jdbc/dsfat3ref" isolation-level="TRANSACTION_NONE" />
+  
+  <resource-ref name="jdbc/dsfat7ref" isolation-level="TRANSACTION_NONE" />
+  
+  <resource-ref name="jdbc/dsfat8ref" isolation-level="TRANSACTION_NONE" />
+  
+  <resource-ref name="jdbc/dsfat9ref" isolation-level="TRANSACTION_NONE" />
+
+</web-ext>

--- a/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/resources/WEB-INF/web.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0"
+    xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee web-app_3_0.xsd"
+    id="WebApp_ID">
+    
+  <display-name>JDBCFATDerbyTestWeb</display-name>
+
+  <!-- SERVLET DEFINITIONS -->
+  <servlet id="Default">
+    <servlet-name>JDBC FAT Derby Servlet</servlet-name>
+    <servlet-class>web.JDBCDerbyServlet</servlet-class>
+    <load-on-startup></load-on-startup>
+  </servlet>
+
+  <!-- SERVLET MAPPINGS -->        
+  <servlet-mapping id="ServletMapping_Default">
+    <servlet-name>JDBC FAT Derby Servlet</servlet-name>
+    <url-pattern>/*</url-pattern>
+  </servlet-mapping>
+  
+  <!-- RESOURCE REFERENCES -->
+  
+  <resource-ref>
+	<res-ref-name>jdbc/dsfat0ref</res-ref-name>
+	<res-type>javax.sql.DataSource</res-type>
+	<res-auth>Container</res-auth>
+  </resource-ref>
+  
+  <resource-ref>
+	<res-ref-name>jdbc/dsfat2ref</res-ref-name>
+	<res-type>javax.sql.DataSource</res-type>
+	<res-auth>Container</res-auth>
+  </resource-ref>
+
+  <resource-ref>
+	<res-ref-name>jdbc/dsfat3ref</res-ref-name>
+	<res-type>javax.sql.DataSource</res-type>
+	<res-auth>Container</res-auth>
+  </resource-ref>
+  
+  <resource-ref>
+    <res-ref-name>jdbc/dsfat7ref</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth> 
+  </resource-ref>
+  
+  <resource-ref>
+    <res-ref-name>jdbc/dsfat8ref</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth>
+  </resource-ref>
+  
+  <resource-ref>
+    <res-ref-name>jdbc/dsfat9ref</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth>
+  </resource-ref>
+  
+</web-app>

--- a/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/src/jdbc/fat/derby/web/JDBCDerbyServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/src/jdbc/fat/derby/web/JDBCDerbyServlet.java
@@ -159,7 +159,7 @@ public class JDBCDerbyServlet extends FATServlet {
      * Data Source - ds4 = DSConfig(TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
      *
      * Ensure that a data source configured with an isolation level of TRANSACTION_NONE
-     * and transactional = false fails during creation.
+     * and transactional = true fails during creation.
      */
     @Test
     @ExpectedFFDC({ "java.sql.SQLException" })

--- a/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/src/jdbc/fat/derby/web/JDBCDerbyServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/src/jdbc/fat/derby/web/JDBCDerbyServlet.java
@@ -148,8 +148,8 @@ public class JDBCDerbyServlet extends FATServlet {
             con = ds0.getConnection();
             con.setTransactionIsolation(Connection.TRANSACTION_NONE);
             fail("Exception should have been thrown when switching isolation level to TRANSACTION_NONE.");
-        } catch (SQLException sql0) {
-            assertTrue("Exception message should have contained", sql0.getMessage().contains("DSRA4011E"));
+        } catch (SQLException sql) {
+            assertTrue("Exception message should have contained", sql.getMessage().contains("DSRA4011E"));
 
             //ensure desired behavior
             assertEquals("Transaction isolation level should not have been changed: ", expected, con.getTransactionIsolation());

--- a/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/src/jdbc/fat/derby/web/JDBCDerbyServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/src/jdbc/fat/derby/web/JDBCDerbyServlet.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package jdbc.fat.derby.web;
 
+import static componenttest.app.FATDatabaseServlet.createTable;
+import static componenttest.app.FATDatabaseServlet.dropTable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -20,6 +22,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import javax.annotation.Resource;
+import javax.annotation.sql.DataSourceDefinition;
+import javax.annotation.sql.DataSourceDefinitions;
 import javax.naming.InitialContext;
 import javax.servlet.annotation.WebServlet;
 import javax.sql.DataSource;
@@ -30,9 +34,46 @@ import org.junit.Test;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.app.FATServlet;
 
+@DataSourceDefinitions(value = {
+                                 @DataSourceDefinition(
+                                                       name = "java:module/env/jdbc/dsfat6",
+                                                       className = "jdbc.tran.none.driver.TranNoneDataSource",
+                                                       databaseName = "memory:ds6",
+                                                       isolationLevel = Connection.TRANSACTION_NONE,
+                                                       transactional = false,
+                                                       properties = {
+                                                                      "createDatabase=create"
+                                                       }),
+                                 @DataSourceDefinition(
+                                                       name = "java:module/env/jdbc/dsfat7",
+                                                       className = "jdbc.tran.none.driver.TranNoneDataSource",
+                                                       databaseName = "memory:ds7",
+                                                       isolationLevel = Connection.TRANSACTION_NONE,
+                                                       transactional = false,
+                                                       properties = {
+                                                                      "createDatabase=create"
+                                                       }),
+                                 @DataSourceDefinition(
+                                                       name = "java:module/env/jdbc/dsfat8",
+                                                       className = "org.apache.derby.jdbc.EmbeddedDataSource40",
+                                                       databaseName = "memory:ds8",
+                                                       properties = {
+                                                                      "createDatabase=create"
+                                                       }),
+                                 @DataSourceDefinition(
+                                                       name = "java:module/env/jdbc/dsfat9",
+                                                       className = "org.apache.derby.jdbc.EmbeddedDataSource40",
+                                                       databaseName = "memory:ds9",
+                                                       isolationLevel = Connection.TRANSACTION_SERIALIZABLE,
+                                                       properties = {
+                                                                      "createDatabase=create"
+                                                       })
+})
 @SuppressWarnings("serial")
 @WebServlet("/JDBCDerbyServlet")
 public class JDBCDerbyServlet extends FATServlet {
+    private static final String CITYTABLE = "cities";
+    private static final String CITYSCHEMA = "name varchar(50) not null primary key, population int, county varchar(30)";
 
     @Resource(name = "jdbc/dsfat0ref", lookup = "jdbc/dsfat0")
     DataSource ds0; //DSConfig (TRAN_SERIALIZABLE) + Res-ref (TRAN_NONE) + Normal JDBC Driver
@@ -46,54 +87,72 @@ public class JDBCDerbyServlet extends FATServlet {
     @Resource(name = "jdbc/dsfat3ref", lookup = "jdbc/dsfat3")
     DataSource ds3; //DSConfig (TRAN_NONE) + Res-ref (TRAN_NONE) + TRAN_NONE JDBC Driver
 
+    @Resource(name = "jdbc/dsfat5")
+    DataSource ds5; //DSConfig (TRAN_NONE) + No Res-ref + Normal JDBC Driver
+
+    @Resource(name = "jdbc/dsfat6", lookup = "java:module/env/jdbc/dsfat6")
+    DataSource ds6; //DataSourceDef (TRAN_NONE) + No Res-ref
+
+    @Resource(name = "jdbc/dsfat7ref", lookup = "java:module/env/jdbc/dsfat7")
+    DataSource ds7; //DataSourceDef (TRAN_NONE) + Res-ref (TRAN_NONE)
+
+    @Resource(name = "jdbc/dsfat8ref", lookup = "java:module/env/jdbc/dsfat8")
+    DataSource ds8; //DataSourceDef(no iso lvl) + Res-ref (TRAN_NONE)
+
+    @Resource(name = "jdbc/dsfat9ref", lookup = "java:module/env/jdbc/dsfat9")
+    DataSource ds9; //DataSourceDef(TRAN_SERIALIZABLE) + Res-ref (TRAN_NONE)
+
+    @Resource(lookup = "jdbc/dsfat10")
+    DataSource ds10; //DSConfig (TRAN_SERIALIZABLE) + No Res-ref + Normal JDBC Driver
+
+    @Resource(lookup = "jdbc/dsfat11")
+    DataSource ds11; //DSConfig (TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
+
+    @Resource(lookup = "jdbc/dsfat12")
+    DataSource ds12; //DSConfig (TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
+
     @Resource
     private UserTransaction tran;
 
     /**
-     * Create the default table used by the tests.
+     * Data Source - ds5 = dsConfig (TRAN_NONE) + No Res-ref + Normal JDBC Driver
+     *
+     * Ensure that when data source is configured with TRANSACTION_NONE that
+     * a JDBC driver that does not support this configuration throws an error.
      */
-    private void createTable(DataSource ds) throws SQLException {
-        Connection con = ds.getConnection();
+    @Test
+    @ExpectedFFDC({ "javax.resource.spi.ResourceAllocationException", "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException" })
+    public void testTNUnsupported() throws Throwable {
         try {
-            Statement st = con.createStatement();
-            try {
-                st.executeUpdate("drop table cities");
-            } catch (SQLException x) {
-            }
-            st.executeUpdate("create table cities (name varchar(50) not null primary key, population int, county varchar(30))");
-        } finally {
-            con.close();
+            @SuppressWarnings("unused")
+            Connection con = ds5.getConnection();
+            fail("Connection should have thrown an exception since the JDBC driver does not support an isolation level of TRANSACTION_NONE.");
+        } catch (SQLException sql) {
+            assertTrue("Exception message should have contained", sql.getMessage().contains("DSRA4008E"));
         }
     }
 
     /**
-     * Data Source - ds1 = DSConfig(TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
      * Data Source - ds0 = DSConfig (TRAN_SERIALIZABLE) + Res-ref (TRAN_NONE) + Normal JDBC Driver
      *
-     * Ensure that if we try to change Transaction Isolation to TRANSACTION_NONE that we throw an exception.
+     * Ensure that if we try to change Transaction Isolation to TRANSACTION_NONE that we throw an exception
+     * and prevent isolation level from being changed.
      */
     @Test
     @ExpectedFFDC({ "java.sql.SQLException" })
-    public void testRejectIsolationChange() throws Throwable {
+    public void testTNRejectIsolationChange() throws Throwable {
         Connection con = null;
-        //TODO if we decide to block users from switching from TRANSACTION_NONE to another isolation level this test will need to be expanded.
-//        try {
-//            con = ds1.getConnection();
-//            con.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
-//            fail("Exception should have been thrown when switching isolation levels on a driver configured with TRANSACTION_NONE.");
-//        } catch (SQLException sql) {
-//            assertTrue("Exception message should have contained", sql.getMessage().contains("DSRA4011E"));
-//        } finally {
-//            con.close();
-//        }
+        int expected = Connection.TRANSACTION_SERIALIZABLE;
 
-        //Change to TRANSACTION_NONE
         try {
             con = ds0.getConnection();
             con.setTransactionIsolation(Connection.TRANSACTION_NONE);
             fail("Exception should have been thrown when switching isolation level to TRANSACTION_NONE.");
-        } catch (SQLException sql) {
-            assertTrue("Exception message should have contained", sql.getMessage().contains("DSRA4011E"));
+        } catch (SQLException sql0) {
+            assertTrue("Exception message should have contained", sql0.getMessage().contains("DSRA4011E"));
+
+            //ensure desired behavior
+            assertEquals("Transaction isolation level should not have been changed: ", expected, con.getTransactionIsolation());
         } finally {
             con.close();
         }
@@ -102,12 +161,12 @@ public class JDBCDerbyServlet extends FATServlet {
     /**
      * Data Source - ds4 = DSConfig(TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
      *
-     * This data source is not configured with "Transactional = false" which should cause
-     * the creation of the data source to fail
+     * Ensure that a data source configured with an isolation level of TRANSACTION_NONE
+     * and transactional = false fails during creation.
      */
     @Test
     @ExpectedFFDC({ "java.sql.SQLException" })
-    public void testTransactionalSetting() throws Throwable {
+    public void testTNTransactionalSetting() throws Throwable {
         InitialContext ctx = new InitialContext();
 
         try {
@@ -120,22 +179,24 @@ public class JDBCDerbyServlet extends FATServlet {
     }
 
     /**
-     * Data Sources - ds1 = DSConfig(TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
+     * Called by testTNConfigTnsl in JDBCDerbyTest but also useful as a stand-alone test
+     * Data Sources - ds12 = DSConfig(TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
      *
-     * Ensure connection is not enlisted in transaction
-     * Begin global transaction, do work, roll-back transaction, ensure work was not rolled-back.
+     * Ensure connection is not enlisted in transaction by beginning a global transaction and doing work.
+     * Then roll-back the transaction and ensure work was not rolled-back.
      */
     @Test
-    public void testTransationEnlistment() throws Throwable {
-        createTable(ds1);
+    public void testTNTransationEnlistment() throws Throwable {
+        createTable(ds12, CITYTABLE, CITYSCHEMA);
         Connection con = null;
+        ResultSet result = null;
 
         try {
-            con = ds1.getConnection();
+            con = ds12.getConnection();
             tran.begin();
             Statement stmt = con.createStatement();
             stmt.executeUpdate("insert into cities values ('Rochester', 106769, 'Olmsted')");
-            ResultSet result = stmt.executeQuery("select county from cities where name='Rochester'");
+            result = stmt.executeQuery("select county from cities where name='Rochester'");
             if (!result.next())
                 throw new Exception("Entry missing from database");
             String value = result.getString(1);
@@ -147,9 +208,9 @@ public class JDBCDerbyServlet extends FATServlet {
         }
 
         try {
-            con = ds1.getConnection();
+            con = ds12.getConnection();
             Statement stmt = con.createStatement();
-            ResultSet result = stmt.executeQuery("select county from cities where name='Rochester'");
+            result = stmt.executeQuery("select county from cities where name='Rochester'");
             if (!result.next()) {
                 throw new Exception("Entry missing from database after rollback. Connection should not have been enlisted in global transation.");
             }
@@ -157,20 +218,40 @@ public class JDBCDerbyServlet extends FATServlet {
             if (!"Olmsted".equals(value))
                 throw new Exception("Incorrect value: " + value);
         } finally {
+            result.close();
+            dropTable(con, CITYTABLE);
             con.close();
         }
     }
 
     /**
-     * Data Sources - ds1 - DSConfig(TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
+     * Called by testTNConfigTnsl in JDBCDerbyTest
+     * Data Sources - ds12 = DSConfig(TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
+     *
+     * Data source has been updated to Transactional = true in JDBCDerbyTest
+     * ensure that the configuration of TRANSACTION_NONE prevents a connection
+     * from being created.
+     */
+    public void testTNTransationEnlistmentModified() throws Throwable {
+        try {
+            @SuppressWarnings("unused")
+            Connection con = ds12.getConnection();
+            fail("Connection should have thrown an exception since a config with Isolation Level = TRANSACTION_NONE and Transactional = true should be rejected.");
+        } catch (SQLException sql) {
+            assertTrue("Exception message should have contained", sql.getMessage().contains("DSRA0080E"));
+        }
+    }
+
+    /**
+     * Data Sources - ds1 = DSConfig(TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
      *
      * Ensure we reject setAutoCommit(false)
      */
     @Test
     @ExpectedFFDC({ "java.sql.SQLException" })
-    public void testRejectAutoCommit() throws Throwable {
-        createTable(ds1);
+    public void testTNRejectAutoCommit() throws Throwable {
         Connection con = null;
+        boolean expected = true;
 
         try {
             con = ds1.getConnection();
@@ -188,25 +269,28 @@ public class JDBCDerbyServlet extends FATServlet {
 
         } catch (SQLException sql) {
             assertTrue("Exception message should have contained", sql.getMessage().contains("DSRA4010E"));
+
+            //ensure desired behavior
+            assertEquals("Auto commit should not have been changed", expected, con.getAutoCommit());
         } finally {
             tran.rollback();
             con.commit();
             con.close();
+
         }
     }
 
     /**
-     * Data Source - ds1 - DSConfig(TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
+     * Data Source - ds1 = DSConfig(TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
      * Data Source - ds3 = DSConfig(TRAN_NONE) + Res-ref (TRAN_NONE) + TRAN_NONE JDBC Driver
      *
-     * Test with and without res-ref that conn.getTransactionIsolation() returns
-     * Driver's isolation level when server config is set to TRAN_NONE
+     * Test with and without resource references that conn.getTransactionIsolation() returns
+     * Driver's isolation level when server config is set to TRANSACTION_NONE.
      */
     @Test
-    public void testResourceRefNone() throws Throwable {
+    public void testTNResRefBehavior() throws Throwable {
         Connection con = null;
         int expected = Connection.TRANSACTION_NONE;
-
         try {
             con = ds1.getConnection();
             assertEquals("Connection with dsConfig = TRAN_NONE and no res-ref should use driver default iso lvl: ", expected, con.getTransactionIsolation());
@@ -220,20 +304,18 @@ public class JDBCDerbyServlet extends FATServlet {
         } finally {
             con.close();
         }
-
     }
 
     /**
-     * Data Source - ds2 - dsConfig (no iso lvl) + Res-ref (TRAN_NONE) + Normal JDBC Driver
-     * Data Source - ds0 - dsConfig (TRAN_SERIALIZABLE) + Res-ref (TRAN_NONE) + Normal JDBC Driver
+     * Data Source - ds2 = dsConfig (no iso lvl) + Res-ref (TRAN_NONE) + Normal JDBC Driver
+     * Data Source - ds0 = dsConfig (TRAN_SERIALIZABLE) + Res-ref (TRAN_NONE) + Normal JDBC Driver
      *
-     * Test that when res-ref isolation level is TRAN_NONE that our behavior is unchanged if the
-     * data source config isolation level is unspecified or is something other than TRAN_NONE
+     * Test that when resource reference isolation level is TRANSACTION_NONE that our behavior is unchanged if the
+     * data source config isolation level is unspecified or is something other than TRANSACTAION_NONE.
      */
     @Test
-    public void testResourceRefBehavior() throws Throwable {
+    public void testTNResRefNoneBehavior() throws Throwable {
         Connection con = null;
-
         try {
             int expected = Connection.TRANSACTION_REPEATABLE_READ; //WAS default
             con = ds2.getConnection();
@@ -251,4 +333,124 @@ public class JDBCDerbyServlet extends FATServlet {
         }
     }
 
+    /**
+     * Data Source - ds6 = DataSourceDef (TRAN_NONE) + No Res-ref
+     * Data Source - ds7 = DataSourceDef (TRAN_NONE) + Res-ref (TRAN_NONE)
+     *
+     * Test with and without a resource reference that conn.getTransactionIsolation() returns
+     * Driver's isolation level when data source definition is set to an isolation level of TRANSACTION_NONE.
+     */
+    @Test
+    public void testTNResRefBehaviorDSDef() throws Throwable {
+        Connection con = null;
+        int expected = Connection.TRANSACTION_NONE;
+
+        try {
+            con = ds6.getConnection();
+            assertEquals("Connection with dsConfig = TRAN_NONE and no res-ref should use driver default iso lvl: ", expected, con.getTransactionIsolation());
+        } finally {
+            con.close();
+        }
+
+        try {
+            con = ds7.getConnection();
+            assertEquals("Connection with dsConfig = TRAN_NONE and res-ref = TRAN_NONE should use driver default iso lvl: ", expected, con.getTransactionIsolation());
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * Data Source - ds8 = DataSourceDef(no iso lvl) + Res-ref (TRAN_NONE)
+     * Data Source - ds9 = DataSourceDef(TRAN_SERIALIZABLE) + Res-ref (TRAN_NONE)
+     *
+     * Test that when resource reference isolation level is TRANSACTION_NONE that our behavior is unchanged if the
+     * data source definition isolation level is unspecified or is something other than TRANSACTION_NONE
+     */
+    @Test
+    public void testTNResRefNoneBehaviorDSDef() throws Throwable {
+        Connection con = null;
+        try {
+            int expected = Connection.TRANSACTION_REPEATABLE_READ; //WAS default
+            con = ds8.getConnection();
+            assertEquals("Connection with no dsConfig and res-ref = TRAN_NONE should use WAS default iso lvl: ", expected, con.getTransactionIsolation());
+        } finally {
+            con.close();
+        }
+
+        try {
+            int expected = Connection.TRANSACTION_SERIALIZABLE; //dsConfig
+            con = ds9.getConnection();
+            assertEquals("Connection with dsConfig = TRAN_SERIALIZABLE and res-ref = TRAN_NONE should use dsConfig iso lvl: ", expected, con.getTransactionIsolation());
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * Called by testTNConfigIsoLvl in JDBCDerbyTest
+     * Data Source - ds11 = DSConfig (TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
+     *
+     * Ensure that the unmodified data source has the expected isolation level.
+     */
+    public void testTNOriginalIsoLvl() throws Throwable {
+        int expected = Connection.TRANSACTION_NONE;
+        final Connection con = ds11.getConnection();
+        try {
+            int actual = con.getTransactionIsolation();
+            assertEquals("Connection should have had an isolation level of: ", expected, actual);
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * Called by testTNConfigIsoLvl in JDBCDerbyTest
+     * Data Source - ds11 = DSConfig (TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
+     *
+     * Ensure that the modified data source has the expected isolation level.
+     */
+    public void testTNModifiedIsoLvl() throws Throwable {
+        int expected = Connection.TRANSACTION_SERIALIZABLE; //Modified isolation level
+        final Connection con = ds11.getConnection();
+        try {
+            int actual = con.getTransactionIsolation();
+            assertEquals("Connection should have had a modified isolation level of: ", expected, actual);
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * Called by testTNConfigIsoLvlReverse in JDBCDerbyTest
+     * Data Source - ds10 = DSConfig (TRAN_SERIALIZABLE) + No Res-ref + Normal JDBC Driver
+     *
+     * Ensure that the unmodified data source has the expected isolation level.
+     */
+    public void testTNOriginalIsoLvlReverse() throws Throwable {
+        int expected = Connection.TRANSACTION_SERIALIZABLE;
+        final Connection con = ds10.getConnection();
+        try {
+            int actual = con.getTransactionIsolation();
+            assertEquals("Connection should have had an isolation level of: ", expected, actual);
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * Called by testTNConfigIsoLvlReverse in JDBCDerbyTest
+     * Data Source - ds10 = DSConfig (TRAN_SERIALIZABLE) + No Res-ref + Normal JDBC Driver
+     *
+     * Ensure that the modified data source results in an error when attempting to get connection.
+     */
+    public void testTNModifiedIsoLvlReverse() throws Throwable {
+        try {
+            @SuppressWarnings("unused")
+            Connection con = ds10.getConnection();
+            fail("Connection should have thrown an exception since the JDBC driver does not support an isolation level of TRANSACTION_NONE.");
+        } catch (SQLException sql) {
+            assertTrue("Exception message should have contained", sql.getMessage().contains("DSRA4011E"));
+        }
+    }
 }

--- a/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/src/jdbc/fat/derby/web/JDBCDerbyServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_derby/test-applications/jdbcapp/src/jdbc/fat/derby/web/JDBCDerbyServlet.java
@@ -102,9 +102,6 @@ public class JDBCDerbyServlet extends FATServlet {
     @Resource(name = "jdbc/dsfat9ref", lookup = "java:module/env/jdbc/dsfat9")
     DataSource ds9; //DataSourceDef(TRAN_SERIALIZABLE) + Res-ref (TRAN_NONE)
 
-    @Resource(lookup = "jdbc/dsfat10")
-    DataSource ds10; //DSConfig (TRAN_SERIALIZABLE) + No Res-ref + Normal JDBC Driver
-
     @Resource(lookup = "jdbc/dsfat11")
     DataSource ds11; //DSConfig (TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
 
@@ -168,7 +165,6 @@ public class JDBCDerbyServlet extends FATServlet {
     @ExpectedFFDC({ "java.sql.SQLException" })
     public void testTNTransactionalSetting() throws Throwable {
         InitialContext ctx = new InitialContext();
-
         try {
             @SuppressWarnings("unused")
             DataSource ds4 = (DataSource) ctx.lookup("jdbc/dsfat4");
@@ -422,33 +418,16 @@ public class JDBCDerbyServlet extends FATServlet {
     }
 
     /**
-     * Called by testTNConfigIsoLvlReverse in JDBCDerbyTest
-     * Data Source - ds10 = DSConfig (TRAN_SERIALIZABLE) + No Res-ref + Normal JDBC Driver
+     * Called by testTNConfigIsoLvl in JDBCDerbyTest
+     * Data Source - ds11 = DSConfig (TRAN_NONE) + No Res-ref + TRAN_NONE JDBC Driver
      *
-     * Ensure that the unmodified data source has the expected isolation level.
+     * Ensure that the attempt to switch back to TRANSACTION_NONE results in an error when attempting to get connection.
      */
-    public void testTNOriginalIsoLvlReverse() throws Throwable {
-        int expected = Connection.TRANSACTION_SERIALIZABLE;
-        final Connection con = ds10.getConnection();
-        try {
-            int actual = con.getTransactionIsolation();
-            assertEquals("Connection should have had an isolation level of: ", expected, actual);
-        } finally {
-            con.close();
-        }
-    }
-
-    /**
-     * Called by testTNConfigIsoLvlReverse in JDBCDerbyTest
-     * Data Source - ds10 = DSConfig (TRAN_SERIALIZABLE) + No Res-ref + Normal JDBC Driver
-     *
-     * Ensure that the modified data source results in an error when attempting to get connection.
-     */
-    public void testTNModifiedIsoLvlReverse() throws Throwable {
+    public void testTNRevertedIsoLvl() throws Throwable {
         try {
             @SuppressWarnings("unused")
-            Connection con = ds10.getConnection();
-            fail("Connection should have thrown an exception since the JDBC driver does not support an isolation level of TRANSACTION_NONE.");
+            Connection con = ds11.getConnection();
+            fail("Connection should have thrown an exception since the JDBC driver does not support setting isolation level to TRANSACTION_NONE.");
         } catch (SQLException sql) {
             assertTrue("Exception message should have contained", sql.getMessage().contains("DSRA4011E"));
         }

--- a/dev/com.ibm.ws.jdbc_fat_derby/test-applications/trandriver/src/jdbc/tran/none/driver/TranNoneConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_derby/test-applications/trandriver/src/jdbc/tran/none/driver/TranNoneConnection.java
@@ -298,7 +298,7 @@ public class TranNoneConnection implements Connection {
 
     @Override
     public void setTransactionIsolation(int arg0) throws SQLException {
-        throw new SQLException("setTransactionIsolation called with " + arg0);
+        impl.setTransactionIsolation(arg0);
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc_fat_derby/test-applications/trandriver/src/jdbc/tran/none/driver/TranNoneConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_derby/test-applications/trandriver/src/jdbc/tran/none/driver/TranNoneConnection.java
@@ -298,7 +298,16 @@ public class TranNoneConnection implements Connection {
 
     @Override
     public void setTransactionIsolation(int arg0) throws SQLException {
-        impl.setTransactionIsolation(arg0);
+        switch (arg0) {
+            case 0: //TRANSACTION_NONE
+                throw new SQLException("setTransactionIsolation called with " + arg0);
+            case 4: //TRANSACTION_REPEATABLE_READ WAS default
+                throw new SQLException("setTransactionIsolation called with " + arg0);
+            default:
+                impl.setTransactionIsolation(arg0);
+                break;
+
+        }
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc_fat_derby/test-applications/trandriver/src/jdbc/tran/none/driver/TranNoneDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_derby/test-applications/trandriver/src/jdbc/tran/none/driver/TranNoneDataSource.java
@@ -25,6 +25,7 @@ import org.apache.derby.jdbc.EmbeddedDataSource;
  */
 public class TranNoneDataSource implements DataSource {
     private final EmbeddedDataSource impl;
+    private String serverName;
 
     /* Methods for wrapping Derby Embedded */
     public void setCreateDatabase(String create) {
@@ -45,6 +46,14 @@ public class TranNoneDataSource implements DataSource {
 
     public TranNoneDataSource() {
         impl = new EmbeddedDataSource();
+    }
+
+    public void setServerName(String serverName) {
+        this.serverName = serverName;
+    }
+
+    public String getServerName() {
+        return this.serverName;
     }
 
     @Override


### PR DESCRIPTION
Added additional test cases to ensure correct behavior when using DataSourceDefinitions and updating the data source configuration while the server is running.  Made edits/additions to Transaction None driver to reduce warnings in the testing log.  Made minor changes to the JDBC package based on previous feedback and to make expected behavior more clear.
