### PR TITLE
prototype matching of shardingkey based on equals

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
@@ -131,6 +131,11 @@ public class JDBC40Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
+    public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
     public void beginRequest(Connection con) {}
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
@@ -157,6 +157,11 @@ public class JDBC41Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
+    public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
     public void beginRequest(Connection con) {}
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
@@ -157,6 +157,11 @@ public class JDBC42Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
+    public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
     public void beginRequest(Connection con) {}
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
@@ -18,6 +18,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.ShardingKey;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
@@ -153,6 +154,15 @@ public class JDBC43Runtime implements JDBCRuntimeVersion {
         try {
             return sqlConn.getNetworkTimeout();
         } catch (IncompatibleClassChangeError e) { // pre-4.1 driver
+            throw new SQLFeatureNotSupportedException(e);
+        }
+    }
+
+    @Override
+    public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException {
+        try {
+            con.setShardingKey((ShardingKey) shardingKey, (ShardingKey) superShardingKey);
+        } catch (IncompatibleClassChangeError e) { // pre-4.3 driver
             throw new SQLFeatureNotSupportedException(e);
         }
     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
@@ -90,6 +90,7 @@ public interface JDBCRuntimeVersion {
     public BatchUpdateException newBatchUpdateException(BatchUpdateException copyFrom, String newMessage);
 
     // JDBC 4.3 Connection methods
+    public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException;
     public void beginRequest(Connection con) throws SQLException;
     public void endRequest(Connection con) throws SQLException;
 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -298,6 +298,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
     private Map<String, Class<?>> defaultTypeMap;
     private boolean defaultReadOnly;
     private String defaultSchema, currentSchema = null;
+    private Object defaultShardingKey, currentShardingKey;
+    private Object defaultSuperShardingKey, currentSuperShardingKey;
     private int defaultNetworkTimeout;
     public int currentNetworkTimeout = 0;
 
@@ -307,7 +309,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
     /** Indicates whether transaction isolation has been changed. */
     private boolean isolationChanged;
 
-    /** Indicates whether catalog, typeMap, readOnly, schema, or networkTimeout has been changed. */
+    /** Indicates whether catalog, typeMap, readOnly, schema, sharding key, super sharding key, or networkTimeout has been changed. */
     private boolean connectionPropertyChanged;
 
     /** current cursor holdability */
@@ -489,7 +491,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
         if (!cri.isCRIChangable())
             cri = WSConnectionRequestInfoImpl.createChangableCRIFromNon(cri);
-        cri.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema, defaultNetworkTimeout);
+        cri.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema,
+                             defaultNetworkTimeout, defaultShardingKey, defaultSuperShardingKey);
 
         // Check to make sure a datasource configured with 'NONE (0)' is compatible with the driver being used. 
         if(config.isolationLevel == Connection.TRANSACTION_NONE) {
@@ -642,7 +645,9 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                                 cri.ivPassword,
                                 isolationChanged ? currentTransactionIsolation : cri.ivIsoLevel,
                                 connectionPropertyChanged ? getCatalog() : cri.ivCatalog,
-                                connectionPropertyChanged && mcf.supportsIsReadOnly ? Boolean.valueOf(isReadOnly()) : cri.ivReadOnly, 
+                                connectionPropertyChanged && mcf.supportsIsReadOnly ? Boolean.valueOf(isReadOnly()) : cri.ivReadOnly,
+                                connectionPropertyChanged ? currentShardingKey : cri.ivShardingKey,
+                                connectionPropertyChanged ? currentSuperShardingKey : cri.ivSuperShardingKey,
                                 connectionPropertyChanged && mcf.supportsGetTypeMap ? getTypeMap() : cri.ivTypeMap,
                                 holdabilityChanged ? getHoldability() : cri.ivHoldability,
                                 connectionPropertyChanged && mcf.supportsGetSchema ? getSchemaSafely() : cri.ivSchema,
@@ -651,7 +656,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                                 cri.supportIsolvlSwitching);
 
                 _criHold.setDefaultValues(cri.defaultCatalog, cri.defaultHoldability, 
-                                          cri.defaultReadOnly, cri.defaultTypeMap, cri.defaultSchema, cri.defaultNetworkTimeout); 
+                                          cri.defaultReadOnly, cri.defaultTypeMap, cri.defaultSchema,
+                                          cri.defaultNetworkTimeout, cri.defaultShardingKey, cri.defaultSuperShardingKey); 
 
                 // now set the cri as changable, otherwise, setters to follow will fail
                 _criHold.markAsChangable();
