### PR TITLE
Remove some unnecessary storage of data.

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
@@ -975,12 +975,12 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
     protected ZipFileEntry createEntry(
         ArtifactContainer nestedContainer,
         String entryName, String a_entryPath,
-        int entryOffset, ZipEntryData zipEntryData) {
+        ZipEntryData zipEntryData) {
 
         if ( (zipEntryData != null) && !zipEntryData.isDirectory() ) {
             return new ZipFileEntry(
                 this, nestedContainer,
-                entryOffset, zipEntryData,
+                zipEntryData,
                 entryName, a_entryPath);
 
         } else {
@@ -990,7 +990,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
                 if ( nestedContainerEntry == null ) {
                     nestedContainerEntry = new ZipFileEntry(
                         this, nestedContainer,
-                        entryOffset, zipEntryData,
+                        zipEntryData,
                         entryName, a_entryPath);                   
                     nestedContainerEntries.put(r_entryPath,  nestedContainerEntry);
                 }
@@ -1029,7 +1029,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         return createEntry(
             null,
             entryName, a_entryPath,
-            location, entryData);
+            entryData);
     }
 
     //
@@ -1150,7 +1150,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         return createEntry(
             null,
             entryName, a_entryPath,
-            location, zipEntryData);
+            zipEntryData);
     }
 
     @Override

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
@@ -158,7 +158,7 @@ public class ZipFileContainerUtils {
             ZipFileEntry nextZipFileEntry = rootContainer.createEntry(
                 nestedContainer,
                 entryName, a_entryPath,
-                location, nextEntryData);
+                nextEntryData);
 
             return nextZipFileEntry;
         }

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileEntry.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileEntry.java
@@ -63,7 +63,6 @@ public class ZipFileEntry implements ExtractableArtifactEntry {
      *
      * @param rootContainer The root zip file type container of this entry.
      * @param enclosingContainer The container enclosing this entry.
-     * @param offset The offset in the root zip container to the zip entry.
      * @param zipEntryData The zip entry of this entry.
      * @param name The name of this entry.
      * @param a_path The absolute path of this entry.
@@ -72,13 +71,12 @@ public class ZipFileEntry implements ExtractableArtifactEntry {
     protected ZipFileEntry(
         ZipFileContainer rootContainer,
         ArtifactContainer enclosingContainer,
-        int offset, ZipEntryData zipEntryData,
+        ZipEntryData zipEntryData,
         String name, String a_path) {
 
         this.rootContainer = rootContainer;
         this.enclosingContainer = enclosingContainer;
 
-        this.offset = offset;
         this.zipEntryData = zipEntryData;
 
         this.name = name;
@@ -107,13 +105,7 @@ public class ZipFileEntry implements ExtractableArtifactEntry {
 
     //
 
-    private final int offset;
     private final ZipEntryData zipEntryData;
-
-    @Trivial
-    public int getOffset() {
-        return offset;
-    }
 
     @Trivial
     public ZipEntryData getZipEntryData() {
@@ -371,7 +363,7 @@ public class ZipFileEntry implements ExtractableArtifactEntry {
             if ( localContainer == null ) {
                 synchronized ( this) { // Having a new object to guard 'localContainer' is too many objects.
                 	if ( localContainer == null ) {
-                		localContainer = new ZipFileNestedDirContainer(rootContainer, offset, this, name, a_path);
+                		localContainer = new ZipFileNestedDirContainer(rootContainer, this, name, a_path);
                 	}
                 }
             }

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileNestedDirContainer.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileNestedDirContainer.java
@@ -43,7 +43,6 @@ public class ZipFileNestedDirContainer implements ArtifactContainer {
      * Nested zip file containers are created directly from zip file entries.
      *
      * @param rootContainer The root container of this nested container.
-     * @param location The location of the entry in the root zip container.
      * @param entryInEnclosingContainer The entry which was interpreted
      *     to create this container.
      * @param name The name of the entry from which the container was created.
@@ -52,12 +51,11 @@ public class ZipFileNestedDirContainer implements ArtifactContainer {
      */
     public ZipFileNestedDirContainer(
         ZipFileContainer rootContainer,
-        int location, ZipFileEntry entryInEnclosingContainer,
+        ZipFileEntry entryInEnclosingContainer,
         String name, String a_path) {
 
         this.rootContainer = rootContainer;
 
-        this.location = location;
         this.entryInEnclosingContainer = entryInEnclosingContainer;
 
         this.name = name;
@@ -139,13 +137,7 @@ public class ZipFileNestedDirContainer implements ArtifactContainer {
 
     //
 
-    private final int location;
     private final ZipFileEntry entryInEnclosingContainer;
-
-    @Trivial
-    protected int getLocation() {
-        return location;
-    }
 
     /**
      * Answer the immediately enclosing container.

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/KernelResolver.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/KernelResolver.java
@@ -83,7 +83,6 @@ public class KernelResolver {
     private static final String SPLIT_CHAR = ";";
     private static final Pattern splitPattern = Pattern.compile(SPLIT_CHAR);
 
-    private final NameBasedLocalBundleRepository repo;
     private final ResolverCache cache;
     private final String logProviderClass;
     private final File kernelMf;
@@ -92,7 +91,7 @@ public class KernelResolver {
     private final boolean forceCleanStart;
 
     private final boolean libertyBoot;
-    private final String BUNDLE_SYMBOLICNAME = "Bundle-SymbolicName";
+    private static final String BUNDLE_SYMBOLICNAME = "Bundle-SymbolicName";
 
     /**
      * @param kernelDefName
@@ -136,7 +135,7 @@ public class KernelResolver {
 
         try {
             // Use a simple repo for bootstrap purposes.
-            repo = new NameBasedLocalBundleRepository(installRoot);
+            NameBasedLocalBundleRepository repo = new NameBasedLocalBundleRepository(installRoot);
 
             File platformDir = new File(installRoot, "lib/platform");
 
@@ -957,6 +956,7 @@ public class KernelResolver {
 
         /**
          * Parse a subsystem content element. Assumes leading/trailing spaces have been trimmed
+         *
          * <pre>
          * org.apache.aries.util; version="[1,1.0.100)"; type="boot.jar"
          * com.ibm.wsspi.org.osgi.cmpn; location="dev/spi/spec/"; version="[5.0, 5.1)"; start-phase:=BOOTSTRAP


### PR DESCRIPTION
Do not keep BundleRepository in the class since it is only used in the
constructor.
Remove entryOffset / location from ZipContainer / ZipEntry code since it
isn't used.