### PR TITLE
Update JWK code to support getting key by use entry

### DIFF
--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JWKSet.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JWKSet.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.common.jwk.impl;
 
@@ -22,16 +22,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.security.common.jwk.interfaces.JWK;
 import com.ibm.ws.webcontainer.security.jwk.JSONWebKey;
 
-/**
- *
- */
 public class JWKSet {
+    private static final TraceComponent tc = Tr.register(JWKSet.class);
 
     protected List<JWK> jwks = Collections.synchronizedList(new ArrayList<JWK>());
-    
+
     private Map<String, Set<JWK>> jwksBySetId = Collections.synchronizedMap(new HashMap<String, Set<JWK>>());
 
     private final long Stale = 10 * 60 * 1000; //10 minutes
@@ -71,10 +71,10 @@ public class JWKSet {
             if (jwks.size() == 1) {
                 return jwks.get(0);
             } else {
-                return null;                
+                return null;
             }
-        }         
-        
+        }
+
         Iterator<JWK> it = jwks.iterator();
         JSONWebKey jwk = null;
         while (it.hasNext()) {
@@ -87,7 +87,7 @@ public class JWKSet {
         //return null;
         return getPEMKey(); // temporary
     }
-    
+
     private JSONWebKey getJWKByKidInCollection(String kid, Collection<JWK> jwkCollection) {
         if (kid == null) {
             if (jwkCollection.size() == 1) {
@@ -105,15 +105,15 @@ public class JWKSet {
                 return jwk;
             }
         }
-        
+
         // If kid is not included in token, and if the subset of keys contains one key, then return the single key
         if (jwkCollection.size() == 1) {
             return (JSONWebKey) jwkCollection.toArray()[0];
         }
-        
+
         return null;
     }
-    
+
     private JSONWebKey getJWKByx5tInCollection(String x5t, Collection<JWK> jwkCollection) {
         Iterator<JWK> it = jwkCollection.iterator();
         JSONWebKey jwk = null;
@@ -124,6 +124,29 @@ public class JWKSet {
             }
         }
         return null;
+    }
+
+    private JSONWebKey getJWKByUseInCollection(String use, Collection<JWK> jwkCollection) {
+        if (use == null) {
+            return null;
+        }
+        JSONWebKey key = null;
+        Iterator<JWK> it = jwkCollection.iterator();
+        JSONWebKey jwk = null;
+        while (it.hasNext()) {
+            jwk = it.next();
+            String thisKeyUse = jwk.getKeyUse();
+            if (key != null && use.equals(thisKeyUse)) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Found more than one key matching the signature algorithm and use, so do not know which key to use");
+                }
+                return null;
+            }
+            if (use.equals(thisKeyUse)) {
+                key = jwk;
+            }
+        }
+        return key;
     }
 
     public PublicKey getPublicKeyByKid(String id) {
@@ -152,11 +175,11 @@ public class JWKSet {
         }
         return null;
     }
-    
+
     public PublicKey getPublicKeyBySetId(String setId) {
         PublicKey publicKey = null;
         Set<JWK> jwks = jwksBySetId.get(setId);
-        
+
         if (jwks != null && jwks.size() == 1) {
             JSONWebKey jwk = jwks.iterator().next();
             publicKey = jwk.getPublicKey();
@@ -164,32 +187,44 @@ public class JWKSet {
 
         return publicKey;
     }
-    
+
     public PublicKey getPublicKeyBySetIdAndKid(String setId, String kid) {
         PublicKey publicKey = null;
         Set<JWK> jwks = jwksBySetId.get(setId);
-        
+
         if (jwks != null) {
             JSONWebKey jwk = getJWKByKidInCollection(kid, jwks);
             if (jwk != null) {
                 publicKey = jwk.getPublicKey();
             }
         }
-        
+
         return publicKey;
     }
-    
+
     public PublicKey getPublicKeyBySetIdAndx5t(String setId, String x5t) {
         PublicKey publicKey = null;
         Set<JWK> jwks = jwksBySetId.get(setId);
-        
+
         if (jwks != null) {
             JSONWebKey jwk = getJWKByx5tInCollection(x5t, jwks);
             if (jwk != null) {
                 publicKey = jwk.getPublicKey();
             }
         }
-        
+
+        return publicKey;
+    }
+
+    public PublicKey getPublicKeyBySetIdAndUse(String setId, String use) {
+        PublicKey publicKey = null;
+        Set<JWK> jwks = jwksBySetId.get(setId);
+        if (jwks != null) {
+            JSONWebKey jwk = getJWKByUseInCollection(use, jwks);
+            if (jwk != null) {
+                publicKey = jwk.getPublicKey();
+            }
+        }
         return publicKey;
     }
 
@@ -214,26 +249,26 @@ public class JWKSet {
         if (jwksBySetId.containsKey(setId) == false) {
             jwksBySetId.put(setId, Collections.synchronizedSet(new HashSet<JWK>()));
         }
-        
+
         jwksBySetId.get(setId).add(jwk);
     }
-    
+
     // the code below here is temporary until cache enhancements for mpjwt-1.1 can be completed.
     JWK theOnePEMJwk = null;
-    public void add(JWK jwk, boolean isFromPEM){
+
+    public void add(JWK jwk, boolean isFromPEM) {
         jwks.add(jwk);
-        if(isFromPEM){
+        if (isFromPEM) {
             theOnePEMJwk = jwk;
         }
     }
-    
-    protected JWK getPEMKey(){
-        if ( theOnePEMJwk != null ){
+
+    protected JWK getPEMKey() {
+        if (theOnePEMJwk != null) {
             return theOnePEMJwk;
         }
         return null;
     }
     // end temporary code.
-    
-}
 
+}

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.jose4j.util;
 
@@ -354,7 +354,7 @@ public class Jose4jUtil {
         } else if (SIGNATURE_ALG_RS256.equals(signatureAlgorithm)) {
             if (clientConfig.getJwkEndpointUrl() != null || clientConfig.getJsonWebKey() != null) {
                 JwKRetriever retriever = createJwkRetriever(clientConfig);
-                keyValue = retriever.getPublicKeyFromJwk(kid, x5t);
+                keyValue = retriever.getPublicKeyFromJwk(kid, x5t, "sig");
             } else {
                 keyValue = clientConfig.getPublicKey();
             }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtilTest.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.jose4j.util;
 
@@ -253,13 +253,14 @@ public class Jose4jUtilTest extends CommonTestClass {
     public void testGetVerifyKey_getKeyFromJwkUrl() throws Exception {
         final String KID = "kid";
         final String x5t = "x5t";
+        final String use = "sig";
         mockery.checking(new Expectations() {
             {
                 one(clientConfig).getSignatureAlgorithm();
                 will(returnValue(SIGNATURE_ALG_RS256));
                 one(clientConfig).getJwkEndpointUrl();
                 will(returnValue(TEST_URL));
-                one(jwKRetriever).getPublicKeyFromJwk(KID, x5t);
+                one(jwKRetriever).getPublicKeyFromJwk(KID, x5t, use);
                 will(returnValue(publicKey));
             }
         });


### PR DESCRIPTION
The OIDC Basic RP certification tests have a scenario where the JWKS URI used by the RP to verify the ID token returns multiple JWKs, but only one of those JWKs matches the signature algorithm used by the test and specifies `"sig"` as the `"use"` value. The common JWK code needs to be updated to iterate through the JWKs that are returned to determine if there is one, and only one, key that matches the signature algorithm and use combination and return that key.