### PR TITLE
Disable ldap endpoint identificiation for JDK 10+

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.ssl/jvm.options
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.ssl/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true


### PR DESCRIPTION
Fixes the following errors on Java 11 builds:

```
junit.framework.AssertionFailedError: 2018-09-14-01:06:02:048 Authentication should succeed. expected:<persona1@ibm.com> but was:<null>
	at com.ibm.ws.security.wim.adapter.ldap.fat.URAPIs_SUNLDAP_SSLTest.checkPassword(URAPIs_SUNLDAP_SSLTest.java:170)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:193)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:323)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:167)
```

Which manifests on the server-side as:
```
[9/14/18, 1:06:01:934 UTC] 00000022 com.ibm.ws.security.wim.registry.util.LoginBridge            E com.ibm.wsspi.security.wim.exception.WIMSystemException: CWIML4520E: The LDAP operation could not be completed. The LDAP naming exception javax.naming.CommunicationException: localhost:30389 [Root exception is javax.net.ssl.SSLException: Unsupported or unrecognized SSL message] occurred during processing. 
                                                                                                               com.ibm.wsspi.security.wim.exception.WIMException: com.ibm.wsspi.security.wim.exception.WIMSystemException: CWIML4520E: The LDAP operation could not be completed. The LDAP naming exception javax.naming.CommunicationException: localhost:30389 [Root exception is javax.net.ssl.SSLException: Unsupported or unrecognized SSL message] occurred during processing.
	at com.ibm.ws.security.wim.ProfileManager.loginImpl(ProfileManager.java:1795)
	at com.ibm.ws.security.wim.ProfileManager.genericProfileManagerMethod(ProfileManager.java:238)
	at com.ibm.ws.security.wim.ProfileManager.login(ProfileManager.java:204)
	at com.ibm.ws.security.wim.VMMService.login(VMMService.java:246)
	at com.ibm.ws.security.wim.registry.util.LoginBridge.checkPassword(LoginBridge.java:115)
	at com.ibm.ws.security.wim.registry.WIMUserRegistry.checkPassword(WIMUserRegistry.java:171)
	at web.UserRegistryServlet.handleMethodRequest(UserRegistryServlet.java:165)
	at web.UserRegistryServlet.doGet(UserRegistryServlet.java:239)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1255)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:743)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:440)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1221)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1005)
	at com.ibm.ws.webcontainer.servlet.CacheServletWrapper.handleRequest(CacheServletWrapper.java:75)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:927)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1011)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:414)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:373)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:532)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:466)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:331)
	at com.ibm.ws.http.channel.internal.inbound.HttpICLReadCallback.complete(HttpICLReadCallback.java:70)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:501)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:571)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:926)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1015)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: com.ibm.wsspi.security.wim.exception.WIMSystemException: CWIML4520E: The LDAP operation could not be completed. The LDAP naming exception javax.naming.CommunicationException: localhost:30389 [Root exception is javax.net.ssl.SSLException: Unsupported or unrecognized SSL message] occurred during processing.
	at com.ibm.ws.security.wim.adapter.ldap.context.ContextManager.getDirContext(ContextManager.java:676)
	at com.ibm.ws.security.wim.adapter.ldap.LdapConnection.search(LdapConnection.java:1370)
	at com.ibm.ws.security.wim.adapter.ldap.LdapConnection.checkSearchCache(LdapConnection.java:1244)
	at com.ibm.ws.security.wim.adapter.ldap.LdapConnection.search(LdapConnection.java:1775)
	at com.ibm.ws.security.wim.adapter.ldap.LdapConnection.searchEntities(LdapConnection.java:1843)
	at com.ibm.ws.security.wim.adapter.ldap.LdapAdapter.login(LdapAdapter.java:571)
	at com.ibm.ws.security.wim.ProfileManager.loginImpl(ProfileManager.java:1756)
	... 31 more
Caused by: javax.naming.CommunicationException: localhost:30389 [Root exception is javax.net.ssl.SSLException: Unsupported or unrecognized SSL message]
	at java.naming/com.sun.jndi.ldap.Connection.<init>(Connection.java:237)
	at java.naming/com.sun.jndi.ldap.LdapClient.<init>(LdapClient.java:137)
	at java.naming/com.sun.jndi.ldap.LdapClient.getInstance(LdapClient.java:1616)
	at java.naming/com.sun.jndi.ldap.LdapCtx.connect(LdapCtx.java:2752)
	at java.naming/com.sun.jndi.ldap.LdapCtx.<init>(LdapCtx.java:320)
	at java.naming/com.sun.jndi.ldap.LdapCtxFactory.getUsingURL(LdapCtxFactory.java:192)
	at java.naming/com.sun.jndi.ldap.LdapCtxFactory.getUsingURLs(LdapCtxFactory.java:210)
	at java.naming/com.sun.jndi.ldap.LdapCtxFactory.getLdapCtxInstance(LdapCtxFactory.java:153)
	at java.naming/com.sun.jndi.ldap.LdapCtxFactory.getInitialContext(LdapCtxFactory.java:83)
	at org.apache.aries.jndi.ContextHelper.getInitialContextUsingBuilder(ContextHelper.java:244)
	at org.apache.aries.jndi.ContextHelper.getContextProvider(ContextHelper.java:208)
	at org.apache.aries.jndi.ContextHelper.getInitialContext(ContextHelper.java:141)
	at org.apache.aries.jndi.OSGiInitialContextFactoryBuilder.getInitialContext(OSGiInitialContextFactoryBuilder.java:51)
	at java.naming/javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:730)
	at java.naming/javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:305)
	at java.naming/javax.naming.InitialContext.init(InitialContext.java:236)
	at java.naming/javax.naming.ldap.InitialLdapContext.<init>(InitialLdapContext.java:154)
	at com.ibm.ws.security.wim.adapter.ldap.context.TimedDirContext.<init>(TimedDirContext.java:80)
	at com.ibm.ws.security.wim.adapter.ldap.context.ContextManager.createDirContext(ContextManager.java:422)
	at com.ibm.ws.security.wim.adapter.ldap.context.ContextManager.createContextPool(ContextManager.java:323)
	at com.ibm.ws.security.wim.adapter.ldap.context.ContextManager.getDirContext(ContextManager.java:673)
	... 37 more
Caused by: javax.net.ssl.SSLException: Unsupported or unrecognized SSL message
	at java.base/sun.security.ssl.SSLSocketInputRecord.handleUnknownRecord(SSLSocketInputRecord.java:439)
	at java.base/sun.security.ssl.SSLSocketInputRecord.decode(SSLSocketInputRecord.java:184)
	at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:108)
	at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1152)
	at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1063)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:402)
	at java.naming/com.sun.jndi.ldap.Connection.createSocket(Connection.java:349)
	at java.naming/com.sun.jndi.ldap.Connection.<init>(Connection.java:216)
	... 57 more
```