### PR TITLE
connection builder cannot allow sharding key when backed by java.sql.Driver

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43ConnectionBuilder.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43ConnectionBuilder.java
@@ -51,6 +51,9 @@ public class WSJdbc43ConnectionBuilder implements ConnectionBuilder {
 
     @Override
     public ConnectionBuilder shardingKey(ShardingKey value) {
+        if (value != null && ds.isBackedByDriver())
+            throw new UnsupportedOperationException("java.sql.Driver.createConnectionBuilder().shardingKey(value)");
+
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "shardingKey", value);
         shardingKey = value;
@@ -59,6 +62,9 @@ public class WSJdbc43ConnectionBuilder implements ConnectionBuilder {
 
     @Override
     public ConnectionBuilder superShardingKey(ShardingKey value) {
+        if (value != null && ds.isBackedByDriver())
+            throw new UnsupportedOperationException("java.sql.Driver.createConnectionBuilder().superShardingKey(value)");
+
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "superShardingKey", value);
         superShardingKey = value;

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.java
@@ -52,4 +52,11 @@ public class WSJdbc43DataSource extends WSJdbcDataSource implements DataSource {
         WSConnectionRequestInfoImpl conRequest = new WSConnectionRequestInfoImpl(mcf, cm, builder.user, builder.password, builder.shardingKey, builder.superShardingKey);
         return super.getConnection(conRequest);
     }
+
+    /**
+     * @return true if the data source is backed by a java.sql.Driver implementation, otherwise false.
+     */
+    final boolean isBackedByDriver() {
+        return mcf.getUnderlyingDataSource() == null;
+    }
 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -1095,7 +1095,7 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
      * 
      * @return the underlying DataSource, null if a Driver is used
      */
-    public CommonDataSource getUnderlyingDataSource() throws SQLException
+    public CommonDataSource getUnderlyingDataSource()
     {
         if(Driver.class.equals(type))
             return null;


### PR DESCRIPTION
When data source is backed by java.sql.Driver, no connection builder is involved on the driver side.  Without any way to set the specified sharding key on the driver, we should reject this.  The shardingKey(key) and shardingKeyBuilder(key) methods don't declare that they raise SQLException, so we will raise UnsupportedOperationException