### PR TITLE
Write fail.log in well-known location to match non-TCK FAT behavior

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
@@ -371,6 +371,10 @@ public class MvnUtils {
                 printStdOutAndScreenIfLocal("                               " + failedTest);
             }
             printStdOutAndScreenIfLocal("\n");
+            new File("output").mkdirs();
+            try (FileOutputStream fos = new FileOutputStream("output/fail.log")) {
+                fos.write("Test FAILED".getBytes());
+            }
         }
         return failingTestsList;
     }


### PR DESCRIPTION
Currently if a TCK-style FAT fails with only TCK-style tests, the FAT output will not be uploaded to the automated build for investigation, and if running the FAT locally the gradle build will report SUCCESS even if tests failed.

Both of these environments rely on the presence of a file at `autoFVT/output/fail.log` if there is a test failure.  The patch here is simply to produce a `fail.log` file in the event we detect failures in TCK-style tests.