### PR TITLE
ignore multi-release jar error message from Bnd. Bnd has not been tau…

### DIFF
--- a/dev/cnf/build.bnd
+++ b/dev/cnf/build.bnd
@@ -84,6 +84,7 @@ javac.args.release: true
 -fixupmessages.javac17: "The .JRE container is set to JavaSE-1.8 but bnd is compiling against 1.7";is:=ignore
 -fixupmessages.nosrc: "bnd's src folder 'src' is not in the Eclipse build path";is:=ignore
 -fixupmessages.missingexport: "Used bundle version * for exported package";is:=error
+-fixupmessages.mrjar: Classes found in the wrong directory:*META-INF/versions
 
 -releaserepo: ${if;${is.remote.publishing};RemotePublish;Release}
 -baselinerepo: Release


### PR DESCRIPTION
This PR is to suppress a Bnd error caused by multi-release jars as maven dependencies. Bnd has not been taught about multi release jars yet so adding "-fixupmessages.mrjar: Classes found in the wrong directory:*META-INF/versions" to the global bnd file at cnf\build.bnd to suppress.