### PR TITLE
MP Rest Client 1.1 TCK default test to EE7, but still test with EE8

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -38,11 +38,6 @@ public class RestClientTckPackageTest {
     @Server("FATServer")
     public static LibertyServer server;
 
-//    @BeforeClass
-//    public static void setUp() throws Exception {
-//        server.startServer();
-//    }
-//
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/servers/FATServer/server.xml
@@ -10,8 +10,8 @@
     <featureManager>
         <feature>componenttest-1.0</feature>
         <feature>localConnector-1.0</feature>
-        <feature>cdi-2.0</feature>
-        <feature>jaxrsClient-2.1</feature>
+        <feature>cdi-1.2</feature>
+        <feature>jaxrsClient-2.0</feature>
         <feature>mpConfig-1.3</feature>
         <feature>mpRestClient-1.1</feature>
     </featureManager>

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
@@ -19,7 +19,7 @@ public class EE7FeatureReplacementAction extends FeatureReplacementAction {
     public static final String ID = "EE7_FEATURES";
 
     static final String[] EE7_FEATURES_ARRAY = { "javaee-7.0", "webProfile-7.0", "javaeeClient-7.0", "servlet-3.1", "jdbc-4.1", "javaMail-1.5", "cdi-1.2", "jpa-2.1",
-                                                 "beanValidation-1.1", "jaxrs-2.0", "jsf-2.2", "appSecurity-2.0", "jsonp-1.0" };
+                                                 "beanValidation-1.1", "jaxrs-2.0", "jaxrsClient-2.0", "jsf-2.2", "appSecurity-2.0", "jsonp-1.0" };
     static final Set<String> EE7_FEATURE_SET = new HashSet<>(Arrays.asList(EE7_FEATURES_ARRAY));
 
     public EE7FeatureReplacementAction() {

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
@@ -19,7 +19,7 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
     public static final String ID = "EE8_FEATURES";
 
     static final String[] EE8_FEATURES_ARRAY = { "javaee-8.0", "webProfile-8.0", "javaeeClient-8.0", "servlet-4.0", "jdbc-4.2", "javaMail-1.6", "cdi-2.0", "jpa-2.2",
-                                                 "beanValidation-2.0", "jaxrs-2.1", "jsf-2.3", "appSecurity-3.0", "jsonp-1.1", "jsonb-1.0", };
+                                                 "beanValidation-2.0", "jaxrs-2.1", "jaxrsClient-2.1", "jsf-2.3", "appSecurity-3.0", "jsonp-1.1", "jsonb-1.0", };
     static final Set<String> EE8_FEATURE_SET = new HashSet<>(Arrays.asList(EE8_FEATURES_ARRAY));
 
     public EE8FeatureReplacementAction() {


### PR DESCRIPTION
Update the MP Rest Client 1.1 TCK to start with the EE7 features, but then repeat with the EE8 features.  Also, add jaxrsClient-2.0/2.1 to EE7/8 feature list.