### PR TITLE
New test case that `@Produces` and `@Consumes` affects the right header

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/.classpath
@@ -7,6 +7,7 @@
 	<classpathentry kind="src" path="test-applications/headerPropagationApp/src"/>
 	<classpathentry kind="src" path="test-applications/multiClientCdiApp/src"/>
 	<classpathentry kind="src" path="test-applications/asyncApp/src"/>
+	<classpathentry kind="src" path="test-applications/produceConsumeApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
@@ -18,7 +18,8 @@ src: \
   test-applications/basicCdiClientApp/src,\
   test-applications/basicRemoteApp/src,\
   test-applications/headerPropagationApp/src,\
-  test-applications/multiClientCdiApp
+  test-applications/multiClientCdiApp/src,\
+  test-applications/produceConsumeApp/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
@@ -21,6 +21,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 BasicCdiInEE8Test.class,
                 HeaderPropagationTest.class,
                 MultiClientCdiTest.class,
-                AsyncMethodTest.class
+                AsyncMethodTest.class,
+                ProduceConsumeTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.rest.client.fat;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import mpRestClient11.produceConsume.ProduceConsumeTestServlet;
+
+/**
+ * This test should only be run with mpRestClient-1.1 and above.
+ * Note that mpRestClient-1.1 can work with Java EE 7.0 (MP 1.4) and EE 8 (MP 2.0).
+ */
+@RunWith(FATRunner.class)
+public class ProduceConsumeTest extends FATServletClient {
+
+    private static final String appName = "produceConsumeApp";
+
+    @Server("mpRestClient11.produceConsume")
+    @TestServlet(servlet = ProduceConsumeTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient11.produceConsume");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer(/*"CWWKF0033E"*/); //ignore this error for mismatch with jsonb-1.0 and Java EE 7
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/server.xml
@@ -1,0 +1,14 @@
+<server>
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>mpRestClient-1.1</feature>
+    <feature>ssl-1.0</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+
+  <!--  Required to read the remote server's port system property 
+  <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" /> -->
+
+</server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/produceConsumeApp/src/mpRestClient11/produceConsume/Filter.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/produceConsumeApp/src/mpRestClient11/produceConsume/Filter.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.produceConsume;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+/**
+ * Aborts with response showing "x:y" where x is the header value for Content-Type
+ * and y is the header value for Accept.
+ */
+public class Filter implements ClientRequestFilter {
+    private final static Logger _log = Logger.getLogger(Filter.class.getName());
+
+    /* (non-Javadoc)
+     * @see javax.ws.rs.client.ClientRequestFilter#filter(javax.ws.rs.client.ClientRequestContext)
+     */
+    @Override
+    public void filter(ClientRequestContext ctx) throws IOException {
+        String contentType = ctx.getHeaderString(HttpHeaders.CONTENT_TYPE);
+        String accept = ctx.getHeaderString(HttpHeaders.ACCEPT);
+        _log.info("filter Content-type: " + contentType + "   Accept: " + accept);
+        ctx.abortWith(Response.ok()
+                              .header("Sent-Accept", accept)
+                              .header("Sent-ContentType", contentType)
+                              .build());
+
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/produceConsumeApp/src/mpRestClient11/produceConsume/MyClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/produceConsumeApp/src/mpRestClient11/produceConsume/MyClient.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.produceConsume;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/hello")
+public interface MyClient {
+
+    @GET
+    @Produces(MediaType.APPLICATION_XML)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response produceXMLConsumeJSON();
+    
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_XML)
+    public Response produceJSONConsumeXML();
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/produceConsumeApp/src/mpRestClient11/produceConsume/ProduceConsumeTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/produceConsumeApp/src/mpRestClient11/produceConsume/ProduceConsumeTestServlet.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.produceConsume;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.util.logging.Logger;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/ProduceConsumeTestServlet")
+public class ProduceConsumeTestServlet extends FATServlet {
+    private final static Logger _log = Logger.getLogger(ProduceConsumeTestServlet.class.getName());
+
+    /**
+     * Tests that MP Rest Client's <code>@Produces</code> annotation affects the value transmitted in
+     * the <code>Accept</code> header, and that it's <code>@Consumes</code> annotation affects the
+     * value transmitted in the <code>Content-Type</code> header.  Note that this is opposite of
+     * what you would expect for JAX-RS resources. 
+     */
+    @Test
+    public void testProducesConsumesAnnotationOnClientInterface(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        final String m = "testProducesConsumesAnnotationOnClientInterface";
+        MyClient client = RestClientBuilder.newBuilder()
+                                           .baseUri(URI.create("http://localhost:23/null"))
+                                           .register(Filter.class)
+                                           .build(MyClient.class);
+        
+        _log.info(m + " @Produce(application/json) @Consume(application/xml)");
+        Response r = client.produceJSONConsumeXML();
+        String acceptHeader = r.getHeaderString("Sent-Accept");
+        _log.info(m + "Sent-Accept: " + acceptHeader);
+        String contentTypeHeader = r.getHeaderString("Sent-ContentType");
+        _log.info(m + "Sent-ContentType: " + contentTypeHeader);
+        assertEquals(MediaType.APPLICATION_JSON, acceptHeader);
+        assertEquals(MediaType.APPLICATION_XML, contentTypeHeader);
+        
+        _log.info(m + " @Produce(application/xml) @Consume(application/json)");
+        r = client.produceXMLConsumeJSON();
+        acceptHeader = r.getHeaderString("Sent-Accept");
+        _log.info(m + "Sent-Accept: " + acceptHeader);
+        contentTypeHeader = r.getHeaderString("Sent-ContentType");
+        _log.info(m + "Sent-ContentType: " + contentTypeHeader);
+        assertEquals(MediaType.APPLICATION_XML, acceptHeader);
+        assertEquals(MediaType.APPLICATION_JSON, contentTypeHeader);
+    }
+}


### PR DESCRIPTION
Unlike JAX-RS resources, the MP Rest Client `@Produces` and `@Consumes` annotation determines the value for the `Accept` and `Content-Type` header, respectively.  The REST client represents a "server view", so the `@Produces` annotation indicates that the _server_ is producing that MediaType.  This test case validates this behavior.

This test case was added due to discussion in the MP Rest Client spec project in Issue [109](https://github.com/eclipse/microprofile-rest-client/issues/109).
Also related to MP Rest Client issue [113](https://github.com/eclipse/microprofile-rest-client/issues/113).