### PR TITLE
make XADataSource default for jdbc-4.3 feature and above

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -435,9 +435,10 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                 Class<?> ifc;
 
                 if (type == null){
-                    vendorImpl = id != null && id.contains("dataSource[DefaultDataSource]")
-                               ? jdbcDriverSvc.createDefaultDataSourceOrDriver(vProps, id)
-                               : jdbcDriverSvc.createAnyDataSourceOrDriver(vProps, id);
+                    boolean atLeastJDBC43 = jdbcRuntime.getVersion().compareTo(JDBCRuntimeVersion.VERSION_4_3) >= 0;
+                    vendorImpl = atLeastJDBC43 || id != null && id.contains("dataSource[DefaultDataSource]")
+                               ? jdbcDriverSvc.createAnyPreferXADataSource(vProps, id)
+                               : jdbcDriverSvc.createAnyPreferLegacyOrder(vProps, id);
                     ifc = vendorImpl instanceof XADataSource ? XADataSource.class
                         : vendorImpl instanceof ConnectionPoolDataSource ? ConnectionPoolDataSource.class
                         : vendorImpl instanceof DataSource ? DataSource.class
@@ -586,9 +587,10 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
             Class<?> ifc;
 
             if(type == null){
-                vendorImpl = id != null && id.contains("dataSource[DefaultDataSource]")
-                                ? jdbcDriverSvc.createDefaultDataSourceOrDriver(vProps, id)
-                                : jdbcDriverSvc.createAnyDataSourceOrDriver(vProps, id);
+                boolean atLeastJDBC43 = jdbcRuntime.getVersion().compareTo(JDBCRuntimeVersion.VERSION_4_3) >= 0;
+                vendorImpl = atLeastJDBC43 || id != null && id.contains("dataSource[DefaultDataSource]")
+                                ? jdbcDriverSvc.createAnyPreferXADataSource(vProps, id)
+                                : jdbcDriverSvc.createAnyPreferLegacyOrder(vProps, id);
                 ifc = vendorImpl instanceof XADataSource ? XADataSource.class
                     : vendorImpl instanceof ConnectionPoolDataSource ? ConnectionPoolDataSource.class
                     : vendorImpl instanceof DataSource ? DataSource.class

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -331,7 +331,8 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
     }
 
     /**
-     * Create any type of data source or java.sql.Driver - whichever is available, looking for known data source impl classes in the following order,
+     * Create any type of data source or java.sql.Driver - whichever is available, looking for
+     * known data source impl classes in the following order,
      * <ul>
      * <li>javax.sql.ConnectionPoolDataSource
      * <li>javax.sql.DataSource
@@ -341,8 +342,9 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
      * @param props typed data source properties
      * @return the data source or driver instance
      * @throws Exception if an error occurs
+     * @deprecated only use this method if the jdbc-4.2 or earlier feature is enabled.
      */
-    public Object createAnyDataSourceOrDriver(Properties props, String dataSourceID) throws Exception {
+    public Object createAnyPreferLegacyOrder(Properties props, String dataSourceID) throws Exception {
         lock.readLock().lock();
         try {
             if (!isInitialized)
@@ -406,20 +408,22 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
     }
     
     /**
-     * Create any type of data source or java.sql.Driver - whichever is available, looking for known data source impl classes in the following order,
+     * Create any type of data source or java.sql.Driver - whichever is available, looking for
+     * known data source impl classes in the following order,
      * <ul>
      * <li>javax.sql.XADataSource
      * <li>javax.sql.ConnectionPoolDataSource
      * <li>javax.sql.DataSource
      * </ul>
-     * This order is different than the standard priority, which prioritizes javax.sql.XADataSource after ConnectionPoolDataSource and DataSource.
+     * This order is different than the legacy (prior to jdbc-4.3 feature) priority,
+     * which prioritizes javax.sql.XADataSource after ConnectionPoolDataSource and DataSource.
      * 
      * @param props typed data source properties
      * @param dataSourceID identifier for the data source config
      * @return the data source or driver instance
      * @throws Exception if an error occurs
      */
-    public Object createDefaultDataSourceOrDriver(Properties props, String dataSourceID) throws Exception {
+    public Object createAnyPreferXADataSource(Properties props, String dataSourceID) throws Exception {
         lock.readLock().lock();
         try {
             if (!isInitialized)

--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -25,14 +25,14 @@
     <properties url="jdbc:d43:memory:testdb;create=true" user="user43" password="{xor}Lyg7a2w="/>
   </dataSource>
 
-  <dataSource jndiName="jdbc/poolOf1"> <!-- TODO will need to specify type once XA becomes the default -->
+  <dataSource jndiName="jdbc/poolOf1" type="javax.sql.ConnectionPoolDataSource">
     <connectionManager maxPoolSize="1"/>
     <jdbcDriver libraryRef="D43Lib"/>
     <properties databaseName="memory:testdb;create=true"/>
     <containerAuthData user="user43" password="{xor}Lyg7a2w="/>
   </dataSource>
 
-  <dataSource jndiName="jdbc/xa" type="javax.sql.XADataSource"> <!-- TODO XA should be made the default -->
+  <dataSource jndiName="jdbc/xa">
     <jdbcDriver libraryRef="D43Lib"/>
     <properties databaseName="memory:testdb;create=true"/>
     <containerAuthData user="user43" password="{xor}Lyg7a2w="/>


### PR DESCRIPTION
Detect the version of Liberty jdbc feature enabled, and for 4.3 or higher, make XADataSource the default type when otherwise unspecified.