### PR TITLE
Rework JPA Diagnostic Dump

### DIFF
--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAApplInfo.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAApplInfo.java
@@ -94,7 +94,7 @@ public abstract class JPAApplInfo {
      * and archive name. <p>
      *
      * @param pxml provides access to a persistence.xml file as well
-     *            as the archive name and scope.
+     *                 as the archive name and scope.
      */
     public void addPersistenceUnits(JPAPXml pxml) {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
@@ -300,9 +300,17 @@ public abstract class JPAApplInfo {
             puScopesClone.putAll(puScopes);
         }
 
+        final JPAIntrospection jpaIntro = JPAIntrospection.getJPAIntrospection();
+
         for (Map.Entry<String, JPAScopeInfo> entry : puScopesClone.entrySet()) {
             final JPAScopeInfo scopeInfo = entry.getValue();
-            scopeInfo.doIntrospect(out);
+
+            jpaIntro.beginPUScopeVisit(scopeInfo);
+            try {
+                scopeInfo.doIntrospect(out);
+            } finally {
+                jpaIntro.endPUScopeVisit();
+            }
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAIntrospection.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAIntrospection.java
@@ -1,0 +1,478 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.management;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import com.ibm.ws.ffdc.FFDCFilter;
+import com.ibm.ws.jpa.diagnostics.JPAORMDiagnostics;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ClassInfoType;
+import com.ibm.ws.jpa.diagnostics.puscanner.PersistenceUnitScannerResults2;
+
+/**
+ *
+ */
+public class JPAIntrospection {
+    private static final ThreadLocal<JPAIntrospection> threadLocal = new ThreadLocal<JPAIntrospection>() {
+        @Override
+        protected JPAIntrospection initialValue() {
+            return new JPAIntrospection();
+        }
+    };
+
+    public static final JPAIntrospection getJPAIntrospection() {
+        return threadLocal.get();
+    }
+
+    public static final void endJPAIntrospection() {
+        threadLocal.remove();
+    }
+
+    private final HashMap<String, JPAApplInfoIntrospect> jpaApplInfoMap = new HashMap<String, JPAApplInfoIntrospect>();
+
+    private JPAApplInfoIntrospect currentAppl = null;
+    private JPAScopeInfoIntrospect currentScopeInfo = null;
+    private JPAPxmlInfoIntrospect currentPxmlInfo = null;
+
+    public final Map<String, JPAApplInfoIntrospect> getJPAApplInfoIntrospectMap() {
+        return Collections.unmodifiableMap(jpaApplInfoMap);
+    }
+
+    public void beginApplicationVisit(String appname, JPAApplInfo appl) {
+        currentAppl = new JPAApplInfoIntrospect(appname, appl);
+        jpaApplInfoMap.put(appname, currentAppl);
+    }
+
+    public void endApplicationVisit() {
+        currentAppl = null;
+    }
+
+    public void beginPUScopeVisit(JPAScopeInfo scopeInfo) {
+        if (currentAppl == null) {
+            return; // Bad State
+        }
+        currentScopeInfo = new JPAScopeInfoIntrospect(scopeInfo);
+        currentAppl.scopeInfoList.add(currentScopeInfo);
+    }
+
+    public void endPUScopeVisit() {
+        currentScopeInfo = null;
+    }
+
+    public void beginPXmlInfoVisit(JPAPxmlInfo pxmlInfo) {
+        if (currentAppl == null || currentScopeInfo == null) {
+            return; // Bad State
+        }
+        currentPxmlInfo = new JPAPxmlInfoIntrospect(pxmlInfo);
+        currentScopeInfo.pxmlInfoList.add(currentPxmlInfo);
+    }
+
+    public void endPXmlInfoVisit() {
+        currentPxmlInfo = null;
+    }
+
+    public void visitJPAPUnitInfo(String puName, JPAPUnitInfo jpaPuInfo) {
+        if (currentAppl == null || currentScopeInfo == null || currentPxmlInfo == null) {
+            return; // Bad State
+        }
+
+        currentPxmlInfo.jpaPuInfoList.add(new JPAPUnitInfoIntrospect(puName, jpaPuInfo));
+        currentAppl.puCount++;
+        currentPxmlInfo.puCount++;
+    }
+
+    public void executeIntrospectionAnalysis(final PrintWriter dout) {
+        final Map<String, JPAAnalysisResult> analysisResultMap = new HashMap<String, JPAAnalysisResult>();
+
+        try {
+            for (Map.Entry<String, JPAApplInfoIntrospect> entry : jpaApplInfoMap.entrySet()) {
+                final String appName = entry.getKey();
+                final JPAApplInfoIntrospect jpaAppl = entry.getValue();
+                final JPAApplInfo appl = jpaAppl.getJPAApplInfo();
+
+                final JPAAnalysisResult analysisResult = new JPAAnalysisResult(appName, jpaAppl);
+                analysisResultMap.put(appName, analysisResult);
+
+                final PrintWriter out = analysisResult.getPw();
+
+                final ArrayList<JPAPUnitInfo> puInfoList = new ArrayList<JPAPUnitInfo>();
+                final HashMap<URL, List<JPAPUnitInfo>> puRootURL_PUInfo_Map = new HashMap<URL, List<JPAPUnitInfo>>();
+                final HashMap<URL, String> puRootURL_pxml_Map = new HashMap<URL, String>();
+
+                final List<JPAScopeInfoIntrospect> scopeInfoList = jpaAppl.getScopeInfoList();
+                for (JPAScopeInfoIntrospect puScope : scopeInfoList) {
+                    final JPAScopeInfo scopeInfo = puScope.getJPAScopeInfo();
+
+                    final List<JPAPxmlInfoIntrospect> pxmlList = puScope.getPxmlInfoList(); // persistence.xml
+                    for (JPAPxmlInfoIntrospect pxml : pxmlList) {
+                        final JPAPxmlInfo pxmlInfo = pxml.getJPAPxmlInfo();
+                        final List<JPAPUnitInfoIntrospect> jpaPuInfoList = pxml.getJPAPUnitInfoList();
+                        for (JPAPUnitInfoIntrospect puInfoIntro : jpaPuInfoList) {
+                            final JPAPUnitInfo jpaPuInfo = puInfoIntro.getJpaPuInfo();
+                            final URL puRootURL = jpaPuInfo.getPersistenceUnitRootUrl();
+
+                            puInfoList.add(jpaPuInfo);
+                            analysisResult.registerJPAPUInfo(puInfoIntro);
+
+                            List<JPAPUnitInfo> list = puRootURL_PUInfo_Map.get(puRootURL);
+                            if (list == null) {
+                                list = new ArrayList<JPAPUnitInfo>();
+                                puRootURL_PUInfo_Map.put(puRootURL, list);
+                            }
+                            list.add(jpaPuInfo);
+                        }
+                    }
+                }
+
+                // Get the persistence.xml associated with each persistence unit root.
+                for (URL url : puRootURL_PUInfo_Map.keySet()) {
+                    String pxml = resolvePersistenceXML(url);
+                    puRootURL_pxml_Map.put(url, pxml);
+                }
+
+                for (Map.Entry<URL, String> ent : puRootURL_pxml_Map.entrySet()) {
+                    out.println("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+                    out.println("Contents of persistence.xml at Peristence Unit Root:\n" + ent.getKey());
+                    out.println();
+                    out.println(ent.getValue());
+                    out.println();
+
+                    List<JPAPUnitInfo> puInfo_List = puRootURL_PUInfo_Map.get(ent.getKey());
+                    for (JPAPUnitInfo puInfo : puInfo_List) {
+                        out.println(puInfo.dump());
+                        out.println("************************************************************");
+                    }
+                }
+
+                jpaAppl.results = JPAORMDiagnostics.performJPAORMDiagnostics(
+                                                                             new ArrayList<javax.persistence.spi.PersistenceUnitInfo>(puInfoList),
+                                                                             puRootURL_pxml_Map,
+                                                                             out);
+            }
+        } finally {
+            dout.println("Applications: ");
+            dout.println();
+
+            for (Map.Entry<String, JPAAnalysisResult> entry : analysisResultMap.entrySet()) {
+                dout.println(entry.getKey() + " ("
+                             + entry.getValue().getAppl().getPersistenceUnitCount()
+                             + " persistence units, " + entry.getValue().getLineCount() + " lines) :");
+                dout.println("   Persistence Unit Roots:");
+                final Map<URL, List<JPAPUnitInfoIntrospect>> urlPUInfoMap = entry.getValue().getURL_JPAPuInfoMap();
+                if (urlPUInfoMap.size() == 0) {
+                    dout.println("      None");
+                } else {
+                    for (Map.Entry<URL, List<JPAPUnitInfoIntrospect>> e2 : urlPUInfoMap.entrySet()) {
+                        dout.println("      " + getShortenedURLPath(e2.getKey()) + " (" + e2.getValue().size() + " persistence units)");
+                    }
+                }
+            }
+
+            dout.println();
+
+            for (Map.Entry<String, JPAAnalysisResult> entry : analysisResultMap.entrySet()) {
+                final JPAAnalysisResult result = entry.getValue();
+                final PersistenceUnitScannerResults2 scannerResults = result.getAppl().results;
+
+                dout.println();
+                dout.println("################################################################################");
+                dout.println("Application \"" + entry.getKey() + "\":");
+
+                if (scannerResults == null) {
+                    dout.println("   No JPA Materials to Analyze.");
+                    continue;
+                }
+
+                dout.println("   Total ORM Files: " + scannerResults.getAllEntityMappingsDefinitions().size());
+
+                {
+                    final Map<URL, Set<ClassInfoType>> urlCitMap = scannerResults.getAllScannedClasses();
+                    int count = 0;
+                    for (Set<ClassInfoType> citSet : urlCitMap.values()) {
+                        count += citSet.size();
+                    }
+
+                    dout.println("   Total JPA Involved Classes: " + count);
+                }
+
+                final Map<URL, List<JPAPUnitInfoIntrospect>> urlPUInfoMap = entry.getValue().getURL_JPAPuInfoMap();
+                if (urlPUInfoMap.size() == 0) {
+                    dout.println("   Persistence Unit Roots:");
+                    dout.println("      None");
+                } else {
+                    dout.println("   Persistence Unit Roots:");
+                    for (Map.Entry<URL, List<JPAPUnitInfoIntrospect>> e2 : urlPUInfoMap.entrySet()) {
+                        dout.println("      " + getShortenedURLPath(e2.getKey()) + " (" + e2.getValue().size() + " persistence units)");
+                    }
+
+                    dout.println("   Persistence Units:");
+                    for (Map.Entry<URL, List<JPAPUnitInfoIntrospect>> e2 : urlPUInfoMap.entrySet()) {
+                        dout.println("      At Persistence Unit Root: " + getShortenedURLPath(e2.getKey()));
+                        final List<JPAPUnitInfoIntrospect> ispecList = new ArrayList<JPAPUnitInfoIntrospect>(e2.getValue());
+                        Collections.sort(ispecList, new Comparator<JPAPUnitInfoIntrospect>() {
+                            @Override
+                            public int compare(JPAPUnitInfoIntrospect o1, JPAPUnitInfoIntrospect o2) {
+                                if (o1 == null || o2 == null || o1.puName == null || o2.puName == null) {
+                                    return 0;
+                                }
+
+                                return o1.puName.compareTo(o2.puName);
+                            }
+                        });
+                        for (JPAPUnitInfoIntrospect puIspec : ispecList) {
+                            dout.println("         " + puIspec.getPuName());
+                        }
+                    }
+                }
+
+                dout.println();
+                dout.println(result.getBaos().toString());
+            }
+        }
+
+    }
+
+    private String getShortenedURLPath(URL url) {
+        final String urlStr = url.toString().replace("%21", "!");
+        final String ptcols = urlStr.substring(0, urlStr.indexOf("/"));
+        String path = urlStr.substring(urlStr.indexOf("/"));
+        if (path.contains(".cache")) {
+            path = path.substring(path.lastIndexOf(".cache") + 6);
+        }
+
+        return ptcols + "..." + path;
+    }
+
+    // out.println("************************************************************");
+    // out.println(jpaPuInfo.dump());
+
+    private String resolvePersistenceXML(final URL puRootURL) {
+        final String pxmlPath = "META-INF/persistence.xml";
+        final String urlPtcol = puRootURL.getProtocol();
+
+        if (urlPtcol.toLowerCase().contains("wsjpa")) {
+            // WSJPA: zip-format InputStream
+            try {
+                try (ZipInputStream zis = new ZipInputStream(puRootURL.openStream())) {
+                    ZipEntry ze = null;
+                    while ((ze = zis.getNextEntry()) != null) {
+                        if (ze.getName().equals(pxmlPath)) {
+                            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                            final byte[] buffer = new byte[4096];
+                            int bytesRead = -1;
+                            while ((bytesRead = zis.read(buffer)) >= 0) {
+                                baos.write(buffer, 0, bytesRead);
+                            }
+
+                            return baos.toString();
+                        }
+                    }
+                }
+                return null;
+            } catch (Exception e) {
+                FFDCFilter.processException(e, JPAIntrospection.class.getName() + ".resolvePersistenceXML", "wsjpa");
+            }
+        } else if (urlPtcol.toLowerCase().contains("jar")) {
+            // Jar file URL
+            try {
+                String urlStr = puRootURL.toString();
+                URL pxmlURL = (urlStr.endsWith("/")) ? new URL(urlStr + pxmlPath) : new URL(urlStr + "/" + pxmlPath);
+                return readData(pxmlURL);
+            } catch (Exception e) {
+                FFDCFilter.processException(e, JPAIntrospection.class.getName() + ".resolvePersistenceXML", "jar");
+            }
+        } else if (urlPtcol.toLowerCase().contains("file")) {
+            // File URL (possibly exploded jar)
+        }
+
+        return null;
+    }
+
+    private String readData(URL url) {
+        final StringBuilder sb = new StringBuilder();
+        BufferedReader br = null;
+
+        try {
+            br = new BufferedReader(new InputStreamReader(url.openStream()));
+
+            String in = null;
+            while ((in = br.readLine()) != null) {
+                sb.append(in);
+            }
+        } catch (IOException e) {
+            FFDCFilter.processException(e, JPAIntrospection.class.getName() + ".readData", "readData");
+        } finally {
+            if (br != null) {
+                try {
+                    br.close();
+                } catch (Throwable t) {
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    public class JPAApplInfoIntrospect {
+        private final String appname;
+        private final JPAApplInfo appl;
+        private final ArrayList<JPAScopeInfoIntrospect> scopeInfoList = new ArrayList<JPAScopeInfoIntrospect>();
+        private int puCount = 0;
+        private PersistenceUnitScannerResults2 results;
+
+        public JPAApplInfoIntrospect(String appname, JPAApplInfo appl) {
+            this.appname = appname;
+            this.appl = appl;
+        }
+
+        public JPAApplInfo getJPAApplInfo() {
+            return appl;
+        }
+
+        public List<JPAScopeInfoIntrospect> getScopeInfoList() {
+            return Collections.unmodifiableList(scopeInfoList);
+        }
+
+        public int getPersistenceUnitCount() {
+            return puCount;
+        }
+    }
+
+    public class JPAScopeInfoIntrospect {
+        private final JPAScopeInfo scopeInfo;
+        private final ArrayList<JPAPxmlInfoIntrospect> pxmlInfoList = new ArrayList<JPAPxmlInfoIntrospect>();
+
+        public JPAScopeInfoIntrospect(JPAScopeInfo scopeInfo) {
+            this.scopeInfo = scopeInfo;
+        }
+
+        public JPAScopeInfo getJPAScopeInfo() {
+            return scopeInfo;
+        }
+
+        public List<JPAPxmlInfoIntrospect> getPxmlInfoList() {
+            return Collections.unmodifiableList(pxmlInfoList);
+        }
+    }
+
+    public class JPAPxmlInfoIntrospect {
+        private final JPAPxmlInfo pxmlInfo;
+        private final ArrayList<JPAPUnitInfoIntrospect> jpaPuInfoList = new ArrayList<JPAPUnitInfoIntrospect>();
+        private int puCount = 0;
+
+        public JPAPxmlInfoIntrospect(JPAPxmlInfo pxmlInfo) {
+            this.pxmlInfo = pxmlInfo;
+        }
+
+        public JPAPxmlInfo getJPAPxmlInfo() {
+            return pxmlInfo;
+        }
+
+        public List<JPAPUnitInfoIntrospect> getJPAPUnitInfoList() {
+            return Collections.unmodifiableList(jpaPuInfoList);
+        }
+
+        public int getPersistenceUnitCount() {
+            return puCount;
+        }
+    }
+
+    public class JPAPUnitInfoIntrospect {
+        private final String puName;
+        private final JPAPUnitInfo jpaPuInfo;
+
+        public JPAPUnitInfoIntrospect(String puName, JPAPUnitInfo jpaPuInfo) {
+            this.puName = puName;
+            this.jpaPuInfo = jpaPuInfo;
+        }
+
+        public String getPuName() {
+            return puName;
+        }
+
+        public JPAPUnitInfo getJpaPuInfo() {
+            return jpaPuInfo;
+        }
+    }
+
+    public class JPAAnalysisResult {
+        private final String appName;
+        private final JPAApplInfoIntrospect appl;
+        private final ByteArrayOutputStream baos;
+        private final PrintWriter pw;
+
+        private final HashMap<URL, List<JPAPUnitInfoIntrospect>> puRootURL_JPAPuInfoMap = new HashMap<URL, List<JPAPUnitInfoIntrospect>>();
+
+        public JPAAnalysisResult(String appName, JPAApplInfoIntrospect appl) {
+            this.appName = appName;
+            this.appl = appl;
+
+            baos = new ByteArrayOutputStream();
+            pw = new PrintWriter(baos);
+        }
+
+        public String getAppName() {
+            return appName;
+        }
+
+        public JPAApplInfoIntrospect getAppl() {
+            return appl;
+        }
+
+        public ByteArrayOutputStream getBaos() {
+            return baos;
+        }
+
+        public PrintWriter getPw() {
+            return pw;
+        }
+
+        public Map<URL, List<JPAPUnitInfoIntrospect>> getURL_JPAPuInfoMap() {
+            return puRootURL_JPAPuInfoMap;
+        }
+
+        public void registerJPAPUInfo(JPAPUnitInfoIntrospect puInfoIntrospect) {
+            final URL puRootURL = puInfoIntrospect.getJpaPuInfo().getPersistenceUnitRootUrl();
+            List<JPAPUnitInfoIntrospect> introList = puRootURL_JPAPuInfoMap.get(puRootURL);
+            if (introList == null) {
+                introList = new ArrayList<JPAPUnitInfoIntrospect>();
+                puRootURL_JPAPuInfoMap.put(puRootURL, introList);
+            }
+            introList.add(puInfoIntrospect);
+        }
+
+        public long getLineCount() {
+            final byte newline = '\n';
+            long count = 0;
+            for (byte b : baos.toByteArray()) {
+                if (newline == b) {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAPxmlInfo.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAPxmlInfo.java
@@ -14,17 +14,12 @@ import static com.ibm.ws.jpa.management.JPAConstants.JPA_RESOURCE_BUNDLE_NAME;
 import static com.ibm.ws.jpa.management.JPAConstants.JPA_TRACE_GROUP;
 import static com.ibm.ws.jpa.management.JPAConstants.PERSISTENCE_XML_RESOURCE_NAME;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -293,60 +288,13 @@ class JPAPxmlInfo {
             ivPuListCopy.putAll(ivPuList);
         }
 
-        out.println("ScopeName = " + ivScopeInfo.getScopeName());
-        out.println("RootURL = " + ivRootURL);
-        out.println("# Persistence Units = " + ivPuList.size());
-        out.println();
+        final JPAIntrospection jpaIntro = JPAIntrospection.getJPAIntrospection();
 
         for (Map.Entry<String, JPAPUnitInfo> entry : ivPuListCopy.entrySet()) {
             final String puName = entry.getKey();
             final JPAPUnitInfo jpaPUInfo = entry.getValue();
 
-            final URL puRootURL = jpaPUInfo.getPersistenceUnitRootUrl();
-            final String urlPtcol = puRootURL.getProtocol();
-
-//            out.println();
-//            out.println("Application Name: " + jpaPUInfo.getApplName());
-            out.println("************************************************************");
-            out.println(jpaPUInfo.dump());
-
-            out.println();
-            out.println("Object Relational Mapping Dump:");
-            out.println();
-            if (urlPtcol.toLowerCase().contains("wsjpa")) {
-                // WSJPA: zip-format InputStream
-                boolean printed = false;
-                try (ZipInputStream zis = new ZipInputStream(puRootURL.openStream())) {
-                    ZipEntry ze = null;
-                    while ((ze = zis.getNextEntry()) != null) {
-                        if (!(ze.getName().endsWith("/persistence.xml"))) {
-                            continue;
-                        }
-
-                        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                        final byte[] buffer = new byte[4096];
-                        int bytesRead = -1;
-                        while ((bytesRead = zis.read(buffer)) >= 0) {
-                            baos.write(buffer, 0, bytesRead);
-                        }
-
-                        JPAORMDiagnostics.writeJPAORMDiagnostics(jpaPUInfo, new ByteArrayInputStream(baos.toByteArray()), out);
-                        printed = true;
-                        break;
-                    }
-                } catch (IOException ioe) {
-                    FFDCFilter.processException(ioe, JPAPxmlInfo.class.getName() + ".doIntrospect", "323");
-                }
-                if (!printed) {
-                    out.println("WARNING: Failed to dump ORM for PURoot: " + puRootURL);
-                }
-            } else if (urlPtcol.toLowerCase().contains("jar")) {
-                // TODO
-                out.println("TODO found jar.");
-            } else if (urlPtcol.toLowerCase().contains("file")) {
-                // TODO
-                out.println("TODO found file.");
-            }
+            jpaIntro.visitJPAPUnitInfo(puName, jpaPUInfo);
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAScopeInfo.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAScopeInfo.java
@@ -247,10 +247,18 @@ public class JPAScopeInfo {
             pxmlsInfoCopy.putAll(pxmlsInfo);
         }
 
+        final JPAIntrospection jpaIntro = JPAIntrospection.getJPAIntrospection();
+
         for (Map.Entry<String, JPAPxmlInfo> entry : pxmlsInfoCopy.entrySet()) {
             final JPAPxmlInfo value = entry.getValue();
-            out.println();
-            value.doIntrospect(out);
+
+            jpaIntro.beginPXmlInfoVisit(value);
+            try {
+                out.println();
+                value.doIntrospect(out);
+            } finally {
+                jpaIntro.endPXmlInfoVisit();
+            }
         }
     }
 }

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/JPAORMDiagnostics.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/JPAORMDiagnostics.java
@@ -17,6 +17,7 @@ import java.io.PrintWriter;
 import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.HashMap;
 import java.util.List;
 
 import javax.persistence.spi.PersistenceUnitInfo;
@@ -28,7 +29,10 @@ import com.ibm.ws.jpa.diagnostics.class_scanner.ano.EntityMappingsScannerResults
 import com.ibm.ws.jpa.diagnostics.ormparser.EntityMappingsDefinition;
 import com.ibm.ws.jpa.diagnostics.ormparser.entitymapping.IEntityMappings;
 import com.ibm.ws.jpa.diagnostics.puscanner.PersistenceUnitScanner;
+import com.ibm.ws.jpa.diagnostics.puscanner.PersistenceUnitScanner2;
+import com.ibm.ws.jpa.diagnostics.puscanner.PersistenceUnitScannerException;
 import com.ibm.ws.jpa.diagnostics.puscanner.PersistenceUnitScannerResults;
+import com.ibm.ws.jpa.diagnostics.puscanner.PersistenceUnitScannerResults2;
 import com.ibm.ws.jpa.diagnostics.utils.encapsulation.EncapsulatedData;
 import com.ibm.ws.jpa.diagnostics.utils.encapsulation.EncapsulatedDataGroup;
 
@@ -48,6 +52,22 @@ public class JPAORMDiagnostics {
                                                                                   return Boolean.getBoolean("com.ibm.websphere.persistence.enablejpadump");
                                                                               }
                                                                           });
+
+    public static PersistenceUnitScannerResults2 performJPAORMDiagnostics(List<PersistenceUnitInfo> puiList, HashMap<URL, String> pxmlMap, PrintWriter out) {
+        if (puiList == null || pxmlMap == null || out == null || puiList.isEmpty() || pxmlMap.isEmpty()) {
+            return null;
+        }
+
+        try {
+            PersistenceUnitScannerResults2 results = PersistenceUnitScanner2.scan(puiList, pxmlMap);
+            results.printReport(out);
+            results.generateORMDump(out);
+            return results;
+        } catch (PersistenceUnitScannerException e) {
+            FFDCFilter.processException(e, JPAORMDiagnostics.class.getName() + ".performJPAORMDiagnostics", "64");
+            return null;
+        }
+    }
 
     public static void writeJPAORMDiagnostics(PersistenceUnitInfo pui, InputStream pxmlIS, PrintWriter out) {
         if (jpaDumpEnabled == false || pui == null || out == null) {

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/ormparser/EntityMappingsDefinition.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/ormparser/EntityMappingsDefinition.java
@@ -23,21 +23,27 @@ import com.ibm.ws.jpa.diagnostics.ormparser.entitymapping.IEntityMappings;
 
 public class EntityMappingsDefinition {
     private final URL source;
+    private final byte[] fileData;
     private final BigInteger hash;
     private final IEntityMappings entityMappings;
 
-    public EntityMappingsDefinition(URL source, BigInteger hash, IEntityMappings entityMappings) {
+    public EntityMappingsDefinition(URL source, byte[] fileData, BigInteger hash, IEntityMappings entityMappings) {
         if (source == null || hash == null || entityMappings == null) {
             throw new NullPointerException("Constructor cannot accept any null arguments.");
         }
 
         this.source = source;
+        this.fileData = fileData;
         this.hash = hash;
         this.entityMappings = entityMappings;
     }
 
     public BigInteger getHash() {
         return hash;
+    }
+
+    public byte[] getFileData() {
+        return fileData;
     }
 
     public URL getSource() {

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/ormparser/EntityMappingsFactory.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/ormparser/EntityMappingsFactory.java
@@ -30,95 +30,95 @@ import javax.xml.parsers.SAXParserFactory;
 import com.ibm.ws.jpa.diagnostics.ormparser.entitymapping.IEntityMappings;
 
 public class EntityMappingsFactory {
-    private static final String digestType = System.getProperty(Constants.JVM_Property_ORMXML_DIGEST_ALGORITHM, 
-            Constants.DEFAULT_DIGEST_ALGORITHM);
-    
+    private static final String digestType = System.getProperty(Constants.JVM_Property_ORMXML_DIGEST_ALGORITHM,
+                                                                Constants.DEFAULT_DIGEST_ALGORITHM);
+
     public static EntityMappingsDefinition parseEntityMappings(URL srcUrl, byte[] mappingFileData) throws EntityMappingsException {
         if (mappingFileData == null || mappingFileData.length == 0) {
             return null;
         }
-        
+
         // Determine the Schema Version of the Mappings File
         try {
             final ByteArrayInputStream bais = new ByteArrayInputStream(mappingFileData);
-            
+
             final String pkg = determineJAXBPackage(bais).getJaxbPackage();
             bais.reset();
-            
-            final JAXBContext jaxbCtx = JAXBContext.newInstance(pkg);       
+
+            final JAXBContext jaxbCtx = JAXBContext.newInstance(pkg);
             final Unmarshaller unmarshaller = jaxbCtx.createUnmarshaller();
-            
-            MessageDigest md = MessageDigest.getInstance(digestType);   
+
+            MessageDigest md = MessageDigest.getInstance(digestType);
             md.reset();
             DigestInputStream dis = new DigestInputStream(bais, md);
             IEntityMappings entityMapping = (IEntityMappings) unmarshaller.unmarshal(dis);
 
             byte[] digest = md.digest();
             BigInteger digestBigInt = new BigInteger(1, digest);
-            
-            return new EntityMappingsDefinition(srcUrl, digestBigInt, entityMapping);
+
+            return new EntityMappingsDefinition(srcUrl, mappingFileData, digestBigInt, entityMapping);
         } catch (EntityMappingsException eme) {
             throw eme;
         } catch (Throwable t) {
             throw new EntityMappingsException(t);
         }
     }
-    
+
     public static EntityMappingsDefinition parseEntityMappings(File file) throws EntityMappingsException {
         if (file == null) {
             return null;
         }
-        
+
         if (!file.exists()) {
             throw new EntityMappingsException(new FileNotFoundException("File does not exist: " + file.getAbsolutePath()));
         }
-        
+
         try (FileInputStream fis = new FileInputStream(file)) {
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            
+
             final byte[] buffer = new byte[4096];
             int bytesRead = -1;
             while ((bytesRead = fis.read(buffer)) > -1) {
                 baos.write(buffer, 0, bytesRead);
             }
-            
+
             byte[] fileData = baos.toByteArray();
             return parseEntityMappings(file.toURI().toURL(), fileData);
         } catch (Throwable t) {
             throw new EntityMappingsException(t);
         }
     }
-    
+
     public static EntityMappingsDefinition parseEntityMappings(URL url) throws EntityMappingsException {
         if (url == null) {
             return null;
         }
-        
+
         try (InputStream is = url.openStream()) {
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            
+
             final byte[] buffer = new byte[4096];
             int bytesRead = -1;
             while ((bytesRead = is.read(buffer)) > -1) {
                 baos.write(buffer, 0, bytesRead);
             }
-            
+
             byte[] fileData = baos.toByteArray();
             return parseEntityMappings(url, fileData);
         } catch (Throwable t) {
             throw new EntityMappingsException(t);
         }
     }
-    
+
     private enum JPAJAXBPackage {
-        V1_0 ("1.0", Constants.JPA_10_JAXB_PACKAGE),
-        V2_0 ("2.0", Constants.JPA_20_JAXB_PACKAGE),
-        V2_1 ("2.1", Constants.JPA_21_JAXB_PACKAGE),
-        V2_2 ("2.2", Constants.JPA_21_JAXB_PACKAGE);
-        
-        private String version;
-        private String jaxbPackage;
-        
+        V1_0("1.0", Constants.JPA_10_JAXB_PACKAGE),
+        V2_0("2.0", Constants.JPA_20_JAXB_PACKAGE),
+        V2_1("2.1", Constants.JPA_21_JAXB_PACKAGE),
+        V2_2("2.2", Constants.JPA_21_JAXB_PACKAGE);
+
+        private final String version;
+        private final String jaxbPackage;
+
         private JPAJAXBPackage(String version, String jaxbPackage) {
             this.version = version;
             this.jaxbPackage = jaxbPackage;
@@ -127,7 +127,7 @@ public class EntityMappingsFactory {
         public String getJaxbPackage() {
             return jaxbPackage;
         }
-        
+
         public String getVersion() {
             return version;
         }
@@ -136,42 +136,42 @@ public class EntityMappingsFactory {
             if (vStr == null || vStr.isEmpty()) {
                 return null;
             }
-            
+
             for (JPAJAXBPackage item : JPAJAXBPackage.values()) {
                 if (vStr.equals(item.getVersion())) {
                     return item;
                 }
             }
-            
+
             return null;
         }
-        
+
         public static JPAJAXBPackage getDefault() {
             for (JPAJAXBPackage item : JPAJAXBPackage.values()) {
                 if (Constants.JPA_DEFAULT_JAXB_PACKAGE.equals(item.getJaxbPackage())) {
                     return item;
                 }
             }
-            
+
             throw new IllegalStateException("Unable to identify default JAXB package.");
         }
     }
-    
+
     private static JPAJAXBPackage determineJAXBPackage(InputStream is) throws EntityMappingsException {
-        try {           
+        try {
             SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setNamespaceAware(true);
             factory.setValidating(true);
             SAXParser parser = factory.newSAXParser();
             PersistenceUnitDocumentHandler handler = new PersistenceUnitDocumentHandler();
-            
-            parser.parse(is, handler);         
-            String version = handler.getVersion(); 
-            
+
+            parser.parse(is, handler);
+            String version = handler.getVersion();
+
             if (version == null) {
                 return JPAJAXBPackage.getDefault();
             }
-            
+
             return JPAJAXBPackage.getByVersion(version);
         } catch (Throwable t) {
             throw new EntityMappingsException(t);

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puscanner/PersistenceUnitScanner2.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puscanner/PersistenceUnitScanner2.java
@@ -1,0 +1,722 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.diagnostics.puscanner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+
+import javax.persistence.spi.PersistenceUnitInfo;
+
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.AsmClassAnalyzer;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.ClassScannerException;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.InnerOuterResolver;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ClassInfoType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.InnerClassesType;
+import com.ibm.ws.jpa.diagnostics.ormparser.EntityMappingsDefinition;
+import com.ibm.ws.jpa.diagnostics.ormparser.EntityMappingsFactory;
+
+/**
+ *
+ */
+public class PersistenceUnitScanner2 {
+    public static PersistenceUnitScannerResults2 scan(List<PersistenceUnitInfo> puiList, HashMap<URL, String> pxmlMap) throws PersistenceUnitScannerException {
+        final PersistenceUnitScanner2 scanner = new PersistenceUnitScanner2(puiList, pxmlMap);
+        return scanner.scan();
+    }
+
+    private final List<PersistenceUnitInfo> puiList;
+    private final HashMap<URL, String> pxmlMap;
+
+    private final Set<URL> urlSet = new HashSet<URL>();
+    private final HashMap<URL, Set<ClassInfoType>> scannedClassesMap = new HashMap<URL, Set<ClassInfoType>>();
+
+    private final HashMap<PersistenceUnitInfo, List<URL>> pu_ormFiles_map = new HashMap<PersistenceUnitInfo, List<URL>>();
+    private final HashMap<URL, EntityMappingsDefinition> scanned_ormfile_map = new HashMap<URL, EntityMappingsDefinition>();
+    private final HashMap<PersistenceUnitInfo, List<EntityMappingsDefinition>> pu_ormFileParsed_map = new HashMap<PersistenceUnitInfo, List<EntityMappingsDefinition>>();
+
+    private final InnerOuterResolver ioResolver = new InnerOuterResolver();
+
+    private PersistenceUnitScanner2(List<PersistenceUnitInfo> puiList, HashMap<URL, String> pxmlMap) {
+        this.puiList = puiList;
+        this.pxmlMap = pxmlMap;
+    }
+
+    private PersistenceUnitScannerResults2 scan() throws PersistenceUnitScannerException {
+        // Collect all URLs which are persistence unit roots and listed jar files.
+        for (PersistenceUnitInfo pui : puiList) {
+            urlSet.add(pui.getPersistenceUnitRootUrl());
+            urlSet.addAll(pui.getJarFileUrls());
+
+            pu_ormFiles_map.put(pui, new ArrayList<URL>());
+            pu_ormFileParsed_map.put(pui, new ArrayList<EntityMappingsDefinition>());
+        }
+
+        scanEntityMappings();
+        scanClasses();
+
+        return new PersistenceUnitScannerResults2(puiList, pxmlMap, urlSet, scannedClassesMap, scanned_ormfile_map, pu_ormFileParsed_map);
+    }
+
+    /**
+     * Scan classes in persistence unit root and referenced jar-files
+     */
+    private void scanClasses() throws PersistenceUnitScannerException {
+        try {
+            for (URL url : urlSet) {
+                final HashSet<ClassInfoType> citSet = new HashSet<ClassInfoType>();
+                final String urlProtocol = url.getProtocol();
+                if ("file".equalsIgnoreCase(urlProtocol)) {
+                    // Protocol is "file", which either addresses a jar file or an exploded jar file
+                    final Path taPath = Paths.get(url.toURI());
+                    if (Files.isDirectory(taPath)) {
+                        // Exploded Archive
+                        citSet.addAll(processExplodedJarFormat(taPath));
+                    } else {
+                        // Unexploded Archive
+                        System.err.println("Unexploded Archive Path");
+                    }
+                } else {
+                    // InputStream will be in jar format.
+                    citSet.addAll(processJarFormatInputStreamURL(url));
+                }
+
+                processInnerClasses(citSet);
+                scannedClassesMap.put(url, citSet);
+            }
+        } catch (Exception e) {
+            throw new PersistenceUnitScannerException(e);
+        }
+    }
+
+    private Set<ClassInfoType> processExplodedJarFormat(Path path) throws ClassScannerException {
+        final HashSet<ClassInfoType> citSet = new HashSet<ClassInfoType>();
+        final HashSet<Path> archiveFiles = new HashSet<Path>();
+
+        try {
+            Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    if (Files.isRegularFile(file) && Files.size(file) > 0
+                        && file.getFileName().toString().endsWith(".class")) {
+                        archiveFiles.add(file);
+                    }
+
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            for (Path p : archiveFiles) {
+                String cName = path.relativize(p).toString().replace("/", ".");
+                cName = cName.substring(0, cName.length() - 6); // Remove ".class" from name
+
+                try (InputStream is = Files.newInputStream(p)) {
+                    citSet.add(scanByteCodeFromInputStream(cName, is));
+                } catch (Throwable t) {
+                    throw new ClassScannerException(t);
+                }
+            }
+        } catch (ClassScannerException cse) {
+            throw cse;
+        } catch (Throwable t) {
+            throw new ClassScannerException(t);
+        }
+
+        return citSet;
+    }
+
+    private Set<ClassInfoType> processJarFormatInputStreamURL(URL jarURL) throws ClassScannerException {
+        final HashSet<ClassInfoType> citSet = new HashSet<ClassInfoType>();
+
+        try (JarInputStream jis = new JarInputStream(jarURL.openStream(), false)) {
+            JarEntry jarEntry = null;
+            while ((jarEntry = jis.getNextJarEntry()) != null) {
+                String name = jarEntry.getName();
+                if (name != null && name.endsWith(".class")) {
+                    name = name.substring(0, name.length() - 6).replace("/", ".");
+                    citSet.add(scanByteCodeFromInputStream(name, jis));
+                }
+            }
+        } catch (Throwable t) {
+            throw new ClassScannerException(t);
+        }
+
+        return citSet;
+    }
+
+    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    private final byte[] buffer = new byte[4096];
+
+    private ClassInfoType scanByteCodeFromInputStream(String cName, InputStream is) throws ClassScannerException {
+        baos.reset();
+
+        try {
+            int bytesRead = 0;
+            while ((bytesRead = is.read(buffer, 0, 4096)) > -1) {
+                if (bytesRead > 0) {
+                    baos.write(buffer, 0, bytesRead);
+                }
+            }
+
+            byte[] classByteCode = baos.toByteArray();
+            baos.reset();
+
+            return AsmClassAnalyzer.analyzeClass(cName, classByteCode, ioResolver);
+        } catch (Throwable t) {
+            throw new ClassScannerException(t);
+        }
+    }
+
+    private void processInnerClasses(final Set<ClassInfoType> citSet) throws ClassScannerException {
+        final HashSet<ClassInfoType> innerClassSet = new HashSet<ClassInfoType>();
+        for (ClassInfoType cit : citSet) {
+            final String className = cit.getClassName();
+            if (className.contains("$")) {
+                innerClassSet.add(cit);
+            }
+        }
+
+        if (innerClassSet.size() == 0) {
+            // No inner classes to process.
+            return;
+        }
+
+        // Found inner classes, (index + 1) identifies the inner class nested depth (index=0 for topmost inner class)
+        final ArrayList<HashSet<ClassInfoType>> innerClassDepthList = new ArrayList<HashSet<ClassInfoType>>();
+
+        // Sort inner classes into increasing nested inner class depth
+        for (ClassInfoType innerCit : innerClassSet) {
+            final String innerClassName = innerCit.getClassName();
+            final String outerClassName = innerClassName.substring(0, innerClassName.lastIndexOf("$"));
+
+            int depth = 1;
+            for (char c : outerClassName.toCharArray()) {
+                if ('$' == c) {
+                    depth++;
+                }
+            }
+
+            if (innerClassDepthList.size() < (depth)) {
+                for (int i = depth - innerClassDepthList.size(); i > 0; i--) {
+                    innerClassDepthList.add(new HashSet<ClassInfoType>());
+                }
+            }
+
+            HashSet<ClassInfoType> innerClassDepthSet = innerClassDepthList.get(depth - 1);
+            innerClassDepthSet.add(innerCit);
+        }
+
+        if (innerClassDepthList.size() > 1) {
+            // Collapse Inner Classes to the top inner class level
+            for (int index = innerClassDepthList.size() - 1; index >= 1; index--) {
+                HashSet<ClassInfoType> innerClassesAtDepth = innerClassDepthList.get(index);
+                HashSet<ClassInfoType> innerClassesAtHigherDepth = innerClassDepthList.get(index - 1);
+
+                for (ClassInfoType cit : innerClassesAtDepth) {
+                    final String innerClassName = cit.getClassName();
+                    final String outerClassName = innerClassName.substring(0, innerClassName.lastIndexOf("$"));
+
+                    ClassInfoType higherInnerClass = null;
+                    for (ClassInfoType uIC : innerClassesAtHigherDepth) {
+                        if (uIC.getClassName().equals(outerClassName)) {
+                            higherInnerClass = uIC;
+                            break;
+                        }
+                    }
+
+                    if (higherInnerClass == null) {
+                        // Didn't find the inner class containing its nested inner class.  That's a problem.
+                        // TODO: <spaceballs>Do Something!</spaceballs>
+                    } else {
+                        // Now we need to walk the higher level inner class's inner classes list until we find the
+                        // placeholder for he current inner class
+                        InnerClassesType ict = higherInnerClass.getInnerclasses();
+                        if (ict == null) {
+                            ict = new InnerClassesType();
+                            higherInnerClass.setInnerclasses(ict);
+                        }
+
+                        final List<ClassInfoType> innerClassList = ict.getInnerclass();
+                        ClassInfoType replaceThis = null;
+                        for (ClassInfoType iclCit : innerClassList) {
+                            if (iclCit.getClassName().equals(innerClassName)) {
+                                replaceThis = iclCit;
+                                break;
+                            }
+                        }
+
+                        if (replaceThis == null) {
+                            innerClassList.remove(replaceThis);
+                        }
+                        innerClassList.add(cit);
+                    }
+                }
+            }
+        }
+
+        // We have collapsed all of the nested inner classes, now to associate first-level inner classes with their
+        // outer class that is a regular class
+        HashSet<ClassInfoType> innerClassesAtDepth = innerClassDepthList.get(0);
+        for (ClassInfoType innerCit : innerClassesAtDepth) {
+            final String innerClassName = innerCit.getClassName();
+            final String outerClassName = innerClassName.substring(0, innerClassName.lastIndexOf("$"));
+
+            for (ClassInfoType cit : citSet) {
+                if (cit.getClassName().equals(outerClassName)) {
+                    InnerClassesType ict = cit.getInnerclasses();
+                    if (ict == null) {
+                        ict = new InnerClassesType();
+                        cit.setInnerclasses(ict);
+                    }
+
+                    final List<ClassInfoType> innerClassList = ict.getInnerclass();
+                    ClassInfoType replaceThis = null;
+                    for (ClassInfoType iclCit : innerClassList) {
+                        if (iclCit.getClassName().equals(innerClassName)) {
+                            replaceThis = iclCit;
+                            break;
+                        }
+                    }
+
+                    if (replaceThis != null) {
+                        innerClassList.remove(replaceThis);
+                    }
+                    innerClassList.add(innerCit);
+                }
+            }
+        }
+
+        // Remove the inner classes from the list of outer classes.
+        citSet.removeAll(innerClassSet);
+    }
+
+    /**
+     * Scan Entity Mappings Files
+     */
+    private void scanEntityMappings() throws PersistenceUnitScannerException {
+        /*
+         * From the JPA 2.1 Specification:
+         *
+         * 8.2.1.6.2 Object/relational Mapping Files
+         * An object/relational mapping XML file contains mapping information for the classes listed in it.
+         *
+         * A object/relational mapping XML file named orm.xml may be specified in the META-INF directory
+         * in the root of the persistence unit or in the META-INF directory of any jar file referenced by the persistence.
+         * xml. Alternatively, or in addition, one or more mapping files may be referenced by the
+         * mapping-file elements of the persistence-unit element. These mapping files may be
+         * present anywhere on the class path.
+         *
+         * An orm.xml mapping file or other mapping file is loaded as a resource by the persistence provider. If
+         * a mapping file is specified, the classes and mapping information specified in the mapping file will be
+         * used as described in Chapter 12. If multiple mapping files are specified (possibly including one or more
+         * orm.xml files), the resulting mappings are obtained by combining the mappings from all of the files.
+         * The result is undefined if multiple mapping files (including any orm.xml file) referenced within a single
+         * persistence unit contain overlapping mapping information for any given class. The object/relational
+         * mapping information contained in any mapping file referenced within the persistence unit must be disjoint
+         * at the class-level from object/relational mapping information contained in any other such mapping
+         * file.
+         */
+        final HashSet<URL> mappingFilesLocated = new HashSet<URL>();
+        final HashSet<String> searchNames = new HashSet<String>();
+
+        for (PersistenceUnitInfo pui : puiList) {
+            try {
+                mappingFilesLocated.clear();
+                searchNames.clear();
+                searchNames.add("META-INF/orm.xml");
+
+                if (pui.getMappingFileNames() != null) {
+                    searchNames.addAll(pui.getMappingFileNames());
+                }
+
+                for (String mappingFile : searchNames) {
+                    mappingFilesLocated.addAll(findORMResources(pui, mappingFile));
+                }
+
+                final List<EntityMappingsDefinition> parsedOrmList = pu_ormFileParsed_map.get(pui);
+                pu_ormFiles_map.get(pui).addAll(mappingFilesLocated);
+
+                // Process discovered mapping files
+                for (final URL mappingFileURL : mappingFilesLocated) {
+                    if (scanned_ormfile_map.containsKey(mappingFileURL)) {
+                        // Already processed this ORM File, no need to process it again.
+                        parsedOrmList.add(scanned_ormfile_map.get(mappingFileURL));
+                        continue;
+                    }
+
+                    EntityMappingsDefinition emapdef = EntityMappingsFactory.parseEntityMappings(mappingFileURL);
+                    parsedOrmList.add(emapdef);
+                    scanned_ormfile_map.put(mappingFileURL, emapdef);
+                }
+            } catch (Exception e) {
+                throw new PersistenceUnitScannerException(e);
+            }
+        }
+    }
+
+    /**
+     * Finds all specified ORM files, by name, constrained in location by the persistence unit root and jar files.
+     *
+     * @param ormFileName The name of the ORM file to search for
+     * @return A List of URLs of resources found by the ClassLoader. Will be an empty List if none are found.
+     * @throws IOException
+     */
+    private List<URL> findORMResources(PersistenceUnitInfo pui, String ormFileName) throws IOException {
+        final boolean isMetaInfoOrmXML = "META-INF/orm.xml".equals(ormFileName);
+        final ArrayList<URL> retArr = new ArrayList<URL>();
+
+        Enumeration<URL> ormEnum = pui.getClassLoader().getResources(ormFileName);
+        while (ormEnum.hasMoreElements()) {
+            final URL url = ormEnum.nextElement();
+            final String urlExtern = url.toExternalForm(); //  ParserUtils.decode(url.toExternalForm());
+
+            if (!isMetaInfoOrmXML) {
+                // If it's not "META-INF/orm.xml", then the mapping files may be present anywhere in the classpath.
+                retArr.add(url);
+                continue;
+            }
+
+            // Check against persistence unit root
+            if (urlExtern.startsWith(pui.getPersistenceUnitRootUrl().toExternalForm())) {
+                retArr.add(url);
+                continue;
+            }
+
+            // Check against Jar files, if any
+            for (URL jarUrl : pui.getJarFileUrls()) {
+                final String jarExtern = jarUrl.toExternalForm();
+                if (urlExtern.startsWith(jarExtern)) {
+                    retArr.add(url);
+                    continue;
+                }
+            }
+        }
+
+        return retArr;
+    }
+
+//    /*
+//     * JPA 2.1: 8.2.1.6 mapping-file, jar-file, class, exclude-unlisted-classes
+//     *
+//     * The following classes must be implicitly or explicitly denoted as managed persistence classes to be
+//     * included within a persistence unit: entity classes; embeddable classes; mapped superclasses;
+//     * converter classes.
+//     *
+//     * 8.2.1.6.1 Annotated Classes in the Root of the Persistence Unit
+//     * All classes contained in the root of the persistence unit are searched for annotated managed persistence
+//     * classes—classes with the Entity, Embeddable, MappedSuperclass, or Converter annotation—
+//     * and any mapping metadata annotations found on these classes will be processed, or they will be
+//     * mapped using the mapping annotation defaults. If it is not intended that the annotated persistence
+//     * classes contained in the root of the persistence unit be included in the persistence unit, the
+//     * exclude-unlisted-classes element must be specified as true. The
+//     * exclude-unlisted-classes element is not intended for use in Java SE environments.
+//     *
+//     * 8.2.1.6.2 Object/relational Mapping Files
+//     * An object/relational mapping XML file contains mapping information for the classes listed in it.
+//     * An object/relational mapping XML file named orm.xml may be specified in the META-INF directory
+//     * in the root of the persistence unit or in the META-INF directory of any jar file referenced by the persistence.
+//     * xml. Alternatively, or in addition, one or more mapping files may be referenced by the
+//     * mapping-file elements of the persistence-unit element. These mapping files may be
+//     * present anywhere on the class path.
+//     *
+//     * An orm.xml mapping file or other mapping file is loaded as a resource by the persistence provider. If
+//     * a mapping file is specified, the classes and mapping information specified in the mapping file will be
+//     * used as described in Chapter 12. If multiple mapping files are specified (possibly including one or more
+//     * orm.xml files), the resulting mappings are obtained by combining the mappings from all of the files.
+//     * The result is undefined if multiple mapping files (including any orm.xml file) referenced within a single
+//     * persistence unit contain overlapping mapping information for any given class. The object/relational
+//     * mapping information contained in any mapping file referenced within the persistence unit must be disjoint
+//     * at the class-level from object/relational mapping information contained in any other such mapping
+//     * file.
+//     *
+//     * 8.2.1.6.3 Jar Files
+//     * One or more JAR files may be specified using the jar-file elements instead of, or in addition to the
+//     * mapping files specified in the mapping-file elements. If specified, these JAR files will be searched
+//     * for managed persistence classes, and any mapping metadata annotations found on them will be processed,
+//     * or they will be mapped using the mapping annotation defaults defined by this specification.
+//     * Such JAR files are specified relative to the directory or jar file that contains[89] the root of the persistence
+//     * unit.[90]
+//     *
+//     * The following examples illustrate the use of the jar-file element to reference additional persistence
+//     * classes. These examples use the convention that a jar file with a name terminating in “PUnit” contains
+//     * the persistence.xml file and that a jar file with a name terminating in “Entities” contains
+//     * additional persistence classes.
+//     *
+//     * 8.2.1.6.4 List of Managed Classes
+//     * A list of named managed persistence classes—entity classes, embeddable classes, mapped superclasses,
+//     * and converter classes—may be specified instead of, or in addition to, the JAR files and mapping files.
+//     * Any mapping metadata annotations found on these classes will be processed, or they will be mapped
+//     * using the mapping annotation defaults. The class element is used to list a managed persistence class.
+//     *
+//     * A list of all named managed persistence classes must be specified in Java SE environments to insure
+//     * portability. Portable Java SE applications should not rely on the other mechanisms described here to
+//     * specify the managed persistence classes of a persistence unit. Persistence providers may require that the
+//     * set of entity classes and classes that are to be managed must be fully enumerated in each of the persistence.
+//     * xml files in Java SE environments.
+//     *
+//     * 12.1 Use of the XML Descriptor
+//     *
+//     * If the xml-mapping-metadata-complete subelement is specified, the complete set of mapping
+//     * metadata for the persistence unit is contained in the XML mapping files for the persistence unit, and any
+//     * persistence annotations on the classes are ignored.
+//     */
+//    private void trim() {
+//        // Relevant data from <persistence-unit>
+//        final boolean excludeUnlistedClasses = pUnit.excludeUnlistedClasses();
+//        final List<String> managedClassNames = pUnit.getManagedClassNames();
+//        final boolean xmlMetaDataComplete = checkXMLMetadataComplete();
+//
+//        // Identify all persistence-involved classes identified by the ORM XML files.  Include entities,
+//        // embeddables, mapped superclasses, idclasses, entitylisteners, etc in the set.
+//        final HashSet<String> persistenceAwareClassSet = new HashSet<String>();
+//
+//        final HashSet<String> ormDefinedEntitySet = new HashSet<String>();
+//        final HashSet<String> metadataCompleteEntitySet = new HashSet<String>();
+//
+//        final HashSet<String> ormDefinedEmbeddableSet = new HashSet<String>();
+//        final HashSet<String> metadataCompleteEmbeddableSet = new HashSet<String>();
+//
+//        final HashSet<String> ormDefinedMappedSuperclassSet = new HashSet<String>();
+//        final HashSet<String> metadataCompleteMappedSuperclassSet = new HashSet<String>();
+//
+//        for (EntityMappingsDefinition emd : entityMappingsDefinitionsList) {
+//            final IEntityMappings entityMappings = emd.getEntityMappings();
+//            parseORMXMLDocument(entityMappings,
+//                                persistenceAwareClassSet,
+//                                ormDefinedEntitySet,
+//                                metadataCompleteEntitySet,
+//                                ormDefinedEmbeddableSet,
+//                                metadataCompleteEmbeddableSet,
+//                                ormDefinedMappedSuperclassSet,
+//                                metadataCompleteMappedSuperclassSet);
+//        }
+//
+//        // All persistence-aware types from the discovered ORM XML documents have been identified.
+//        // If xml-metadata-complete has been flagged, then there is no need to scan classes for
+//        // annotations.
+//
+//        // First, identify all classes found by the class scanner
+//        final Map<String, List<ClassInfoType>> allClassMap = new HashMap<String, List<ClassInfoType>>();
+//        final Map<ClassInfoType, EntityMappingsScannerResults> citEmsrMap = new HashMap<ClassInfoType, EntityMappingsScannerResults>();
+//
+//        for (EntityMappingsScannerResults emsr : classScannerResults) {
+//            final ClassInformationType citInfo = emsr.getCit();
+//            final List<ClassInfoType> citList = citInfo.getClassInfo();
+//            if (citList == null || citList.size() == 0) {
+//                continue;
+//            }
+//
+//            for (ClassInfoType cit : citList) {
+//                final String className = cit.getClassName();
+//
+//                List<ClassInfoType> cList = allClassMap.get(className);
+//                if (cList == null) {
+//                    cList = new ArrayList<ClassInfoType>();
+//                    allClassMap.put(className, cList);
+//                }
+//                cList.add(cit);
+//                citEmsrMap.put(cit, emsr);
+//            }
+//        }
+//
+//        // Trim the Class scanner report
+//
+//        if (!xmlMetaDataComplete) {
+//            // Since no ORM XML file declared XML Metadata Complete, we need to scan classes for
+//            // annotations.  If exclude-unlisted-classes is set true, then only scan those classes
+//            // in the managed classes list -- otherwise scan every class in the persistence unit
+//            // root and designated jar-files.
+//
+//            if (excludeUnlistedClasses) {
+//                // Excluding unlisted classes, which means only persistence capable classes defined by the
+//                // ORM files or by the persistence unit's managed class names are permitted.
+//
+//                final Set<String> trimSet = new HashSet<String>(allClassMap.keySet());
+//                trimSet.removeAll(persistenceAwareClassSet); // Remove every class identified in the ORM XML as persistence-aware
+//                trimSet.removeAll(managedClassNames); // Remove classes listed in managed-class-names
+//                removeScannedClassEntries(trimSet, allClassMap, citEmsrMap);
+//            } else {
+//                // Not excluding unlisted classes, which means we scan all classes in the persistence unit
+//                // root and designed jar-files for annotated classes.
+//                final Set<String> trimSet = new HashSet<String>(allClassMap.keySet());
+//                trimSet.removeAll(persistenceAwareClassSet); // Remove every class identified in the ORM XML as persistence-aware
+//                trimSet.removeAll(managedClassNames); // Remove classes listed in managed-class-names
+//
+//                for (final String className : allClassMap.keySet()) {
+//                    if (persistenceAwareClassSet.contains(className) || managedClassNames.contains(className)) {
+//                        continue;
+//                    }
+//
+//                    final List<ClassInfoType> citList = allClassMap.get(className);
+//                    boolean hasJpaAnnotations = false;
+//
+//                    classsearch: for (ClassInfoType cit : citList) {
+//                        AnnotationsType ait = cit.getAnnotations();
+//                        if (ait != null) {
+//                            for (AnnotationInfoType aInfT : ait.getAnnotation()) {
+//                                String type = aInfT.getType();
+//                                if (type != null && type.startsWith("javax.persistence.")) {
+//                                    hasJpaAnnotations = true;
+//                                    break classsearch;
+//                                }
+//                            }
+//                        }
+//                    }
+//
+//                    if (hasJpaAnnotations) {
+//                        trimSet.add(className);
+//                    }
+//                }
+//
+//                removeScannedClassEntries(trimSet, allClassMap, citEmsrMap);
+//            }
+//        } else {
+//            // Trim out every class not listed in the ORM XML.
+//            final Set<String> trimSet = new HashSet<String>(allClassMap.keySet());
+//            trimSet.removeAll(persistenceAwareClassSet); // Remove every class identified in the ORM XML as persistence-aware
+//            removeScannedClassEntries(trimSet, allClassMap, citEmsrMap);
+//        }
+//
+//    }
+//
+//    private void removeScannedClassEntries(final Set<String> classNamesToRemove,
+//                                           final Map<String, List<ClassInfoType>> allClassMap,
+//                                           final Map<ClassInfoType, EntityMappingsScannerResults> citEmsrMap) {
+//        for (final String className : classNamesToRemove) {
+//            final List<ClassInfoType> citList = allClassMap.get(className);
+//            for (final ClassInfoType cit : citList) {
+//                final EntityMappingsScannerResults emsr = citEmsrMap.get(cit);
+//                final ClassInformationType c = emsr.getCit();
+//                final List<ClassInfoType> cList = c.getClassInfo();
+//                cList.remove(cit);
+//            }
+//        }
+//    }
+//
+//    private boolean checkXMLMetadataComplete() {
+//        boolean xmlMetaDataComplete = false;
+//        for (EntityMappingsDefinition emd : entityMappingsDefinitionsList) {
+//            final IEntityMappings entityMappings = emd.getEntityMappings();
+//            final IPersistenceUnitMetadata puMetaData = entityMappings.getIPersistenceUnitMetadata();
+//            if (puMetaData == null) {
+//                continue;
+//            }
+//            if (puMetaData.isXmlMappingMetadataComplete()) {
+//                xmlMetaDataComplete = true;
+//            }
+//        }
+//        return xmlMetaDataComplete;
+//    }
+//
+//    /*
+//     * Invariants: None of the arguments can be null.
+//     */
+//    private void parseORMXMLDocument(final IEntityMappings entityMappings,
+//                                     final Set<String> persistenceAwareClassSet,
+//                                     final Set<String> ormDefinedEntitySet,
+//                                     final Set<String> metadataCompleteEntitySet,
+//                                     final Set<String> ormDefinedEmbeddableSet,
+//                                     final Set<String> metadataCompleteEmbeddableSet,
+//                                     final Set<String> ormDefinedMappedSuperclassSet,
+//                                     final Set<String> metadataCompleteMappedSuperclassSet) {
+//        // Process Persistence Unit Defaults
+//        final IPersistenceUnitMetadata puMetaData = entityMappings.getIPersistenceUnitMetadata();
+//        if (puMetaData != null) {
+//            IPersistenceUnitDefaults puDefaults = puMetaData.getIPersistenceUnitDefaults();
+//            if (puDefaults != null) {
+//                persistenceAwareClassSet.addAll(puDefaults._getEntityListeners());
+//            }
+//        }
+//
+//        // Process Entity definitions for entity class and JPA important classes
+//        final List<IEntity> entityList = entityMappings.getEntityList();
+//        if (entityList != null && entityList.size() > 0) {
+//            for (IEntity entity : entityList) {
+//                final String className = entity.getClazz();
+//                persistenceAwareClassSet.add(className);
+//                ormDefinedEntitySet.add(className);
+//
+//                if (Boolean.TRUE.equals(entity.isMetadataComplete())) {
+//                    metadataCompleteEntitySet.add(className);
+//                }
+//
+//                if (entity._getIDClass() != null) {
+//                    persistenceAwareClassSet.add(entity._getIDClass());
+//                }
+//
+//                persistenceAwareClassSet.addAll(entity._getConverters());
+//                persistenceAwareClassSet.addAll(entity._getEntityListeners());
+//                persistenceAwareClassSet.addAll(entity._getNamedEntityGraphClasses());
+//                persistenceAwareClassSet.addAll(entity._getNamedNativeQueryClasses());
+//                persistenceAwareClassSet.addAll(entity._getSQLResultSetClasses());
+//
+//                // TODO: Process attributes
+//            }
+//        }
+//
+//        // Process Embeddable definitions for embeddable class and JPA important classes
+//        final List<IEmbeddable> embeddableList = entityMappings.getEmbeddableList();
+//        if (embeddableList != null && embeddableList.size() > 0) {
+//            for (IEmbeddable embeddable : embeddableList) {
+//                final String className = embeddable.getClazz();
+//                persistenceAwareClassSet.add(className);
+//                ormDefinedEmbeddableSet.add(className);
+//
+//                if (Boolean.TRUE.equals(embeddable.isMetadataComplete())) {
+//                    metadataCompleteEmbeddableSet.add(className);
+//                }
+//
+//                // TODO: Need to dive into the EmbeddableAttributes to find converters, etc.
+//            }
+//        }
+//
+//        // Process MappedSuperclass definitions for mapped super class and JPA important classes
+//        final List<IMappedSuperclass> mappedSuperclassList = entityMappings.getMappedSuperclassList();
+//        if (mappedSuperclassList != null && mappedSuperclassList.size() > 0) {
+//            for (IMappedSuperclass msc : mappedSuperclassList) {
+//                final String className = msc.getClazz();
+//                persistenceAwareClassSet.add(className);
+//                ormDefinedMappedSuperclassSet.add(className);
+//
+//                if (msc._getIDClass() != null) {
+//                    persistenceAwareClassSet.add(msc._getIDClass());
+//                }
+//
+//                if (Boolean.TRUE.equals(msc.isMetadataComplete())) {
+//                    metadataCompleteMappedSuperclassSet.add(className);
+//                }
+//
+//                // TODO: Need to dive into the Attributes to find converters, etc.
+//            }
+//        }
+//
+//        // Named Native Query
+//
+//        // NamedStoredProcedureQuery
+//
+//        // SQL Result Set Mapping
+//    }
+}

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puscanner/PersistenceUnitScannerResults2.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puscanner/PersistenceUnitScannerResults2.java
@@ -1,0 +1,612 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.diagnostics.puscanner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.persistence.spi.PersistenceUnitInfo;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+
+import com.ibm.ws.ffdc.FFDCFilter;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.AnnotationInfoType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.AnnotationValueType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.AnnotationsType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ArrayEntryType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ArrayInstanceType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ClassInfoType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ClassInformationType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ExceptionType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.FieldInfoType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.FieldsType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ListEntryType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ListInstanceType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.MapEntryType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.MapInstanceType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.MethodInfoType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.MethodsType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ModifierType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ModifiersType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ObjectFieldInstanceType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ObjectInstanceType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ParameterType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ParametersType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ValueInstanceType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ValueType;
+import com.ibm.ws.jpa.diagnostics.ormparser.EntityMappingsDefinition;
+import com.ibm.ws.jpa.diagnostics.utils.encapsulation.EncapsulatedData;
+import com.ibm.ws.jpa.diagnostics.utils.encapsulation.EncapsulatedDataGroup;
+
+/**
+ *
+ */
+public class PersistenceUnitScannerResults2 {
+    private final List<PersistenceUnitInfo> puiList = new ArrayList<PersistenceUnitInfo>();
+    private final Map<URL, String> pxmlMap = new HashMap<URL, String>();
+
+    private final Set<URL> urlSet = new HashSet<URL>();
+    private final Map<URL, Set<ClassInfoType>> scannedClassesMap = new HashMap<URL, Set<ClassInfoType>>();
+
+    private final Map<URL, EntityMappingsDefinition> scanned_ormfile_map = new HashMap<URL, EntityMappingsDefinition>();
+    private final Map<PersistenceUnitInfo, List<EntityMappingsDefinition>> pu_ormFileParsed_map = new HashMap<PersistenceUnitInfo, List<EntityMappingsDefinition>>();
+
+    public PersistenceUnitScannerResults2(List<PersistenceUnitInfo> puiList,
+                                          Map<URL, String> pxmlMap,
+                                          Set<URL> urlSet,
+                                          Map<URL, Set<ClassInfoType>> scannedClassesMap,
+                                          Map<URL, EntityMappingsDefinition> scanned_ormfile_map,
+                                          Map<PersistenceUnitInfo, List<EntityMappingsDefinition>> pu_ormFileParsed_map) {
+        if (puiList != null)
+            this.puiList.addAll(puiList);
+
+        if (pxmlMap != null)
+            this.pxmlMap.putAll(pxmlMap);
+
+        if (urlSet != null)
+            this.urlSet.addAll(urlSet);
+
+        if (scannedClassesMap != null)
+            this.scannedClassesMap.putAll(scannedClassesMap);
+
+        if (scanned_ormfile_map != null)
+            this.scanned_ormfile_map.putAll(scanned_ormfile_map);
+
+        if (pu_ormFileParsed_map != null)
+            this.pu_ormFileParsed_map.putAll(pu_ormFileParsed_map);
+    }
+
+    public List<PersistenceUnitInfo> getPersistenceUnitInfoList() {
+        return Collections.unmodifiableList(puiList);
+    }
+
+    public Map<URL, EntityMappingsDefinition> getAllEntityMappingsDefinitions() {
+        return Collections.unmodifiableMap(scanned_ormfile_map);
+    }
+
+    public Map<URL, Set<ClassInfoType>> getAllScannedClasses() {
+        final Map<URL, Set<ClassInfoType>> retMap = new HashMap<URL, Set<ClassInfoType>>();
+        for (Map.Entry<URL, Set<ClassInfoType>> entry : scannedClassesMap.entrySet()) {
+            retMap.put(entry.getKey(), Collections.unmodifiableSet(entry.getValue()));
+        }
+
+        return retMap;
+    }
+
+    public List<EntityMappingsDefinition> getEntityMappingsForPersistenceUnit(PersistenceUnitInfo pui) {
+        List<EntityMappingsDefinition> entMappings = pu_ormFileParsed_map.get(pui);
+        if (entMappings == null) {
+            return new ArrayList<EntityMappingsDefinition>();
+        }
+
+        return Collections.unmodifiableList(entMappings);
+    }
+
+    public Map<URL, Set<ClassInfoType>> getScannedClassesForPersistenceUnit(PersistenceUnitInfo pui) {
+        HashSet<URL> urlSet = new HashSet<URL>();
+        urlSet.add(pui.getPersistenceUnitRootUrl());
+        if (pui.getJarFileUrls() != null) {
+            urlSet.addAll(pui.getJarFileUrls());
+        }
+
+        HashMap<URL, Set<ClassInfoType>> retMap = new HashMap<URL, Set<ClassInfoType>>();
+        for (URL url : urlSet) {
+            if (scannedClassesMap.containsKey(url)) {
+                retMap.put(url, Collections.unmodifiableSet(scannedClassesMap.get(url)));
+            }
+        }
+
+        return retMap;
+    }
+
+    public void generateORMDump(PrintWriter out) {
+        // Map Persistence Unit Root URLs to PersistenceUnitInfo instances
+        final Map<URL, List<PersistenceUnitInfo>> commonPuRootMap = new HashMap<URL, List<PersistenceUnitInfo>>();
+        for (PersistenceUnitInfo pui : puiList) {
+            final URL puRoot = pui.getPersistenceUnitRootUrl();
+            List<PersistenceUnitInfo> puList = commonPuRootMap.get(puRoot);
+            if (puList == null) {
+                puList = new ArrayList<PersistenceUnitInfo>();
+                commonPuRootMap.put(puRoot, puList);
+            }
+            puList.add(pui);
+        }
+
+        final EncapsulatedDataGroup root = EncapsulatedDataGroup.createEncapsulatedDataGroup("ORMDiagnostics", "ORMDiagnostics");
+        int id = 0;
+
+        // Set Properties
+        root.setProperty("execution.environment", "WebSphere Liberty");
+
+        //
+        // Store persistence.xml documents in /PersistenceXML
+        // Properties:
+        //   pu.root.url - persistence unit root URL
+        //
+
+        // Folder for containing application persistence.xml documents
+        final String pxmlFolderId = new Integer(id++).toString();
+        final EncapsulatedDataGroup pxmlFolder = EncapsulatedDataGroup.createEncapsulatedDataGroup("PersistenceXML", pxmlFolderId);
+        root.putDataSubGroup(pxmlFolder);
+
+        final Map<URL, String> puRootToEncapIdMap = new HashMap<URL, String>();
+        for (Map.Entry<URL, String> entry : pxmlMap.entrySet()) {
+            final String pxmlDocId = new Integer(id++).toString();
+            try {
+                final EncapsulatedData ed = EncapsulatedData.createEncapsulatedData("persistence.xml", pxmlDocId, entry.getValue().getBytes());
+                ed.setProperty("pu.root.url", entry.getKey().toString());
+                pxmlFolder.putDataItem(ed);
+                puRootToEncapIdMap.put(entry.getKey(), pxmlDocId);
+            } catch (Exception e) {
+                FFDCFilter.processException(e, PersistenceUnitScannerResults2.class.getName() + ".generateORMDump", "pxml-proc");
+            }
+        }
+
+        //
+        // Store server PersistenceUnitInfo.toString() output
+        // Properties:
+        //    pu.name - persistence unit name
+        //    pu.root.url - persistence unit root URL
+        //
+        final String pxmlToStringFolderId = new Integer(id++).toString();
+        final EncapsulatedDataGroup pxmlToStringFolder = EncapsulatedDataGroup.createEncapsulatedDataGroup("PersistenceXMLToString", pxmlToStringFolderId);
+        root.putDataSubGroup(pxmlToStringFolder);
+        for (Map.Entry<URL, List<PersistenceUnitInfo>> entry : commonPuRootMap.entrySet()) {
+            for (PersistenceUnitInfo pui : entry.getValue()) {
+                final String docId = new Integer(id++).toString();
+                try {
+                    final EncapsulatedData ed = EncapsulatedData.createEncapsulatedData("jpa-persistence-unit-info", docId, pui.toString().getBytes());
+                    ed.setProperty("pu.name", pui.getPersistenceUnitName());
+                    ed.setProperty("pu.root.url", entry.getKey().toString());
+                    pxmlToStringFolder.putDataItem(ed);
+                } catch (Exception e) {
+                    FFDCFilter.processException(e, PersistenceUnitScannerResults2.class.getName() + ".generateORMDump", "pxml-tostring");
+                }
+            }
+        }
+
+        //
+        // Store Object Relational Mapping Files
+        // Properties:
+        //   url - URL of the ORM asset
+        //
+        final String ormFileFolderId = new Integer(id++).toString();
+        final EncapsulatedDataGroup ormFileFolder = EncapsulatedDataGroup.createEncapsulatedDataGroup("Object Relational Mapping Files", ormFileFolderId);
+        root.putDataSubGroup(ormFileFolder);
+        for (Map.Entry<URL, EntityMappingsDefinition> entry : scanned_ormfile_map.entrySet()) {
+            final String docId = new Integer(id++).toString();
+            try {
+                final EntityMappingsDefinition emd = entry.getValue();
+                final EncapsulatedData ed = EncapsulatedData.createEncapsulatedData("ORM File", docId, emd.getFileData());
+                ed.setProperty("url", emd.getSource().toString());
+                ormFileFolder.putDataItem(ed);
+            } catch (Exception e) {
+                FFDCFilter.processException(e, PersistenceUnitScannerResults2.class.getName() + ".generateORMDump", "orm-file-collection");
+            }
+        }
+
+        //
+        // Store Processed Class Info
+        // Properties:
+        // url - URL of the archive containing the analyzed class
+        //
+        final String scannedClassesFolderId = new Integer(id++).toString();
+        final EncapsulatedDataGroup scannedClassesFolder = EncapsulatedDataGroup.createEncapsulatedDataGroup("Scanned Classes", scannedClassesFolderId);
+        root.putDataSubGroup(scannedClassesFolder);
+        for (Map.Entry<URL, Set<ClassInfoType>> entry : scannedClassesMap.entrySet()) {
+            final String docId = new Integer(id++).toString();
+            try {
+                final ClassInformationType cit = new ClassInformationType();
+                cit.getClassInfo().addAll(entry.getValue());
+
+                final JAXBContext jaxbCtx = JAXBContext.newInstance("com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10");
+                final Marshaller marshaller = jaxbCtx.createMarshaller();
+                marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+                final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                marshaller.marshal(cit, baos);
+
+                final EncapsulatedData ed = EncapsulatedData.createEncapsulatedData("Classes", docId, baos.toByteArray());
+                ed.setProperty("url", entry.getKey().toString());
+                scannedClassesFolder.putDataItem(ed);
+            } catch (Exception e) {
+                FFDCFilter.processException(e, PersistenceUnitScannerResults2.class.getName() + ".generateORMDump", "orm-file-collection");
+            }
+        }
+
+        out.println();
+        out.println("Encapsulated JPA Diagnostic Data:");
+        out.println();
+        try {
+            root.write(out);
+        } catch (Exception e) {
+            FFDCFilter.processException(e, PersistenceUnitScannerResults2.class.getName() + ".generateORMDump", "store-encapsulated-data");
+        }
+    }
+
+    public void printReport(PrintWriter out) {
+        // Print ORM Files
+        for (Map.Entry<URL, EntityMappingsDefinition> entry : scanned_ormfile_map.entrySet()) {
+            out.println();
+            out.println("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
+            out.println("Object Relational Mapping (ORM) File:");
+
+            String urlStr = entry.getKey().toString().replace("%21", "!");
+            String ptcols = urlStr.substring(0, urlStr.indexOf("/"));
+            String path = urlStr.substring(urlStr.indexOf("/"));
+            if (path.contains(".cache")) {
+                path = path.substring(path.lastIndexOf(".cache") + 6);
+            }
+
+            out.println("Location: " + ptcols + "..." + path);
+
+            out.println("Referenced by Persistence Unit:");
+            for (Map.Entry<PersistenceUnitInfo, List<EntityMappingsDefinition>> e2 : pu_ormFileParsed_map.entrySet()) {
+                if (e2.getValue().contains(entry.getValue())) {
+                    out.println("   " + e2.getKey().getPersistenceUnitName());
+                }
+            }
+
+            out.println();
+            out.println(new String(entry.getValue().getFileData()));
+        }
+
+        // Print Scanned Classes
+        for (Map.Entry<URL, Set<ClassInfoType>> entry : scannedClassesMap.entrySet()) {
+            out.println();
+            out.println("Scanned Classes for location: " + entry.getKey());
+
+            String urlStr = entry.getKey().toString().replace("%21", "!");
+            String ptcols = urlStr.substring(0, urlStr.indexOf("/"));
+            String path = urlStr.substring(urlStr.indexOf("/"));
+            if (path.contains(".cache")) {
+                path = path.substring(path.lastIndexOf(".cache") + 6);
+            }
+
+            final ArrayList<ClassInfoType> sortedCitList = new ArrayList<ClassInfoType>(entry.getValue());
+            Collections.sort(sortedCitList, new Comparator<ClassInfoType>() {
+                @Override
+                public int compare(ClassInfoType o1, ClassInfoType o2) {
+                    if (o1 == null || o2 == null || o1.getClassName() == null || o2.getClassName() == null)
+                        return 0;
+                    return o1.getClassName().compareTo(o2.getClassName());
+                }
+            });
+
+            for (ClassInfoType cit : sortedCitList) {
+                out.println("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
+                out.println("Class: " + cit.getClassName());
+                out.println("Location: " + ptcols + "..." + path);
+                out.println();
+                out.println(process(cit));
+            }
+            out.println();
+        }
+    }
+
+    public static String process(ClassInfoType cit) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("package ").append(cit.getPackageName()).append(";").append("\n");
+        sb.append("\n");
+
+        processAnnotationsType(cit.getAnnotations(), "", sb, false);
+
+        printModifiersType(cit.getModifiers(), sb);
+
+        if (cit.isIsInterface()) {
+            sb.append("interface ");
+        } else {
+            sb.append("class ");
+        }
+
+        sb.append(cit.getName());
+        sb.append(" {\n");
+
+        printFields(cit, sb);
+        sb.append("\n");
+        printMethods(cit, sb);
+
+        sb.append("\n}\n");
+        return sb.toString();
+    }
+
+    private static void printModifiersType(ModifiersType mods, StringBuilder sb) {
+        if (mods == null) {
+            return;
+        }
+
+        List<ModifierType> modList = mods.getModifier();
+        for (ModifierType mt : modList) {
+            sb.append(mt.toString().toLowerCase());
+            sb.append(" ");
+        }
+    }
+
+    private static void printFields(ClassInfoType cit, StringBuilder sb) {
+        FieldsType ft = cit.getFields();
+        if (ft == null) {
+            return;
+        }
+        sb.append("  // Fields\n");
+
+        boolean first = true;
+        List<FieldInfoType> fiList = ft.getField();
+        for (FieldInfoType fit : fiList) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append("\n");
+            }
+            processAnnotationsType(fit.getAnnotations(), "  ", sb, false);
+            sb.append("  ");
+            printModifiersType(fit.getModifiers(), sb);
+            sb.append(fit.getType()).append(" ");
+            sb.append(fit.getName()).append(";\n");
+        }
+    }
+
+    private static void printMethods(ClassInfoType cit, StringBuilder sb) {
+        MethodsType mt = cit.getMethods();
+        if (mt == null) {
+            return;
+        }
+
+        sb.append("  // Methods\n");
+
+        boolean first = true;
+        List<MethodInfoType> miList = mt.getMethod();
+        for (MethodInfoType mit : miList) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append("\n");
+            }
+
+            processAnnotationsType(mit.getAnnotations(), "  ", sb, false);
+            sb.append("  ");
+            printModifiersType(mit.getModifiers(), sb);
+
+            if (mit.isIsCtor()) {
+                sb.append(cit.getName());
+            } else {
+                sb.append(mit.getReturnType()).append(" ");
+                sb.append(mit.getMethodName());
+            }
+
+            sb.append("(");
+
+            ParametersType pt = mit.getParameters();
+            if (pt != null) {
+                boolean first2 = true;
+
+                List<ParameterType> ptList = pt.getParameter();
+                for (ParameterType parmType : ptList) {
+                    if (first2) {
+                        first2 = false;
+                    } else {
+                        sb.append(", ");
+                    }
+                    sb.append(parmType.getType());
+                    if (parmType.isIsArray()) {
+                        sb.append("[]");
+                    }
+                }
+            }
+
+            sb.append(")");
+
+            if (mit.getExceptions() != null) {
+                List<ExceptionType> exList = mit.getExceptions().getException();
+                sb.append(" throws ");
+
+                boolean first2 = true;
+                for (ExceptionType et : exList) {
+                    if (first2) {
+                        first2 = false;
+                    } else {
+                        sb.append(", ");
+                    }
+                    sb.append(et.getExceptionType());
+                }
+                sb.append(" ");
+            }
+
+            sb.append(";\n");
+
+        }
+    }
+
+    private static void processAnnotationsType(AnnotationsType at, String indent, StringBuilder sb, boolean printComma) {
+        if (indent == null) {
+            indent = "";
+        }
+
+        if (at == null) {
+            return;
+        }
+
+        boolean first = true;
+
+        List<AnnotationInfoType> annoInfoTypeList = at.getAnnotation();
+        for (AnnotationInfoType ait : annoInfoTypeList) {
+            if (printComma) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+            }
+            processAnnotationInfoType(ait, indent, sb);
+        }
+    }
+
+    private static void processAnnotationInfoType(AnnotationInfoType ait, String indent, StringBuilder sb) {
+        final String type = ait.getType();
+        sb.append(indent).append("@").append(type);
+
+        final List<AnnotationValueType> avtList = ait.getAnnoKeyVal();
+        if (avtList.size() > 0) {
+            sb.append("(");
+
+            boolean first = true;
+
+            for (AnnotationValueType avt : avtList) {
+                final String name = avt.getName();
+
+                final AnnotationInfoType ait2 = avt.getAnnotation();
+                final AnnotationsType at2 = avt.getAnnotations();
+                final ValueInstanceType vit = avt.getValue();
+                final ArrayInstanceType arrit = avt.getValues();
+
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                sb.append(name).append("=");
+
+                if (vit != null) {
+                    processValueInstanceType(vit, sb);
+                } else if (ait2 != null) {
+                    processAnnotationInfoType(ait2, indent + "  ", sb);
+                } else if (at2 != null) {
+                    sb.append("{ ");
+                    processAnnotationsType(at2, indent + "  ", sb, true);
+                    sb.append("} ");
+                }
+            }
+
+            sb.append(")");
+        }
+
+        sb.append("\n");
+
+    }
+
+    private static void processValueInstanceType(ValueInstanceType vit, StringBuilder sb) {
+        final ValueType valType = vit.getType();
+        if (valType == ValueType.ARRAY) {
+            final ArrayInstanceType arrIt = vit.getArray();
+            final List<ArrayEntryType> entryList = arrIt.getEntry();
+            try {
+                sb.append("[");
+                boolean first = true;
+                for (ArrayEntryType aet : entryList) {
+                    if (!first) {
+                        sb.append(", ");
+                    } else {
+                        first = false;
+                    }
+                    processValueInstanceType(aet.getValue(), sb);
+                }
+            } finally {
+                sb.append("]");
+            }
+        } else if (valType == ValueType.LIST) {
+            final ListInstanceType lit = vit.getList();
+            final List<ListEntryType> letList = lit.getEntry();
+            try {
+                sb.append("{");
+                boolean first = true;
+                for (ListEntryType let : letList) {
+                    if (!first) {
+                        sb.append(", ");
+                    } else {
+                        first = false;
+                    }
+                    processValueInstanceType(let.getValue(), sb);
+                }
+            } finally {
+                sb.append("}");
+            }
+        } else if (valType == ValueType.MAP) {
+            final MapInstanceType mit = vit.getMap();
+            final List<MapEntryType> metList = mit.getEntry();
+            try {
+                sb.append("{");
+
+                boolean first = true;
+                for (MapEntryType met : metList) {
+                    if (!first) {
+                        sb.append(", ");
+                    } else {
+                        first = false;
+                    }
+                    processValueInstanceType(met.getKey(), sb);
+                    sb.append(" = ");
+                    processValueInstanceType(met.getValue(), sb);
+                }
+
+            } finally {
+                sb.append("}");
+            }
+        } else if (valType == ValueType.OBJECT) {
+            final ObjectInstanceType oit = vit.getObject();
+            final String className = oit.getClassName();
+            final int id = oit.getId();
+            final List<ObjectFieldInstanceType> fieldList = oit.getField();
+
+            sb.append("<<Object <").append(className).append("> ");
+            sb.append("id=").append(id).append(" ");
+
+            try {
+                boolean first = true;
+                for (ObjectFieldInstanceType field : fieldList) {
+                    if (!first) {
+                        sb.append(", ");
+                    } else {
+                        first = false;
+                    }
+
+                    final String fieldName = field.getName();
+                    sb.append(fieldName).append("= |");
+                    processValueInstanceType(field.getValue(), sb);
+                    sb.append("|");
+                }
+            } finally {
+                sb.append(">>");
+            }
+        } else if (valType == ValueType.JAVA_LANG_STRING) {
+            sb.append("\"").append(vit.getSimple()).append("\"");
+        } else {
+            sb.append(vit.getSimple());
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puscanner/PersistenceUnitScannerResults2.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puscanner/PersistenceUnitScannerResults2.java
@@ -37,6 +37,7 @@ import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ClassInform
 import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ExceptionType;
 import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.FieldInfoType;
 import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.FieldsType;
+import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.InterfacesType;
 import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ListEntryType;
 import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ListInstanceType;
 import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.MapEntryType;
@@ -337,6 +338,28 @@ public class PersistenceUnitScannerResults2 {
         }
 
         sb.append(cit.getName());
+        final String superclassName = cit.getSuperclassName();
+        if (superclassName != null && !superclassName.trim().isEmpty() && !superclassName.trim().equals("java.lang.Object")) {
+            sb.append(" extends ").append(superclassName.replace("/", ".")).append(" ");
+        }
+
+        final InterfacesType ifaces = cit.getInterfaces();
+        if (ifaces != null) {
+            List<String> ifaceList = ifaces.getInterface();
+            if (ifaceList.size() > 0) {
+                sb.append(" implements ");
+                boolean first = true;
+                for (String iface : ifaceList) {
+                    if (!first) {
+                        sb.append(", ");
+                    } else {
+                        first = false;
+                    }
+                    sb.append(iface.replace("/", "."));
+                }
+            }
+        }
+
         sb.append(" {\n");
 
         printFields(cit, sb);


### PR DESCRIPTION
Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>

Reworked the JPA ORM Diagnostic Output produced in the introspector (have not changed ORM diagnostic produced in JPAORM trace spec, yet.)

Rework includes the following:
1) Pre-collect and organizes all app scopes and persistence units
2) Scans and processes ORM XML files only once, not once per persistence unit (perf improvement)
3) Scans and processes classes in persistence unit root modules and referenced library jars only once (perf improvement)
4) Introspection doc produces original persistence.xml, ORM XML docs, and application class/field/method signatures and annotations in human readable format
5) Encoded data group (intended for future analysis tools) reorganized to avoid data repeat.  Encoded data group now represents one entire application's JPA persistence information, instead of a single persistence unit.  (eliminates redundancy)


