### PR TITLE
Revert version upgrade

### DIFF
--- a/dev/com.ibm.ws.cdi.third.party_fat/build.gradle
+++ b/dev/com.ibm.ws.cdi.third.party_fat/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     'org.apache.deltaspike.modules:deltaspike-scheduler-module-api:1.5.0',
     'org.apache.deltaspike.modules:deltaspike-scheduler-module-impl:1.5.0',
     'org.quartz-scheduler:quartz:2.2.1',
-    'org.slf4j:slf4j-jdk14:1.8.0-beta2',
-    'org.slf4j:slf4j-api:1.8.0-beta2', 
+    'org.slf4j:slf4j-jdk14:1.7.7',
+    'org.slf4j:slf4j-api:1.7.7', 
     'net.sf.jtidy:jtidy:9.3.8'
 }
 


### PR DESCRIPTION
Reverting slf4k upgrade in the FAT test because of validation for specific version in the shrinkwrap test