### PR TITLE
ConnectionBuilder tests with user and password for Driver and DataSource

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -25,6 +25,11 @@
     <properties url="jdbc:d43:memory:testdb;create=true" user="user43" password="{xor}Lyg7a2w="/>
   </dataSource>
 
+  <dataSource jndiName="jdbc/ds" type="javax.sql.DataSource">
+    <jdbcDriver libraryRef="D43Lib"/>
+    <properties databaseName="memory:testdb;create=true"/>
+  </dataSource>
+
   <dataSource jndiName="jdbc/poolOf1" type="javax.sql.ConnectionPoolDataSource">
     <connectionManager maxPoolSize="1"/>
     <jdbcDriver libraryRef="D43Lib"/>

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43DataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43DataSource.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.ConnectionBuilder;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
+
+public class D43DataSource implements DataSource {
+    private final org.apache.derby.jdbc.EmbeddedDataSource ds;
+
+    public D43DataSource() {
+        ds = new org.apache.derby.jdbc.EmbeddedDataSource();
+    }
+
+    @Override
+    public ConnectionBuilder createConnectionBuilder() throws SQLException {
+        return (ConnectionBuilder) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                          new Class[] { ConnectionBuilder.class },
+                                                          new D43Handler(ds.createConnectionBuilder(), null));
+    }
+
+    public String getDatabaseName() {
+        return ds.getDatabaseName();
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return ds.getLoginTimeout();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return ds.getLogWriter();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return ds.getParentLogger();
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return (Connection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                   new Class[] { Connection.class },
+                                                   new D43Handler(ds.getConnection(), null));
+    }
+
+    @Override
+    public Connection getConnection(String user, String pwd) throws SQLException {
+        return (Connection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                   new Class[] { Connection.class },
+                                                   new D43Handler(ds.getConnection(user, pwd), null));
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> type) throws SQLException {
+        return type.isInstance(this);
+    }
+
+    public void setDatabaseName(String value) {
+        ds.setDatabaseName(value);
+    }
+
+    @Override
+    public void setLoginTimeout(int value) throws SQLException {
+        ds.setLoginTimeout(value);
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter value) throws SQLException {
+        ds.setLogWriter(value);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> type) throws SQLException {
+        if (isWrapperFor(type))
+            return type.cast(this);
+        throw new SQLFeatureNotSupportedException("Not a wrapper for " + type);
+    }
+}


### PR DESCRIPTION
Add tests for using ConnectionBuilder where user/password are specified (no sharding) and the Liberty data source is backed by either java.sql.Driver or javax.sql.DataSource (separate tests for each).