### PR TITLE
Update components to depend on internal copy of JAXB and CORBA

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.optional.corba-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.optional.corba-1.5.feature
@@ -1,0 +1,18 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.internal.optional.corba-1.5
+visibility=private
+IBM-App-ForceRestart: uninstall, \
+ install
+IBM-Process-Types: client, \
+ server
+Subsystem-Name: OMG CORBA APIs and RMI-IIOP API
+-bundles=\
+  com.ibm.ws.org.apache.yoko.corba.spec.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
+  com.ibm.ws.org.apache.yoko.osgi.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
+  com.ibm.ws.org.apache.servicemix.bundles.bcel.5.2; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
+  com.ibm.ws.org.apache.yoko.rmi.impl.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
+  com.ibm.ws.org.apache.yoko.core.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
+  com.ibm.ws.org.apache.yoko.util.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
+  com.ibm.ws.org.apache.yoko.rmi.spec.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.0.feature
@@ -5,11 +5,15 @@ singleton=true
 IBM-App-ForceRestart: uninstall, \
  install
 Subsystem-Name: Java RESTful Services API 2.0
--features=com.ibm.websphere.appserver.javax.servlet-3.1, \
- com.ibm.websphere.appserver.javax.annotation-1.2; apiJar=false, \
- com.ibm.websphere.appserver.javaeeCompatible-7.0
--bundles=com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
- com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0.1"
+-features=\
+  com.ibm.websphere.appserver.javax.servlet-3.1, \
+  com.ibm.websphere.appserver.javax.annotation-1.2; apiJar=false, \
+  com.ibm.websphere.appserver.javaeeCompatible-7.0
+-bundles=\
+  com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
+  com.ibm.websphere.javaee.activation.1.1; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.activation:activation:1.1",\
+  com.ibm.websphere.javaee.jaxb.2.2; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.bind:jaxb-api:2.2.12", \
+  com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0.1"
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.1.feature
@@ -5,11 +5,15 @@ singleton=true
 IBM-App-ForceRestart: uninstall, \
  install
 Subsystem-Name: Java RESTful Services API 2.1
--features=com.ibm.websphere.appserver.javax.servlet-4.0, \
- com.ibm.websphere.appserver.javax.annotation-1.3; apiJar=false, \
- com.ibm.websphere.appserver.javaeeCompatible-8.0
--bundles=com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
- com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.1"
+-features=\
+  com.ibm.websphere.appserver.javax.servlet-4.0, \
+  com.ibm.websphere.appserver.javax.annotation-1.3; apiJar=false, \
+  com.ibm.websphere.appserver.javaeeCompatible-8.0
+-bundles=\
+  com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
+  com.ibm.websphere.javaee.activation.1.1; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.activation:activation:1.1",\
+  com.ibm.websphere.javaee.jaxb.2.2; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.bind:jaxb-api:2.2.12", \
+  com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.1"
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.managedBeansCore-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.managedBeansCore-1.0.feature
@@ -1,15 +1,19 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.managedBeansCore-1.0
-IBM-API-Package: com.ibm.ejs.container; type="internal", \
- javax.interceptor; type="spec"
--features=com.ibm.websphere.appserver.injection-1.0, \
- com.ibm.websphere.appserver.jndi-1.0, \
- com.ibm.websphere.appserver.containerServices-1.0, \
- com.ibm.websphere.appserver.classloading-1.0, \
- com.ibm.websphere.appserver.anno-1.0
--bundles=com.ibm.ws.jaxrpc.stub, \
- com.ibm.ws.managedobject, \
- com.ibm.ws.ejbcontainer, \
- com.ibm.ws.javaee.dd.ejb
+IBM-API-Package: \
+  com.ibm.ejs.container; type="internal", \
+  javax.interceptor; type="spec"
+-features=\
+  com.ibm.websphere.appserver.injection-1.0, \
+  com.ibm.websphere.appserver.internal.optional.corba-1.5, \
+  com.ibm.websphere.appserver.jndi-1.0, \
+  com.ibm.websphere.appserver.containerServices-1.0, \
+  com.ibm.websphere.appserver.classloading-1.0, \
+  com.ibm.websphere.appserver.anno-1.0
+-bundles=\
+  com.ibm.ws.jaxrpc.stub, \
+  com.ibm.ws.managedobject, \
+  com.ibm.ws.ejbcontainer, \
+  com.ibm.ws.javaee.dd.ejb
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.springBootHandler-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.springBootHandler-1.0.feature
@@ -1,17 +1,21 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.springBootHandler-1.0
 visibility=private
