### PR TITLE
Add testPingFrameBadFlags to the full tracing bucket to get more debug

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullModeTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullModeTests.java
@@ -572,10 +572,11 @@ public class Http2FullModeTests extends FATServletClient {
      *
      * @throws Exception
      */
-    @Test
-    public void testPingFrameBadFlags() throws Exception {
-        runTest(defaultServletPath, testName.getMethodName());
-    }
+    // Moved to Tracing test bucket - build break 258154
+    //@Test
+    //public void testPingFrameBadFlags() throws Exception {
+    //    runTest(defaultServletPath, testName.getMethodName());
+    //}
 
     /**
      * Test Coverage Send a Ping that has the reserve bit set

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullTracingTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullTracingTests.java
@@ -104,4 +104,10 @@ public class Http2FullTracingTests extends FATServletClient {
         runTest(defaultServletPath, testName.getMethodName());
     }
 
+    // moved for debug - build break 258154
+    @Test
+    public void testPingFrameBadFlags() throws Exception {
+        runTest(defaultServletPath, testName.getMethodName());
+    }
+
 }

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2LiteModeTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2LiteModeTests.java
@@ -149,10 +149,11 @@ public class Http2LiteModeTests extends FATServletClient {
      *
      * @throws Exception
      */
-    @Test
-    public void testHeaderAndDataPost() throws Exception {
-        runTest(defaultServletPath, testName.getMethodName());
-    }
+    // Currently in Http2FullTracingTests
+    //@Test
+    //public void testHeaderAndDataPost() throws Exception {
+    //    runTest(defaultServletPath, testName.getMethodName());
+    //}
 
     /**
      * Test Coverage: Client sends two HTTP/2 Requests on two HTTP/2 Streams.


### PR DESCRIPTION
Add testPingFrameBadFlags to the full tracing bucket to get more debug on the next intermittent failure

