### PR TITLE
beginRequest and endRequest when aborted from same thread

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -2444,8 +2444,10 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 inRequest = false;
                 mcf.jdbcRuntime.endRequest(sqlConn);
             } catch (SQLException x) {
-                FFDCFilter.processException(x, getClass().getName(), "2447", this);
-                dsae = new DataStoreAdapterException("DSA_ERROR", x, getClass());
+                if (!isAborted()) {
+                    FFDCFilter.processException(x, getClass().getName(), "2447", this);
+                    dsae = new DataStoreAdapterException("DSA_ERROR", x, getClass());
+                }
             }
 
         if(isAborted()){
@@ -2679,8 +2681,10 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 inRequest = false;
                 mcf.jdbcRuntime.endRequest(sqlConn);
             } catch (SQLException x) {
-                FFDCFilter.processException(x, getClass().getName(), "2682", this);
-                firstX = new DataStoreAdapterException("DSA_ERROR", x, getClass());
+                if (!isAborted()) {
+                    FFDCFilter.processException(x, getClass().getName(), "2682", this);
+                    firstX = new DataStoreAdapterException("DSA_ERROR", x, getClass());
+                }
             }
 
         if(isAborted()){

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbSpiLocalTransactionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbSpiLocalTransactionImpl.java
@@ -400,11 +400,8 @@ public class WSRdbSpiLocalTransactionImpl implements LocalTransaction, FFDCSelfI
                 ivStateManager.transtate = WSStateManager.NO_TRANSACTION_ACTIVE;
             } 
             catch (SQLException se) {
-                FFDCFilter.processException(
-                                            se,
-                                            "com.ibm.ws.rsadapter.spi.WSRdbSpiLocalTransactionImpl.rollback",
-                                            "192",
-                                            this);
+                if (!ivMC.isAborted())
+                    FFDCFilter.processException(se, getClass().getName(), "192", this);
 
                 ResourceException resX = AdapterUtil.translateSQLException(se, ivMC, true, currClass);
                 if (tc.isEntryEnabled())

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcPreparedStatement.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcPreparedStatement.java
@@ -337,10 +337,10 @@ public class WSJdbcPreparedStatement extends WSJdbcStatement implements Prepared
                 }
 
             } catch (SQLException cleanupX) {
-                FFDCFilter.processException(cleanupX,
-                                            getClass().getName() + ".closeWrapper", "310", this);
-
-                sqlX = cleanupX;
+                if (!mc.isAborted()) {
+                    FFDCFilter.processException(cleanupX, getClass().getName() + ".closeWrapper", "310", this);
+                    sqlX = cleanupX;
+                }
 
                 try {
                     pstmtImpl.close();

--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -44,6 +44,7 @@
   </library>
 
   <javaPermission codebase="${server.config.dir}/drivers/d43driver.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${server.config.dir}/apps/app43.war" className="java.sql.SQLPermission" name="callAbort"/>
 
   <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
@@ -458,7 +458,8 @@ public class JDBC43TestServlet extends FATServlet {
     }
 
     /**
-     * Abort an unsharable connection from the same thread that is using it.
+     * Abort a sharable connection from the same thread that is using it.
+     * Verify that endRequest is invoked on the JDBC driver.
      */
     @AllowedFFDC("javax.transaction.xa.XAException") // seen by transaction manager for aborted connection
     @Test
@@ -532,6 +533,7 @@ public class JDBC43TestServlet extends FATServlet {
 
     /**
      * Abort an unsharable connection from the same thread that is using it.
+     * Verify that endRequest is invoked on the JDBC driver in response to the abort.
      */
     @AllowedFFDC("javax.transaction.xa.XAException") // seen by transaction manager for aborted connection
     @Test

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
@@ -12,6 +12,7 @@ package jdbc.fat.v43.web;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -19,9 +20,12 @@ import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -39,6 +43,7 @@ import org.junit.Test;
 
 import com.ibm.tx.jta.TransactionManagerFactory;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.app.FATServlet;
 
@@ -59,10 +64,17 @@ public class JDBC43TestServlet extends FATServlet {
     @Resource(lookup = "jdbc/xa", shareable = false)
     DataSource unsharableXADataSource;
 
+    private final ExecutorService singleThreadExecutor = Executors.newFixedThreadPool(1);
+
     @Resource
     UserTransaction tx;
 
     private final static TransactionManager txm = TransactionManagerFactory.getTransactionManager();
+
+    @Override
+    public void destroy() {
+        singleThreadExecutor.shutdown();
+    }
 
     // create a table for tests to use and pre-populate it with some data
     @Override
@@ -443,6 +455,131 @@ public class JDBC43TestServlet extends FATServlet {
                 }
             }
         }
+    }
+
+    /**
+     * Abort an unsharable connection from the same thread that is using it.
+     */
+    @AllowedFFDC("javax.transaction.xa.XAException") // seen by transaction manager for aborted connection
+    @Test
+    public void testSameThreadAbortSharable() throws Exception {
+        AtomicInteger[] requests;
+        int begins, ends;
+
+        Connection con1 = defaultDataSource.getConnection();
+        try {
+            requests = (AtomicInteger[]) con1.unwrap(Supplier.class).get();
+            begins = requests[BEGIN].get();
+            ends = requests[END].get();
+            assertEquals(ends + 1, begins);
+
+            // con1.setAutoCommit(false); // TODO enable once abort path is fixed
+            PreparedStatement ps = con1.prepareStatement("INSERT INTO STREETS VALUES(?, ?, ?)");
+            ps.setString(1, "Superior Drive NW");
+            ps.setString(2, "Rochester");
+            ps.setString(3, "MN");
+            ps.executeUpdate();
+        } finally {
+            con1.close();
+        }
+
+        assertEquals(ends, requests[END].get());
+
+        Connection con2 = defaultDataSource.getConnection();
+        try {
+            AtomicInteger[] requests2 = (AtomicInteger[]) con2.unwrap(Supplier.class).get();
+            assertSame(requests[BEGIN], requests2[BEGIN]);
+            assertSame(requests[END], requests2[END]);
+
+            PreparedStatement ps2 = con2.prepareStatement("INSERT INTO STREETS VALUES(?, ?, ?)");
+            ps2.setString(1, "Technology Drive NW");
+            ps2.setString(2, "Rochester");
+            ps2.setString(3, "MN");
+            ps2.executeUpdate();
+        } finally {
+            con2.abort(singleThreadExecutor);
+        }
+
+        tx.begin();
+        try {
+            assertEquals(ends + 1, requests[END].get());
+
+            Connection con3 = defaultDataSource.getConnection();
+            requests = (AtomicInteger[]) con3.unwrap(Supplier.class).get();
+            begins = requests[BEGIN].get();
+            ends = requests[END].get();
+            assertEquals(ends + 1, begins);
+
+            PreparedStatement ps3 = con3.prepareStatement("SELECT CITY, STATE FROM STREETS WHERE NAME = ?");
+            ps3.setString(1, "Superior Drive NW");
+            ResultSet result = ps3.executeQuery();
+            // assertFalse(result.next()); // TODO enable once prior TODOs are removed
+            ps3.close();
+
+            Connection con4 = defaultDataSource.getConnection();
+            PreparedStatement ps4 = con4.prepareStatement("SELECT CITY, STATE FROM STREETS WHERE NAME = ?");
+            ps4.setString(1, "Technology Drive NW");
+            result = ps4.executeQuery();
+            // assertFalse(result.next()); // TODO enable once prior TODOs are removed
+
+            con4.abort(singleThreadExecutor);
+        } finally {
+            tx.rollback();
+        }
+
+        assertEquals(ends + 1, requests[END].get());
+    }
+
+    /**
+     * Abort an unsharable connection from the same thread that is using it.
+     */
+    @AllowedFFDC("javax.transaction.xa.XAException") // seen by transaction manager for aborted connection
+    @Test
+    public void testSameThreadAbortUnsharable() throws Exception {
+        AtomicInteger[] requests;
+        int begins, ends;
+
+        Connection con1 = unsharablePool1DataSource.getConnection();
+        try {
+            requests = (AtomicInteger[]) con1.unwrap(Supplier.class).get();
+            begins = requests[BEGIN].get();
+            ends = requests[END].get();
+            assertEquals(ends + 1, begins);
+
+            // con1.setAutoCommit(false); TODO enable once abort path is fixed
+            PreparedStatement ps = con1.prepareStatement("INSERT INTO STREETS VALUES(?, ?, ?)");
+            ps.setString(1, "Commerce Drive NW");
+            ps.setString(2, "Rochester");
+            ps.setString(3, "MN");
+            ps.executeUpdate();
+        } finally {
+            con1.abort(singleThreadExecutor);
+        }
+
+        // TODO Why is crossing the LTC boundary needed for ManagedConnection.destroy/Connection.endRequest to be invoked after abort?
+        tx.begin();
+        try {
+            assertEquals(ends + 1, requests[END].get()); // TODO move the assert before tx.begin once abort path is fixed
+
+            Connection con2 = unsharablePool1DataSource.getConnection();
+            try {
+                requests = (AtomicInteger[]) con2.unwrap(Supplier.class).get();
+                begins = requests[BEGIN].get();
+                ends = requests[END].get();
+                assertEquals(ends + 1, begins);
+
+                PreparedStatement ps2 = con2.prepareStatement("SELECT CITY, STATE FROM STREETS WHERE NAME = ?");
+                ps2.setString(1, "Commerce Drive NW");
+                ResultSet result = ps2.executeQuery();
+                // assertFalse(result.next()); TODO enable once prior TODOs are removed
+            } finally {
+                con2.abort(singleThreadExecutor);
+            }
+        } finally {
+            tx.rollback();
+        }
+
+        assertEquals(ends + 1, requests[END].get());
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/AbortedException.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/AbortedException.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.sql.SQLNonTransientConnectionException;
+
+public class AbortedException extends SQLNonTransientConnectionException {
+    private static final long serialVersionUID = 1L;
+
+    public AbortedException(Class<?> type) {
+        super(type.getSimpleName() + " is aborted", "08003", 2);
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/ClosedException.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/ClosedException.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.sql.SQLNonTransientConnectionException;
+
+public class ClosedException extends SQLNonTransientConnectionException {
+    private static final long serialVersionUID = 1L;
+
+    public ClosedException(Class<?> type) {
+        super(type.getSimpleName() + " is closed", "08003", 1);
+    }
+}


### PR DESCRIPTION
Coverage for begin/endRequest on the path where Connection.abort is invoked from the same thread that is using the connection.  This can be within an LTC or a global transaction, and could be on a sharable or unsharable connection.