### PR TITLE
Enhance social login code with more OIDC client config options

### DIFF
--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -178,3 +178,9 @@ isClientSideRedirectSupported.desc=Specifies whether client side redirection is 
 
 trustAliasName=Trusted alias name
 trustAliasName.desc=Specifies a trusted key alias for using the public key to verify the signature of the token.
+
+responseType.code=Authorization code
+responseType.idTokenToken=ID token and access token
+responseType.token=Access token
+
+responseMode.formPost=Form post

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -65,8 +65,18 @@
             required="false" type="Integer" default="300000" />
         <AD id="signatureAlgorithm" name="%signatureAlgorithm"  description="%signatureAlgorithm.desc"
             required="false" type="String" default="RS256" /> 
-            
-            
+        <AD id="responseType" name="internal" description="internal use only" required="false" type="String" default="code">
+            <Option label="%responseType.code" value="code" />
+            <Option label="%responseType.idTokenToken" value="id_token token" />
+            <Option label="%responseType.token" value="token" />
+        </AD>
+        <AD id="responseMode" name="internal" description="internal use only" required="false" type="String">
+            <Option label="%responseMode.formPost" value="form_post" />
+        </AD>
+        <AD id="nonceEnabled" name="internal" description="internal use only" required="false" type="Boolean" default="true" />
+        <AD id="realmName" name="internal" description="internal use only" required="false" type="String" ibm:type="token" />
+        <AD id="includeCustomCacheKeyInSubject" name="internal" description="internal use only" required="false" type="Boolean" default="true" />
+        <AD id="resource" name="internal" description="internal use only" required="false" type="String" cardinality="2147483647" />
     </OCD>
 
     <Designate pid="com.ibm.ws.security.social.google">
@@ -361,7 +371,19 @@
                <Option label="client_secret_post"  value="client_secret_post" /> 
          </AD>
         <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
