### PR TITLE
Add and test JDBC 4.3 pass through methods and block builder access

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43CallableStatement.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43CallableStatement.java
@@ -18,6 +18,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcUtil;
 import com.ibm.ws.rsadapter.jdbc.v42.WSJdbc42CallableStatement;
 
 public class WSJdbc43CallableStatement extends WSJdbc42CallableStatement implements CallableStatement {
@@ -39,27 +40,51 @@ public class WSJdbc43CallableStatement extends WSJdbc42CallableStatement impleme
     public String enquoteLiteral(String val) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return cstmtImpl.enquoteLiteral(val);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 
     @Override
     public String enquoteIdentifier(String identifier, boolean alwaysQuote) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return cstmtImpl.enquoteIdentifier(identifier, alwaysQuote);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 
     @Override
     public boolean isSimpleIdentifier(String identifier) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return cstmtImpl.isSimpleIdentifier(identifier);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 
     @Override
     public String enquoteNCharLiteral(String val) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return cstmtImpl.enquoteNCharLiteral(val);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 }

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DatabaseMetaData.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DatabaseMetaData.java
@@ -13,7 +13,9 @@ package com.ibm.ws.rsadapter.jdbc.v43;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
+import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcUtil;
 import com.ibm.ws.rsadapter.jdbc.v42.WSJdbc42DatabaseMetaData;
 
 public class WSJdbc43DatabaseMetaData extends WSJdbc42DatabaseMetaData implements DatabaseMetaData {
@@ -24,7 +26,15 @@ public class WSJdbc43DatabaseMetaData extends WSJdbc42DatabaseMetaData implement
 
     @Override
     public boolean supportsSharding() throws SQLException {
-        throw new UnsupportedOperationException();
+        try {
+            return mDataImpl.supportsSharding();
+        } catch (SQLException ex) {
+            FFDCFilter.processException(ex, getClass().getName(), "32", this);
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            // No FFDC code needed; we might be closed.
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 
 }

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43PreparedStatement.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43PreparedStatement.java
@@ -18,6 +18,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcUtil;
 import com.ibm.ws.rsadapter.jdbc.v42.WSJdbc42PreparedStatement;
 
 public class WSJdbc43PreparedStatement extends WSJdbc42PreparedStatement implements PreparedStatement {
@@ -46,27 +47,51 @@ public class WSJdbc43PreparedStatement extends WSJdbc42PreparedStatement impleme
     public String enquoteLiteral(String val) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return pstmtImpl.enquoteLiteral(val);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 
     @Override
     public String enquoteIdentifier(String identifier, boolean alwaysQuote) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return pstmtImpl.enquoteIdentifier(identifier, alwaysQuote);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 
     @Override
     public boolean isSimpleIdentifier(String identifier) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return pstmtImpl.isSimpleIdentifier(identifier);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 
     @Override
     public String enquoteNCharLiteral(String val) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return pstmtImpl.enquoteNCharLiteral(val);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 }

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Statement.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Statement.java
@@ -17,6 +17,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcUtil;
 import com.ibm.ws.rsadapter.jdbc.v42.WSJdbc42Statement;
 
 public class WSJdbc43Statement extends WSJdbc42Statement implements Statement {
@@ -38,27 +39,51 @@ public class WSJdbc43Statement extends WSJdbc42Statement implements Statement {
     public String enquoteLiteral(String val) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return stmtImpl.enquoteLiteral(val);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 
     @Override
     public String enquoteIdentifier(String identifier, boolean alwaysQuote) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return stmtImpl.enquoteIdentifier(identifier, alwaysQuote);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 
     @Override
     public boolean isSimpleIdentifier(String identifier) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return stmtImpl.isSimpleIdentifier(identifier);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 
     @Override
     public String enquoteNCharLiteral(String val) throws SQLException {
         // KEEP CODE IN SYNC: This method is duplicated in WSJdbc43Statement, WSJdbc43PreparedStatement,
         // and WSJdbc43CallableStatement because multiple inheritance isn't allowed.
-        throw new UnsupportedOperationException();
+        try {
+            return stmtImpl.enquoteNCharLiteral(val);
+        } catch (SQLException ex) {
+            throw WSJdbcUtil.mapException(this, ex);
+        } catch (NullPointerException nullX) {
+            throw runtimeXIfNotClosed(nullX);
+        }
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -44,6 +44,7 @@
   </library>
 
   <javaPermission codebase="${server.config.dir}/drivers/d43driver.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${server.config.dir}/apps/app43.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
 
   <variable name="onError" value="FAIL"/>
 </server>


### PR DESCRIPTION
Adds and tests the JDBC 4.3 pass through methods on DatabaseMetadata and the Statement variants.  It also adds tests to ensure the 4 builder methods cannot be called on the wrapper or underlying datasource objects.