### PR TITLE
update oidc clients common code to hash and encode the oidccode cookie

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
@@ -542,25 +542,44 @@ public class OIDCClientAuthenticatorUtil {
      * @return
      */
     @FFDCIgnore({ IndexOutOfBoundsException.class })
-    public boolean validateReqParameters(ConvergedClientConfig clientConfig, Hashtable<String, String> reqParameters, String encodedReqParams) {
+    public boolean validateReqParameters(ConvergedClientConfig clientConfig, Hashtable<String, String> reqParameters, String cookieValue) {
         boolean validCookie = true;
-        String decodedReqParams = Base64Coder.toString(Base64Coder.base64DecodeString(encodedReqParams));
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "decodedRequestParameters:" + decodedReqParams);
-        }
+        String encoded = null;
+        String cookieName = "WASOidcCode";
+//        String decodedReqParams = Base64Coder.toString(Base64Coder.base64DecodeString(encodedReqParams));
+
         String requestParameters = null;
         try {
-            int iAfterLastBrace = decodedReqParams.lastIndexOf("}") + 1;
-            String digestCode = decodedReqParams.substring(iAfterLastBrace);
-            requestParameters = decodedReqParams.substring(0, iAfterLastBrace);
-            // digest with the client_secret value
-            String newDigestCode = HashUtils.digest(requestParameters + clientConfig.getClientSecret());
-            validCookie = digestCode.equals(newDigestCode);
-            if (!validCookie) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "newHashCode:" + newDigestCode);
+            int lastindex = cookieValue.lastIndexOf("_");
+            if (lastindex < 1) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "The cookie may have been tampered with.");
+                    if (lastindex < 0) Tr.debug(tc,"The cookie does not contain an underscore.");
+                    if (lastindex == 0) Tr.debug(tc,"The cookie does not contain a value before the underscore.");
                 }
+                return false;
             }
+            encoded = cookieValue.substring(0, lastindex);
+            String testCookie = OidcClientUtil.calculateOidcCodeCookieValue(encoded, clientConfig.getClientSecret());
+            
+            if (!cookieValue.equals(testCookie)) {
+                String msg = "The value for the OIDC state cookie ["+cookieName+"] failed validation.";
+                if (tc.isDebugEnabled()) {
+                  Tr.debug(tc,msg);
+                }
+                validCookie = false;
+            }
+            
+            //String digestCode = decodedReqParams.substring(iAfterLastBrace);
+            //requestParameters = decodedReqParams.substring(0, iAfterLastBrace);
+            // digest with the client_secret value
+            //String newDigestCode = HashUtils.digest(requestParameters + clientConfig.getClientSecret());
+            //validCookie = digestCode.equals(newDigestCode);
+//            if (!validCookie) {
+//                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+//                    Tr.debug(tc, "newHashCode:" + newDigestCode);
+//                }
+//            }
         } catch (IndexOutOfBoundsException e) {
             // anything wrong indicated the requestParameter cookie is not right or is not in right format
             validCookie = false;
@@ -570,6 +589,10 @@ public class OIDCClientAuthenticatorUtil {
         }
 
         if (validCookie) {
+            requestParameters = Base64Coder.toString(Base64Coder.base64DecodeString(encoded));
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "decodedRequestParameters:" + requestParameters);
+            }
             JsonParser parser = new JsonParser();
             JsonObject jsonObject = (JsonObject) parser.parse(requestParameters);
             Set<Map.Entry<String, JsonElement>> entries = jsonObject.entrySet();

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
@@ -352,7 +352,7 @@ public class OidcClientUtil {
     }
 
     // set the code cookie during authentication
