### PR TITLE
Update eclipse settings for .classpath

### DIFF
--- a/dev/com.ibm.ws.app.manager_fat/.classpath
+++ b/dev/com.ibm.ws.app.manager_fat/.classpath
@@ -10,5 +10,5 @@
 	<classpathentry kind="src" path="test-bundles/test.app.notifications/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="output" path="build/classes"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.security.fat.common.social/.classpath
+++ b/dev/com.ibm.ws.security.fat.common.social/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="bin" path="src"/>
-	<classpathentry kind="src" output="bin_test" path="test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
Change eclipse output to bin instead of build/classes so it is separate
from gradle output location.
Remove test directory from source where there is no test directory.