### PR TITLE
Update eclipse / bnd settings for new components.

### DIFF
--- a/dev/com.ibm.websphere.javaee.activation.1.1/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.activation.1.1/bnd.bnd
@@ -15,6 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 Bundle-SymbolicName: com.ibm.websphere.javaee.activation.1.1; singleton:=true
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Export-Package: \
 	javax.activation;version=1.1

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.source=1.7
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation=0


### PR DESCRIPTION
Change openidconnect.clients.common eclipse compiler settings to be 1.7
instead of 1.6 and add bnd tools prefs file.
Update javaee.activation component to require Java 8 to match the byte
code setting.
