### PR TITLE
Handle Tx Recovery log bundle startup variations

### DIFF
--- a/dev/com.ibm.rls.jdbc/bnd.bnd
+++ b/dev/com.ibm.rls.jdbc/bnd.bnd
@@ -23,7 +23,7 @@ Service-Component: com.ibm.rls.jdbc; \
             
 Export-Package: com.ibm.rls.jdbc;version=1.0.16,\
  com.ibm.ws.recoverylog.custom.jdbc.impl;version=1.0.0
-
+	
 instrument.disabled: true
 
 -buildpath: \

--- a/dev/com.ibm.rls.jdbc/src/com/ibm/ws/recoverylog/custom/jdbc/impl/SQLNonTransactionalDataSource.java
+++ b/dev/com.ibm.rls.jdbc/src/com/ibm/ws/recoverylog/custom/jdbc/impl/SQLNonTransactionalDataSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,14 +30,13 @@ import com.ibm.wsspi.resource.ResourceFactory;
  * object that represents the special non-transactional data source that has been defined
  * by an administrator for storing Transaction Logs.
  * </p>
- * 
+ *
  * <p>
  * The Liberty implementation relies on Declarative Services to coordinate the initialisation
  * of the Transaction and DataSource (com.ibm.ws.jdbc) components.
  * </p>
  */
-public class SQLNonTransactionalDataSource
-{
+public class SQLNonTransactionalDataSource {
     /**
      * WebSphere RAS TraceComponent registration.
      */
@@ -56,12 +55,11 @@ public class SQLNonTransactionalDataSource
      * <p> Constructor for the creation of
      * SQLNonTransactionalDataSource objects.
      * </p>
-     * 
+     *
      * @param dsName The name of the Data Source.
      * @param customLogProperties The custom properties of the log.
      */
-    public SQLNonTransactionalDataSource(String dsName, CustomLogProperties customLogProperties)
-    {
+    public SQLNonTransactionalDataSource(String dsName, CustomLogProperties customLogProperties) {
         _customLogProperties = customLogProperties;
         if (tc.isDebugEnabled())
             Tr.debug(tc, "Setting CustomLogProperties in constructor" + customLogProperties);
@@ -72,14 +70,13 @@ public class SQLNonTransactionalDataSource
     //------------------------------------------------------------------------------
     /**
      * Locates a DataSource in config
-     * 
+     *
      * @return The DataSource.
-     * 
+     *
      * @exception
      */
     @FFDCIgnore(Exception.class)
-    public DataSource getDataSource() throws Exception
-    {
+    public DataSource getDataSource() throws Exception {
         if (tc.isEntryEnabled())
             Tr.entry(tc, "getDataSource");
 
@@ -88,23 +85,18 @@ public class SQLNonTransactionalDataSource
         // then sets it into CustomLogProperties.
         ResourceFactory dataSourceFactory = _customLogProperties.resourceFactory();
 
-        if (dataSourceFactory != null)
-        {
+        if (dataSourceFactory != null) {
             if (tc.isDebugEnabled())
                 Tr.debug(tc, "Using DataSourceFactory " + dataSourceFactory);
-        }
-        else
-        {
+        } else {
             if (tc.isEntryEnabled())
                 Tr.exit(tc, "getDataSource", "Null ResourceFactory InternalLogException");
             throw new InternalLogException("Failed to locate DataSource, null Resourcefactory", null);
         }
 
-        try
-        {
+        try {
             nonTranDataSource = (DataSource) dataSourceFactory.createResource(null);
-        } catch (Exception e)
-        {
+        } catch (Exception e) {
             //e.printStackTrace();
             if (tc.isEntryEnabled())
                 Tr.exit(tc, "getDataSource", "Caught exception " + e + "throw InternalLogException");
@@ -148,7 +140,7 @@ public class SQLNonTransactionalDataSource
 //            if (!refSet)
 //                Thread.sleep(200);
 //        }
-// eof TEMPORARY 
+// eof TEMPORARY
 
         if (tc.isEntryEnabled())
             Tr.exit(tc, "getDataSource", nonTranDataSource);

--- a/dev/com.ibm.tx.core/bnd.bnd
+++ b/dev/com.ibm.tx.core/bnd.bnd
@@ -24,5 +24,6 @@ publish.wlp.jar.disabled: true
 	com.ibm.ws.resource;version=latest,\
 	com.ibm.websphere.javaee.connector.1.6;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest, \
+	com.ibm.websphere.org.osgi.service.component;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.ws.kernel.service;version=latest

--- a/dev/com.ibm.tx.core/src/com/ibm/tx/jta/config/DefaultConfigurationProvider.java
+++ b/dev/com.ibm.tx.core/src/com/ibm/tx/jta/config/DefaultConfigurationProvider.java
@@ -1,7 +1,7 @@
 package com.ibm.tx.jta.config;
 
 /*******************************************************************************
- * Copyright (c) 2007, 2013 IBM Corporation and others.
+ * Copyright (c) 2007, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -268,4 +268,26 @@ public class DefaultConfigurationProvider implements ConfigurationProvider {
         // TODO Auto-generated method stub
 
     }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.ibm.tx.config.ConfigurationProvider#isSQLRecoveryLog()
+     */
+    @Override
+    public boolean isSQLRecoveryLog() {
+        return false;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.ibm.tx.config.ConfigurationProvider#needToCoordinateServices()
+     */
+    @Override
+    public boolean needToCoordinateServices() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
 }

--- a/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/TxRecoveryAgentImpl.java
+++ b/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/TxRecoveryAgentImpl.java
@@ -273,7 +273,7 @@ public class TxRecoveryAgentImpl implements RecoveryAgent {
                 //
                 partnerLog = rlm.getRecoveryLog(fs, partnerLogProps);
 
-                // In the special case where we support tx recovery (eg for operating in the cloud), we'll also work with a "lease" log
+                // In the special case where we support tx peer recovery (eg for operating in the cloud), we'll also work with a "lease" log
                 if (tc.isDebugEnabled())
                     Tr.debug(tc, "Test to see if peer recovery is supported -  ", _isPeerRecoverySupported);
                 if (_isPeerRecoverySupported) {

--- a/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/XARecoveryDataHelper.java
+++ b/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/XARecoveryDataHelper.java
@@ -1,6 +1,6 @@
 package com.ibm.tx.jta.impl;
 /*******************************************************************************
- * Copyright (c) 2011, 2012 IBM Corporation and others.
+ * Copyright (c) 2011, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,57 +16,55 @@ import org.osgi.framework.ServiceReference;
 
 import com.ibm.tx.TranConstants;
 import com.ibm.tx.jta.XAResourceFactory;
-import com.ibm.tx.jta.util.TxBundleTools;
+import com.ibm.tx.jta.util.TxTMHelper;
 import com.ibm.tx.util.logging.Tr;
 import com.ibm.tx.util.logging.TraceComponent;
 
-public class XARecoveryDataHelper
-{
-	private static final TraceComponent tc = Tr.register(XARecoveryDataHelper.class, TranConstants.TRACE_GROUP, TranConstants.NLS_FILE);
+public class XARecoveryDataHelper {
+    private static final TraceComponent tc = Tr.register(XARecoveryDataHelper.class, TranConstants.TRACE_GROUP, TranConstants.NLS_FILE);
 
-	public static XAResourceFactory lookupXAResourceFactory(String filter)
-	{
-		if (tc.isEntryEnabled()) Tr.entry(tc, "lookupXAResourceFactory", filter);
+    public static XAResourceFactory lookupXAResourceFactory(String filter) {
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "lookupXAResourceFactory", filter);
 
-		final BundleContext bundleContext = TxBundleTools.getBundleContext();
-		
-		if (bundleContext == null)
-		{
-			if (tc.isEntryEnabled()) Tr.exit(tc, "lookupXAResourceFactory", null);
-			return null;
-		}
+        final BundleContext bundleContext = TxTMHelper.getBundleContext();
 
-		ServiceReference[] results = null;
+        if (bundleContext == null) {
+            if (tc.isEntryEnabled())
+                Tr.exit(tc, "lookupXAResourceFactory", null);
+            return null;
+        }
 
-		try
-		{
-			results = bundleContext.getServiceReferences(XAResourceFactory.class.getCanonicalName(), filter);
-		}
-		catch (InvalidSyntaxException e)
-		{
-		    // Wasn't a filter
-			if (tc.isEntryEnabled()) Tr.exit(tc, "lookupXAResourceFactory", "not a filter");
-			return null;
-		}
-		
-		if (results == null || results.length <= 0) {
-			if (results == null) {
-				if (tc.isDebugEnabled())
-					Tr.debug(tc, "Results returned from registry are null");
-			} else {
-				if (tc.isDebugEnabled())
-					Tr.debug(tc, "Results of length " + results.length + " returned from registry");
-			}
-			if (tc.isEntryEnabled())
-				Tr.exit(tc, "lookupXAResourceFactory", null);
-			return null;
-		}
+        ServiceReference[] results = null;
 
-		if (tc.isDebugEnabled())
-        	Tr.debug(tc, "Found " + results.length + " service references in the registry");
+        try {
+            results = bundleContext.getServiceReferences(XAResourceFactory.class.getCanonicalName(), filter);
+        } catch (InvalidSyntaxException e) {
+            // Wasn't a filter
+            if (tc.isEntryEnabled())
+                Tr.exit(tc, "lookupXAResourceFactory", "not a filter");
+            return null;
+        }
 
-		final XAResourceFactory xaresFactory = (XAResourceFactory) bundleContext.getService(results[0]);
-		if (tc.isEntryEnabled()) Tr.exit(tc, "lookupXAResourceFactory", xaresFactory);
-		return xaresFactory;
-	}
+        if (results == null || results.length <= 0) {
+            if (results == null) {
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "Results returned from registry are null");
+            } else {
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "Results of length " + results.length + " returned from registry");
+            }
+            if (tc.isEntryEnabled())
+                Tr.exit(tc, "lookupXAResourceFactory", null);
+            return null;
+        }
+
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "Found " + results.length + " service references in the registry");
+
+        final XAResourceFactory xaresFactory = (XAResourceFactory) bundleContext.getService(results[0]);
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "lookupXAResourceFactory", xaresFactory);
+        return xaresFactory;
+    }
 }

--- a/dev/com.ibm.tx.util/bnd.bnd
+++ b/dev/com.ibm.tx.util/bnd.bnd
@@ -38,5 +38,7 @@ instrument.disabled: true
 -buildpath: \
 	com.ibm.ws.resource;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest, \
+	com.ibm.websphere.org.osgi.core;version=latest, \
+	com.ibm.websphere.org.osgi.service.component;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.ws.kernel.service;version=latest

--- a/dev/com.ibm.tx.util/src/com/ibm/tx/config/ConfigurationProvider.java
+++ b/dev/com.ibm.tx.util/src/com/ibm/tx/config/ConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 IBM Corporation and others.
+ * Copyright (c) 2013, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,15 +16,14 @@ import java.util.logging.Level;
 import com.ibm.tx.util.alarm.AlarmManager;
 import com.ibm.wsspi.resource.ResourceFactory;
 
-public interface ConfigurationProvider
-{
+public interface ConfigurationProvider {
     /**
      * <p>
      * The maximum period, in seconds, that a transaction may be active. If completion
      * processing for a transaction has not begun within the timeout period that
      * transaction will be marked rollback only.
      * </p>
-     * 
+     *
      * @return The maximum period, in seconds, that a transaction may be active.
      */
     public int getTotalTransactionLifetimeTimeout();
@@ -33,7 +32,7 @@ public interface ConfigurationProvider
      * <p>
      * The maximum period, in seconds, of a transaction's lifetime for which a client
      * may be inactive before the transaction will be marked rollback only.
-     * 
+     *
      * @return The client inactivity timeout period, in seconds.
      */
     public int getClientInactivityTimeout();
@@ -44,7 +43,7 @@ public interface ConfigurationProvider
      * begun programatically or imported into the transaction manager. Should a timeout
      * be greater than the maximum it will be capped to this maximum.
      * </p>
-     * 
+     *
      * @return The maximum allowed timeout value, in seconds, for imported or
      *         programatically begun transactions.
      */
@@ -57,7 +56,7 @@ public interface ConfigurationProvider
      * outcome of a transaction (i.e. commit or rollback) to a resource manager before
      * the transaction manager makes a heuristic decision.
      * </p>
-     * 
+     *
      * @return The maximum number of attempts to be made to deliver a transaction's
      *         outcome to a resource manager. A value of zero indicates that the outcome
      *         delivery should be retried for ever.
@@ -72,7 +71,7 @@ public interface ConfigurationProvider
      * outcome to a resource manager in the event of a transient failure. A value
      * of zero or less results in a transaction manager default being used.
      * </p>
-     * 
+     *
      * @return The period, in seconds, to wait between retry attempts.
      */
     public int getHeuristicRetryInterval();
@@ -111,9 +110,9 @@ public interface ConfigurationProvider
      * Returns the completion direction, i.e. commit, rollback, or manual, for
      * transactions that complete heuristically.
      * </p>
-     * 
+     *
      * @return The completion direction for heuristic transactions
-     * 
+     *
      * @see #HEURISTIC_COMPLETION_DIRECTION_COMMIT
      * @see #HEURISTIC_COMPLETION_DIRECTION_ROLLBACK
      * @see #HUERISTIC_COMPLETION_DIRECTION_MANUAL
@@ -125,7 +124,7 @@ public interface ConfigurationProvider
      * Returns the completion direction, i.e. commit, rollback, or manual, for
      * transactions that complete heuristically as a human-readable String.
      * </p>
-     * 
+     *
      * @return The completion direction for heuristic transactions
      */
     public String getHeuristicCompletionDirectionAsString();
@@ -136,7 +135,7 @@ public interface ConfigurationProvider
      * service's log files. The directoy name may be relative or absolute
      * and will be created if it does not already exist.
      * </p>
-     * 
+     *
      * @return The name of the directory in which the transaction logs will be stored.
      */
     public String getTransactionLogDirectory();
@@ -148,13 +147,13 @@ public interface ConfigurationProvider
      * Returns the size of the transaction log in kilobytes (KB). The minimum value
      * is 64KB; any value less than that will be rounded up to this minimum.
      * </p>
-     * 
+     *
      * @return The transaction log size in KB.
      */
     // TODO Do we want to allow the configuration of two log sizes? One for the transaction log and one for the partner log?
     public int getTransactionLogSize();
 
-    // TODO WAS-specific LPS setting? Do we want to support LPS in the componentised TM?    
+    // TODO WAS-specific LPS setting? Do we want to support LPS in the componentised TM?
     public boolean isLoggingForHeuristicReportingEnabled();
 
     public boolean isAcceptHeuristicHazard();
@@ -164,7 +163,7 @@ public interface ConfigurationProvider
      * to be used by the transaction manager. <code>null</code> may be
      * returned and indicates that the transaction manager should use its default
      * implementation.
-     * 
+     *
      * @return The AlarmManager implementation to be used by the transaction manager
      */
     public AlarmManager getAlarmManager();
@@ -178,10 +177,10 @@ public interface ConfigurationProvider
     /**
      * The Maximum Shutdown Delay configuration is an integer number of seconds
      * with the following semantics:<br>
-     * 
+     *
      * >=0 shutdown() will wait a maximum of this long for transactions to complete<br>
      * <0 shutdown() will wait indefinitely for transactions to complete
-     * 
+     *
      * @return The configured delay
      */
     public int getDefaultMaximumShutdownDelay();
@@ -219,7 +218,7 @@ public interface ConfigurationProvider
 
     /**
      * Sets the applId of the server.
-     * 
+     *
      * @param name The applId. Non-recoverable servers may have an applId but no name.
      */
     public void setApplId(byte[] name);
@@ -228,9 +227,22 @@ public interface ConfigurationProvider
      * Returns the applId of the server.
      * <p>
      * Non-recoverable servers may have an applid but not a name.
-     * 
+     *
      * @return The applId of the server.
      */
     public byte[] getApplId();
 
+    /**
+     * Return true if the Tran recovery logs are to be stored in a database.
+     * 
+     * @return
+     */
+    public boolean isSQLRecoveryLog();
+
+    /**
+     * Return true if this ConfigurationProvider has dependencies on other Declarative Services.
+     * 
+     * @return
+     */
+    public boolean needToCoordinateServices();
 }

--- a/dev/com.ibm.ws.recoverylog/bnd.bnd
+++ b/dev/com.ibm.ws.recoverylog/bnd.bnd
@@ -25,10 +25,9 @@ Export-Package: com.ibm.ws.recoverylog.spi,\
 
 Service-Component: \
   RecoveryLogManager; \
-    implementation:=com.ibm.ws.recoverylog.spi.LibertyRecoveryDirectorImpl; \
-    provide:='com.ibm.ws.recoverylog.spi.RecoveryDirector'; \
+    implementation:=com.ibm.ws.recoverylog.spi.RecLogServiceImpl; \
+    provide:='com.ibm.ws.recoverylog.spi.RecLogServiceImpl'; \
     immediate:='true'; \
-    recoveryLogFactory=com.ibm.ws.recoverylog.spi.RecoveryLogFactory; \
     properties:='service.vendor=IBM'
 
 Private-Package: com.ibm.ws.recoverylog.resources
@@ -39,5 +38,6 @@ instrument.classesExcludes: com/ibm/ws/recoverylog/resources/*.class
 	com.ibm.ws.logging.core,\
 	com.ibm.tx.util;version=latest,\
 	com.ibm.ws.resource;version=latest,\
+	com.ibm.ws.kernel.service,\
 	com.ibm.websphere.org.osgi.service.component;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/CustomLogProperties.java
+++ b/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/CustomLogProperties.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.recoverylog.spi;
 
 import java.util.Properties;
+
 import com.ibm.tx.util.logging.Tr;
 import com.ibm.tx.util.logging.TraceComponent;
 import com.ibm.wsspi.resource.ResourceFactory;
@@ -19,245 +20,255 @@ import com.ibm.wsspi.resource.ResourceFactory;
 // Class: CustomLogProperties
 //------------------------------------------------------------------------------
 /**
-* <p>
-* An implementation of the LogProperties interface that defines the physical 
-* characteristics of a generic or custom recovery log.
-* </p>
-*
-* <p>
-* Custom recovery log implementations use an eclipse extension point to add
-* functionality to the recovery log service.  Each implementation is identified
-* by its extension id and consists of a set of properties
-* </p>
-*/                                                                          
-public class CustomLogProperties implements LogProperties
-{
-  /**
-  * WebSphere RAS TraceComponent registration
-  */
-  private static final TraceComponent tc = Tr.register(CustomLogProperties.class,
-                                           TraceConstants.TRACE_GROUP,
-                                           TraceConstants.NLS_FILE);
-                                           
-  /**
-   * Indicates that a log that may contain multiple
-   * failure scopes is required.
-   */
-  protected static final int LOG_TYPE_MULTIPLE_SCOPE = 0;
-  
-  /**
-   * Indicates that a log that will only contain records
-   * for a single failure scope is required.  
-   */
-  protected static final int LOG_TYPE_SINGLE_SCOPE = 1;
+ * <p>
+ * An implementation of the LogProperties interface that defines the physical
+ * characteristics of a generic or custom recovery log.
+ * </p>
+ *
+ * <p>
+ * Custom recovery log implementations use an eclipse extension point to add
+ * functionality to the recovery log service. Each implementation is identified
+ * by its extension id and consists of a set of properties
+ * </p>
+ */
+public class CustomLogProperties implements LogProperties {
+    /**
+     * WebSphere RAS TraceComponent registration
+     */
+    private static final TraceComponent tc = Tr.register(CustomLogProperties.class,
+                                                         TraceConstants.TRACE_GROUP,
+                                                         TraceConstants.NLS_FILE);
 
-  /**
-   * default log type.  Set during initalization.
-   */
-  static int defaultLogType = LOG_TYPE_SINGLE_SCOPE;
+    /**
+     * Indicates that a log that may contain multiple
+     * failure scopes is required.
+     */
+    protected static final int LOG_TYPE_MULTIPLE_SCOPE = 0;
 
-  /**
-  * The unique RLI value.
-  */
-  private int _logIdentifier;
+    /**
+     * Indicates that a log that will only contain records
+     * for a single failure scope is required.
+     */
+    protected static final int LOG_TYPE_SINGLE_SCOPE = 1;
 
-  /**
-  * The unique RLN value.
-  */
-  private String _logName;
+    /**
+     * default log type. Set during initalization.
+     */
+    static int defaultLogType = LOG_TYPE_SINGLE_SCOPE;
 
-  /**
-   * The identifier of the log that is required.  Corresponds to the eclipse plugin id
-   */
-  private String _pluginId;
+    /**
+     * The unique RLI value.
+     */
+    private final int _logIdentifier;
 
-  /**
-   * The properties associated with the log
-   */
-  private Properties _props;
+    /**
+     * The unique RLN value.
+     */
+    private final String _logName;
 
-  /**
-   * The type of the log that is required (single or multi-scope).
-   */
-  private int _logType;
- 
-  /**
-   * The Resource Factory associated with this log implementation 
-   */
-  private ResourceFactory _resourceFactory;
+    /**
+     * The identifier of the log that is required. Corresponds to the eclipse plugin id
+     */
+    private final String _pluginId;
 
-  //------------------------------------------------------------------------------
-  // Method: CustomLogProperties.CustomLogProperties
-  //------------------------------------------------------------------------------
-  /**
-  * <p>
-  * Constructor for a new CustomLogProperties object.   
-  * </p>
-  *
-  * <p>
-  * The logIdentifier and logName both uniquely identify a recovery log within
-  * the client service.
-  * </p>
-  *
-  * @param logIdentifier The unique RLI value.
-  * @param logName The unique RLN value.
-  */
-  public CustomLogProperties(int logIdentifier,String logName, String pluginId, Properties props)
-  {
-    if (tc.isEntryEnabled()) Tr.entry(tc, "CustomLogProperties",new java.lang.Object[]{new Integer(logIdentifier),
-                                                              logName,
-                                                              pluginId,
-                                                              props});
+    /**
+     * The properties associated with the log
+     */
+    private final Properties _props;
 
-    // Cache the supplied information.
-    _logIdentifier = logIdentifier;
-    _logName       = logName;
-    _pluginId      = pluginId;
-    _props         = props;
-    _logType = defaultLogType;
- 
-    if (tc.isEntryEnabled()) Tr.exit(tc, "CustomLogProperties", this);
-  }
+    /**
+     * The type of the log that is required (single or multi-scope).
+     */
+    private final int _logType;
 
-  //------------------------------------------------------------------------------
-  // Method: CustomLogProperties.logIdentifier
-  //------------------------------------------------------------------------------
-  /**
-  * Returns the unique (within service) "Recovery Log Identifier" (RLI) value.
-  *
-  * @return int The unique RLI value.
-  */
-  public int logIdentifier()
-  {
-    if (tc.isEntryEnabled()) Tr.entry(tc, "logIdentifier",this);
-    if (tc.isEntryEnabled()) Tr.exit(tc, "logIdentifier",new Integer(_logIdentifier));
-    return _logIdentifier;
-  }
+    /**
+     * The Resource Factory associated with this log implementation
+     */
+    private ResourceFactory _resourceFactory;
 
-  //------------------------------------------------------------------------------
-  // Method: CustomLogProperties.logName
-  //------------------------------------------------------------------------------
-  /**
-  * Returns the unique (within service) "Recovery Log Name" (RLN). 
-  *
-  * @return String The unique RLN value.
-  */
-  public String logName()
-  {
-    if (tc.isEntryEnabled()) Tr.entry(tc, "logName",this);
-    if (tc.isEntryEnabled()) Tr.exit(tc, "logName",_logName);
-    return _logName;
-  }
+    //------------------------------------------------------------------------------
+    // Method: CustomLogProperties.CustomLogProperties
+    //------------------------------------------------------------------------------
+    /**
+     * <p>
+     * Constructor for a new CustomLogProperties object.
+     * </p>
+     *
+     * <p>
+     * The logIdentifier and logName both uniquely identify a recovery log within
+     * the client service.
+     * </p>
+     *
+     * @param logIdentifier The unique RLI value.
+     * @param logName The unique RLN value.
+     */
+    public CustomLogProperties(int logIdentifier, String logName, String pluginId, Properties props) {
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "CustomLogProperties", new java.lang.Object[] { new Integer(logIdentifier),
+                                                                         logName,
+                                                                         pluginId,
+                                                                         props });
 
-  //------------------------------------------------------------------------------
-  // Method: CustomLogProperties.pluginId
-  //------------------------------------------------------------------------------
-  /**
-  * Returns the pluginId associated with this type of log
-  * @return int eclipse plugin id
-  */
-  public String pluginId()
-  {
-    if (tc.isEntryEnabled()) Tr.entry(tc, "pluginId",this);
-    if (tc.isEntryEnabled()) Tr.exit(tc, "pluginId",_pluginId);
-    return _pluginId;
-  }
+        // Cache the supplied information.
+        _logIdentifier = logIdentifier;
+        _logName = logName;
+        _pluginId = pluginId;
+        _props = props;
+        _logType = defaultLogType;
 
-  //------------------------------------------------------------------------------
-  // Method: CustomLogProperties.properties
-  //------------------------------------------------------------------------------
-  /**
-  * Returns the set of properties associated with this log implementation
-  * 
-  * @return Properties custom properties associated with this log implementation
-  */
-  public Properties properties()
-  {
-    if (tc.isEntryEnabled()) Tr.entry(tc, "propertis",this);
-    if (tc.isEntryEnabled()) Tr.exit(tc, "properties", _props);
-    return _props;
-  }
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "CustomLogProperties", this);
+    }
 
-  
-  protected int logType()
-  {
-  	if (tc.isEntryEnabled()) Tr.entry(tc, "logType", this);  
-  	if (tc.isEntryEnabled()) Tr.exit(tc, "logType", new Integer(_logType));	
-  	return _logType;
-  }
+    //------------------------------------------------------------------------------
+    // Method: CustomLogProperties.logIdentifier
+    //------------------------------------------------------------------------------
+    /**
+     * Returns the unique (within service) "Recovery Log Identifier" (RLI) value.
+     *
+     * @return int The unique RLI value.
+     */
+    @Override
+    public int logIdentifier() {
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "logIdentifier", this);
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "logIdentifier", new Integer(_logIdentifier));
+        return _logIdentifier;
+    }
 
-  //------------------------------------------------------------------------------
-  // Method: CustomLogProperties.equals
-  //---------------------------------------------------------------------
-  /**
-   * Determine if two LogProperties references are the same.
-   * @param logProps The log properties to be checked
-   * @return boolean true If compared objects are equal.
-   */
-  public boolean equals(Object lp)
-  {
-      if(lp == null) return false;
-      else if (lp == this) return true;
-      else if (lp instanceof CustomLogProperties)
-      {
-          CustomLogProperties clp = (CustomLogProperties)lp;
+    //------------------------------------------------------------------------------
+    // Method: CustomLogProperties.logName
+    //------------------------------------------------------------------------------
+    /**
+     * Returns the unique (within service) "Recovery Log Name" (RLN).
+     *
+     * @return String The unique RLN value.
+     */
+    @Override
+    public String logName() {
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "logName", this);
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "logName", _logName);
+        return _logName;
+    }
 
-          if (clp.logIdentifier()== this.logIdentifier()    &&
-              clp.logType() == this.logType() &&
-              clp.pluginId() == (this.pluginId()))
-          {
-              return true;
-          }
-      }
+    //------------------------------------------------------------------------------
+    // Method: CustomLogProperties.pluginId
+    //------------------------------------------------------------------------------
+    /**
+     * Returns the pluginId associated with this type of log
+     *
+     * @return int eclipse plugin id
+     */
+    public String pluginId() {
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "pluginId", this);
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "pluginId", _pluginId);
+        return _pluginId;
+    }
 
-      return false;
-  }
+    //------------------------------------------------------------------------------
+    // Method: CustomLogProperties.properties
+    //------------------------------------------------------------------------------
+    /**
+     * Returns the set of properties associated with this log implementation
+     *
+     * @return Properties custom properties associated with this log implementation
+     */
+    public Properties properties() {
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "propertis", this);
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "properties", _props);
+        return _props;
+    }
 
-  //------------------------------------------------------------------------------
-  // Method: CustomLogProperties.hashCode
-  //--------------------------------------------------------------------
-  /**
-   * HashCode implementation.
-   * @return int The hash code value.
-   */
-  public int hashCode()
-  {
-       int hashCode = 0;
+    protected int logType() {
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "logType", this);
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "logType", new Integer(_logType));
+        return _logType;
+    }
 
-       hashCode += _logIdentifier/5;
-       hashCode += _logName.hashCode()/5;
-       hashCode += _logType;
-       hashCode += _props.hashCode()/5;
+    //------------------------------------------------------------------------------
+    // Method: CustomLogProperties.equals
+    //---------------------------------------------------------------------
+    /**
+     * Determine if two LogProperties references are the same.
+     *
+     * @param logProps The log properties to be checked
+     * @return boolean true If compared objects are equal.
+     */
+    @Override
+    public boolean equals(Object lp) {
+        if (lp == null)
+            return false;
+        else if (lp == this)
+            return true;
+        else if (lp instanceof CustomLogProperties) {
+            CustomLogProperties clp = (CustomLogProperties) lp;
 
-       return hashCode;
-  }
+            if (clp.logIdentifier() == this.logIdentifier() &&
+                clp.logType() == this.logType() &&
+                clp.pluginId() == (this.pluginId())) {
+                return true;
+            }
+        }
 
-  public static void setDefaultLogType(int t)
-  {
-      defaultLogType = t;
-  }
+        return false;
+    }
 
