### PR TITLE
Add additional OIDC certification tests for social login feature

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.social/src/com/ibm/ws/security/fat/common/social/MessageConstants.java
+++ b/dev/com.ibm.ws.security.fat.common.social/src/com/ibm/ws/security/fat/common/social/MessageConstants.java
@@ -6,12 +6,20 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.fat.common.social;
 
-public class MessageConstants {
+public class MessageConstants extends com.ibm.ws.security.fat.common.MessageConstants {
 
-    public static final String CWWKT0016I_WEB_APP_AVAILABLE = "CWWKT0016I";
+    public static final String CWWKS5489E_PUBLIC_FACING_ERROR = "CWWKS5489E";
+
+    public static final String CWWKS1706E_OIDC_CLIENT_IDTOKEN_VERIFY_ERR = "CWWKS1706E";
+    public static final String CWWKS1714E_OIDC_CLIENT_REQUEST_NONCE_FAILED = "CWWKS1714E";
+    public static final String CWWKS1739E_OIDC_CLIENT_NO_VERIFYING_KEY = "CWWKS1739E";
+    public static final String CWWKS1751E_OIDC_IDTOKEN_VERIFY_ISSUER_ERR = "CWWKS1751E";
+    public static final String CWWKS1754E_OIDC_IDTOKEN_VERIFY_AUD_ERR = "CWWKS1754E";
+    public static final String CWWKS1756E_OIDC_IDTOKEN_SIGNATURE_VERIFY_ERR = "CWWKS1756E";
+    public static final String CWWKS1775E_OIDC_ID_VERIFY_IAT_ERR = "CWWKS1775E";
 
 }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/MessageConstants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/MessageConstants.java
@@ -13,5 +13,6 @@ package com.ibm.ws.security.fat.common;
 public class MessageConstants {
 
     public static final String CWWKT0016I_WEB_APP_AVAILABLE = "CWWKT0016I";
+    public static final String CWWKG0032W_CONFIG_INVALID_VALUE = "CWWKG0032W";
 
 }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/logging/CommonFatLoggingUtils.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/logging/CommonFatLoggingUtils.java
@@ -100,6 +100,7 @@ public class CommonFatLoggingUtils {
         Log.info(thisClass, testName, "Request URL: " + request.getUrl());
         printRequestHeaders(request, testName);
         printRequestParameters(request, testName);
+        printRequestBody(request, testName);
     }
 
     void printRequestHeaders(WebRequest request, String testName) {
@@ -118,6 +119,10 @@ public class CommonFatLoggingUtils {
                 Log.info(thisClass, testName, "Request parameter: " + req.getName() + ", set to: " + req.getValue());
             }
         }
+    }
+
+    void printRequestBody(WebRequest request, String testName) {
+        Log.info(thisClass, testName, "Request body: " + request.getRequestBody());
     }
 
     public void printResponseParts(Object response, String testName) throws Exception {

--- a/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/logging/CommonFatLoggingUtilsTest.java
+++ b/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/logging/CommonFatLoggingUtilsTest.java
@@ -432,6 +432,7 @@ public class CommonFatLoggingUtilsTest extends CommonTestClass {
                     one(webRequest).getAdditionalHeaders();
                     will(returnValue(headers));
                     one(webRequest).getRequestParameters();
+                    one(webRequest).getRequestBody();
                 }
             });
 
@@ -475,6 +476,7 @@ public class CommonFatLoggingUtilsTest extends CommonTestClass {
                     one(webRequest).getAdditionalHeaders();
                     one(webRequest).getRequestParameters();
                     will(returnValue(requestParams));
+                    one(webRequest).getRequestBody();
                 }
             });
 
@@ -1955,6 +1957,7 @@ public class CommonFatLoggingUtilsTest extends CommonTestClass {
                 will(returnValue(new URL(SIMPLE_URL)));
                 one(webRequest).getAdditionalHeaders();
                 one(webRequest).getRequestParameters();
+                one(webRequest).getRequestBody();
             }
         });
     }

--- a/dev/com.ibm.ws.security.social_fat.oidcCertification/fat/src/com/ibm/ws/security/social/fat/oidc/certification/Constants.java
+++ b/dev/com.ibm.ws.security.social_fat.oidcCertification/fat/src/com/ibm/ws/security/social/fat/oidc/certification/Constants.java
@@ -29,6 +29,8 @@ public class Constants extends SocialConstants {
     public static final String CONFIG_VAR_AUTHORIZATION_ENDPOINT = "oidc.certification.authorizationEndpoint";
     public static final String CONFIG_VAR_TOKEN_ENDPOINT = "oidc.certification.tokenEndpoint";
     public static final String CONFIG_VAR_JWKS_URI = "oidc.certification.jwksUri";
+    public static final String CONFIG_VAR_SIGNATURE_ALGORITHM = "oidc.certification.signatureAlgorithm";
+    public static final String CONFIG_VAR_TOKEN_ENDPOINT_AUTH_METHOD = "oidc.certification.tokenEndpointAuthMethod";
 
     public static final String CLIENT_REGISTRATION_KEY_REDIRECT_URIS = "redirect_uris";
     public static final String CLIENT_REGISTRATION_KEY_CONTACTS = "contacts";

--- a/dev/com.ibm.ws.security.social_fat.oidcCertification/publish/shared/config/oidcCertification_oidcLoginConfigs.xml
+++ b/dev/com.ibm.ws.security.social_fat.oidcCertification/publish/shared/config/oidcCertification_oidcLoginConfigs.xml
@@ -17,6 +17,8 @@
         authorizationEndpoint="${oidc.certification.authorizationEndpoint}"
         tokenEndpoint="${oidc.certification.tokenEndpoint}"
         jwksUri="${oidc.certification.jwksUri}"
+        signatureAlgorithm="${oidc.certification.signatureAlgorithm}"
+        tokenEndpointAuthMethod="${oidc.certification.tokenEndpointAuthMethod}"
     >
     </oidcLogin>
 


### PR DESCRIPTION
Adds automated tests for the following OIDC RP certification tests:
- rp-id_token-issuer-mismatch
- rp-id_token-sub
- rp-id_token-aud
- rp-id_token-iat
- rp-id_token-kid-absent-single-jwks
- rp-id_token-kid-absent-multiple-jwks
- rp-id_token-sig-rs256
- rp-id_token-sig-none
- rp-id_token-bad-sig-rs256
- rp-nonce-invalid
- rp-token_endpoint-client_secret_basic