-        <AD id="hostNameVerificationEnabled" name="%hostNameVerificationEnabled" description="%hostNameVerificationEnabled.desc" required="false" type="Boolean" default="true"/>       
+        <AD id="hostNameVerificationEnabled" name="%hostNameVerificationEnabled" description="%hostNameVerificationEnabled.desc" required="false" type="Boolean" default="true"/>
+        <AD id="responseType" name="internal" description="internal use only" required="false" type="String" default="code">
+            <Option label="%responseType.code" value="code" />
+            <Option label="%responseType.idTokenToken" value="id_token token" />
+            <Option label="%responseType.token" value="token" />
+        </AD>
+        <AD id="responseMode" name="internal" description="internal use only" required="false" type="String">
+            <Option label="%responseMode.formPost" value="form_post" />
+        </AD>
+        <AD id="nonceEnabled" name="internal" description="internal use only" required="false" type="Boolean" default="true" />
+        <AD id="realmName" name="internal" description="internal use only" required="false" type="String" ibm:type="token" />
+        <AD id="includeCustomCacheKeyInSubject" name="internal" description="internal use only" required="false" type="Boolean" default="true" />
+        <AD id="resource" name="internal" description="internal use only" required="false" type="String" cardinality="2147483647" />
     </OCD>
 
      <!-- 238750, configurable context root.

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/SocialLoginConfig.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/SocialLoginConfig.java
@@ -67,6 +67,8 @@ public interface SocialLoginConfig {
 
     String getResponseType();
 
+    String getGrantType();
+
     boolean createNonce();
 
     String getResource();
@@ -104,5 +106,7 @@ public interface SocialLoginConfig {
     public String getAlgorithm();
 
     boolean getUserApiNeedsSpecialHeader();
+
+    String getResponseMode();
 
 }

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/GithubLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/GithubLoginConfigImpl.java
@@ -56,6 +56,7 @@ public class GithubLoginConfigImpl extends Oauth2LoginConfigImpl {
         haveUserApiResponseIdentifier(userApi, userNameAttribute);
         initializeJwt(props);
         resetLazyInitializedMembers();
+        setGrantType();
     }
 
     @Override

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/GoogleLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/GoogleLoginConfigImpl.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.security.social.internal;
 
-import java.util.Arrays;
-import java.util.Map;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
@@ -21,7 +18,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.security.jwt.config.JwtConsumerConfig;
 import com.ibm.ws.security.social.SocialLoginConfig;
 import com.ibm.ws.security.social.TraceConstants;
-import com.ibm.ws.security.social.error.SocialLoginException;
 
 /**
  * Extends from OidcLogin so we can have a different metatype element with all the defaults set for Google.
@@ -34,65 +30,6 @@ import com.ibm.ws.security.social.error.SocialLoginException;
 @Component(name = "com.ibm.ws.security.social.google", configurationPolicy = ConfigurationPolicy.REQUIRE, immediate = true, service = { SocialLoginConfig.class, JwtConsumerConfig.class }, property = { "service.vendor=IBM", "type=googleLogin" })
 public class GoogleLoginConfigImpl extends OidcLoginConfigImpl {
     public static final TraceComponent tc = Tr.register(GoogleLoginConfigImpl.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
-
-    @Override
-    protected void setRequiredConfigAttributes(Map<String, Object> props) {
-        this.clientId = getRequiredConfigAttribute(props, KEY_clientId);
-        this.clientSecret = getRequiredSerializableProtectedStringConfigAttribute(props, KEY_clientSecret);
-    }
-
-    @Override
-    protected void setOptionalConfigAttributes(Map<String, Object> props) throws SocialLoginException {
-        this.authorizationEndpoint = configUtils.getConfigAttribute(props, KEY_authorizationEndpoint);
-        this.tokenEndpoint = configUtils.getConfigAttribute(props, KEY_tokenEndpoint);
-        this.jwksUri = configUtils.getConfigAttribute(props, KEY_jwksUri);
-        this.scope = configUtils.getConfigAttribute(props, KEY_scope);
-        this.userNameAttribute = configUtils.getConfigAttribute(props, KEY_userNameAttribute);
-        this.mapToUserRegistry = configUtils.getBooleanConfigAttribute(props, KEY_mapToUserRegistry, this.mapToUserRegistry);
-        this.sslRef = configUtils.getConfigAttribute(props, KEY_sslRef);
-        this.authFilterRef = configUtils.getConfigAttribute(props, KEY_authFilterRef);
-        this.isClientSideRedirectSupported = configUtils.getBooleanConfigAttribute(props, KEY_isClientSideRedirectSupported, this.isClientSideRedirectSupported);
-        this.displayName = configUtils.getConfigAttribute(props, KEY_displayName);
-        this.website = configUtils.getConfigAttribute(props, KEY_website);
-        this.tokenEndpointAuthMethod = configUtils.getConfigAttribute(props, KEY_tokenEndpointAuthMethod);
-        this.redirectToRPHostAndPort = configUtils.getConfigAttribute(props, KEY_redirectToRPHostAndPort);
-        this.issuer = configUtils.getConfigAttribute(props, KEY_ISSUER);
-        this.realmNameAttribute = configUtils.getConfigAttribute(props, KEY_realmNameAttribute);
-        this.groupNameAttribute = configUtils.getConfigAttribute(props, KEY_groupNameAttribute);
-        this.userUniqueIdAttribute = configUtils.getConfigAttribute(props, KEY_userUniqueIdAttribute);
-        this.clockSkewMsec = configUtils.getIntegerConfigAttribute(props, KEY_CLOCKSKEW, this.clockSkewMsec);
-        this.signatureAlgorithm = configUtils.getConfigAttribute(props, KEY_SIGNATURE_ALGORITHM);
-    }
-
-    @Override
-    protected void debug() {
-        if (tc.isDebugEnabled()) {
-            Tr.debug(tc, "" + this);
-            Tr.debug(tc, KEY_clientId + " = " + clientId);
-            Tr.debug(tc, KEY_clientSecret + " is null = " + (clientSecret == null));
-            Tr.debug(tc, KEY_authorizationEndpoint + " = " + authorizationEndpoint);
-            Tr.debug(tc, KEY_tokenEndpoint + " = " + tokenEndpoint);
-            Tr.debug(tc, KEY_jwksUri + " = " + jwksUri);
-            Tr.debug(tc, KEY_scope + " = " + scope);
-            Tr.debug(tc, KEY_userNameAttribute + " = " + userNameAttribute);
-            Tr.debug(tc, KEY_mapToUserRegistry + " = " + mapToUserRegistry);
-            Tr.debug(tc, KEY_sslRef + " = " + sslRef);
-            Tr.debug(tc, KEY_authFilterRef + " = " + authFilterRef);
-            Tr.debug(tc, CFG_KEY_jwtRef + " = " + jwtRef);
-            Tr.debug(tc, CFG_KEY_jwtClaims + " = " + ((jwtClaims == null) ? null : Arrays.toString(jwtClaims)));
-            Tr.debug(tc, KEY_isClientSideRedirectSupported + " = " + isClientSideRedirectSupported);
-            Tr.debug(tc, KEY_displayName + " = " + displayName);
-            Tr.debug(tc, KEY_website + " = " + website);
-            Tr.debug(tc, KEY_tokenEndpointAuthMethod + " = " + tokenEndpointAuthMethod);
-            Tr.debug(tc, KEY_redirectToRPHostAndPort + " = " + redirectToRPHostAndPort);
-            Tr.debug(tc, KEY_ISSUER + " = " + issuer);
-            Tr.debug(tc, KEY_realmNameAttribute + " = " + realmNameAttribute);
-            Tr.debug(tc, KEY_groupNameAttribute + " = " + groupNameAttribute);
-            Tr.debug(tc, KEY_userUniqueIdAttribute + " = " + userUniqueIdAttribute);
-            Tr.debug(tc, KEY_CLOCKSKEW + " = " + clockSkewMsec);
-            Tr.debug(tc, KEY_SIGNATURE_ALGORITHM + " = " + signatureAlgorithm);
-        }
-    }
 
     @Override
     public String getSignatureAlgorithm() {

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/Oauth2LoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/Oauth2LoginConfigImpl.java
@@ -108,6 +108,8 @@ public class Oauth2LoginConfigImpl implements SocialLoginConfig {
     public static final String KEY_responseType = "responseType";
     protected String responseType = null;
 
+    protected String grantType = null;
+
     public static final String KEY_nonce = "nonce";
     protected boolean nonce = false;
 
@@ -253,6 +255,7 @@ public class Oauth2LoginConfigImpl implements SocialLoginConfig {
         initializeUserApiConfigs();
         initializeJwt(props);
         resetLazyInitializedMembers();
+        setGrantType();
     }
 
     protected void initializeUserApiConfigs() throws SocialLoginException {
@@ -298,6 +301,13 @@ public class Oauth2LoginConfigImpl implements SocialLoginConfig {
         this.authFilter = null;
         this.sslContext = null;
         this.sslSocketFactory = null;
+    }
+
+    protected void setGrantType() {
+        grantType = ClientConstants.AUTHORIZATION_CODE;
+        if (responseType != null && responseType.contains(ClientConstants.TOKEN)) {
+            grantType = ClientConstants.IMPLICIT;
+        }
     }
 
     protected String getRequiredConfigAttribute(Map<String, Object> props, String key) {
@@ -477,6 +487,11 @@ public class Oauth2LoginConfigImpl implements SocialLoginConfig {
     @Override
     public String getResponseType() {
         return this.responseType;
+    }
+
+    @Override
+    public String getGrantType() {
+        return this.grantType;
     }
 
     @Override
@@ -708,6 +723,11 @@ public class Oauth2LoginConfigImpl implements SocialLoginConfig {
 
     protected SslRefInfoImpl createSslRefInfoImpl(SocialLoginService socialLoginService) {
         return new SslRefInfoImpl(socialLoginService.getSslSupport(), socialLoginService.getKeyStoreServiceRef(), sslRef, keyAliasName);
+    }
+
+    @Override
+    public String getResponseMode() {
+        return null;
     }
 
 }

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -31,7 +31,6 @@ import com.ibm.ws.security.social.SocialLoginConfig;
 import com.ibm.ws.security.social.SocialLoginService;
 import com.ibm.ws.security.social.TraceConstants;
 import com.ibm.ws.security.social.error.SocialLoginException;
-import com.ibm.ws.security.social.internal.utils.ClientConstants;
 
 /**
  * This class was derived from GoogleLoginConfigImpl, it's purpose is to provide common superclass
@@ -65,6 +64,14 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements JwtCon
     public static final String KEY_TRUSTED_ALIAS = "trustAliasName";
     private String trustAliasName = null;
 
+    public static final String KEY_RESPONSE_MODE = "responseMode";
+    private String responseMode = null;
+
+    public static final String KEY_NONCE_ENABLED = "nonceEnabled";
+
+    public static final String KEY_INCLUDE_CUSTOM_CACHE_KEY_IN_SUBJECT = "includeCustomCacheKeyInSubject";
+    private boolean includeCustomCacheKeyInSubject = true;
+
     @Override
     protected void setRequiredConfigAttributes(Map<String, Object> props) {
         this.clientId = getRequiredConfigAttribute(props, KEY_clientId);
@@ -94,7 +101,12 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements JwtCon
         this.tokenEndpointAuthMethod = configUtils.getConfigAttribute(props, KEY_tokenEndpointAuthMethod);
         this.redirectToRPHostAndPort = configUtils.getConfigAttribute(props, KEY_redirectToRPHostAndPort);
         this.hostNameVerificationEnabled = configUtils.getBooleanConfigAttribute(props, CFG_KEY_HOST_NAME_VERIFICATION_ENABLED, this.hostNameVerificationEnabled);
-        this.nonce = true;
+        this.responseType = configUtils.getConfigAttribute(props, KEY_responseType);
+        this.responseMode = configUtils.getConfigAttribute(props, KEY_RESPONSE_MODE);
+        this.nonce = configUtils.getBooleanConfigAttribute(props, KEY_NONCE_ENABLED, this.nonce);
+        this.realmName = configUtils.getConfigAttribute(props, KEY_realmName);
+        this.includeCustomCacheKeyInSubject = configUtils.getBooleanConfigAttribute(props, KEY_INCLUDE_CUSTOM_CACHE_KEY_IN_SUBJECT, this.includeCustomCacheKeyInSubject);
+        this.resource = configUtils.getConfigAttribute(props, KEY_resource);
     }
 
     @Override
@@ -102,13 +114,13 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements JwtCon
         // OIDC configs do not use userApi, so this method overrides the version in Oauth2LoginConfigImpl to remove that step
         initializeJwt(props);
         resetLazyInitializedMembers();
+        setGrantType();
     }
 
     @Override
     protected void resetLazyInitializedMembers() {
         super.resetLazyInitializedMembers();
 
-        this.responseType = ClientConstants.CODE;
         this.jwkSet = null; // the jwkEndpoint may have been changed during dynamic update
         this.consumerUtils = null; // the parameters in consumerUtils may have been changed during dynamic changing
     }
@@ -143,6 +155,11 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements JwtCon
             Tr.debug(tc, KEY_redirectToRPHostAndPort + " = " + redirectToRPHostAndPort);
             Tr.debug(tc, CFG_KEY_HOST_NAME_VERIFICATION_ENABLED + " = " + hostNameVerificationEnabled);
             Tr.debug(tc, KEY_nonce + " = " + nonce);
+            Tr.debug(tc, KEY_responseType + " = " + responseType);
+            Tr.debug(tc, KEY_RESPONSE_MODE + " = " + responseMode);
+            Tr.debug(tc, KEY_realmName + " = " + realmName);
+            Tr.debug(tc, KEY_INCLUDE_CUSTOM_CACHE_KEY_IN_SUBJECT + " = " + includeCustomCacheKeyInSubject);
+            Tr.debug(tc, KEY_resource + " = " + resource);
         }
     }
 
@@ -296,6 +313,15 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements JwtCon
     public boolean getTokenReuse() {
         // The common JWT code is not allowed to reuse JWTs. This could be revisited later as a potential config option.
         return false;
+    }
+
+    @Override
+    public String getResponseMode() {
+        return responseMode;
+    }
+
+    public boolean includeCustomCacheKeyInSubject() {
+        return includeCustomCacheKeyInSubject;
     }
 
     @Override

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/ClientConstants.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/ClientConstants.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.security.social.internal.utils;
 
-/**
- *
- */
 public class ClientConstants {
     public static final String OIDC_CLIENT = "oidc_client";
     public static final String OIDC_AUTHN_HINT_HEADER = "oidcAuthnHint";
@@ -32,6 +29,8 @@ public class ClientConstants {
     public static final String ENCRYPTED_TOKEN = "encrypted_token";
     public static final String ACCESS_TOKEN_ALIAS = "accessTokenAlias";
     public static final String RESPONSE_TYPE = "response_type";
+    public static final String RESPONSE_MODE = "response_mode";
+    public static final String FORM_POST = "form_post";
 
     public final static String USER_ID = "user_id";
     public final static String USER_NAME = "user_name";
@@ -42,6 +41,7 @@ public class ClientConstants {
     public static final String CHARSET = "UTF-8";
     public static final String CODE = "code";
     public final static String AUTHORIZATION_CODE = "authorization_code";
+    public final static String IMPLICIT = "implicit";
     public static final String STATE = "state";
 
     public final static String RESPONSEMAP_CODE = "RESPONSEMAP_CODE";

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/OAuthLoginFlow.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/OAuthLoginFlow.java
@@ -126,9 +126,8 @@ public class OAuthLoginFlow {
                 query = String.format("%s&acr_values=%s", query, URLEncoder.encode(acr_values, ClientConstants.CHARSET));
 
             }
+            query = addResponseModeToQuery(query, clientConfig);
             if (!strResponse_type.equals(ClientConstants.CODE)) {
-                query = String.format("%s&response_mode=%s", query, URLEncoder.encode("form_post", ClientConstants.CHARSET));
-                // add resource
                 String resources = clientConfig.getResource();
                 if (resources != null) {
                     query = String.format("%s&%s", query, URLEncoder.encode(resources, ClientConstants.CHARSET));
@@ -140,6 +139,19 @@ public class OAuthLoginFlow {
         }
         String s = authzEndpoint + "?" + query;
         return s;
+    }
+
+    String addResponseModeToQuery(String query, SocialLoginConfig config) throws UnsupportedEncodingException {
+        String responseMode = config.getResponseMode();
+        String responseType = config.getResponseType();
+        if (!responseType.equals(ClientConstants.CODE)) {
+            // Implicit types will always use the form_post response mode
+            responseMode = ClientConstants.FORM_POST;
+        }
+        if (responseMode != null) {
+            query = String.format("%s&" + ClientConstants.RESPONSE_MODE + "=%s", query, URLEncoder.encode(responseMode, ClientConstants.CHARSET));
+        }
+        return query;
     }
 
     TAIResult handleAuthorizationCode(HttpServletRequest req, HttpServletResponse res, String authzCode, SocialLoginConfig clientConfig) throws WebTrustAssociationFailedException {

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/tai/OAuthLoginFlowTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/tai/OAuthLoginFlowTest.java
@@ -427,7 +427,7 @@ public class OAuthLoginFlowTest extends CommonTestClass {
                     will(returnValue(authorizationEndpointURL));
                 }
             });
-            authorizationEndpointQueryExpectations("code", "", "", false);
+            authorizationEndpointQueryExpectations("code", "", "", "", false);
 
             String result = loginFlow.buildAuthorizationUrlWithQuery("", config, "", "");
 
@@ -438,7 +438,8 @@ public class OAuthLoginFlowTest extends CommonTestClass {
             verifyPattern(result, "client_id=&");
             verifyPattern(result, "state=&");
             verifyPattern(result, "redirect_uri=&");
-            verifyPattern(result, "scope=$");
+            verifyPattern(result, "scope=&");
+            verifyPattern(result, "response_mode=$");
 
             verifyNoLogMessage(outputMgr, MSG_BASE);
 
@@ -456,7 +457,7 @@ public class OAuthLoginFlowTest extends CommonTestClass {
                     will(returnValue(authorizationEndpointURL));
                 }
             });
-            authorizationEndpointQueryExpectations("code", null, null, false);
+            authorizationEndpointQueryExpectations("code", null, null, null, false);
 
             String result = loginFlow.buildAuthorizationUrlWithQuery("", config, redirectUri, null);
 
@@ -485,7 +486,7 @@ public class OAuthLoginFlowTest extends CommonTestClass {
                     will(returnValue(authorizationEndpointURL));
                 }
             });
-            authorizationEndpointQueryExpectations("code", clientId, clientConfigScope, true);
+            authorizationEndpointQueryExpectations("code", null, clientId, clientConfigScope, true);
 
             String result = loginFlow.buildAuthorizationUrlWithQuery(state, config, redirectUri, null);
 
@@ -515,7 +516,7 @@ public class OAuthLoginFlowTest extends CommonTestClass {
                     will(returnValue(authorizationEndpointURL));
                 }
             });
