### PR TITLE
For issue #4504: mpMetrics FAT test cases for authetication config

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/bnd.bnd
@@ -32,13 +32,14 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 # For all project names that match the pattern "*_fat*", dependencies for junit,
 # fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
 -buildpath: \
-	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	com.ibm.ws.junit.extensions;version=latest, \
-	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
-	org.jmock:jmock;strategy=exact;version=2.5.1, \
-	com.ibm.ws.componenttest:public.api;version=1.0.0, \
-	org.apache.commons:commons-compress;version=1.10, \
-	com.ibm.websphere.rest.handler;version=latest, \
-	com.ibm.websphere.javaee.servlet.3.1;version=latest, \
+	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
+	com.ibm.ws.junit.extensions;version=latest,\
+	org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
+	org.jmock:jmock;strategy=exact;version=2.5.1,\
+	com.ibm.ws.componenttest:public.api;version=1.0.0,\
+	org.apache.commons:commons-compress;version=1.10,\
+	com.ibm.websphere.rest.handler;version=latest,\
+	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.metrics.1.0;version=latest
+	com.ibm.websphere.org.eclipse.microprofile.metrics.1.0;version=latest,\
+	com.ibm.ws.common.encoder;version=latest

--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/fat/utils/MetricsAuthTestUtil.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/fat/utils/MetricsAuthTestUtil.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.metrics.fat.utils;
+
+import java.util.Set;
+
+import org.junit.Assert;
+
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ *
+ */
+public class MetricsAuthTestUtil {
+
+    /**
+     * @param server - Liberty server
+     * @param name - The name of a feature to remove e.g. mpMetrics-1.0
+     */
+    public static void removeFeature(LibertyServer server, String name) {
+        try {
+            ServerConfiguration config = server.getServerConfiguration();
+            Set<String> features = config.getFeatureManager().getFeatures();
+            if (features.isEmpty()) {
+                return;
+            } else {
+                if (!features.contains(name))
+                    return;
+                features.remove(name);
+                server.updateServerConfiguration(config);
+//                assertNotNull("Config wasn't updated successfully",
+//                              server.waitForStringInLogUsingMark("CWWKG0017I.* | CWWKG0018I.*"));
+            }
+        } catch (Exception e) {
+            Assert.fail("Unable to remove feature:" + name);
+        }
+    }
+
+    /**
+     * @param server - Liberty server
+     * @param name - The name of a feature to add e.g. mpMetrics-1.0
+     */
+    public static void addFeature(LibertyServer server, String name) {
+        try {
+            ServerConfiguration config = server.getServerConfiguration();
+            Set<String> features = config.getFeatureManager().getFeatures();
+            if (features.contains(name))
+                return;
+            features.add(name);
+            server.updateServerConfiguration(config);
+//            assertNotNull("Config wasn't updated successfully",
+//                          server.waitForStringInLogUsingMark("CWWKG0017I.* | CWWKG0018I.*"));
+        } catch (Exception e) {
+            Assert.fail("Unable to add feature:" + name);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/fat/utils/MetricsConnection.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/fat/utils/MetricsConnection.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.metrics.fat.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.junit.Assert;
+
+import com.ibm.ws.common.internal.encoder.Base64Coder;
+
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+import componenttest.topology.utils.HttpUtils.HTTPRequestMethod;
+
+/**
+ *
+ */
+public class MetricsConnection {
+
+    public static final String METRICS_ENDPOINT = "/metrics/";
+    public static final String SERVER_PASSWORD = "adminpwd";
+    public static final String SERVER_USERNAME = "admin";
+    public static final String WRONG_SERVER_PASSWORD = "user";
+    public static final String WRONG_SERVER_USERNAME = "user";
+    private int expectedResponseCode = HttpURLConnection.HTTP_OK;
+    private final int[] allowedUnexpectedResponseCodes = new int[] { HttpURLConnection.HTTP_MOVED_TEMP };
+    private final Map<String, String> headers = new HashMap<>();
+    private final Map<String, String> queryParams = new HashMap<>();
+    private InputStream streamToWrite = null;
+
+    private HTTPRequestMethod method = HTTPRequestMethod.GET;
+    private final String path;
+    private boolean secure = false;
+    private final LibertyServer server;
+    private int port = -1;
+    private String hostname = null;
+
+    /**
+     * Creates connection with default values
+     *
+     * @param server - server to use to construct connection
+     * @param path - URI to connect to
+     */
+    public MetricsConnection(LibertyServer server, String path) {
+        this.server = server;
+        if (!path.startsWith("/"))
+            path = "/" + path;
+        this.path = path;
+    }
+
+    /**
+     * Set explicit HTTP response code, default is 200
+     *
+     * @param expectedResponseCode
+     * @return
+     */
+    public MetricsConnection expectedResponseCode(int expectedResponseCode) {
+        this.expectedResponseCode = expectedResponseCode;
+        return this;
+    }
+
+    private URL constructUrl() {
+        String protocol = this.secure ? "https" : "http";
+        int port;
+        if (this.port == -1)
+            port = this.secure ? this.server.getHttpDefaultSecurePort() : this.server.getHttpDefaultPort();
+        else
+            port = this.port;
+        try {
+            String path = this.path;
+            if (queryParams.size() > 0) {
+                path += "?";
+                for (Entry<String, String> queryParam : queryParams.entrySet()) {
+                    path += queryParam.getKey() + "=" + queryParam.getValue() + "&";
+                }
+                path = path.substring(0, path.length() - 1);
+            }
+            String hostname = this.hostname != null ? this.hostname : this.server.getHostname();
+            return new URL(protocol, hostname, port, path);
+        } catch (MalformedURLException e) {
+            Assert.fail(e.getMessage());
+        }
+        return null;
+    }
+
+    /*
+     * @return
+     *
+     * @throws IOException
+     *
+     * @throws ProtocolException
+     */
+    public HttpURLConnection getConnection() throws IOException, ProtocolException {
+        HttpURLConnection conn = HttpUtils.getHttpConnection(constructUrl(), expectedResponseCode, allowedUnexpectedResponseCodes, 30, method, headers, streamToWrite);
+        return conn;
+    }
+
+    /**
+     * Sets the data to be written for POST/PUT operations
+     *
+     * @param streamToWrite - stream to be written to the connection
+     * @return
+     */
+    public MetricsConnection streamToWrite(InputStream streamToWrite) {
+        this.streamToWrite = streamToWrite;
+        return this;
+    }
+
+    /**
+     * Sets value for specific header
+     *
+     * @param headerName - header to be set
+     * @param headerValue - value of the header
+     * @return
+     */
+    public MetricsConnection header(String headerName, String headerValue) {
+        this.headers.put(headerName, headerValue);
+        return this;
+    }
+
+    /**
+     *
+     * @return map containing headers
+     */
+    public Map<String, String> headers() {
+        return this.headers;
+    }
+
+    /**
+     * Set explicit host to be used, by default server's host is used
+     *
+     * @param hostname
+     * @return
+     */
+    public MetricsConnection hostname(String hostname) {
+        this.hostname = hostname;
+        return this;
+    }
+
+    /**
+     * Set HTTP method to be used. Default is GET
+     *
+     * @param method
+     * @return
+     */
+    public MetricsConnection method(HTTPRequestMethod method) {
+        this.method = method;
+        return this;
+    }
+
+    /**
+     * Sets explicit port number to be used
+     *
+     * @param port
+     * @return
+     */
+    public MetricsConnection port(int port) {
+        this.port = port;
+        return this;
+    }
+
+    /**
+     * Set to true to use HTTPS connection, uses HTTP by default
+     *
+     * @param secure
+     * @return
+     */
+    public MetricsConnection secure(boolean secure) {
+        this.secure = secure;
+        return this;
+    }
+
+    /**
+     * creates default connection for private docs endpoint using HTTPS
+     *
+     * @param server - server to connect to
+     * @return
+     */
+    public static MetricsConnection privateConnection(LibertyServer server) {
+        return new MetricsConnection(server, METRICS_ENDPOINT).secure(true).header("Authorization", "Basic " + Base64Coder.base64Encode(SERVER_USERNAME + ":" + SERVER_PASSWORD));
+    }
+
+    /**
+     * creates default connection for private docs endpoint using HTTPS
+     *
+     * @param server - server to connect to
+     * @return
+     */
+    public static MetricsConnection privateConnectionInvalidHeader(LibertyServer server) {
+        return new MetricsConnection(server, METRICS_ENDPOINT).secure(true).header("Authorization",
+                                                                                   "Basic " + Base64Coder.base64Encode(WRONG_SERVER_USERNAME + ":" + WRONG_SERVER_PASSWORD));
+    }
+
+    /**
+     * creates default connection for public docs endpoint using HTTP
+     *
+     * @param server - server to connect to
+     * @return
+     */
+    public static MetricsConnection publicConnection(LibertyServer server) {
+        return new MetricsConnection(server, METRICS_ENDPOINT);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/FATSuite.java
@@ -17,7 +17,8 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
                 MetricsClassLoaderTest_10.class,
-                MetricsClassLoaderTest_11.class
+                MetricsClassLoaderTest_11.class,
+                MetricsAuthenticationTest.class
 })
 
 public class FATSuite {}

--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.metrics.tck.launcher;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.net.HttpURLConnection;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.microprofile.metrics.fat.utils.MetricsAuthTestUtil;
+import com.ibm.ws.microprofile.metrics.fat.utils.MetricsConnection;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+/**
+ *
+ */
+
+@RunWith(FATRunner.class)
+public class MetricsAuthenticationTest {
+
+    private final static int TIMEOUT = 60000; // in milliseconds
+
+    @Server("MetricsAuthenticationServer")
+    public static LibertyServer server;
+
+    @Before
+    public void setUp() throws Exception {
+
+        HttpUtils.trustAllCertificates();
+
+        server.startServer("MetricsAuthenticationServer.log", true);
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stopServer();
+        MetricsAuthTestUtil.removeFeature(server, "mpMetrics-1.0");
+        MetricsAuthTestUtil.removeFeature(server, "mpMetrics-1.1");
+    }
+
+    @Test
+    public void testMetrics10Auth() throws Exception {
+        addFeature(false);
+
+        testMetricsAuth();
+    }
+
+    @Test
+    public void testMetrics11Auth() throws Exception {
+        addFeature(true);
+
+        testMetricsAuth();
+    }
+
+    private void addFeature(boolean enable11) throws Exception {
+        server.setMarkToEndOfLog();
+
+        if (enable11) {
+            MetricsAuthTestUtil.addFeature(server, "mpMetrics-1.1");
+        } else {
+            MetricsAuthTestUtil.addFeature(server, "mpMetrics-1.0");
+        }
+
+        waitForMetricsEndpoint(server);
+    }
+
+    private void waitForMetricsEndpoint(LibertyServer server) throws Exception {
+        assertNotNull("Web application is not available at */metrics/", server.waitForStringInLog("CWWKT0016I.*/metrics/", TIMEOUT, server.getDefaultLogFile()));
+    }
+
+    private static void setMetricsAuthConfig(LibertyServer server, Boolean authentication) throws Exception {
+        server.setMarkToEndOfLog();
+
+        ServerConfiguration config = server.getServerConfiguration();
+        config.getMPMetricsElement().setAuthentication(authentication);
+        server.updateServerConfiguration(config);
+        assertNotNull("Config wasn't updated successfully",
+                      server.waitForStringInLogUsingMark("CWWKG0017I.* | CWWKG0018I.*", TIMEOUT));
+    }
+
+    private void testMetricsAuth() throws Exception {
+
+        //1. When authentication is not explicitly set in server.xml, it defaults to private,
+        //  i.e. requires authentication into metrics endpoint
+
+        //check that opening connection to /metrics requires authentication by default
+
+        Thread.sleep(10000);
+
+        MetricsConnection authenticationNotSpecified = MetricsConnection.privateConnection(server);
+        authenticationNotSpecified.expectedResponseCode(HttpURLConnection.HTTP_OK).getConnection();
+
+        //check that opening connection to /metrics with default authentication with invalid credentials returns HTTP 401 ERROR
+
+        MetricsConnection authenticationNotSpecifiedInvalidHeader = MetricsConnection.privateConnectionInvalidHeader(server);
+        authenticationNotSpecifiedInvalidHeader.expectedResponseCode(HttpURLConnection.HTTP_UNAUTHORIZED).getConnection();
+
+        //2. When authentication is explicitly set to true in server.xml, metrics endpoint requires authentication,
+        //  i.e. is private
+
+        setMetricsAuthConfig(server, true);
+        MetricsConnection authenticationTrue = MetricsConnection.privateConnection(server);
+        authenticationTrue.expectedResponseCode(HttpURLConnection.HTTP_OK).getConnection();
+
+        //3. When authentication is explicitly set to false in server.xml, metrics enpoint does not require authentication,
+        // i.e. is public
+
+        setMetricsAuthConfig(server, false);
+        waitForMetricsEndpoint(server);
+        MetricsConnection authenticationFalse = MetricsConnection.publicConnection(server);
+        //Thread.sleep(5000);
+        authenticationFalse.expectedResponseCode(HttpURLConnection.HTTP_OK).getConnection();
+
+        //4. When mpMetrics authentication option is removed from the server.xml,
+        // the default metrics endpoint requires authentication
+
+        setMetricsAuthConfig(server, null);
+        waitForMetricsEndpoint(server);
+        MetricsConnection authenticationRemoved = MetricsConnection.privateConnection(server);
+        authenticationRemoved.expectedResponseCode(HttpURLConnection.HTTP_OK).getConnection();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.metrics_fat/publish/servers/MetricsAuthenticationServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/publish/servers/MetricsAuthenticationServer/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.microprofile.metrics_fat/publish/servers/MetricsAuthenticationServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/publish/servers/MetricsAuthenticationServer/server.xml
@@ -1,0 +1,9 @@
+<server description="mpMetrics authentication server">
+    <featureManager />
+    
+    <include location="../fatTestPorts.xml" />
+
+	<quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <keyStore id="defaultKeyStore" password="Liberty"/>
+
+</server>

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/MPMetricsElement.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/MPMetricsElement.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.simplicity.config;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+/**
+ *
+ */
+public class MPMetricsElement {
+
+    private Boolean authentication;
+
+    public Boolean getAuthentication() {
+        return authentication;
+    }
+
+    @XmlAttribute(name = "authentication")
+    public void setAuthentication(Boolean authentication) {
+        this.authentication = authentication;
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer("mpMetricsElement [");
+        sb.append("authentication=").append(authentication);
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/ServerConfiguration.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/ServerConfiguration.java
@@ -234,6 +234,9 @@ public class ServerConfiguration implements Cloneable {
     @XmlElement(name = "apiDiscovery")
     private APIDiscoveryElement apiDiscoveryElement;
 
+    @XmlElement(name = "mpMetrics")
+    private MPMetricsElement mpMetricsElement;
+
     @XmlElement(name = "openapi")
     private OpenAPIElement openAPIElement;
 
@@ -611,6 +614,14 @@ public class ServerConfiguration implements Cloneable {
         return this.openAPIElement;
     }
 
+    public MPMetricsElement getMPMetricsElement() {
+        if (this.mpMetricsElement == null) {
+            this.mpMetricsElement = new MPMetricsElement();
+        }
+
+        return this.mpMetricsElement;
+    }
+
     /**
      * @return the Jsp configuration for this server
      */
@@ -708,7 +719,7 @@ public class ServerConfiguration implements Cloneable {
      * Removes all applications with a specific name
      *
      * @param name
-     *                 the name of the applications to remove
+     *            the name of the applications to remove
      * @return the removed applications (no longer bound to the server
      *         configuration)
      */
@@ -729,12 +740,12 @@ public class ServerConfiguration implements Cloneable {
      * a specific name if it already exists
      *
      * @param name
-     *                 the name of the application
+     *            the name of the application
      * @param path
-     *                 the fully qualified path to the application archive on the
-     *                 liberty machine
+     *            the fully qualified path to the application archive on the
+     *            liberty machine
      * @param type
-     *                 the type of the application (ear/war/etc)
+     *            the type of the application (ear/war/etc)
      * @return the deployed application
      */
     public Application addApplication(String name, String path, String type) {
@@ -1018,7 +1029,7 @@ public class ServerConfiguration implements Cloneable {
      * Finds all of the objects in the given config element that implement the
      * ModifiableConfigElement interface.
      *
-     * @param element                  The config element to check.
+     * @param element The config element to check.
      * @param modifiableConfigElements The list containing all modifiable elements.
      * @throws Exception
      */


### PR DESCRIPTION
This PR contains additional test cases for authentication config in com.ibm.ws.microprofile.metrics_fat for mpMetrics-1.0 and mpMetrics-1.1 features

Re-opening, bcz original PRs #4615 and #4644 were closed when branches were deleted.

This PR is for issue #4504