### PR TITLE
Add optional dependency on javax.activation API for JavaMail features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.5/com.ibm.websphere.appserver.javaMail-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.5/com.ibm.websphere.appserver.javaMail-1.5.feature
@@ -25,6 +25,7 @@ Subsystem-Name: JavaMail 1.5
   com.ibm.websphere.appserver.injection-1.0,\
   com.ibm.websphere.appserver.javax.mail-1.5
 -bundles=\
+  com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
   com.ibm.ws.javamail,\
   com.ibm.ws.javamail.config
 -jars=com.ibm.websphere.javaee.mail.1.5; location:=dev/api/spec/; mavenCoordinates="javax.mail:javax.mail-api:1.5.6", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.6/com.ibm.websphere.appserver.javaMail-1.6.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/javaMail-1.6/com.ibm.websphere.appserver.javaMail-1.6.feature
@@ -27,6 +27,7 @@ IBM-API-Package: \
   com.ibm.websphere.appserver.javax.mail-1.6,\
   com.ibm.websphere.appserver.javaeeCompatible-8.0
 -bundles=\
+  com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
   com.ibm.ws.javamail.1.6,\
   com.ibm.ws.javamail.config
 -jars=com.ibm.websphere.javaee.mail.1.6; location:=dev/api/spec/; mavenCoordinates="javax.mail:javax.mail-api:1.6.1", \


### PR DESCRIPTION
#build 

Resolves the following error when running SMTP test on Java 11:
```
java.lang.NoClassDefFoundError: javax/activation/DataHandler
	at javax.mail.internet.MimeMessage.setContent(MimeMessage.java:1508)
	at javax.mail.internet.MimeBodyPart.setText(MimeBodyPart.java:1155)
	at javax.mail.internet.MimeMessage.setText(MimeMessage.java:1547)
	at javax.mail.internet.MimeMessage.setText(MimeMessage.java:1531)
	at SMTP.SMTPInlineServlet.doGet(SMTPInlineServlet.java:72)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:575)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:668)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1255)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:743)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:440)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1208)
	at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:4954)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:996)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1011)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:414)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:373)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:532)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:466)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:331)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:302)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:165)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:74)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:501)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:571)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:926)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1015)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.ClassNotFoundException: javax.activation.DataHandler cannot be found by com.ibm.ws.com.sun.mail.javax.mail.1.5_1.5.22.201809030213
	at org.eclipse.osgi.internal.loader.BundleLoader.findClassInternal(BundleLoader.java:484)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:395)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:387)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:150)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 31 more
```