### PR TITLE
CXF exported version should be 3.2.6 instead of 3.2.4

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
@@ -7,7 +7,7 @@ Bundle-Activator: com.ibm.ws.jaxrs21.cxf.core.NoOpActivator
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
-exportVer=3.2.4
+exportVer=3.2.6
 
 #Export-Package: org.apache.cxf,\
 #  org.apache.cxf.attachment,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/bnd.overrides
@@ -20,7 +20,7 @@ Import-Package: \
   com.ibm.json.java;resolution:=optional,\
   *
 
-exportVer=3.2.4
+exportVer=3.2.6
 
 Export-Package: com.ibm.ws.jaxrs20.cache,\
   org.apache.cxf.jaxrs;version=${exportVer},\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/bnd.overrides
@@ -15,8 +15,10 @@ Import-Package: \
   !org.osgi.service.blueprint.*,\
   *
 
+exportVer=3.2.6
+  
 Export-Package: com.ibm.ws.jaxrs21.clientconfig,\
   org.apache.cxf.jaxrs.client,\
-  org.apache.cxf.jaxrs.client.blueprint;version=3.2.4,\
+  org.apache.cxf.jaxrs.client.blueprint;version=${exportVer},\
   org.apache.cxf.jaxrs.client.spec
   

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/bnd.overrides
@@ -5,14 +5,16 @@ Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
+exportVer=3.2.6
+ 
 Export-Package: \
   com.ibm.ws.microprofile.rest.client.component,\
-  org.apache.cxf.microprofile.client.cdi;version="3.2.4",\
-  org.apache.cxf.microprofile.client;version="3.2.4",\
-  org.apache.cxf.microprofile.client.cdi;version="3.2.4",\
-  org.apache.cxf.microprofile.client.config;version="3.2.4",\
-  org.apache.cxf.microprofile.client.proxy;version="3.2.4",\
-  org.apache.cxf.microprofile.client.spi;thread-context=true;version="3.2.4"
+  org.apache.cxf.microprofile.client.cdi;version=${exportVer},\
+  org.apache.cxf.microprofile.client;version=${exportVer},\
+  org.apache.cxf.microprofile.client.cdi;version=${exportVer},\
+  org.apache.cxf.microprofile.client.config;version=${exportVer},\
+  org.apache.cxf.microprofile.client.proxy;version=${exportVer},\
+  org.apache.cxf.microprofile.client.spi;thread-context=true;version=${exportVer}
 
 Import-Package: \
  javax.annotation;version="[1.2,2)",\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.sse.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.sse.3.2/bnd.overrides
@@ -5,7 +5,7 @@ Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.rs.sse.3.2
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
-exportVer=3.2.4
+exportVer=3.2.6
 
 Import-Package: \
   !org.atmosphere.*,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
@@ -7,6 +7,8 @@ Bundle-Activator: com.ibm.ws.jaxrs21.transports.http.NoOpActivator
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
+exportVer=3.2.6
+
 Export-Package: \
   com.ibm.ws.jaxrs21.transports.http,\
   org.apache.cxf.transport.http,\
@@ -14,7 +16,7 @@ Export-Package: \
   org.apache.cxf.transport.http.osgi,\
   org.apache.cxf.transport.https,\
   org.apache.cxf.transport.servlet,\
-  org.apache.cxf.transports.http;version=3.2.4,\
+  org.apache.cxf.transports.http;version=${exportVer},\
   org.apache.cxf.transports.http.configuration
   
 Import-Package: \


### PR DESCRIPTION
CXF exported version should be 3.2.6 instead of 3.2.4 now that we updated the CXF jars to 3.2.6 from 3.2.4

PR for #4968