### PR TITLE
Remove JAX-B dependency in http2_fat

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/GenericFrameTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/GenericFrameTests.java
@@ -17,7 +17,6 @@ import java.util.concurrent.CountDownLatch;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.xml.bind.DatatypeConverter;
 
 import com.ibm.ws.http.channel.h2internal.frames.FrameData;
 import com.ibm.ws.http.channel.h2internal.frames.FrameGoAway;
@@ -188,7 +187,7 @@ public class GenericFrameTests extends H2FATDriverServlet {
         // malformed frame: set frame type byte to unknown
         //_________________________||____________________ - frame type byte
         String dataString = "0000060f0000000003414243313233";
-        byte[] b = DatatypeConverter.parseHexBinary(dataString);
+        byte[] b = parseHexBinary(dataString);
         h2Client.sendBytes(b);
 
         waitForTestCompletion(blockUntilConnectionIsDone);
@@ -221,5 +220,16 @@ public class GenericFrameTests extends H2FATDriverServlet {
 
         waitForTestCompletion(blockUntilConnectionIsDone);
         handleErrors(h2Client, testName);
+    }
+
+    // This does the same thing as DatatypeConverter.parseHexBinary(str), but it allows us to avoid a dependency on JAX-B for this FAT
+    private static byte[] parseHexBinary(String str) {
+        int len = str.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(str.charAt(i), 16) << 4)
+                                  + Character.digit(str.charAt(i + 1), 16));
+        }
+        return data;
     }
 }


### PR DESCRIPTION
Fixes the following error when running com.ibm.ws.transport.http2_fat on Java 11:

```
junit.framework.AssertionFailedError: 2018-09-14-01:23:26:957 The response did not contain "[SUCCESS]".  Full output is:"
ERROR: Caught exception attempting to call test method testUnknownFrameType on servlet http2.test.driver.war.servlets.GenericFrameTests
java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter
	at http2.test.driver.war.servlets.GenericFrameTests.testUnknownFrameType(GenericFrameTests.java:191)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at componenttest.app.FATServlet.doGet(FATServlet.java:67)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1255)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:743)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:440)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1221)
	at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:4954)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:996)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1011)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:414)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:373)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:532)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:466)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:331)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:302)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:165)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:74)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:501)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:571)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:926)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1015)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter
	at com.ibm.ws.classloading.internal.AppClassLoader.findClassCommonLibraryClassLoaders(AppClassLoader.java:504)
	at com.ibm.ws.classloading.internal.AppClassLoader.findClass(AppClassLoader.java:276)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588)
	at com.ibm.ws.classloading.internal.AppClassLoader.findOrDelegateLoadClass(AppClassLoader.java:482)
	at com.ibm.ws.classloading.internal.AppClassLoader.loadClass(AppClassLoader.java:443)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
". expected:<0> but was:<1>
	at componenttest.topology.utils.HttpUtils.findStringInHttpConnection(HttpUtils.java:537)
	at componenttest.topology.utils.HttpUtils.findStringInHttpConnection(HttpUtils.java:495)
	at componenttest.topology.utils.HttpUtils.findStringInUrl(HttpUtils.java:472)
	at componenttest.topology.utils.HttpUtils.findStringInReadyUrl(HttpUtils.java:444)
	at componenttest.topology.utils.HttpUtils.findStringInReadyUrl(HttpUtils.java:414)
	at componenttest.topology.utils.FATServletClient.runTest(FATServletClient.java:81)
	at test.server.transport.http2.Http2LiteModeTests.runTest(Http2LiteModeTests.java:87)
	at test.server.transport.http2.Http2LiteModeTests.testUnknownFrameType(Http2LiteModeTests.java:273)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:193)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:323)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:167)
```