### PR TITLE
Update eclipse settings

### DIFF
--- a/dev/com.ibm.websphere.javaee.jws.1.0/.classpath
+++ b/dev/com.ibm.websphere.javaee.jws.1.0/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/.classpath
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/.classpath
@@ -3,6 +3,5 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="src" path="/fattest.simplicity"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Change to use Java 7 for component that is not marked java 8.
Remove referencing of a project in .classpath.  Projects should only be
referenced in bnd.bnd files.