### PR TITLE
Added Java permissions

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.custom.certmapper.bell/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.custom.certmapper.bell/server.xml
@@ -42,5 +42,6 @@
 	</application>
 
 	<include location="../fatTestPorts.xml" />
-
+	<javaPermission className="javax.security.auth.PrivateCredentialPermission"  name='* * "*"' actions="read" />
+	<javaPermission className="java.net.SocketPermission" name="*" actions="resolve" />
 </server>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.custom.certmapper.feature/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.custom.certmapper.feature/server.xml
@@ -42,5 +42,6 @@
 	</application>
 
 	<include location="../fatTestPorts.xml" />
-
+	<javaPermission className="javax.security.auth.PrivateCredentialPermission"  name='* * "*"' actions="read" />
+	<javaPermission className="java.net.SocketPermission" name="*" actions="resolve" />
 </server>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin/server.xml
@@ -59,5 +59,6 @@
 	</application>
 
 	<include location="../fatTestPorts.xml"/>
-
+	<javaPermission className="javax.security.auth.PrivateCredentialPermission"  name='* * "*"' actions="read" />
+	<javaPermission className="java.net.SocketPermission" name="*" actions="resolve" />
 </server>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin_SBInFilter/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin_SBInFilter/server.xml
@@ -59,5 +59,6 @@
 	</application>
 
 	<include location="../fatTestPorts.xml"/>
-
+	<javaPermission className="javax.security.auth.PrivateCredentialPermission"  name='* * "*"' actions="read" />
+	<javaPermission className="java.net.SocketPermission"  name="*" actions="resolve" />
 </server>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.fedcertlogin/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.fedcertlogin/server.xml
@@ -77,5 +77,6 @@
 	</application>
 
 	<include location="../fatTestPorts.xml"/>
-
+	<javaPermission className="javax.security.auth.PrivateCredentialPermission"  name='* * "*"' actions="read" />
+	<javaPermission className="java.net.SocketPermission"  name="*" actions="resolve" />
 </server>


### PR DESCRIPTION
WIM LDAP FAT tests were failing due to access control exceptions. Resolved by adding the Java Permissions lines to the proper server.xml
<javaPermission className="javax.security.auth.PrivateCredentialPermission"  name='* * "*"' actions="read" />
<javaPermission className="java.net.SocketPermission"  name="*" actions="resolve" />

fixes #3868 