### PR TITLE
add more tests of unsharable connections with beginRequest and endRequest

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_v43/bnd.bnd
@@ -35,4 +35,5 @@ fat.project: true
     com.ibm.websphere.javaee.annotation.1.3;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
+	com.ibm.tx.core;version=latest,\
 	org.apache.derby:derby;version=10.11.1.1

--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -25,7 +25,14 @@
     <properties url="jdbc:d43:memory:testdb;create=true" user="user43" password="{xor}Lyg7a2w="/>
   </dataSource>
 
-  <dataSource jndiName="jdbc/xa">
+  <dataSource jndiName="jdbc/poolOf1"> <!-- TODO will need to specify type once XA becomes the default -->
+    <connectionManager maxPoolSize="1"/>
+    <jdbcDriver libraryRef="D43Lib"/>
+    <properties databaseName="memory:testdb;create=true"/>
+    <containerAuthData user="user43" password="{xor}Lyg7a2w="/>
+  </dataSource>
+
+  <dataSource jndiName="jdbc/xa" type="javax.sql.XADataSource"> <!-- TODO XA should be made the default -->
     <jdbcDriver libraryRef="D43Lib"/>
     <properties databaseName="memory:testdb;create=true"/>
     <containerAuthData user="user43" password="{xor}Lyg7a2w="/>

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ConnectionPoolDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ConnectionPoolDataSource.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.PooledConnection;
+import javax.sql.PooledConnectionBuilder;
+
+public class D43ConnectionPoolDataSource implements ConnectionPoolDataSource {
+    private final org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource ds;
+
+    public D43ConnectionPoolDataSource() {
+        ds = new org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource();
+    }
+
+    @Override
+    public PooledConnectionBuilder createPooledConnectionBuilder() throws SQLException {
+        return (PooledConnectionBuilder) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                                new Class[] { PooledConnectionBuilder.class },
+                                                                new D43Handler(ds.createPooledConnectionBuilder()));
+    }
+
+    public String getDatabaseName() {
+        return ds.getDatabaseName();
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return ds.getLoginTimeout();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return ds.getLogWriter();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return ds.getParentLogger();
+    }
+
+    @Override
+    public PooledConnection getPooledConnection() throws SQLException {
+        return (PooledConnection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                         new Class[] { PooledConnection.class },
+                                                         new D43Handler(ds.getPooledConnection()));
+    }
+
+    @Override
+    public PooledConnection getPooledConnection(String user, String pwd) throws SQLException {
+        return (PooledConnection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                         new Class[] { PooledConnection.class },
+                                                         new D43Handler(ds.getPooledConnection(user, pwd)));
+    }
+
+    public void setDatabaseName(String value) {
+        ds.setDatabaseName(value);
+    }
+
+    @Override
+    public void setLoginTimeout(int value) throws SQLException {
+        ds.setLoginTimeout(value);
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter value) throws SQLException {
+        ds.setLogWriter(value);
+    }
+}


### PR DESCRIPTION
Add test coverage for beginRequest/endRequest when multiple unshared connections are obtained, used, and closed, within global transactions and local transaction containments (LTCs).

Also adding a ConnectionPoolDataSource to the mock JDBC driver, for which we configure a data sources with pool size of 1.  This allows us to always get the same managed connection back so that we can verify that request counts increment sequentially, and only when connections are handed out to the application.