### PR TITLE
Run Fault Tolerance tests against 1.1

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/enablement/DisableEnableTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/enablement/DisableEnableTest.java
@@ -47,8 +47,8 @@ public class DisableEnableTest extends FATServletClient {
 
     @ClassRule
     public static RepeatTests r = RepeatTests
-                    .with(new FeatureReplacementAction("mpFaultTolerance-1.1").removeFeature("mpFaultTolerance-1.0").forServers(SERVER_NAME))
-                    .andWith(new FeatureReplacementAction("mpFaultTolerance-1.0").removeFeature("mpFaultTolerance-1.1").forServers(SERVER_NAME));
+                    .with(new FeatureReplacementAction("mpFaultTolerance-1.0").removeFeature("mpFaultTolerance-1.1").forServers(SERVER_NAME))
+                    .andWith(new FeatureReplacementAction("mpFaultTolerance-1.1").removeFeature("mpFaultTolerance-1.0").forServers(SERVER_NAME));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/CDIFaultTolerance/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/CDIFaultTolerance/server.xml
@@ -19,7 +19,7 @@
 		<feature>appSecurity-3.0</feature>
 		<feature>cdi-2.0</feature>
 		<feature>servlet-4.0</feature>
-		<feature>mpFaultTolerance-1.0</feature>
+		<feature>mpFaultTolerance-1.1</feature>
 	</featureManager>
 
 	<!-- Usually, we recommend customers not to change this, however our Async 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/CDIFaultTolerance/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/CDIFaultTolerance/server.xml
@@ -32,4 +32,6 @@
 		the test run take longer, so instead I'm setting a minimum number of threads. -->
 	<executor coreThreads="20"/>
 	
+	<logging traceSpecification="FAULTTOLERANCE=all=enabled:METRICS=all=enabled"/>
+	
 </server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FTFallback/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FTFallback/server.xml
@@ -19,7 +19,7 @@
 		<feature>appSecurity-3.0</feature>
 		<feature>cdi-2.0</feature>
 		<feature>servlet-4.0</feature>
-		<feature>mpFaultTolerance-1.0</feature>
+		<feature>mpFaultTolerance-1.1</feature>
 	</featureManager>
 
 	<!-- Usually, we recommend customers not to change this, however our Async 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FaultToleranceMultiModule/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FaultToleranceMultiModule/server.xml
@@ -19,7 +19,7 @@
 		<feature>appSecurity-3.0</feature>
 		<feature>cdi-2.0</feature>
 		<feature>servlet-4.0</feature>
-		<feature>mpFaultTolerance-1.0</feature>
+		<feature>mpFaultTolerance-1.1</feature>
 	</featureManager>
 	
 </server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/TxFaultTolerance/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/TxFaultTolerance/server.xml
@@ -19,7 +19,7 @@
 		<feature>appSecurity-3.0</feature>
 		<feature>cdi-2.0</feature>
 		<feature>servlet-4.0</feature>
-		<feature>mpFaultTolerance-1.0</feature>
+		<feature>mpFaultTolerance-1.1</feature>
 	</featureManager>
 
     <logging traceSpecification="Transaction=all=enabled:FAULTTOLERANCE=all=enabled"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/TxFaultToleranceReordered/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/TxFaultToleranceReordered/server.xml
@@ -19,7 +19,7 @@
 		<feature>appSecurity-3.0</feature>
 		<feature>cdi-2.0</feature>
 		<feature>servlet-4.0</feature>
-		<feature>mpFaultTolerance-1.0</feature>
+		<feature>mpFaultTolerance-1.1</feature>
 	</featureManager>
 
     <logging traceSpecification="Transaction=all=enabled:FAULTTOLERANCE=all=enabled"/>


### PR DESCRIPTION
Change all fault tolerance FAT tests to run against 1.1, with a few also
run against 1.0, rather than the reverse.