### PR TITLE
Add Java permissions for test using plain Java sockets to connect.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/publish/servers/jaxrs20.cxfClientProps/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/publish/servers/jaxrs20.cxfClientProps/server.xml
@@ -6,4 +6,6 @@
 
 	<include location="../fatTestPorts.xml"/>
 
+	<javaPermission className="java.net.SocketPermission" name="*" actions="connect"/>
+	<javaPermission className="java.net.URLPermission" name="http://localhost:23/blah" actions="GET"/>
 </server>


### PR DESCRIPTION
The `CxfClientPropsTest`'s `testUrlConnectTimeout` fails with Java 2 security enabled.  This fix resolves the issue, and describes what permissions would be required to make a `URLConnection` to a remote endpoint.