### PR TITLE
Add JAX-B to JSF Container Servers

### DIFF
--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.beanval/server.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.beanval/server.xml
@@ -13,6 +13,7 @@
 		<feature>jsfContainer-2.3</feature>
         <feature>beanValidation-2.0</feature>
 	    <feature>componenttest-1.0</feature>
+        <feature>jaxb-2.2</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.cdi/server.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat.cdi/server.xml
@@ -14,6 +14,7 @@
         <feature>cdi-2.0</feature>
         <feature>concurrent-1.0</feature>
         <feature>componenttest-1.0</feature>
+        <feature>jaxb-2.2</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>


### PR DESCRIPTION
Apache Myfaces has a dependency on JAX-B in some code paths.  Add the jaxb-2.2 feature to the two servers in the jsfContainer_fat_2.3 project needing access to APIs.