### PR TITLE
Cap unit tests to JDK 8 which rely on legacy cglib ClassImposteriser

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/AttributeToSubjectTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/AttributeToSubjectTest.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -26,7 +26,9 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
@@ -35,8 +37,13 @@ import com.ibm.ws.security.test.common.CommonTestClass;
 import com.ibm.wsspi.security.token.AttributeNameConstants;
 
 import test.common.SharedOutputManager;
+import test.common.junit.rules.MaximumJavaLevelRule;
 
 public class AttributeToSubjectTest extends CommonTestClass {
+
+    // Cap this unit test to Java 8 because it relies on legacy cglib which is not supported post JDK 8
+    @ClassRule
+    public static TestRule maxJavaLevel = new MaximumJavaLevelRule(8);
 
     static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.openidconnect.*=all=enabled");
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
@@ -43,9 +43,11 @@ import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
 
 import com.google.gson.JsonObject;
 import com.ibm.websphere.ras.annotation.Sensitive;
@@ -70,8 +72,13 @@ import com.ibm.wsspi.ssl.SSLSupport;
 import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 
 import test.common.SharedOutputManager;
+import test.common.junit.rules.MaximumJavaLevelRule;
 
 public class OIDCClientAuthenticatorUtilTest {
+
+    // Cap this unit test to Java 8 because it relies on legacy cglib which is not supported post JDK 8
+    @ClassRule
+    public static TestRule maxJavaLevel = new MaximumJavaLevelRule(8);
 
     protected static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
 
@@ -202,7 +209,7 @@ public class OIDCClientAuthenticatorUtilTest {
         map.put("refresh_token", new String[] { "refresh_token_content" });
         map.put("code", new String[] { "YMKexUVcHci2dhDJzNRHW2w9rhf70u" });
         map.put("state", new String[] { "001534964952438QID21LdnF" });
-        
+
         JsonObject jsonObject = new JsonObject();
         Set<Map.Entry<String, String[]>> entries = map.entrySet();
         for (Map.Entry<String, String[]> entry : entries) {
@@ -213,7 +220,7 @@ public class OIDCClientAuthenticatorUtilTest {
             }
         }
         String requestParameters = jsonObject.toString();
-        
+
         String localEncoded = null;
         try {
             localEncoded = Base64Coder.toString(Base64Coder.base64Encode(requestParameters.getBytes(ClientConstants.CHARSET)));
@@ -223,9 +230,9 @@ public class OIDCClientAuthenticatorUtilTest {
 
         // digest with the client_secret value
         String tmpStr = new String(localEncoded);
-        tmpStr = tmpStr.concat("_").concat(convClientConfig.getClass().getName()+clientSecret);
-        
-        encodedReqParams = new String(localEncoded).concat("_").concat(HashUtils.digest(tmpStr));   
+        tmpStr = tmpStr.concat("_").concat(convClientConfig.getClass().getName() + clientSecret);
+
+        encodedReqParams = new String(localEncoded).concat("_").concat(HashUtils.digest(tmpStr));
         reqParameterCookie = new Cookie(ClientConstants.WAS_OIDC_CODE, encodedReqParams);
     }
 

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/tai/TAIEncryptionUtilsTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/tai/TAIEncryptionUtilsTest.java
@@ -39,9 +39,11 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
 
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.security.social.SocialLoginConfig;
@@ -49,8 +51,13 @@ import com.ibm.ws.security.social.error.SocialLoginException;
 import com.ibm.ws.security.social.test.CommonTestClass;
 
 import test.common.SharedOutputManager;
+import test.common.junit.rules.MaximumJavaLevelRule;
 
 public class TAIEncryptionUtilsTest extends CommonTestClass {
+	
+	// Cap this unit test to Java 8 because it relies on legacy cglib which is not supported post JDK 8
+	@ClassRule
+	public static TestRule maxJavaLevel = new MaximumJavaLevelRule(8);
 
     private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.social.*=all");
 


### PR DESCRIPTION
On JDK 11 some of the security unit tests fail with the following exception.  From my understanding cglib will never be capable of updating itself to properly support JDK 11, so the best option I see here is to cap these unit tests to JDK 8 until we can re-write them to use something besides cglib and its legacy ClassImposterizer.

```
java.lang.UnsupportedOperationException
	at net.sf.cglib.asm.$ClassVisitor.visitNestMemberExperimental(ClassVisitor.java:248)
	at net.sf.cglib.asm.$ClassReader.accept(ClassReader.java:651)
	at net.sf.cglib.asm.$ClassReader.accept(ClassReader.java:391)
	at net.sf.cglib.proxy.BridgeMethodResolver.resolveAll(BridgeMethodResolver.java:70)
	at net.sf.cglib.proxy.Enhancer.emitMethods(Enhancer.java:1132)
	at net.sf.cglib.proxy.Enhancer.generateClass(Enhancer.java:630)
	at net.sf.cglib.core.DefaultGeneratorStrategy.generate(DefaultGeneratorStrategy.java:25)
	at net.sf.cglib.core.AbstractClassGenerator.generate(AbstractClassGenerator.java:329)
	at net.sf.cglib.proxy.Enhancer.generate(Enhancer.java:492)
	at net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:93)
	at net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:91)
	at net.sf.cglib.core.internal.LoadingCache$2.call(LoadingCache.java:54)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at net.sf.cglib.core.internal.LoadingCache.createEntry(LoadingCache.java:61)
	at net.sf.cglib.core.internal.LoadingCache.get(LoadingCache.java:34)
	at net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData.get(AbstractClassGenerator.java:116)
	at net.sf.cglib.core.AbstractClassGenerator.create(AbstractClassGenerator.java:291)
	at net.sf.cglib.proxy.Enhancer.createHelper(Enhancer.java:480)
	at net.sf.cglib.proxy.Enhancer.createClass(Enhancer.java:337)
	at org.jmock.lib.legacy.ClassImposteriser.createProxyClass(ClassImposteriser.java:122)
	at org.jmock.lib.legacy.ClassImposteriser.imposterise(ClassImposteriser.java:65)
	at org.jmock.Mockery.mock(Mockery.java:139)
	at com.ibm.ws.security.openidconnect.clients.common.OIDCClientAuthenticatorUtilTest.<init>(OIDCClientAuthenticatorUtilTest.java:127)
	at com.ibm.ws.security.openidconnect.clients.common.OIDCClientAuthenticatorUtilWithTraceTest.<init>(OIDCClientAuthenticatorUtilWithTraceTest.java:21)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:187)
	at org.junit.runners.BlockJUnit4ClassRunner$1.runReflectiveCall(BlockJUnit4ClassRunner.java:236)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
	at org.junit.runners.BlockJUnit4ClassRunner.methodBlock(BlockJUnit4ClassRunner.java:233)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:68)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:47)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:28)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:30)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:106)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:66)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
	at com.sun.proxy.$Proxy1.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:109)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:155)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:137)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:404)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
	at java.base/java.lang.Thread.run(Thread.java:834)
```