### PR TITLE
Add option to ignore unittest failures

### DIFF
--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -333,6 +333,7 @@ compileJava {
 }
 
 test {
+  ignoreFailures = Boolean.valueOf(rootProject.ext.generatedProps.getProperty("gradle.test.ignoreFailures", "false"))
   environment("WLP_INSTALL_DIR", buildImage.file('wlp'))
   jvmArgs "-Dtest.buildDir=${buildDir}"
   jvmArgs "-Djava.io.tmpdir=${buildDir}/tmp"


### PR DESCRIPTION
Allow users to specify `gradle.test.ignoreFailures` in build properties to ignore unittest failures.