### PR TITLE
Remove JAX-B dependency from javaeesec_fat

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecBasicAuthServlet.war/src/web/war/basic/BasicHttpAuthenticationMechanism.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecBasicAuthServlet.war/src/web/war/basic/BasicHttpAuthenticationMechanism.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package web.war.basic;
 
+import java.util.Base64;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -33,7 +34,6 @@ import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.xml.bind.DatatypeConverter;
 
 @Default
 @ApplicationScoped
@@ -134,8 +134,9 @@ public class BasicHttpAuthenticationMechanism implements HttpAuthenticationMecha
 
     private String decodeCookieString(String cookieString) {
         try {
-            return new String(DatatypeConverter.parseBase64Binary(cookieString));
+            return new String(Base64.getDecoder().decode(cookieString));
         } catch (Exception e) {
+            e.printStackTrace();
             return null;
         }
     }


### PR DESCRIPTION
Resolves the following error when running the com.ibm.ws.javaeesec_fat on Java 11:

```
Stack Dump = java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter
	at web.war.basic.BasicHttpAuthenticationMechanism.decodeCookieString(BasicHttpAuthenticationMechanism.java:137)
	at web.war.basic.BasicHttpAuthenticationMechanism.handleAuthorizationHeader(BasicHttpAuthenticationMechanism.java:108)
	at web.war.basic.BasicHttpAuthenticationMechanism.validateRequest(BasicHttpAuthenticationMechanism.java:74)
	at web.war.basic.BasicHttpAuthenticationMechanism$Proxy$_$$_WeldClientProxy.validateRequest(Unknown Source)
	at com.ibm.ws.security.javaeesec.AuthModule.validateRequest(AuthModule.java:85)
	at com.ibm.ws.security.javaeesec.AuthContext.validateRequest(AuthContext.java:74)
	at com.ibm.ws.security.jaspi.JaspiServiceImpl.authenticate(JaspiServiceImpl.java:378)
	at com.ibm.ws.security.jaspi.JaspiServiceImpl.authenticate(JaspiServiceImpl.java:289)
	at com.ibm.ws.webcontainer.security.WebProviderAuthenticatorProxy.authenticateForOtherMechanisms(WebProviderAuthenticatorProxy.java:138)
	at com.ibm.ws.webcontainer.security.WebProviderAuthenticatorProxy.handleJaspi(WebProviderAuthenticatorProxy.java:100)
	at com.ibm.ws.webcontainer.security.extended.WebProviderAuthenticatorProxyExtended.handleJaspi(WebProviderAuthenticatorProxyExtended.java:147)
	at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.handleJaspi(WebAppSecurityCollaboratorImpl.java:695)
	at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.performSecurityChecks(WebAppSecurityCollaboratorImpl.java:637)
	at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.preInvoke(WebAppSecurityCollaboratorImpl.java:567)
	at com.ibm.wsspi.webcontainer.collaborator.CollaboratorHelper.preInvokeCollaborators(CollaboratorHelper.java:459)
	at com.ibm.ws.webcontainer.osgi.collaborator.CollaboratorHelperImpl.preInvokeCollaborators(CollaboratorHelperImpl.java:270)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1109)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1005)
	at com.ibm.ws.webcontainer.servlet.CacheServletWrapper.handleRequest(CacheServletWrapper.java:75)
	at com.ibm.ws.webcontainer40.servlet.CacheServletWrapper40.handleRequest(CacheServletWrapper40.java:83)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:927)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1011)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:414)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:373)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:532)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:466)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:331)
	at com.ibm.ws.http.channel.internal.inbound.HttpICLReadCallback.complete(HttpICLReadCallback.java:70)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:501)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:571)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:926)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1015)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter
	at com.ibm.ws.classloading.internal.AppClassLoader.findClassCommonLibraryClassLoaders(AppClassLoader.java:504)
	at com.ibm.ws.classloading.internal.AppClassLoader.findClass(AppClassLoader.java:276)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588)
	at com.ibm.ws.classloading.internal.AppClassLoader.findOrDelegateLoadClass(AppClassLoader.java:482)
	at com.ibm.ws.classloading.internal.AppClassLoader.loadClass(AppClassLoader.java:443)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 36 more
```