### PR TITLE
Add missing doPriv in unwrap path

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -44,7 +44,6 @@
   </library>
 
   <javaPermission codebase="${server.config.dir}/drivers/d43driver.jar" className="java.security.AllPermission"/>
-  <javaPermission codebase="${server.config.dir}/apps/app43.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
 
   <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
@@ -92,17 +92,10 @@ public class JDBC43TestServlet extends FATServlet {
     }
 
     /**
-     * Test that attempting to use the connection builder methods on an unwrapped connection or the liberty wrapper are blocked.
+     * Test that attempting to use the connection builder methods on an unwrapped connection are blocked.
      */
     @Test
     public void testBuilderMethodsBlocked() throws Exception {
-        try {
-            defaultDataSource.createConnectionBuilder();
-            fail("Call to createConnectionBuilder should result in an exception");
-        } catch (SQLFeatureNotSupportedException ex) {
-            //expected
-        }
-
         XADataSource xaDS = unsharableXADataSource.unwrap(XADataSource.class);
         try {
             xaDS.createXAConnectionBuilder();


### PR DESCRIPTION
Add missing do priv in the unwrap path.  Also removes the assertion that `createConnectionBuilder()` should result in a SQLFeatureNotSupportedException.  Fix for issue #4912.