### PR TITLE
Fix NPE in ConsumerUtil.validateClaims()

### DIFF
--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
@@ -66,7 +66,6 @@ public class ConsumerUtil {
     }
 
     public JwtToken parseJwt(String jwtString, JwtConsumerConfig config) throws Exception {
-
         return parseJwt(jwtString, config, null);
     }
 
@@ -85,8 +84,7 @@ public class ConsumerUtil {
         return jwtContext;
     }
 
-    JwtContext getSigningKeyAndParseJwtWithValidation(String jwtString, JwtConsumerConfig config, JwtContext jwtContext,
-            Map properties) throws Exception {
+    JwtContext getSigningKeyAndParseJwtWithValidation(String jwtString, JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws Exception {
         Key signingKey = getSigningKey(config, jwtContext, properties);
         return parseJwtWithValidation(jwtString, jwtContext, config, signingKey, properties);
     }
@@ -106,11 +104,9 @@ public class ConsumerUtil {
     void throwExceptionIfJwtReused(JwtTokenConsumerImpl jwt) throws InvalidTokenException {
         if (jtiCache.contains(jwt)) {
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "JWT token can only be submitted once. The issuer is " + jwt.getClaims().getIssuer()
-                        + ", and JTI is " + jwt.getClaims().getJwtId());
+                Tr.debug(tc, "JWT token can only be submitted once. The issuer is " + jwt.getClaims().getIssuer() + ", and JTI is " + jwt.getClaims().getJwtId());
             }
-            String errorMsg = Tr.formatMessage(tc, "JWT_DUP_JTI_ERR",
-                    new Object[] { jwt.getClaims().getIssuer(), jwt.getClaims().getJwtId() });
+            String errorMsg = Tr.formatMessage(tc, "JWT_DUP_JTI_ERR", new Object[] { jwt.getClaims().getIssuer(), jwt.getClaims().getJwtId() });
             throw new InvalidTokenException(errorMsg);
         }
     }
@@ -136,8 +132,7 @@ public class ConsumerUtil {
         return signingKey;
     }
 
-    Key getSigningKeyBasedOnSignatureAlgorithm(JwtConsumerConfig config, JwtContext jwtContext, Map properties)
-            throws KeyException {
+    Key getSigningKeyBasedOnSignatureAlgorithm(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
         Key signingKey = null;
         String sigAlg = config.getSignatureAlgorithm();
 
@@ -214,8 +209,7 @@ public class ConsumerUtil {
         try {
             signingKey = getJwksKey(config, jwtContext, properties);
         } catch (Exception e) {
-            String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_JWK_KEY",
-                    new Object[] { config.getJwkEndpointUrl(), e.getLocalizedMessage() });
+            String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_JWK_KEY", new Object[] { config.getJwkEndpointUrl(), e.getLocalizedMessage() });
             throw new KeyException(msg, e);
         }
         return signingKey;
@@ -234,22 +228,11 @@ public class ConsumerUtil {
                         null, null, publickey, keyLocation);
             }
         }
-
         if (jwkRetriever == null) {
             jwkRetriever = new JwKRetriever(config.getId(), config.getSslRef(), config.getJwkEndpointUrl(),
-                    config.getJwkSet(), JwtUtils.getSSLSupportService(), config.isHostNameVerificationEnabled(), null,
-                    null);
+                    config.getJwkSet(), JwtUtils.getSSLSupportService(), config.isHostNameVerificationEnabled(), null, null);
         }
-        Key signingKey = jwkRetriever.getPublicKeyFromJwk(kid, null); // only
-                                                                      // kid
-                                                                      // or
-                                                                      // x5t
-                                                                      // will
-                                                                      // work
-                                                                      // but
-                                                                      // not
-                                                                      // both
-
+        Key signingKey = jwkRetriever.getPublicKeyFromJwk(kid, null); // only kid or x5t will work but not both
         return signingKey;
     }
 
@@ -269,8 +252,7 @@ public class ConsumerUtil {
             Tr.debug(tc, "JsonWebStructure class: " + jwtHeader.getClass().getName() + " data:" + jwtHeader);
             if (jwtHeader instanceof JsonWebSignature) {
                 JsonWebSignature signature = (JsonWebSignature) jwtHeader;
-                Tr.debug(tc, "JsonWebSignature alg: " + signature.getAlgorithmHeaderValue() + " 3rd:'"
-                        + signature.getEncodedSignature() + "'");
+                Tr.debug(tc, "JsonWebSignature alg: " + signature.getAlgorithmHeaderValue() + " 3rd:'" + signature.getEncodedSignature() + "'");
             }
         }
     }
