### PR TITLE
Remove liberty change flags for function ported to the cxf community.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/lifecycle/PerRequestResourceProvider.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/lifecycle/PerRequestResourceProvider.java
@@ -51,22 +51,19 @@ public class PerRequestResourceProvider implements ResourceProvider {
     private final Constructor<?> c;
     private final Method postConstructMethod;
     private final Method preDestroyMethod;
-    // Liberty Change for CXF Begin
     private final Class<?>[] params;
     private final Annotation[][] anns;
     private final Type[] genericTypes;
-    //Liberty Change for CXF End
+
     public PerRequestResourceProvider(Class<?> clazz) {
         c = ResourceUtils.findResourceConstructor(clazz, true);
         if (c == null) {
             throw new RuntimeException("Resource class " + clazz
                                        + " has no valid constructor");
         }
-        // Liberty Change for CXF Begin
         params = c.getParameterTypes();
         anns = c.getParameterAnnotations();
         genericTypes = c.getGenericParameterTypes();
-        //Liberty Change for CXF End
         postConstructMethod = ResourceUtils.findPostConstructMethod(clazz);
         preDestroyMethod = ResourceUtils.findPreDestroyMethod(clazz);
     }
@@ -92,9 +89,7 @@ public class PerRequestResourceProvider implements ResourceProvider {
                         (ProviderInfo<?>) m.getExchange().getEndpoint().get(Application.class.getName());
         Map<Class<?>, Object> mapValues = CastUtils.cast(application == null ? null
                         : Collections.singletonMap(Application.class, application.getProvider()));
-        // Liberty Change for CXF Begin
         Object[] values = ResourceUtils.createConstructorArguments(c, m, true, mapValues, params, anns, genericTypes);
-        // Liberty Change for CXF End
         try {
             Object instance = values.length > 0 ? c.newInstance(values) : c.newInstance(new Object[] {});
 //Liberty Change for CXF Begin

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -117,8 +117,6 @@ public final class HttpUtils {
     }
 
     private static String componentEncode(String reservedChars, String value) {
-
-        // Liberty Change for CXF Begin
         StringBuilder buffer = null;
         int length = value.length();
         int startingIndex = 0;
@@ -143,7 +141,6 @@ public final class HttpUtils {
         if (startingIndex < length) {
             buffer.append(urlEncode(value.substring(startingIndex, length)));
         }
-        // Liberty Change for CXF Begin
 
         return buffer.toString();
     }
@@ -195,7 +192,6 @@ public final class HttpUtils {
         }
         Matcher m = ENCODE_PATTERN.matcher(encoded);
 
-        // Liberty Change for CXF Begin
         if (!m.find()) {
             return query ? HttpUtils.queryEncode(encoded) : HttpUtils.pathEncode(encoded);
         }
@@ -210,7 +206,6 @@ public final class HttpUtils {
             i = m.end();
         } while (m.find());
         String tail = encoded.substring(i, length);
-        // Liberty Change for CXF End
         sb.append(query ? HttpUtils.queryEncode(tail) : HttpUtils.pathEncode(tail));
         return sb.toString();
     }
@@ -314,12 +309,14 @@ public final class HttpUtils {
         if (index == 0 || index == value.length() - 1) {
             throw new IllegalArgumentException("Illegal locale value : " + value);
         }
+        
         if (index > 0) {
             language = value.substring(0, index);
             locale = value.substring(index + 1);
         } else {
             language = value;
         }
+        
         if (locale == null) {
             return new Locale(language);
         } else {
@@ -421,6 +418,7 @@ public final class HttpUtils {
         uriStringBuffer.append(uriString);
         return result;
     }
+    
     private static boolean replaceLoopBackAddress(Message m) {
         Object prop = m.getContextualProperty(REPLACE_LOOPBACK_PROPERTY);
         return prop == null || PropertyUtils.isTrue(prop);
@@ -698,6 +696,7 @@ public final class HttpUtils {
 
         return false;
     }
+    
     public static <T> T createServletResourceValue(Message m, Class<T> clazz) {
 
         Object value = null;

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
@@ -882,7 +882,6 @@ public final class ResourceUtils {
                                                       Message m,
                                                       boolean perRequest,
                                                       Map<Class<?>, Object> contextValues) {
-        // Liberty Change for CXF Begin
         Class<?>[] params = c.getParameterTypes();
         Annotation[][] anns = c.getParameterAnnotations();
         Type[] genericTypes = c.getGenericParameterTypes();
@@ -892,14 +891,14 @@ public final class ResourceUtils {
     public static Object[] createConstructorArguments(Constructor<?> c,
                                                       Message m,
                                                       boolean perRequest,
-                                                      Map<Class<?>, Object> contextValues,
+                                                      Map<Class<?>,
+                                                      Object> contextValues,
                                                       Class<?>[] params,
                                                       Annotation[][] anns,
                                                       Type[] genericTypes) {
         if (m == null) {
             m = new MessageImpl();
         }
-        // Liberty Change for CXF End
         @SuppressWarnings("unchecked")
         MultivaluedMap<String, String> templateValues =
             (MultivaluedMap<String, String>)m.get(URITemplate.TEMPLATE_PARAMETERS);
@@ -960,6 +959,7 @@ public final class ResourceUtils {
                 }
             }
         }
+
         // we can get either a provider or resource class here
         for (Object o : singletons) {
             if (isValidProvider(o.getClass())) {
@@ -976,6 +976,7 @@ public final class ResourceUtils {
         if (bus != null) {
             bean.setBus(bus);
         }
+
         String address = "/";
         if (!ignoreAppPath) {
             ApplicationPath appPath = locateApplicationPath(app.getClass());

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/lifecycle/PerRequestResourceProvider.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/lifecycle/PerRequestResourceProvider.java
@@ -51,22 +51,19 @@ public class PerRequestResourceProvider implements ResourceProvider {
     private final Constructor<?> c;
     private final Method postConstructMethod;
     private final Method preDestroyMethod;
-    // Liberty Change for CXF Begin
     private final Class<?>[] params;
     private final Annotation[][] anns;
     private final Type[] genericTypes;
-    //Liberty Change for CXF End
+
     public PerRequestResourceProvider(Class<?> clazz) {
         c = ResourceUtils.findResourceConstructor(clazz, true);
         if (c == null) {
             throw new RuntimeException("Resource class " + clazz
                                        + " has no valid constructor");
         }
-        // Liberty Change for CXF Begin
         params = c.getParameterTypes();
         anns = c.getParameterAnnotations();
         genericTypes = c.getGenericParameterTypes();
-        //Liberty Change for CXF End
         postConstructMethod = ResourceUtils.findPostConstructMethod(clazz);
         preDestroyMethod = ResourceUtils.findPreDestroyMethod(clazz);
     }
@@ -92,9 +89,7 @@ public class PerRequestResourceProvider implements ResourceProvider {
                         (ProviderInfo<?>) m.getExchange().getEndpoint().get(Application.class.getName());
         Map<Class<?>, Object> mapValues = CastUtils.cast(application == null ? null
                         : Collections.singletonMap(Application.class, application.getProvider()));
-        // Liberty Change for CXF Begin
         Object[] values = ResourceUtils.createConstructorArguments(c, m, true, mapValues, params, anns, genericTypes);
-        // Liberty Change for CXF End
         try {
             Object instance = values.length > 0 ? c.newInstance(values) : c.newInstance(new Object[] {});
 //Liberty Change for CXF Begin

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -333,9 +333,7 @@ public abstract class ProviderFactory {
                         if (argCls != null && argCls.isAssignableFrom(contextCls)) {
                             List<MediaType> mTypes = JAXRSUtils.getProduceTypes(
                                                                                 cr.getProvider().getClass().getAnnotation(Produces.class));
-                            //Liberty code change begin
                             if (JAXRSUtils.doMimeTypesIntersect(mTypes, type)) {
-                            //Liberty code change end
                                 injectContextValues(cr, m);
                                 candidates.add((ContextResolver<T>) cr.getProvider());
                             }
@@ -1056,9 +1054,7 @@ public abstract class ProviderFactory {
         MessageBodyReader<?> ep = pi.getProvider();
         List<MediaType> supportedMediaTypes = JAXRSUtils.getProviderConsumeTypes(ep);
 
-        //Liberty code change begin
         return JAXRSUtils.doMimeTypesIntersect(Collections.singletonList(mediaType), supportedMediaTypes);
-        //Liberty code change end
     }
 
     private boolean isReadable(ProviderInfo<MessageBodyReader<?>> pi,

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -25,8 +25,8 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -119,7 +119,6 @@ public final class HttpUtils {
 
     private static String componentEncode(String reservedChars, String value) {
 
-        // Liberty Change for CXF Begin
         StringBuilder buffer = null;
         int length = value.length();
         int startingIndex = 0;
@@ -144,7 +143,6 @@ public final class HttpUtils {
         if (startingIndex < length) {
             buffer.append(urlEncode(value.substring(startingIndex, length)));
         }
-        // Liberty Change for CXF Begin
 
         return buffer.toString();
     }
@@ -196,7 +194,6 @@ public final class HttpUtils {
         }
         Matcher m = ENCODE_PATTERN.matcher(encoded);
 
-        // Liberty Change for CXF Begin
         if (!m.find()) {
             return query ? HttpUtils.queryEncode(encoded) : HttpUtils.pathEncode(encoded);
         }
@@ -211,7 +208,6 @@ public final class HttpUtils {
             i = m.end();
         } while (m.find());
         String tail = encoded.substring(i, length);
-        // Liberty Change for CXF End
         sb.append(query ? HttpUtils.queryEncode(tail) : HttpUtils.pathEncode(tail));
         return sb.toString();
     }
@@ -315,12 +311,14 @@ public final class HttpUtils {
         if (index == 0 || index == value.length() - 1) {
             throw new IllegalArgumentException("Illegal locale value : " + value);
         }
+
         if (index > 0) {
             language = value.substring(0, index);
             locale = value.substring(index + 1);
         } else {
             language = value;
         }
+
         if (locale == null) {
             return new Locale(language);
         }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -568,7 +567,7 @@ public final class JAXRSUtils {
         return logLevel;
     }
 
-    public static List<MediaType> intersectSortMediaTypes(List<MediaType> acceptTypes,
+    private static List<MediaType> intersectSortMediaTypes(List<MediaType> acceptTypes,
                                                           List<MediaType> producesTypes,
                                                           final boolean checkDistance) {
         List<MediaType> all = intersectMimeTypes(acceptTypes, producesTypes, true, checkDistance);
@@ -1443,27 +1442,21 @@ public final class JAXRSUtils {
     public static boolean matchConsumeTypes(MediaType requestContentType,
                                             OperationResourceInfo ori) {
 
-        // Liberty change begin
         return doMimeTypesIntersect(ori.getConsumeTypes(), requestContentType);
-        // Liberty change end
     }
 
     public static boolean matchProduceTypes(MediaType acceptContentType,
                                             OperationResourceInfo ori) {
 
-        // Liberty change begin
         return doMimeTypesIntersect(ori.getProduceTypes(), acceptContentType);
-        // Liberty change end
     }
 
     public static boolean matchMimeTypes(MediaType requestContentType,
                                          MediaType acceptContentType,
                                          OperationResourceInfo ori) {
 
-        // Liberty change begin
-        return doMimeTypesIntersect(ori.getConsumeTypes(), requestContentType) &&
-               doMimeTypesIntersect(ori.getProduceTypes(), acceptContentType);
-        // Liberty change end
+        return doMimeTypesIntersect(ori.getConsumeTypes(), requestContentType)
+                && doMimeTypesIntersect(ori.getProduceTypes(), acceptContentType);
     }
 
     public static List<MediaType> parseMediaTypes(String types) {
@@ -1488,6 +1481,16 @@ public final class JAXRSUtils {
         return acceptValues;
     }
 
+    public static boolean doMimeTypesIntersect(List<MediaType> mimeTypesA, MediaType mimeTypeB) {
+        return doMimeTypesIntersect(mimeTypesA, Collections.singletonList(mimeTypeB));
+    }
+
+    public static boolean doMimeTypesIntersect(List<MediaType> requiredMediaTypes, List<MediaType> userMediaTypes) {
+        final NonAccumulatingIntersector intersector = new NonAccumulatingIntersector();
+        intersectMimeTypes(requiredMediaTypes, userMediaTypes, intersector);
+        return intersector.doIntersect();
+    }
+
     /**
      * intersect two mime types
      *
@@ -1501,47 +1504,18 @@ public final class JAXRSUtils {
         return intersectMimeTypes(requiredMediaTypes, userMediaTypes, addRequiredParamsIfPossible, false);
     }
 
-    // Liberty change begin
-    public static boolean doMimeTypesIntersect(List<MediaType> requiredMediaTypes,
-                                               List<MediaType> userMediaTypes) {
-        for (MediaType requiredType : requiredMediaTypes) {
-            for (MediaType userType : userMediaTypes) {
-                boolean isCompatible = isMediaTypeCompatible(requiredType, userType);
-                if (isCompatible) {
-                    boolean parametersMatched = true;
-                    for (Map.Entry<String, String> entry : userType.getParameters().entrySet()) {
-                        String value = requiredType.getParameters().get(entry.getKey());
-                        if (value != null && entry.getValue() != null
-                            && !(stripDoubleQuotesIfNeeded(value).equals(stripDoubleQuotesIfNeeded(entry.getValue())))) {
-                            if (HTTP_CHARSET_PARAM.equals(entry.getKey())
-                                && value.equalsIgnoreCase(entry.getValue())) {
-                                continue;
-                            }
-                            parametersMatched = false;
-                            break;
-                        }
-                    }
-                    if (!parametersMatched) {
-                        continue;
-                    }
-                    return true;
-                }
-            }
-        }
-        return false;
-
-    }
-
-    public static boolean doMimeTypesIntersect(List<MediaType> mimeTypesA, MediaType mimeTypeB) {
-        return doMimeTypesIntersect(mimeTypesA, Collections.singletonList(mimeTypeB));
-    }
-    // Liberty change end
-
     public static List<MediaType> intersectMimeTypes(List<MediaType> requiredMediaTypes,
                                                      List<MediaType> userMediaTypes,
                                                      boolean addRequiredParamsIfPossible,
                                                      boolean addDistanceParameter) {
-        Set<MediaType> supportedMimeTypeList = new LinkedHashSet<MediaType>();
+        final AccumulatingIntersector intersector = new AccumulatingIntersector(addRequiredParamsIfPossible,
+                addDistanceParameter);
+        intersectMimeTypes(requiredMediaTypes, userMediaTypes, intersector);
+        return new ArrayList<>(intersector.getSupportedMimeTypeList());
+    }
+
+    private static void intersectMimeTypes(List<MediaType> requiredMediaTypes, List<MediaType> userMediaTypes,
+            MimeTypesIntersector intersector) {
 
         for (MediaType requiredType : requiredMediaTypes) {
             for (MediaType userType : userMediaTypes) {
@@ -1550,12 +1524,10 @@ public final class JAXRSUtils {
                     boolean parametersMatched = true;
                     for (Map.Entry<String, String> entry : userType.getParameters().entrySet()) {
                         String value = requiredType.getParameters().get(entry.getKey());
-                        if (value != null && entry.getValue() != null
-                            && !(stripDoubleQuotesIfNeeded(value).equals(
-                                                                         stripDoubleQuotesIfNeeded(entry.getValue())))) {
+                        if (value != null && entry.getValue() != null && !(stripDoubleQuotesIfNeeded(value)
+                                .equals(stripDoubleQuotesIfNeeded(entry.getValue())))) {
 
-                            if (HTTP_CHARSET_PARAM.equals(entry.getKey())
-                                && value.equalsIgnoreCase(entry.getValue())) {
+                            if (HTTP_CHARSET_PARAM.equals(entry.getKey()) && value.equalsIgnoreCase(entry.getValue())) {
                                 continue;
                             }
                             parametersMatched = false;
@@ -1565,38 +1537,13 @@ public final class JAXRSUtils {
                     if (!parametersMatched) {
                         continue;
                     }
-                    boolean requiredTypeWildcard = requiredType.getType().equals(MediaType.MEDIA_TYPE_WILDCARD);
-                    boolean requiredSubTypeWildcard = requiredType.getSubtype().contains(MediaType.MEDIA_TYPE_WILDCARD);
 
-                    String type = requiredTypeWildcard ? userType.getType() : requiredType.getType();
-                    String subtype = requiredSubTypeWildcard ? userType.getSubtype() : requiredType.getSubtype();
-
-                    Map<String, String> parameters = userType.getParameters();
-                    if (addRequiredParamsIfPossible) {
-                        parameters = new LinkedHashMap<String, String>(parameters);
-                        for (Map.Entry<String, String> entry : requiredType.getParameters().entrySet()) {
-                            if (!parameters.containsKey(entry.getKey())) {
-                                parameters.put(entry.getKey(), entry.getValue());
-                            }
-                        }
+                    if (!intersector.intersect(requiredType, userType)) {
+                        return;
                     }
-                    if (addDistanceParameter) {
-                        int distance = 0;
-                        if (requiredTypeWildcard) {
-                            distance++;
-                        }
-                        if (requiredSubTypeWildcard) {
-                            distance++;
-                        }
-                        parameters.put(MEDIA_TYPE_DISTANCE_PARAM, Integer.toString(distance));
-                    }
-                    supportedMimeTypeList.add(new MediaType(type, subtype, parameters));
                 }
             }
         }
-
-        return new ArrayList<>(supportedMimeTypeList);
-
     }
 
     private static String stripDoubleQuotesIfNeeded(String value) {
@@ -1607,7 +1554,7 @@ public final class JAXRSUtils {
         return value;
     }
 
-    public static boolean isMediaTypeCompatible(MediaType requiredType, MediaType userType) {
+    private static boolean isMediaTypeCompatible(MediaType requiredType, MediaType userType) {
         boolean isCompatible = requiredType.isCompatible(userType);
         if (!isCompatible && requiredType.getType().equalsIgnoreCase(userType.getType())) {
             isCompatible = compareCompositeSubtypes(requiredType, userType,

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/ResourceUtils.java
@@ -880,7 +880,6 @@ public final class ResourceUtils {
                                                       Message m,
                                                       boolean perRequest,
                                                       Map<Class<?>, Object> contextValues) {
-        // Liberty Change for CXF Begin
         Class<?>[] params = c.getParameterTypes();
         Annotation[][] anns = c.getParameterAnnotations();
         Type[] genericTypes = c.getGenericParameterTypes();
@@ -890,14 +889,14 @@ public final class ResourceUtils {
     public static Object[] createConstructorArguments(Constructor<?> c,
                                                       Message m,
                                                       boolean perRequest,
-                                                      Map<Class<?>, Object> contextValues,
+                                                      Map<Class<?>,
+                                                      Object> contextValues,
                                                       Class<?>[] params,
                                                       Annotation[][] anns,
                                                       Type[] genericTypes) {
         if (m == null) {
             m = new MessageImpl();
         }
-        // Liberty Change for CXF End
         @SuppressWarnings("unchecked")
         MultivaluedMap<String, String> templateValues =
             (MultivaluedMap<String, String>)m.get(URITemplate.TEMPLATE_PARAMETERS);
@@ -958,6 +957,7 @@ public final class ResourceUtils {
                 }
             }
         }
+
         // we can get either a provider or resource class here
         for (Object o : singletons) {
             if (isValidProvider(o.getClass())) {
@@ -974,6 +974,7 @@ public final class ResourceUtils {
         if (bus != null) {
             bean.setBus(bus);
         }
+
         String address = "/";
         if (!ignoreAppPath) {
             ApplicationPath appPath = locateApplicationPath(app.getClass());
@@ -997,7 +998,6 @@ public final class ResourceUtils {
             bean.getProperties(true).putAll(appProps);
         }
         bean.setApplication(app);
-
         return bean;
     }
 


### PR DESCRIPTION
- Remove liberty change flags for change that went into
https://github.com/apache/cxf/pull/407 and that are now in CXF 3.2.6
that was recently brought into open liberty. This also pulls in the
community way of doing one of the changes that is different than what
IBM originally proposed.
- Remove liberty change flags for changes that went into apache/cxf#407
and that are now in CXF 3.1.16 that was recently brought into open
liberty. This also pulls in the community way of doing one of the
changes that is different than what IBM originally proposed.
- Also update ProviderFactory to use the commonBaseClass as part of the
cache key like is done with the 3.2 code now that that the 3.1 code uses
a commonBase Class.
