### PR TITLE
initial implementation of beginRequest and endRequest

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
@@ -120,4 +120,10 @@ public class JDBC40Runtime implements JDBCRuntimeVersion {
     public int doGetNetworkTimeout(Connection sqlConn) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
+
+    @Override
+    public void beginRequest(Connection con) {}
+
+    @Override
+    public void endRequest(Connection con) {}
 }

--- a/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
@@ -146,4 +146,10 @@ public class JDBC41Runtime implements JDBCRuntimeVersion {
     public BatchUpdateException newBatchUpdateException(BatchUpdateException copyFrom, String newMessage) {
         return new BatchUpdateException(newMessage, copyFrom.getSQLState(), copyFrom.getErrorCode(), copyFrom.getUpdateCounts());
     }
+
+    @Override
+    public void beginRequest(Connection con) {}
+
+    @Override
+    public void endRequest(Connection con) {}
 }

--- a/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
@@ -146,4 +146,10 @@ public class JDBC42Runtime implements JDBCRuntimeVersion {
             throw new SQLFeatureNotSupportedException(e);
         }
     }
+
+    @Override
+    public void beginRequest(Connection con) {}
+
+    @Override
+    public void endRequest(Connection con) {}
 }

--- a/dev/com.ibm.ws.jdbc.4.3.feature/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc.4.3.feature/bnd.bnd
@@ -15,6 +15,8 @@ bVersion=1.0
 javac.source: 1.8
 javac.target: 1.8
 
+javac.args.release: current
+
 Bundle-Name: Database Connectivity
 Bundle-SymbolicName: com.ibm.ws.jdbc.4.3.feature
 Bundle-Description: Database connectivity infrastructure, version ${bVersion}
@@ -25,8 +27,13 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=9))"
 
 Private-Package: \
   com.ibm.ws.jdbc.osgi.v43
-  
+
 -dsannotations: com.ibm.ws.jdbc.osgi.v43.JDBC43Runtime
+
+# TODO: remove bootcp override once javac.source is set to '9'
+-buildpath.bootclasspath: \
+    ../com.ibm.ws.jdbc.4.3/lib/java.sql.4.3.jar;version=file;boot=true,\
+    ${javac.bootclasspath.${javac.source}}
   
 -buildpath: \
 	com.ibm.websphere.javaee.connector.1.6;version=latest,\

--- a/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
@@ -146,4 +146,15 @@ public class JDBC43Runtime implements JDBCRuntimeVersion {
             throw new SQLFeatureNotSupportedException(e);
         }
     }
+
+    @Override
+    public void beginRequest(Connection con) throws SQLException {
+        con.beginRequest();
+    }
+
+    @Override
+    public void endRequest(Connection con) throws SQLException {
+        con.endRequest();
+    }
+
 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
@@ -82,4 +82,8 @@ public interface JDBCRuntimeVersion {
     
     // JDBC 4.2 BatchUpdateException constructor
     public BatchUpdateException newBatchUpdateException(BatchUpdateException copyFrom, String newMessage);
+
+    // JDBC 4.3 Connection methods
+    public void beginRequest(Connection con) throws SQLException;
+    public void endRequest(Connection con) throws SQLException;
 }

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
@@ -17,11 +17,14 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import javax.annotation.Resource;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.sql.DataSource;
+import javax.transaction.UserTransaction;
 
 import org.junit.Test;
 
