### PR TITLE
Timed removal of EarlyMessageQueue and EarlyTraceQueue from BaseTraceService

### DIFF
--- a/dev/com.ibm.ws.junit.extensions/src/com/ibm/websphere/ras/CapturedOutputHolder.java
+++ b/dev/com.ibm.ws.junit.extensions/src/com/ibm/websphere/ras/CapturedOutputHolder.java
@@ -47,6 +47,21 @@ public class CapturedOutputHolder extends BaseTraceService {
     private final DelegateTrWriter messageDelegate = new DelegateTrWriter();
     private final DelegateTrWriter traceDelegate = new DelegateTrWriter();
 
+    public CapturedOutputHolder() {
+        super();
+        /*
+         * CaputuredOutputHolder is created frequently for Junits.
+         * The Parent class BaseTraceSerivce creates a Timer object
+         * that will remove the earlyMessageQueue and earlyTraceQueue.
+         *
+         * Due to the frequency of Junit executions that create new
+         * CapturedOutputHolders, this can lead to a scenario with multiple
+         * Timer objects which can cause an OOM during builds.
+         */
+        earlyMessageTraceKiller_Timer.cancel();
+        earlyMessageTraceKiller_Timer = null;
+    }
+
     /**
      * This is not to be used by the SharedOutputManager! This is an override
      * of the BaseTraceService method that captures system streams.

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/WsMessageRouterImpl.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/WsMessageRouterImpl.java
@@ -63,7 +63,12 @@ public class WsMessageRouterImpl extends MessageRouterImpl implements WsMessageR
      */
     @Override
     public void setEarlierMessages(Queue<RoutedMessage> earlierMessages) {
-        this.earlierMessages = earlierMessages;
+        RERWLOCK.writeLock().lock();
+        try {
+        	this.earlierMessages = earlierMessages;
+        } finally {
+        	RERWLOCK.writeLock().unlock();
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -199,6 +199,7 @@ public class BaseTraceService implements TrService {
     protected volatile BufferManagerImpl logConduit;
     protected volatile BufferManagerImpl traceConduit;
     protected volatile CollectorManagerPipelineUtils collectorMgrPipelineUtils = null;
+    protected volatile Timer earlyMessageTraceKiller_Timer = new Timer();
 
     protected volatile String serverName = null;
     protected volatile String wlpUserDir = null;
@@ -224,7 +225,6 @@ public class BaseTraceService implements TrService {
         systemOut = new SystemLogHolder(LoggingConstants.SYSTEM_OUT, System.out);
         systemErr = new SystemLogHolder(LoggingConstants.SYSTEM_ERR, System.err);
 
-        Timer earlyMessageTraceKiller_Timer = new Timer();
         earlyMessageTraceKiller_Timer.schedule(new EarlyMessageTraceCleaner(), 5 * MINUTE); // 5 minutes wait time
     }
 


### PR DESCRIPTION
fixes #3860 
#build
Original PR : #3861 was reverted due to OOM causes during junit test executions.

The code creates a Timer object with the BaseTraceService class which will subsequently remove the early messages and trace queue when needed.

The Junit tests create multiple `BaseTraceService` (or rather the `CapturedOutputHolder`)as part of the Junit's ability to capture output during it's test execution. Due the speed of at which these Junit tests run and the number of them, a large amount of Timer objects can be created causing an OOM only during (release) build time. This will not affect run-time as there are is only ever one `BaseTraceService` created during runtime.

This PR addresses the OOM by cancelling and removing the Timer object from `CapturedOutputHolder` during the instantiation of a `CapturedOutputHolder`.