### PR TITLE
Issue #3675: Fix J2Sec problems in EJBContainer FATs

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 task addEJBTools(type: Copy) {
   from configurations.ejbTools
   into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.injection.fat.server/lib/global"
+  rename 'com.ibm.ws.ejbcontainer.fat_tools-(.*).jar', 'com.ibm.ws.ejbcontainer.fat_tools.jar'
 }
 
 addRequiredLibraries {

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/RemoteInjectionTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/RemoteInjectionTest.java
@@ -8,7 +8,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
 package com.ibm.ws.ejbcontainer.injection.fat.tests;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -36,7 +35,6 @@ import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 public class RemoteInjectionTest {
-
     @Server("com.ibm.ws.ejbcontainer.injection.fat.server")
     @TestServlets({ @TestServlet(servlet = SFEnvInjectionServlet.class, contextRoot = "EJB3INJSAWeb"),
                     @TestServlet(servlet = SFRemoteEnvInjectionServlet.class, contextRoot = "EJB3INJSAWeb"),
@@ -49,20 +47,18 @@ public class RemoteInjectionTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        //Use ShrinkHelper to build the Ear
+        // Use ShrinkHelper to build the ear
 
         JavaArchive EJB3INJSABeanJar = ShrinkHelper.buildJavaArchive("EJB3INJSABean.jar", "com.ibm.ws.ejbcontainer.injection.ann.ejb.");
         WebArchive EJB3INJSAWeb = ShrinkHelper.buildDefaultApp("EJB3INJSAWeb.war", "com.ibm.ws.ejbcontainer.injection.ann.web.");
 
         EnterpriseArchive EJB3INJSATestApp = ShrinkWrap.create(EnterpriseArchive.class, "EJB3INJSATestApp.ear");
         EJB3INJSATestApp.addAsModule(EJB3INJSABeanJar).addAsModule(EJB3INJSAWeb);
-        //This particular app does not have an application.xml, but most will
-        //ShrinkHelper.addDirectory(EJB3INJSATestApp, "test-applications/EJB3INJSATestApp.ear/resources");
+        EJB3INJSATestApp = (EnterpriseArchive) ShrinkHelper.addDirectory(EJB3INJSATestApp, "test-applications/EJB3INJSATestApp.ear/resources");
 
         ShrinkHelper.exportDropinAppToServer(server, EJB3INJSATestApp);
 
         server.startServer();
-
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/publish/servers/com.ibm.ws.ejbcontainer.injection.fat.server/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/publish/servers/com.ibm.ws.ejbcontainer.injection.fat.server/bootstrap.properties
@@ -1,3 +1,2 @@
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:EJBContainer=all:JITDeploy=all:Injection=all
-websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/publish/servers/com.ibm.ws.ejbcontainer.injection.fat.server/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/publish/servers/com.ibm.ws.ejbcontainer.injection.fat.server/server.xml
@@ -9,8 +9,7 @@
     <include location="../fatTestPorts.xml"/>
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
-    
-    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
-    <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
-    <javaPermission className="org.osgi.framework.AdminPermission" name="*" actions="class,resolve"/>
+	
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/EJB3INJSATestApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/EJB3INJSATestApp.ear/resources/META-INF/permissions.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>line.separator</name>
+        <actions>read</actions>
+    </permission> 
+
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission> 
+</permissions>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 task addEJBTools(type: Copy) {
   from configurations.ejbTools
   into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServer/lib/global"
+  rename 'com.ibm.ws.ejbcontainer.fat_tools-(.*).jar', 'com.ibm.ws.ejbcontainer.fat_tools.jar'
 }
 
 addRequiredLibraries {

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/RemoteTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/RemoteTests.java
@@ -136,6 +136,7 @@ public class RemoteTests extends AbstractTest {
 
         EnterpriseArchive EnvEntryApp = ShrinkWrap.create(EnterpriseArchive.class, "EnvEntryApp.ear");
         EnvEntryApp.addAsModule(EnvEntryEJBJar).addAsModule(EnvEntryWeb);
+        EnvEntryApp = (EnterpriseArchive) ShrinkHelper.addDirectory(EnvEntryApp, "test-applications/EnvEntryApp.ear/resources");
 
         ShrinkHelper.exportDropinAppToServer(server, EnvEntryApp);
 
@@ -181,6 +182,7 @@ public class RemoteTests extends AbstractTest {
 
         EnterpriseArchive JitDeployApp = ShrinkWrap.create(EnterpriseArchive.class, "JitDeployApp.ear");
         JitDeployApp.addAsModule(JitDeployEJBJar).addAsModule(JitDeployWeb);
+		JitDeployApp = (EnterpriseArchive) ShrinkHelper.addDirectory(JitDeployApp, "test-applications/JitDeployApp.ear/resources");
 
         ShrinkHelper.exportDropinAppToServer(server, JitDeployApp);
 
@@ -190,6 +192,7 @@ public class RemoteTests extends AbstractTest {
 
         EnterpriseArchive StatelessAnnApp = ShrinkWrap.create(EnterpriseArchive.class, "StatelessAnnTest.ear");
         StatelessAnnApp.addAsModule(StatelessAnnEJBJar).addAsModule(StatelessAnnWeb);
+		StatelessAnnApp = (EnterpriseArchive) ShrinkHelper.addDirectory(StatelessAnnApp, "test-applications/StatelessAnnTest.ear/resources");
 
         ShrinkHelper.exportDropinAppToServer(server, StatelessAnnApp);
 
@@ -204,6 +207,7 @@ public class RemoteTests extends AbstractTest {
         EnterpriseArchive StatelessMixApp = ShrinkWrap.create(EnterpriseArchive.class, "StatelessMixTest.ear");
         StatelessMixApp.addAsModule(StatelessMixASMDescEJBJar).addAsModule(StatelessMixEJBJar).addAsModule(StatelessMixMDCEJBJar).addAsModule(StatelessMixSCEJBJar).addAsModule(StatelessMixWeb);
         StatelessMixApp.addAsLibrary(StatelessMixIntfJar);
+		StatelessMixApp = (EnterpriseArchive) ShrinkHelper.addDirectory(StatelessMixApp, "test-applications/StatelessMixTest.ear/resources");
 
         ShrinkHelper.exportDropinAppToServer(server, StatelessMixApp);
 

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServer/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServer/bootstrap.properties
@@ -1,3 +1,2 @@
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:EJBContainer=all:JITDeploy=all:Injection=all
-websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServer/server.xml
@@ -9,4 +9,7 @@
     <include location="../fatTestPorts.xml"/>
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
+
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+	<javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="testLauncher" actions="read"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/EnvEntryApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/EnvEntryApp.ear/resources/META-INF/permissions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission> 
+</permissions>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/JitDeployApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/JitDeployApp.ear/resources/META-INF/permissions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission> 
+</permissions>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessAnnTest.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessAnnTest.ear/resources/META-INF/permissions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>line.separator</name>
+        <actions>read</actions>
+    </permission>
+
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>testLauncher</name>
+        <actions>read</actions>
+    </permission>
+
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission> 
+</permissions>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessMixTest.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessMixTest.ear/resources/META-INF/permissions.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>testLauncher</name>
+        <actions>read</actions>
+    </permission>
+
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission> 
+</permissions>


### PR DESCRIPTION
Fixing J2Sec issues and removing servers from being exempted in the following FATs:
com.ibm.ws.ejbcontainer.injection_fat
com.ibm.ws.ejbcontainer.remote_fat