### PR TITLE
data source wrapper for jdbc 4.3

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
@@ -21,15 +21,19 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
+import javax.resource.spi.ConnectionManager;
+
 import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
+import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcCallableStatement;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcDatabaseMetaData;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcObject;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcPreparedStatement;
@@ -53,6 +57,11 @@ public class JDBC40Runtime implements JDBCRuntimeVersion {
     public WSJdbcDatabaseMetaData newDatabaseMetaData(DatabaseMetaData metaDataImpl,
                                                       WSJdbcConnection connWrapper) throws SQLException {
         return new WSJdbcDatabaseMetaData(metaDataImpl, connWrapper);
+    }
+
+    @Override
+    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
+        return new WSJdbcDataSource(mcf, connMgr);
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
@@ -21,15 +21,19 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
+import javax.resource.spi.ConnectionManager;
+
 import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
+import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcCallableStatement;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcDatabaseMetaData;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcObject;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcPreparedStatement;
@@ -59,6 +63,11 @@ public class JDBC41Runtime implements JDBCRuntimeVersion {
     public WSJdbcDatabaseMetaData newDatabaseMetaData(DatabaseMetaData metaDataImpl,
                                                       WSJdbcConnection connWrapper) throws SQLException {
         return new WSJdbc41DatabaseMetaData(metaDataImpl, connWrapper);
+    }
+
+    @Override
+    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
+        return new WSJdbcDataSource(mcf, connMgr);
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
@@ -21,15 +21,19 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
+import javax.resource.spi.ConnectionManager;
+
 import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
+import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcCallableStatement;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcDatabaseMetaData;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcObject;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcPreparedStatement;
@@ -54,6 +58,11 @@ public class JDBC42Runtime implements JDBCRuntimeVersion {
     public WSJdbcDatabaseMetaData newDatabaseMetaData(DatabaseMetaData metaDataImpl,
                                                       WSJdbcConnection connWrapper) throws SQLException {
         return new WSJdbc42DatabaseMetaData(metaDataImpl, connWrapper);
+    }
+
+    @Override
+    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
+        return new WSJdbcDataSource(mcf, connMgr);
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
@@ -21,15 +21,19 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
+import javax.resource.spi.ConnectionManager;
+
 import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
+import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcCallableStatement;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcDatabaseMetaData;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcObject;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcPreparedStatement;
@@ -38,6 +42,7 @@ import com.ibm.ws.rsadapter.jdbc.WSJdbcStatement;
 import com.ibm.ws.rsadapter.jdbc.v42.WSJdbc42ResultSet;
 import com.ibm.ws.rsadapter.jdbc.v43.WSJdbc43CallableStatement;
 import com.ibm.ws.rsadapter.jdbc.v43.WSJdbc43Connection;
+import com.ibm.ws.rsadapter.jdbc.v43.WSJdbc43DataSource;
 import com.ibm.ws.rsadapter.jdbc.v43.WSJdbc43DatabaseMetaData;
 import com.ibm.ws.rsadapter.jdbc.v43.WSJdbc43PreparedStatement;
 import com.ibm.ws.rsadapter.jdbc.v43.WSJdbc43Statement;
@@ -59,6 +64,11 @@ public class JDBC43Runtime implements JDBCRuntimeVersion {
     public WSJdbcDatabaseMetaData newDatabaseMetaData(DatabaseMetaData metaDataImpl,
                                                       WSJdbcConnection connWrapper) throws SQLException {
         return new WSJdbc43DatabaseMetaData(metaDataImpl, connWrapper);
+    }
+
+    @Override
+    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
+        return new WSJdbc43DataSource(mcf, connMgr);
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.3/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc.4.3/bnd.bnd
@@ -36,6 +36,7 @@ instrument.disabled: true
     ${javac.bootclasspath.${javac.source}}
   
 -buildpath: \
+	com.ibm.websphere.javaee.connector.1.6;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.jdbc;version=latest,\

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.rsadapter.jdbc.v43;
+
+import java.sql.ConnectionBuilder;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.ShardingKeyBuilder;
+
+import javax.resource.spi.ConnectionManager;
+import javax.sql.DataSource;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.rsadapter.AdapterUtil;
+import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource;
+
+public class WSJdbc43DataSource extends WSJdbcDataSource implements DataSource {
+    private static final TraceComponent tc = Tr.register(WSJdbc43DataSource.class, AdapterUtil.TRACE_GROUP, AdapterUtil.NLS_FILE);
+
+    public WSJdbc43DataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
+        super(mcf, connMgr);
+    }
+
+    @Override
+    public ConnectionBuilder createConnectionBuilder() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public ShardingKeyBuilder createShardingKeyBuilder() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+}

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
@@ -20,16 +20,20 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
+import javax.resource.spi.ConnectionManager;
+
 import org.osgi.framework.Version;
 
 import com.ibm.ws.rsadapter.jdbc.WSJdbcCallableStatement;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
+import com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcDatabaseMetaData;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcObject;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcPreparedStatement;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcResultSet;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcStatement;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
+import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 
 /**
@@ -54,6 +58,8 @@ public interface JDBCRuntimeVersion {
 
     public WSJdbcDatabaseMetaData newDatabaseMetaData(DatabaseMetaData metaDataImpl,
                                                       WSJdbcConnection connWrapper) throws SQLException;
+
+    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr);
 
     public WSJdbcStatement newStatement(Statement stmtImplObject, WSJdbcConnection connWrapper, int theHoldability);
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -343,21 +343,20 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
     }
 
     /**
-     * Creates a ConnectionFactory. The created ConnectionFactory will use the application server
-     * connection manager passed in as a parameter to manage the connections.
+     * Creates a javax.sql.DataSource that uses the application server provided
+     * connection manager to manage its connections.
      * 
-     * @param ConnectionManager connMgr - An application server ConnectionManager.
-     * @return a new instance of WSJdbcDataSource.
-     * @exception ResourceException
+     * @param ConnectionManager connMgr - An application server provided ConnectionManager.
+     * @return a new instance of WSJdbcDataSource or a subclass of it pertaining to a particular JDBC spec level.
      */
-    public final Object createConnectionFactory(ConnectionManager connMgr)
-                    throws ResourceException {
+    @Override
+    public final DataSource createConnectionFactory(ConnectionManager connMgr) {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled(); 
 
         if (isTraceOn && tc.isEntryEnabled()) 
             Tr.entry(this, tc, "createConnectionFactory", connMgr); 
 
-        Object connFactory = new WSJdbcDataSource(this, (WSConnectionManager)connMgr);
+        DataSource connFactory = jdbcRuntime.newDataSource(this, connMgr);
 
         if (isTraceOn && tc.isEntryEnabled())
             Tr.exit(this, tc, "createConnectionFactory", connFactory); 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcDataSource.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcDataSource.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
 import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionManager;
 import javax.resource.spi.ConnectionRequestInfo;
 import javax.sql.DataSource;
 
@@ -60,19 +61,14 @@ public class WSJdbcDataSource extends WSJdbcWrapper implements DataSource, FFDCS
     private final transient AtomicReference<Class<?>[]> vendorConnectionInterfaces = new AtomicReference<Class<?>[]>();
 
     /**
-     * Create a WebSphere DataSource wrapper. This constructor is called by the Managed
-     * Connection Factory. The ConnectionFactoryBuilder or DataSourceFactory are responsible
-     * for setting all properties into the MCF, which then creates this wrapper on a call to
-     * createConnectionFactory. This means that most MCF properties are configurable
-     * only on the DataSourceFactory or ConnectionFactoryBuilder, and they will not be changed
-     * in the middle of execution. DataSource properties, however, can be changed at any time.
+     * Create a DataSource wrapper. The ManagedConnectionFactory invokes this constructor
+     * indirectly via the JDBC##Runtime class in order to create a wrapper for the JDBC spec
+     * level that corresponds to the jdbc-#.# feature that is enabled in the server configuration.
      * 
-     * @param mcf Managed Connection Factory for this WebSphere Data Source.
-     * @param connMgr Connection Manager for this WebSphere Data Source.
-     * 
-     * @exception ResourceException if an error occurs during data source creation.
+     * @param mcf ManagedConnectionFactory implementation that created this data source.
+     * @param connMgr connection manager that manages connections from this data source.
      */
-    public WSJdbcDataSource(WSManagedConnectionFactoryImpl mcf, WSConnectionManager connMgr) throws ResourceException 
+    public WSJdbcDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) 
     {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled(); 
 
@@ -80,7 +76,7 @@ public class WSJdbcDataSource extends WSJdbcWrapper implements DataSource, FFDCS
             Tr.entry(this, tc, "<init>", mcf, connMgr);
 
         this.mcf = mcf;
-        cm = connMgr;
+        cm = (WSConnectionManager) connMgr;
         resRefInfo = cm.getResourceRefInfo(); 
         dsConfig = mcf.dsConfig; 
 


### PR DESCRIPTION
Create a data source wrapper with the JDBC 4.3 method signatures.  For now, the new methods will raise SQLFeatureNotSupportedException (matching the default implementation).  Later we will implement these methods or get them properly delegated to the JDBC driver as appropriate.  This pull includes the necessary infrastructure/refactoring to be able to use different data source wrappers based on the jdbc feature level that is configured in the server configuration.