### PR TITLE
Updates to LibertyServer in FAT framework

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitor.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LogMonitor.java
@@ -225,22 +225,35 @@ public class LogMonitor {
      * and verify that the regex does not show up in the logs during the
      * specfied duration.
      *
-     * @param regexp a regular expression to search for
-     * @param intendedTimeout a timeout, in milliseconds, within which the wait should complete. Exceeding this is a soft fail.
-     * @param extendedTimeout a timeout, in milliseconds, within which the wait must complete. Exceeding this is a hard fail.
-     * @param outputFile file to check
+     * @param timeout Timeout (in milliseconds)
      * @return line that matched the regexp
      */
-    public boolean verifyStringNotInLogUsingMark(String regexp, long timeout) {
+    public String verifyStringNotInLogUsingMark(String regexToSearchFor, long timeout) {
         try {
-            String result = waitForStringInLogUsingMarkWithException(regexp, timeout, timeout * 2, client.lmcGetDefaultLogFile());
-            if (result != null)
-                return false;
-            else
-                return true;
+            return verifyStringNotInLogUsingMark(regexToSearchFor, timeout, client.lmcGetDefaultLogFile());
         } catch (Exception ex) {
             if (ex instanceof NoStringFoundInLogException) {
-                return true;
+                return null;
+            } else {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    /**
+     * Wait for the specified regexp in the default logs from the last mark
+     * and verify that the regex does not show up in the logs during the
+     * specfied duration.
+     *
+     * @param timeout Timeout (in milliseconds)
+     * @return line that matched the regexp
+     */
+    public String verifyStringNotInLogUsingMark(String regexToSearchFor, long timeout, RemoteFile logFileToSearch) {
+        try {
+            return waitForStringInLogUsingMarkWithException(regexToSearchFor, timeout, timeout * 2, logFileToSearch);
+        } catch (Exception ex) {
+            if (ex instanceof NoStringFoundInLogException) {
+                return null;
             } else {
                 throw new RuntimeException(ex);
             }


### PR DESCRIPTION
Adds some new startup/reconfig methods to `LibertyServer` and updates the `LogMonitor.verifyStringNotInLogUsingMark()` method to return the line in the log that was found to match the provided string (or `null` if no such line was found). The latter allows us to include the line that was found to match the string in a test failure as opposed to the simple boolean "yes, the string was there" or "no, the string was not there."