### PR TITLE
Upgrading to Johnzon 1.1.8 and giving it full permission in this FAT.

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -161,6 +161,9 @@ org.apache.httpcomponents:httpmime:4.3.1
 org.apache.johnzon:johnzon-core:1.1.5
 org.apache.johnzon:johnzon-jsonb:1.1.5
 org.apache.johnzon:johnzon-mapper:1.1.5
+org.apache.johnzon:johnzon-core:1.1.8
+org.apache.johnzon:johnzon-jsonb:1.1.8
+org.apache.johnzon:johnzon-mapper:1.1.8
 org.apache.maven:maven-model:3.5.0
 org.apache.myfaces.core:myfaces-api:2.2.12
 org.apache.myfaces.core:myfaces-api:2.3.1

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/build.gradle
@@ -15,9 +15,9 @@ configurations {
 }
 
 dependencies {
-  johnzon 'org.apache.johnzon:johnzon-core:1.1.5',
-    'org.apache.johnzon:johnzon-jsonb:1.1.5',
-    'org.apache.johnzon:johnzon-mapper:1.1.5'
+  johnzon 'org.apache.johnzon:johnzon-core:1.1.8',
+    'org.apache.johnzon:johnzon-jsonb:1.1.8',
+    'org.apache.johnzon:johnzon-mapper:1.1.8'
   jsonbapi 'javax.json.bind:javax.json.bind-api:1.0'
 }
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.packageJsonBWithFeature/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.packageJsonBWithFeature/server.xml
@@ -8,11 +8,14 @@
 	<!-- Define Johnzon as a 'bell' so it can be registered in the server's service registry and used by JAX-RS -->
 	<bell libraryRef="johnzon"/>
 	<library id="johnzon">
-	  <fileset dir="${shared.resource.dir}/johnzon" includes="*.jar"/>
+	  <fileset dir="${shared.resource.dir}/johnzon" includes="*-1.1.8.jar"/>
 	</library>
 
 	<include location="../fatTestPorts.xml"/>
 	
+	<javaPermission codebase="${shared.resource.dir}/johnzon/johnzon-core-1.1.8.jar" className="java.security.AllPermission"/>
+	<javaPermission codebase="${shared.resource.dir}/johnzon/johnzon-jsonb-1.1.8.jar" className="java.security.AllPermission"/>
+	<javaPermission codebase="${shared.resource.dir}/johnzon/johnzon-mapper-1.1.8.jar" className="java.security.AllPermission"/>
 	<javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
 	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
 	<javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>


### PR DESCRIPTION
When Java 2 security is enabled, the com.ibm.ws.jaxrs.2.1_fat_extended test bucket will fail with permission issues stemming from Johnzon - doing things like reading system properties or using reflection, etc.  This is because the FAT test server did not specify the correct permissions for the Johnzon JAR _codebase_.  This change addresses that issue and upgrades the version of Johnzon used in the tests to 1.1.8.