### PR TITLE
test request boundaries for multiple unshared connections in global tran

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -25,6 +25,12 @@
     <properties url="jdbc:d43:memory:testdb;create=true" user="user43" password="{xor}Lyg7a2w="/>
   </dataSource>
 
+  <dataSource jndiName="jdbc/xa">
+    <jdbcDriver libraryRef="D43Lib"/>
+    <properties databaseName="memory:testdb;create=true"/>
+    <containerAuthData user="user43" password="{xor}Lyg7a2w="/>
+  </dataSource>
+
   <!-- This is a Derby driver with custom implementations added for certain JDBC 4.3 methods -->
   <library id="D43Lib" fat.modify="true">
     <file name="${server.config.dir}/drivers/d43driver.jar"/>

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43XADataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43XADataSource.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+import javax.sql.XAConnection;
+import javax.sql.XAConnectionBuilder;
+import javax.sql.XADataSource;
+
+public class D43XADataSource implements XADataSource {
+    private final org.apache.derby.jdbc.EmbeddedXADataSource ds;
+
+    public D43XADataSource() {
+        ds = new org.apache.derby.jdbc.EmbeddedXADataSource();
+    }
+
+    @Override
+    public XAConnectionBuilder createXAConnectionBuilder() throws SQLException {
+        return (XAConnectionBuilder) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                            new Class[] { XAConnectionBuilder.class },
+                                                            new D43Handler(ds.createXAConnectionBuilder()));
+    }
+
+    public String getDatabaseName() {
+        return ds.getDatabaseName();
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return ds.getLoginTimeout();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return ds.getLogWriter();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return ds.getParentLogger();
+    }
+
+    @Override
+    public XAConnection getXAConnection() throws SQLException {
+        return (XAConnection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                     new Class[] { XAConnection.class },
+                                                     new D43Handler(ds.getXAConnection()));
+    }
+
+    @Override
+    public XAConnection getXAConnection(String user, String pwd) throws SQLException {
+        return (XAConnection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                     new Class[] { XAConnection.class },
+                                                     new D43Handler(ds.getXAConnection(user, pwd)));
+    }
+
+    public void setDatabaseName(String value) {
+        ds.setDatabaseName(value);
+    }
+
+    @Override
+    public void setLoginTimeout(int value) throws SQLException {
+        ds.setLoginTimeout(value);
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter value) throws SQLException {
+        ds.setLogWriter(value);
+    }
+}


### PR DESCRIPTION
Write a test case with multiple unshared connections in a global transaction, verifying that Liberty invokes beginRequest/endRequest for each connection and that the endRequest is not invoke until both the connection is closed and the global transaction has ended, reflecting the fact that the connection manager must keep the connection around until commit time so that it can perform the commit/rollback to the database.

This will also require updating the mock JDBC driver with an XADataSource that is backed by Derby, given that we will need to have multiple connections (two-phase capable resources) within the transaction. 