@@ -30,9 +33,16 @@ import componenttest.app.FATServlet;
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/JDBC43TestServlet")
 public class JDBC43TestServlet extends FATServlet {
+    /**
+     * Array indices for beginRequest/endRequest tracking.
+     */
+    private static final int BEGIN = 0, END = 1;
 
     @Resource
     DataSource defaultDataSource;
+
+    @Resource
+    UserTransaction tx;
 
     // create a table for tests to use and pre-populate it with some data
     @Override
@@ -75,5 +85,200 @@ public class JDBC43TestServlet extends FATServlet {
         } finally {
             con.close();
         }
+    }
+
+    /**
+     * Verify that within a global transaction, a single request is made that covers all shared handles.
+     * In this test, the shared handles are open at the same time.
+     */
+    @Test
+    public void testMultipleOpenSharableHandlesInTransaction() throws Exception {
+        AtomicInteger[] requests;
+        int begins = -1000, ends = -1000;
+
+        tx.begin();
+        try {
+            Connection con1 = defaultDataSource.getConnection();
+            requests = (AtomicInteger[]) con1.unwrap(Supplier.class).get();
+            begins = requests[BEGIN].get();
+            ends = requests[END].get();
+            assertEquals(ends + 1, begins);
+
+            PreparedStatement ps1 = con1.prepareStatement("INSERT INTO STREETS VALUES(?, ?, ?)");
+            ps1.setString(1, "North Broadway Avenue");
+            ps1.setString(2, "Rochester");
+            ps1.setString(3, "MN");
+            ps1.executeUpdate();
+            ps1.close();
+
+            Connection con2 = defaultDataSource.getConnection();
+            PreparedStatement ps2 = con2.prepareStatement("INSERT INTO STREETS VALUES(?, ?, ?)");
+            ps2.setString(1, "South Broadway Avenue");
+            ps2.setString(2, "Rochester");
+            ps2.setString(3, "MN");
+            ps2.executeUpdate();
+            ps2.close();
+
+            assertEquals(begins, requests[BEGIN].get());
+            assertEquals(ends, requests[END].get());
+
+            Connection con3 = defaultDataSource.getConnection();
+            assertEquals(begins, requests[BEGIN].get());
+            assertEquals(ends, requests[END].get());
+        } finally {
+            tx.commit();
+        }
+
+        assertEquals(begins, requests[BEGIN].get());
+        assertEquals(ends + 1, requests[END].get());
+    }
+
+    /**
+     * Verify that within a global transaction, a single request is used across get/use/close of all shared handles.
+     */
+    @Test
+    public void testSerialReuseInGlobalTransaction() throws Exception {
+        AtomicInteger[] requests;
+        int begins = -1000, ends = -1000;
+
+        Connection con3;
+        tx.begin();
+        try {
+            Connection con1 = defaultDataSource.getConnection();
+            requests = (AtomicInteger[]) con1.unwrap(Supplier.class).get();
+            begins = requests[BEGIN].get();
+            ends = requests[END].get();
+            assertEquals(ends + 1, begins);
+
+            PreparedStatement ps1 = con1.prepareStatement("INSERT INTO STREETS VALUES(?, ?, ?)");
+            ps1.setString(1, "East River Road");
+            ps1.setString(2, "Rochester");
+            ps1.setString(3, "MN");
+            ps1.executeUpdate();
+            ps1.close();
+            con1.close();
+
+            Connection con2 = defaultDataSource.getConnection();
+            PreparedStatement ps2 = con2.prepareStatement("INSERT INTO STREETS VALUES(?, ?, ?)");
+            ps2.setString(1, "West River Road");
+            ps2.setString(2, "Rochester");
+            ps2.setString(3, "MN");
+            ps2.executeUpdate();
+            ps2.close();
+            con2.close();
+
+            assertEquals(begins, requests[BEGIN].get());
+            assertEquals(ends, requests[END].get());
+
+            con3 = defaultDataSource.getConnection();
+            assertEquals(begins, requests[BEGIN].get());
+            assertEquals(ends, requests[END].get());
+        } finally {
+            tx.commit();
+        }
+
+        assertEquals(begins, requests[BEGIN].get());
+        assertEquals(ends + 1, requests[END].get());
+
+        tx.begin();
+        try {
+            // might use different managed connection instance
+            PreparedStatement ps3 = con3.prepareStatement("UPDATE STREETS SET NAME=? WHERE NAME=? AND CITY=? AND STATE=?");
+            requests = (AtomicInteger[]) con3.unwrap(Supplier.class).get();
+            begins = requests[BEGIN].get();
+            ends = requests[END].get();
+            assertEquals(ends + 1, begins);
+
+            ps3.setString(1, "West River Parkway");
+            ps3.setString(2, "West River Road");
+            ps3.setString(3, "Rochester");
+            ps3.setString(4, "MN");
+            ps3.executeUpdate();
+            ps3.close();
+
+            assertEquals(ends + 1, begins);
+        } finally {
+            tx.commit();
+        }
+
+        assertEquals(begins, requests[BEGIN].get());
+        assertEquals(ends + 1, requests[END].get());
+    }
+
+    /**
+     * Verify that within an LTC, a single request is used across get/use/close of all shared handles.
+     */
+    @Test
+    public void testSerialReuseInLTC() throws Exception {
+        AtomicInteger[] requests;
+        int begins = -1000, ends = -1000;
+
+        Connection con1 = defaultDataSource.getConnection();
+        try {
+            requests = (AtomicInteger[]) con1.unwrap(Supplier.class).get();
+            begins = requests[BEGIN].get();
+            ends = requests[END].get();
+            assertEquals(ends + 1, begins);
+
+            PreparedStatement ps1 = con1.prepareStatement("INSERT INTO STREETS VALUES(?, ?, ?)");
+            ps1.setString(1, "East Center Street");
+            ps1.setString(2, "Rochester");
+            ps1.setString(3, "MN");
+            ps1.executeUpdate();
+            ps1.close();
+        } finally {
+            con1.close();
+        }
+
+        Connection con2 = defaultDataSource.getConnection();
+        try {
+            PreparedStatement ps2 = con2.prepareStatement("INSERT INTO STREETS VALUES(?, ?, ?)");
+            ps2.setString(1, "W Center Street");
+            ps2.setString(2, "Rochester");
+            ps2.setString(3, "MN");
+            ps2.executeUpdate();
+            ps2.close();
+
+            assertEquals(begins, requests[BEGIN].get());
+            assertEquals(ends, requests[END].get());
+        } finally {
+            con2.close();
+        }
+
+        Connection con3 = defaultDataSource.getConnection();
+        try {
+            assertEquals(begins, requests[BEGIN].get());
+            assertEquals(ends, requests[END].get());
+
+            // end the LTC
+            tx.begin();
+            tx.commit();
+
+            assertEquals(begins, requests[BEGIN].get());
+            assertEquals(ends + 1, requests[END].get());
+
+            // new LTC, might use different managed connection instance
+            PreparedStatement ps3 = con3.prepareStatement("UPDATE STREETS SET NAME=? WHERE NAME=? AND CITY=? AND STATE=?");
+            requests = (AtomicInteger[]) con3.unwrap(Supplier.class).get();
+            begins = requests[BEGIN].get();
+            ends = requests[END].get();
+            assertEquals(ends + 1, begins);
+
+            ps3.setString(1, "West Center Street");
+            ps3.setString(2, "W Center Street");
+            ps3.setString(3, "Rochester");
+            ps3.setString(4, "MN");
+            ps3.executeUpdate();
+            ps3.close();
+        } finally {
+            con3.close();
+        }
+
+        // end the second LTC
+        tx.begin();
+        tx.commit();
+
+        assertEquals(begins, requests[BEGIN].get());
+        assertEquals(ends + 1, requests[END].get());
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
@@ -18,7 +18,7 @@ import java.sql.Connection;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-public class D43Handler implements InvocationHandler, Supplier<int[]> {
+public class D43Handler implements InvocationHandler, Supplier<AtomicInteger[]> {
     // for tracking Connection.beginRequest/endRequest
     private final AtomicInteger beginRequests = new AtomicInteger();
     private final AtomicInteger endRequests = new AtomicInteger();
@@ -30,10 +30,10 @@ public class D43Handler implements InvocationHandler, Supplier<int[]> {
     }
 
     // Accessible via wrapper pattern for obtaining the count of Connection.beginRequest/endRequest
-    // Usage: requestCounts = (int[]) con.unwrap(Supplier).get();
+    // Usage: requestCounts = (AtomicInteger[]) con.unwrap(Supplier).get();
     @Override
-    public int[] get() {
-        return new int[] { beginRequests.get(), endRequests.get() };
+    public AtomicInteger[] get() {
+        return new AtomicInteger[] { beginRequests, endRequests };
     }
 
     @Override


### PR DESCRIPTION
To start out with, invoke the beginRequest operation when associating or getting the first connection handle and invoke the endRequest operation when cleaning up or destroying a managed connection.  Add a few test cases to start experimenting with different scenarios where beginRequest/endRequest should be sent to the JDBC driver.