### PR TITLE
Update MP Config tests to target 1.3

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.2_fat/publish/servers/ConverterServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat/publish/servers/ConverterServer/server.xml
@@ -7,7 +7,7 @@
 		<feature>cdi-2.0</feature>
 		<feature>servlet-4.0</feature>
 		<feature>componentTest-1.0</feature>
-		<feature>mpConfig-1.2</feature>
+		<feature>mpConfig-1.3</feature>
 	</featureManager>
 
 	<application location="converterApp.war" />

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CDIConfigServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CDIConfigServer/server.xml
@@ -7,6 +7,6 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CDIScopeServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CDIScopeServer/server.xml
@@ -7,6 +7,6 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ClassLoadersServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ClassLoadersServer/server.xml
@@ -7,6 +7,6 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConverterServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConverterServer/server.xml
@@ -7,7 +7,7 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 
 	<application location="converterApp.war" />

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConvertersServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/ConvertersServer/server.xml
@@ -7,6 +7,6 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CustomSourcesServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/CustomSourcesServer/server.xml
@@ -7,6 +7,6 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/DynamicSourcesServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/DynamicSourcesServer/server.xml
@@ -7,6 +7,6 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/OrdForDefaultsServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/OrdForDefaultsServer/server.xml
@@ -7,6 +7,6 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SharedLibUserServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SharedLibUserServer/server.xml
@@ -7,7 +7,7 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 	
 	<variable name="server.xml.variable.value" value="server.xml.variable.v1" />

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SimpleConfigSourcesServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SimpleConfigSourcesServer/server.xml
@@ -7,7 +7,7 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 
 	<variable name="server.xml.variable.value" value="server.xml.variable.v1" />

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SimultaneousRequestsServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/SimultaneousRequestsServer/server.xml
@@ -7,7 +7,7 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 
 <logging traceSpecification="*=info:JCDI=all:com.ibm.ws.webbeans*=all:org.apache.webbeans*=all:org.jboss.weld*=all:com.ibm.ws.cdi*=all"/>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/StressServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/StressServer/server.xml
@@ -7,6 +7,6 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/TypesServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/TypesServer/server.xml
@@ -7,6 +7,6 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-        <feature>mpConfig-1.2</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.config_fat/publish/servers/brokenCDIConfigServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config_fat/publish/servers/brokenCDIConfigServer/server.xml
@@ -7,6 +7,6 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componentTest-1.0</feature>
-    	<feature>mpConfig-1.2</feature>
+    	<feature>mpConfig-1.3</feature>
 	</featureManager>
 </server>


### PR DESCRIPTION
A selection of tests will still be run against older versions but
everything will now run against 1.3.