-    public void setCookieForRequestParameter(HttpServletRequest request, HttpServletResponse response, String id, String state, boolean isHttpsRequest, ConvergedClientConfig clientCfg) {
+    public static void setCookieForRequestParameter(HttpServletRequest request, HttpServletResponse response, String id, String state, boolean isHttpsRequest, ConvergedClientConfig clientCfg) {
         //OidcClientConfigImpl clientCfg = activatedOidcClientImpl.getOidcClientConfig(request, id);
         Map<String, String[]> map = request.getParameterMap(); // at least it gets state parameter
         JsonObject jsonObject = new JsonObject();
@@ -371,23 +371,42 @@ public class OidcClientUtil {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "requestParameters:" + requestParameters);
         }
-        // digest with the client_secret value
-        String digestValue = HashUtils.digest(requestParameters + clientCfg.getClientSecret());
-        String hashReqParams = requestParameters + digestValue;
         String encodedReqParams = null;
         try {
-            encodedReqParams = Base64Coder.toString(Base64Coder.base64Encode(hashReqParams.getBytes(ClientConstants.CHARSET)));
+            encodedReqParams = Base64Coder.toString(Base64Coder.base64Encode(requestParameters.getBytes(ClientConstants.CHARSET)));
         } catch (UnsupportedEncodingException e) {
             //This should not happen, we are using UTF-8
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "get unexpected exception", e);
             }
         }
-
-        Cookie c = OidcClientUtil.createCookie(ClientConstants.WAS_OIDC_CODE, encodedReqParams, request);
+        
+        String encodedHash = null;
+        if (encodedReqParams != null) {
+            encodedHash = calculateOidcCodeCookieValue(encodedReqParams, clientCfg.getClientSecret());
+        }
+        Cookie c = OidcClientUtil.createCookie(ClientConstants.WAS_OIDC_CODE, encodedHash, request);
         if (clientCfg.isHttpsRequired() && isHttpsRequest) {
             c.setSecure(true);
         }
         response.addCookie(c);
+    }
+
+    /**
+     * @param encodedReqParams
+     * @param clientSecret
+     * @return
+     */
+    public static String calculateOidcCodeCookieValue(String encoded, String secret) {
+        
+        String retVal = new String(encoded);
+
+        if (secret != null && secret.length() > 0) {
+          String tmpStr = new String(encoded);
+          tmpStr = tmpStr.concat("_").concat(secret);   
+          retVal = retVal.concat("_").concat(HashUtils.digest(tmpStr));   // digest encoded request params and client_secret
+        }
+       
+        return retVal;
     }
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
@@ -200,6 +200,9 @@ public class OIDCClientAuthenticatorUtilTest {
         map.put("access_token", new String[] { "access_token_content" });
         map.put(id_token, idTokens);
         map.put("refresh_token", new String[] { "refresh_token_content" });
+        map.put("code", new String[] { "YMKexUVcHci2dhDJzNRHW2w9rhf70u" });
+        map.put("state", new String[] { "001534964952438QID21LdnF" });
+        
         JsonObject jsonObject = new JsonObject();
         Set<Map.Entry<String, String[]>> entries = map.entrySet();
         for (Map.Entry<String, String[]> entry : entries) {
@@ -210,16 +213,19 @@ public class OIDCClientAuthenticatorUtilTest {
             }
         }
         String requestParameters = jsonObject.toString();
-
-        // digest with the client_secret value
-        String digestValue = HashUtils.digest(requestParameters + clientSecret);
-        String hashReqParams = requestParameters + digestValue;
-
+        
+        String localEncoded = null;
         try {
-            encodedReqParams = Base64Coder.toString(Base64Coder.base64Encode(hashReqParams.getBytes(ClientConstants.CHARSET)));
+            localEncoded = Base64Coder.toString(Base64Coder.base64Encode(requestParameters.getBytes(ClientConstants.CHARSET)));
         } catch (UnsupportedEncodingException e) {
             //This should not happen, we are using UTF-8
         }
+
+        // digest with the client_secret value
+        String tmpStr = new String(localEncoded);
+        tmpStr = tmpStr.concat("_").concat(clientSecret);
+        
+        encodedReqParams = new String(localEncoded).concat("_").concat(HashUtils.digest(tmpStr));   
         reqParameterCookie = new Cookie(ClientConstants.WAS_OIDC_CODE, encodedReqParams);
     }
 


### PR DESCRIPTION
Before this change - we are taking the hash and encoding.
Receiving side, the order is decode, calculate hash and compare. This may cause some extraneous effects (especially if the cookie is tampered with...).

After this change - We encode first and take the hash
Receiving side - calculate hash and compare to make sure that the data is not tampered with and then decode

