### PR TITLE
Issue #5011: Avoid Loading CORBA classes if remote EJB is not enabled

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/runtime/EJBRuntime.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/runtime/EJBRuntime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2016 IBM Corporation and others.
+ * Copyright (c) 2009, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,8 +67,7 @@ import com.ibm.wsspi.injectionengine.InjectionEngine;
  * The interface between the core EJB container and the services provided by
  * the runtime environment that contains the EJB container.
  */
-public interface EJBRuntime
-{
+public interface EJBRuntime {
     /**
      * Returns a class loader for the server runtime. Specifically, this class
      * loader should not be an application class loader.
@@ -148,8 +147,7 @@ public interface EJBRuntime
      * @throws RemoteException if the bean implements rmi remote business interface, wrap
      *             the exception in a RemoteException instead of EJBException
      */
-    Future<?> scheduleAsync(EJSWrapperBase wrapper, EJBMethodInfoImpl methodInfo, int methodId, Object[] args)
-                    throws RemoteException; // d617700
+    Future<?> scheduleAsync(EJSWrapperBase wrapper, EJBMethodInfoImpl methodInfo, int methodId, Object[] args) throws RemoteException;
 
     /**
      * Notifies the runtime that the metadata for a bean with timers has been
@@ -478,6 +476,13 @@ public interface EJBRuntime
      * @param bmd
      */
     void resolveMessageDestinationJndiName(BeanMetaData bmd);
+
+    /**
+     * Determines if the EJB runtime supports remote interfaces.
+     *
+     * @return true if the EJB runtime supports remote interfaces; otherwise false.
+     */
+    boolean isRemoteSupported();
 
     /**
      * Used to determine if looking up / injecting a remote interface is a

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
@@ -3952,14 +3952,16 @@ public abstract class EJBMDOrchestrator {
                                                                        bmd.j2eeName.toString(), // d443878
                                                                        runtime.getClassDefiner()); // F70650
 
-                    bmd.remoteTieClass = JITDeploy.generate_Tie // d413752
-                    (classLoader,
-                     classNameToLoad,
-                     bmd.remoteInterfaceClass,
-                     bmd.j2eeName.toString(), // d443878
-                     runtime.getClassDefiner(), // F70650
-                     mmd.getRMICCompatible(),
-                     runtime.isRemoteUsingPortableServer());
+                    // Only generate the Tie if remote is supported (CORBA classes are available)
+                    if (runtime.isRemoteSupported()) {
+                        bmd.remoteTieClass = JITDeploy.generate_Tie(classLoader,
+                                                                    classNameToLoad,
+                                                                    bmd.remoteInterfaceClass,
+                                                                    bmd.j2eeName.toString(),
+                                                                    runtime.getClassDefiner(),
+                                                                    mmd.getRMICCompatible(),
+                                                                    runtime.isRemoteUsingPortableServer());
+                    }
                 }
 
                 // Generate/Load the Component Local Implementation ('Wrapper')
@@ -4052,14 +4054,16 @@ public abstract class EJBMDOrchestrator {
                                                                                           bmd.j2eeName.toString(), // d443878
                                                                                           runtime.getClassDefiner()); // F70650
 
-                        bmd.ivBusinessRemoteTieClasses[i] = JITDeploy.generate_Tie // d413752
-                        (classLoader,
-                         classNameToLoad,
-                         bmd.ivBusinessRemoteInterfaceClasses[i],
-                         bmd.j2eeName.toString(), // d443878
-                         runtime.getClassDefiner(), // F70650
-                         mmd.getRMICCompatible(),
-                         runtime.isRemoteUsingPortableServer());
+                        // Only generate the Tie if remote is supported (CORBA classes are available)
+                        if (runtime.isRemoteSupported()) {
+                            bmd.ivBusinessRemoteTieClasses[i] = JITDeploy.generate_Tie(classLoader,
+                                                                                       classNameToLoad,
+                                                                                       bmd.ivBusinessRemoteInterfaceClasses[i],
+                                                                                       bmd.j2eeName.toString(),
+                                                                                       runtime.getClassDefiner(),
+                                                                                       mmd.getRMICCompatible(),
+                                                                                       runtime.isRemoteUsingPortableServer());
+                        }
                     }
                 }
 

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
@@ -1608,6 +1608,14 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
     }
 
     @Override
+    public boolean isRemoteSupported() {
+        if (remoteFeatureLatch != null || ejbRemoteRuntimeServiceRef.getReference() != null) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
     public void checkRemoteSupported(EJSHome home, String interfaceName) throws EJBNotFoundException {
         waitForEJBRemoteRuntime();
         if (ejbRemoteRuntimeServiceRef.getReference() == null) {


### PR DESCRIPTION
There is no need to generate and/or load the Tie classes for remote
EJB interfaces if the ejbRemote feature is not enabled. This is
important for Java 11, which doesn't provide the CORBA classes
used by the Ties.

The remote wrappers are still generated/loaded to allow an appropriate
error message if an attempt is made to use them when the ejbRemote
feature is not enabled.

fixes #5011 