--features= \
+-features=\
  com.ibm.websphere.appserver.artifact-1.0, \
  com.ibm.websphere.appserver.appmanager-1.0, \
+ com.ibm.websphere.appserver.internal.optional.jaxb-2.2,\
  com.ibm.websphere.appserver.javaeePlatform-7.0
--bundles=com.ibm.ws.app.manager.springboot, \
+-bundles=\
+ com.ibm.ws.app.manager.springboot, \
  com.ibm.ws.springboot.support.shutdown, \
  com.ibm.ws.springboot.utility
--files=bin/tools/ws-springbootutil.jar, \
+-files=\
+ bin/tools/ws-springbootutil.jar, \
  bin/springBootUtility; ibm.executable:=true; ibm.file.encoding:=ebcdic, \
  bin/springBootUtility.bat
 kind=ga
 edition=core
-IBM-API-Package: com.ibm.ws.app.manager.springboot.container.config; type="internal", \
+IBM-API-Package: \
+ com.ibm.ws.app.manager.springboot.container.config; type="internal", \
  com.ibm.ws.app.manager.springboot.container; type="internal"

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/batch-1.0/com.ibm.websphere.appserver.batch-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/batch-1.0/com.ibm.websphere.appserver.batch-1.0.feature
@@ -3,30 +3,34 @@ symbolicName=com.ibm.websphere.appserver.batch-1.0
 visibility=public
 IBM-App-ForceRestart: uninstall, \
  install
-IBM-API-Package: javax.batch.api; type="spec", \
- javax.batch.api.chunk; type="spec", \
- javax.batch.api.chunk.listener; type="spec", \
- javax.batch.api.listener; type="spec", \
- javax.batch.api.partition; type="spec", \
- javax.batch.operations; type="spec", \
- javax.batch.runtime; type="spec", \
- javax.batch.runtime.context; type="spec", \
- javax.inject;  type="spec"
+IBM-API-Package: \
+  javax.batch.api; type="spec", \
+  javax.batch.api.chunk; type="spec", \
+  javax.batch.api.chunk.listener; type="spec", \
+  javax.batch.api.listener; type="spec", \
+  javax.batch.api.partition; type="spec", \
+  javax.batch.operations; type="spec", \
+  javax.batch.runtime; type="spec", \
+  javax.batch.runtime.context; type="spec", \
+  javax.inject;  type="spec"
 IBM-ShortName: batch-1.0
 Subsystem-Name: Batch API 1.0
--features=com.ibm.websphere.appserver.javax.cdi-1.2; ibm.tolerates:=2.0,\
- com.ibm.websphere.appserver.jndi-1.0, \
- com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:=4.0, \
- com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3, \
- com.ibm.ws.persistence-1.0, \
- com.ibm.websphere.appserver.contextService-1.0, \
- com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.0, 4.2", \
- com.ibm.websphere.appserver.transaction-1.2, \
- com.ibm.websphere.appserver.javaeeCompatible-7.0; ibm.tolerates:=8.0
--bundles=com.ibm.jbatch.spi, \
- com.ibm.ws.security.credentials, \
- com.ibm.websphere.security, \
- com.ibm.jbatch.container, \
- com.ibm.websphere.javaee.batch.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.batch:javax.batch-api:1.0.1"
+-features=\
+  com.ibm.websphere.appserver.internal.optional.jaxb-2.2,\
+  com.ibm.websphere.appserver.javax.cdi-1.2; ibm.tolerates:=2.0,\
+  com.ibm.websphere.appserver.jndi-1.0, \
+  com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:=4.0, \
+  com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3, \
+  com.ibm.ws.persistence-1.0, \
+  com.ibm.websphere.appserver.contextService-1.0, \
+  com.ibm.websphere.appserver.jdbc-4.1; ibm.tolerates:="4.0, 4.2", \
+  com.ibm.websphere.appserver.transaction-1.2, \
+  com.ibm.websphere.appserver.javaeeCompatible-7.0; ibm.tolerates:=8.0
+-bundles=\
+  com.ibm.jbatch.spi, \
+  com.ibm.ws.security.credentials, \
+  com.ibm.websphere.security, \
+  com.ibm.jbatch.container, \
+  com.ibm.websphere.javaee.batch.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.batch:javax.batch-api:1.0.1"
 kind=ga
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-1.2/com.ibm.websphere.appserver.cdi-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-1.2/com.ibm.websphere.appserver.cdi-1.2.feature
@@ -56,6 +56,8 @@ Subsystem-Name: Contexts and Dependency Injection 1.2
  com.ibm.ws.cdi.weld, \
  com.ibm.ws.cdi.internal, \
  com.ibm.ws.cdi.1.2.weld, \