-  public void setResourceFactory(ResourceFactory fac)
-  {
-      if (tc.isEntryEnabled()) Tr.entry(tc, "setResourceFactory", this);  
-      if (tc.isEntryEnabled()) Tr.exit(tc, "setResourceFactory", fac);
-      _resourceFactory = fac;
-  }
+    //------------------------------------------------------------------------------
+    // Method: CustomLogProperties.hashCode
+    //--------------------------------------------------------------------
+    /**
+     * HashCode implementation.
+     *
+     * @return int The hash code value.
+     */
+    @Override
+    public int hashCode() {
+        int hashCode = 0;
 
-  //------------------------------------------------------------------------------
-  // Method: CustomLogProperties.resourceFactory
-  //------------------------------------------------------------------------------
-  /**
-  * Returns the Resource Factory associated with this log 
-  * implementation 
-  * 
-  * @return ResourceFactory associated with this log
-  *         implementation
-  */
-  public ResourceFactory resourceFactory()
-  {
-  	if (tc.isEntryEnabled()) Tr.entry(tc, "resourceFactory", this);  
-  	if (tc.isEntryEnabled()) Tr.exit(tc, "resourceFactory", _resourceFactory);	
-  	return _resourceFactory;
-  }
+        hashCode += _logIdentifier / 5;
+        hashCode += _logName.hashCode() / 5;
+        hashCode += _logType;
+        hashCode += _props.hashCode() / 5;
+
+        return hashCode;
+    }
+
+    public static void setDefaultLogType(int t) {
+        defaultLogType = t;
+    }
+
+    public void setResourceFactory(ResourceFactory fac) {
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "setResourceFactory", this);
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "setResourceFactory", fac);
+        _resourceFactory = fac;
+    }
+
+    //------------------------------------------------------------------------------
+    // Method: CustomLogProperties.resourceFactory
+    //------------------------------------------------------------------------------
+    /**
+     * Returns the Resource Factory associated with this log
+     * implementation
+     *
+     * @return ResourceFactory associated with this log
+     *         implementation
+     */
+    public ResourceFactory resourceFactory() {
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "resourceFactory", this);
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "resourceFactory", _resourceFactory);
+        return _resourceFactory;
+    }
 }

--- a/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/LibertyRecoveryDirectorImpl.java
+++ b/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/LibertyRecoveryDirectorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,16 +14,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.osgi.service.component.ComponentContext;
-
 import com.ibm.tx.util.logging.Tr;
 import com.ibm.tx.util.logging.TraceComponent;
 
 /**
  *
  */
