### PR TITLE
Add JAX-B api+impl to FAT, and upgrade to javassist 3.23.1

### DIFF
--- a/dev/com.ibm.ws.tx.jta_fat_hibernate/build.gradle
+++ b/dev/com.ibm.ws.tx.jta_fat_hibernate/build.gradle
@@ -19,11 +19,15 @@ dependencies {
     'com.fasterxml:classmate:1.3.4',
     'dom4j:dom4j:1.6.1',
     'org.hibernate.common:hibernate-commons-annotations:5.0.1.Final',
-    'org.javassist:javassist:3.22.0-GA',
+    'org.javassist:javassist:3.23.1-GA',
     'org.jboss:jandex:2.0.3.Final',
     'com.ibm.ws.javax.j2ee:persistence:2.1',
     'org.jboss.logging:jboss-logging:3.3.1.Final',
-    'javax.transaction:javax.transaction-api:1.2'
+    'javax.transaction:javax.transaction-api:1.2',
+    'javax.xml.bind:jaxb-api:2.2.12-b140109.1041',
+    'com.sun.xml.bind:jaxb-core:2.2.11',
+    'com.sun.xml.bind:jaxb-impl:2.2.11',
+    'javax.activation:activation:1.1'
 }
 
 

--- a/dev/com.ibm.ws.tx.jta_fat_hibernate/fat/src/com/ibm/ws/tx/jta/fat/hibernate/HibernateTxTest.java
+++ b/dev/com.ibm.ws.tx.jta_fat_hibernate/fat/src/com/ibm/ws/tx/jta/fat/hibernate/HibernateTxTest.java
@@ -46,6 +46,6 @@ public class HibernateTxTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("SRVE9967W"); // Ignore manifest classpath errors from all the third-party libs we're pulling in
     }
 }


### PR DESCRIPTION
Resolves the following error when running the com.ibm.ws.tx.jta_fat_hibernate bucket on Java 11:

```
junit.framework.AssertionFailedError: 2018-09-25-09:25:30:542 The response did not contain "[SUCCESS]".  Full output is:"
ERROR: Caught exception attempting to call test method testHibernate on servlet fat.tx.jta.hibernate.web.HibernateTxTestServlet
java.lang.NoClassDefFoundError: javax.xml.bind.ValidationEventHandler
	at org.hibernate.boot.spi.XmlMappingBinderAccess.<init>(XmlMappingBinderAccess.java:43)
	at org.hibernate.boot.MetadataSources.<init>(MetadataSources.java:87)
	at fat.tx.jta.hibernate.web.HibernateTxTestServlet.testHibernate(HibernateTxTestServlet.java:77)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@11-adoptopenjdk/Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@11-adoptopenjdk/NativeMethodAccessorImpl.java:62)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@11-adoptopenjdk/DelegatingMethodAccessorImpl.java:43)
	at componenttest.app.FATServlet.doGet(FATServlet.java:71)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1255)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:743)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:440)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1221)
	at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:4954)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:996)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1011)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:414)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:373)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:532)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:466)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:331)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:302)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:165)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:74)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:501)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:571)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:926)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1015)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11-adoptopenjdk/ThreadPoolExecutor.java:1128)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11-adoptopenjdk/ThreadPoolExecutor.java:628)
	at java.lang.Thread.run(java.base@11-adoptopenjdk/Thread.java:825)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.ValidationEventHandler
	at com.ibm.ws.classloading.internal.AppClassLoader.findClassCommonLibraryClassLoaders(AppClassLoader.java:504)
	at com.ibm.ws.classloading.internal.AppClassLoader.findClass(AppClassLoader.java:276)
	at java.lang.ClassLoader.loadClassHelper(java.base@11-adoptopenjdk/ClassLoader.java:1134)
	at java.lang.ClassLoader.loadClass(java.base@11-adoptopenjdk/ClassLoader.java:1049)
	at com.ibm.ws.classloading.internal.AppClassLoader.findOrDelegateLoadClass(AppClassLoader.java:482)
	at com.ibm.ws.classloading.internal.AppClassLoader.loadClass(AppClassLoader.java:443)
	at java.lang.ClassLoader.loadClass(java.base@11-adoptopenjdk/ClassLoader.java:1032)
". expected:<0> but was:<1>
	at componenttest.topology.utils.HttpUtils.findStringInHttpConnection(HttpUtils.java:537)
	at componenttest.topology.utils.HttpUtils.findStringInHttpConnection(HttpUtils.java:495)
	at componenttest.topology.utils.HttpUtils.findStringInUrl(HttpUtils.java:472)
	at componenttest.topology.utils.HttpUtils.findStringInReadyUrl(HttpUtils.java:444)
	at componenttest.topology.utils.HttpUtils.findStringInReadyUrl(HttpUtils.java:414)
	at componenttest.topology.utils.FATServletClient.runTest(FATServletClient.java:81)
	at componenttest.custom.junit.runner.SyntheticServletTest.invokeExplosively(SyntheticServletTest.java:40)
	at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:193)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:323)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:167)
```