### PR TITLE
Add JAX-B to Metrics 1.1 TCK FATS

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/tck/pom.xml
@@ -76,6 +76,12 @@
     		<artifactId>javax.inject</artifactId>
     		<version>1</version>
 		</dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+            <scope>test</scope>
+        </dependency>
  	</dependencies>
  	
 	<build>

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -76,6 +76,12 @@
     		<artifactId>javax.inject</artifactId>
     		<version>1</version>
 		</dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+            <scope>test</scope>
+        </dependency>
  	</dependencies>
  	
 	<build>


### PR DESCRIPTION
Add JAX-B dependency to the MP Metrics 1.1 FATs so they can run with Java 11.