### PR TITLE
Disable LDAP endpoint identification for Sun JNDI impl

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/ldap/LocalLDAPServerSuite.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/ldap/LocalLDAPServerSuite.java
@@ -18,6 +18,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import com.ibm.websphere.simplicity.log.Log;
+
 import componenttest.topology.utils.LDAPUtils;
 
 public class LocalLDAPServerSuite {
@@ -45,6 +46,8 @@ public class LocalLDAPServerSuite {
 
         // Check if physical LDAP servers are up, if not then use in-memory LDAP
         if (!LDAPUtils.USE_LOCAL_LDAP_SERVER || !isInMemoryAllowed) {
+            // Workaround property for OpenJDKs sun JNDI implementation
+            System.setProperty("com.sun.jndi.ldap.object.disableEndpointIdentification", "true");
             boolean isLdapServersAvailable = false;
             if (testServers != null) {
                 Set<String> primaryServers = testServers.keySet();
@@ -122,7 +125,7 @@ public class LocalLDAPServerSuite {
 
     /**
      * Performs the usual setup, but only check the availability of the specified servers and failovers as needed.
-     * 
+     *
      * @param servers
      * @throws Exception
      */
@@ -133,7 +136,7 @@ public class LocalLDAPServerSuite {
     /**
      * Performs the usual setup, but only check the availability of the specified servers and failovers as needed.
      * If {@code isInMemoryLdapAllowed} is false, no in-memory LDAP server instances will be started.
-     * 
+     *
      * @param servers
      * @param isInMemoryLdapAllowed
      * @throws Exception
@@ -145,7 +148,7 @@ public class LocalLDAPServerSuite {
     /**
      * Performs the usual setup, but only check the availability of the specified servers and failovers as needed.
      * If {@code isInMemoryLdapAllowed} is false, no in-memory LDAP server instances will be started.
-     * 
+     *
      * @param servers
      * @param isInMemoryLdapAllowed
      * @throws Exception
@@ -165,7 +168,7 @@ public class LocalLDAPServerSuite {
      * Adds a primary test server and failover to the list of LDAP servers to be used during testing. If the primary server specified
      * is already included in {@code existingServerMap}, the failover server specified will be added to the list of failovers for that
      * primary server. This method assumes that neither the primary nor the failover server requires SSL.
-     * 
+     *
      * @param primaryHost
      * @param primaryPort
      * @param failoverHost
@@ -182,7 +185,7 @@ public class LocalLDAPServerSuite {
      * Adds a primary test server and failover to the list of LDAP servers to be used during testing. If the primary server specified
      * is already included in {@code existingServerMap}, the failover server specified will be added to the list of failovers for that
      * primary server.
-     * 
+     *
      * @param primaryHost
      * @param primaryPort
      * @param primaryUseSsl
@@ -247,7 +250,7 @@ public class LocalLDAPServerSuite {
     /**
      * Check each of the failover servers specified for the given host and port and return true if there is an available
      * failover server.
-     * 
+     *
      * @param host
      * @param port
      * @return


### PR DESCRIPTION
When running FATs against internal LDAP test servers on Java 11 release candidate, we get the following exception due to not having proper certificates for some test machines:

```
[09/06/2018 13:44:51:711 CDT] 001 LDAPUtils                      isLdapServerAvaialble          S Error while creating context to ldap with hostname nc9042057196.tivlab.raleigh.ibm.com and port 636
javax.naming.CommunicationException: nc9042057196.tivlab.raleigh.ibm.com:636 [Root exception is javax.net.ssl.SSLHandshakeException: No name matching nc9042057196.tivlab.raleigh.ibm.com found]
	at java.naming/com.sun.jndi.ldap.Connection.<init>(Connection.java:237)
	at java.naming/com.sun.jndi.ldap.LdapClient.<init>(LdapClient.java:137)
	at java.naming/com.sun.jndi.ldap.LdapClient.getInstance(LdapClient.java:1616)
	at java.naming/com.sun.jndi.ldap.LdapCtx.connect(LdapCtx.java:2752)
	at java.naming/com.sun.jndi.ldap.LdapCtx.<init>(LdapCtx.java:320)
	at java.naming/com.sun.jndi.ldap.LdapCtxFactory.getUsingURL(LdapCtxFactory.java:192)
	at java.naming/com.sun.jndi.ldap.LdapCtxFactory.getUsingURLs(LdapCtxFactory.java:210)
	at java.naming/com.sun.jndi.ldap.LdapCtxFactory.getLdapCtxInstance(LdapCtxFactory.java:153)
	at java.naming/com.sun.jndi.ldap.LdapCtxFactory.getInitialContext(LdapCtxFactory.java:83)
	at java.naming/javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:730)
	at java.naming/javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:305)
	at java.naming/javax.naming.InitialContext.init(InitialContext.java:236)
	at java.naming/javax.naming.InitialContext.<init>(InitialContext.java:208)
	at java.naming/javax.naming.directory.InitialDirContext.<init>(InitialDirContext.java:101)
	at componenttest.topology.utils.LDAPUtils.isLdapServerAvailable(LDAPUtils.java:425)
	at componenttest.topology.ldap.LocalLDAPServerSuite.setUp(LocalLDAPServerSuite.java:67)
	at componenttest.topology.ldap.LocalLDAPServerSuite.setUpUsingServers(LocalLDAPServerSuite.java:164)
	at componenttest.topology.ldap.LocalLDAPServerSuite.setUpUsingServers(LocalLDAPServerSuite.java:146)
	at componenttest.topology.ldap.LocalLDAPServerSuite.setUpUsingServers(LocalLDAPServerSuite.java:134)
	at com.ibm.ws.security.jwt.fat.builder.CommonLocalLDAPServerSuite.setUp(CommonLocalLDAPServerSuite.java:64)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:27)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:30)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:39)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.run(JUnitTestRunner.java:535)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.launch(JUnitTestRunner.java:1182)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.main(JUnitTestRunner.java:1033)
Caused by: javax.net.ssl.SSLHandshakeException: No name matching nc9042057196.tivlab.raleigh.ibm.com found
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:128)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:321)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:264)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:259)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:642)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.onCertificate(CertificateMessage.java:461)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.consume(CertificateMessage.java:361)
	at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:392)
	at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:444)
	at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:421)
	at java.base/sun.security.ssl.TransportContext.dispatch(TransportContext.java:178)
	at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:164)
	at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1152)
	at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1063)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:402)
	at java.naming/com.sun.jndi.ldap.Connection.createSocket(Connection.java:349)
	at java.naming/com.sun.jndi.ldap.Connection.<init>(Connection.java:216)
	... 33 more
Caused by: java.security.cert.CertificateException: No name matching nc9042057196.tivlab.raleigh.ibm.com found
	at java.base/sun.security.util.HostnameChecker.matchDNS(HostnameChecker.java:225)
	at java.base/sun.security.util.HostnameChecker.match(HostnameChecker.java:98)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:463)
	at java.base/sun.security.ssl.X509TrustManagerImpl.checkIdentity(X509TrustManagerImpl.java:445)
	at java.base/sun.security.ssl.AbstractTrustManagerWrapper.checkAdditionalTrust(SSLContextImpl.java:1543)
	at java.base/sun.security.ssl.AbstractTrustManagerWrapper.checkServerTrusted(SSLContextImpl.java:1510)
	at java.base/sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:626)
	... 45 more
```