### PR TITLE
use builders to create connections with sharding keys

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
@@ -22,6 +22,11 @@ import java.sql.Statement;
 import java.util.concurrent.Executor;
 
 import javax.resource.spi.ConnectionManager;
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.PooledConnection;
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
 
 import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
@@ -29,6 +34,7 @@ import org.osgi.service.component.annotations.Component;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
+import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
 import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcCallableStatement;
@@ -127,6 +133,21 @@ public class JDBC40Runtime implements JDBCRuntimeVersion {
 
     @Override
     public int doGetNetworkTimeout(Connection sqlConn) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public Connection buildConnection(DataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public PooledConnection buildPooledConnection(ConnectionPoolDataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public XAConnection buildXAConnection(XADataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 

--- a/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
@@ -131,6 +131,11 @@ public class JDBC40Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
+    public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
     public void beginRequest(Connection con) {}
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
@@ -157,6 +157,11 @@ public class JDBC41Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
+    public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
     public void beginRequest(Connection con) {}
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
@@ -22,6 +22,11 @@ import java.sql.Statement;
 import java.util.concurrent.Executor;
 
 import javax.resource.spi.ConnectionManager;
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.PooledConnection;
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
 
 import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
@@ -29,6 +34,7 @@ import org.osgi.service.component.annotations.Component;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
+import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
 import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcCallableStatement;
@@ -154,6 +160,21 @@ public class JDBC41Runtime implements JDBCRuntimeVersion {
     @Override
     public BatchUpdateException newBatchUpdateException(BatchUpdateException copyFrom, String newMessage) {
         return new BatchUpdateException(newMessage, copyFrom.getSQLState(), copyFrom.getErrorCode(), copyFrom.getUpdateCounts());
+    }
+
+    @Override
+    public Connection buildConnection(DataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public PooledConnection buildPooledConnection(ConnectionPoolDataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public XAConnection buildXAConnection(XADataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
@@ -157,6 +157,11 @@ public class JDBC42Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
+    public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
     public void beginRequest(Connection con) {}
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
@@ -22,6 +22,11 @@ import java.sql.Statement;
 import java.util.concurrent.Executor;
 
 import javax.resource.spi.ConnectionManager;
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.PooledConnection;
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
 
 import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
@@ -29,6 +34,7 @@ import org.osgi.service.component.annotations.Component;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
+import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
 import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcCallableStatement;
@@ -154,6 +160,21 @@ public class JDBC42Runtime implements JDBCRuntimeVersion {
         } catch (IncompatibleClassChangeError e) { // pre-4.1 driver
             throw new SQLFeatureNotSupportedException(e);
         }
+    }
+
+    @Override
+    public Connection buildConnection(DataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public PooledConnection buildPooledConnection(ConnectionPoolDataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public XAConnection buildXAConnection(XADataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
@@ -13,6 +13,7 @@ package com.ibm.ws.jdbc.osgi.v43;
 import java.sql.BatchUpdateException;
 import java.sql.CallableStatement;
 import java.sql.Connection;
+import java.sql.ConnectionBuilder;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -23,6 +24,13 @@ import java.sql.Statement;
 import java.util.concurrent.Executor;
 
 import javax.resource.spi.ConnectionManager;
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.PooledConnection;
+import javax.sql.PooledConnectionBuilder;
+import javax.sql.XAConnection;
+import javax.sql.XAConnectionBuilder;
+import javax.sql.XADataSource;
 
 import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
@@ -30,6 +38,7 @@ import org.osgi.service.component.annotations.Component;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
+import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
 import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcCallableStatement;
@@ -156,6 +165,54 @@ public class JDBC43Runtime implements JDBCRuntimeVersion {
         } catch (IncompatibleClassChangeError e) { // pre-4.1 driver
             throw new SQLFeatureNotSupportedException(e);
         }
+    }
+
+    @Override
+    public Connection buildConnection(DataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        ConnectionBuilder builder = ds.createConnectionBuilder();
+        if (user != null)
+            builder.user(user);
+        if (password != null)
+            builder.password(password);
+        Object shardingKey = cri.getShardingKey();
+        if (shardingKey != null)
+            builder.shardingKey((ShardingKey) shardingKey);
+        Object superShardingKey = cri.getSuperShardingKey();
+        if (superShardingKey != null)
+            builder.superShardingKey((ShardingKey) superShardingKey);
+        return builder.build();
+    }
+
+    @Override
+    public PooledConnection buildPooledConnection(ConnectionPoolDataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        PooledConnectionBuilder builder = ds.createPooledConnectionBuilder();
+        if (user != null)
+            builder.user(user);
+        if (password != null)
+            builder.password(password);
+        Object shardingKey = cri.getShardingKey();
+        if (shardingKey != null)
+            builder.shardingKey((ShardingKey) shardingKey);
+        Object superShardingKey = cri.getSuperShardingKey();
+        if (superShardingKey != null)
+            builder.superShardingKey((ShardingKey) superShardingKey);
+        return builder.build();
+    }
+
+    @Override
+    public XAConnection buildXAConnection(XADataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException {
+        XAConnectionBuilder builder = ds.createXAConnectionBuilder();
+        if (user != null)
+            builder.user(user);
+        if (password != null)
+            builder.password(password);
+        Object shardingKey = cri.getShardingKey();
+        if (shardingKey != null)
+            builder.shardingKey((ShardingKey) shardingKey);
+        Object superShardingKey = cri.getSuperShardingKey();
+        if (superShardingKey != null)
+            builder.superShardingKey((ShardingKey) superShardingKey);
+        return builder.build();
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
@@ -18,6 +18,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.ShardingKey;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
@@ -153,6 +154,15 @@ public class JDBC43Runtime implements JDBCRuntimeVersion {
         try {
             return sqlConn.getNetworkTimeout();
         } catch (IncompatibleClassChangeError e) { // pre-4.1 driver
+            throw new SQLFeatureNotSupportedException(e);
+        }
+    }
+
+    @Override
+    public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException {
+        try {
+            con.setShardingKey((ShardingKey) shardingKey, (ShardingKey) superShardingKey);
+        } catch (IncompatibleClassChangeError e) { // pre-4.3 driver
             throw new SQLFeatureNotSupportedException(e);
         }
     }

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.java
@@ -17,6 +17,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.ShardingKeyBuilder;
 
 import javax.resource.spi.ConnectionManager;
+import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 
 import com.ibm.websphere.ras.Tr;
@@ -40,7 +41,11 @@ public class WSJdbc43DataSource extends WSJdbcDataSource implements DataSource {
 
     @Override
     public ShardingKeyBuilder createShardingKeyBuilder() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        CommonDataSource ds = mcf.getUnderlyingDataSource();
+        if (ds == null) // not available because data source is backed by java.sql.Driver
+            throw new SQLFeatureNotSupportedException("java.sql.Driver.createShardingKeyBuilder");
+        else
+            return ds.createShardingKeyBuilder();
     }
 
     Connection getConnection(WSJdbc43ConnectionBuilder builder) throws SQLException {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 IBM Corporation and others.
+ * Copyright (c) 2014, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,11 @@ import java.sql.Statement;
 import java.util.concurrent.Executor;
 
 import javax.resource.spi.ConnectionManager;
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.PooledConnection;
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
 
 import org.osgi.framework.Version;
 
@@ -33,6 +38,7 @@ import com.ibm.ws.rsadapter.jdbc.WSJdbcPreparedStatement;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcResultSet;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcStatement;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
+import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
 import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 
@@ -89,7 +95,10 @@ public interface JDBCRuntimeVersion {
     // JDBC 4.2 BatchUpdateException constructor
     public BatchUpdateException newBatchUpdateException(BatchUpdateException copyFrom, String newMessage);
 
-    // JDBC 4.3 Connection methods
+    // JDBC 4.3 connection builder and Connection methods
+    public Connection buildConnection(DataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException;
+    public PooledConnection buildPooledConnection(ConnectionPoolDataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException;
+    public XAConnection buildXAConnection(XADataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException;
     public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException;
     public void beginRequest(Connection con) throws SQLException;
     public void endRequest(Connection con) throws SQLException;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
@@ -90,6 +90,7 @@ public interface JDBCRuntimeVersion {
     public BatchUpdateException newBatchUpdateException(BatchUpdateException copyFrom, String newMessage);
 
     // JDBC 4.3 Connection methods
+    public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException;
     public void beginRequest(Connection con) throws SQLException;
     public void endRequest(Connection con) throws SQLException;
 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -981,35 +981,17 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
         try {
             conn = AccessController.doPrivileged(new PrivilegedExceptionAction<Connection>() {
                 public Connection run() throws Exception {
-                    // OracleDataSource.getConnection(Properties)
-                    Properties oracleProps = cri.getOracleProperties();
-                    if (oracleProps != null)
-                        try {
-                            if (isTraceOn && tc.isDebugEnabled())
-                                Tr.debug(this, tc, "obtain Oracle data source with properties:", oracleProps);
-                            final Object ods = WSJdbcTracer.getImpl(dataSourceOrDriver);
-                            Class<?> dsClass = null;
-                            if(System.getSecurityManager() == null) {
-                                dsClass = jdbcDriverLoader.loadClass("oracle.jdbc.pool.OracleDataSource");
-                            } else 
-                                dsClass = AccessController.doPrivileged(new PrivilegedExceptionAction<Class<?>>() {
-                                    @Override
-                                    public Class<?> run() throws ClassNotFoundException {
-                                        return jdbcDriverLoader.loadClass("oracle.jdbc.pool.OracleDataSource");
-                                    }
-                                }); 
-                            Method method = dsClass.getMethod("getConnection", Properties.class);
-                            return (Connection) method.invoke(ods, oracleProps.clone());
-                        } catch (InvocationTargetException x) {
-                            throw x.getCause() instanceof Exception ? (Exception) x.getCause() : x;
-                        }
-
-                    if (dataSourceOrDriver instanceof XADataSource) {
+                    boolean buildConnection = cri.ivShardingKey != null || cri.ivSuperShardingKey != null;
+                    if (!buildConnection && dataSourceOrDriver instanceof XADataSource) {
+                        // TODO this code path is very suspect, and so we are not continuing it for connection builder path.
+                        // Why convert what was requested to be a DataSource to XADataSource?
+                        // And then it also leaks the XAConnection. It is not tracked, so it never gets closed! 
                         return user == null ? ((XADataSource) dataSourceOrDriver).getXAConnection().getConnection()
-                                        : ((XADataSource) dataSourceOrDriver).getXAConnection(user, pwd).getConnection();
+                                            : ((XADataSource) dataSourceOrDriver).getXAConnection(user, pwd).getConnection();
                     } else {
-                        return user == null ? ((DataSource) dataSourceOrDriver).getConnection()
-                                        : ((DataSource) dataSourceOrDriver).getConnection(user, pwd);
+                        return buildConnection ? jdbcRuntime.buildConnection((DataSource) dataSourceOrDriver, user, pwd, cri)
+                                        : user == null ? ((DataSource) dataSourceOrDriver).getConnection()
+                                                        : ((DataSource) dataSourceOrDriver).getConnection(user, pwd);
                     }
                 }
             });

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -298,6 +298,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
     private Map<String, Class<?>> defaultTypeMap;
     private boolean defaultReadOnly;
     private String defaultSchema, currentSchema = null;
+    private Object defaultShardingKey, currentShardingKey;
+    private Object defaultSuperShardingKey, currentSuperShardingKey;
     private int defaultNetworkTimeout;
     public int currentNetworkTimeout = 0;
 
@@ -307,7 +309,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
     /** Indicates whether transaction isolation has been changed. */
     private boolean isolationChanged;
 
-    /** Indicates whether catalog, typeMap, readOnly, schema, or networkTimeout has been changed. */
+    /** Indicates whether catalog, typeMap, readOnly, schema, sharding key, super sharding key, or networkTimeout has been changed. */
     private boolean connectionPropertyChanged;
 
     /** current cursor holdability */
@@ -489,7 +491,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
         if (!cri.isCRIChangable())
             cri = WSConnectionRequestInfoImpl.createChangableCRIFromNon(cri);
-        cri.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema, defaultNetworkTimeout);
+        cri.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema,
+                             defaultNetworkTimeout, defaultShardingKey, defaultSuperShardingKey);
 
         // Check to make sure a datasource configured with 'NONE (0)' is compatible with the driver being used. 
         if(config.isolationLevel == Connection.TRANSACTION_NONE) {
@@ -642,7 +645,9 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                                 cri.ivPassword,
                                 isolationChanged ? currentTransactionIsolation : cri.ivIsoLevel,
                                 connectionPropertyChanged ? getCatalog() : cri.ivCatalog,
-                                connectionPropertyChanged && mcf.supportsIsReadOnly ? Boolean.valueOf(isReadOnly()) : cri.ivReadOnly, 
+                                connectionPropertyChanged && mcf.supportsIsReadOnly ? Boolean.valueOf(isReadOnly()) : cri.ivReadOnly,
+                                connectionPropertyChanged ? currentShardingKey : cri.ivShardingKey,
+                                connectionPropertyChanged ? currentSuperShardingKey : cri.ivSuperShardingKey,
                                 connectionPropertyChanged && mcf.supportsGetTypeMap ? getTypeMap() : cri.ivTypeMap,
                                 holdabilityChanged ? getHoldability() : cri.ivHoldability,
                                 connectionPropertyChanged && mcf.supportsGetSchema ? getSchemaSafely() : cri.ivSchema,
@@ -651,7 +656,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                                 cri.supportIsolvlSwitching);
 
                 _criHold.setDefaultValues(cri.defaultCatalog, cri.defaultHoldability, 
-                                          cri.defaultReadOnly, cri.defaultTypeMap, cri.defaultSchema, cri.defaultNetworkTimeout); 
+                                          cri.defaultReadOnly, cri.defaultTypeMap, cri.defaultSchema,
+                                          cri.defaultNetworkTimeout, cri.defaultShardingKey, cri.defaultSuperShardingKey); 
 
                 // now set the cri as changable, otherwise, setters to follow will fail
                 _criHold.markAsChangable();
@@ -1014,6 +1020,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
             defaultCatalog = sqlConn.getCatalog();
             defaultReadOnly = mcf.supportsIsReadOnly ? sqlConn.isReadOnly() : false;
             defaultTypeMap = getTypeMapSafely();
+            currentShardingKey = defaultShardingKey = null; // spec provides no getter method
+            currentSuperShardingKey = defaultSuperShardingKey = null; // spec provides no getter method
             currentSchema = defaultSchema = getSchemaSafely();
             currentNetworkTimeout = defaultNetworkTimeout = getNetworkTimeoutSafely();
             currentHoldability = defaultHoldability; 
@@ -1064,7 +1072,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         info.append("The gssCredential is: ").append(mc_gssCredential == null ? null : mc_gssCredential.toString());
         info.append("The gssName is: ").append(mc_gssName == null ? null : mc_gssName.toString());
 
-        info.append("Catalog, IsReadOnly, TypeMap, Schema, or NetworkTimeout has changed? :", 
+        info.append("Catalog, IsReadOnly, TypeMap, Schema, ShardingKey, SuperShardingKey, or NetworkTimeout has changed? :", 
                     connectionPropertyChanged ? Boolean.TRUE : Boolean.FALSE); 
 
         info.append("Default Holdability:",
@@ -1946,7 +1954,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
         if (!newCRI.isCRIChangable())
             newCRI = WSConnectionRequestInfoImpl.createChangableCRIFromNon(newCRI);
-        newCRI.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema, defaultNetworkTimeout);
+        newCRI.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema,
+                                defaultNetworkTimeout, defaultShardingKey, defaultSuperShardingKey);
 
         cri = newCRI;
 
@@ -1988,7 +1997,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         // The ManagedConnection should use the new CRI value in place of its current CRI.
         if (!newCRI.isCRIChangable())
             newCRI = WSConnectionRequestInfoImpl.createChangableCRIFromNon(newCRI);
-        newCRI.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema, defaultNetworkTimeout);
+        newCRI.setDefaultValues(defaultCatalog, defaultHoldability, defaultReadOnly, defaultTypeMap, defaultSchema,
+                                defaultNetworkTimeout, defaultShardingKey, defaultSuperShardingKey);
         cri = newCRI;
 
         //  -- don't intialize the properties, deplay to synchronizePropertiesWithCRI().
@@ -2089,6 +2099,11 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 helper.setReadOnly(this, cri.ivReadOnly.booleanValue(), false); 
             }
 
+            if (cri.ivShardingKey != null && !cri.ivShardingKey.equals(defaultShardingKey)
+             || cri.ivSuperShardingKey != null && !cri.ivSuperShardingKey.equals(defaultShardingKey)) {
+                setShardingKeys(cri.ivShardingKey, cri.ivSuperShardingKey);
+            }
+
             if (cri.ivTypeMap != null && defaultTypeMap != cri.ivTypeMap && mcf.supportsGetTypeMap) {
                 setTypeMap(cri.ivTypeMap);
             }
@@ -2130,6 +2145,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                                                    "/" + AdapterUtil.getIsolationLevelString(currentTransactionIsolation),
                                    "Catalog:       " + defaultCatalog + "/" + (cri.ivCatalog == null ? defaultCatalog : cri.ivCatalog),
                                    "Schema:        " + defaultSchema + "/" + (cri.ivSchema == null ? defaultSchema : cri.ivSchema),
+                                   "ShardingKey:   " + defaultShardingKey + "/" + (cri.ivShardingKey == null ? defaultShardingKey : cri.ivShardingKey),
+                                   "SuperShardingK:" + defaultSuperShardingKey + "/" + (cri.ivSuperShardingKey == null ? defaultSuperShardingKey : cri.ivSuperShardingKey),
                                    "NetworkTimeout:" + defaultNetworkTimeout + "/" + (cri.ivNetworkTimeout == 0 ? defaultNetworkTimeout : cri.ivNetworkTimeout),
                                    "IsReadOnly:    " + defaultReadOnly + "/" + (cri.ivReadOnly == null ? defaultReadOnly : cri.ivReadOnly), 
                                    "TypeMap:       " + defaultTypeMap + "/" + (cri.ivTypeMap == null ? defaultTypeMap : cri.ivTypeMap),
@@ -2570,6 +2587,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         defaultCatalog = null; 
         defaultTypeMap = null; 
         defaultSchema = null;
+        defaultShardingKey = null;
+        defaultSuperShardingKey = null;
 
         handlesInUse = null;
 
@@ -2923,7 +2942,28 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                     }
                 }
             }
-            
+
+            if (!AdapterUtil.match(currentShardingKey, defaultShardingKey)
+             || !AdapterUtil.match(currentSuperShardingKey, defaultSuperShardingKey)) {
+                try {
+                    setShardingKeys(defaultShardingKey, defaultSuperShardingKey);
+
+                    // Update the connection request information after switching back to the
+                    // default sharding keys.
+                    if (connectionSharing == ConnectionSharing.MatchCurrentState)
+                    {
+                        if (!cri.isCRIChangable()) // create a changable CRI if existing one is not
+                            setCRI(WSConnectionRequestInfoImpl.createChangableCRIFromNon(cri));
+
+                        cri.setShardingKey(defaultShardingKey);
+                        cri.setSuperShardingKey(defaultSuperShardingKey);
+                    }
+                } catch (SQLException sqle) {
+                    FFDCFilter.processException(sqle, getClass().getName(), "2959", this);
+                    throw new DataStoreAdapterException("DSA_ERROR", sqle, getClass());
+                }
+            }
+
             if(mcf.supportsGetNetworkTimeout){
                 try{
                     ExecutorService libertyThreadPool = mcf.connectorSvc.getLibertyThreadPool();
@@ -2987,7 +3027,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                     currentHoldability = mcf.getHelper().getHoldability(sqlConn);
 
                     // Update the connection request information after switching back to the
-                    // default catalog.
+                    // default holdability.
                     if (connectionSharing == ConnectionSharing.MatchCurrentState)
                     {
                         if (!cri.isCRIChangable()) // create a changable CRI if existing one is not
@@ -3997,6 +4037,25 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
             Tr.debug(this, tc, "Set readOnly to " + isReadOnly); 
         sqlConn.setReadOnly(isReadOnly);
         connectionPropertyChanged = true; 
+    }
+
+    /**
+     * Updates the value of the sharding keys.
+     * 
+     * @param shardingKey the new sharding key.
+     * @param superShardingKey the new super sharding key.
+     */
+    public final void setShardingKeys(Object shardingKey, Object superShardingKey) throws SQLException {
+        if (mcf.beforeJDBCVersion(JDBCRuntimeVersion.VERSION_4_3))
+            throw new SQLFeatureNotSupportedException();
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "Set sharding key/super sharding key to " + shardingKey + "/" + superShardingKey); 
+
+        mcf.jdbcRuntime.doSetShardingKeys(sqlConn, shardingKey, superShardingKey);
+        currentShardingKey = shardingKey;
+        currentSuperShardingKey = superShardingKey;
+        connectionPropertyChanged = true;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -20,6 +20,8 @@
 
   <application location="app43.war"/>
 
+  <authData id="user43Auth" user="user43" password="{xor}Lyg7a2w="/>
+
   <dataSource id="DefaultDataSource">
     <jdbcDriver libraryRef="D43Lib"/>
     <properties url="jdbc:d43:memory:testdb;create=true" user="user43" password="{xor}Lyg7a2w="/>

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/resources/WEB-INF/ibm-web-bnd.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd" version="1.0">
+
+  <resource-ref name="java:module/env/jdbc/ds-with-container-auth" binding-name="jdbc/ds">
+    <authentication-alias name="user43Auth"/>
+  </resource-ref>
+
+</web-bnd>

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
@@ -189,8 +189,10 @@ public class D43Handler implements InvocationHandler, Supplier<AtomicInteger[]> 
             Object result = method.invoke(instance, args);
             if (returnType.isInterface() && (returnType.getPackage().getName().startsWith("java.sql")
                                              || returnType.getPackage().getName().startsWith("javax.sql")
-                                             || returnType.equals(XAResource.class)))
-                return Proxy.newProxyInstance(D43Handler.class.getClassLoader(), new Class[] { returnType }, new D43Handler(result, this, commonDataSource));
+                                             || returnType.equals(XAResource.class))) {
+                D43Handler handler = new D43Handler(result, this, commonDataSource, shardingKey, superShardingKey);
+                return Proxy.newProxyInstance(D43Handler.class.getClassLoader(), new Class[] { returnType }, handler);
+            }
             return result;
         } catch (InvocationTargetException x) {
             throw x.getCause();

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
@@ -173,6 +173,7 @@ public class D43Handler implements InvocationHandler, Supplier<AtomicInteger[]> 
             shardingKey = (ShardingKey) args[0];
             if (args.length == 2)
                 superShardingKey = (ShardingKey) args[1];
+            return null;
         }
         if ("setShardingKeyIfValid".equals(methodName)) {
             boolean valid = (args[0] instanceof D43ShardingKey || args[0] == null)


### PR DESCRIPTION
Add code to utilize the ConnectionBuilder/PooledConnectionBuilder/XAConnectionBuilder, depending on which type of data source, when a connection is requested with a sharding key and a matching connection does not already exist in the pool.
Add basic test cases of connection sharing, and at least one that verifies that an existing connection is matched from the free pool.