### PR TITLE
SseBroadcaster fix

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/.classpath
@@ -5,6 +5,7 @@
 	<classpathentry kind="src" path="test-applications/SseJaxbApp/src"/>
 	<classpathentry kind="src" path="test-applications/BasicSseApp/src"/>
 	<classpathentry kind="src" path="test-applications/DelaySseApp/src"/>
+	<classpathentry kind="src" path="test-applications/BroadcasterApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/bnd.bnd
@@ -15,20 +15,20 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
-	test-applications/BasicSseApp/src,\
-	test-applications/DelaySseApp/src,\
-        test-applications/SseJaxbApp/src,\
-	test-applications/SseJsonbApp/src
+  fat/src,\
+  test-applications/BasicSseApp/src,\
+  test-applications/BroadcasterApp/src,\
+  test-applications/DelaySseApp/src,\
+  test-applications/SseJaxbApp/src,\
+  test-applications/SseJsonbApp/src
 
 fat.project: true
 
-
 -buildpath: \
-	com.ibm.wsspi.org.osgi.core;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
-	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-	com.ibm.websphere.javaee.jsonb.1.0;version=latest
-	
+  com.ibm.wsspi.org.osgi.core;version=latest,\
+  com.ibm.wsspi.org.osgi.service.component;version=latest,\
+  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+  com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
+  com.ibm.websphere.javaee.servlet.4.0;version=latest,\
+  com.ibm.websphere.javaee.jsonb.1.0;version=latest
+

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BroadcasterTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BroadcasterTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs21.sse.fat;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.sse.broadcaster.BroadcasterTestServlet;
+
+@RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 8)
+public class BroadcasterTest extends FATServletClient {
+
+    static final String appName = "BroadcasterApp";
+
+    @Server("io.openliberty.sse.broadcaster")
+    @TestServlet(servlet = BroadcasterTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive app = ShrinkHelper.buildDefaultApp(appName, "io.openliberty.sse.broadcaster");
+        ShrinkHelper.exportDropinAppToServer(server, app);
+        server.addInstalledAppForValidation(appName);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer();
+    }
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/FATSuite.java
@@ -22,6 +22,7 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
                 BasicSseTest.class,
                 SseJaxbTest.class,
                 SseJsonbTest.class,
-                DelaySseTest.class
+                DelaySseTest.class,
+                BroadcasterTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/io.openliberty.sse.broadcaster/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/io.openliberty.sse.broadcaster/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:org.apache.cxf.*=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/io.openliberty.sse.broadcaster/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/publish/servers/io.openliberty.sse.broadcaster/server.xml
@@ -1,0 +1,23 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+    <feature>osgiConsole-1.0</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml" />
+  <variable name="onError" value="FAIL" />
+
+  <javaPermission className="java.lang.RuntimePermission" name="modifyThread" actions="*"/>
+  <javaPermission className="java.net.URLPermission" name="http://localhost:8010/BroadcasterApp/broadcaster" actions="POST:AcceptUser-Agent"/>
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BroadcasterApp/src/io/openliberty/sse/broadcaster/BroadcasterTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BroadcasterApp/src/io/openliberty/sse/broadcaster/BroadcasterTestServlet.java
@@ -1,0 +1,470 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.sse.broadcaster;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.sse.InboundSseEvent;
+import javax.ws.rs.sse.SseEventSource;
+
+import org.junit.After;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/BroadcasterTestServlet")
+public class BroadcasterTestServlet extends FATServlet {
+    private final static Logger _log = Logger.getLogger(BroadcasterTestServlet.class.getName());
+    private final static int NUM_CLIENTS = 5;
+
+    ExecutorService executor = Executors.newFixedThreadPool(NUM_CLIENTS * 2);
+
+    @Test
+    public void testClientReceivesBroadcastedEvents(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        final String m = "testClientReceivesBroadcastedEvents";
+        Client client = ClientBuilder.newClient();
+        int port = req.getServerPort();
+        WebTarget target = client.target("http://localhost:" + port + "/BroadcasterApp/broadcaster");
+
+        // setup the broadcaster
+        target.request().post(Entity.text(""));
+
+        CountDownLatch latch = new CountDownLatch(NUM_CLIENTS);
+        List<ClientListener> clients = new ArrayList<>();
+        try {
+            for (int i = 0; i < NUM_CLIENTS; i++) {
+                ClientListener clientListener = new ClientListener(target, latch);
+                clients.add(clientListener);
+                executor.submit(clientListener);
+            }
+
+            if (!latch.await(4, TimeUnit.SECONDS)) {
+                _log.info(m + " timed out waiting for initial registration welcome");
+            }
+
+            latch = new CountDownLatch(NUM_CLIENTS);
+            for (ClientListener clientListener : clients) {
+                List<String> events = clientListener.getReceivedEvents();
+                assertTrue(events.size() == 0 || (events.size() == 1 && events.get(0).equals("Welcome")));
+                events.clear();
+                clientListener.setLatch(latch);
+            }
+
+            target.request().put(Entity.text("Event1"));
+
+            if (!latch.await(4, TimeUnit.SECONDS)) {
+                _log.info(m + " timed out waiting for first broadcasted event");
+            }
+
+            latch = new CountDownLatch(NUM_CLIENTS);
+            for (ClientListener clientListener : clients) {
+                List<String> events = clientListener.getReceivedEvents();
+                assertTrue(events.size() == 1 && events.get(0).equals("Event1"));
+                events.clear();
+                clientListener.setLatch(latch);
+            }
+
+            target.request().put(Entity.text("Event2"));
+
+            if (!latch.await(4, TimeUnit.SECONDS)) {
+                _log.info(m + " timed out waiting for second broadcasted event");
+            }
+
+            for (ClientListener clientListener : clients) {
+                List<String> events = clientListener.getReceivedEvents();
+                assertTrue(events.size() == 1 && events.get(0).equals("Event2"));
+                events.clear();
+            }
+        } finally {
+            target.request().delete();
+            for (ClientListener clientListener : clients) {
+                clientListener.close();
+            }
+        }
+    }
+
+//    private void blah() {
+//        final List<String> receivedEvents = new ArrayList<String>();
+//        final CountDownLatch executionLatch = new CountDownLatch(1);
+//
+//        try (SseEventSource source = SseEventSource.target(target).build()) {
+//            System.out.println("client invoking server SSE resource on: " + source);
+//            source.register(
+//                            new Consumer<InboundSseEvent>() { // event
+//
+//                                @Override
+//                                public void accept(InboundSseEvent t) {
+//                                    System.out.println("new plain event: " + t.getId() + " " + t.getName() + " " + t.readData());
+//                                    receivedEvents.add(t.readData(String.class));
+//                                }
+//                            },
+//                            new Consumer<Throwable>() {
+//
+//                                @Override
+//                                public void accept(Throwable t) {
+//                                    t.printStackTrace();
+//                                    fail("Caught unexpected exception: " + t);
+//                                }
+//                            },
+//                            new Runnable() {
+//
+//                                @Override
+//                                public void run() {
+//                                    System.out.println("completion runnable executed");
+//                                    executionLatch.countDown();
+//                                }
+//                            });
+//
+//            source.open();
+//            System.out.println("client source open");
+//            assertTrue("Completion listener runnable was not executed", executionLatch.await(30, TimeUnit.SECONDS));
+//
+//        } catch (InterruptedException e) {
+//            // falls through
+//            e.printStackTrace();
+//        }
+//
+//        assertEquals("Received an unexpected number of events", 3, receivedEvents.size());
+//        assertEquals("Unexpected event or event out of order", "uno", receivedEvents.get(0));
+//        assertEquals("Unexpected event or event out of order", "dos", receivedEvents.get(1));
+//        assertEquals("Unexpected event or event out of order", "tres", receivedEvents.get(2));
+//    }
+//
+//    public void testIntegerSse(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+//
+//        final List<Integer> receivedEvents = new ArrayList<Integer>();
+//        final CountDownLatch executionLatch = new CountDownLatch(1);
+//
+//        Client client = ClientBuilder.newClient();
+//        int port = req.getServerPort();
+//        WebTarget target = client.target("http://localhost:" + port + "/BasicSseApp/basic/integer3");
+//
+//        try (SseEventSource source = SseEventSource.target(target).build()) {
+//            System.out.println("client invoking server SSE resource on: " + source);
+//            source.register(
+//                            new Consumer<InboundSseEvent>() { // event
+//
+//                                @Override
+//                                public void accept(InboundSseEvent t) {
+//                                    System.out.println("new integer event: " + t.getId() + " " + t.getName() + " " + t.readData());
+//                                    receivedEvents.add(t.readData(Integer.class));
+//                                }
+//                            },
+//                            new Consumer<Throwable>() {
+//
+//                                @Override
+//                                public void accept(Throwable t) {
+//                                    t.printStackTrace();
+//                                    fail("Caught unexpected exception: " + t);
+//                                }
+//                            },
+//                            new Runnable() {
+//
+//                                @Override
+//                                public void run() {
+//                                    System.out.println("completion runnable executed");
+//                                    executionLatch.countDown();
+//                                }
+//                            });
+//
+//            source.open();
+//            System.out.println("client source open");
+//            assertTrue("Completion listener runnable was not executed", executionLatch.await(30, TimeUnit.SECONDS));
+//
+//        } catch (InterruptedException e) {
+//            // falls through
+//            e.printStackTrace();
+//        }
+//
+//        assertEquals("Received an unexpected number of events", 3, receivedEvents.size());
+//        assertEquals("Unexpected event or event out of order", 1, receivedEvents.get(0).intValue());
+//        assertEquals("Unexpected event or event out of order", 2, receivedEvents.get(1).intValue());
+//        assertEquals("Unexpected event or event out of order", 3, receivedEvents.get(2).intValue());
+//    }
+//
+//    public void testJsonSse(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+//
+//        final List<JsonObject> receivedEvents = new ArrayList<JsonObject>();
+//        final CountDownLatch executionLatch = new CountDownLatch(1);
+//
+//        Client client = ClientBuilder.newClient();
+//        int port = req.getServerPort();
+//        WebTarget target = client.target("http://localhost:" + port + "/BasicSseApp/basic/json3");
+//
+//        SseEventSource source = SseEventSource.target(target).build();
+//        try {
+//            System.out.println("client invoking server SSE resource on: " + source);
+//            source.register(
+//                            new Consumer<InboundSseEvent>() { // event
+//
+//                                @Override
+//                                public void accept(InboundSseEvent t) {
+//                                    JsonObject o = t.readData(JsonObject.class, MediaType.APPLICATION_JSON_TYPE);
+//                                    System.out.println("new json event: " + o);
+//                                    receivedEvents.add(o);
+//                                }
+//                            },
+//                            new Consumer<Throwable>() {
+//
+//                                @Override
+//                                public void accept(Throwable t) {
+//                                    t.printStackTrace();
+//                                    fail("Caught unexpected exception: " + t);
+//                                }
+//                            },
+//                            new Runnable() {
+//
+//                                @Override
+//                                public void run() {
+//                                    System.out.println("completion runnable executed");
+//                                    executionLatch.countDown();
+//                                }
+//                            });
+//
+//            for (int i = 0; i < 3; i++) {
+//                try {
+//                    source.open();
+//                    break;
+//                } catch (Throwable t) {
+//                    t.printStackTrace();
+//                    source.close();
+//                    source = SseEventSource.target(target).build();
+//                }
+//            }
+//
+//            System.out.println("client source open");
+//            assertTrue("Completion listener runnable was not executed", executionLatch.await(30, TimeUnit.SECONDS));
+//
+//        } catch (InterruptedException e) {
+//            // falls through
+//            e.printStackTrace();
+//        } finally {
+//            source.close();
+//        }
+//
+//        assertEquals("Received an unexpected number of events", 3, receivedEvents.size());
+//        assertEquals("Unexpected event or event out of order", JSON_OBJECTS[0], receivedEvents.get(0));
+//        assertEquals("Unexpected event or event out of order", JSON_OBJECTS[1], receivedEvents.get(1));
+//        assertEquals("Unexpected event or event out of order", JSON_OBJECTS[2], receivedEvents.get(2));
+//    }
+//
+//    public void testJaxbSse(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+//
+//        final List<JaxbObject> receivedEvents = new ArrayList<JaxbObject>();
+//        final CountDownLatch executionLatch = new CountDownLatch(1);
+//
+//        Client client = ClientBuilder.newClient();
+//        int port = req.getServerPort();
+//        System.out.println("port = " + port);
+//        WebTarget target = client.target("http://localhost:" + port + "/BasicSseApp/basic/jaxb3");
+//
+//        SseEventSource source = SseEventSource.target(target).build();
+//        try {
+//            System.out.println("client invoking server SSE resource on: " + source);
+//            source.register(
+//                            new Consumer<InboundSseEvent>() { // event
+//
+//                                @Override
+//                                public void accept(InboundSseEvent t) {
+//                                    JaxbObject o = t.readData(JaxbObject.class, MediaType.APPLICATION_XML_TYPE);
+//                                    System.out.println("new jaxb event: " + o);
+//                                    receivedEvents.add(o);
+//                                }
+//                            },
+//                            new Consumer<Throwable>() {
+//
+//                                @Override
+//                                public void accept(Throwable t) {
+//                                    t.printStackTrace();
+//                                    fail("Caught unexpected exception: " + t);
+//                                }
+//                            },
+//                            new Runnable() {
+//
+//                                @Override
+//                                public void run() {
+//                                    System.out.println("completion runnable executed");
+//                                    executionLatch.countDown();
+//                                }
+//                            });
+//
+//            for (int i = 0; i < 3; i++) {
+//                try {
+//                    source.open();
+//                    break;
+//                } catch (Throwable t) {
+//                    t.printStackTrace();
+//                    source.close();
+//                    source = SseEventSource.target(target).build();
+//                }
+//            }
+//
+//            System.out.println("client source open");
+//            assertTrue("Completion listener runnable was not executed", executionLatch.await(30, TimeUnit.SECONDS));
+//
+//        } catch (InterruptedException e) {
+//            // falls through
+//            e.printStackTrace();
+//        } finally {
+//            source.close();
+//        }
+//
+//        assertEquals("Received an unexpected number of events", 3, receivedEvents.size());
+//        assertEquals("Unexpected event or event out of order", JAXB_OBJECTS[0], receivedEvents.get(0));
+//        assertEquals("Unexpected event or event out of order", JAXB_OBJECTS[1], receivedEvents.get(1));
+//        assertEquals("Unexpected event or event out of order", JAXB_OBJECTS[2], receivedEvents.get(2));
+//    }
+//
+//    public void testSseWithRX(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+//
+//        String[] nameData = new String[] { "John", "Jacob", "Jingleheimer", "Schmidt" };
+//        final List<String> receivedEvents = new ArrayList<String>();
+//        final CountDownLatch executionLatch = new CountDownLatch(1);
+//
+//        Client client = ClientBuilder.newClient();
+//        int port = req.getServerPort();
+//        WebTarget postTarget = client.target("http://localhost:" + port + "/BasicSseApp/basic/postPort");
+//        postTarget.request().post(Entity.xml(String.valueOf(port)));
+//
+//        WebTarget nameTarget = client.target("http://localhost:" + port + "/BasicSseApp/basic/postName");
+//        for (int i = 0; i < nameData.length; i++) {
+//            nameTarget.request().rx().post(Entity.xml(nameData[i]));
+//        }
+//
+//        WebTarget target = client.target("http://localhost:" + port + "/BasicSseApp/basic/rx");
+//        SseEventSource.Builder sseBuilder = SseEventSource.target(target);
+//        SseEventSource source = sseBuilder.build();
+//
+//        try {
+//            System.out.println("testSseWithRX:client invoking server SSE resource on: " + source);
+//            source.register(
+//                            new Consumer<InboundSseEvent>() { // event
+//
+//                                @Override
+//                                public void accept(InboundSseEvent t) {
+//                                    System.out.println("testSseWithRX: new event: " + t.readData());
+//                                    receivedEvents.add(t.readData(String.class));
+//                                }
+//                            },
+//                            new Consumer<Throwable>() {
+//
+//                                @Override
+//                                public void accept(Throwable t) {
+//                                    t.printStackTrace();
+//                                    fail("Caught unexpected exception: " + t);
+//                                }
+//                            },
+//                            new Runnable() {
+//
+//                                @Override
+//                                public void run() {
+//                                    System.out.println("testSseWithRX: completion runnable executed");
+//                                    executionLatch.countDown();
+//                                }
+//                            });
+//
+//            source.open();
+//            System.out.println("testSseWithRX: client source open");
+//            assertTrue("Completion listener runnable was not executed", executionLatch.await(30, TimeUnit.SECONDS));
+//
+//        } catch (InterruptedException e) {
+//            // falls through
+//            e.printStackTrace();
+//        } finally {
+//            source.close();
+//        }
+//        assertEquals("Received an unexpected number of events", nameData.length, receivedEvents.size());
+//        System.out.println("testSseWithRX: " + receivedEvents + " that's my name too");
+//    }
+//
+//    public void testErrorSse(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+//
+//        final List<JaxbObject> receivedEvents = new ArrayList<JaxbObject>();
+//        final CountDownLatch executionLatch = new CountDownLatch(1);
+//
+//        Client client = ClientBuilder.newClient();
+//        int port = req.getServerPort();
+//        System.out.println("port = " + port);
+//        WebTarget target = client.target("http://localhost:" + port + "/BasicSseApp/basic/error");
+//
+//        SseEventSource source = SseEventSource.target(target).build();
+//        try {
+//            System.out.println("client invoking server SSE resource on: " + source);
+//            source.register(
+//                            new Consumer<InboundSseEvent>() { // event
+//
+//                                @Override
+//                                public void accept(InboundSseEvent t) {
+//                                    JaxbObject o = t.readData(JaxbObject.class, MediaType.APPLICATION_XML_TYPE);
+//                                    System.out.println("new error event: " + o);
+//                                    receivedEvents.add(o);
+//                                }
+//                            },
+//                            new Consumer<Throwable>() {
+//
+//                                @Override
+//                                public void accept(Throwable t) {
+//                                    t.printStackTrace();
+//                                    fail("Caught unexpected exception: " + t);
+//                                }
+//                            },
+//                            new Runnable() {
+//
+//                                @Override
+//                                public void run() {
+//                                    System.out.println("completion runnable executed");
+//                                    executionLatch.countDown();
+//                                }
+//                            });
+//
+//            try {
+//                source.open();
+//            } catch (Throwable t) {
+//                t.printStackTrace();
+//                source.close();
+//                source = SseEventSource.target(target).build();
+//            }
+//
+//            System.out.println("client source open");
+//            assertTrue("Completion listener runnable was not executed", executionLatch.await(30, TimeUnit.SECONDS));
+//
+//        } catch (InterruptedException e) {
+//            // falls through
+//            e.printStackTrace();
+//        } finally {
+//            source.close();
+//        }
+//
+//        assertEquals("Received an unexpected number of events", 0, receivedEvents.size());
+//    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BroadcasterApp/src/io/openliberty/sse/broadcaster/ClientListener.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BroadcasterApp/src/io/openliberty/sse/broadcaster/ClientListener.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.sse.broadcaster;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.sse.SseEventSource;
+
+/**
+ *
+ */
+public class ClientListener implements Runnable, Closeable {
+    private final static Logger _log = Logger.getLogger(ClientListener.class.getName());
+    private final static long TEST_WAIT_TIME = 60;
+    private final static AtomicInteger ID_GENERATOR = new AtomicInteger(1);
+    private final int id = ID_GENERATOR.getAndIncrement();
+    private final WebTarget target;
+    private final AtomicReference<CountDownLatch> sharedLatch = new AtomicReference<>();
+    private CountDownLatch privateLatch;
+    private final List<String> receivedEvents = new ArrayList<>();
+
+    ClientListener(WebTarget target, CountDownLatch latch) {
+        this.target = target;
+        this.sharedLatch.set(latch);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Runnable#run()
+     */
+    @Override
+    public void run() {
+        privateLatch = new CountDownLatch(1);
+
+        try (SseEventSource source = SseEventSource.target(target).build()) {
+            source.register(event -> {
+                _log.info("listener id " + id + " received event " + event);
+                String msg = event.readData();
+                receivedEvents.add(msg);
+                //_log.info("id " + id + " received event " + msg);
+            });
+            source.open();
+            try {
+                if (!privateLatch.await(TEST_WAIT_TIME, TimeUnit.SECONDS)) {
+                    _log.warning("run (" + id + ") TIMED OUT!");
+                    receivedEvents.add("TIMED OUT!");
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+        }
+    }
+
+    void setLatch(CountDownLatch latch) {
+        this.sharedLatch.set(latch);
+    }
+
+    List<String> getReceivedEvents() {
+        return receivedEvents;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.io.Closeable#close()
+     */
+    @Override
+    public void close() throws IOException {
+        privateLatch.countDown();
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BroadcasterApp/src/io/openliberty/sse/broadcaster/Resource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BroadcasterApp/src/io/openliberty/sse/broadcaster/Resource.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.sse.broadcaster;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.sse.Sse;
+import javax.ws.rs.sse.SseBroadcaster;
+import javax.ws.rs.sse.SseEventSink;
+
+@ApplicationPath("/")
+@Path("/broadcaster")
+@Consumes(MediaType.TEXT_PLAIN)
+public class Resource extends Application {
+    private static final Logger _log = Logger.getLogger(Resource.class.getName());
+
+    static SseBroadcaster broadcaster;
+    final static AtomicInteger registeredClients = new AtomicInteger();
+
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean setup(@Context Sse sse) { //returns whether setup was necessary
+        synchronized (Resource.class) {
+            if (broadcaster == null) {
+                broadcaster = sse.newBroadcaster();
+                _log.info("setup created new Broadcaster: " + broadcaster);
+                return true;
+            }
+        }
+        _log.info("setup Broadcaster previously created: " + broadcaster);
+        return false;
+    }
+
+    @GET
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public void register(@Context Sse sse, @Context SseEventSink sink) {
+        _log.info("register - registering new sink: " + sink);
+        try {
+            broadcaster.register(sink);
+            int numClients = registeredClients.incrementAndGet();
+            _log.info("register - new sink registered(total " + numClients + ")");
+            sink.send(sse.newEvent("Welcome"));
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+    }
+
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response broadcast(@Context Sse sse, String msg) {
+        int numClients;
+        synchronized (Resource.class) {
+            numClients = registeredClients.get();
+            broadcaster.broadcast(sse.newEvent(msg));
+        }
+        _log.info("broadcast - just sent new event to " + numClients + " clients with message: " + msg);
+        return Response.ok("Broadcast \"" + msg + "\" to " + numClients + " clients").build();
+    }
+
+    @DELETE
+    @Produces(MediaType.TEXT_PLAIN)
+    public boolean clear() {
+        try {
+            synchronized (Resource.class) {
+                broadcaster.close();
+                registeredClients.set(0);
+                return true;
+            }
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+        return false;
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.sse.3.2/src/org/apache/cxf/jaxrs/sse/SseBroadcasterImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.sse.3.2/src/org/apache/cxf/jaxrs/sse/SseBroadcasterImpl.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.jaxrs.sse;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import javax.ws.rs.sse.OutboundSseEvent;
+import javax.ws.rs.sse.SseBroadcaster;
+import javax.ws.rs.sse.SseEventSink;
+
+public class SseBroadcasterImpl implements SseBroadcaster {
+    private final Set<SseEventSink> subscribers = new CopyOnWriteArraySet<>();
+
+    private final Set<Consumer<SseEventSink>> closers =
+            new CopyOnWriteArraySet<>();
+
+    private final Set<BiConsumer<SseEventSink, Throwable>> exceptioners =
+            new CopyOnWriteArraySet<>();
+
+    @Override
+    public void register(SseEventSink sink) {
+        subscribers.add(sink);
+    }
+
+    @Override
+    public CompletionStage<?> broadcast(OutboundSseEvent event) {
+        final Collection<CompletableFuture<?>> futures = new ArrayList<>();
+        
+        for (SseEventSink sink: subscribers) {
+            try {
+                futures.add(sink.send(event).toCompletableFuture());
+            } catch (final Exception ex) {
+                exceptioners.forEach(exceptioner -> exceptioner.accept(sink, ex));
+            }
+        }
+        
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]));
+    }
+
+    @Override
+    public void onClose(Consumer<SseEventSink> subscriber) {
+        closers.add(subscriber);
+    }
+
+    @Override
+    public void onError(BiConsumer<SseEventSink, Throwable> exceptioner) {
+        exceptioners.add(exceptioner);
+    }
+
+    @Override
+    public void close() {
+        subscribers.forEach(subscriber -> {
+            subscriber.close();
+            closers.forEach(closer -> closer.accept(subscriber));
+        });
+    }
+}


### PR DESCRIPTION
This fix resolves an issue discovered late in the release cycle that was introduced as part of the upgrade to CXF 3.2.6 - CXF changed it's SseBroadcasterImpl code to require that the instance of `SseEventSink` be a CXF-specific `SseEventSinkImpl` - this change breaks our implementation which uses a custom `LibertySseEventSinkImpl`.  The change in this pull request reverts the `SseBroadcasterImpl` to the 3.2.4 version so that we can continue to function normally.  After this release, we should update the Liberty code to use the CXF-specific classes.