### PR TITLE
Remove unused trace variables to work around OpenJ9 JDK 11 bug

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43CallableStatement.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43CallableStatement.java
@@ -13,17 +13,12 @@ package com.ibm.ws.rsadapter.jdbc.v43;
 import java.sql.CallableStatement;
 import java.sql.SQLException;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcUtil;
 import com.ibm.ws.rsadapter.jdbc.v42.WSJdbc42CallableStatement;
 
 public class WSJdbc43CallableStatement extends WSJdbc42CallableStatement implements CallableStatement {
-
-    private static final TraceComponent tc = Tr.register(WSJdbc43CallableStatement.class, AdapterUtil.TRACE_GROUP, AdapterUtil.NLS_FILE);
 
     public WSJdbc43CallableStatement(CallableStatement cstmtImplObject, WSJdbcConnection connWrapper,
                                      int theHoldability, String cstmtSQL) throws SQLException {

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Connection.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Connection.java
@@ -14,15 +14,10 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.ShardingKey;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.v41.WSJdbc41Connection;
 
 public class WSJdbc43Connection extends WSJdbc41Connection implements Connection {
-
-    private static final TraceComponent tc = Tr.register(WSJdbc43Connection.class, AdapterUtil.TRACE_GROUP, AdapterUtil.NLS_FILE);
 
     public WSJdbc43Connection(WSRdbManagedConnectionImpl mc, Connection conn, Object key, Object currentThreadID) {
         super(mc, conn, key, currentThreadID);

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.java
@@ -19,15 +19,11 @@ import java.sql.ShardingKeyBuilder;
 import javax.resource.spi.ConnectionManager;
 import javax.sql.DataSource;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
 import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource;
 
 public class WSJdbc43DataSource extends WSJdbcDataSource implements DataSource {
-    private static final TraceComponent tc = Tr.register(WSJdbc43DataSource.class, AdapterUtil.TRACE_GROUP, AdapterUtil.NLS_FILE);
 
     public WSJdbc43DataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
         super(mcf, connMgr);

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43PreparedStatement.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43PreparedStatement.java
@@ -13,17 +13,12 @@ package com.ibm.ws.rsadapter.jdbc.v43;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcUtil;
 import com.ibm.ws.rsadapter.jdbc.v42.WSJdbc42PreparedStatement;
 
 public class WSJdbc43PreparedStatement extends WSJdbc42PreparedStatement implements PreparedStatement {
-
-    private static final TraceComponent tc = Tr.register(WSJdbc43PreparedStatement.class, AdapterUtil.TRACE_GROUP, AdapterUtil.NLS_FILE);
 
     /**
      * Do not use. Constructor exists only for CallableStatement wrapper.

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Statement.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Statement.java
@@ -13,16 +13,11 @@ package com.ibm.ws.rsadapter.jdbc.v43;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcConnection;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcUtil;
 import com.ibm.ws.rsadapter.jdbc.v42.WSJdbc42Statement;
 
 public class WSJdbc43Statement extends WSJdbc42Statement implements Statement {
-
-    private static final TraceComponent tc = Tr.register(WSJdbc43Statement.class, AdapterUtil.TRACE_GROUP, AdapterUtil.NLS_FILE);
 
     /**
      * Do not use. Constructor exists only for PreparedStatement wrapper.


### PR DESCRIPTION
Works around https://github.com/eclipse/openj9/issues/2911

Stack trace of the issue we are working around:
```
Stack Dump = java.lang.IllegalAccessError: Attempt to set static final field com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.tc from method "<clinit>" that is not <clinit>
	at com.ibm.ws.rsadapter.jdbc.v43.WSJdbc43DataSource.<clinit>(WSJdbc43DataSource.java:30)
	at com.ibm.ws.jdbc.osgi.v43.JDBC43Runtime.newDataSource(JDBC43Runtime.java:71)
	at com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl.createConnectionFactory(WSManagedConnectionFactoryImpl.java:359)
	at com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl.createConnectionFactory(WSManagedConnectionFactoryImpl.java:99)
	at com.ibm.ws.jca.cm.AbstractConnectionFactoryService.createResource(AbstractConnectionFactoryService.java:158)
	at com.ibm.ws.injectionengine.osgi.internal.IndirectJndiLookupObjectFactory.createResourceWithFilterPrivileged(IndirectJndiLookupObjectFactory.java:383)
	at com.ibm.ws.injectionengine.osgi.internal.IndirectJndiLookupObjectFactory.access$100(IndirectJndiLookupObjectFactory.java:57)
	at com.ibm.ws.injectionengine.osgi.internal.IndirectJndiLookupObjectFactory$3.run(IndirectJndiLookupObjectFactory.java:365)
	at java.security.AccessController.doPrivileged(java.base@11-adoptopenjdk/AccessController.java:696)
	at com.ibm.ws.injectionengine.osgi.internal.IndirectJndiLookupObjectFactory.createResourceWithFilter(IndirectJndiLookupObjectFactory.java:362)
	at com.ibm.ws.injectionengine.osgi.internal.IndirectJndiLookupObjectFactory.createDefaultResource(IndirectJndiLookupObjectFactory.java:350)
	at com.ibm.ws.injectionengine.osgi.internal.IndirectJndiLookupObjectFactory.getObjectInstance(IndirectJndiLookupObjectFactory.java:183)
	at com.ibm.ws.injectionengine.osgi.internal.IndirectJndiLookupObjectFactory.getObjectInstance(IndirectJndiLookupObjectFactory.java:100)
	at com.ibm.wsspi.injectionengine.InjectionBinding.getInjectionObjectInstance(InjectionBinding.java:1552)
	at com.ibm.wsspi.injectionengine.InjectionBinding.getInjectionObject(InjectionBinding.java:1428)
	at com.ibm.wsspi.injectionengine.InjectionBinding.getInjectableObject(InjectionBinding.java:1368)
	at com.ibm.wsspi.injectionengine.InjectionTarget.inject(InjectionTarget.java:104)
	at com.ibm.ws.managedobject.internal.ManagedObjectImpl.inject(ManagedObjectImpl.java:96)
	at com.ibm.ws.managedobject.internal.ManagedObjectImpl.inject(ManagedObjectImpl.java:87)
	at com.ibm.ws.webcontainer.osgi.webapp.WebApp.inject(WebApp.java:1279)
	at com.ibm.ws.webcontainer.osgi.webapp.WebApp.injectAndPostConstruct(WebApp.java:1420)
	at com.ibm.ws.webcontainer.osgi.webapp.WebApp.injectAndPostConstruct(WebApp.java:1408)
	at com.ibm.ws.webcontainer.osgi.servlet.ServletWrapper.createTarget(ServletWrapper.java:63)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper$1.run(ServletWrapper.java:1540)
	at java.security.AccessController.doPrivileged(java.base@11-adoptopenjdk/AccessController.java:696)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.loadServlet(ServletWrapper.java:1508)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:587)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:440)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1221)
	at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:4954)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:996)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1011)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:414)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:373)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:532)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:466)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:331)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:302)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:165)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:74)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:501)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:571)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:926)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1015)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11-adoptopenjdk/ThreadPoolExecutor.java:1128)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11-adoptopenjdk/ThreadPoolExecutor.java:628)
	at java.lang.Thread.run(java.base@11-adoptopenjdk/Thread.java:825)
```