### PR TITLE
Mechanism for a feature to conditionally expose APIs based on JDK level

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.optional.corba-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.optional.corba-1.5.feature
@@ -7,12 +7,12 @@ IBM-Process-Types: client, \
  server
 Subsystem-Name: OMG CORBA APIs and RMI-IIOP API
 -bundles=\
-  com.ibm.ws.org.apache.yoko.corba.spec.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
-  com.ibm.ws.org.apache.yoko.osgi.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
-  com.ibm.ws.org.apache.servicemix.bundles.bcel.5.2; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
-  com.ibm.ws.org.apache.yoko.rmi.impl.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
-  com.ibm.ws.org.apache.yoko.core.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
-  com.ibm.ws.org.apache.yoko.util.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))",\
-  com.ibm.ws.org.apache.yoko.rmi.spec.1.5; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"
+  com.ibm.ws.org.apache.yoko.corba.spec.1.5; require-java:="9",\
+  com.ibm.ws.org.apache.yoko.osgi.1.5; require-java:="9",\
+  com.ibm.ws.org.apache.servicemix.bundles.bcel.5.2; require-java:="9",\
+  com.ibm.ws.org.apache.yoko.rmi.impl.1.5; require-java:="9",\
+  com.ibm.ws.org.apache.yoko.core.1.5; require-java:="9",\
+  com.ibm.ws.org.apache.yoko.util.1.5; require-java:="9",\
+  com.ibm.ws.org.apache.yoko.rmi.spec.1.5; require-java:="9"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.optional.jaxb-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.optional.jaxb-2.2.feature
@@ -9,9 +9,9 @@ Subsystem-Name: Java XML Bindings 2.2 for Java 9 and above
 -features=\
   com.ibm.websphere.appserver.classloading-1.0
 -bundles=\
-  com.ibm.websphere.javaee.activation.1.1; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.activation:activation:1.1", \
-  com.ibm.websphere.javaee.jaxb.2.2; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.bind:jaxb-api:2.2.12", \
-  com.ibm.ws.org.apache.geronimo.osgi.registry.1.1; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))", \
-  com.ibm.ws.jaxb.tools.2.2.10; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"
+  com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
+  com.ibm.websphere.javaee.jaxb.2.2; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
+  com.ibm.ws.org.apache.geronimo.osgi.registry.1.1; require-java:="9", \
+  com.ibm.ws.jaxb.tools.2.2.10; require-java:="9"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.0.feature
@@ -11,8 +11,8 @@ Subsystem-Name: Java RESTful Services API 2.0
   com.ibm.websphere.appserver.javaeeCompatible-7.0
 -bundles=\
   com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
-  com.ibm.websphere.javaee.activation.1.1; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.activation:activation:1.1",\
-  com.ibm.websphere.javaee.jaxb.2.2; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.bind:jaxb-api:2.2.12", \
+  com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false,\
+  com.ibm.websphere.javaee.jaxb.2.2; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
   com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0.1"
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.1.feature
@@ -11,8 +11,8 @@ Subsystem-Name: Java RESTful Services API 2.1
   com.ibm.websphere.appserver.javaeeCompatible-8.0
 -bundles=\
   com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
-  com.ibm.websphere.javaee.activation.1.1; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.activation:activation:1.1",\
-  com.ibm.websphere.javaee.jaxb.2.2; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.bind:jaxb-api:2.2.12", \
+  com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false,\
+  com.ibm.websphere.javaee.jaxb.2.2; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
   com.ibm.websphere.javaee.jaxrs.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.1"
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.0-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
@@ -22,8 +22,8 @@ IBM-SPI-Package: com.ibm.wsspi.webservices.handler
  com.ibm.websphere.appserver.globalhandler-1.0, \
  com.ibm.websphere.appserver.json-1.0
 -bundles=\
- com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/",\
- com.ibm.websphere.javaee.jws.1.0; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/",\
+ com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/",\
+ com.ibm.websphere.javaee.jws.1.0; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/",\
  com.ibm.ws.org.apache.xml.resolver.1.2, \
  com.ibm.ws.org.apache.neethi.3.0.2, \
  com.ibm.ws.jaxrs.2.0.common, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
@@ -18,8 +18,8 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.websphere.appserver.internal.cxf.common-3.2
 -bundles=\
  com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
- com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/",\
- com.ibm.websphere.javaee.jws.1.0; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/",\
+ com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/",\
+ com.ibm.websphere.javaee.jws.1.0; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/",\
  com.ibm.ws.jaxrs.2.1.common, \
  com.ibm.ws.jaxrs.2.x.config, \
  com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-1.2/com.ibm.websphere.appserver.cdi-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-1.2/com.ibm.websphere.appserver.cdi-1.2.feature
