### PR TITLE
suppress begin/endRequest when invoked by application or external connection manager

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Connection.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Connection.java
@@ -14,6 +14,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.ShardingKey;
 
+import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.v41.WSJdbc41Connection;
 
@@ -25,12 +26,12 @@ public class WSJdbc43Connection extends WSJdbc41Connection implements Connection
 
     @Override
     public void beginRequest() throws SQLException {
-        throw new UnsupportedOperationException();
+        AdapterUtil.suppressBeginAndEndRequest();
     }
 
     @Override
     public void endRequest() throws SQLException {
-        throw new UnsupportedOperationException();
+        AdapterUtil.suppressBeginAndEndRequest();
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -486,6 +486,10 @@ DEFAULT_MATCH_ORIGINAL.useraction=Verify that the data source custom property is
 
 # 8780 deleted
 
+DSRA8790_SUPPRESS_BEGIN_END_REQUEST=DSRA8790W: The beginRequest and endRequest methods must only be used by connection managers. The JDBC specification does not account for the possibility that multiple connection managers might be involved in the management of a connection. Usage of beginRequest and endRequest by other connection managers is suppressed when connection management is provided by the application server. The following stack indicates the code path on which the beginRequest or endRequest operation was invoked: {0}.
+DSRA8790_SUPPRESS_BEGIN_END_REQUEST.explanation=The beginRequest and endRequest hints are suppressed in order to avoid side-effects that interfere with proper connection management.
+DSRA8790_SUPPRESS_BEGIN_END_REQUEST.useraction=To avoid this warning, remove the code that invokes beginRequest and endRequest as identified by the supplied stack.
+
 # ----------------------------------------------------------------------------
 # 
 # Using the 9000's for JDBC wrapper messages.

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -486,8 +486,8 @@ DEFAULT_MATCH_ORIGINAL.useraction=Verify that the data source custom property is
 
 # 8780 deleted
 
-DSRA8790_SUPPRESS_BEGIN_END_REQUEST=DSRA8790W: The beginRequest and endRequest methods must only be used by connection managers. The JDBC specification does not account for the possibility that multiple connection managers might be involved in the management of a connection. Usage of beginRequest and endRequest by other connection managers is suppressed when connection management is provided by the application server. The following stack indicates the code path on which the beginRequest or endRequest operation was invoked: {0}.
-DSRA8790_SUPPRESS_BEGIN_END_REQUEST.explanation=The beginRequest and endRequest hints are suppressed in order to avoid side-effects that interfere with proper connection management.
+DSRA8790_SUPPRESS_BEGIN_END_REQUEST=DSRA8790W: The beginRequest and endRequest methods must only be used by connection managers. The JDBC specification does not account for multiple connection managers that can manage a connection. Usage of beginRequest and endRequest by other connection managers is suppressed when connection management is provided by the application server. The following stack indicates the code path on which the beginRequest or endRequest operation was invoked: {0}.
+DSRA8790_SUPPRESS_BEGIN_END_REQUEST.explanation=The beginRequest and endRequest hints are suppressed to avoid side effects that interfere with connection management.
 DSRA8790_SUPPRESS_BEGIN_END_REQUEST.useraction=To avoid this warning, remove the code that invokes beginRequest and endRequest as identified by the supplied stack.
 
 # ----------------------------------------------------------------------------

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
@@ -122,6 +122,9 @@ public class AdapterUtil {
     /** A blank string for indenting. */
     private static final String INDENT = "                                 ";
 
+    /** Limits the number of times the user is warned about using begin/endRequest. */
+    private static volatile boolean warnedAboutBeginAndEndRequest;
+
     /**
      * Create an XAException with a translated error message and an XA error code.
      * The XAException constructors provided by the XAException API allow only for either an
@@ -728,6 +731,22 @@ public class AdapterUtil {
     public static final SQLException staleX() {
         String message = getNLSMessage("INVALID_CONNECTION");
         return new SQLRecoverableException(message);
+    }
+
+    /**
+     * Logs a warning message indicating that Connection.beginRequest and Connection.endRequest
+     * methods are suppressed.
+     */
+    public static final void suppressBeginAndEndRequest() {
+        if (!warnedAboutBeginAndEndRequest) {
+            warnedAboutBeginAndEndRequest = true;
+
+            StringBuilder stack = new StringBuilder();
+            for (StackTraceElement frame : new Exception().getStackTrace())
+                stack.append(EOLN).append(frame.toString());
+
+            Tr.warning(tc, "DSRA8790_SUPPRESS_BEGIN_END_REQUEST", stack);
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
@@ -61,6 +61,7 @@ public class JDBC43Test extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer("DSRA0302E.*XA_RBOTHER", // raised by mock JDBC driver for XA operations after abort
+                          "DSRA8790W", // expected for begin/endRequest invoked by application being ignored
                           "WLTC0018E"); // TODO remove once transactions bug is fixed
     }
 }


### PR DESCRIPTION
Disallow begin/endRequest invoked by application or external connection manager, issuing a warning when this is attempted.  Given that the JDBC spec doesn't adequately account for this scenario (it says that the first endRequest invoked on the JDBC driver ends the request, which would allow the external invocation to interfere with the how the request boundary is communicated to the JDBC driver), we will be suppressing these external invocations to avoid corrupting connection state and to ensure that connections are truly done being used when endRequest is invoked, which better matches the intent of the specification.