### PR TITLE
create connection builders for mock JDBC 4.3 driver

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43CommonDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43CommonDataSource.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.sql.ShardingKeyBuilder;
+
+import javax.sql.CommonDataSource;
+
+public abstract class D43CommonDataSource implements CommonDataSource {
+    D43ShardingKey defaultShardingKey;
+    D43ShardingKey defaultSuperShardingKey;
+
+    @Override
+    public ShardingKeyBuilder createShardingKeyBuilder() {
+        return new D43ShardingKeyBuilder();
+    }
+
+    public String getShardingKey() {
+        return defaultShardingKey == null ? null : defaultShardingKey.key;
+    }
+
+    public String getSuperShardingKey() {
+        return defaultSuperShardingKey == null ? null : defaultSuperShardingKey.key;
+    }
+
+    public void setShardingKey(String value) {
+        defaultShardingKey = value == null || value.length() == 0 ? null : new D43ShardingKey(value);
+    }
+
+    public void setSuperShardingKey(String value) {
+        defaultSuperShardingKey = value == null || value.length() == 0 ? null : new D43ShardingKey(value);
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ConnectionBuilder.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ConnectionBuilder.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.ConnectionBuilder;
+import java.sql.SQLException;
+import java.sql.ShardingKey;
+
+public class D43ConnectionBuilder implements ConnectionBuilder {
+    private final D43DataSource d43DataSource;
+
+    private String password;
+    private ShardingKey shardingKey;
+    private ShardingKey superShardingKey;
+    private String user;
+
+    public D43ConnectionBuilder(D43DataSource ds) {
+        this.d43DataSource = ds;
+    }
+
+    @Override
+    public Connection build() throws SQLException {
+        Connection con;
+        if (user == null && password == null)
+            con = d43DataSource.ds.getConnection();
+        else
+            con = d43DataSource.ds.getConnection(user, password);
+
+        con = (Connection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                  new Class[] { Connection.class },
+                                                  new D43Handler(con, null, d43DataSource, shardingKey, superShardingKey));
+        return con;
+    }
+
+    @Override
+    public D43ConnectionBuilder password(String value) {
+        password = value;
+        return this;
+    }
+
+    @Override
+    public D43ConnectionBuilder shardingKey(ShardingKey value) {
+        shardingKey = value;
+        return this;
+    }
+
+    @Override
+    public D43ConnectionBuilder superShardingKey(ShardingKey value) {
+        superShardingKey = value;
+        return this;
+    }
+
+    @Override
+    public D43ConnectionBuilder user(String value) {
+        user = value;
+        return this;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ConnectionPoolDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ConnectionPoolDataSource.java
@@ -20,8 +20,8 @@ import javax.sql.ConnectionPoolDataSource;
 import javax.sql.PooledConnection;
 import javax.sql.PooledConnectionBuilder;
 
-public class D43ConnectionPoolDataSource implements ConnectionPoolDataSource {
-    private final org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource ds;
+public class D43ConnectionPoolDataSource extends D43CommonDataSource implements ConnectionPoolDataSource {
+    final org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource ds;
 
     public D43ConnectionPoolDataSource() {
         ds = new org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource();
@@ -29,9 +29,7 @@ public class D43ConnectionPoolDataSource implements ConnectionPoolDataSource {
 
     @Override
     public PooledConnectionBuilder createPooledConnectionBuilder() throws SQLException {
-        return (PooledConnectionBuilder) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
-                                                                new Class[] { PooledConnectionBuilder.class },
-                                                                new D43Handler(ds.createPooledConnectionBuilder(), null));
+        return new D43PooledConnectionBuilder(this);
     }
 
     public String getDatabaseName() {
@@ -57,14 +55,14 @@ public class D43ConnectionPoolDataSource implements ConnectionPoolDataSource {
     public PooledConnection getPooledConnection() throws SQLException {
         return (PooledConnection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
                                                          new Class[] { PooledConnection.class },
-                                                         new D43Handler(ds.getPooledConnection(), null));
+                                                         new D43Handler(ds.getPooledConnection(), null, this));
     }
 
     @Override
     public PooledConnection getPooledConnection(String user, String pwd) throws SQLException {
         return (PooledConnection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
                                                          new Class[] { PooledConnection.class },
-                                                         new D43Handler(ds.getPooledConnection(user, pwd), null));
+                                                         new D43Handler(ds.getPooledConnection(user, pwd), null, this));
     }
 
     public void setDatabaseName(String value) {

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43DataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43DataSource.java
@@ -20,18 +20,16 @@ import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
-public class D43DataSource implements DataSource {
-    private final org.apache.derby.jdbc.EmbeddedDataSource ds;
+public class D43DataSource extends D43CommonDataSource implements DataSource {
+    final org.apache.derby.jdbc.EmbeddedDataSource ds;
 
     public D43DataSource() {
         ds = new org.apache.derby.jdbc.EmbeddedDataSource();
     }
 
     @Override
-    public ConnectionBuilder createConnectionBuilder() throws SQLException {
-        return (ConnectionBuilder) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
-                                                          new Class[] { ConnectionBuilder.class },
-                                                          new D43Handler(ds.createConnectionBuilder(), null));
+    public ConnectionBuilder createConnectionBuilder() {
+        return new D43ConnectionBuilder(this);
     }
 
     public String getDatabaseName() {
@@ -57,14 +55,14 @@ public class D43DataSource implements DataSource {
     public Connection getConnection() throws SQLException {
         return (Connection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
                                                    new Class[] { Connection.class },
-                                                   new D43Handler(ds.getConnection(), null));
+                                                   new D43Handler(ds.getConnection(), null, this));
     }
 
     @Override
     public Connection getConnection(String user, String pwd) throws SQLException {
         return (Connection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
                                                    new Class[] { Connection.class },
-                                                   new D43Handler(ds.getConnection(user, pwd), null));
+                                                   new D43Handler(ds.getConnection(user, pwd), null, this));
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Driver.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Driver.java
@@ -29,7 +29,7 @@ public class D43Driver extends org.apache.derby.jdbc.AutoloadedDriver implements
         String url2 = url.replace("jdbc:d43:", "jdbc:derby:");
         Connection con = url2.equals(url) ? null : super.connect(url2, props);
         if (con != null)
-            con = (Connection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(), new Class[] { Connection.class }, new D43Handler(con, null));
+            con = (Connection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(), new Class[] { Connection.class }, new D43Handler(con, null, null));
         return con;
     }
 

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.ShardingKey;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -32,6 +33,8 @@ public class D43Handler implements InvocationHandler, Supplier<AtomicInteger[]> 
     private final AtomicInteger beginRequests = new AtomicInteger();
     private final AtomicInteger endRequests = new AtomicInteger();
 
+    private final D43CommonDataSource commonDataSource;
+
     private final Object instance;
 
     private boolean isAborted;
@@ -39,11 +42,23 @@ public class D43Handler implements InvocationHandler, Supplier<AtomicInteger[]> 
 
     private final D43Handler parent;
 
+    private ShardingKey shardingKey;
+    private ShardingKey superShardingKey;
+
     private final static TransactionManager tm = TransactionManagerFactory.getTransactionManager();
 
-    D43Handler(Object instance, D43Handler parent) {
+    D43Handler(Object instance, D43Handler parent, D43CommonDataSource commonDataSource) {
+        this.commonDataSource = commonDataSource;
         this.instance = instance;
         this.parent = parent;
+    }
+
+    D43Handler(Object instance, D43Handler parent, D43CommonDataSource commonDataSource, ShardingKey shardingKey, ShardingKey superShardingKey) {
+        this.commonDataSource = commonDataSource;
+        this.instance = instance;
+        this.parent = parent;
+        this.shardingKey = shardingKey;
+        this.superShardingKey = superShardingKey;
     }
 
     // Accessible via wrapper pattern for obtaining the count of Connection.beginRequest/endRequest
@@ -135,6 +150,15 @@ public class D43Handler implements InvocationHandler, Supplier<AtomicInteger[]> 
                 throw new AbortedException(method.getDeclaringClass());
             return null;
         }
+        // Abuse getClientInfo to expose the sharding key value to the application so that tests can compare it
+        if ("getClientInfo".equals(methodName) && args != null && args.length == 1 && "SHARDING_KEY".equals(args[0]))
+            return shardingKey != null ? shardingKey.toString() //
+                            : commonDataSource != null && commonDataSource.defaultShardingKey != null ? commonDataSource.defaultShardingKey.toString() //
+                                            : null;
+        if ("getClientInfo".equals(methodName) && args != null && args.length == 1 && "SUPER_SHARDING_KEY".equals(args[0]))
+            return superShardingKey != null ? superShardingKey.toString() //
+                            : commonDataSource != null && commonDataSource.defaultSuperShardingKey != null ? commonDataSource.defaultSuperShardingKey.toString() //
+                                            : null;
         if ("getJDBCMajorVersion".equals(methodName))
             return 4;
         if ("getJDBCMinorVersion".equals(methodName))
@@ -145,12 +169,27 @@ public class D43Handler implements InvocationHandler, Supplier<AtomicInteger[]> 
             && connectionHandler != null && connectionHandler.isAborted) {
             return null;
         }
+        if ("setShardingKey".equals(methodName)) {
+            shardingKey = (ShardingKey) args[0];
+            if (args.length == 2)
+                superShardingKey = (ShardingKey) args[1];
+        }
+        if ("setShardingKeyIfValid".equals(methodName)) {
+            boolean valid = (args[0] instanceof D43ShardingKey || args[0] == null)
+                            && (args.length == 2 || args[1] instanceof D43ShardingKey || args[1] == null);
+            if (valid) {
+                shardingKey = (ShardingKey) args[0];
+                if (args.length == 2)
+                    superShardingKey = (ShardingKey) args[1];
+            }
+            return valid;
+        }
         try {
             Object result = method.invoke(instance, args);
             if (returnType.isInterface() && (returnType.getPackage().getName().startsWith("java.sql")
                                              || returnType.getPackage().getName().startsWith("javax.sql")
                                              || returnType.equals(XAResource.class)))
-                return Proxy.newProxyInstance(D43Handler.class.getClassLoader(), new Class[] { returnType }, new D43Handler(result, this));
+                return Proxy.newProxyInstance(D43Handler.class.getClassLoader(), new Class[] { returnType }, new D43Handler(result, this, commonDataSource));
             return result;
         } catch (InvocationTargetException x) {
             throw x.getCause();

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43PooledConnectionBuilder.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43PooledConnectionBuilder.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.sql.ShardingKey;
+
+import javax.sql.PooledConnection;
+import javax.sql.PooledConnectionBuilder;
+
+public class D43PooledConnectionBuilder implements PooledConnectionBuilder {
+    private final D43ConnectionPoolDataSource d43PoolDataSource;
+
+    private String password;
+    private ShardingKey shardingKey;
+    private ShardingKey superShardingKey;
+    private String user;
+
+    public D43PooledConnectionBuilder(D43ConnectionPoolDataSource ds) {
+        this.d43PoolDataSource = ds;
+    }
+
+    @Override
+    public PooledConnection build() throws SQLException {
+        PooledConnection con;
+        if (user == null && password == null)
+            con = d43PoolDataSource.ds.getPooledConnection();
+        else
+            con = d43PoolDataSource.ds.getPooledConnection(user, password);
+
+        con = (PooledConnection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                        new Class[] { PooledConnection.class },
+                                                        new D43Handler(con, null, d43PoolDataSource, shardingKey, superShardingKey));
+        return con;
+    }
+
+    @Override
+    public D43PooledConnectionBuilder password(String value) {
+        password = value;
+        return this;
+    }
+
+    @Override
+    public D43PooledConnectionBuilder shardingKey(ShardingKey value) {
+        shardingKey = value;
+        return this;
+    }
+
+    @Override
+    public D43PooledConnectionBuilder superShardingKey(ShardingKey value) {
+        superShardingKey = value;
+        return this;
+    }
+
+    @Override
+    public D43PooledConnectionBuilder user(String value) {
+        user = value;
+        return this;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ShardingKey.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ShardingKey.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.sql.ShardingKey;
+
+public class D43ShardingKey implements ShardingKey {
+    final String key;
+
+    D43ShardingKey(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public boolean equals(Object shardingKey) {
+        return shardingKey instanceof D43ShardingKey && ((D43ShardingKey) shardingKey).key.equals(key);
+    }
+
+    @Override
+    public int hashCode() {
+        return key.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("D43ShardingKey@")
+                        .append(Integer.toHexString(hashCode()))
+                        .append('|')
+                        .append(key)
+                        .toString();
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ShardingKeyBuilder.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ShardingKeyBuilder.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.sql.SQLException;
+import java.sql.SQLType;
+import java.sql.ShardingKey;
+import java.sql.ShardingKeyBuilder;
+
+public class D43ShardingKeyBuilder implements ShardingKeyBuilder {
+    private final StringBuilder sb = new StringBuilder();
+
+    @Override
+    public ShardingKey build() throws SQLException {
+        return new D43ShardingKey(sb.toString());
+    }
+
+    @Override
+    public D43ShardingKeyBuilder subkey(Object subkey, SQLType subkeyType) {
+        sb.append(subkeyType.getName()).append(':').append(subkey).append(';');
+        return this;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43XAConnectionBuilder.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43XAConnectionBuilder.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.d43.jdbc;
+
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.sql.ShardingKey;
+
+import javax.sql.XAConnection;
+import javax.sql.XAConnectionBuilder;
+
+public class D43XAConnectionBuilder implements XAConnectionBuilder {
+    private final D43XADataSource d43XADataSource;
+
+    private String password;
+    private ShardingKey shardingKey;
+    private ShardingKey superShardingKey;
+    private String user;
+
+    public D43XAConnectionBuilder(D43XADataSource ds) {
+        this.d43XADataSource = ds;
+    }
+
+    @Override
+    public XAConnection build() throws SQLException {
+        XAConnection con;
+        if (user == null && password == null)
+            con = d43XADataSource.ds.getXAConnection();
+        else
+            con = d43XADataSource.ds.getXAConnection(user, password);
+
+        con = (XAConnection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
+                                                    new Class[] { XAConnection.class },
+                                                    new D43Handler(con, null, d43XADataSource, shardingKey, superShardingKey));
+        return con;
+    }
+
+    @Override
+    public D43XAConnectionBuilder password(String value) {
+        password = value;
+        return this;
+    }
+
+    @Override
+    public D43XAConnectionBuilder shardingKey(ShardingKey value) {
+        shardingKey = value;
+        return this;
+    }
+
+    @Override
+    public D43XAConnectionBuilder superShardingKey(ShardingKey value) {
+        superShardingKey = value;
+        return this;
+    }
+
+    @Override
+    public D43XAConnectionBuilder user(String value) {
+        user = value;
+        return this;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43XADataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43XADataSource.java
@@ -20,8 +20,8 @@ import javax.sql.XAConnection;
 import javax.sql.XAConnectionBuilder;
 import javax.sql.XADataSource;
 
-public class D43XADataSource implements XADataSource {
-    private final org.apache.derby.jdbc.EmbeddedXADataSource ds;
+public class D43XADataSource extends D43CommonDataSource implements XADataSource {
+    final org.apache.derby.jdbc.EmbeddedXADataSource ds;
 
     public D43XADataSource() {
         ds = new org.apache.derby.jdbc.EmbeddedXADataSource();
@@ -29,9 +29,7 @@ public class D43XADataSource implements XADataSource {
 
     @Override
     public XAConnectionBuilder createXAConnectionBuilder() throws SQLException {
-        return (XAConnectionBuilder) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
-                                                            new Class[] { XAConnectionBuilder.class },
-                                                            new D43Handler(ds.createXAConnectionBuilder(), null));
+        return new D43XAConnectionBuilder(this);
     }
 
     public String getDatabaseName() {
@@ -57,14 +55,14 @@ public class D43XADataSource implements XADataSource {
     public XAConnection getXAConnection() throws SQLException {
         return (XAConnection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
                                                      new Class[] { XAConnection.class },
-                                                     new D43Handler(ds.getXAConnection(), null));
+                                                     new D43Handler(ds.getXAConnection(), null, this));
     }
 
     @Override
     public XAConnection getXAConnection(String user, String pwd) throws SQLException {
         return (XAConnection) Proxy.newProxyInstance(D43Handler.class.getClassLoader(),
                                                      new Class[] { XAConnection.class },
-                                                     new D43Handler(ds.getXAConnection(user, pwd), null));
+                                                     new D43Handler(ds.getXAConnection(user, pwd), null, this));
     }
 
     public void setDatabaseName(String value) {


### PR DESCRIPTION
The mock JDBC 4.3 driver needs implementations of
ConnectionBuilder
PooledConnectionBuilder
XAConnectionBuilder
that allow ShardingKeys to be specified.
It also needs implementations of 
ShardingKeyBuilder
ShardingKey
so that we can start to experiment with sharding in JDBC 4.3.