@@ -56,9 +56,9 @@ Subsystem-Name: Contexts and Dependency Injection 1.2
  com.ibm.ws.cdi.weld, \
  com.ibm.ws.cdi.internal, \
  com.ibm.ws.cdi.1.2.weld, \
- com.ibm.websphere.javaee.jaxb.2.2; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.bind:jaxb-api:2.2.12", \
- com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.ws:jaxws-api:2.2.12", \
- com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
+ com.ibm.websphere.javaee.jaxb.2.2; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/", \
  com.ibm.ws.cdi.interfaces
 -jars=com.ibm.websphere.appserver.thirdparty.cdi; location:="dev/api/third-party/,lib/"; mavenCoordinates="org.jboss.weld:weld-osgi-bundle:2.4.7.Final"
 -files=dev/api/ibm/schema/ibm-managed-bean-bnd_1_0.xsd, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
@@ -61,10 +61,10 @@ Subsystem-Name: Contexts and Dependency Injection 2.0
  com.ibm.ws.cdi.weld, \
  com.ibm.ws.cdi.internal, \
  com.ibm.ws.cdi.2.0.weld, \
- com.ibm.websphere.javaee.jaxb.2.2; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/",\
- com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/", \
- com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:jstl:1.2", \
- com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.websocket:javax.websocket-api:1.1", \
+ com.ibm.websphere.javaee.jaxb.2.2; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/",\
+ com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/", \
+ com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/", \
  com.ibm.ws.cdi.interfaces
 -jars=com.ibm.websphere.appserver.thirdparty.cdi-2.0; location:="dev/api/third-party/,lib/"; mavenCoordinates="org.jboss.weld:weld-osgi-bundle:3.0.3.Final"
 -files=dev/api/ibm/schema/ibm-managed-bean-bnd_1_0.xsd, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxb-2.2/com.ibm.websphere.appserver.jaxb-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxb-2.2/com.ibm.websphere.appserver.jaxb-2.2.feature
@@ -17,7 +17,7 @@ Subsystem-Name: Java XML Bindings 2.2
 -features=\
   com.ibm.websphere.appserver.classloading-1.0
 -bundles=\
-  com.ibm.websphere.javaee.activation.1.1; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.activation:activation:1.1", \
+  com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.activation:activation:1.1", \
   com.ibm.websphere.javaee.jaxb.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.bind:jaxb-api:2.2.12", \
   com.ibm.ws.org.apache.geronimo.osgi.registry.1.1, \
   com.ibm.ws.jaxb.tools.2.2.10

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxws-2.2/com.ibm.websphere.appserver.jaxws-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxws-2.2/com.ibm.websphere.appserver.jaxws-2.2.feature
@@ -4,6 +4,9 @@ visibility=public
 IBM-App-ForceRestart: uninstall, \
  install
 IBM-API-Package: \
+ javax.jws; type="spec"; require-osgi-ee="9", \
+ javax.jws.soap; type="spec"; require-osgi-ee="9", \
+ javax.xml.soap; type="spec"; require-osgi-ee="9", \
  javax.xml.ws.handler; type="spec", \
  javax.xml.ws.http; type="spec", \
  javax.xml.ws.spi; type="spec", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxws-2.2/com.ibm.websphere.appserver.jaxws-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxws-2.2/com.ibm.websphere.appserver.jaxws-2.2.feature
@@ -4,9 +4,9 @@ visibility=public
 IBM-App-ForceRestart: uninstall, \
  install
 IBM-API-Package: \
- javax.jws; type="spec"; require-osgi-ee="9", \
- javax.jws.soap; type="spec"; require-osgi-ee="9", \
- javax.xml.soap; type="spec"; require-osgi-ee="9", \
+ javax.jws; type="spec"; require-java:="9", \
+ javax.jws.soap; type="spec"; require-java:="9", \
+ javax.xml.soap; type="spec"; require-java:="9", \
  javax.xml.ws.handler; type="spec", \
  javax.xml.ws.http; type="spec", \
  javax.xml.ws.spi; type="spec", \