-public class LibertyRecoveryDirectorImpl extends RecoveryDirectorImpl
-{
+public class LibertyRecoveryDirectorImpl extends RecoveryDirectorImpl {
     /**
      * WebSphere RAS TraceComponent registration.
      */
@@ -42,18 +39,15 @@ public class LibertyRecoveryDirectorImpl extends RecoveryDirectorImpl
      * method. Client services may access this instance via the RecoveryDirectorFactory.
      * recoveryDirector() method.
      */
-    public LibertyRecoveryDirectorImpl()
-    {
+    public LibertyRecoveryDirectorImpl() {
         super();
 
-        if (theRecoveryLogFactory != null)
-        {
+        if (theRecoveryLogFactory != null) {
             String className = theRecoveryLogFactory.getClass().getName();
             _customLogFactories.put(className, theRecoveryLogFactory);
             if (tc.isDebugEnabled())
                 Tr.debug(tc, "LibertyRecoveryDirectorImpl: setting RecoveryLogFactory, " + theRecoveryLogFactory + "for classname, " + className);
-        }
-        else if (tc.isDebugEnabled())
+        } else if (tc.isDebugEnabled())
             Tr.debug(tc, "LibertyRecoveryDirectorImpl: the RecoveryLogFactory is null");
 
         if (tc.isDebugEnabled())
@@ -67,16 +61,14 @@ public class LibertyRecoveryDirectorImpl extends RecoveryDirectorImpl
      * Create or lookup the singleton instance of the LibertyRecoveryDirectorImpl class. This
      * method is intended for internal use only. Client services should access this
      * instance via the RecoveryDirectorFactory.recoveryDirector() method.
-     * 
+     *
      * @return The singleton instance of the WSRecoveryDirectorImpl class.
      */
-    public static synchronized RecoveryDirector instance()
-    {
+    public static synchronized RecoveryDirector instance() {
         if (tc.isEntryEnabled())
             Tr.entry(tc, "instance");
 
-        if (_instance == null)
-        {
+        if (_instance == null) {
             _instance = new LibertyRecoveryDirectorImpl();
         }
 
@@ -85,36 +77,13 @@ public class LibertyRecoveryDirectorImpl extends RecoveryDirectorImpl
         return _instance;
     }
 
-    /*
-     * Called by DS to activate service
-     */
-    protected void activate(ComponentContext cc) {
-        if (tc.isDebugEnabled())
-            Tr.debug(tc, "activate", this);
-    }
-
-    // methods to handle dependency injection in osgi environment
-    protected void setRecoveryLogFactory(RecoveryLogFactory fac) {
-        if (tc.isDebugEnabled())
-            Tr.debug(tc, "setRecoveryLogFactory, factory: " + fac, this);
-        theRecoveryLogFactory = fac;
-
-    }
-
-    protected void unsetRecoveryLogFactory(RecoveryLogFactory fac) {
-        if (tc.isDebugEnabled())
-            Tr.debug(tc, "unsetRecoveryLogFactory, factory: " + fac, this);
-    }
-
-    public static void reset()
-    {
+    public static void reset() {
         if (tc.isEntryEnabled())
             Tr.exit(tc, "reset");
         _instance = null;
     }
 
-    public void drivePeerRecovery() throws RecoveryFailedException
-    {
+    public void drivePeerRecovery() throws RecoveryFailedException {
         if (tc.isEntryEnabled())
             Tr.entry(tc, "drivePeerRecovery", this);
         RecoveryAgent libertyRecoveryAgent = null;
@@ -134,8 +103,7 @@ public class LibertyRecoveryDirectorImpl extends RecoveryDirectorImpl
         if (tc.isDebugEnabled())
             Tr.debug(tc, "work with RA values: " + registeredRecoveryAgentsValues + ", collection size: " + registeredRecoveryAgentsValues.size(), this);
         Iterator registeredRecoveryAgentsValuesIterator = registeredRecoveryAgentsValues.iterator();
-        while (registeredRecoveryAgentsValuesIterator.hasNext())
-        {
+        while (registeredRecoveryAgentsValuesIterator.hasNext()) {
             // Extract the next ArrayList and create an iterator from it. This iterator will return RecoveryAgent
             // objects that are registered at the same sequence priority value.
             final ArrayList registeredRecoveryAgentsArray = (java.util.ArrayList) registeredRecoveryAgentsValuesIterator.next();
@@ -143,8 +111,7 @@ public class LibertyRecoveryDirectorImpl extends RecoveryDirectorImpl
                 Tr.debug(tc, "work with Agents array: " + registeredRecoveryAgentsArray + ", of size: " + registeredRecoveryAgentsArray.size(), this);
             final Iterator registeredRecoveryAgentsArrayIterator = registeredRecoveryAgentsArray.iterator();
 
-            while (registeredRecoveryAgentsArrayIterator.hasNext())
-            {
+            while (registeredRecoveryAgentsArrayIterator.hasNext()) {
                 // Extract the next RecoveryAgent object
                 final RecoveryAgent recoveryAgent = (RecoveryAgent) registeredRecoveryAgentsArrayIterator.next();
 
@@ -165,21 +132,17 @@ public class LibertyRecoveryDirectorImpl extends RecoveryDirectorImpl
             Tr.exit(tc, "drivePeerRecovery");
     }
 
-    public void peerRecoverServers(RecoveryAgent recoveryAgent, String myRecoveryIdentity, ArrayList<String> peersToRecover) throws RecoveryFailedException
-    {
+    public void peerRecoverServers(RecoveryAgent recoveryAgent, String myRecoveryIdentity, ArrayList<String> peersToRecover) throws RecoveryFailedException {
         if (tc.isEntryEnabled())
             Tr.entry(tc, "peerRecoverServers", new Object[] { recoveryAgent, myRecoveryIdentity, peersToRecover });
 
-        for (String peerRecoveryIdentity : peersToRecover)
-        {
+        for (String peerRecoveryIdentity : peersToRecover) {
 
-            try
-            {
+            try {
                 //Read lease check if it is still expired. If so, then update lease and proceed to peer recover
                 // if not still expired (someone else has grabbed it) then bypass peer recover.
                 LeaseInfo leaseInfo = new LeaseInfo();
-                if (recoveryAgent.claimPeerLeaseForRecovery(peerRecoveryIdentity, myRecoveryIdentity, leaseInfo))
-                {
+                if (recoveryAgent.claimPeerLeaseForRecovery(peerRecoveryIdentity, myRecoveryIdentity, leaseInfo)) {
 
                     // drive directInitialization(**retrieved scope**);
                     Tr.audit(tc, "WTRN0108I: " +
@@ -188,14 +151,11 @@ public class LibertyRecoveryDirectorImpl extends RecoveryDirectorImpl
                     FileFailureScope peerFFS = new FileFailureScope(peerRecoveryIdentity, leaseInfo);
 
                     directInitialization(peerFFS);
-                }
-                else
-                {
+                } else {
                     if (tc.isDebugEnabled())
                         Tr.debug(tc, "Failed to claim lease for peer", this);
                 }
-            } catch (Exception exc)
-            {
+            } catch (Exception exc) {
                 if (tc.isEntryEnabled())
                     Tr.exit(tc, "peerRecoverServers", exc);
                 throw new RecoveryFailedException(exc);
@@ -206,4 +166,24 @@ public class LibertyRecoveryDirectorImpl extends RecoveryDirectorImpl
         if (tc.isEntryEnabled())
             Tr.exit(tc, "peerRecoverServers");
     }
+
+    @Override
+    public void setRecoveryLogFactory(RecoveryLogFactory fac) {
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "setRecoveryLogFactory, factory: " + fac, this);
+        theRecoveryLogFactory = fac;
+
+        if (theRecoveryLogFactory != null) {
+            String className = theRecoveryLogFactory.getClass().getName();
+            _customLogFactories.put(className, theRecoveryLogFactory);
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "LibertyRecoveryDirectorImpl: setting RecoveryLogFactory, " + theRecoveryLogFactory + "for classname, " + className);
+        } else if (tc.isDebugEnabled())
+            Tr.debug(tc, "LibertyRecoveryDirectorImpl: the RecoveryLogFactory is null");
+
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "LibertyRecoveryDirectorImpl", this);
+
+    }
+
 }

--- a/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/RecoveryAgent.java
+++ b/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/RecoveryAgent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2007 IBM Corporation and others.
+ * Copyright (c) 1997, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,20 +22,20 @@ import java.util.ArrayList;
  * interface. A single instance of this object is passed to the RLS during initial
  * service registration.
  * </p>
- * 
+ *
  * <p>
  * The RLS will invoke this object asynchronously (by calling
  * <code>RecoveryAgent.initiateRecovery</code>) to direct the client service to
  * handle units of recovery identified by Failure Scope.
  * </p>
- * 
+ *
  * <p>
  * The client service responds to these requests by performing recovery
  * processing through interaction with the RLS. Once this is done, the client
  * service invokes the <code>RecoveryDirector.recoveryComplete</code> method to
  * inform the RLS that the recovery processing is complete.
  * </p>
- * 
+ *
  * <p>
  * By calling recoveryComplete, the client service tells the RLS that it has
  * finished any processing for a given failure scope that has to be performed
@@ -44,10 +44,10 @@ import java.util.ArrayList;
  * recoveryAgent returns from the initiateRecovery() method. The RecoveryAgent
  * is free to perform additional recovery work after this point asynchronously.
  * </p>
- * 
+ *
  * <p>
  * The two likely models are:-
- * 
+ *
  * <ul>
  * <li>1. <code>RecoveryAgent.initiateRecovery</code> directs recovery of the
  * failure scope, and calls <code>RecoveryDirector.recoveryComplete</code>
@@ -64,8 +64,7 @@ import java.util.ArrayList;
  * </ul>
  * </p>
  */
-public interface RecoveryAgent
-{
+public interface RecoveryAgent {
     //------------------------------------------------------------------------------
     // Method: RecoveryAgent.prepareForRecovery
     //------------------------------------------------------------------------------
@@ -73,7 +72,7 @@ public interface RecoveryAgent
      * Directs the client service to get ready to process recovery for the given
      * FailureScope. The client service uses the RecoveryLogManager instance it
      * obtained when it registered to 'getRecoveryLog' the corresponding recovery
-     * 
+     *
      * @param failureScope The failure scope for which recovery may be about to start.
      */
     void prepareForRecovery(FailureScope failureScope);
@@ -87,11 +86,12 @@ public interface RecoveryAgent
      * obtained when it registered to open the corresponding recovery logs and
      * perform any recovery processing it deems necessary. When this is complete
      * the client service should invoke RecoveryDirector.recoveryComplete()
-     * 
+     *
      * @param failureScope The failure scope for which recovery is starting
-     * 
+     *
      * @exception RecoveryFailedException Thrown by the client service if it is
      *                unable to complete recovery processing
+     * @throws LogPropertiesNotReadyException
      */
     void initiateRecovery(FailureScope failureScope) throws RecoveryFailedException;
 
@@ -101,9 +101,9 @@ public interface RecoveryAgent
     /**
      * Directs the client service to halt any recovery processing for the given
      * FailureScope.
-     * 
+     *
      * @param failureScope The failure scope for which recovery is terminating
-     * 
+     *
      * @exception TerminationFailedException Thrown by the client service if it is
      *                unable to terminate recovery processing
      */
@@ -115,7 +115,7 @@ public interface RecoveryAgent
     /**
      * Returns the unique "Recovery Log Client Identifier" (RLCI). RLCI values are
      * owned by the RLS and stored inside com.ibm.ws.recoverylog.spi.ClientId
-     * 
+     *
      * @return int The client identifier.
      */
     int clientIdentifier();
@@ -126,7 +126,7 @@ public interface RecoveryAgent
     /**
      * Returns the unique "Recovery Log Client Name" (RLCN). RLCN values are
      * owned by the RLS and stored inside com.ibm.ws.recoverylog.spi.ClientId
-     * 
+     *
      * @return String The client name.
      */
     String clientName();
@@ -141,7 +141,7 @@ public interface RecoveryAgent
      * intended to addess changes to the nature of the information written by client
      * services rather than the format of the log itself. Clients should start at '1'
      * and only change this value if their recovery log content changes.
-     * 
+     *
      * @return int The client version number.
      */
     int clientVersion();
@@ -152,9 +152,9 @@ public interface RecoveryAgent
     /**
      * Returns an array of strings such that each string is a fully qualified log
      * directory that the client indends to use for logging.
-     * 
+     *
      * @param failureScope The target failure scope
-     * 
+     *
      * @return String[] The log directory set.
      */
     String[] logDirectories(FailureScope failureScope);
@@ -165,10 +165,10 @@ public interface RecoveryAgent
     /**
      * Informs the recovery agent that another recovery agent (identified by the client
      * id) has been upable to handle recovery processing for the given failure scope.
-     * 
+     *
      * @param int The client id of the failing recovery agent.
      * @param failureScope The target failure scope.
-     * 
+     *
      * @return String[] The log directory set.
      */
     void agentReportedFailure(int clientId, FailureScope failureScope);
@@ -182,9 +182,9 @@ public interface RecoveryAgent
      * has the WCCM basis to make this chocie for itself. If any client returns TRUE
      * then file locking will be DISABLED, however currently only the transaction service
      * recovery agent is actually checked.
-     * 
+     *
      * by default, file locking is ENABLED.
-     * 
+     *
      * @return boolean
      */
     boolean disableFileLocking();
@@ -193,12 +193,12 @@ public interface RecoveryAgent
      * Returns a flag to indicate if the client wants RLS to prepare the recovery logs
      * for a system snapshot in a safe fashion - i.e. the data in the recovery log files
      * provide a consistent state in the event of disaster recovery.
-     * 
+     *
      * To make the RLS snapshot safe will have a impact on recovery log (and therefore it's
      * client services, such as Transaction).
-     * 
+     *
      * By default, isSnapshotSafe is FALSE.
-     * 
+     *
      * @return boolean
      */
     boolean isSnapshotSafe();
@@ -209,7 +209,7 @@ public interface RecoveryAgent
     /**
      * Notify RecoveryAgent of logfile space running out.
      * Called when the log file first crosses the 75% full threshold.
-     * 
+     *
      * @param logname The name provided by the client service on the FileLogProperties
      *            used to create this logfile
      * @param bytesInUse The space required for current log data

--- a/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/RecoveryDirector.java
+++ b/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/RecoveryDirector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2009 IBM Corporation and others.
+ * Copyright (c) 1997, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,290 +15,293 @@ package com.ibm.ws.recoverylog.spi;
 // Interface: RecoveryDirector
 //------------------------------------------------------------------------------
 /**
-* <p>
-* The RecoveryDirector provides support for the registration of those components
-* that need to use use the Recovery Log Service (RLS) to store persistent
-* information.
-* </p>
-*
-* <p>
-* In order to support interaction with the High Availability (HA) framework in
-* the future, the RecoveryDirector acts as a bridge between the registered
-* components (client services) and the controlling logic that determines when
-* recovery processing is needed.
-* </p>
-*
-* <p>
-* Client services obtain a reference to the RecoveryDirector through its factory
-* class, the RecoveryDirectorFactory, by calling its recoveryDirector method.
-* </p>
-* 
-* <p>
-* Client services supply a RecoveryAgent callback object when they register
-* that is driven asynchronously by the RLS when recovery processing is required. 
-* Upon registration, they are provided with a RecoveryLogManager object through 
-* which they interact with the RLS.
-* </p>
-*/
-public interface RecoveryDirector
-{
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirector.registerService
-  //------------------------------------------------------------------------------
-  /**
-  * <p>
-  * Invoked by a client service during its initialization to register with the RLS
-  * The client service provides RecoveryAgent callback object that will be invoked
-  * each time a FailureScope requires recovery. One registration is required per
-  * client service. Any re-registration will result in the
-  * ConflictingCredentialsException being thrown.
-  * </p>
-  * 
-  * <p>
-  * The client service provides a 'sequence' value that is used by the RLS to
-  * determine the order in which registered RecoveryAgents should be directed
-  * to recover. The client service whose RecoveryAgent was registered with the 
-  * lowest numeric sequence value will be driven first. The remaining
-  * RecoveryAgents are driven in ascending sequence value order. RecoveryAgents
-  * that are registered with the same sequence value will be driven in 
-  * an undefined order.
-  * </p>
-  *
-  * <p>
-  * The result of registration is a new instance of the RecoveryLogManager
-  * class to control recovery logging on behalf of the client service.
-  * </p>
-  *
-  * <p>
-  * The RecoveryAgent object is also used to identify the client service
-  * and the registration process will fail if it provides a client service
-  * identifier or name that has already been used.
-  * </p>
-  * 
-  * @param recoveryAgent Client service identification and callback object.
-  * @param sequence Client service sequence value.
-  *
-  * @return RecoveryLogManager A RecoveryLogManager object that the client
-  *                            service can use to control recovery logging.
-  *
-  * @exception ConflictingCredentialsException Thrown if the RecoveryAgent identity or
-  *                                            name clashes with a client service that
-  *                                            is already registered
-  * @exception InvalidStateException           Thrown if the registration occurs after
-  *                                            the first recovery process has been 
-  *                                            started.
-  */
-  public RecoveryLogManager registerService(RecoveryAgent recoveryAgent,int sequence) throws ConflictingCredentialsException,InvalidStateException;
+ * <p>
+ * The RecoveryDirector provides support for the registration of those components
+ * that need to use use the Recovery Log Service (RLS) to store persistent
+ * information.
+ * </p>
+ *
+ * <p>
+ * In order to support interaction with the High Availability (HA) framework in
+ * the future, the RecoveryDirector acts as a bridge between the registered
+ * components (client services) and the controlling logic that determines when
+ * recovery processing is needed.
+ * </p>
+ *
+ * <p>
+ * Client services obtain a reference to the RecoveryDirector through its factory
+ * class, the RecoveryDirectorFactory, by calling its recoveryDirector method.
+ * </p>
+ *
+ * <p>
+ * Client services supply a RecoveryAgent callback object when they register
+ * that is driven asynchronously by the RLS when recovery processing is required.
+ * Upon registration, they are provided with a RecoveryLogManager object through
+ * which they interact with the RLS.
+ * </p>
+ */
+public interface RecoveryDirector {
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirector.registerService
+    //------------------------------------------------------------------------------
+    /**
+     * <p>
+     * Invoked by a client service during its initialization to register with the RLS
+     * The client service provides RecoveryAgent callback object that will be invoked
+     * each time a FailureScope requires recovery. One registration is required per
+     * client service. Any re-registration will result in the
+     * ConflictingCredentialsException being thrown.
+     * </p>
+     *
+     * <p>
+     * The client service provides a 'sequence' value that is used by the RLS to
+     * determine the order in which registered RecoveryAgents should be directed
+     * to recover. The client service whose RecoveryAgent was registered with the
+     * lowest numeric sequence value will be driven first. The remaining
+     * RecoveryAgents are driven in ascending sequence value order. RecoveryAgents
+     * that are registered with the same sequence value will be driven in
+     * an undefined order.
+     * </p>
+     *
+     * <p>
+     * The result of registration is a new instance of the RecoveryLogManager
+     * class to control recovery logging on behalf of the client service.
+     * </p>
+     *
+     * <p>
+     * The RecoveryAgent object is also used to identify the client service
+     * and the registration process will fail if it provides a client service
+     * identifier or name that has already been used.
+     * </p>
+     *
+     * @param recoveryAgent Client service identification and callback object.
+     * @param sequence Client service sequence value.
+     *
+     * @return RecoveryLogManager A RecoveryLogManager object that the client
+     *         service can use to control recovery logging.
+     *
+     * @exception ConflictingCredentialsException Thrown if the RecoveryAgent identity or
+     *                name clashes with a client service that
+     *                is already registered
+     * @exception InvalidStateException Thrown if the registration occurs after
+     *                the first recovery process has been
+     *                started.
+     */
+    public RecoveryLogManager registerService(RecoveryAgent recoveryAgent, int sequence) throws ConflictingCredentialsException, InvalidStateException;
 
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirector.serialRecoveryComplete
-  //------------------------------------------------------------------------------
-  /**
-  * <p>
-  * Invoked by a client service to indicate that serial recovery processing for the 
-  * unit of recovery, identified by FailureScope has been completed. The client
-  * service supplies its RecoveryAgent reference to identify itself.
-  * </p>
-  *
-  * <p>
-  * When recovery events occur, each client services RecoveryAgent callback object
-  * has its initiateRecovery() method invoked. As a result of this call, the client
-  * services has an opportunity to perform any SERIAL recovery processing for that
-  * failure scope. Once this is complete, the client calls the serialRecoveryComplete
-  * method to give the next client service to handle recovery processing. Recovery
-  * processing as a whole may or may not be complete before this call is issued - 
-  * it may continue afterwards on a parrallel thread if required. The latter design
-  * is prefereable in an HA-enabled environment as controll must be passed back as
-  * quickly as possible to avoid the HA framework shutting down the JVM.
-  * </p>
-  *
-  * <p>
-  * Regardless of the style adopted, once the recovery process has performed as much
-  * processing as can be conducted without any failed resources becoming available
-  * again (eg a failed database), the initialRecoveryComplete call must be issued 
-  * to indicate this fact. This call is used by the RLS to optomize its interactions
-  * with the HA framework.
-  * </p>
-  *
-  * <p>
-  * The RecoveryDirector will then pass the recovery request on to other registered
-  * client services.
-  * </p>
-  *
-  * @param recoveryAgent The client services RecoveryAgent instance.
-  * @param failureScope The unit of recovery that is completed.
-  *
-  * @exception InvalidFailureScope The supplied FailureScope was not recognized as
-  *                                outstanding unit of recovery for the client
-  *                                service.
-  */
-  public void serialRecoveryComplete(RecoveryAgent recoveryAgent,FailureScope failureScope) throws InvalidFailureScopeException;
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirector.serialRecoveryComplete
+    //------------------------------------------------------------------------------
+    /**
+     * <p>
+     * Invoked by a client service to indicate that serial recovery processing for the
+     * unit of recovery, identified by FailureScope has been completed. The client
+     * service supplies its RecoveryAgent reference to identify itself.
+     * </p>
+     *
+     * <p>
+     * When recovery events occur, each client services RecoveryAgent callback object
+     * has its initiateRecovery() method invoked. As a result of this call, the client
+     * services has an opportunity to perform any SERIAL recovery processing for that
+     * failure scope. Once this is complete, the client calls the serialRecoveryComplete
+     * method to give the next client service to handle recovery processing. Recovery
+     * processing as a whole may or may not be complete before this call is issued -
+     * it may continue afterwards on a parrallel thread if required. The latter design
+     * is prefereable in an HA-enabled environment as controll must be passed back as
+     * quickly as possible to avoid the HA framework shutting down the JVM.
+     * </p>
+     *
+     * <p>
+     * Regardless of the style adopted, once the recovery process has performed as much
+     * processing as can be conducted without any failed resources becoming available
+     * again (eg a failed database), the initialRecoveryComplete call must be issued
+     * to indicate this fact. This call is used by the RLS to optomize its interactions
+     * with the HA framework.
+     * </p>
+     *
+     * <p>
+     * The RecoveryDirector will then pass the recovery request on to other registered
+     * client services.
+     * </p>
+     *
+     * @param recoveryAgent The client services RecoveryAgent instance.
+     * @param failureScope The unit of recovery that is completed.
+     *
+     * @exception InvalidFailureScope The supplied FailureScope was not recognized as
+     *                outstanding unit of recovery for the client
+     *                service.
+     */
+    public void serialRecoveryComplete(RecoveryAgent recoveryAgent, FailureScope failureScope) throws InvalidFailureScopeException;
 
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirector.initialRecoveryComplete
-  //------------------------------------------------------------------------------
-  /**
-  * <p>
-  * Invoked by a client service to indicate that initial recovery processing for the 
-  * unit of recovery, identified by FailureScope has been completed. The client
-  * service supplies its RecoveryAgent reference to identify itself.
-  * </p>
-  *
-  * <p>
-  * When recovery events occur, each client services RecoveryAgent callback object
-  * has its initiateRecovery() method invoked. As a result of this call, the client
-  * services has an opportunity to perform any SERIAL recovery processing for that
-  * failure scope. Once this is complete, the client calls the serialRecoveryComplete
-  * method to give the next client service to handle recovery processing. Recovery
-  * processing as a whole may or may not be complete before this call is issued - 
-  * it may continue afterwards on a parrallel thread if required. The latter design
-  * is prefereable in an HA-enabled environment as controll must be passed back as
-  * quickly as possible to avoid the HA framework shutting down the JVM.
-  * </p>
-  *
-  * <p>
-  * Regardless of the style adopted, once the recovery process has performed as much
-  * processing as can be conducted without any failed resources becoming available
-  * again (eg a failed database), the initialRecoveryComplete call must be issued 
-  * to indicate this fact. This call is used by the RLS to optomize its interactions
-  * with the HA framework.
-  * </p>
-  *
-  * <p>
-  * The RecoveryDirector will then pass the recovery request on to other registered
-  * client services.
-  * </p>
-  *
-  * @param recoveryAgent The client services RecoveryAgent instance.
-  * @param failureScope The unit of recovery that is completed.
-  *
-  * @exception InvalidFailureScope The supplied FailureScope was not recognized as
-  *                                outstanding unit of recovery for the client
-  *                                service.
-  */
-  public void initialRecoveryComplete(RecoveryAgent recoveryAgent,FailureScope failureScope) throws InvalidFailureScopeException;
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirector.initialRecoveryComplete
+    //------------------------------------------------------------------------------
+    /**
+     * <p>
+     * Invoked by a client service to indicate that initial recovery processing for the
+     * unit of recovery, identified by FailureScope has been completed. The client
+     * service supplies its RecoveryAgent reference to identify itself.
+     * </p>
+     *
+     * <p>
+     * When recovery events occur, each client services RecoveryAgent callback object
+     * has its initiateRecovery() method invoked. As a result of this call, the client
+     * services has an opportunity to perform any SERIAL recovery processing for that
+     * failure scope. Once this is complete, the client calls the serialRecoveryComplete
+     * method to give the next client service to handle recovery processing. Recovery
+     * processing as a whole may or may not be complete before this call is issued -
+     * it may continue afterwards on a parrallel thread if required. The latter design
+     * is prefereable in an HA-enabled environment as controll must be passed back as
+     * quickly as possible to avoid the HA framework shutting down the JVM.
+     * </p>
+     *
+     * <p>
+     * Regardless of the style adopted, once the recovery process has performed as much
+     * processing as can be conducted without any failed resources becoming available
+     * again (eg a failed database), the initialRecoveryComplete call must be issued
+     * to indicate this fact. This call is used by the RLS to optomize its interactions
+     * with the HA framework.
+     * </p>
+     *
+     * <p>
+     * The RecoveryDirector will then pass the recovery request on to other registered
+     * client services.
+     * </p>
+     *
+     * @param recoveryAgent The client services RecoveryAgent instance.
+     * @param failureScope The unit of recovery that is completed.
+     *
+     * @exception InvalidFailureScope The supplied FailureScope was not recognized as
+     *                outstanding unit of recovery for the client
+     *                service.
+     */
+    public void initialRecoveryComplete(RecoveryAgent recoveryAgent, FailureScope failureScope) throws InvalidFailureScopeException;
 
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirector.initialRecoveryFailed
-  //------------------------------------------------------------------------------
-  /**
-  * <p>
-  * Invoked by a client service to indicate that initial recovery processing for the 
-  * unit of recovery, identified by FailureScope has been attempted but failed. The
-  * client service supplies its RecoveryAgent reference to identify itself.
-  * </p>
-  *
-  * <p>
-  * Invoking this method on the local failure scope will result in the server being
-  * termianted (by the HA framework)
-  * </p> 
-  *
-  * @param recoveryAgent The client services RecoveryAgent instance.
-  * @param failureScope The unit of recovery that is failed.
-  *
-  * @exception InvalidFailureScope The supplied FailureScope was not recognized as
-  *                                outstanding unit of recovery for the client
-  *                                service.
-  */
-  public void initialRecoveryFailed(RecoveryAgent recoveryAgent,FailureScope failureScope) throws InvalidFailureScopeException;
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirector.initialRecoveryFailed
+    //------------------------------------------------------------------------------
+    /**
+     * <p>
+     * Invoked by a client service to indicate that initial recovery processing for the
+     * unit of recovery, identified by FailureScope has been attempted but failed. The
+     * client service supplies its RecoveryAgent reference to identify itself.
+     * </p>
+     *
+     * <p>
+     * Invoking this method on the local failure scope will result in the server being
+     * termianted (by the HA framework)
+     * </p>
+     *
+     * @param recoveryAgent The client services RecoveryAgent instance.
+     * @param failureScope The unit of recovery that is failed.
+     *
+     * @exception InvalidFailureScope The supplied FailureScope was not recognized as
+     *                outstanding unit of recovery for the client
+     *                service.
+     */
+    public void initialRecoveryFailed(RecoveryAgent recoveryAgent, FailureScope failureScope) throws InvalidFailureScopeException;
 
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirector.terminationComplete
-  //------------------------------------------------------------------------------
-  /**
-  * <p>
-  * Invoked by a client service to indicate recovery processing for the identified
-  * FailureScope ceased. The client service supplies its RecoveryAgent reference to
-  * identify itself.
-  * </p>
-  *
-  * <p>
-  * The RecoveryDirector will then pass the termination request on to other registered
-  * client services.
-  * </p>
-  *
-  * @param recoveryAgent The client services RecoveryAgent instance.
-  * @param failureScope The unit of recovery that is completed.
-  *
-  * @exception InvalidFailureScopeException The supplied FailureScope was not recognized as
-  *                                         outstanding unit of recovery for the client
-  *                                         service.
-  */
-  public void terminationComplete(RecoveryAgent recoveryAgent,FailureScope failureScope) throws InvalidFailureScopeException;
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirector.terminationComplete
+    //------------------------------------------------------------------------------
+    /**
+     * <p>
+     * Invoked by a client service to indicate recovery processing for the identified
+     * FailureScope ceased. The client service supplies its RecoveryAgent reference to
+     * identify itself.
+     * </p>
+     *
+     * <p>
+     * The RecoveryDirector will then pass the termination request on to other registered
+     * client services.
+     * </p>
+     *
+     * @param recoveryAgent The client services RecoveryAgent instance.
+     * @param failureScope The unit of recovery that is completed.
+     *
+     * @exception InvalidFailureScopeException The supplied FailureScope was not recognized as
+     *                outstanding unit of recovery for the client
+     *                service.
+     */
+    public void terminationComplete(RecoveryAgent recoveryAgent, FailureScope failureScope) throws InvalidFailureScopeException;
 
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirector.currentFailureScope
-  //------------------------------------------------------------------------------
-  /**
-  * Invoked by a client service to determine the "current" FailureScope. This is 
-  * defined as a FailureScope that identifies the current point of execution. In
-  * practice this means the current server on distributed or server region on 390.
-  *
-  * @return FailureScope The current FailureScope.
-  */
-  public FailureScope currentFailureScope();
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirector.currentFailureScope
+    //------------------------------------------------------------------------------
+    /**
+     * Invoked by a client service to determine the "current" FailureScope. This is
+     * defined as a FailureScope that identifies the current point of execution. In
+     * practice this means the current server on distributed or server region on 390.
+     *
+     * @return FailureScope The current FailureScope.
+     */
+    public FailureScope currentFailureScope();
 
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirector.addCallBack
-  //------------------------------------------------------------------------------
-  /**
-  * Invoked to add a recovery log service callback object that is invoked whenever
-  * recovery events occur.
-  * 
-  * The caller must supply an object that implements the RecoveryLogCallBack 
-  * interface.
-  *
-  * @param callback The new callback object.
-  */
-  public void addCallBack(RecoveryLogCallBack callback);
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirector.addCallBack
+    //------------------------------------------------------------------------------
+    /**
+     * Invoked to add a recovery log service callback object that is invoked whenever
+     * recovery events occur.
+     *
+     * The caller must supply an object that implements the RecoveryLogCallBack
+     * interface.
+     *
+     * @param callback The new callback object.
+     */
+    public void addCallBack(RecoveryLogCallBack callback);
 
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirector.getRecoveryLogConfiguration
-  //------------------------------------------------------------------------------
-  /**
-  * Allows a client service to obtain the recovery log configuration object from
-  * the configuration model for the associated failure scope. The recovery log
-  * configuration object contains the physical location and size of both 
-  * the transactions and cscopes logs.
-  *
-  * @param failureScope The failure scope for which recovery log configuration
-  *                     is to be retrieved.
-  *
-  * @return Object The recovery log configuration.
-  */
-  public Object getRecoveryLogConfiguration(FailureScope failureScope);
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirector.getRecoveryLogConfiguration
+    //------------------------------------------------------------------------------
+    /**
+     * Allows a client service to obtain the recovery log configuration object from
+     * the configuration model for the associated failure scope. The recovery log
+     * configuration object contains the physical location and size of both
+     * the transactions and cscopes logs.
+     *
+     * @param failureScope The failure scope for which recovery log configuration
+     *            is to be retrieved.
+     *
+     * @return Object The recovery log configuration.
+     */
+    public Object getRecoveryLogConfiguration(FailureScope failureScope);
 
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirectorImpl.getNonNullCurrentFailureScopeIDString
-  //------------------------------------------------------------------------------
-  /**
-  * returns the value of clusterService.clusterToIdentity for the current 
-  * failureScope, even if HA is not enabled.
-  * 
-  * @return String The clusterIdentityString for the current failure scope.
-  */
-  public String getNonNullCurrentFailureScopeIDString();
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirectorImpl.getNonNullCurrentFailureScopeIDString
+    //------------------------------------------------------------------------------
+    /**
+     * returns the value of clusterService.clusterToIdentity for the current
+     * failureScope, even if HA is not enabled.
+     *
+     * @return String The clusterIdentityString for the current failure scope.
+     */
+    public String getNonNullCurrentFailureScopeIDString();
 
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirectorImpl.registerRecoveryEventListener
-  //------------------------------------------------------------------------------
-  /**
-  * Register a <code>RecoveryEventListener</code> that will be notified of
-  * various recovery events.
-  * 
-  * @param rel The new recovery event listener.
-  */
-  public void registerRecoveryEventListener(RecoveryEventListener rel); /* @MD19638A*/
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirectorImpl.registerRecoveryEventListener
+    //------------------------------------------------------------------------------
+    /**
+     * Register a <code>RecoveryEventListener</code> that will be notified of
+     * various recovery events.
+     *
+     * @param rel The new recovery event listener.
+     */
+    public void registerRecoveryEventListener(RecoveryEventListener rel); /* @MD19638A */
 
-  //------------------------------------------------------------------------------
-  // Method: RecoveryDirectorImpl.isHAEnabled()
-  //------------------------------------------------------------------------------
-  /**
-  * This method allows a client service to determine if High Availability support
-  * has been enabled for the local cluster. 
-  * 
-  * @return boolean true if HA support is enabled, otherwise false.
-  */
-  public boolean isHAEnabled();
+    //------------------------------------------------------------------------------
+    // Method: RecoveryDirectorImpl.isHAEnabled()
+    //------------------------------------------------------------------------------
+    /**
+     * This method allows a client service to determine if High Availability support
+     * has been enabled for the local cluster.
+     *
+     * @return boolean true if HA support is enabled, otherwise false.
+     */
+    public boolean isHAEnabled();
+
+    public void directInitialization(FailureScope failureScope) throws RecoveryFailedException;
+
+    public void setRecoveryLogFactory(RecoveryLogFactory fac);
+
 }
-

--- a/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/RecoveryLogManager.java
+++ b/dev/com.ibm.ws.recoverylog/src/com/ibm/ws/recoverylog/spi/RecoveryLogManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2003 IBM Corporation and others.
+ * Copyright (c) 2002, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,14 +19,13 @@ package com.ibm.ws.recoverylog.spi;
  * The RecoveryLogManager interface provides support for access to the recovery
  * logs associated with a client service.
  * </p>
- * 
+ *
  * <p>
  * An object that implements this interface is provided to each client service
  * when it registers with the RecoveryDirector.
  * </p>
  */
-public interface RecoveryLogManager
-{
+public interface RecoveryLogManager {
     //------------------------------------------------------------------------------
     // Method: RecoveryLogManager.getRecoveryLog
     //------------------------------------------------------------------------------
@@ -34,26 +33,26 @@ public interface RecoveryLogManager
      * <p>
      * Returns a RecoveryLog that can be used to access a specific recovery log.
      * </p>
-     * 
+     *
      * <p>
      * Each recovery log is contained within a FailureScope. For example, the
      * transaction service on a distributed system has a transaction log in each
      * server node (ie in each FailureScope). Because of this, the caller must
      * specify the FailureScope of the required recovery log.
      * </p>
-     * 
+     *
      * <p>
      * Additionally, the caller must specify information regarding the identity and
      * physical properties of the recovery log. This is done through the LogProperties
      * object provided by the client service.
      * </p>
-     * 
+     *
      * @param FailureScope The required FailureScope
      * @param LogProperties Contains the identity and physical properties of the
      *            recovery log.
-     * 
+     *
      * @return The RecoveryLog instance.
-     * 
+     *
      * @exception InvalidLogPropertiesException The RLS does not recognize or cannot
      *                support the supplied LogProperties
      */

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/build.gradle
@@ -14,8 +14,8 @@ dependencies {
   requiredLibs 'commons-logging:commons-logging:1.1.3'
 }
 
-File serverDir1 = new File(autoFvtDir, 'publish/servers/com.ibm.ws.transaction_FSCLOUD001')
-File serverDir2 = new File(autoFvtDir, 'publish/servers/com.ibm.ws.transaction_FSCLOUD002')
+File serverDir1 = new File(autoFvtDir, 'publish/servers/com.ibm.ws.transaction_CLOUD001')
+File serverDir2 = new File(autoFvtDir, 'publish/servers/com.ibm.ws.transaction_CLOUD002')
 
 task addDerbyToServerDir1(type: Copy) {
   from configurations.derby

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/fat/src/com/ibm/ws/transaction/test/FATSuite.java
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/fat/src/com/ibm/ws/transaction/test/FATSuite.java
@@ -24,6 +24,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 @RunWith(Suite.class)
 @SuiteClasses({
                 SimpleFS2PCCloudTest.class,
+                Simple2PCCloudTest.class,
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/fat/src/com/ibm/ws/transaction/test/Simple2PCCloudTest.java
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/fat/src/com/ibm/ws/transaction/test/Simple2PCCloudTest.java
@@ -1,0 +1,272 @@
+package com.ibm.ws.transaction.test;
+
+/*
+ * IBM Confidential
+ *
+ * OCO Source Materials
+ *
+ * Copyright IBM Corp. 2018
+ *
+ * The source code for this program is not published or other-
+ * wise divested of its trade secrets, irrespective of what has
+ * been deposited with the U.S. Copyright Office.
+ */
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ProgramOutput;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.transaction.web.Simple2PCCloudServlet;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class Simple2PCCloudTest extends FATServletClient {
+
+    public static final String APP_NAME = "transaction";
+    public static final String SERVLET_NAME = "transaction/Simple2PCCloudServlet";
+    protected static final int cloud2ServerPort = 9992;
+
+    @Server("com.ibm.ws.transaction_CLOUD001")
+    @TestServlet(servlet = Simple2PCCloudServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server1;
+
+    @Server("com.ibm.ws.transaction_CLOUD002")
+    @TestServlet(servlet = Simple2PCCloudServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server2;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        // Create a WebArchive that will have the file name 'app1.war' once it's written to a file
+        // Include the 'app1.web' package and all of it's java classes and sub-packages
+        // Automatically includes resources under 'test-applications/APP_NAME/resources/' folder
+        // Exports the resulting application to the ${server.config.dir}/apps/ directory
+        ShrinkHelper.defaultApp(server1, APP_NAME, "com.ibm.ws.transaction.*");
+        ShrinkHelper.defaultApp(server2, APP_NAME, "com.ibm.ws.transaction.*");
+
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {}
+
+    /**
+     * Test access to the Lease table.
+     *
+     * This is a readiness check to verify that resources are available and accessible.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLeaseTableAccess() throws Exception {
+        final String method = "testLeaseTableAccess";
+        StringBuilder sb = null;
+        String id = "001";
+
+        // Start Server1
+        server1.startServer();
+
+        try {
+            sb = runTestWithResponse(server1, SERVLET_NAME, "testLeaseTableAccess");
+
+        } catch (Throwable e) {
+        }
+        Log.info(this.getClass(), method, "testLeaseTableAccess" + id + " returned: " + sb);
+
+        // "CWWKE0701E" error message is allowed
+        server1.stopServer("CWWKE0701E");
+
+        // Lastly, clean up XA resource files
+        server1.deleteFileFromLibertyServerRoot("XAResourceData.dat");
+
+    }
+
+    /**
+     * The purpose of this test is as a control to verify that single server recovery is working.
+     *
+     * The Cloud001 server is started and halted by a servlet that leaves an indoubt transaction.
+     * Cloud001 is restarted and transaction recovery verified.
+     *
+     * @throws Exception
+     */
+    @Test
+    @AllowedFFDC(value = { "javax.transaction.xa.XAException", "com.ibm.ws.recoverylog.spi.RecoveryFailedException" })
+    public void testDBBaseRecovery() throws Exception {
+        final String method = "testDBBaseRecovery";
+        StringBuilder sb = null;
+        String id = "001";
+        // Start Server1
+        server1.startServer();
+
+        try {
+            // We expect this to fail since it is gonna crash the server
+            sb = runTestWithResponse(server1, SERVLET_NAME, "setupRec" + id);
+        } catch (Throwable e) {
+        }
+        Log.info(this.getClass(), method, "setupRec" + id + " returned: " + sb);
+
+        server1.waitForStringInLog("Dump State:");
+
+        // Now re-start cloud1
+        ProgramOutput po = server1.startServerAndValidate(false, true, true);
+        if (po.getReturnCode() != 0) {
+            Log.info(this.getClass(), method, po.getCommand() + " returned " + po.getReturnCode());
+            Log.info(this.getClass(), method, "Stdout: " + po.getStdout());
+            Log.info(this.getClass(), method, "Stderr: " + po.getStderr());
+            Exception ex = new Exception("Could not restart the server");
+            Log.error(this.getClass(), "recoveryTest", ex);
+            throw ex;
+        }
+
+        // Server appears to have started ok. Check for key string to see whether recovery has succeeded
+        server1.waitForStringInTrace("Performed recovery for cloud001");
+
+        // Lastly stop server1
+        // "WTRN0075W", "WTRN0076W", "CWWKE0701E" error messages are expected/allowed
+        server1.stopServer("WTRN0075W", "WTRN0076W", "CWWKE0701E");
+
+        // Lastly, clean up XA resource file
+        server1.deleteFileFromLibertyServerRoot("XAResourceData.dat");
+    }
+
+    /**
+     * The purpose of this test is to verify simple peer transaction recovery.
+     *
+     * The Cloud001 server is started and halted by a servlet that leaves an indoubt transaction.
+     * Cloud002, a peer server as it belongs to the same recovery group is started and recovery the
+     * transaction that belongs to Cloud001.
+     *
+     * @throws Exception
+     */
+    @Test
+    @AllowedFFDC(value = { "com.ibm.ws.recoverylog.spi.RecoveryFailedException" })
+    public void testDBRecoveryTakeover() throws Exception {
+        final String method = "testDBRecoveryTakeover";
+        StringBuilder sb = null;
+        String id = "001";
+        // Start Server1
+        server1.startServer();
+
+        try {
+            // We expect this to fail since it is gonna crash the server
+            sb = runTestWithResponse(server1, SERVLET_NAME, "setupRec" + id);
+        } catch (Throwable e) {
+        }
+        Log.info(this.getClass(), method, "setupRec" + id + " returned: " + sb);
+
+        server1.waitForStringInLog("Dump State:");
+
+        // Now start server2
+        server2.setHttpDefaultPort(cloud2ServerPort);
+        ProgramOutput po = server2.startServerAndValidate(false, true, true);
+        if (po.getReturnCode() != 0) {
+            Log.info(this.getClass(), method, po.getCommand() + " returned " + po.getReturnCode());
+            Log.info(this.getClass(), method, "Stdout: " + po.getStdout());
+            Log.info(this.getClass(), method, "Stderr: " + po.getStderr());
+            Exception ex = new Exception("Could not restart the server");
+            Log.error(this.getClass(), "recoveryTest", ex);
+            throw ex;
+        }
+
+        // Server appears to have started ok. Check for key string to see whether peer recovery has succeeded
+        server2.waitForStringInTrace("Performed recovery for cloud001");
+        // "CWWKE0701E" error message is allowed
+        server2.stopServer("CWWKE0701E");
+
+        // Lastly, clean up XA resource files
+        server1.deleteFileFromLibertyServerRoot("XAResourceData.dat");
+        server2.deleteFileFromLibertyServerRoot("XAResourceData.dat");
+    }
+
+    /**
+     * The purpose of this test is to verify correct behaviour when peer servers compete for a log.
+     *
+     * The Cloud001 server is started and a servlet invoked. The servlet modifies the owner of the server's
+     * lease recored in the lease table. This simulates the situation where a peer server has acquired the
+     * ownership of the lease and is recovering Cloud001's logs. Finally the servlet halts the server leaving
+     * an indoubt transaction.
+     *
+     * Cloud001 is restarted but should fail to acquire the lease to its recovery logs as it is no longer the owner.
+     *
+     * @throws Exception
+     */
+    @Test
+    @ExpectedFFDC(value = { "com.ibm.ws.recoverylog.spi.RecoveryFailedException" })
+    @AllowedFFDC(value = { "javax.transaction.xa.XAException", "com.ibm.tx.jta.XAResourceNotAvailableException", "com.ibm.ws.recoverylog.spi.RecoveryFailedException",
+                           "java.lang.IllegalStateException" })
+    // defect 227411, if cloud002 starts slowly, then access to cloud001's indoubt tx
+    // XAResources may need to be retried (tx recovery is, in such cases, working as designed.
+    public void testDBRecoveryCompeteForLog() throws Exception {
+        final String method = "testDBRecoveryCompeteForLog";
+        StringBuilder sb = null;
+        String id = "001";
+
+        // Start Server1
+        server1.startServer();
+
+        try {
+            sb = runTestWithResponse(server1, SERVLET_NAME, "modifyLeaseOwner");
+
+            // We expect this to fail since it is gonna crash the server
+            sb = runTestWithResponse(server1, SERVLET_NAME, "setupRec" + id);
+        } catch (Throwable e) {
+        }
+        Log.info(this.getClass(), method, "setupRec" + id + " returned: " + sb);
+
+        server1.waitForStringInLog("Dump State:");
+
+        // Defect 209842: Pull in a jvm.options file that ensures that we have a long (5 minute) timeout
+        // for the lease, otherwise we may decide that we CAN delete and renew our own lease.
+        server1.copyFileToLibertyServerRoot("jvm.options");
+
+        // Now re-start cloud1 but we fully expect this to fail
+        try {
+            server1.startServerExpectFailure("recovery-dblog-fail.log", false, true);
+        } catch (Exception ex) {
+            // Tolerate an exception here, as recovery is asynch and the "successful start" message
+            // may have been produced by the main thread before the recovery thread had completed
+            Log.info(this.getClass(), method, "startServerExpectFailure threw exc: " + ex);
+        }
+
+        // Server appears to have failed as expected. Check for log failure string
+        if (server1.waitForStringInLog("RECOVERY_LOG_FAILED") == null) {
+            Exception ex = new Exception("Recovery logs should have failed");
+            Log.error(this.getClass(), "recoveryTestCompeteForLock", ex);
+            throw ex;
+        }
+
+        server1.deleteFileFromLibertyServerRoot("jvm.options");
+
+        // defect 210055: Now start cloud2 so that we can tidy up the environment, otherwise cloud1
+        // is unstartable because its lease is owned by cloud2.
+        server2.setHttpDefaultPort(cloud2ServerPort);
+
+        ProgramOutput po = server2.startServerAndValidate(false, true, true);
+        if (po.getReturnCode() != 0) {
+            Log.info(this.getClass(), method, po.getCommand() + " returned " + po.getReturnCode());
+            Log.info(this.getClass(), method, "Stdout: " + po.getStdout());
+            Log.info(this.getClass(), method, "Stderr: " + po.getStderr());
+            Exception ex = new Exception("Could not restart the server");
+            Log.error(this.getClass(), "recoveryTest", ex);
+            throw ex;
+        }
+
+        // Server appears to have started ok. Check for 2 key strings to see whether peer recovery has succeeded
+        server2.waitForStringInTrace("Performed recovery for cloud001");
+        // "CWWKE0701E" error message is allowed
+        server2.stopServer("CWWKE0701E");
+
+        // Lastly, clean up XA resource files
+        server1.deleteFileFromLibertyServerRoot("XAResourceData.dat");
+        server2.deleteFileFromLibertyServerRoot("XAResourceData.dat");
+    }
+}

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/fat/src/com/ibm/ws/transaction/test/SimpleFS2PCCloudTest.java
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/fat/src/com/ibm/ws/transaction/test/SimpleFS2PCCloudTest.java
@@ -1,15 +1,16 @@
 package com.ibm.ws.transaction.test;
 
-/*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+/*
+ * IBM Confidential
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+ * OCO Source Materials
+ *
+ * Copyright IBM Corp. 2018
+ *
+ * The source code for this program is not published or other-
+ * wise divested of its trade secrets, irrespective of what has
+ * been deposited with the U.S. Copyright Office.
+ */
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -31,7 +32,6 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.transaction.web.SimpleFS2PCCloudServlet;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -187,8 +187,7 @@ public class SimpleFS2PCCloudTest extends FATServletClient {
 
     @Mode(TestMode.LITE)
     @Test
-    @ExpectedFFDC(value = { "java.lang.IllegalStateException" })
-    @AllowedFFDC(value = { "javax.transaction.xa.XAException" })
+    @AllowedFFDC(value = { "javax.transaction.xa.XAException", "java.lang.IllegalStateException" })
     // defect 227411, if FScloud002 starts slowly, then access to FScloud001's indoubt tx
     // XAResources may need to be retried (tx recovery is, in such cases, working as designed.
     public void testFSRecoveryCompeteForLog() throws Exception {

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_CLOUD001/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_CLOUD001/bootstrap.properties
@@ -1,0 +1,4 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled
+ds.loglevel=DEBUG
+osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_CLOUD001/server.xml
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_CLOUD001/server.xml
@@ -1,0 +1,52 @@
+<server>
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <featureManager>
+      <feature>servlet-3.1</feature>
+      <feature>jdbc-4.0</feature>
+      <feature>jndi-1.0</feature>
+      <feature>componentTest-1.0</feature>
+      <feature>txfat-1.0</feature>
+      <feature>cdi-1.2</feature>
+    </featureManager>
+    
+    <jdbcDriver id="DerbyEmbedded" libraryRef="DerbyLib" />
+    <library id="DerbyLib" filesetRef="DerbyFileset" />
+    <fileset id="DerbyFileset"
+             dir="${server.config.dir}/derby"
+             includes="derby.jar" />
+    
+    <transaction
+        dataSourceRef="tranlogDataSource"
+        recoverOnStartup="true"
+        waitForRecovery="false"
+        heuristicRetryInterval="10"
+        recoveryIdentity="cloud001"
+        recoveryGroup="defaultGroup"
+    />
+    <application location="transaction.war"/>
+	<dataSource id="tranlogDataSource" 
+	            jdbcDriverRef="DerbyEmbedded"
+	            jndiName="jdbc/tranlogDataSource" 
+	            transactional="false"> 
+        <properties databaseName="${shared.resource.dir}/data/tranlogdb"
+                    createDatabase="create" />
+
+	</dataSource>
+	
+    <dataSource id="jdbc/derby" jndiName="jdbc/derby" jdbcDriverRef="DerbyEmbedded">
+      <properties
+        databaseName="${shared.resource.dir}/data/transactionFATCloud"
+        createDatabase="create"
+        user="dbuser1"
+        password="{xor}Oz0vKDtu"
+      />  <!-- password="dbpwd1" -->
+    </dataSource>
+    
+    <javaPermission codebase="${server.config.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
+        
+    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:com.ibm.wsspi.kernel.service.*=all:*=info=enabled"/>
+     
+</server>

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_CLOUD002/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_CLOUD002/bootstrap.properties
@@ -1,0 +1,4 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled
+ds.loglevel=DEBUG
+osgi.console=5471

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_CLOUD002/server.xml
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_CLOUD002/server.xml
@@ -1,0 +1,57 @@
+<server>
+
+    <featureManager>
+      <feature>servlet-3.1</feature>
+      <feature>jdbc-4.1</feature>
+      <feature>txfat-1.0</feature>
+      <feature>jndi-1.0</feature>
+      <feature>componentTest-1.0</feature>
+      <feature>cdi-1.2</feature>
+      <feature>timedexit-1.0</feature>
+    </featureManager>
+
+  	<httpEndpoint
+		httpPort="9992"
+		httpsPort="9996"
+		id="defaultHttpEndpoint"
+	/>
+    
+    <jdbcDriver id="DerbyEmbedded" libraryRef="DerbyLib" />
+    <library id="DerbyLib" filesetRef="DerbyFileset" />
+    <fileset id="DerbyFileset"
+             dir="${server.config.dir}/derby"
+             includes="derby.jar" />
+    
+    <transaction
+        dataSourceRef="tranlogDataSource"
+        recoverOnStartup="true"
+        waitForRecovery="false"
+        heuristicRetryInterval="10"
+        recoveryIdentity="cloud002"
+        recoveryGroup="defaultGroup"
+    />
+    <application location="transaction.war"/>
+	<dataSource id="tranlogDataSource" 
+	            jdbcDriverRef="DerbyEmbedded"
+	            jndiName="jdbc/tranlogDataSource" 
+	            transactional="false"> 
+        <properties databaseName="${shared.resource.dir}/data/tranlogdb"
+                    createDatabase="create" />
+
+	</dataSource>
+	
+    <dataSource id="jdbc/derby" jndiName="jdbc/derby" jdbcDriverRef="DerbyEmbedded">
+      <properties
+        databaseName="${shared.resource.dir}/data/transactionFATCloud"
+        createDatabase="create"
+        user="dbuser1"
+        password="{xor}Oz0vKDtu"
+      />  <!-- password="dbpwd1" -->
+    </dataSource>
+    
+    <javaPermission codebase="${server.config.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
+        
+    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:com.ibm.wsspi.kernel.service.*=all:*=info=enabled"/>
+     
+</server>

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_FSCLOUD001/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_FSCLOUD001/bootstrap.properties
@@ -10,4 +10,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 osgi.console=7773
+com.ibm.tx.auditRecovery=true
 com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_FSCLOUD001/server.xml
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_FSCLOUD001/server.xml
@@ -20,7 +20,7 @@
       <feature>osgiconsole-1.0</feature>
       <feature>cdi-1.2</feature>
     </featureManager>
-    
+      
     <transaction
         recoverOnStartup="true"
         waitForRecovery="false"

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_FSCLOUD002/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_FSCLOUD002/bootstrap.properties
@@ -10,4 +10,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 osgi.console=7773
+com.ibm.tx.auditRecovery=true
 com.ibm.ws.logging.trace.specification=com.ibm.tx.jta.util.TxTMHelper=all=enabled

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_FSCLOUD002/server.xml
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/publish/servers/com.ibm.ws.transaction_FSCLOUD002/server.xml
@@ -9,9 +9,7 @@
         IBM Corporation - initial API and implementation
  -->
 <server>
-
-    <include location="../fatTestPorts.xml"/>
-    
+   
     <featureManager>
       <feature>servlet-3.1</feature>
       <feature>jdbc-4.1</feature>
@@ -19,8 +17,15 @@
       <feature>txfat-1.0</feature>
       <feature>osgiconsole-1.0</feature>
       <feature>cdi-1.2</feature>
+      <feature>timedexit-1.0</feature>
     </featureManager>
     
+  	<httpEndpoint
+		httpPort="9992"
+		httpsPort="9996"
+		id="defaultHttpEndpoint"
+	/>  
+	    
     <transaction
         recoverOnStartup="true"
         waitForRecovery="false"

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/test-applications/transaction/src/com/ibm/ws/transaction/web/Simple2PCCloudServlet.java
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/test-applications/transaction/src/com/ibm/ws/transaction/web/Simple2PCCloudServlet.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.transaction.web;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import javax.annotation.Resource;
+import javax.annotation.Resource.AuthenticationType;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import javax.transaction.Transaction;
+
+import com.ibm.tx.jta.ExtendedTransactionManager;
+import com.ibm.tx.jta.TransactionManagerFactory;
+import com.ibm.tx.jta.ut.util.XAResourceImpl;
+import com.ibm.ws.cloudtx.ut.util.LastingXAResourceImpl;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/Simple2PCCloudServlet")
+public class Simple2PCCloudServlet extends FATServlet {
+
+    /**  */
+    private static final String filter = "(testfilter=jon)";
+
+    @Resource(name = "jdbc/derby", shareable = true, authenticationType = AuthenticationType.APPLICATION)
+    DataSource ds;
+    @Resource(name = "jdbc/tranlogDataSource", shareable = true, authenticationType = AuthenticationType.APPLICATION)
+    DataSource dsTranLog;
+
+    public void commitSuicide(HttpServletRequest request,
+                              HttpServletResponse response) throws Exception {
+        Runtime.getRuntime().halt(0);
+    }
+
+    public void testLeaseTableAccess(HttpServletRequest request,
+                                     HttpServletResponse response) throws Exception {
+        Connection con = ds.getConnection();
+        try {
+            // Statement used to drop table
+            Statement stmt = con.createStatement();
+
+            try {
+                System.out.println("modifyLeaseOwner: sel-for-update against Lease table");
+                String selForUpdateString = "SELECT LEASE_OWNER" +
+                                            " FROM WAS_LEASES_LOG" +
+                                            " WHERE SERVER_IDENTITY='cloud001' FOR UPDATE OF LEASE_OWNER";
+                ResultSet rs = stmt.executeQuery(selForUpdateString);
+                while (rs.next()) {
+                    String owner = rs.getString("LEASE_OWNER");
+                    System.out.println("testLeaseTableAccess: owner is - " + owner);
+                }
+                rs.close();
+
+                String updateString = "UPDATE WAS_LEASES_LOG" +
+                                      " SET LEASE_OWNER = 'cloud002'" +
+                                      " WHERE SERVER_IDENTITY='cloud001'";
+                stmt.executeUpdate(updateString);
+            } catch (SQLException x) {
+                System.out.println("testLeaseTableAccess: caught exception - " + x);
+            }
+
+            System.out.println("testLeaseTableAccess: commit changes to database");
+            con.commit();
+        } catch (Exception ex) {
+            System.out.println("testLeaseTableAccess: caught exception in testSetup: " + ex);
+        }
+    }
+
+    public void setupRec001(HttpServletRequest request,
+                            HttpServletResponse response) throws Exception {
+        final ExtendedTransactionManager tm = TransactionManagerFactory
+                        .getTransactionManager();
+        System.out.println("NYTRACE: setUpRec001 started for tm: " + tm);
+        try {
+            tm.begin();
+
+            final Transaction tx = tm.getTransaction();
+
+            System.out.println("NYTRACE: setUpRec001 got transaction tx: " + tx);
+            LastingXAResourceImpl xares1 = new LastingXAResourceImpl();
+            System.out.println("NYTRACE: setUpRec001 working with res: " + xares1);
+            xares1.setCommitAction(XAResourceImpl.DIE);
+            try {
+                tx.enlistResource(xares1);
+            } catch (IllegalStateException ex) {
+                System.out.println("NYTRACE: setUpRec001 caught: " + ex);
+                // Assume transient (recovery incomplete) and retry after pause
+                Thread.sleep(5000);
+                tx.enlistResource(xares1);
+            }
+
+            tx.enlistResource(new LastingXAResourceImpl());
+            tx.enlistResource(new LastingXAResourceImpl());
+
+            tm.commit();
+        } catch (Exception e) {
+            System.out.println("NYTRACE: ImplodeServlet caught exc: " + e);
+            e.printStackTrace();
+        }
+    }
+
+    public void modifyLeaseOwner(HttpServletRequest request,
+                                 HttpServletResponse response) throws Exception {
+//        InitialContext context = new InitialContext();
+//        DataSource dsTranLog = (DataSource) context.lookup("java:comp/env/jdbc/tranlogDataSource");
+
+        Connection con = dsTranLog.getConnection();
+        try {
+            // Statement used to drop table
+            Statement stmt = con.createStatement();
+
+            try {
+                System.out.println("modifyLeaseOwner: sel-for-update against Lease table");
+                String selForUpdateString = "SELECT LEASE_OWNER" +
+                                            " FROM WAS_LEASES_LOG" +
+                                            " WHERE SERVER_IDENTITY='cloud001' FOR UPDATE OF LEASE_OWNER";
+                ResultSet rs = stmt.executeQuery(selForUpdateString);
+                while (rs.next()) {
+                    String owner = rs.getString("LEASE_OWNER");
+                    System.out.println("modifyLeaseOwner: owner is - " + owner);
+                }
+                rs.close();
+
+                String updateString = "UPDATE WAS_LEASES_LOG" +
+                                      " SET LEASE_OWNER = 'cloud002'" +
+                                      " WHERE SERVER_IDENTITY='cloud001'";
+                stmt.executeUpdate(updateString);
+            } catch (SQLException x) {
+                System.out.println("modifyLeaseOwner: caught exception - " + x);
+            }
+
+            System.out.println("modifyLeaseOwner: commit changes to database");
+            con.commit();
+        } catch (Exception ex) {
+            System.out.println("modifyLeaseOwner: caught exception in testSetup: " + ex);
+        }
+    }
+}

--- a/dev/com.ibm.ws.transaction.cloudsim_fat/test-applications/transaction/src/com/ibm/ws/transaction/web/SimpleFS2PCCloudServlet.java
+++ b/dev/com.ibm.ws.transaction.cloudsim_fat/test-applications/transaction/src/com/ibm/ws/transaction/web/SimpleFS2PCCloudServlet.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.ws.transaction.web;
 
 import java.io.Serializable;

--- a/dev/com.ibm.ws.transaction.core_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.core_fat/build.gradle
@@ -11,17 +11,24 @@
 
 // Define G:A:V coordinates of each dependency
 dependencies {
-  requiredLibs 'commons-logging:commons-logging:1.1.3'
+  requiredLibs project(":com.ibm.ws.tx.embeddable"), 'commons-logging:commons-logging:1.1.3'
 }
 
-File serverDir = new File(autoFvtDir, 'publish/servers/com.ibm.ws.transaction')
+File serverDir1 = new File(autoFvtDir, 'publish/servers/com.ibm.ws.transaction')
+File serverDir2 = new File(autoFvtDir, 'publish/servers/com.ibm.ws.transaction_waitForRecovery')
 
-task addDerbyToServerDir(type: Copy) {
+task addDerbyToServerDir1(type: Copy) {
   from configurations.derby
-  into new File(serverDir, 'derby')
+  into new File(serverDir1, 'derby')
+  rename 'derby-.*.jar', 'derby.jar'
+}
+
+task addDerbyToServerDir2(type: Copy) {
+  from configurations.derby
+  into new File(serverDir2, 'derby')
   rename 'derby-.*.jar', 'derby.jar'
 }
 
 addRequiredLibraries {
-  dependsOn addDerbyToServerDir
+  dependsOn addDerbyToServerDir1,addDerbyToServerDir2
 }

--- a/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/FATSuite.java
+++ b/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/FATSuite.java
@@ -26,10 +26,12 @@ import componenttest.topology.impl.LibertyServerFactory;
                 SimpleTest.class,
                 XATest.class,
                 RecoveryTest.class,
+                WaitForRecoveryTest.class,
 })
 public class FATSuite {
 
-    private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.transaction");
+    private static LibertyServer server1 = LibertyServerFactory.getLibertyServer("com.ibm.ws.transaction");
+    private static LibertyServer server2 = LibertyServerFactory.getLibertyServer("com.ibm.ws.transaction_waitForRecovery");
     // Using the RepeatTests @ClassRule will cause all tests to be run twice.
     // First without any modifications, then again with all features upgraded to their EE8 equivalents.
     @ClassRule
@@ -39,9 +41,11 @@ public class FATSuite {
     @BeforeClass
     public static void beforeSuite() throws Exception {
         // Install user feature
-        server.copyFileToLibertyInstallRoot("lib/features/", "features/txfat-1.0.mf");
+        server1.copyFileToLibertyInstallRoot("lib/features/", "features/txfat-1.0.mf");
+        server2.copyFileToLibertyInstallRoot("lib/features/", "features/txfat-1.0.mf");
 
         // Install bundle for txfat feature
-        server.copyFileToLibertyInstallRoot("lib/", "bundles/com.ibm.ws.transactions.fat.utils.jar");
+        server1.copyFileToLibertyInstallRoot("lib/", "bundles/com.ibm.ws.transactions.fat.utils.jar");
+        server2.copyFileToLibertyInstallRoot("lib/", "bundles/com.ibm.ws.transactions.fat.utils.jar");
     }
 }

--- a/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/WaitForRecoveryTest.java
+++ b/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/WaitForRecoveryTest.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.transaction.test;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ProgramOutput;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.transaction.web.WaitForRecoveryServlet;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Example Shrinkwrap FAT project:
+ * <li> Application packaging is done in the @BeforeClass, instead of ant scripting.
+ * <li> Injects servers via @Server annotation. Annotation value corresponds to the
+ * server directory name in 'publish/servers/%annotation_value%' where ports get
+ * assigned to the LibertyServer instance when the 'testports.properties' does not
+ * get used.
+ * <li> Specifies an @RunWith(FATRunner.class) annotation. Traditionally this has been
+ * added to bytecode automatically by ant.
+ * <li> Uses the @TestServlet annotation to define test servlets. Notice that not all @Test
+ * methods are defined in this class. All of the @Test methods are defined on the test
+ * servlet referenced by the annotation, and will be run whenever this test class runs.
+ */
+@Mode
+@RunWith(FATRunner.class)
+public class WaitForRecoveryTest extends FATServletClient {
+
+    public static final String APP_NAME = "transaction";
+    public static final String SERVLET_NAME = "transaction/WaitForRecoveryServlet";
+
+    @Server("com.ibm.ws.transaction_waitForRecovery")
+    @TestServlet(servlet = WaitForRecoveryServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server1;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Create a WebArchive that will have the file name 'app1.war' once it's written to a file
+        // Include the 'app1.web' package and all of it's java classes and sub-packages
+        // Automatically includes resources under 'test-applications/APP_NAME/resources/' folder
+        // Exports the resulting application to the ${server.config.dir}/apps/ directory
+        ShrinkHelper.defaultApp(server1, APP_NAME, "com.ibm.ws.transaction.*");
+
+        server1.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server1.stopServer("WTRN0075W", "WTRN0076W"); // Stop the server and indicate the '"WTRN0075W", "WTRN0076W" error messages were expected
+    }
+
+    @Mode(TestMode.LITE)
+    @Test
+    @AllowedFFDC(value = { "javax.transaction.xa.XAException" })
+    public void testWaitForRecovery() throws Exception {
+        final String method = "testBaseRecovery";
+        StringBuilder sb = null;
+
+        try {
+            // We expect this to fail since it is gonna crash the server
+            sb = runTestWithResponse(server1, SERVLET_NAME, "testRec001");
+        } catch (Throwable e) {
+        }
+        Log.info(this.getClass(), method, "testRec001 returned: " + sb);
+
+        server1.waitForStringInLog("Dump State:");
+
+        // Now re-start cloud1
+        ProgramOutput po = server1.startServerAndValidate(false, true, true);
+        if (po.getReturnCode() != 0) {
+            Log.info(this.getClass(), method, po.getCommand() + " returned " + po.getReturnCode());
+            Log.info(this.getClass(), method, "Stdout: " + po.getStdout());
+            Log.info(this.getClass(), method, "Stderr: " + po.getStderr());
+            Exception ex = new Exception("Could not restart the server");
+            Log.error(this.getClass(), "WaitForRecoveryTest", ex);
+            throw ex;
+        }
+
+        // Server appears to have started ok. Check for key string to see whether recovery has succeeded
+        server1.waitForStringInTrace("Performed recovery for server");
+
+        // Lastly stop server1
+        server1.stopServer("WTRN0075W", "WTRN0076W"); // Stop the server and indicate the '"WTRN0075W", "WTRN0076W" error messages were expected
+
+        // Lastly, clean up XA resource file
+        server1.deleteFileFromLibertyServerRoot("XAResourceData.dat");
+    }
+
+}

--- a/dev/com.ibm.ws.transaction.core_fat/publish/servers/com.ibm.ws.transaction_waitForRecovery/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.core_fat/publish/servers/com.ibm.ws.transaction_waitForRecovery/bootstrap.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2017,2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7773
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.transaction.core_fat/publish/servers/com.ibm.ws.transaction_waitForRecovery/jvm.options
+++ b/dev/com.ibm.ws.transaction.core_fat/publish/servers/com.ibm.ws.transaction_waitForRecovery/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.websphere.tx.propagateXAResourceTransactionTimeout=true

--- a/dev/com.ibm.ws.transaction.core_fat/publish/servers/com.ibm.ws.transaction_waitForRecovery/server.xml
+++ b/dev/com.ibm.ws.transaction.core_fat/publish/servers/com.ibm.ws.transaction_waitForRecovery/server.xml
@@ -1,0 +1,55 @@
+<!--
+    Copyright (c) 2017,2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <featureManager>
+      <feature>servlet-3.1</feature>
+      <feature>componentTest-1.0</feature>
+      <feature>txfat-1.0</feature>
+      <!--  feature>utdecorator-1.0</feature -->
+      <feature>osgiconsole-1.0</feature>
+      <feature>jndi-1.0</feature>
+      <feature>cdi-1.2</feature>
+      <feature>ejb-3.2</feature>
+    </featureManager>
+    
+    <jdbcDriver id="DerbyEmbedded" libraryRef="DerbyLib" />
+    <library id="DerbyLib" filesetRef="DerbyFileset" />
+    <fileset id="DerbyFileset"
+             dir="${server.config.dir}/derby"
+             includes="derby.jar" />
+    
+    <transaction
+        recoverOnStartup="true"
+        waitForRecovery="false"
+        heuristicRetryInterval="10"
+    />
+
+    <dataSource jndiName="jdbc/derby" jdbcDriverRef="DerbyEmbedded" type="javax.sql.XADataSource">
+      <properties
+        databaseName="${shared.resource.dir}/data/transactionFAT7"
+        createDatabase="create"
+        user="dbuser1"
+        password="{xor}Oz0vKDtu"
+      />  <!-- password="dbpwd1" -->
+    </dataSource>
+    
+	<application location="transaction.war"/>
+	
+    <javaPermission codebase="${server.config.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
+ 
+    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
+     
+
+</server>

--- a/dev/com.ibm.ws.transaction.core_fat/test-applications/transaction/src/com/ibm/ws/transaction/web/WaitForRecoveryServlet.java
+++ b/dev/com.ibm.ws.transaction.core_fat/test-applications/transaction/src/com/ibm/ws/transaction/web/WaitForRecoveryServlet.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.transaction.web;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import javax.annotation.Resource;
+import javax.annotation.Resource.AuthenticationType;
+import javax.naming.InitialContext;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import javax.transaction.UserTransaction;
+import javax.transaction.xa.XAResource;
+
+import com.ibm.tx.jta.ExtendedTransactionManager;
+import com.ibm.tx.jta.TransactionManagerFactory;
+import com.ibm.tx.jta.ut.util.XAResourceFactoryImpl;
+import com.ibm.tx.jta.ut.util.XAResourceImpl;
+import com.ibm.tx.jta.ut.util.XAResourceInfoFactory;
+import com.ibm.websphere.uow.UOWSynchronizationRegistry;
+import com.ibm.wsspi.uow.ExtendedUOWAction;
+import com.ibm.wsspi.uow.UOWManager;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/WaitForRecoveryServlet")
+public class WaitForRecoveryServlet extends FATServlet {
+
+    /**  */
+    private static final String filter = "(testfilter=jon)";
+
+    @Resource
+    UOWManager uowm;
+    @Resource(name = "jdbc/derby", shareable = true, authenticationType = AuthenticationType.APPLICATION)
+    DataSource ds;
+
+    public void commitSuicide(HttpServletRequest request,
+                              HttpServletResponse response) throws Exception {
+        Runtime.getRuntime().halt(0);
+    }
+
+    public void testRec001(HttpServletRequest request,
+                           HttpServletResponse response) throws Exception {
+        UserTransaction ut = null;
+        final Connection con = ds.getConnection();
+        // Do the lookups on the DS
+        final InitialContext ctx = new InitialContext();
+        System.out.println("testRec001: Context is: " + ctx.toString());
+
+        try {
+            // Preliminary work to create the DUMMY table, if necessary and to
+            // set the row to its initial state.
+            setupDatabaseTable(con);
+
+            // Look up the User Transaction
+            ut = (UserTransaction) ctx.lookup("java:comp/UserTransaction");
+            System.out.println("testRec001: Have looked up UT: " + ut);
+
+            // Start a new transaction
+            ut.begin();
+            System.out.println("testRec001: Start Transaction");
+
+            Statement stmt = con.createStatement();
+            String selForUpdateString = "SELECT ADDR" +
+                                        " FROM DUMMY" +
+                                        " WHERE NUM=1 FOR UPDATE OF ADDR";
+            ResultSet rs = stmt.executeQuery(selForUpdateString);
+            while (rs.next()) {
+                String owner = rs.getString("ADDR");
+                System.out.println("testTableAccess: addr is - " + owner);
+            }
+            rs.close();
+
+            String updateString = "UPDATE DUMMY" +
+                                  " SET ADDR = 'avenue'" +
+                                  " WHERE NUM=1";
+            stmt.executeUpdate(updateString);
+
+            final Object res = uowm.runUnderUOW(UOWSynchronizationRegistry.UOW_TYPE_GLOBAL_TRANSACTION, true, new ExtendedUOWAction() {
+                @Override
+                public Object run() throws Exception {
+                    final ExtendedTransactionManager tm = TransactionManagerFactory
+                                    .getTransactionManager();
+
+                    final Serializable xaResInfo1 = XAResourceInfoFactory
+                                    .getXAResourceInfo(0);
+                    final Serializable xaResInfo2 = XAResourceInfoFactory
+                                    .getXAResourceInfo(1);
+                    final Serializable xaResInfo3 = XAResourceInfoFactory
+                                    .getXAResourceInfo(2);
+
+                    final XAResource xaRes1 = XAResourceFactoryImpl.instance()
+                                    .getXAResourceImpl(xaResInfo1)
+                                    .setCommitAction(XAResourceImpl.DIE);
+                    final int recoveryId1 = tm.registerResourceInfo(filter, xaResInfo1);
+                    tm.enlist(xaRes1, recoveryId1);
+
+                    final XAResource xaRes2 = XAResourceFactoryImpl.instance()
+                                    .getXAResourceImpl(xaResInfo2);
+                    final int recoveryId2 = tm.registerResourceInfo(filter, xaResInfo2);
+                    tm.enlist(xaRes2, recoveryId2);
+
+                    final XAResource xaRes3 = XAResourceFactoryImpl.instance()
+                                    .getXAResourceImpl(xaResInfo3);
+                    final int recoveryId3 = tm.registerResourceInfo(filter, xaResInfo3);
+                    tm.enlist(xaRes3, recoveryId3);
+                    return Boolean.TRUE;
+                }
+            }, new Class[] { InstantiationException.class }, new Class[] { IllegalStateException.class });
+
+            if (!(Boolean) res) {
+                throw new Exception("Didn't get expected value back from runUnderUOW");
+            }
+
+            if (ut != null) {
+
+                System.out.println("NYTRACE: Drive COMMIT processing");
+                ut.commit();
+
+            }
+        } catch (SQLException x) {
+            System.out.println("testLeaseTableAccess: caught exception - " + x);
+        } catch (Exception e) {
+            System.out.println("NYTRACE: SetupRecCore caught exc: " + e);
+            e.printStackTrace();
+        }
+    }
+
+    private void setupDatabaseTable(Connection connection) throws SQLException {
+        try {
+            // Drop the table
+            System.out.println("testRec001: Drop DUMMY table");
+            Statement dStmt = connection.createStatement();
+            dStmt.executeUpdate("DROP TABLE DUMMY");
+        } catch (Exception ex) {
+            // swallow this exception, supposition is that table simply does not exist
+            System.out.println("testRec001: Caught exception - " + ex);
+        }
+
+        System.out.println("testRec001: create a table");
+        Statement cStmt = connection.createStatement();
+
+        cStmt.executeUpdate("CREATE TABLE DUMMY( " +
+                            "NUM SMALLINT, " +
+                            "ADDR VARCHAR(30)) ");
+        System.out.println("Have created the table - insert row");
+        Statement iStmt = connection.createStatement();
+        String insertString = "INSERT INTO DUMMY " +
+                              "VALUES (1, 'Lane')";
+
+        iStmt.executeUpdate(insertString);
+        iStmt.close();
+        connection.commit();
+    }
+}

--- a/dev/com.ibm.ws.transaction/bnd.bnd
+++ b/dev/com.ibm.ws.transaction/bnd.bnd
@@ -35,6 +35,11 @@ Service-Component: com.ibm.ws.transaction; \
       uOWEventListener=com.ibm.wsspi.tx.UOWEventListener ;\
       optional:='uOWEventListener' ;\
       dynamic:='uOWEventListener', \
+   TMRecoveryService; \
+      implementation:=com.ibm.ws.transaction.services.TMRecoveryService; \
+      provide:='com.ibm.ws.transaction.services.TMRecoveryService'; \
+      immediate:=true; \
+      transactionManager=com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager, \
    LocalTransactionCurrent; \
       implementation:=com.ibm.ws.transaction.services.LocalTransactionCurrentService; \
       provide:='com.ibm.ws.LocalTransaction.LocalTransactionCurrent'; \

--- a/dev/com.ibm.ws.transaction/src/com/ibm/ws/transaction/services/JTMConfigurationProvider.java
+++ b/dev/com.ibm.ws.transaction/src/com/ibm/ws/transaction/services/JTMConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2013 IBM Corporation and others.
+ * Copyright (c) 2009, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,6 @@ import com.ibm.tx.jta.config.DefaultConfigurationProvider;
 import com.ibm.tx.jta.embeddable.TransactionSettingsProvider;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.location.WsResource;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
@@ -56,26 +55,12 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
      * stored in an RDBMS.
      */
     private static boolean _isSQLRecoveryLog = false;
-    private ResourceFactory theDataSourceFactory = null;
+    private ResourceFactory _theDataSourceFactory = null;
+
     private String _recoveryIdentity = null;
     private String _recoveryGroup = null;
     private TransactionManagerService tmsRef = null;
     private byte[] _applId;
-
-    /*
-     * static {
-     * try {
-     * java.io.InputStream is =
-     * JTMConfigurationProvider.class.getClassLoader().getResourceAsStream(
-     * DEFAULT_PROPERTIES_FILE);
-     * if (is != null) _props.load(is);
-     * else throw new NullPointerException("unable to find properties file: "
-     * + DEFAULT_PROPERTIES_FILE);
-     * } catch (IOException e) {
-     * e.printStackTrace();
-     * }
-     * }
-     */
 
     public JTMConfigurationProvider() {}
 
@@ -93,50 +78,37 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
 
         // There is additional work to do if we are storing transaction log in an RDBMS. The key
         // determinant that we are using an RDBMS is the specification of the dataSourceRef
-        // attribute of the transaction stanza in the server.xml. So start by checking this 
+        // attribute of the transaction stanza in the server.xml. So start by checking this
         // attribute. If it is present, set the _isSQLRecoveryLog flag and set the logDir
         // to "custom" <- this will allow compatibility with tWAS code.
         //
         // Drive the getTransactionLogDirectory() method if we're working against the filesys.
         checkDataSourceRef();
 
-        if (_isSQLRecoveryLog)
-        {
+        if (_isSQLRecoveryLog) {
             if (tc.isDebugEnabled())
                 Tr.debug(tc, "activate  working with Tran Log in an RDBMS");
-            ServiceReference<ResourceFactory> serviceRef = dataSourceFactoryRef.getReference();
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "activate  datasourceFactory ref " + dataSourceFactoryRef +
-                             ", underlying reference: " + serviceRef);
-            dataSourceFactoryRef.activate(_cc);
 
-            if (serviceRef != null)
-            {
-                // RTC 175005 - add additional check to ensure that the underlying Data Source Factory
-                // is available. This defect revealed that it is possible for the serviceRef to be non-null
-                // while the factory has yet to be resolved.
-                theDataSourceFactory = getDataSourceFactory();
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "retrieved datasourceFactory " + theDataSourceFactory);
-                if (theDataSourceFactory != null)
-                {
-                    // The DataSource is available, which means that we are able to drive recovery
-                    // processing. This is driven through the reference to the TransactionManagerService,
-                    // assuming that it is available
-                    if (tmsRef != null)
-                        tmsRef.doStartup(this, theDataSourceFactory, _isSQLRecoveryLog);
-                }
+            ServiceReference<ResourceFactory> serviceRef = dataSourceFactoryRef.getReference();
+
+            //  If we already have a dataSourceFactory then we can startup (and drive recovery) now.
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "retrieved datasourceFactory service ref " + serviceRef);
+            if (serviceRef != null) {
+                // The DataSource is available, which means that we are able to drive recovery
+                // processing. This is driven through the reference to the TransactionManagerService,
+                // assuming that it is available
+                if (tmsRef != null)
+                    tmsRef.doStartup(this, _isSQLRecoveryLog);
             }
-        }
-        else
-        {
+        } else {
             getTransactionLogDirectory();
             if (tmsRef != null)
-                tmsRef.doStartup(this, theDataSourceFactory, _isSQLRecoveryLog);
+                tmsRef.doStartup(this, _isSQLRecoveryLog);
         }
 
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "activate  retrieved datasourceFactory is " + theDataSourceFactory);
+            Tr.debug(tc, "activate  retrieved datasourceFactory is " + _theDataSourceFactory);
 
     }
 
@@ -182,18 +154,18 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
     protected void setDataSourceFactory(ServiceReference<ResourceFactory> ref) {
 
         dataSourceFactoryRef.setReference(ref);
+        if (tc.isEntryEnabled())
+            Tr.debug(tc, "setDataSourceFactory, service ref " + ref + ", activate the dataSourceFactoryRef");
+        dataSourceFactoryRef.activate(_cc);
 
         // If the JTMConfigurationProvider has been activated, we can proceed to set
         // the DataSourceFactory and initiate recovery
-        if (_cc != null)
-        {
-            theDataSourceFactory = dataSourceFactoryRef.getServiceWithException();
+        if (_cc != null) {
             if (tc.isDebugEnabled())
-                Tr.debug(tc, "setDataSourceFactory to " + theDataSourceFactory);
-            // The DataSource is available, which means that we are able to drive recovery
-            // processing. This is driven through the reference to the TransactionManagerService.
+                Tr.debug(tc, "setDataSourceFactory and activate have been called, initiate recovery");
+
             if (tmsRef != null)
-                tmsRef.doStartup(this, theDataSourceFactory, _isSQLRecoveryLog);
+                tmsRef.doStartup(this, _isSQLRecoveryLog);
         }
     }
 
@@ -260,9 +232,9 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.tx.jta.config.DefaultConfigurationProvider#getTraceLevel()
-     * 
+     *
      * Use Tr configuration for 'transaction' group.
      */
     @Override
@@ -282,8 +254,7 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
     }
 
     @Override
-    public String getServerName()
-    {
+    public String getServerName() {
         String serverName = "";
         synchronized (this) {
             if (locationService != null)
@@ -355,16 +326,18 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
     }
 
     @Override
-    public ResourceFactory getResourceFactory()
-    {
+    public ResourceFactory getResourceFactory() {
+
+        _theDataSourceFactory = dataSourceFactoryRef.getService();
+
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "getResourceFactory " + theDataSourceFactory);
-        return theDataSourceFactory;
+            Tr.debug(tc, "getResourceFactory has factory " + _theDataSourceFactory);
+
+        return _theDataSourceFactory;
     }
 
     @Override
-    public RuntimeMetaDataProvider getRuntimeMetaDataProvider()
-    {
+    public RuntimeMetaDataProvider getRuntimeMetaDataProvider() {
         return _runtimeMetaDataProvider;
     }
 
@@ -386,70 +359,49 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
         return _recoveryGroup;
     }
 
-    public void setTMS(TransactionManagerService tms)
-    {
+    public void setTMS(TransactionManagerService tms) {
         if (tc.isDebugEnabled())
             Tr.debug(tc, "setTMS " + tms);
         tmsRef = tms;
-        if (!_isSQLRecoveryLog)
-        {
-            if (_cc != null)
-            {
-                tmsRef.doStartup(this, theDataSourceFactory, _isSQLRecoveryLog);
+        if (!_isSQLRecoveryLog) {
+            if (_cc != null) {
+                tmsRef.doStartup(this, _isSQLRecoveryLog);
             }
-        }
-        else
-        {
+        } else {
             // If the JTMConfigurationProvider has been activated, and if the DataSourceFactory
             // has been provided, we can initiate recovery
             ServiceReference<ResourceFactory> serviceRef = dataSourceFactoryRef.getReference();
-            if (_cc != null && serviceRef != null)
-            {
-                // RTC 175005 - add additional check to ensure that the underlying Data Source Factory
-                // is available. This defect revealed that it is possible for the serviceRef to be non-null
-                // while the factory has yet to be resolved.
-                theDataSourceFactory = getDataSourceFactory();
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "retrieved datasourceFactory " + theDataSourceFactory);
-                if (theDataSourceFactory != null)
-                {
-                    tmsRef.doStartup(this, theDataSourceFactory, _isSQLRecoveryLog);
-                }
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "retrieved datasourceFactory service ref " + serviceRef);
+            if (_cc != null && serviceRef != null) {
+                tmsRef.doStartup(this, _isSQLRecoveryLog);
             }
         }
+
     }
 
     /**
      * Is the Transaction Log hosted in a database?
-     * 
+     *
      * @return true if it is
      */
-    public boolean isSQLRecoveryLog()
-    {
+    @Override
+    public boolean isSQLRecoveryLog() {
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "isSQLRecoveryLog " + _isSQLRecoveryLog);
         return _isSQLRecoveryLog;
     }
 
-    /**
-     * Retrieve the DataSourceFactory reference if it is available, return null otherwise.
-     * 
-     * @return
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.ibm.tx.config.ConfigurationProvider#needToCoordinateServices()
      */
-    @FFDCIgnore({ IllegalStateException.class })
-    private ResourceFactory getDataSourceFactory()
-    {
-        ResourceFactory dataSourceFactory = null;
-        try
-        {
-            if (dataSourceFactoryRef != null)
-                dataSourceFactory = dataSourceFactoryRef.getServiceWithException();
-        } catch (IllegalStateException iex)
-        {
-            // RTC 175513. Tolerate an IllegalStateException at this point but trace it. Allow the calling method method to
-            // continue with a null DataSourceFactory.
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "Caught IllegalStateException, could not get the service, " + iex);
-        }
-        return dataSourceFactory;
+    @Override
+    public boolean needToCoordinateServices() {
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "needToCoordinateServices");
+        return true;
     }
 
     /**
@@ -458,14 +410,11 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
     private void checkDataSourceRef() {
 
         Object configuredDSR = _props.get("dataSourceRef");
-        if (configuredDSR == null)
-        {
+        if (configuredDSR == null) {
             if (tc.isDebugEnabled())
                 Tr.debug(tc, "dataSourceRef is not specified, log to filesys");
             _isSQLRecoveryLog = false;
-        }
-        else
-        {
+        } else {
             if (tc.isDebugEnabled())
                 Tr.debug(tc, "dataSourceRef is specified, log to RDBMS");
             // We'll set the logDir to maintain tWAS code compatibility. First we need to
@@ -475,13 +424,11 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
             if (tc.isDebugEnabled())
                 Tr.debug(tc, "suffixStr is " + suffixStr + ", of length " + suffixStr.length());
 
-            if (suffixStr != null && !suffixStr.trim().isEmpty())
-            {
+            if (suffixStr != null && !suffixStr.trim().isEmpty()) {
                 suffixStr = suffixStr.trim();
                 logDir = "custom://com.ibm.rls.jdbc.SQLRecoveryLogFactory?datasource=Liberty" +
                          ",tablesuffix=" + suffixStr;
-            }
-            else
+            } else
                 logDir = "custom://com.ibm.rls.jdbc.SQLRecoveryLogFactory?datasource=Liberty";
 
             if (tc.isDebugEnabled())
@@ -492,7 +439,7 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
 
     /**
      * This method should only be used where logging to a file system.
-     * 
+     *
      * @return the full path of the log directory
      */
     private String parseTransactionLogDirectory() {
@@ -553,8 +500,7 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
     }
 
     @Override
-    public void setApplId(byte[] name)
-    {
+    public void setApplId(byte[] name) {
         if (tc.isDebugEnabled())
             Tr.debug(tc, "setApplId - " + Arrays.toString(name));
         // Store the applId.
@@ -562,8 +508,7 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
     }
 
     @Override
-    public byte[] getApplId()
-    {
+    public byte[] getApplId() {
         // Determine the applId.
         final byte[] result = _applId;
 
@@ -576,8 +521,7 @@ public class JTMConfigurationProvider extends DefaultConfigurationProvider imple
     public void shutDownFramework() {
         if (tc.isDebugEnabled())
             Tr.debug(tc, "JTMConfigurationProvider shutDownFramework has been called");
-        if (tmsRef != null)
-        {
+        if (tmsRef != null) {
             tmsRef.shutDownFramework();
         }
     }

--- a/dev/com.ibm.ws.transaction/src/com/ibm/ws/transaction/services/TMRecoveryService.java
+++ b/dev/com.ibm.ws.transaction/src/com/ibm/ws/transaction/services/TMRecoveryService.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.transaction.services;
+
+import org.osgi.framework.BundleContext;
+
+import com.ibm.tx.config.ConfigurationProvider;
+import com.ibm.tx.config.ConfigurationProviderManager;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
+
+/**
+ * The TMRecoveryService class was introduced under issue #5119 to support a new Declarative Service
+ * to break a potential circular reference between the TransactionManagerService and jdbc's DataSourceService
+ * which are mutually dependent.
+ *
+ * The TMRecoveryService requires that the TransactionManagerService is available (as does the DataSourceService).
+ * Once it is available, Transaction Recovery can proceed as the DataSourceService can, if necessary be activated.
+ * Previously, intermittently, DS would attempt to activate the DataSourceService in the context of TransactionManagerService
+ * activation. That would fail with a DS Circular Reference error.
+ */
+public class TMRecoveryService {
+
+    private static final TraceComponent tc = Tr.register(TMRecoveryService.class);
+
+    protected void activate(BundleContext ctxt) {
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "activate  context " + ctxt);
+        final ConfigurationProvider cp = ConfigurationProviderManager.getConfigurationProvider();
+
+        //This needs tidying a little.
+        if (cp != null) {
+            if (cp instanceof JTMConfigurationProvider) {
+                JTMConfigurationProvider jtmCP = (JTMConfigurationProvider) cp;
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "its a jtmconfigurationprovider ");
+
+                // Set a reference to this TMRecoveryService into the JTMConfigurationProvider.
+                // If other resources are in place this method will also start recovery by calling
+                // doStart()
+                jtmCP.setTMRecoveryService(this);
+
+            }
+        }
+    }
+
+    /**
+     * Called by DS to reference the Transaction Manager Service
+     *
+     * @param tm
+     */
+    public void setTransactionManager(EmbeddableWebSphereTransactionManager tm) {
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "setTransactionManagerService " + tm);
+    }
+
+    /**
+     * Called by DS to dereference the Transaction Manager Service
+     *
+     * @param tm
+     */
+    protected void unsetTransactionManager(EmbeddableWebSphereTransactionManager tm) {
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "unsetTransactionManagerService, tms " + tm);
+    }
+}

--- a/dev/com.ibm.ws.transaction/src/com/ibm/ws/transaction/services/TransactionManagerService.java
+++ b/dev/com.ibm.ws.transaction/src/com/ibm/ws/transaction/services/TransactionManagerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2013 IBM Corporation and others.
+ * Copyright (c) 2010, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,16 +44,16 @@ import com.ibm.tx.util.TMHelper;
 import com.ibm.tx.util.TMService;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.Transaction.JTA.Util;
 import com.ibm.ws.Transaction.UOWCallback;
 import com.ibm.ws.Transaction.UOWCoordinator;
 import com.ibm.ws.Transaction.UOWCurrent;
-import com.ibm.ws.Transaction.JTA.Util;
 import com.ibm.ws.Transaction.test.XAFlowCallbackControl;
 import com.ibm.ws.ffdc.FFDCFilter;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
 import com.ibm.ws.uow.UOWScopeCallback;
 import com.ibm.wsspi.kernel.service.location.WsLocationConstants;
-import com.ibm.wsspi.resource.ResourceFactory;
 import com.ibm.wsspi.tx.UOWEventListener;
 
 public class TransactionManagerService implements ExtendedTransactionManager, TransactionManager, EmbeddableWebSphereTransactionManager, UOWCurrent {
@@ -106,9 +106,9 @@ public class TransactionManagerService implements ExtendedTransactionManager, Tr
      *
      * @param cp
      */
-    public void doStartup(ConfigurationProvider cp, ResourceFactory dataSourceFactory, boolean isSQLRecoveryLog) {
+    public void doStartup(ConfigurationProvider cp, boolean isSQLRecoveryLog) {
         if (tc.isDebugEnabled())
-            Tr.debug(tc, "doStartup with cp: " + cp + "and factory: " + dataSourceFactory + " and flag: " + isSQLRecoveryLog);
+            Tr.debug(tc, "doStartup with cp: " + cp + " and flag: " + isSQLRecoveryLog);
 
         // Create an AppId that will be unique for this server to be used in the generation of Xids.
 
@@ -452,6 +452,7 @@ public class TransactionManagerService implements ExtendedTransactionManager, Tr
         ((EmbeddableTranManagerSet) etm()).registerLTCCallback(arg0);
     }
 
+    @FFDCIgnore({ org.osgi.framework.BundleException.class })
     public void shutDownFramework() {
 //        Tr.audit(tc, "TransactionManagerService.shutDownFramework");
         try {
@@ -461,6 +462,9 @@ public class TransactionManagerService implements ExtendedTransactionManager, Tr
                 if (bundle != null)
                     bundle.stop();
             }
+        } catch (org.osgi.framework.BundleException e) {
+            // do not FFDC this.
+            // exceptions during bundle stop occur if framework is already stopping or stopped
         } catch (Exception e) {
             // do not FFDC this.
             // exceptions during bundle stop occur if framework is already stopping or stopped

--- a/dev/com.ibm.ws.transaction/test/com/ibm/ws/transaction/LocalTranTest.java
+++ b/dev/com.ibm.ws.transaction/test/com/ibm/ws/transaction/LocalTranTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.tx.embeddable/bnd.bnd
+++ b/dev/com.ibm.ws.tx.embeddable/bnd.bnd
@@ -34,11 +34,18 @@ Export-Package: \
 
 WS-TraceGroup: Transaction
 
+Bundle-Activator: com.ibm.tx.jta.embeddable.impl.EmbeddableTxBundleTools
+
 Service-Component: \
   TMService; \
     implementation:=com.ibm.tx.jta.embeddable.impl.EmbeddableTMHelper; \
     provide:='com.ibm.tx.util.TMService,com.ibm.ws.uow.UOWScopeCallbackAgent'; \
-    configurationProvider//shutdown=com.ibm.tx.config.ConfigurationProvider
+    xaResourceFactory=com.ibm.tx.jta.XAResourceFactory; \
+    recoveryLogService=com.ibm.ws.recoverylog.spi.RecLogServiceImpl; \
+    recoveryLogFactory=com.ibm.ws.recoverylog.spi.RecoveryLogFactory; \
+    optional:='xaResourceFactory,RecoveryLogFactory';\
+    dynamic:='xaResourceFactory,RecoveryLogFactory';\
+    configurationProvider//shutdown=com.ibm.tx.config.ConfigurationProvider  
 
 instrument.disabled: true
 
@@ -48,6 +55,7 @@ instrument.disabled: true
 	com.ibm.tx.util;version=latest,\
 	com.ibm.ws.resource;version=latest,\
 	com.ibm.ws.logging.core,\
+	com.ibm.ws.kernel.service,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.ws.recoverylog;version=latest,\
 	com.ibm.websphere.org.osgi.core,\

--- a/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/config/EmbeddableConfigurationProviderImpl.java
+++ b/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/config/EmbeddableConfigurationProviderImpl.java
@@ -1,7 +1,7 @@
 package com.ibm.tx.jta.embeddable.config;
 
 /*******************************************************************************
- * Copyright (c) 2010, 2013 IBM Corporation and others.
+ * Copyright (c) 2010, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,10 +20,9 @@ import com.ibm.tx.config.ConfigurationProvider;
 import com.ibm.tx.config.RuntimeMetaDataProvider;
 import com.ibm.tx.jta.util.alarm.AlarmManagerImpl;
 import com.ibm.tx.util.alarm.AlarmManager;
-import com.ibm.ws.resource.ResourceFactory;
+import com.ibm.wsspi.resource.ResourceFactory;
 
-public class EmbeddableConfigurationProviderImpl implements ConfigurationProvider
-{
+public class EmbeddableConfigurationProviderImpl implements ConfigurationProvider {
     private static final TraceComponent tc = Tr.register(EmbeddableConfigurationProviderImpl.class, TranConstants.TRACE_GROUP, TranConstants.NLS_FILE);
 
     // these are copied and duplicated from RegisteredResources!
@@ -70,8 +69,7 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
 
     private final RuntimeMetaDataProvider _runtimeMetaDataProvider = new EmbeddableRuntimeMetaDataProviderImpl(this);
 
-    public EmbeddableConfigurationProviderImpl(Map<String, Object> properties)
-    {
+    public EmbeddableConfigurationProviderImpl(Map<String, Object> properties) {
         final boolean traceOn = TraceComponent.isAnyTracingEnabled();
 
         _acceptHeuristicHazard = Boolean.valueOf((String) properties.get(ACCEPT_HEURISTIC_HAZARD));
@@ -92,16 +90,11 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
 
         _heuristicCompletionDirectionString = (String) properties.get(LPS_HEURISTIC_COMPLETION);
 
-        if ("COMMIT".equalsIgnoreCase(_heuristicCompletionDirectionString))
-        {
+        if ("COMMIT".equalsIgnoreCase(_heuristicCompletionDirectionString)) {
             _heuristicCompletionDirection = HEURISTIC_COMPLETION_DIRECTION_COMMIT;
-        }
-        else if ("MANUAL".equalsIgnoreCase(_heuristicCompletionDirectionString))
-        {
+        } else if ("MANUAL".equalsIgnoreCase(_heuristicCompletionDirectionString)) {
             _heuristicCompletionDirection = HEURISTIC_COMPLETION_DIRECTION_MANUAL;
-        }
-        else
-        {
+        } else {
             _heuristicCompletionDirectionString = "ROLLBACK";
             if (traceOn && tc.isDebugEnabled())
                 Tr.debug(tc, LPS_HEURISTIC_COMPLETION + " = ROLLBACK");
@@ -140,8 +133,7 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
             Tr.debug(tc, MAXIMUM_TRANSACTION_TIMEOUT + " = " + _maximumTransactionTimeout);
 
         _tranLogDirectory = (String) properties.get(TRAN_LOG_DIRECTORY);
-        if (null == _tranLogDirectory || _tranLogDirectory.isEmpty())
-        {
+        if (null == _tranLogDirectory || _tranLogDirectory.isEmpty()) {
             _tranLogDirectory = System.getProperty("user.dir");
         }
         if (traceOn && tc.isDebugEnabled())
@@ -156,16 +148,11 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
             Tr.debug(tc, PROPAGATE_XARESOURCE_TIMEOUT + " = " + _propagateXAResourceTransactionTimeout);
 
         _wsatPrepareOrderString = (String) properties.get(WSAT_PREPARE_ORDER);
-        if ("before".equalsIgnoreCase(_wsatPrepareOrderString))
-        {
+        if ("before".equalsIgnoreCase(_wsatPrepareOrderString)) {
             _wsatPrepareOrder = WSAT_PREPARE_ORDER_BEFORE;
-        }
-        else if ("after".equalsIgnoreCase(_wsatPrepareOrderString))
-        {
+        } else if ("after".equalsIgnoreCase(_wsatPrepareOrderString)) {
             _wsatPrepareOrder = WSAT_PREPARE_ORDER_AFTER;
-        }
-        else
-        {
+        } else {
             _wsatPrepareOrder = WSAT_PREPARE_ORDER_CONCURRENT;
         }
         if (traceOn && tc.isDebugEnabled())
@@ -173,163 +160,142 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
     }
 
     @Override
-    public AlarmManager getAlarmManager()
-    {
+    public AlarmManager getAlarmManager() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getAlarmManager", _alarmManager);
         return _alarmManager;
     }
 
     @Override
-    public int getClientInactivityTimeout()
-    {
+    public int getClientInactivityTimeout() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getClientInactivityTimeout", _clientInactivityTimeout);
         return _clientInactivityTimeout;
     }
 
     @Override
-    public int getHeuristicCompletionDirection()
-    {
+    public int getHeuristicCompletionDirection() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getHeuristicCompletionDirection", _heuristicCompletionDirection);
         return _heuristicCompletionDirection;
     }
 
     @Override
-    public String getHeuristicCompletionDirectionAsString()
-    {
+    public String getHeuristicCompletionDirectionAsString() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getHeuristicCompletionDirectionAsString", _heuristicCompletionDirectionString);
         return _heuristicCompletionDirectionString;
     }
 
     @Override
-    public int getHeuristicRetryInterval()
-    {
+    public int getHeuristicRetryInterval() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getHeuristicRetryInterval", _heuristicRetryInterval);
         return _heuristicRetryInterval;
     }
 
     @Override
-    public int getHeuristicRetryLimit()
-    {
+    public int getHeuristicRetryLimit() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getHeuristicRetryLimit", _heuristicRetryLimit);
         return _heuristicRetryLimit;
     }
 
     @Override
-    public int getMaximumTransactionTimeout()
-    {
+    public int getMaximumTransactionTimeout() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getMaximumTransactionTimeout", _maximumTransactionTimeout);
         return _maximumTransactionTimeout;
     }
 
     @Override
-    public RuntimeMetaDataProvider getRuntimeMetaDataProvider()
-    {
+    public RuntimeMetaDataProvider getRuntimeMetaDataProvider() {
         return _runtimeMetaDataProvider;
     }
 
     @Override
-    public int getTotalTransactionLifetimeTimeout()
-    {
+    public int getTotalTransactionLifetimeTimeout() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getTotalTransactionLifetimeTimeout", _totalTranLifetimeTimeout);
         return _totalTranLifetimeTimeout;
     }
 
     @Override
-    public String getTransactionLogDirectory()
-    {
+    public String getTransactionLogDirectory() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getTransactionLogDirectory", _tranLogDirectory);
         return _tranLogDirectory;
     }
 
     @Override
-    public int getTransactionLogSize()
-    {
+    public int getTransactionLogSize() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getTransactionLogSize", _tranLogSize);
         return _tranLogSize;
     }
 
     @Override
-    public boolean isRecoverOnStartup()
-    {
+    public boolean isRecoverOnStartup() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "isRecoverOnStartup", _recoverOnStartup);
         return _recoverOnStartup;
     }
 
     @Override
-    public boolean isWaitForRecovery()
-    {
+    public boolean isWaitForRecovery() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "isWaitForRecovery", _waitForRecovery);
         return _waitForRecovery;
     }
 
     @Override
-    public boolean isAcceptHeuristicHazard()
-    {
+    public boolean isAcceptHeuristicHazard() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "isAcceptHeuristicHazard", _acceptHeuristicHazard);
         return _acceptHeuristicHazard;
     }
 
     @Override
-    public boolean isLoggingForHeuristicReportingEnabled()
-    {
+    public boolean isLoggingForHeuristicReportingEnabled() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "isLoggingForHeuristicReportingEnabled", _enableLoggingForHeuristicReporting);
         return _enableLoggingForHeuristicReporting;
     }
 
-    public static void setMaximumTransactionTimeout(int maximumTimeout)
-    {
+    public static void setMaximumTransactionTimeout(int maximumTimeout) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "setMaximumTransactionTimeout", maximumTimeout);
         _maximumTransactionTimeout = maximumTimeout;
     }
 
-    public static void setClientInactivityTimeout(int timeout)
-    {
+    public static void setClientInactivityTimeout(int timeout) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "setClientInactivityTimeout", timeout);
         _clientInactivityTimeout = timeout;
     }
 
-    public static void setTotalTransactionLifetimeTimeout(int timeout)
-    {
+    public static void setTotalTransactionLifetimeTimeout(int timeout) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "setTotalTransactionLifetimeTimeout", timeout);
         _totalTranLifetimeTimeout = timeout;
     }
 
     @Override
-    public Level getTraceLevel()
-    {
+    public Level getTraceLevel() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getTraceLevel", Level.OFF);
         return Level.OFF;
     }
 
     @Override
-    public int getDefaultMaximumShutdownDelay()
-    {
+    public int getDefaultMaximumShutdownDelay() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "getDefaultMaximumShutdownDelay", 0);
         return 0;
     }
 
     @Override
-    public boolean getAuditRecovery()
-    {
+    public boolean getAuditRecovery() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "auditRecovery", _auditRecovery);
         return _auditRecovery;
@@ -340,20 +306,18 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
      * we'll return null.
      */
     @Override
-    public ResourceFactory getResourceFactory()
-    {
+    public ResourceFactory getResourceFactory() {
         return null;
     }
 
     @Override
-    public boolean getPropagateXAResourceTransactionTimeout()
-    {
+    public boolean getPropagateXAResourceTransactionTimeout() {
         return _propagateXAResourceTransactionTimeout;
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.tx.config.ConfigurationProvider#getRecoveryIdentity()
      */
     @Override
@@ -364,7 +328,7 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.tx.config.ConfigurationProvider#getRecoveryGroup()
      */
     @Override
@@ -375,7 +339,7 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.tx.config.ConfigurationProvider#getServerName()
      */
     @Override
@@ -385,7 +349,7 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.tx.config.ConfigurationProvider#setApplId(byte[])
      */
     @Override
@@ -395,7 +359,7 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.tx.config.ConfigurationProvider#getApplId()
      */
     @Override
@@ -405,13 +369,34 @@ public class EmbeddableConfigurationProviderImpl implements ConfigurationProvide
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.tx.config.ConfigurationProvider#shutDownFramework()
      */
     @Override
     public void shutDownFramework() {
         // TODO Auto-generated method stub
 
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.ibm.tx.config.ConfigurationProvider#isSQLRecoveryLog()
+     */
+    @Override
+    public boolean isSQLRecoveryLog() {
+        return false;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.ibm.tx.config.ConfigurationProvider#needToCoordinateServices()
+     */
+    @Override
+    public boolean needToCoordinateServices() {
+        // TODO Auto-generated method stub
+        return false;
     }
 
 }

--- a/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTMHelper.java
+++ b/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTMHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,11 @@
  *******************************************************************************/
 package com.ibm.tx.jta.embeddable.impl;
 
+import org.osgi.framework.BundleContext;
+
 import com.ibm.tx.TranConstants;
 import com.ibm.tx.jta.impl.TxRecoveryAgentImpl;
+import com.ibm.tx.jta.util.TxBundleTools;
 import com.ibm.tx.jta.util.TxTMHelper;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -34,4 +37,23 @@ public class EmbeddableTMHelper extends TxTMHelper {
         return txAgent;
     }
 
+    /**
+     * This method retrieves bundle context from the the ws.tx.embeddable bundle so that if that
+     * bundle has started before the tx.jta bundle, then we are still able to access the Service Registry.
+     *
+     * @return
+     */
+    @Override
+    protected void retrieveBundleContext() {
+
+        BundleContext bc = TxBundleTools.getBundleContext();
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "retrieveBundleContext from TxBundleTools, bc " + bc);
+        if (bc == null) {
+            bc = EmbeddableTxBundleTools.getBundleContext();
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "retrieveBundleContext from EmbeddableTxBundleTools, bc " + bc);
+        }
+        _bc = bc;
+    }
 }

--- a/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTxBundleTools.java
+++ b/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTxBundleTools.java
@@ -1,0 +1,49 @@
+package com.ibm.tx.jta.embeddable.impl;
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+import com.ibm.tx.TranConstants;
+import com.ibm.tx.util.logging.Tr;
+import com.ibm.tx.util.logging.TraceComponent;
+
+/**
+ * This class provides the implementation of an OSGi Bundle Activator. It allows the transactions bundle
+ * to gain access to the BundleContext when the OSGi framework starts.
+ *
+ */
+public class EmbeddableTxBundleTools implements BundleActivator {
+    private static final TraceComponent tc = Tr.register(EmbeddableTxBundleTools.class, TranConstants.TRACE_GROUP, TranConstants.NLS_FILE);
+
+    static BundleContext _bc;
+
+    @Override
+    public void start(BundleContext bundleContext) throws Exception {
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "start", bundleContext);
+        _bc = bundleContext;
+    }
+
+    @Override
+    public void stop(BundleContext bundleContext) throws Exception {
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "stop", bundleContext);
+        _bc = null;
+    }
+
+    public static BundleContext getBundleContext() {
+        if (tc.isDebugEnabled())
+            Tr.debug(tc, "getBundleContext", _bc);
+        return _bc;
+    }
+}

--- a/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/WSATRecoveryCoordinator.java
+++ b/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/WSATRecoveryCoordinator.java
@@ -1,7 +1,7 @@
 package com.ibm.tx.jta.embeddable.impl;
 
 /*******************************************************************************
- * Copyright (c) 2004, 2008 IBM Corporation and others.
+ * Copyright (c) 2004, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -160,7 +160,7 @@ public final class WSATRecoveryCoordinator implements RecoveryCoordinator, Seria
         if (tc.isEntryEnabled())
             Tr.entry(tc, "lookupRecoveryCoordinatorFactory", filter);
 
-        final BundleContext bundleContext = TxBundleTools.getBundleContext();
+        final BundleContext bundleContext = EmbeddableTxBundleTools.getBundleContext();
 
         if (bundleContext == null)
         {


### PR DESCRIPTION
fixes #5119 

The Changes under this PR include:

1/ *KEY CHANGE*  The TMRecoveryService class was introduced to support a new Declarative Service to break a potential circular reference between the TransactionManagerService and jdbc's DataSourceService  which are mutually dependent.
 
The mutual dependency arises in the situation where the Transaction service is logging to an RDBMS. The DataSourceService (actually related Connection Manager Services) require a Transaction Manager, the Transaction Manager requires a DataSourceService through which to write its logs.

The new TMRecoveryService requires that the TransactionManagerService is available (as does the DataSourceService). Once it is available, Transaction Recovery can proceed as the DataSourceService can, if necessary be activated. Previously, intermittently, DS would attempt to activate the DataSourceService in the context of TransactionManagerService activation. That would fail with a DS Circular Reference error.

2/ Some classes have merely been reformatted. They were changed during the course of investigative work but the change to standard OL Java formatting is retained. The classes are,
SQLNonTransactionalDataSource.java, CustomLogProperties.java, FileSharedServerLeaseLog.java, RecoveryAgent.java, RecoveryLogManager.java, RecoveryLogManagerImpl.java, LocalTranTest.java, com.ibm.rls.jdbc.bnd

3/ There is a requirement to lookup the DS Services Registry during recovery (see XARecoveryDataHelper.lookupXAResourceFactory()). Any bundle context will do for the lookup so allow getBundleContext() method in TxTMHelper to be overridden in the EmbeddedTMHelper class in the ws.tx.embeddable bundle so that if that bundle has started before the tx.jta bundle then Services can be found. In testing, I found that sometimes the tx.jta bundle had not started wheras the ws.tx.embeddable bundle had started.

4/ Make TxTMHelper (and the ws.tx.embeddable bnd.bnd) the focus for DS Service availability for recovery, thus allowing it to control when recovery starts based on Service availability.

5/ Make RecLogServiceImpl the implementor of the DS RecoveryLog Service and allow it to determine that the Recoverylog bundle is ready to start recovery. Previously this was only part OSGi bundlerised and recovery could be started before the Recoverylog bundle had started.

6/ Add a new waitForRecovery test (note the flag is currently set to FALSE).

7/ Add the ported cloud sim FAT tests ported from Commercial Liberty.