### PR TITLE
MP Rest Client CompletionStage completing for subsequent stages

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/common/logging/LogUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/common/logging/LogUtils.java
@@ -23,8 +23,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
@@ -106,7 +104,7 @@ public final class LogUtils {
 //                    Class<?> fcls = cls.getMethod("getILoggerFactory").invoke(null).getClass();
 //                    String clsName = fcls.getName();
 //                    if (clsName.contains("NOPLogger")) {
-//                        //no real slf4j implementation, use j.u.l 
+//                        //no real slf4j implementation, use j.u.l
 //                        cname = null;
 //                    } else if (clsName.contains("Log4j")) {
 //                        cname = "org.apache.cxf.common.logging.Log4jLogger";
@@ -118,7 +116,7 @@ public final class LogUtils {
 //                        }
 //                    } else if (clsName.contains("JDK14")
 //                               || clsName.contains("pax.logging")) {
-//                        //both of these we can use the appropriate j.u.l API's 
+//                        //both of these we can use the appropriate j.u.l API's
 //                        //directly and have it work properly
 //                        cname = null;
 //                    } else {
@@ -157,32 +155,32 @@ public final class LogUtils {
 
     /**
      * Get a Logger with the associated default resource bundle for the class.
-     * 
+     *
      * @param cls the Class to contain the Logger
      * @return an appropriate Logger
      */
     public static Logger getLogger(Class<?> cls) {
-        //Liberty Change for CXF Begain
+        //Liberty Change for CXF Begin
         return createLogger(cls, null, cls.getName() + cls.getClassLoader());
         //Liberty Change for CXF End
     }
 
     /**
      * Get a Logger with an associated resource bundle.
-     * 
+     *
      * @param cls the Class to contain the Logger
      * @param resourcename the resource name
      * @return an appropriate Logger
      */
     public static Logger getLogger(Class<?> cls, String resourcename) {
-        //Liberty Change for CXF Begain
+        //Liberty Change for CXF Begin
         return createLogger(cls, resourcename, cls.getName() + cls.getClassLoader());
         //Liberty Change for CXF End
     }
 
     /**
      * Get a Logger with an associated resource bundle.
-     * 
+     *
      * @param cls the Class to contain the Logger (to find resources)
      * @param resourcename the resource name
      * @param loggerName the full name for the logger
@@ -196,32 +194,32 @@ public final class LogUtils {
 
     /**
      * Get a Logger with the associated default resource bundle for the class.
-     * 
+     *
      * @param cls the Class to contain the Logger
      * @return an appropriate Logger
      */
     public static Logger getL7dLogger(Class<?> cls) {
-        //Liberty Change for CXF Begain
-        return createLogger(cls, null, cls.getName() + cls.getClassLoader());
+        //Liberty Change for CXF Begin
+        return createLogger(cls, null, cls.getName() + getClassLoader(cls));
         //Liberty Change for CXF End
     }
 
     /**
      * Get a Logger with an associated resource bundle.
-     * 
+     *
      * @param cls the Class to contain the Logger
      * @param resourcename the resource name
      * @return an appropriate Logger
      */
     public static Logger getL7dLogger(Class<?> cls, String resourcename) {
-        //Liberty Change for CXF Begain
+        //Liberty Change for CXF Begin
         return createLogger(cls, resourcename, cls.getName() + cls.getClassLoader());
         //Liberty Change for CXF End
     }
 
     /**
      * Get a Logger with an associated resource bundle.
-     * 
+     *
      * @param cls the Class to contain the Logger (to find resources)
      * @param resourcename the resource name
      * @param loggerName the full name for the logger
@@ -250,7 +248,7 @@ public final class LogUtils {
             Logger logger = null;
             ResourceBundle b = null;
             if (bundleName == null) {
-                //grab the bundle prior to the call to Logger.getLogger(...) so the 
+                //grab the bundle prior to the call to Logger.getLogger(...) so the
                 //ResourceBundle can be loaded outside the big sync block that getLogger really is
                 bundleName = BundleUtils.getBundleName(cls);
                 try {
@@ -336,6 +334,7 @@ public final class LogUtils {
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                @Override
                 public ClassLoader run() {
                     return Thread.currentThread().getContextClassLoader();
                 }
@@ -348,6 +347,7 @@ public final class LogUtils {
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                @Override
                 public ClassLoader run() {
                     return clazz.getClassLoader();
                 }
@@ -357,7 +357,7 @@ public final class LogUtils {
     }
     /**
      * Allows both parameter substitution and a typed Throwable to be logged.
-     * 
+     *
      * @param logger the Logger the log to
      * @param level the severity level
      * @param message the log message
@@ -378,7 +378,7 @@ public final class LogUtils {
 
     /**
      * Allows both parameter substitution and a typed Throwable to be logged.
-     * 
+     *
      * @param logger the Logger the log to
      * @param level the severity level
      * @param message the log message
@@ -399,7 +399,7 @@ public final class LogUtils {
 
     /**
      * Checks log level and logs
-     * 
+     *
      * @param logger the Logger the log to
      * @param level the severity level
      * @param message the log message
@@ -412,7 +412,7 @@ public final class LogUtils {
 
     /**
      * Checks log level and logs
-     * 
+     *
      * @param logger the Logger the log to
      * @param level the severity level
      * @param message the log message
@@ -427,7 +427,7 @@ public final class LogUtils {
 
     /**
      * Checks log level and logs
-     * 
+     *
      * @param logger the Logger the log to
      * @param level the severity level
      * @param message the log message
@@ -442,7 +442,7 @@ public final class LogUtils {
 
     /**
      * Checks log level and logs
-     * 
+     *
      * @param logger the Logger the log to
      * @param level the severity level
      * @param message the log message
@@ -492,7 +492,7 @@ public final class LogUtils {
     /**
      * Retrieve localized message retrieved from a logger's resource
      * bundle.
-     * 
+     *
      * @param logger the Logger
      * @param message the message to be localized
      */

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/client/AbstractClient.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/client/AbstractClient.java
@@ -104,6 +104,7 @@ import org.apache.cxf.transport.MessageObserver;
  *
  */
 public abstract class AbstractClient implements Client {
+    protected static final String EXECUTOR_SERVICE_PROPERTY = "executorService"; //Liberty change for MP Rest Client 1.1
     protected static final String REQUEST_CONTEXT = "RequestContext";
     protected static final String RESPONSE_CONTEXT = "ResponseContext";
     protected static final String KEEP_CONDUIT_ALIVE = "KeepConduitAlive";

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/.classpath
@@ -6,6 +6,7 @@
 	<classpathentry kind="src" path="test-applications/basicCdiClientApp/src"/>
 	<classpathentry kind="src" path="test-applications/headerPropagationApp/src"/>
 	<classpathentry kind="src" path="test-applications/multiClientCdiApp/src"/>
+	<classpathentry kind="src" path="test-applications/asyncApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
@@ -13,6 +13,7 @@ bVersion=1.0
 
 src: \
   fat/src,\
+  test-applications/asyncApp/src,\
   test-applications/basicClientApp/src,\
   test-applications/basicCdiClientApp/src,\
   test-applications/basicRemoteApp/src,\
@@ -29,6 +30,7 @@ javac.target: 1.8
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
 	com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.rest.client.1.0;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.rest.client.1.1;version=latest,\
 	com.ibm.ws.cdi.interfaces;version=latest,\
-	com.ibm.websphere.javaee.jsonp.1.0;version=latest
+	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
+	com.ibm.websphere.javaee.jsonb.1.0;version=latest

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.rest.client.fat;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import mpRestClient11.async.AsyncTestServlet;
+
+@RunWith(FATRunner.class)
+public class AsyncMethodTest extends FATServletClient {
+
+    private static final String appName = "asyncApp";
+
+    /*
+     * We need two servers to clearly distiguish that the "client" server
+     * only has the client features enabled - it includes mpRestClient-1.0
+     * which includes the jaxrsClient-2.0 feature, but not the jaxrs-2.0
+     * feature that contains server code. The client should be able to
+     * work on its own - by splitting out the "server" server into it's
+     * own server, we can verify this.
+     */
+    @Server("mpRestClient11.async")
+    @TestServlet(servlet = AsyncTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient11.async");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 BasicCdiTest.class,
                 BasicCdiInEE8Test.class,
                 HeaderPropagationTest.class,
-                MultiClientCdiTest.class
+                MultiClientCdiTest.class,
+                AsyncMethodTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/bootstrap.properties
@@ -1,0 +1,12 @@
+com.ibm.ws.logging.trace.specification=*=info:\
+com.ibm.ws.jaxrs2*=all:\
+com.ibm.websphere.jaxrs2*=all:\
+org.apache.cxf.*=all:\
+com.ibm.ws.microprofile.rest.*=all:\
+com.ibm.websphere.microprofile.rest.*=all
+
+com.ibm.ws.logging.max.file.size=0
+
+osgi.console=5678
+
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/server.xml
@@ -1,0 +1,15 @@
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>jaxrs-2.1</feature>
+        <feature>mpRestClient-1.1</feature>
+        <feature>jsonb-1.0</feature>
+        <feature>concurrent-1.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission className="java.util.logging.LoggingPermission" name="control" actions=""/>
+    <javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/resources/META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/resources/META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener
@@ -1,0 +1,1 @@
+mpRestClient11.async.RestClientAuditLogger

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountInfo.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountInfo.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+public class AccountInfo {
+
+    String customerName;
+    String accountNumber;
+    
+    public AccountInfo() {}
+    public AccountInfo(String customerName, String accountNumber) {
+        this.customerName = customerName;
+        this.accountNumber = accountNumber;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+    
+    public String getCustomerName() {
+        return customerName;
+    }
+    public void setCustomerName(String customerName) {
+        this.customerName = customerName;
+    }
+    
+    @Override
+    public String toString() {
+        return "AccountInfo(" + customerName + ", " + accountNumber + ")";
+    }
+    
+}
+

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountInfoListReaderWriter.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountInfoListReaderWriter.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class AccountInfoListReaderWriter
+        implements MessageBodyReader<List<AccountInfo>>, MessageBodyWriter<List<AccountInfo>> {
+
+    @Override
+    public long getSize(List<AccountInfo> arg0, Class<?> arg1, Type arg2, Annotation[] arg3, MediaType arg4) {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> clazz, Type type, Annotation[] annos, MediaType mt) {
+        return clazz == List.class && mt.equals(MediaType.APPLICATION_JSON_TYPE);
+    }
+
+    @Override
+    public void writeTo(List<AccountInfo> list, Class<?> clazz, Type type, Annotation[] annos, MediaType mt,
+            MultivaluedMap<String, Object> headers, OutputStream os) throws IOException, WebApplicationException {
+        Jsonb jsonb = JsonbBuilder.create();
+        String result = jsonb.toJson(list);
+        os.write(result.getBytes());
+        os.flush();
+    }
+
+    @Override
+    public boolean isReadable(Class<?> clazz, Type type, Annotation[] anno, MediaType mt) {
+        return clazz == List.class && mt.equals(MediaType.APPLICATION_JSON_TYPE);
+    }
+
+    @SuppressWarnings("serial")
+    @Override
+    public List<AccountInfo> readFrom(Class<List<AccountInfo>> clazz, Type type, Annotation[] anno, MediaType mt,
+            MultivaluedMap<String, String> headers, InputStream is) throws IOException, WebApplicationException {
+        int size = Integer.parseInt( headers.getFirst(HttpHeaders.CONTENT_LENGTH) );
+        byte[] buf = new byte[size];
+        is.read(buf);
+        String json = new String(buf);
+        Jsonb jsonb = JsonbBuilder.create();
+        return jsonb.fromJson(json, new ArrayList<AccountInfo>(){}.getClass().getGenericSuperclass());
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountsPayableClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountsPayableClient.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@Path("/accountsPayable")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface AccountsPayableClient {
+
+    @GET
+    @Path("/accounts")
+    CompletionStage<List<AccountInfo>> getAllAccounts();
+    
+    @GET
+    @Path("/accountInfo")
+    CompletionStage<AccountInfo> accountDetails(@QueryParam("acct") String acctNumber) throws UnknownAccountException;
+    
+    @GET
+    @Path("/accountBalance")
+    CompletionStage<Double> checkBalance(@QueryParam("acct")String acctNumber) throws UnknownAccountException;
+    
+    @POST
+    @Path("/pay")
+    CompletionStage<Double> /*remaining balance*/ pay(@QueryParam("acct")String acctNumber, Payment payment) 
+        throws UnknownAccountException, InsufficientFundsException;
+    
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountsPayableService.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountsPayableService.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+@Path("/accountsPayable")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class AccountsPayableService {
+    private final static Logger _log = Logger.getLogger(AccountsPayableService.class.getName());
+    
+    static final Map<String,AccountInfo> accountInfos = new ConcurrentHashMap<>();
+    static final Map<String,Double> accountBalances = new ConcurrentHashMap<>();
+    static final BankAccountClient bankAccountClient;
+    
+    static {
+        accountInfos.put("12300567", new AccountInfo("abc123", "12300567"));
+        accountInfos.put("12300678", new AccountInfo("xyz789", "12300678"));
+        accountInfos.put("12300946", new AccountInfo("qrs456", "12300946"));
+        accountInfos.put("12300444", new AccountInfo("mno852", "12300444"));
+        accountInfos.put("12300963", new AccountInfo("ijk147", "12300963"));
+        
+        accountBalances.put("12300567", 560.50);
+        accountBalances.put("12300678", 300.75);
+        accountBalances.put("12300946", 50.25);
+        accountBalances.put("12300444", 250.00);
+        accountBalances.put("12300963", 2287.35);
+        
+        bankAccountClient = RestClientBuilder.newBuilder().baseUri(URI.create(AsyncTestServlet.URI_CONTEXT_ROOT)).build(BankAccountClient.class);
+    }
+    
+    @GET
+    @Path("/accounts")
+    public List<AccountInfo> getAllAccounts() {
+        _log.info("getAllAccounts " + accountInfos.values());
+        return Arrays.asList(accountInfos.values().toArray(new AccountInfo[]{}));
+    }
+    
+    @GET
+    @Path("/accountInfo")
+    public AccountInfo accountDetails(@QueryParam("acct") String acctNumber) throws UnknownAccountException {
+        AccountInfo info = accountInfos.get(acctNumber);
+        _log.info("accountDetails " + acctNumber + " " + info);
+        if (info == null) {
+            throw new UnknownAccountException();
+        }
+        return info;
+    }
+    
+    @GET
+    @Path("/accountBalance")
+    public Double checkBalance(@QueryParam("acct")String acctNumber) throws UnknownAccountException {
+        Double balance = accountBalances.get(acctNumber);
+        _log.info("checkBalance " + acctNumber + " " + balance);
+        if (balance == null) {
+            throw new UnknownAccountException();
+        }
+        return balance;
+    }
+    
+    @POST
+    @Path("/pay")
+    public Double pay(@QueryParam("acct")String acctNumber, Payment payment) throws UnknownAccountException, InsufficientFundsException {
+        
+        Double balance = accountBalances.get(acctNumber);
+        if (balance == null) {
+            throw new UnknownAccountException();
+        }
+
+        Double paymentAmt = payment.getAmount();
+        bankAccountClient.withdraw(paymentAmt);
+
+        Double remainingBalance = balance - paymentAmt;
+        accountBalances.put(acctNumber, remainingBalance);
+        _log.info("pay " + acctNumber + " " + remainingBalance);
+        return remainingBalance;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/App.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/App.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class App extends Application {
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AsyncTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AsyncTestServlet.java
@@ -1,0 +1,231 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/AsyncTestServlet")
+public class AsyncTestServlet extends FATServlet {
+    private final static Logger _log = Logger.getLogger(AsyncTestServlet.class.getName());
+
+    final static String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/asyncApp/";
+
+    @Resource
+    ExecutorService executor;
+
+    /**
+     * Tests multi-stage CompletionStage (async) from a Rest Client.
+     * Tests baseUri API.
+     * 
+     */
+    @Test
+    public void testMultiStageAsyncRestClientMethod(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        AccountsPayableClient acctsPayable = RestClientBuilder.newBuilder()
+                        .register(AccountInfoListReaderWriter.class)
+                        .register(DoubleReader.class)
+                        .executorService(executor)
+                        .baseUri(URI.create(URI_CONTEXT_ROOT))
+                        .build(AccountsPayableClient.class);
+        BankAccountClient bank = RestClientBuilder.newBuilder()
+                        .register(DoubleReader.class)
+                        .executorService(executor)
+                        .baseUri(URI.create(URI_CONTEXT_ROOT))
+                        .build(BankAccountClient.class);
+
+        List<AccountInfo> paidInFull = Collections.synchronizedList(new ArrayList<>());
+        DoubleAdder stillOwe = new DoubleAdder();
+        AtomicBoolean timedOut = new AtomicBoolean(false);
+        AtomicInteger numOfAccounts = new AtomicInteger(0);
+        CompletionStage<List<AccountInfo>> cs = acctsPayable.getAllAccounts();
+        CompletionStage<Void> cs2 = cs.thenAccept(accounts -> {
+            if (!numOfAccounts.compareAndSet(0, accounts.size())) {
+                _log.info("Unexpected initial value for numOfAccounts: " + numOfAccounts.get());
+                numOfAccounts.set(-1);
+            }
+            _log.info("payAccountsThatWeCanPay - applying payment to " + accounts.size() + " accounts");
+            
+            CountDownLatch latch = new CountDownLatch(accounts.size());
+            accounts.forEach(acct -> {
+                try {
+                    _log.info("checking to see if we can pay off account " + acct);
+                    acctsPayable.checkBalance(acct.getAccountNumber()).thenCombine(bank.currentBalance(), (owed, balance) -> {
+                        _log.info("payAccountsThatWeCanPay we owe " + owed + " to account " + acct.accountNumber);
+                        if (balance > owed) {
+                            try {
+                                Double d = acctsPayable.pay(acct.getAccountNumber(), new Payment(owed)).toCompletableFuture().get();
+                                if (d > 0) {
+                                    stillOwe.add(d);
+                                } else {
+                                    paidInFull.add(acct);
+                                }
+                            } catch (InterruptedException | ExecutionException | UnknownAccountException e) {
+                                _log.log(Level.SEVERE, "Unexpected error paying account " + acct.getAccountNumber(), e);
+
+                            } catch (InsufficientFundsException e) {
+                                stillOwe.add(owed);
+                            }
+                        } else {
+                            stillOwe.add(owed);
+                        }
+                        latch.countDown();
+                        return acct;
+                    });
+                } catch (UnknownAccountException e) {
+                    // Unexpected since we've already checked that we owe money on this account - log and continue.
+                    _log.log(Level.SEVERE, "Unexpected error checking balance on account " + acct.getAccountNumber(), e);
+                }
+            });
+            try {
+                timedOut.set(!latch.await(20, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+        try {
+            List<AccountInfo> accts = cs.toCompletableFuture().get(25, TimeUnit.SECONDS);
+            accts.forEach(acctInfo -> {_log.info("listAccounts " + acctInfo);});
+            cs2.toCompletableFuture().get(25, TimeUnit.SECONDS);
+        } catch (TimeoutException ex) {
+            ex.printStackTrace();
+            fail("Timed out... this most likely indicates a slow test machine...");
+        }
+        _log.info("Paid off " + paidInFull.size() + " accounts.  Still owe: " + stillOwe.sum());
+        assertEquals(Boolean.FALSE, timedOut.get());
+        assertEquals(5, numOfAccounts.get());
+        assertEquals(4, paidInFull.size());
+        assertEquals(2287.35, stillOwe.sum(), 0.0);
+    }
+
+    /**
+     * Tests RestClientBuilderListener is executed for new Rest Clients.
+     */
+    @Test
+    public void testRestClientBuilderListener(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        AccountsPayableClient acctsPayable = RestClientBuilder.newBuilder()
+                        .register(AccountInfoListReaderWriter.class)
+                        .register(DoubleReader.class)
+                        .executorService(executor)
+                        .baseUri(URI.create(URI_CONTEXT_ROOT))
+                        .build(AccountsPayableClient.class);
+        BankAccountClient bank = RestClientBuilder.newBuilder()
+                        .register(DoubleReader.class)
+                        .executorService(executor)
+                        .baseUri(URI.create(URI_CONTEXT_ROOT))
+                        .build(BankAccountClient.class);
+        
+        List<String> uris = Collections.synchronizedList(new ArrayList<>());
+        Handler auditLog = new Handler(){
+
+            @Override
+            public void publish(LogRecord record) {
+                uris.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {
+                //no-op
+            }
+
+            @Override
+            public void close() throws SecurityException {
+                // no-op
+            }};
+        RestClientAuditLogger._log.addHandler(auditLog);
+        
+        acctsPayable.getAllAccounts().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertEquals(1, uris.size());
+        assertTrue(uris.get(0).contains("/accountsPayable/accounts"));
+        
+        bank.currentBalance().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertEquals(2, uris.size());
+        assertTrue(uris.get(1).contains("/bank"));
+        
+        acctsPayable.getAllAccounts().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        assertEquals(3, uris.size());
+        assertTrue(uris.get(2).contains("/accountsPayable/accounts"));
+        assertTrue("UniqueURIFilter not invoked", !uris.get(0).equals(uris.get(2)));
+    }
+    
+    @Test
+    public void testCompletionStageCompletesExceptionally(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        BankAccountClient bank = RestClientBuilder.newBuilder()
+                        .register(DoubleReader.class)
+                        .register(InsufficientFundsExceptionMapper.class)
+                        .executorService(executor)
+                        .baseUri(URI.create(URI_CONTEXT_ROOT))
+                        .build(BankAccountClient.class);
+        CountDownLatch latch = new CountDownLatch(1);
+        CompletionStage<Double> cs = bank.withdraw(500000.00);
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+        Double exceptionValue = cs.exceptionally(t -> {
+            _log.log(Level.INFO, "Expected exception", t);
+            exception.set(t);
+            latch.countDown();
+            return -1.0;
+        }).toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        try {
+            Double responseValue = cs.thenApply(d -> {
+                _log.info("Unexpectedly, this withdrawal worked... " + d);
+                latch.countDown();
+                return d;
+            }).toCompletableFuture().get(5, TimeUnit.SECONDS);
+            fail("Failed to throw expected exception");
+        } catch (ExecutionException ex) {
+            Throwable t = ex.getCause();
+            assertEquals(InsufficientFundsException.class.getName(), t.getClass().getName());
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        Throwable t = exception.get();
+        if (t instanceof CompletionException) {
+            t = t.getCause();
+        }
+        assertNotNull(t);
+        assertEquals(InsufficientFundsException.class.getName(), t.getClass().getName());
+        assertEquals(-1.0, exceptionValue, 0.0);
+        
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/BankAccountClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/BankAccountClient.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/bank")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface BankAccountClient {
+
+    @GET
+    CompletionStage<Double> currentBalance();
+    
+    @DELETE
+    @Path("/{amt}")
+    CompletionStage<Double> withdraw(@PathParam("amt") Double amount) throws InsufficientFundsException;
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/BankAccountService.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/BankAccountService.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/bank")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class BankAccountService {
+    private final static Logger _log = Logger.getLogger(BankAccountService.class.getName());
+    
+    static Double balance = 1300.75;
+    
+    @GET
+    public Double currentBalance() {
+        synchronized (balance) {
+            _log.info("currentBalance " + balance);
+            return balance;
+        }
+    }
+    
+    @DELETE
+    @Path("/{amt}")
+    public Double withdraw(@PathParam("amt") Double amount) throws InsufficientFundsException {
+        synchronized (balance) {
+            if (balance < amount) {
+                throw new InsufficientFundsException();
+            }
+            balance = balance - amount;
+            _log.info("withdraw " + amount + " " + balance);
+            return balance;
+        }
+        
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/DoubleReader.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/DoubleReader.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class DoubleReader implements MessageBodyReader<Double> {
+    private final static Logger _log = Logger.getLogger(DoubleReader.class.getName());
+
+    @Context
+    UriInfo uriInfo;
+    
+    @Override
+    public boolean isReadable(Class<?> clazz, Type type, Annotation[] anno, MediaType mt) {
+        return clazz == Double.class && mt.equals(MediaType.APPLICATION_JSON_TYPE);
+    }
+
+    @Override
+    public Double readFrom(Class<Double> clazz, Type type, Annotation[] anno, MediaType mt,
+            MultivaluedMap<String, String> headers, InputStream is) throws IOException, WebApplicationException {
+
+        byte[] buf = new byte[4096];
+        int bytesRead = is.read(buf);
+        if (bytesRead < 0) {
+            _log.log(Level.INFO, "!!! No response body from URI " + uriInfo.getAbsolutePath(), new Throwable());
+            return 0.0;
+        }
+        String json = new String(Arrays.copyOf(buf, bytesRead));
+        
+        Double d;
+        try {
+            d = Double.parseDouble(json);
+        } catch (NumberFormatException ex) {
+            Jsonb jsonb = JsonbBuilder.create();
+            d = jsonb.fromJson(json, Double.class);
+        }
+        _log.info("Response body from URI " + uriInfo.getAbsolutePath() + " = " + json + " ; parsed value is: " + d);
+        return d;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/InsufficientFundsException.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/InsufficientFundsException.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+
+@SuppressWarnings("serial")
+public class InsufficientFundsException extends Exception {
+
+    /**
+     * 
+     */
+    public InsufficientFundsException() {
+    }
+
+    /**
+     * @param message
+     */
+    public InsufficientFundsException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param cause
+     */
+    public InsufficientFundsException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * @param message
+     * @param cause
+     */
+    public InsufficientFundsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * @param message
+     * @param cause
+     * @param enableSuppression
+     * @param writableStackTrace
+     */
+    public InsufficientFundsException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/InsufficientFundsExceptionMapper.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/InsufficientFundsExceptionMapper.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+@Provider
+public class InsufficientFundsExceptionMapper implements ExceptionMapper<InsufficientFundsException>, ResponseExceptionMapper<InsufficientFundsException> {
+
+    /* (non-Javadoc)
+     * @see org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper#toThrowable(javax.ws.rs.core.Response)
+     */
+    @Override
+    public InsufficientFundsException toThrowable(Response response) {
+        if (response.getStatus() == 413) {
+            return new InsufficientFundsException();
+        }
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.ext.ExceptionMapper#toResponse(java.lang.Throwable)
+     */
+    @Override
+    public Response toResponse(InsufficientFundsException ex) {
+        return Response.status(413).build();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/Payment.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/Payment.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+public class Payment {
+
+    Double amount;
+
+    public Payment() {}
+
+    public Payment(Double amount) {
+        this.amount = amount;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Double amount) {
+        this.amount = amount;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/RestClientAuditLogger.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/RestClientAuditLogger.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener;
+
+public class RestClientAuditLogger implements RestClientBuilderListener {
+    static Logger _log = Logger.getLogger(RestClientAuditLogger.class.getName());
+    
+    @Override
+    public void onNewBuilder(RestClientBuilder builder) {
+        builder.register(UniqueURIFilter.class)
+               .register(new ClientRequestFilter() {
+            @Override
+            public void filter(ClientRequestContext ctx) throws IOException {
+                _log.info("New request to: " + ctx.getUri());
+            }});
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/UniqueURIFilter.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/UniqueURIFilter.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Priority(Priorities.USER-1)
+public class UniqueURIFilter implements ClientRequestFilter {
+
+    private static AtomicInteger counter = new AtomicInteger(1);
+    @Override
+    public void filter(ClientRequestContext ctx) throws IOException {
+        String uri = ctx.getUri().toString();
+        char queryMarker = uri.contains("?") ? '&' : '?';
+        ctx.setUri(URI.create(uri + queryMarker + "REQUEST_ID=" + counter.getAndIncrement()));
+
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/UnknownAccountException.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/UnknownAccountException.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.async;
+
+@SuppressWarnings("serial")
+public class UnknownAccountException extends Exception {
+
+    /**
+     * 
+     */
+    public UnknownAccountException() {
+    }
+
+    /**
+     * @param message
+     */
+    public UnknownAccountException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param cause
+     */
+    public UnknownAccountException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * @param message
+     * @param cause
+     */
+    public UnknownAccountException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * @param message
+     * @param cause
+     * @param enableSuppression
+     * @param writableStackTrace
+     */
+    public UnknownAccountException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/org/apache/cxf/jaxrs/client/JaxrsClientCallback.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/org/apache/cxf/jaxrs/client/JaxrsClientCallback.java
@@ -1,0 +1,150 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxrs.client;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.ws.rs.client.InvocationCallback;
+
+import org.apache.cxf.endpoint.ClientCallback;
+
+public class JaxrsClientCallback<T> extends ClientCallback {
+    private final InvocationCallback<T> handler;
+    private final Type outType;
+    private final Class<?> responseClass;
+
+    public JaxrsClientCallback(final InvocationCallback<T> handler,
+                        Class<?> responseClass,
+                        Type outGenericType) {
+        this.handler = handler;
+        this.outType = outGenericType;
+        this.responseClass = responseClass;
+    }
+
+    public InvocationCallback<T> getHandler() {
+        return handler;
+    }
+
+    public Type getOutGenericType() {
+        return outType;
+    }
+    public Class<?> getResponseClass() {
+        return responseClass;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        boolean result = super.cancel(mayInterruptIfRunning);
+        if (result && handler != null) {
+            handler.failed(new CancellationException());
+        }
+        return result;
+    }
+
+    public Future<T> createFuture() {
+        return new JaxrsResponseFuture<T>(this);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void handleResponse(Map<String, Object> ctx, Object[] res) {
+        context = ctx;
+        result = res;
+        if (handler != null) {
+            handler.completed((T)res[0]);
+        }
+        done = true;
+        synchronized (this) {
+            notifyAll();
+        }
+    }
+
+    @Override
+    public void handleException(Map<String, Object> ctx, final Throwable ex) {
+        context = ctx;
+        exception = ex;
+        if (handler != null) {
+            handler.failed(exception);
+        }
+        done = true;
+        synchronized (this) {
+            notifyAll();
+        }
+    }
+
+
+    //Liberty change (default to protected visibility)
+    protected static class JaxrsResponseFuture<T> implements Future<T> {
+        JaxrsClientCallback<T> callback;
+        protected JaxrsResponseFuture(JaxrsClientCallback<T> cb) {
+            callback = cb;
+        }
+
+        public Map<String, Object> getContext() {
+            try {
+                return callback.getResponseContext();
+            } catch (Exception ex) {
+                return null;
+            }
+        }
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return callback.cancel(mayInterruptIfRunning);
+        }
+
+        public T get() throws InterruptedException, ExecutionException {
+            try {
+                return getObject(callback.get()[0]);
+            } catch (InterruptedException ex) {
+                if (callback.handler != null) {
+                    callback.handler.failed(ex);
+                }
+                throw ex;
+            }
+        }
+        public T get(long timeout, TimeUnit unit) throws InterruptedException,
+            ExecutionException, TimeoutException {
+            try {
+                return getObject(callback.get(timeout, unit)[0]);
+            } catch (InterruptedException ex) {
+                if (callback.handler != null) {
+                    callback.handler.failed(ex);
+                }
+                throw ex;
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private T getObject(Object object) {
+            return (T)object;
+        }
+
+        public boolean isCancelled() {
+            return callback.isCancelled();
+        }
+        public boolean isDone() {
+            return callback.isDone();
+        }
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/MPRestClientCallback.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/MPRestClientCallback.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.ws.rs.client.InvocationCallback;
+
+import org.apache.cxf.jaxrs.client.JaxrsClientCallback;
+import org.apache.cxf.message.Message;
+
+public class MPRestClientCallback<T> extends JaxrsClientCallback<T> {
+
+    private final ExecutorService executor;
+    public MPRestClientCallback(InvocationCallback<T> handler,
+                                Message outMessage,
+                                Class<?> responseClass,
+                                Type outGenericType) {
+        super(handler, responseClass, outGenericType);
+        ExecutorService es = outMessage.get(ExecutorService.class);
+        executor = es != null ? es : ForkJoinPool.commonPool();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Future<T> createFuture() {
+        return (Future<T>)CompletableFuture.supplyAsync(() -> {
+            synchronized(this) {
+                if (!isDone()) {
+                    try {
+                        this.wait();
+                    } catch (InterruptedException e) {
+                        throw new CompletionException(e);
+                    }
+                }
+            }
+            if (exception != null) {
+                throw new CompletionException(exception);
+            }
+            if (isCancelled()) {
+                throw new CancellationException();
+            }
+            if (!isDone()) {
+                throw new IllegalStateException("CompletionStage has been notified, indicating completion, but is not completed.");
+            }
+            try {
+                return get()[0];
+            } catch (InterruptedException | ExecutionException e) {
+                throw new CompletionException(e);
+            }
+        }, executor);
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
@@ -1,0 +1,150 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.proxy;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.core.Response;
+
+import org.apache.cxf.jaxrs.client.ClientProxyImpl;
+import org.apache.cxf.jaxrs.client.ClientState;
+import org.apache.cxf.jaxrs.client.JaxrsClientCallback;
+import org.apache.cxf.jaxrs.client.LocalClientState;
+import org.apache.cxf.jaxrs.model.ClassResourceInfo;
+import org.apache.cxf.jaxrs.model.OperationResourceInfo;
+import org.apache.cxf.jaxrs.utils.InjectionUtils;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.microprofile.client.MPRestClientCallback;
+import org.apache.cxf.microprofile.client.MicroProfileClientProviderFactory;
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+public class MicroProfileClientProxyImpl extends ClientProxyImpl {
+
+    private static final InvocationCallback<Object> NO_OP_CALLBACK = new InvocationCallback<Object>() {
+        @Override
+        public void failed(Throwable t) { }
+
+        @Override
+        public void completed(Object o) { }
+    };
+
+    private final MPAsyncInvocationInterceptorImpl aiiImpl = new MPAsyncInvocationInterceptorImpl();
+
+    public MicroProfileClientProxyImpl(URI baseURI, ClassLoader loader, ClassResourceInfo cri,
+                                       boolean isRoot, boolean inheritHeaders, ExecutorService executorService,
+                                       Object... varValues) {
+        super(new LocalClientState(baseURI), loader, cri, isRoot, inheritHeaders, varValues);
+        cfg.getRequestContext().put(EXECUTOR_SERVICE_PROPERTY, executorService);
+    }
+
+    public MicroProfileClientProxyImpl(ClientState initialState, ClassLoader loader, ClassResourceInfo cri,
+                                       boolean isRoot, boolean inheritHeaders, ExecutorService executorService,
+                                       Object... varValues) {
+        super(initialState, loader, cri, isRoot, inheritHeaders, varValues);
+        cfg.getRequestContext().put(EXECUTOR_SERVICE_PROPERTY, executorService);
+    }
+
+
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected InvocationCallback<Object> checkAsyncCallback(OperationResourceInfo ori,
+                                                            Map<String, Object> reqContext,
+                                                            Message outMessage) {
+        InvocationCallback<Object> callback = outMessage.getContent(InvocationCallback.class);
+        if (callback == null && CompletionStage.class.equals(ori.getMethodToInvoke().getReturnType())) {
+            callback = NO_OP_CALLBACK;
+            outMessage.setContent(InvocationCallback.class, callback);
+        }
+        return callback;
+    }
+
+    protected boolean checkAsyncReturnType(OperationResourceInfo ori,
+                                           Map<String, Object> reqContext,
+                                           Message outMessage) {
+        return CompletionStage.class.equals(ori.getMethodToInvoke().getReturnType());
+    }
+
+    @Override
+    protected Object doInvokeAsync(OperationResourceInfo ori, Message outMessage,
+                                   InvocationCallback<Object> asyncCallback) {
+        outMessage.getInterceptorChain().add(aiiImpl);
+        MPAsyncInvocationInterceptorPostAsyncImpl asyncInterceptorImpl = 
+            new MPAsyncInvocationInterceptorPostAsyncImpl(aiiImpl.getInterceptors());
+        try {
+            cfg.getInInterceptors().add(asyncInterceptorImpl);
+
+            super.doInvokeAsync(ori, outMessage, asyncCallback);
+
+            JaxrsClientCallback<?> cb = outMessage.getExchange().get(JaxrsClientCallback.class);
+
+            return cb.createFuture();
+        } finally {
+            cfg.getInInterceptors().remove(asyncInterceptorImpl);
+        }
+    }
+
+    @Override
+    protected JaxrsClientCallback<?> newJaxrsClientCallback(InvocationCallback<Object> asyncCallback,
+                                                            Message outMessage,
+                                                            Class<?> responseClass,
+                                                            Type outGenericType) {
+        return new MPRestClientCallback<Object>(asyncCallback, outMessage, responseClass, outGenericType);
+    }
+
+    @Override
+    protected void checkResponse(Method m, Response r, Message inMessage) throws Throwable {
+        MicroProfileClientProviderFactory factory = MicroProfileClientProviderFactory.getInstance(inMessage);
+        List<ResponseExceptionMapper<?>> mappers = factory.createResponseExceptionMapper(inMessage,
+                Throwable.class);
+        for (ResponseExceptionMapper<?> mapper : mappers) {
+            if (mapper.handles(r.getStatus(), r.getHeaders())) {
+                Throwable t = mapper.toThrowable(r);
+                if (t instanceof RuntimeException) {
+                    throw t;
+                } else if (t != null && m.getExceptionTypes() != null) {
+                    // its a checked exception, make sure its declared
+                    for (Class<?> c : m.getExceptionTypes()) {
+                        if (t.getClass().isAssignableFrom(c)) {
+                            throw t;
+                        }
+                    }
+                    // TODO Log the unhandled declarable
+                }
+            }
+        }
+    }
+
+    @Override
+    protected Class<?> getReturnType(Method method, Message outMessage) {
+        Class<?> returnType = super.getReturnType(method, outMessage);
+        if (CompletionStage.class.isAssignableFrom(returnType)) {
+            Type t = method.getGenericReturnType();
+            returnType = InjectionUtils.getActualType(t);
+        }
+        return returnType;
+    }
+}


### PR DESCRIPTION
This fixes an issue where the CompletionStage returned by instances of
MicroProfile Rest Client interfaces do not execute subsequent stages.
The method completes normally and the remote invocation occurred
asynchronously, but if the user attempted a `then*` type method on the
returned `CompletionStage`, that stage would not execute because the
internal implementation assumed that the initial stage was not complete.
This fix resolves that issue.

This is a fix for a feature that is not yet released, so it is not a release bug.

This PR also include FAT tests for the above issue, but also for `RestClientBuilderListener` and exception path cases with `CompletionStage` responses.