### PR TITLE
Add switching of virtual host for MP features

### DIFF
--- a/dev/com.ibm.ws.app.manager.wab/bnd.bnd
+++ b/dev/com.ibm.ws.app.manager.wab/bnd.bnd
@@ -21,16 +21,16 @@ Private-Package: com.ibm.ws.app.manager.wab*
 -dsannotations:, \
   com.ibm.ws.app.manager.wab.internal.WABInstaller, \
   com.ibm.ws.app.manager.wab.internal.WABExtensionFactory
-  
+
 
 Export-Package: com.ibm.wsspi.wab.configure, \
     com.ibm.ws.app.manager.wab.helper
 Import-Package: \
     com.ibm.ws.app.manager.module.internal, \
     *
-    
+
 Include-Resource: OSGI-INF=resources/OSGI-INF
-    
+
 IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 instrument.classesExcludes: com/ibm/ws/app/manager/wab/internal/resources/*.class
@@ -48,6 +48,7 @@ instrument.classesExcludes: com/ibm/ws/app/manager/wab/internal/resources/*.clas
 	com.ibm.ws.artifact;version=latest,\
 	com.ibm.ws.webcontainer;version=latest,\
 	com.ibm.ws.app.manager.module;version=latest,\
+    com.ibm.ws.runtime.update,\
 	com.ibm.ws.threading,\
 	com.ibm.websphere.appserver.spi.javaeedd;version=latest,\
 	com.ibm.ws.eba.wab.integrator;version=latest,\

--- a/dev/com.ibm.ws.app.manager.wab/src/com/ibm/ws/app/manager/wab/internal/WAB.java
+++ b/dev/com.ibm.ws.app.manager.wab/src/com/ibm/ws/app/manager/wab/internal/WAB.java
@@ -76,6 +76,8 @@ class WAB implements BundleTrackerCustomizer<WAB> {
     private final Version wabBundleVersion;
     private final String wabContextPath;
     private final WABInstaller installer;
+    private final String rawVirtualHost;
+    private final String resolvedVirtualHost;
 
     private final WABTracker<WAB> trackerForThisWAB;
 
@@ -92,6 +94,8 @@ class WAB implements BundleTrackerCustomizer<WAB> {
         this.wabBundleVersion = wabBundle.getVersion();
         this.wabContextPath = wabContextPath;
         this.installer = installer;
+        this.rawVirtualHost = wabBundle.getHeaders().get("OL-VirtualHost");
+        this.resolvedVirtualHost = resolveVirtualHost();
         trackerForThisWAB = installer.getTracker(this);
     }
 
@@ -218,6 +222,34 @@ class WAB implements BundleTrackerCustomizer<WAB> {
 
     State getState() {
         return state.get();
+    }
+
+    String getVirtualHost() {
+        return this.resolvedVirtualHost;
+    }
+
+    boolean isResolvedVirtualHostValid() {
+        String reResolvedVirtualHost = resolveVirtualHost();
+
+        if (resolvedVirtualHost == null) {
+            return reResolvedVirtualHost == null;
+        }
+
+        return resolvedVirtualHost.equals(reResolvedVirtualHost);
+    }
+
+    private String resolveVirtualHost() {
+        if (rawVirtualHost == null) return null;
+    
+        if (rawVirtualHost.startsWith("${")) {
+            String resolvedVirtHost = installer.resolveVariable(rawVirtualHost);
+            if (rawVirtualHost.equals(resolvedVirtHost)) {
+                return null;
+            } else {
+                return resolvedVirtHost;
+            }
+        }
+        return rawVirtualHost;
     }
 
     /**

--- a/dev/com.ibm.ws.app.manager.wab/src/com/ibm/ws/app/manager/wab/internal/WABGroup.java
+++ b/dev/com.ibm.ws.app.manager.wab/src/com/ibm/ws/app/manager/wab/internal/WABGroup.java
@@ -12,6 +12,7 @@ package com.ibm.ws.app.manager.wab.internal;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import com.ibm.ws.app.manager.module.DeployedAppInfo;
@@ -43,6 +44,10 @@ final class WABGroup {
         //if the group is uninstalled, this is a late wab addition, so clean it up.
         if (groupUninstalled)
             uninstallGroup(installer);
+    }
+
+    Queue<WAB> getWABs() {
+      return wabs;
     }
 
     //this method MUST NOT be called with the wabgroup locked.. (and must not lock the wabGroup)

--- a/dev/com.ibm.ws.jmx.connector.server.rest/bnd.bnd
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/bnd.bnd
@@ -16,6 +16,7 @@ Bundle-SymbolicName: com.ibm.ws.jmx.connector.server.rest
 Bundle-Description: Project for JMX Connector; version=${bVersion}
 
 Web-ContextPath: /IBMJMXConnectorREST
+OL-VirtualHost: ${admin.virtual.host}
 
 IBM-Authorization-Roles: com.ibm.ws.management
 IBM-Web-Extension-Processing-Disabled: true

--- a/dev/com.ibm.ws.microprofile.health/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health/bnd.bnd
@@ -19,6 +19,7 @@ Bundle-SymbolicName: com.ibm.ws.microprofile.health
 Bundle-Description:MicroProfile Health Check; version ${bVersion}
 
 Web-ContextPath: health
+OL-VirtualHost: ${admin.virtual.host}
 
 WS-TraceGroup: HEALTH
 
@@ -53,12 +54,12 @@ Private-Package: \
 Include-Resource: \
     META-INF/services=resources/META-INF/services, \
     WEB-INF=resources/WEB-INF
-  
+
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 src: src,resources
 testsrc: test/src
-  
+
 -buildpath: \
         com.ibm.websphere.javaee.annotation.1.2;version=latest,\
         com.ibm.websphere.javaee.servlet.3.1; version=latest,\
@@ -81,7 +82,7 @@ testsrc: test/src
         com.ibm.ws.webcontainer;version=latest,\
         com.ibm.ws.org.apache.commons.lang3;version=latest,\
         org.eclipse.osgi;version=latest,\
-        
+
 -testpath: \
         ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
         com.ibm.ws.junit.extensions;version=latest, \

--- a/dev/com.ibm.ws.microprofile.metrics.private/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.private/bnd.bnd
@@ -23,6 +23,7 @@ IBM-Authorization-Roles: com.ibm.ws.management
 IBM-Web-Extension-Processing-Disabled: true
 
 Web-ContextPath: @privateMetricsURL
+OL-VirtualHost: ${admin.virtual.host}
 
 Private-Package: \
 	com.ibm.ws.microprofile.metrics.privateapi,\
@@ -47,4 +48,3 @@ WS-TraceGroup: METRICS
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest
- 

--- a/dev/com.ibm.ws.microprofile.metrics.public/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.public/bnd.bnd
@@ -23,6 +23,7 @@ IBM-Authorization-Roles: com.ibm.ws.management
 IBM-Web-Extension-Processing-Disabled: true
 
 Web-ContextPath: @publicMetricsURL
+OL-VirtualHost: ${admin.virtual.host}
 
 Private-Package: \
 	com.ibm.ws.microprofile.metrics.publicapi,\
@@ -47,4 +48,3 @@ WS-TraceGroup: METRICS
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest
- 

--- a/dev/com.ibm.ws.rest.handler/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler/bnd.bnd
@@ -16,6 +16,7 @@ Bundle-SymbolicName: com.ibm.ws.rest.handler
 Bundle-Description: Project for REST handler; version=${bVersion}
 
 Web-ContextPath: ibm/api
+OL-VirtualHost: ${admin.virtual.host}
 
 IBM-Authorization-Roles: com.ibm.ws.management
 IBM-Web-Extension-Processing-Disabled: true


### PR DESCRIPTION
Allow a WAB to have an OL-Virtaul-Host header than indicates the virtual host the app should run on. If it contains a variable then resolve the variable. This only supports a total variable substitution.