### PR TITLE
Issue #5136: Avoid Loading CORBA classes if remote EJB is not enabled

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
@@ -4105,14 +4105,16 @@ public abstract class EJBMDOrchestrator {
                                                                            bmd.j2eeName.toString(), // d443878
                                                                            runtime.getClassDefiner()); // F70650
 
-                    bmd.homeRemoteTieClass = JITDeploy.generate_Tie // d413752
-                    (classLoader,
-                     classNameToLoad,
-                     bmd.homeInterfaceClass,
-                     bmd.j2eeName.toString(), // d443878
-                     runtime.getClassDefiner(), // F70650
-                     mmd.getRMICCompatible(),
-                     runtime.isRemoteUsingPortableServer());
+                    // Only generate the Tie if remote is supported (CORBA classes are available)
+                    if (runtime.isRemoteSupported()) {
+                        bmd.homeRemoteTieClass = JITDeploy.generate_Tie(classLoader,
+                                                                        classNameToLoad,
+                                                                        bmd.homeInterfaceClass,
+                                                                        bmd.j2eeName.toString(), // d443878
+                                                                        runtime.getClassDefiner(), // F70650
+                                                                        mmd.getRMICCompatible(),
+                                                                        runtime.isRemoteUsingPortableServer());
+                    }
                 }
 
                 // load generated local Home ('Wrapper') Impl class - EJSLocal[Type]HomeItf


### PR DESCRIPTION
There is no need to generate and/or load the Tie classes for remote
EJB interfaces if the ejbRemote feature is not enabled. This is
important for Java 11, which doesn't provide the CORBA classes
used by the Ties.

The remote wrappers are still generated/loaded to allow an appropriate
error message if an attempt is made to use them when the ejbRemote
feature is not enabled.

Similar to issue 5011, but now handles EJB 2.x home ties.

fixes #5136 
