### PR TITLE
Remove CORBA dependency from com.ibm.ws.install

### DIFF
--- a/dev/com.ibm.ws.install/bnd.bnd
+++ b/dev/com.ibm.ws.install/bnd.bnd
@@ -65,10 +65,4 @@ instrument.disabled: true
     com.ibm.ws.repository.resolver;version=latest,\
     wlp.lib.extract;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\
-    com.ibm.wsspi.org.osgi.service.component.annotations,\
-    com.ibm.ws.org.apache.yoko.corba.spec.1.5;version=latest,\
-    com.ibm.ws.org.apache.yoko.core.1.5;version=latest,\
-    com.ibm.ws.org.apache.yoko.osgi.1.5;version=latest,\
-    com.ibm.ws.org.apache.yoko.rmi.impl.1.5;version=latest,\
-    com.ibm.ws.org.apache.yoko.rmi.spec.1.5;version=latest,\
-    com.ibm.ws.org.apache.yoko.util.1.5;version=latest
+    com.ibm.wsspi.org.osgi.service.component.annotations

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/FeatureDependencyChecker.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/FeatureDependencyChecker.java
@@ -18,9 +18,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
-
-import org.omg.CORBA.IntHolder;
 
 import com.ibm.ws.install.internal.asset.UninstallAsset;
 import com.ibm.ws.kernel.feature.Visibility;
@@ -122,17 +121,18 @@ public class FeatureDependencyChecker {
         for (UninstallAsset ua : list) {
             assetsMap.put(ua.getProvisioningFeatureDefinition().getSymbolicName(), ua);
         }
-        IntHolder order = new IntHolder(list.size());
+        AtomicInteger order = new AtomicInteger(list.size()); // Doesn't really need to be atomic, just using it for an int holder object
         for (UninstallAsset ua : list) {
-            if (!!!visited.containsKey(ua.getProvisioningFeatureDefinition().getSymbolicName()))
+            if (!!!visited.containsKey(ua.getProvisioningFeatureDefinition().getSymbolicName())) {
                 DFS(ua, visited, assetsMap, order);
+            }
         }
 
         Collections.sort(list, new FeatureDependencyComparator(visited));
         return list;
     }
 
-    private void DFS(UninstallAsset asset, Map<String, Integer> visited, Map<String, UninstallAsset> assetsMap, IntHolder order) {
+    private void DFS(UninstallAsset asset, Map<String, Integer> visited, Map<String, UninstallAsset> assetsMap, AtomicInteger order) {
 
         visited.put(asset.getProvisioningFeatureDefinition().getSymbolicName(), -1);
         for (FeatureResource fr : asset.getProvisioningFeatureDefinition().getConstituents(null)) {
@@ -140,8 +140,8 @@ public class FeatureDependencyChecker {
             if (ua != null && !!!visited.containsKey(ua.getProvisioningFeatureDefinition().getSymbolicName()))
                 DFS(ua, visited, assetsMap, order);
         }
-        visited.put(asset.getProvisioningFeatureDefinition().getSymbolicName(), order.value);
-        order.value--;
+        visited.put(asset.getProvisioningFeatureDefinition().getSymbolicName(), order.get());
+        order.decrementAndGet();
 
     }
 


### PR DESCRIPTION
Resolves the following error when running install tests with Java 11:

```
java.lang.NoClassDefFoundError: 2018-09-15-06:43:50:016 org/omg/CORBA/IntHolder
	at com.ibm.ws.install.internal.FeatureDependencyChecker.determineOrder(FeatureDependencyChecker.java:125)
	at com.ibm.ws.install.internal.UninstallDirector.getNotUninstallableAssets(UninstallDirector.java:470)
	at com.ibm.ws.install.internal.UninstallDirector.uninstallFeatures(UninstallDirector.java:171)
	at com.ibm.ws.install.internal.UninstallDirector.uninstall(UninstallDirector.java:143)
	at com.ibm.ws.install.internal.Director.uninstall(Director.java:1829)
	at com.ibm.ws.install.internal.InstallKernelImpl.uninstall(InstallKernelImpl.java:289)
	at com.ibm.ws.install.internal.InstallKernelImpl.uninstallFeature(InstallKernelImpl.java:312)
	at com.ibm.ws.install.fat.InstallKernelTest.testGetInstalledLicense(InstallKernelTest.java:92)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:194)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:334)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:168)
```