@@ -51,7 +51,7 @@ Subsystem-Name: Java Web Services 2.2
  com.ibm.ws.org.apache.cxf-rt-ws-addr.2.6.2, \
  com.ibm.ws.jaxws.common, \
  com.ibm.websphere.javaee.jaxws.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.xml.ws:jaxws-api:2.2.12", \
- com.ibm.websphere.javaee.jws.1.0; required-osgi-ee:="(&(osgi.ee=JavaSE)(version>=9))"; location:="dev/api/spec/,lib/",\
+ com.ibm.websphere.javaee.jws.1.0; require-java:="9"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.jws:jsr181-api:1.0-MR1",\
  com.ibm.ws.jaxws.tools.2.2.10, \
  com.ibm.ws.org.apache.cxf-rt-frontend-simple.2.6.2, \
  com.ibm.websphere.prereq.wsdl4j.api; location:="dev/api/spec/,lib/", \

--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -70,7 +72,6 @@ public class FeatureList {
     private static final Map<String, Collection<GenericMetadata>> eeToCapability = new HashMap<String, Collection<GenericMetadata>>();
 
     static {
-
         if (writingJavaVersion) {
             // When we add Java 9 we need to add it here and update the 1.6 and 1.7 and 1.8 filters. Need to ensure this is captured in docs.
             addJVM(possibleJavaVersions, "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
@@ -243,8 +244,8 @@ public class FeatureList {
         if (!!!privateFeature) {
             ContentBasedLocalBundleRepository cbr = getBundleRepo(fd.getFeatureName(), mfp);
             Set<File> bundles = new TreeSet<File>();
-            Set<File> apiJars = showExternals ? new TreeSet<File>() : null;
-            Set<File> spiJars = new TreeSet<File>();
+            Map<File,Map<String,String>> apiJars = showExternals ? new TreeMap<File,Map<String,String>>() : null;
+            Map<File,Map<String,String>> spiJars = new TreeMap<File,Map<String,String>>();
 
             if (publicFeature) {
                 Set<String> enabledFeatureNames = new TreeSet<String>();
@@ -432,9 +433,10 @@ public class FeatureList {
         return metadata;
     }
 
-    private void writeApiSpiJars(FeatureListWriter writer, File installDir, Set<File> jars, String elementName) throws IOException, XMLStreamException {
+    private void writeApiSpiJars(FeatureListWriter writer, File installDir, Map<File,Map<String,String>> jars, String elementName) throws IOException, XMLStreamException {
         if (jars != null) {
-            for (File f : jars) {
+            for (Entry<File, Map<String, String>> e : jars.entrySet()) {
+                File f = e.getKey();
                 String nameToWrite;
 
                 if (f.getAbsolutePath().startsWith(installDir.getAbsolutePath())) {
@@ -444,7 +446,7 @@ public class FeatureList {
                     nameToWrite = PathUtils.slashify(f.getAbsolutePath());
                 }
 
-                writer.writeTextElement(elementName, nameToWrite);
+                writer.writeTextElementWithAttributes(elementName, nameToWrite, e.getValue());
             }
         }
     }
@@ -481,8 +483,8 @@ public class FeatureList {
                                ContentBasedLocalBundleRepository cbr,
                                Set<String> enabledFeatureNames,
                                Set<File> bundles,
-                               Set<File> apiJars,
-                               Set<File> spiJars) {
+                               Map<File,Map<String,String>> apiJars,
+                               Map<File,Map<String,String>> spiJars) {
         for (FeatureResource fr : feature.getConstituents(SubsystemContentType.FEATURE_TYPE)) {
             String symbolicName = fr.getSymbolicName();
             ProvisioningFeatureDefinition other = features.get(symbolicName);
@@ -513,8 +515,8 @@ public class FeatureList {
     private void searchJars(ProvisioningFeatureDefinition feature,
                             ContentBasedLocalBundleRepository cbr,
                             Set<File> bundles,
-                            Set<File> apiJars,
-                            Set<File> spiJars) {
+                            Map<File,Map<String,String>> apiJars,
+                            Map<File,Map<String,String>> spiJars) {
         if (bundles != null || apiJars != null || spiJars != null) {
             searchJars(feature, cbr, SubsystemContentType.JAR_TYPE, null, apiJars, spiJars);
             searchJars(feature, cbr, SubsystemContentType.BUNDLE_TYPE, bundles, apiJars, spiJars);
@@ -525,8 +527,8 @@ public class FeatureList {
                             ContentBasedLocalBundleRepository cbr,
                             SubsystemContentType contentType,
                             Set<File> bundles,
-                            Set<File> apiJars,
-                            Set<File> spiJars) {
+                            Map<File,Map<String,String>> apiJars,
+                            Map<File,Map<String,String>> spiJars) {
         for (FeatureResource fr : feature.getConstituents(contentType)) {
             String location = fr.getLocation();
             File f = cbr.selectBundle(location, fr.getSymbolicName(), fr.getVersionRange());
@@ -536,13 +538,16 @@ public class FeatureList {
                 }
 
                 APIType apiType = APIType.getAPIType(fr);
+                Map<String,String> attrs = new HashMap<String,String>(1);
+                if (fr.getRequireJava() != null)
+                    attrs.put("require-java", fr.getRequireJava().toString());
                 if (apiType == APIType.API) {
                     if (apiJars != null) {
-                        apiJars.add(f);
+                        apiJars.put(f, attrs);
                     }
                 } else if (apiType == APIType.SPI) {
                     if (spiJars != null) {
-                        spiJars.add(f);
+                        spiJars.put(f, attrs);
                     }
                 }
             }

--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureListWriter.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureListWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 IBM Corporation and others.
+ * Copyright (c) 2013, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,9 +18,6 @@ import java.util.Map;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
-/**
- *
- */
 public class FeatureListWriter {
     private final XMLStreamWriter writer;
     private final Indenter i;
@@ -41,7 +38,9 @@ public class FeatureListWriter {
         i.indent(2);
         writer.writeStartElement(nodeName);
         for (Map.Entry<String, String> attr : attrs.entrySet()) {
-            writer.writeAttribute(attr.getKey(), attr.getValue());
+            String rawKey = attr.getKey();
+            String key = rawKey.endsWith(":") ? rawKey.substring(0, rawKey.length() -1) : rawKey;
+            writer.writeAttribute(key, attr.getValue());
         }
         writer.writeCharacters(text);
         writer.writeEndElement();

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/BundleList.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/BundleList.java
@@ -38,17 +38,17 @@ import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
 import com.ibm.ws.kernel.feature.provisioning.SubsystemContentType;
 import com.ibm.ws.kernel.provisioning.BundleRepositoryRegistry.BundleRepositoryHolder;
 import com.ibm.ws.kernel.provisioning.VersionUtility;
+import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.wsspi.kernel.service.location.WsResource;
 
 public class BundleList {
     private static final String CACHE_WRITE_TIME = "Cache-WriteTime";
-    static final String PROP_JVM_SPEC_VERSION = "java.specification.version";
     private static final TraceComponent tc = Tr.register(BundleList.class);
     private final WsResource cacheFile;
     private final AtomicBoolean stale = new AtomicBoolean(false);
     private final List<RuntimeFeatureResource> resources = new ArrayList<RuntimeFeatureResource>();
     private long writeTime;
-    private String javaSpecVersion = "";
+    private Integer javaSpecVersion;
     private final FeatureManager featureManager;
 
     public static interface FeatureResourceHandler {
@@ -278,8 +278,8 @@ public class BundleList {
         }
 
         @Override
-        public String getRequiredOSGiEE() {
-            return fr.getRequiredOSGiEE();
+        public Integer getRequireJava() {
+            return fr.getRequireJava();
         }
     }
 
@@ -425,7 +425,7 @@ public class BundleList {
         }
 
         @Override
-        public String getRequiredOSGiEE() {
+        public Integer getRequireJava() {
             return null;
         }
 
@@ -520,7 +520,7 @@ public class BundleList {
                 String sTime = javaSpecVersionIndex > timeIndex ? line.substring(timeIndex + 1, javaSpecVersionIndex) : line.substring(timeIndex + 1);
                 writeTime = Long.parseLong(sTime);
                 if (javaSpecVersionIndex != -1) {
-                    javaSpecVersion = line.substring(javaSpecVersionIndex + 1);
+                    javaSpecVersion = Integer.valueOf(line.substring(javaSpecVersionIndex + 1));
                 }
             } catch (NumberFormatException nfe) {
             }
@@ -542,7 +542,7 @@ public class BundleList {
                 writeTime = System.currentTimeMillis();
                 writer.write(String.valueOf(writeTime));
                 writer.write(';');
-                writer.write(System.getProperty(PROP_JVM_SPEC_VERSION));
+                writer.write(JavaInfo.majorVersion());
                 writer.write(FeatureDefinitionUtils.NL);
                 for (RuntimeFeatureResource entry : resources) {
                     if (entry.getURLString() != null) {
@@ -578,7 +578,7 @@ public class BundleList {
         for (FeatureResource fr : fdefinition.getConstituents(SubsystemContentType.BUNDLE_TYPE)) {
             RuntimeFeatureResource rfr = (RuntimeFeatureResource) ((fr instanceof RuntimeFeatureResource) ? fr : new RuntimeFeatureResource(fr));
             // only add bundles that match the current osgi.ee capability
-            if (!featureManager.missingRequiredOSGiEE(rfr)) {
+            if (!featureManager.missingRequiredJava(rfr)) {
                 resources.add(rfr);
             }
         }
@@ -631,7 +631,7 @@ public class BundleList {
         return b;
     }
 
-    public String getJavaSpecVersion() {
+    public Integer getJavaSpecVersion() {
         return javaSpecVersion;
     }
 }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -49,9 +49,7 @@ import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleRequirement;
 import org.osgi.framework.wiring.BundleRevision;
 import org.osgi.framework.wiring.FrameworkWiring;
-import org.osgi.resource.Namespace;
 import org.osgi.resource.Requirement;
-import org.osgi.resource.Resource;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.osgi.service.component.ComponentContext;
@@ -97,6 +95,7 @@ import com.ibm.ws.kernel.provisioning.BundleRepositoryRegistry.BundleRepositoryH
 import com.ibm.ws.kernel.provisioning.LibertyBootRuntime;
 import com.ibm.ws.kernel.provisioning.ProductExtension;
 import com.ibm.ws.kernel.provisioning.ProductExtensionInfo;
+import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.ws.runtime.update.RuntimeUpdateManager;
 import com.ibm.ws.runtime.update.RuntimeUpdateNotification;
 import com.ibm.wsspi.kernel.service.location.VariableRegistry;
@@ -292,7 +291,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * activated and when changes to our configuration have occurred.
      *
      * @param componentContext
-     *                             the OSGi DS context
+     *            the OSGi DS context
      */
     @Activate()
     protected void activate(ComponentContext componentContext, Map<String, Object> properties) {
@@ -403,7 +402,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * implementation is stopped.
      *
      * @param componentContext
-     *                             the OSGi DS context
+     *            the OSGi DS context
      */
     @Deactivate()
     @FFDCIgnore(InterruptedException.class)
@@ -442,7 +441,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * reference required by activator, inject directly.
      *
      * @param locationService
-     *                            a location service
+     *            a location service
      */
     @Reference(name = "locationService", service = WsLocationAdmin.class)
     protected void setLocationService(WsLocationAdmin locationService) {
@@ -455,7 +454,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * deactivate. Do nothing.
      *
      * @param locationService
-     *                            a location service
+     *            a location service
      */
     protected void unsetLocationService(WsLocationAdmin locationService) {}
 
@@ -532,7 +531,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * Inject an <code>ExecutorService</code> service instance.
      *
      * @param executorService
-     *                            an executor service
+     *            an executor service
      */
     @Reference(name = "executorService", service = ExecutorService.class)
     protected void setExecutorService(ExecutorService executorService) {
@@ -543,7 +542,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * Remove the <code>ExecutorService</code> service instance.
      *
      * @param executorService
-     *                            an executor service
+     *            an executor service
      */
     protected void unsetExecutorService(ExecutorService executorService) {}
 
@@ -831,9 +830,9 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      *
      * @param provisioningMode
      * @param preInstalledFeatures
-     * @param deletedAutoFeatures       - The list of deleted AutoFeatures.This is used to trace which auto features have been deleted.
+     * @param deletedAutoFeatures - The list of deleted AutoFeatures.This is used to trace which auto features have been deleted.
      * @param deletedPublicAutoFeatures - The list of deleted Public AutoFeatures.This is used to issue to the console which public
-     *                                      auto features have been deleted.
+     *            auto features have been deleted.
      */
     private void writeUpdateMessages(ProvisioningMode provisioningMode, Set<String> preInstalledFeatures, Set<String> deletedAutoFeatures,
                                      Set<String> deletedPublicAutoFeatures) {
@@ -1087,10 +1086,10 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
     /**
      * Update installed features and bundles
      *
-     * @param locService           Location service used to resolve resources (feature definitions or bundles)
-     * @param provisioner          Provisioner for installing/starting bundles
+     * @param locService Location service used to resolve resources (feature definitions or bundles)
+     * @param provisioner Provisioner for installing/starting bundles
      * @param preInstalledFeatures
-     * @param newFeatureSet        New/revised list of active features
+     * @param newFeatureSet New/revised list of active features
      * @return true if no errors occurred during the update, false otherwise
      */
     @FFDCIgnore(Throwable.class)
@@ -1277,11 +1276,8 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
         return status;
     }
 
-    /**
-     * @return
-     */
     private boolean sameJavaSpecVersion() {
-        return Objects.equals(System.getProperty(BundleList.PROP_JVM_SPEC_VERSION), bundleCache.getJavaSpecVersion());
+        return Objects.equals(JavaInfo.majorVersion(), bundleCache.getJavaSpecVersion());
     }
 
     /**
@@ -1312,7 +1308,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * and the unsatisfied java version dependency.
      *
      * @param installedBundles A list of the currently installed bundles
-     * @param features         A list of the currently installed features
+     * @param features A list of the currently installed features
      */
     private void analyzeUnresolvedBundles(List<Bundle> installedBundles, Set<String> features) {
 
@@ -1440,7 +1436,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * Find which features include the given bundle
      *
      * @param features The feature list to scan for this bundle
-     * @param b1       The bundle to look for in features
+     * @param b1 The bundle to look for in features
      * @return List of features this bundle is included in
      */
     public Set<String> findIncludingFeatures(Set<String> features, Bundle b1) {
@@ -1657,10 +1653,10 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * Issues appropriate diagnostics & messages for this environment.
      *
      * @param listName
-     *                          the name of the feature that was installed
+     *            the name of the feature that was installed
      * @param installStatus
-     *                          Status object holding any warnings or exceptions that occurred
-     *                          during bundle installation
+     *            Status object holding any warnings or exceptions that occurred
+     *            during bundle installation
      * @return true if no exceptions occurred during bundle installation, false otherwise.
      */
     protected boolean checkInstallStatus(BundleInstallStatus installStatus) throws IllegalStateException {
@@ -1774,8 +1770,8 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * and issue appropriate diagnostics & messages for this environment.
      *
      * @param bundleStatus
-     *                         Status object holding any exceptions that occurred
-     *                         during bundle start or stop/uninstall
+     *            Status object holding any exceptions that occurred
+     *            during bundle start or stop/uninstall
      * @return true if no exceptions occurred while stating bundles, false otherwise.
      */
     protected boolean checkBundleStatus(BundleLifecycleStatus bundleStatus) {
@@ -1829,7 +1825,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
      * necessarily know that it's ours..).
      *
      * @param level
-     *                  StartLevel to change to
+     *            StartLevel to change to
      * @return BundleStartStatus containing any exceptions encountered
      *         during the StartLevel change operation.
      */
@@ -1940,33 +1936,9 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
         refreshFeatures();
     }
 
-    boolean missingRequiredOSGiEE(FeatureResource fr) {
-        final String requiredOSGiEE = fr.getRequiredOSGiEE();
-        if (requiredOSGiEE != null) {
-            Collection<BundleCapability> foundEEs = frameworkWiring.findProviders(new Requirement() {
-                @Override
-                public Resource getResource() {
-                    return null;
-                }
-
-                @Override
-                public String getNamespace() {
-                    return ExecutionEnvironmentNamespace.EXECUTION_ENVIRONMENT_NAMESPACE;
-                }
-
-                @Override
-                public Map<String, String> getDirectives() {
-                    return Collections.singletonMap(Namespace.REQUIREMENT_FILTER_DIRECTIVE, requiredOSGiEE);
-                }
-
-                @Override
-                public Map<String, Object> getAttributes() {
-                    return Collections.emptyMap();
-                }
-            });
-            return foundEEs.isEmpty();
-        }
-        return false;
+    boolean missingRequiredJava(FeatureResource fr) {
+        Integer requiredJava = fr.getRequireJava();
+        return requiredJava == null ? false : JavaInfo.majorVersion() < requiredJava;
     }
 
 }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/PackageInspectorImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/PackageInspectorImpl.java
@@ -365,7 +365,7 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
                 for (NameValuePair nvp : ManifestHeaderProcessor.parseExportString(packages)) {
                     String packageName = nvp.getName();
                     String type = nvp.getAttributes().get("type");
-                    String requireOsgiEE = nvp.getAttributes().get("require-osgi-ee");
+                    String requireOsgiEE = nvp.getAttributes().get("require-java:");
 
                     // If the Java requirements are not met for exposing this package, do not add the package
                     if (requireOsgiEE != null && JavaInfo.majorVersion() < Integer.parseInt(requireOsgiEE))

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/PackageInspectorImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/PackageInspectorImpl.java
@@ -28,12 +28,14 @@ import org.osgi.framework.ServiceRegistration;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.feature.internal.subsystem.FeatureDefinitionUtils;
 import com.ibm.ws.kernel.feature.internal.subsystem.KernelFeatureDefinitionImpl;
 import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
 import com.ibm.ws.kernel.provisioning.ExtensionConstants;
 import com.ibm.ws.kernel.provisioning.packages.PackageIndex;
 import com.ibm.ws.kernel.provisioning.packages.PackageIndex.Filter;
 import com.ibm.ws.kernel.provisioning.packages.SharedPackageInspector;
+import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.wsspi.logging.Introspector;
 
 /**
@@ -54,7 +56,7 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
         Dictionary<String, Object> props = new Hashtable<String, Object>();
         props.put("service.vendor", "IBM");
         registration = bundleContext.registerService(new String[] { SharedPackageInspector.class.getName(),
-                                                                   Introspector.class.getName() },
+                                                                    Introspector.class.getName() },
                                                      this, props);
     }
 
@@ -86,9 +88,9 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
             allInstalledFeatures.addAll(KernelFeatureDefinitionImpl.getKernelFeatures(bundleContext, fm.getLocationService()));
 
             // For all installed features, get information about the declared product packages
-            // and the declared osgi bundles.. 
+            // and the declared osgi bundles..
             for (ProvisioningFeatureDefinition def : allInstalledFeatures) {
-                // Add package information to ProductPackages.. 
+                // Add package information to ProductPackages..
                 newPackageIndex.addPackages(def);
             }
 
@@ -103,7 +105,7 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
     /**
      * This iterator will walk the package index, returning only packages that indicate
      * they are API packages.
-     * 
+     *
      * @see com.ibm.ws.kernel.provisioning.packages.SharedPackageInspector#listApiPackages()
      */
     @Override
@@ -139,7 +141,7 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
         API_SpecOsgi(true, "spec:osgi"),
         API_ThirdParty(true, "third-party"),
         API_Stable(true, "stable"),
-        
+
         SPI(false, "spi"),
         SPI_Spec(false, "spec"),
         SPI_ThirdParty(false, "third-party");
@@ -212,7 +214,7 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
         private void evaluateForFeatureType(String repo, boolean isKrnlExport) {
 
             // Determine what type of feature is exporting this package
-            // It is expected to be one of the three. 
+            // It is expected to be one of the three.
             if (isKrnlExport) {
                 isKernelExport = true;
             }
@@ -304,10 +306,9 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
 
         /** type="stable" only */
         @Override
-		public boolean isStableApi() {
-			return types.contains(PkgType.API_Stable);
-		}
-               
+        public boolean isStableApi() {
+            return types.contains(PkgType.API_Stable);
+        }
 
         public boolean isKernelExportBlacklistedPackage() {
 
@@ -323,13 +324,12 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
             return types + "|" + productRepo;
         }
 
-		
     }
 
     /**
      * This *is* the package index. We have a simple subclass to both simplify
      * parameter declaration.
-     * 
+     *
      * The PackageIndex is a trie organized by package name. Each node is a package
      * segment. In this usage of the package index, there are no wildcards.
      */
@@ -340,12 +340,12 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
          * We're working from the assumption that most of the time, we won't have multiple
          * features working with the same package: i.e. try to add the package first, then if there
          * is a collision, modify the attributes of the existing element.
-         * 
+         *
          * @param def ProvisioningFeatureDefinition that is the source of the API/SPI packages
          */
         public void addPackages(ProvisioningFeatureDefinition def) {
-            addPackages(def, "IBM-API-Package", PkgType.API);
-            addPackages(def, "IBM-SPI-Package", PkgType.SPI);
+            addPackages(def, FeatureDefinitionUtils.IBM_API_PACKAGE, PkgType.API);
+            addPackages(def, FeatureDefinitionUtils.IBM_SPI_PACKAGE, PkgType.SPI);
         }
 
         private void addPackages(ProvisioningFeatureDefinition def, String packageHeader, PkgType defaultPkgType) {
@@ -365,6 +365,11 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
                 for (NameValuePair nvp : ManifestHeaderProcessor.parseExportString(packages)) {
                     String packageName = nvp.getName();
                     String type = nvp.getAttributes().get("type");
+                    String requireOsgiEE = nvp.getAttributes().get("require-osgi-ee");
+
+                    // If the Java requirements are not met for exposing this package, do not add the package
+                    if (requireOsgiEE != null && JavaInfo.majorVersion() < Integer.parseInt(requireOsgiEE))
+                        continue;
 
                     PkgType expType = PkgType.fromString(type, defaultPkgType);
                     if (expType == null) {
@@ -373,13 +378,13 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
                         }
                     } else {
                         // Assume we aren't going to have package collisions often.
-                        // Try to just add first: 
+                        // Try to just add first:
                         PackageInfo packageInfo = new PackageInfo(expType, def.getBundleRepositoryType(), def.isKernel());
                         if (!add(packageName, packageInfo)) {
                             // ok. so the add didn't work because something else already marked this
-                            // package as API or SPI. Find the existing EnumSet and add 
+                            // package as API or SPI. Find the existing EnumSet and add
                             // this export/package type to it..
-                            // Note: we have packages that we promote from SPI to API for tests. 
+                            // Note: we have packages that we promote from SPI to API for tests.
                             PackageInfo prevValue = find(packageName);
                             prevValue.add(expType, def.getBundleRepositoryType(), def.isKernel());
 
@@ -421,7 +426,7 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
     }
 
     @Override
-    public void introspect(PrintWriter ps) throws IOException {       
+    public void introspect(PrintWriter ps) throws IOException {
 
         ProductPackages index = packageIndex;
         if (index == null)
@@ -464,7 +469,7 @@ public class PackageInspectorImpl implements SharedPackageInspector, Introspecto
      * This iterator will walk the package index, returning only packages that indicate
      * they are API packages and are included both by the kernel (core)feature and
      * another enabled liberty feature or features.
-     * 
+     *
      * @see com.ibm.ws.kernel.provisioning.packages.SharedPackageInspector#listKernelApiPackages()
      */
     public Iterator<String> listKernelBlackListApiPackages() {

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureResourceImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureResourceImpl.java
@@ -285,7 +285,7 @@ public class FeatureResourceImpl implements FeatureResource {
                && Objects.equals(getLocation(), other.getLocation())
                && Objects.equals(getOsList(), other.getOsList())
                && Objects.equals(getTolerates(), other.getTolerates())
-               && Objects.equals(getRequiredOSGiEE(), other.getRequiredOSGiEE());
+               && Objects.equals(getRequireJava(), other.getRequireJava());
     }
 
     /** {@inheritDoc} */
@@ -329,8 +329,9 @@ public class FeatureResourceImpl implements FeatureResource {
     }
 
     @Override
-    public String getRequiredOSGiEE() {
+    public Integer getRequireJava() {
         // Directive names are in the attributes map, but end with a colon
-        return _rawAttributes.get("required-osgi-ee:");
+        String requireJava = _rawAttributes.get("require-java:");
+        return requireJava == null ? null : Integer.valueOf(requireJava);
     }
 }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/provisioning/FeatureResource.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/provisioning/FeatureResource.java
@@ -50,5 +50,5 @@ public interface FeatureResource extends HeaderElementDefinition {
 
     public List<String> getTolerates();
 
-    public String getRequiredOSGiEE();
+    public Integer getRequireJava();
 }

--- a/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/FeatureResolverInterfacesTest.java
+++ b/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/FeatureResolverInterfacesTest.java
@@ -39,7 +39,6 @@ import org.osgi.framework.VersionRange;
 import com.ibm.ws.kernel.feature.AppForceRestart;
 import com.ibm.ws.kernel.feature.ProcessType;
 import com.ibm.ws.kernel.feature.Visibility;
-import com.ibm.ws.kernel.feature.internal.FeatureResolverInterfacesTest.TestFeature;
 import com.ibm.ws.kernel.feature.provisioning.FeatureResource;
 import com.ibm.ws.kernel.feature.provisioning.HeaderElementDefinition;
 import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
@@ -548,7 +547,7 @@ public class FeatureResolverInterfacesTest {
         }
 
         @Override
-        public String getRequiredOSGiEE() {
+        public Integer getRequireJava() {
             throw new UnsupportedOperationException();
         }
 

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRequirement.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRequirement.java
@@ -117,7 +117,7 @@ public class KernelResolverRequirement implements FeatureResource {
     }
 
     @Override
-    public String getRequiredOSGiEE() {
+    public Integer getRequireJava() {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
In Java 7/8 there are 3 JAX-WS packages that come from the JDK:
 - javax.jws
 - javax.jws.soap
 - javax.xml.soap

In Java 9+, these packages are no longer provided by the JDK, so the jaxws-2.2 feature will conditionally provide these packages to the runtime on JDK 9+.  However, the jaxws-2.2 feature currently does not declare these 3 packages as `IBM-API-Package`, because they come from the system bundle.  Simply adding these packages as regular `IBM-API-Package`s would not work because it would cause the system bundle packages to be "blacklisted" on JDK 7/8 whilst no feature as providing these packages.

To solve this problem, add a mechanism that will allow a feature manifest to conditionally expose `IBM-API-Package` based on java level.

For example:
`IBM-API-Package: javax.jws; type="spec"; require-java="9"`
would result in the `javax.jws` package being exposed by the feature on Java 9+, but not on Java 7/8.