### PR TITLE
Add JAX-B API and Impl as a dependency for opentracing FATs

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracing.java
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracing.java
@@ -78,10 +78,6 @@ import componenttest.topology.impl.LibertyServerFactory;
 @Mode(TestMode.FULL)
 @MinimumJavaLevel(javaLevel = 8)
 public class FATOpentracing implements FATOpentracingConstants {
-    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.31.mf";
-    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-0.31.jar";
-    // Logging ...
-
     private static final Class<? extends FATOpentracing> CLASS = FATOpentracing.class;
 
     private static void info(String methodName, String text, Object value) {
@@ -101,8 +97,6 @@ public class FATOpentracing implements FATOpentracingConstants {
 
     private static void setUpServer() throws Exception {
         server = LibertyServerFactory.getLibertyServer(OPENTRACING_FAT_SERVER1_NAME);
-        server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/" + FEATURE_NAME);
-        server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/" + BUNDLE_NAME);
     }
 
     private static LibertyServer getServer() {
@@ -124,10 +118,6 @@ public class FATOpentracing implements FATOpentracingConstants {
     private static void stopServer() throws Exception {
         getServer().stopServer(); // 'stopServer' throws Exception
     }
-
-    // Test setup ...
-    //
-    // TODO: Maybe this should be done by the FAT suite.
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATSuite.java
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATSuite.java
@@ -16,6 +16,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
 /**
  * <p>The open tracing FAT suite.</p>
  *
@@ -33,6 +36,8 @@ import org.junit.runners.Suite.SuiteClasses;
 })
 public class FATSuite implements FATOpentracingConstants {
     private static final Class<? extends FATSuite> CLASS = FATSuite.class;
+    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.31.mf";
+    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-0.31.jar";
 
     private static void info(String methodName, String text) {
         FATLogging.info(CLASS, methodName, text);
@@ -42,6 +47,9 @@ public class FATSuite implements FATOpentracingConstants {
     public static void setUp() throws Exception {
         String methodName = "setUp";
         info(methodName, "ENTER / RETURN");
+        LibertyServer server = LibertyServerFactory.getLibertyServer(OPENTRACING_FAT_SERVER1_NAME);
+        server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/" + FEATURE_NAME);
+        server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/" + BUNDLE_NAME);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.opentracing.1.1_fat/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/publish/tckRunner/tck/pom.xml
@@ -109,6 +109,28 @@
              <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
              <version>2.2.4</version>
          </dependency>
+         
+        <!-- Include JAX-B API+Impl for Java 9+ -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
 
     </dependencies>
 

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracing.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATOpentracing.java
@@ -78,9 +78,6 @@ import componenttest.topology.impl.LibertyServerFactory;
 @Mode(TestMode.FULL)
 @MinimumJavaLevel(javaLevel = 8)
 public class FATOpentracing implements FATOpentracingConstants {
-    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.30.mf";
-    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock.jar";
-    // Logging ...
 
     private static final Class<? extends FATOpentracing> CLASS = FATOpentracing.class;
 
@@ -101,8 +98,6 @@ public class FATOpentracing implements FATOpentracingConstants {
 
     private static void setUpServer() throws Exception {
         server = LibertyServerFactory.getLibertyServer(OPENTRACING_FAT_SERVER1_NAME);
-        server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/" + FEATURE_NAME);
-        server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/" + BUNDLE_NAME);
     }
 
     private static LibertyServer getServer() {
@@ -124,10 +119,6 @@ public class FATOpentracing implements FATOpentracingConstants {
     private static void stopServer() throws Exception {
         getServer().stopServer(); // 'stopServer' throws Exception
     }
-
-    // Test setup ...
-    //
-    // TODO: Maybe this should be done by the FAT suite.
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATSuite.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATSuite.java
@@ -16,6 +16,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
 /**
  * <p>The open tracing FAT suite.</p>
  *
@@ -33,6 +36,9 @@ import org.junit.runners.Suite.SuiteClasses;
 })
 public class FATSuite implements FATOpentracingConstants {
     private static final Class<? extends FATSuite> CLASS = FATSuite.class;
+    
+    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.30.mf";
+    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock.jar";
 
     private static void info(String methodName, String text) {
         FATLogging.info(CLASS, methodName, text);
@@ -42,6 +48,9 @@ public class FATSuite implements FATOpentracingConstants {
     public static void setUp() throws Exception {
         String methodName = "setUp";
         info(methodName, "ENTER / RETURN");
+        LibertyServer server = LibertyServerFactory.getLibertyServer(OPENTRACING_FAT_SERVER1_NAME);
+        server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/" + FEATURE_NAME);
+        server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/" + BUNDLE_NAME);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.opentracing_fat/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.opentracing_fat/publish/tckRunner/tck/pom.xml
@@ -109,6 +109,28 @@
              <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
              <version>2.2.4</version>
          </dependency>
+         
+        <!-- Include JAX-B API+Impl for Java 9+ -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
On Java 9+ JAX-B was removed from the JDK, so we need to add it back as a traditional dependency.

Exception we get on JDK 11:
```
java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlElement

      java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlElement
	at org.codehaus.jackson.xc.JaxbAnnotationIntrospector.<init>(JaxbAnnotationIntrospector.java:80)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at java.base/java.lang.Class.newInstance(Class.java:584)
	at org.codehaus.jackson.jaxrs.MapperConfigurator._resolveIntrospector(MapperConfigurator.java:173)
	at org.codehaus.jackson.jaxrs.MapperConfigurator._resolveIntrospectors(MapperConfigurator.java:146)
	at org.codehaus.jackson.jaxrs.MapperConfigurator._setAnnotations(MapperConfigurator.java:133)
	at org.codehaus.jackson.jaxrs.MapperConfigurator.getDefaultMapper(MapperConfigurator.java:70)
	at org.codehaus.jackson.jaxrs.JacksonJsonProvider.locateMapper(JacksonJsonProvider.java:649)
	at org.codehaus.jackson.jaxrs.JacksonJsonProvider.readFrom(JacksonJsonProvider.java:413)
	at org.jboss.resteasy.core.interception.jaxrs.AbstractReaderInterceptorContext.readFrom(AbstractReaderInterceptorContext.java:66)
	at org.jboss.resteasy.core.interception.jaxrs.AbstractReaderInterceptorContext.proceed(AbstractReaderInterceptorContext.java:56)
	at org.jboss.resteasy.client.jaxrs.internal.ClientResponse.readFrom(ClientResponse.java:266)
	at org.jboss.resteasy.client.jaxrs.internal.ClientResponse.readEntity(ClientResponse.java:196)
	at org.jboss.resteasy.specimpl.BuiltResponse.readEntity(BuiltResponse.java:218)
	at org.eclipse.microprofile.opentracing.tck.OpentracingClientTests.executeRemoteWebServiceTracer(OpentracingClientTests.java:1038)
	at org.eclipse.microprofile.opentracing.tck.OpentracingClientTests.executeRemoteWebServiceTracerTree(OpentracingClientTests.java:1046)
	at org.eclipse.microprofile.opentracing.tck.OpentracingClientTests.testAnnotations(OpentracingClientTests.java:169)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
	at org.testng.internal.MethodInvocationHelper$1.runTestMethod(MethodInvocationHelper.java:196)
	at org.jboss.arquillian.testng.Arquillian$2.invoke(Arquillian.java:173)
	at org.jboss.arquillian.container.test.impl.execution.LocalTestExecuter.execute(LocalTestExecuter.java:60)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:96)
	at org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:103)
	at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:85)
	at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:143)
	at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:114)
	at org.jboss.arquillian.core.impl.EventImpl.fire(EventImpl.java:67)
	at org.jboss.arquillian.container.test.impl.execution.ClientTestExecuter.execute(ClientTestExecuter.java:53)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:96)
	at org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:103)
	at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:85)
	at org.jboss.arquillian.container.test.impl.client.ContainerEventController.createContext(ContainerEventController.java:142)
	at org.jboss.arquillian.container.test.impl.client.ContainerEventController.createTestContext(ContainerEventController.java:129)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:96)
	at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:92)
	at org.jboss.arquillian.test.impl.TestContextHandler.createTestContext(TestContextHandler.java:130)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:96)
	at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:92)
	at org.jboss.arquillian.test.impl.TestContextHandler.createClassContext(TestContextHandler.java:92)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:96)
	at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:92)
	at org.jboss.arquillian.test.impl.TestContextHandler.createSuiteContext(TestContextHandler.java:73)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:96)
	at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:92)
	at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:143)
	at org.jboss.arquillian.test.impl.EventTestRunnerAdaptor.test(EventTestRunnerAdaptor.java:136)
	at org.jboss.arquillian.testng.Arquillian.run(Arquillian.java:164)
	at org.testng.internal.MethodInvocationHelper.invokeHookable(MethodInvocationHelper.java:208)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:635)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:816)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1124)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
	at org.testng.TestRunner.privateRun(TestRunner.java:774)
	at org.testng.TestRunner.run(TestRunner.java:624)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:359)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:354)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:312)
	at org.testng.SuiteRunner.run(SuiteRunner.java:261)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1215)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
	at org.testng.TestNG.run(TestNG.java:1048)
	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:293)
	at org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:91)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
```