@@ -1014,6 +1020,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
             defaultCatalog = sqlConn.getCatalog();
             defaultReadOnly = mcf.supportsIsReadOnly ? sqlConn.isReadOnly() : false;
             defaultTypeMap = getTypeMapSafely();
+            currentShardingKey = defaultShardingKey = null; // spec provides no getter method
+            currentSuperShardingKey = defaultSuperShardingKey = null; // spec provides no getter method
             currentSchema = defaultSchema = getSchemaSafely();
             currentNetworkTimeout = defaultNetworkTimeout = getNetworkTimeoutSafely();
             currentHoldability = defaultHoldability; 
@@ -1064,7 +1072,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         info.append("The gssCredential is: ").append(mc_gssCredential == null ? null : mc_gssCredential.toString());
         info.append("The gssName is: ").append(mc_gssName == null ? null : mc_gssName.toString());
 
-        info.append("Catalog, IsReadOnly, TypeMap, Schema, or NetworkTimeout has changed? :", 
+        info.append("Catalog, IsReadOnly, TypeMap, Schema, ShardingKey, SuperShardingKey, or NetworkTimeout has changed? :", 
                     connectionPropertyChanged ? Boolean.TRUE : Boolean.FALSE); 
 
         info.append("Default Holdability:",
@@ -1946,7 +1954,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
         if (!newCRI.isCRIChangable())
             newCRI = WSConnectionRequestInfoImpl.createChangableCRIFromNon(newCRI);
-        newCRI.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema, defaultNetworkTimeout);
+        newCRI.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema,
+                                defaultNetworkTimeout, defaultShardingKey, defaultSuperShardingKey);
 
         cri = newCRI;
 
@@ -1988,7 +1997,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         // The ManagedConnection should use the new CRI value in place of its current CRI.
         if (!newCRI.isCRIChangable())
             newCRI = WSConnectionRequestInfoImpl.createChangableCRIFromNon(newCRI);
-        newCRI.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema, defaultNetworkTimeout);
+        newCRI.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema,
+                                defaultNetworkTimeout, defaultShardingKey, defaultSuperShardingKey);
         cri = newCRI;
 
         //  -- don't intialize the properties, deplay to synchronizePropertiesWithCRI().
@@ -2089,6 +2099,11 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 helper.setReadOnly(this, cri.ivReadOnly.booleanValue(), false); 
             }
 
+            if (cri.ivShardingKey != null && !cri.ivShardingKey.equals(defaultShardingKey)
+             || cri.ivSuperShardingKey != null && !cri.ivSuperShardingKey.equals(defaultShardingKey)) {
+                setShardingKeys(cri.ivShardingKey, cri.ivSuperShardingKey);
+            }
+
             if (cri.ivTypeMap != null && defaultTypeMap != cri.ivTypeMap && mcf.supportsGetTypeMap) {
                 setTypeMap(cri.ivTypeMap);
             }
@@ -2130,6 +2145,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                                                    "/" + AdapterUtil.getIsolationLevelString(currentTransactionIsolation),
                                    "Catalog:       " + defaultCatalog + "/" + (cri.ivCatalog == null ? defaultCatalog : cri.ivCatalog),
                                    "Schema:        " + defaultSchema + "/" + (cri.ivSchema == null ? defaultSchema : cri.ivSchema),