-            authorizationEndpointQueryExpectations("code", clientId, clientConfigScope, false);
+            authorizationEndpointQueryExpectations("code", null, clientId, clientConfigScope, false);
 
             String result = loginFlow.buildAuthorizationUrlWithQuery(state, config, redirectUri, acrValues);
 
@@ -539,14 +540,14 @@ public class OAuthLoginFlowTest extends CommonTestClass {
     @Test
     public void buildAuthorizationUrlWithQuery_responseTypeNotCode() throws Exception {
         try {
-            final String responseCode = "id_token";
+            final String responseType = "id_token";
             mockery.checking(new Expectations() {
                 {
                     one(taiWebUtils).getAuthorizationEndpoint(config);
                     will(returnValue(authorizationEndpointURL));
                 }
             });
-            authorizationEndpointQueryExpectations(responseCode, clientId, clientConfigScope, false);
+            authorizationEndpointQueryExpectations(responseType, null, clientId, clientConfigScope, false);
             mockery.checking(new Expectations() {
                 {
                     one(config).getResource();
@@ -559,7 +560,7 @@ public class OAuthLoginFlowTest extends CommonTestClass {
             // Verify that only subset of ASCII characters are in result
             verifyAuthzEndpointFormat(result, authorizationEndpointURL);
             // Verify each param value matches its mocked value
-            verifyPattern(result, "response_type=" + responseCode + "&");
+            verifyPattern(result, "response_type=" + responseType + "&");
             verifyPattern(result, "client_id=" + clientId + "&");
             verifyPattern(result, "state=" + state + "&");
             verifyPattern(result, "redirect_uri=" + REGEX_URL_ENCODED_CHARS + "+&");
@@ -576,7 +577,7 @@ public class OAuthLoginFlowTest extends CommonTestClass {
     @Test
     public void buildAuthorizationUrlWithQuery_responseTypeNotCode_withResource() throws Exception {
         try {
-            final String responseCode = "id_token";
+            final String responseType = "id_token";
             final String resource = "The quick brown fox jumps over<script>alert(100)</script> the lazy dog.";
             mockery.checking(new Expectations() {
                 {
@@ -584,7 +585,7 @@ public class OAuthLoginFlowTest extends CommonTestClass {
                     will(returnValue(authorizationEndpointURL));
                 }
             });
-            authorizationEndpointQueryExpectations(responseCode, clientId, clientConfigScope, false);
+            authorizationEndpointQueryExpectations(responseType, null, clientId, clientConfigScope, false);
             mockery.checking(new Expectations() {
                 {
                     one(config).getResource();
@@ -597,7 +598,7 @@ public class OAuthLoginFlowTest extends CommonTestClass {
             // Verify that only subset of ASCII characters are in result
             verifyAuthzEndpointFormat(result, authorizationEndpointURL);
             // Verify each param value matches its mocked value
-            verifyPattern(result, "response_type=" + responseCode + "&");
+            verifyPattern(result, "response_type=" + responseType + "&");
             verifyPattern(result, "client_id=" + clientId + "&");
             verifyPattern(result, "state=" + state + "&");
             verifyPattern(result, "redirect_uri=" + REGEX_URL_ENCODED_CHARS + "+&");
@@ -703,12 +704,14 @@ public class OAuthLoginFlowTest extends CommonTestClass {
         });
     }
 
-    private void authorizationEndpointQueryExpectations(final String responseType, final String clientId, final String scope, final boolean nonce) {
+    private void authorizationEndpointQueryExpectations(final String responseType, final String responseMode, final String clientId, final String scope, final boolean nonce) {
         mockery.checking(new Expectations() {
             {
                 // Metatype enforces that responseType will always have one of a set of values
-                one(config).getResponseType();
+                allowing(config).getResponseType();
                 will(returnValue(responseType));
+                one(config).getResponseMode();
+                will(returnValue(responseMode));
                 one(config).getClientId();
                 will(returnValue(clientId));
                 one(config).getScope();


### PR DESCRIPTION
Adds the following configuration options:
- `responseType`
- `responseMode`
- `nonceEnabled`
- `realmName`
- `includeCustomCacheKeyInSubject`
- `resource`

These will help achieve closer parity to the full OIDC client.