### PR TITLE
Update local build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Our [CONTRIBUTING](https://github.com/OpenLiberty/open-liberty/blob/master/CONTR
     
     ```./gradlew cnf:initialize```
     
-    ```./gradlew assemble :com.ibm.websphere.appserver.features:releaseNeeded```
+    ```./gradlew assemble```
 
 3. Run the unit or FAT tests.
 


### PR DESCRIPTION
It is no longer necessary to run `./gradlew :com.ibm.websphere.appserver.features:releaseNeeded` in order to compile the .feature files into .mf files in build.image, so the setup instructions can simplify the local build step to simply a top-level `assemble`