@@ -282,8 +264,7 @@ public class ConsumerUtil {
         try {
             signingKey = getPublicKey(trustedAlias, trustStoreRef, Constants.SIGNATURE_ALG_RS256);
         } catch (Exception e) {
-            String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_PUBLIC_KEY",
-                    new Object[] { trustedAlias, trustStoreRef, e.getLocalizedMessage() });
+            String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_PUBLIC_KEY", new Object[] { trustedAlias, trustStoreRef, e.getLocalizedMessage() });
             throw new KeyException(msg, e);
         }
         return signingKey;
@@ -293,10 +274,8 @@ public class ConsumerUtil {
      * Creates a Key object from the certificate stored in the trust store and
      * alias provided.
      */
-    Key getPublicKey(String trustedAlias, String trustStoreRef, String signatureAlgorithm)
-            throws KeyStoreServiceException, KeyException {
+    Key getPublicKey(String trustedAlias, String trustStoreRef, String signatureAlgorithm) throws KeyStoreServiceException, KeyException {
         Key signingKey = getPublicKeyFromKeystore(trustedAlias, trustStoreRef, signatureAlgorithm);
-
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, "Trusted alias: " + trustedAlias + ", Truststore: " + trustStoreRef);
             Tr.debug(tc, "RSAPublicKey: " + (signingKey instanceof RSAPublicKey));
@@ -307,8 +286,7 @@ public class ConsumerUtil {
         return signingKey;
     }
 
-    Key getPublicKeyFromKeystore(String trustedAlias, String trustStoreRef, String signatureAlgorithm)
-            throws KeyException {
+    Key getPublicKeyFromKeystore(String trustedAlias, String trustStoreRef, String signatureAlgorithm) throws KeyException {
         try {
             if (keyStoreService == null) {
                 String msg = Tr.formatMessage(tc, "JWT_TRUSTSTORE_SERVICE_NOT_AVAILABLE");
@@ -316,16 +294,14 @@ public class ConsumerUtil {
             }
             return JwtUtils.getPublicKey(trustedAlias, trustStoreRef, keyStoreService.getService());
         } catch (Exception e) {
-            String msg = Tr.formatMessage(tc, "JWT_NULL_SIGNING_KEY_WITH_ERROR",
-                    new Object[] { signatureAlgorithm, Constants.SIGNING_KEY_X509, e.getLocalizedMessage() });
+            String msg = Tr.formatMessage(tc, "JWT_NULL_SIGNING_KEY_WITH_ERROR", new Object[] { signatureAlgorithm, Constants.SIGNING_KEY_X509, e.getLocalizedMessage() });
             throw new KeyException(msg, e);
         }
     }
 
     protected JwtContext parseJwtWithoutValidation(String jwtString, JwtConsumerConfig config) throws Exception {
         if (jwtString == null || jwtString.isEmpty()) {
-            String errorMsg = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_OR_EMPTY_STRING",
-                    new Object[] { config.getId(), jwtString });
+            String errorMsg = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_OR_EMPTY_STRING", new Object[] { config.getId(), jwtString });
             throw new InvalidTokenException(errorMsg);
         }
         JwtConsumerBuilder builder = initializeJwtConsumerBuilderWithoutValidation(config);
@@ -333,9 +309,7 @@ public class ConsumerUtil {
         return firstPassJwtConsumer.process(jwtString);
     }
 
-    protected JwtContext parseJwtWithValidation(String jwtString, JwtContext jwtContext, JwtConsumerConfig config,
-            Key key, Map properties) throws Exception {
-
+    protected JwtContext parseJwtWithValidation(String jwtString, JwtContext jwtContext, JwtConsumerConfig config, Key key, Map properties) throws Exception {
         JwtClaims jwtClaims = jwtContext.getJwtClaims();
 
         if (tc.isDebugEnabled()) {
@@ -359,8 +333,7 @@ public class ConsumerUtil {
         return builder;
     }
 
-    JwtConsumerBuilder initializeJwtConsumerBuilderWithValidation(JwtConsumerConfig config, JwtClaims jwtClaims,
-            Key key) throws MalformedClaimException {
+    JwtConsumerBuilder initializeJwtConsumerBuilderWithValidation(JwtConsumerConfig config, JwtClaims jwtClaims, Key key) throws MalformedClaimException {
         JwtConsumerBuilder builder = new JwtConsumerBuilder();
         builder.setExpectedIssuer(jwtClaims.getIssuer());
         builder.setSkipDefaultAudienceValidation();
@@ -371,18 +344,16 @@ public class ConsumerUtil {
         return builder;
     }
 
-    void validateClaims(JwtClaims jwtClaims, JwtContext jwtContext, JwtConsumerConfig config, Map properties)
-            throws MalformedClaimException, InvalidClaimException, InvalidTokenException {
+    void validateClaims(JwtClaims jwtClaims, JwtContext jwtContext, JwtConsumerConfig config, Map properties) throws MalformedClaimException, InvalidClaimException, InvalidTokenException {
         String issuer = config.getIssuer();
         if (issuer == null) {
-            issuer = (String) properties.get(ISSUER);
+            issuer = (properties == null) ? null : (String) properties.get(ISSUER);
         }
 
         validateIssuer(config.getId(), issuer, jwtClaims.getIssuer());
 
         if (!validateAudience(config.getAudiences(), jwtClaims.getAudience())) {
-            String msg = Tr.formatMessage(tc, "JWT_AUDIENCE_NOT_TRUSTED",
-                    new Object[] { jwtClaims.getAudience(), config.getId(), config.getAudiences() });
+            String msg = Tr.formatMessage(tc, "JWT_AUDIENCE_NOT_TRUSTED", new Object[] { jwtClaims.getAudience(), config.getId(), config.getAudiences() });
             throw new InvalidClaimException(msg);
         }
 
@@ -414,8 +385,7 @@ public class ConsumerUtil {
     boolean validateIssuer(String consumerConfigId, String issuers, String tokenIssuer) throws InvalidClaimException {
         boolean isIssuer = false;
         if (issuers == null || issuers.isEmpty()) {
-            String msg = Tr.formatMessage(tc, "JWT_TRUSTED_ISSUERS_NULL",
-                    new Object[] { tokenIssuer, consumerConfigId });
+            String msg = Tr.formatMessage(tc, "JWT_TRUSTED_ISSUERS_NULL", new Object[] { tokenIssuer, consumerConfigId });
             throw new InvalidClaimException(msg);
         }
 
@@ -432,8 +402,7 @@ public class ConsumerUtil {
         }
 
         if (!isIssuer) {
-            String msg = Tr.formatMessage(tc, "JWT_ISSUER_NOT_TRUSTED",
-                    new Object[] { tokenIssuer, consumerConfigId, issuers });
+            String msg = Tr.formatMessage(tc, "JWT_ISSUER_NOT_TRUSTED", new Object[] { tokenIssuer, consumerConfigId, issuers });
             throw new InvalidClaimException(msg);
         }
         return isIssuer;
@@ -493,30 +462,23 @@ public class ConsumerUtil {
             long now = (new Date()).getTime();
             NumericDate currentTimeMinusSkew = NumericDate.fromMilliseconds(now - clockSkewInMilliseconds);
             NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
-            Tr.debug(tc, "Checking iat [" + createDateString(issueAtClaim) + "] and exp ["
-                    + createDateString(expirationClaim) + "]");
-            Tr.debug(tc, "Comparing against current time (minus clock skew of " + (clockSkewInMilliseconds / 1000)
-                    + " seconds) [" + createDateString(currentTimeMinusSkew) + "]");
-            Tr.debug(tc, "Comparing against current time (plus clock skew of " + (clockSkewInMilliseconds / 1000)
-                    + " seconds) [" + createDateString(currentTimePlusSkew) + "]");
+            Tr.debug(tc, "Checking iat [" + createDateString(issueAtClaim) + "] and exp [" + createDateString(expirationClaim) + "]");
+            Tr.debug(tc, "Comparing against current time (minus clock skew of " + (clockSkewInMilliseconds / 1000) + " seconds) [" + createDateString(currentTimeMinusSkew) + "]");
+            Tr.debug(tc, "Comparing against current time (plus clock skew of " + (clockSkewInMilliseconds / 1000) + " seconds) [" + createDateString(currentTimePlusSkew) + "]");
         }
     }
 
-    void validateIssuedAtClaim(NumericDate issueAtClaim, NumericDate expirationClaim, long clockSkewInMilliseconds)
-            throws InvalidClaimException {
+    void validateIssuedAtClaim(NumericDate issueAtClaim, NumericDate expirationClaim, long clockSkewInMilliseconds) throws InvalidClaimException {
         long now = (new Date()).getTime();
         NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
 
         if (issueAtClaim != null && expirationClaim != null) {
             if (issueAtClaim.isAfter(currentTimePlusSkew)) {
-                String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_CURRENT_TIME",
-                        new Object[] { createDateString(issueAtClaim), createDateString(currentTimePlusSkew),
-                                (clockSkewInMilliseconds / 1000) });
+                String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_CURRENT_TIME", new Object[] { createDateString(issueAtClaim), createDateString(currentTimePlusSkew), (clockSkewInMilliseconds / 1000) });
                 throw new InvalidClaimException(msg);
             }
             if (issueAtClaim.isOnOrAfter(expirationClaim)) {
-                String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_EXP",
-                        new Object[] { createDateString(issueAtClaim), createDateString(expirationClaim) });
+                String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_EXP", new Object[] { createDateString(issueAtClaim), createDateString(expirationClaim) });
                 throw new InvalidClaimException(msg);
             }
         } else {
@@ -525,16 +487,14 @@ public class ConsumerUtil {
         }
     }
 
-    void validateExpirationClaim(NumericDate expirationClaim, long clockSkewInMilliseconds)
-            throws InvalidClaimException {
+    void validateExpirationClaim(NumericDate expirationClaim, long clockSkewInMilliseconds) throws InvalidClaimException {
         long now = (new Date()).getTime();
         NumericDate currentTimeMinusSkew = NumericDate.fromMilliseconds(now - clockSkewInMilliseconds);
 
         // Check that expiration claim is in the future, accounting for the
         // clock skew
         if (expirationClaim == null || (!expirationClaim.isAfter(currentTimeMinusSkew))) {
-            String msg = Tr.formatMessage(tc, "JWT_TOKEN_EXPIRED", new Object[] { createDateString(expirationClaim),
-                    createDateString(currentTimeMinusSkew), (clockSkewInMilliseconds / 1000) });
+            String msg = Tr.formatMessage(tc, "JWT_TOKEN_EXPIRED", new Object[] { createDateString(expirationClaim), createDateString(currentTimeMinusSkew), (clockSkewInMilliseconds / 1000) });
             throw new InvalidClaimException(msg);
         }
     }
@@ -560,8 +520,7 @@ public class ConsumerUtil {
 
         // Check that nbf claim is in the past, accounting for the clock skew
         if (nbfClaim != null && (nbfClaim.isOnOrAfter(currentTimePlusSkew))) {
-            String msg = Tr.formatMessage(tc, "JWT_TOKEN_BEFORE_NBF", new Object[] { createDateString(nbfClaim),
-                    createDateString(currentTimePlusSkew), (clockSkewInMilliseconds / 1000) });
+            String msg = Tr.formatMessage(tc, "JWT_TOKEN_BEFORE_NBF", new Object[] { createDateString(nbfClaim), createDateString(currentTimePlusSkew), (clockSkewInMilliseconds / 1000) });
             throw new InvalidClaimException(msg);
         }
     }
@@ -571,8 +530,7 @@ public class ConsumerUtil {
         try {
             iatClaim = jwtClaims.getIssuedAt();
         } catch (MalformedClaimException e) {
-            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
-                    new Object[] { Claims.ISSUED_AT, e.getLocalizedMessage() });
+            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM", new Object[] { Claims.ISSUED_AT, e.getLocalizedMessage() });
             throw new InvalidClaimException(msg, e);
         }
         return iatClaim;
@@ -583,8 +541,7 @@ public class ConsumerUtil {
         try {
             expClaim = jwtClaims.getExpirationTime();
         } catch (MalformedClaimException e) {
-            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
-                    new Object[] { Claims.EXPIRATION, e.getLocalizedMessage() });
+            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM", new Object[] { Claims.EXPIRATION, e.getLocalizedMessage() });
             throw new InvalidClaimException(msg, e);
         }
         return expClaim;
@@ -595,8 +552,7 @@ public class ConsumerUtil {
         try {
             nbfClaim = jwtClaims.getNotBefore();
         } catch (MalformedClaimException e) {
-            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
-                    new Object[] { Claims.NOT_BEFORE, e.getLocalizedMessage() });
+            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM", new Object[] { Claims.NOT_BEFORE, e.getLocalizedMessage() });
             throw new InvalidClaimException(msg, e);
         }
         return nbfClaim;
@@ -631,8 +587,7 @@ public class ConsumerUtil {
         }
     }
 
-    JwtContext processJwtStringWithConsumer(JwtConsumer jwtConsumer, String jwtString)
-            throws InvalidTokenException, InvalidJwtException {
+    JwtContext processJwtStringWithConsumer(JwtConsumer jwtConsumer, String jwtString) throws InvalidTokenException, InvalidJwtException {
         JwtContext validatedJwtContext = null;
         try {
             validatedJwtContext = jwtConsumer.process(jwtString);


### PR DESCRIPTION
Got this in a FAT:

```
------Start of DE processing------ = [8/15/18 13:39:27:723 UTC]
Exception = java.lang.NullPointerException
Source = com.ibm.ws.security.jwt.internal.ConsumerImpl
probeid = 189
Stack Dump = java.lang.NullPointerException
	at com.ibm.ws.security.jwt.internal.ConsumerUtil.validateClaims(ConsumerUtil.java:378)
	at com.ibm.ws.security.jwt.internal.ConsumerUtil.parseJwtWithValidation(ConsumerUtil.java:345)
	at com.ibm.ws.security.jwt.internal.ConsumerUtil.getSigningKeyAndParseJwtWithValidation(ConsumerUtil.java:91)
```