+ com.ibm.websphere.javaee.jaxb.2.2; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.bind:jaxb-api:2.2.12", \
+ com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.ws:jaxws-api:2.2.12", \
  com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
  com.ibm.ws.cdi.interfaces
 -jars=com.ibm.websphere.appserver.thirdparty.cdi; location:="dev/api/third-party/,lib/"; mavenCoordinates="org.jboss.weld:weld-osgi-bundle:2.4.7.Final"

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
@@ -61,6 +61,8 @@ Subsystem-Name: Contexts and Dependency Injection 2.0
  com.ibm.ws.cdi.weld, \
  com.ibm.ws.cdi.internal, \
  com.ibm.ws.cdi.2.0.weld, \
+ com.ibm.websphere.javaee.jaxb.2.2; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/",\
+ com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/", \
  com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
  com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.websocket:javax.websocket-api:1.1", \
  com.ibm.ws.cdi.interfaces

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaspic-1.1/com.ibm.websphere.appserver.jaspic-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaspic-1.1/com.ibm.websphere.appserver.jaspic-1.1.feature
@@ -1,17 +1,22 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.jaspic-1.1
 visibility=public
-IBM-API-Package: javax.security.auth.message; type="spec", \
- javax.security.auth.message.callback; type="spec", \
- javax.security.auth.message.config; type="spec", \
- javax.security.auth.message.module; type="spec"
+IBM-API-Package: \
+  javax.security.auth.message; type="spec", \
+  javax.security.auth.message.callback; type="spec", \
+  javax.security.auth.message.config; type="spec", \
+  javax.security.auth.message.module; type="spec"
 IBM-ShortName: jaspic-1.1
-IBM-SPI-Package: com.ibm.wsspi.security.jaspi; type="ibm-spi"
+IBM-SPI-Package: \
+  com.ibm.wsspi.security.jaspi; type="ibm-spi"
 Subsystem-Name: Java Authentication SPI for Containers 1.1
--features=com.ibm.websphere.appserver.appSecurity-2.0; ibm.tolerates:=3.0, \
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1, 4.0"
--bundles=com.ibm.websphere.javaee.jaspic.1.1; location:=dev/api/spec/; mavenCoordinates="javax.security.auth.message:javax.security.auth.message-api:1.1", \
- com.ibm.ws.security.jaspic.1.1
+-features=\
+  com.ibm.websphere.appserver.appSecurity-2.0; ibm.tolerates:=3.0, \
+  com.ibm.websphere.appserver.internal.optional.jaxb-2.2, \
+  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1, 4.0"
+-bundles=\
+  com.ibm.websphere.javaee.jaspic.1.1; location:=dev/api/spec/; mavenCoordinates="javax.security.auth.message:javax.security.auth.message-api:1.1", \
+  com.ibm.ws.security.jaspic.1.1
 kind=ga
 edition=core
 -jars=com.ibm.websphere.appserver.spi.jaspic; location:=dev/spi/ibm/

--- a/dev/com.ibm.ws.ejbcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer/bnd.bnd
@@ -37,7 +37,8 @@ Import-Package: \
   *
 
 DynamicImport-Package: \
-  org.omg.stub.java.rmi
+  org.omg.stub.java.rmi,\
+  javax.xml.bind
 
 Export-Package: \
   com.ibm.ejs.container;-split-package:=merge-first, \


### PR DESCRIPTION
Updates batch, jaxrs, springboot, cdi, and jaspic features to depend on internal copies of JAX-B/CORBA APIs.

Also removes EJB's dependency on JAX-B code for JDK 9+.