### PR TITLE
Update EJB to expose CORBA apis on Java 11

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.ejbCore-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.ejbCore-1.0.feature
@@ -6,7 +6,8 @@ IBM-API-Package: javax.ejb; type="spec", \
 -features=com.ibm.websphere.appserver.appmanager-1.0, \
  com.ibm.websphere.appserver.javaeePlatform-6.0, \
  com.ibm.websphere.appserver.managedBeansCore-1.0, \
- com.ibm.websphere.appserver.javaeeddSchema-1.0
+ com.ibm.websphere.appserver.javaeeddSchema-1.0, \
+ com.ibm.websphere.appserver.optional.corba-1.5
 -bundles=com.ibm.ws.app.manager.war, \
  com.ibm.ws.app.manager.ejb
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.optional.corba-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.optional.corba-1.5.feature
@@ -1,0 +1,65 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.optional.corba-1.5
+visibility=private
+IBM-App-ForceRestart: uninstall, install
+IBM-Process-Types: client, server
+Subsystem-Name:  OMG CORBA APIs and RMI-IIOP API
+IBM-API-Package: \
+  javax.rmi; type="spec"; require-java:="9", \
+  javax.rmi.CORBA; type="spec"; require-java:="9", \
+  org.omg.stub.java.rmi; type="spec"; require-java:="9", \
+  org.omg.BiDirPolicy; type="spec"; require-java:="9", \
+  org.omg.CONV_FRAME; type="spec"; require-java:="9", \
+  org.omg.CORBA; type="spec"; require-java:="9", \
+  org.omg.CORBA.ContainedPackage; type="spec"; require-java:="9", \
+  org.omg.CORBA.ContainerPackage; type="spec"; require-java:="9", \
+  org.omg.CORBA.InterfaceDefPackage; type="spec"; require-java:="9", \
+  org.omg.CORBA.ORBPackage; type="spec"; require-java:="9", \
+  org.omg.CORBA.PollableSetPackage; type="spec"; require-java:="9", \
+  org.omg.CORBA.TypeCodePackage; type="spec"; require-java:="9", \
+  org.omg.CORBA.ValueDefPackage; type="spec"; require-java:="9", \
+  org.omg.CORBA.portable; type="spec"; require-java:="9", \
+  org.omg.CORBA_2_3; type="spec"; require-java:="9", \
+  org.omg.CORBA_2_3.portable; type="spec"; require-java:="9", \
+  org.omg.CORBA_2_4; type="spec"; require-java:="9", \
+  org.omg.CORBA_2_4.portable; type="spec"; require-java:="9", \
+  org.omg.CSI; type="spec"; require-java:="9", \
+  org.omg.CSIIOP; type="spec"; require-java:="9", \
+  org.omg.CosNaming; type="spec"; require-java:="9", \
+  org.omg.CosNaming.NamingContextExtPackage; type="spec"; require-java:="9", \
+  org.omg.CosNaming.NamingContextPackage; type="spec"; require-java:="9", \
+  org.omg.CosTSInteroperation; type="spec"; require-java:="9", \
+  org.omg.CosTransactions; type="spec"; require-java:="9", \
+  org.omg.Dynamic; type="spec"; require-java:="9", \
+  org.omg.DynamicAny; type="spec"; require-java:="9", \
+  org.omg.DynamicAny.DynAnyFactoryPackage; type="spec"; require-java:="9", \
+  org.omg.DynamicAny.DynAnyPackage; type="spec"; require-java:="9", \
+  org.omg.GIOP; type="spec"; require-java:="9", \
+  org.omg.GSSUP; type="spec"; require-java:="9", \
+  org.omg.IIOP; type="spec"; require-java:="9", \
+  org.omg.IOP; type="spec"; require-java:="9", \
+  org.omg.IOP.CodecFactoryPackage; type="spec"; require-java:="9", \
+  org.omg.IOP.CodecPackage; type="spec"; require-java:="9", \
+  org.omg.MessageRouting; type="spec"; require-java:="9", \
+  org.omg.Messaging; type="spec"; require-java:="9", \
+  org.omg.PortableInterceptor; type="spec"; require-java:="9", \
+  org.omg.PortableInterceptor.ORBInitInfoPackage; type="spec"; require-java:="9", \
+  org.omg.PortableServer; type="spec"; require-java:="9", \
+  org.omg.PortableServer.CurrentPackage; type="spec"; require-java:="9", \
+  org.omg.PortableServer.POAManagerFactoryPackage; type="spec"; require-java:="9", \
+  org.omg.PortableServer.POAManagerPackage; type="spec"; require-java:="9", \
+  org.omg.PortableServer.POAPackage; type="spec"; require-java:="9", \
+  org.omg.PortableServer.ServantLocatorPackage; type="spec"; require-java:="9", \
+  org.omg.PortableServer.portable; type="spec"; require-java:="9", \
+  org.omg.SSLIOP; type="spec"; require-java:="9", \
+  org.omg.Security; type="spec"; require-java:="9", \
+  org.omg.SecurityLevel1; type="spec"; require-java:="9", \
+  org.omg.SecurityLevel2; type="spec"; require-java:="9", \
+  org.omg.SendingContext; type="spec"; require-java:="9", \
+  org.omg.SendingContext.CodeBasePackage; type="spec"; require-java:="9", \
+  org.omg.TimeBase; type="spec"; require-java:="9"
+
+-features=\
+  com.ibm.websphere.appserver.internal.optional.corba-1.5
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/ejbLite-3.2/com.ibm.websphere.appserver.ejbLite-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/ejbLite-3.2/com.ibm.websphere.appserver.ejbLite-3.2.feature
@@ -14,7 +14,7 @@ Subsystem-Category: JavaEE7Application
  com.ibm.websphere.appserver.transaction-1.2, \
  com.ibm.websphere.appserver.javaeeCompatible-7.0; ibm.tolerates:=8.0, \
  com.ibm.websphere.appserver.javax.interceptor-1.2
--bundles=com.ibm.ws.ejbcontainer.v32, \
+ -bundles=com.ibm.ws.ejbcontainer.v32, \
  com.ibm.ws.ejbcontainer.timer, \
  com.ibm.ws.ejbcontainer.async
 -jars=com.ibm.websphere.appserver.api.ejbcontainer; location:=dev/api/ibm/


### PR DESCRIPTION
Add an optional feature for exposing the CORBA APIs to the application for EJB.  Still need to determine if APIs should be added to dev/api/spec.