### PR TITLE
Revert getLocation change - should only be non-null if explicitly set

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/impl/ResponseImpl.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/impl/ResponseImpl.java
@@ -309,9 +309,6 @@ public final class ResponseImpl extends Response {
     @Override
     public URI getLocation() {
         Object header = metadata.getFirst(HttpHeaders.LOCATION);
-        if (header == null && outMessage != null) { // Liberty change
-            header = outMessage.get(Message.REQUEST_URI);
-        }
         return header == null || header instanceof URI ? (URI) header : URI.create(header.toString());
     }
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/impl/ResponseImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/impl/ResponseImpl.java
@@ -300,9 +300,6 @@ public final class ResponseImpl extends Response {
     @Override
     public URI getLocation() {
         Object header = metadata.getFirst(HttpHeaders.LOCATION);
-        if (header == null && outMessage != null) {
-            header = outMessage.get(Message.REQUEST_URI);
-        }
         return header == null || header instanceof URI ? (URI)header
             : URI.create(header.toString());
     }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 
 import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
 import org.apache.cxf.jaxrs.client.ClientProxyImpl;
@@ -118,6 +119,9 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
     @Override
     protected void checkResponse(Method m, Response r, Message inMessage) throws Throwable {
         MicroProfileClientProviderFactory factory = MicroProfileClientProviderFactory.getInstance(inMessage);
+        if (r.getLocation() == null) {
+            r.getMetadata().putSingle(HttpHeaders.LOCATION, URI.create((String)inMessage.get(Message.REQUEST_URI)));
+        }
         List<ResponseExceptionMapper<?>> mappers = factory.createResponseExceptionMapper(inMessage,
                 Throwable.class);
         for (ResponseExceptionMapper<?> mapper : mappers) {


### PR DESCRIPTION
or if the Location header was set on the HTTP response.

This change was made in development of 18.0.0.3, and then reverted - so not a release bug.