+                                   "ShardingKey:   " + defaultShardingKey + "/" + (cri.ivShardingKey == null ? defaultShardingKey : cri.ivShardingKey),
+                                   "SuperShardingK:" + defaultSuperShardingKey + "/" + (cri.ivSuperShardingKey == null ? defaultSuperShardingKey : cri.ivSuperShardingKey),
                                    "NetworkTimeout:" + defaultNetworkTimeout + "/" + (cri.ivNetworkTimeout == 0 ? defaultNetworkTimeout : cri.ivNetworkTimeout),
                                    "IsReadOnly:    " + defaultReadOnly + "/" + (cri.ivReadOnly == null ? defaultReadOnly : cri.ivReadOnly), 
                                    "TypeMap:       " + defaultTypeMap + "/" + (cri.ivTypeMap == null ? defaultTypeMap : cri.ivTypeMap),
@@ -2570,6 +2587,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         defaultCatalog = null; 
         defaultTypeMap = null; 
         defaultSchema = null;
+        defaultShardingKey = null;
+        defaultSuperShardingKey = null;
 
         handlesInUse = null;
 
@@ -2923,7 +2942,28 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                     }
                 }
             }
-            
+
+            if (!AdapterUtil.match(currentShardingKey, defaultShardingKey)
+             || !AdapterUtil.match(currentSuperShardingKey, defaultSuperShardingKey)) {
+                try {
+                    setShardingKeys(defaultShardingKey, defaultSuperShardingKey);
+
+                    // Update the connection request information after switching back to the
+                    // default sharding keys.
+                    if (connectionSharing == ConnectionSharing.MatchCurrentState)
+                    {
+                        if (!cri.isCRIChangable()) // create a changable CRI if existing one is not
+                            setCRI(WSConnectionRequestInfoImpl.createChangableCRIFromNon(cri));
+
+                        cri.setShardingKey(defaultShardingKey);
+                        cri.setSuperShardingKey(defaultSuperShardingKey);
+                    }
+                } catch (SQLException sqle) {
+                    FFDCFilter.processException(sqle, getClass().getName(), "2959", this);
+                    throw new DataStoreAdapterException("DSA_ERROR", sqle, getClass());
+                }
+            }
+
             if(mcf.supportsGetNetworkTimeout){
                 try{
                     ExecutorService libertyThreadPool = mcf.connectorSvc.getLibertyThreadPool();
@@ -2987,7 +3027,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                     currentHoldability = mcf.getHelper().getHoldability(sqlConn);
 
                     // Update the connection request information after switching back to the
-                    // default catalog.
+                    // default holdability.
                     if (connectionSharing == ConnectionSharing.MatchCurrentState)
                     {
                         if (!cri.isCRIChangable()) // create a changable CRI if existing one is not
@@ -3997,6 +4037,25 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
             Tr.debug(this, tc, "Set readOnly to " + isReadOnly); 
         sqlConn.setReadOnly(isReadOnly);
         connectionPropertyChanged = true; 
+    }
+
+    /**
+     * Updates the value of the sharding keys.
+     * 
+     * @param shardingKey the new sharding key.
+     * @param superShardingKey the new super sharding key.
+     */
+    public final void setShardingKeys(Object shardingKey, Object superShardingKey) throws SQLException {
+        if (mcf.beforeJDBCVersion(JDBCRuntimeVersion.VERSION_4_3))
+            throw new SQLFeatureNotSupportedException();
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "Set sharding key/super sharding key to " + shardingKey + "/" + superShardingKey); 
+
+        mcf.jdbcRuntime.doSetShardingKeys(sqlConn, shardingKey, superShardingKey);
+        currentShardingKey = shardingKey;
+        currentSuperShardingKey = superShardingKey;
+        connectionPropertyChanged = true;
     }
 
     /**


### PR DESCRIPTION
Create a prototype implementation of matching for sharding keys based on the existing approach that is used for other connection properties, so that we can start experimenting with writing some tests and further investigating how to best add support for sharding keys.

For now, we will make the assumption that .equals can be used for comparisons and that default value of sharding keys will always be null (the spec has no way to ask for a current value).