### PR TITLE
4767 metrics monitor fat sun jdk

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
@@ -214,7 +214,7 @@ public class MetricsMonitorTest {
       	
        	Log.info(c, testName, "------- Remove monitor-1.0 ------");
     	server.setMarkToEndOfLog();
-    	server.setServerConfigurationFile("server_mpMetric11.xml");
+    	server.setServerConfigurationFile("server_noJDBCMonitor.xml");
        	Log.info(c, testName, server.waitForStringInLogUsingMark("CWPMI2002I"));
        	Log.info(c, testName, "------- no vendor metrics should be available ------");
       	checkStrings(getHttpsServlet("/metrics"), 

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
@@ -94,6 +94,7 @@ public class MetricsMonitorTest {
     	String testName = "testEnableDisableFeatures";
     	
     	Log.info(c, testName, "------- No monitor-1.0: no vendor metrics should be available ------");
+    	server.setServerConfigurationFile("server_mpMetric11.xml");
     	server.startServer();
     	Log.info(c, testName, server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- server started -----");

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/files/server_noJDBCMonitor.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/files/server_noJDBCMonitor.xml
@@ -1,0 +1,9 @@
+<server>
+    <featureManager>
+    	<feature>servlet-3.1</feature>
+    	<feature>mpMetrics-1.1</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+    <include location="serverConfig.xml"/>
+</server>


### PR DESCRIPTION
Fix the com.ibm.ws.microprofile.metrics.monitor_fat, so that it can be run by SUN JDK.

