### PR TITLE
Interceptor test fix

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/test-applications/interceptorapp/src/jaxrs21/fat/interceptor/ResourceApplicationScoped.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/test-applications/interceptorapp/src/jaxrs21/fat/interceptor/ResourceApplicationScoped.java
@@ -57,6 +57,8 @@ public class ResourceApplicationScoped {
         if (interceptors == null) {
             return "NONE";
         }
-        return String.join(" ", interceptors);
+        String result = String.join(" ", interceptors);
+        interceptors.clear();
+        return result;
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/test-applications/interceptorapp/src/jaxrs21/fat/interceptor/ResourceRequestScoped.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/test-applications/interceptorapp/src/jaxrs21/fat/interceptor/ResourceRequestScoped.java
@@ -54,7 +54,9 @@ public class ResourceRequestScoped {
         if (interceptors == null) {
             return "NONE";
         }
-        return String.join(" ", interceptors);
+        String result = String.join(" ", interceptors);
+        interceptors.clear();
+        return result;
     }
 
     private static String whichLifecycleInterceptorsWereInvoked() {
@@ -62,6 +64,8 @@ public class ResourceRequestScoped {
         if (interceptors == null) {
             return "NONE";
         }
-        return String.join(" ", interceptors);
+        String result = String.join(" ", interceptors);
+        interceptors.clear();
+        return result;
     }
 }


### PR DESCRIPTION
Resolves a test bug a failure could occur if a test sets the interceptors used on one thread, and then a different test ends up running on that same thread.  This clears the thread local's set of invoked interceptors.