### PR TITLE
Allow setShardingKey on Connection, with basic test

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
@@ -218,7 +218,10 @@ public class JDBC43Runtime implements JDBCRuntimeVersion {
     @Override
     public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException {
         try {
-            con.setShardingKey((ShardingKey) shardingKey, (ShardingKey) superShardingKey);
+            if (superShardingKey == SUPER_SHARDING_KEY_UNCHANGED)
+                con.setShardingKey((ShardingKey) shardingKey);
+            else
+                con.setShardingKey((ShardingKey) shardingKey, (ShardingKey) superShardingKey);
         } catch (IncompatibleClassChangeError e) { // pre-4.3 driver
             throw new SQLFeatureNotSupportedException(e);
         }

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Connection.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Connection.java
@@ -14,7 +14,11 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.ShardingKey;
 
+import com.ibm.ws.ffdc.FFDCFilter;
+import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.AdapterUtil;
+import com.ibm.ws.rsadapter.ConnectionSharing;
+import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
 import com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl;
 import com.ibm.ws.rsadapter.jdbc.v41.WSJdbc41Connection;
 
@@ -46,12 +50,65 @@ public class WSJdbc43Connection extends WSJdbc41Connection implements Connection
 
     @Override
     public void setShardingKey(ShardingKey shardingKey) throws SQLException {
-        throw new UnsupportedOperationException();
+        activate();
+
+        try {
+            // Setters are not permitted when multiple handles are sharing the same ManagedConnection,
+            // except when the specified value is the same as the current value, which is a no-op.
+            if (managedConn.getHandleCount() > 1 && !AdapterUtil.match(shardingKey, managedConn.getCurrentShardingKey()))
+                throw createSharingException("setShardingKey");
+
+            managedConn.setShardingKeys(shardingKey, JDBCRuntimeVersion.SUPER_SHARDING_KEY_UNCHANGED);
+
+            // Update the connection request information with the new value, so that
+            // requests for shared connections will match based on the updated criteria.
+            if (managedConn.connectionSharing == ConnectionSharing.MatchCurrentState) {
+                WSConnectionRequestInfoImpl cri = (WSConnectionRequestInfoImpl) managedConn.getConnectionRequestInfo();
+                if (!cri.isCRIChangable())
+                    managedConn.setCRI(cri = WSConnectionRequestInfoImpl.createChangableCRIFromNon(cri));
+
+                cri.setShardingKey(shardingKey);
+            }
+        } catch (SQLException x) {
+            FFDCFilter.processException(x, getClass().getName(), "71", this);
+            throw proccessSQLException(x);
+        } catch (NullPointerException x) {
+            // No FFDC code needed; we might be closed.
+            throw runtimeXIfNotClosed(x);
+        }
     }
 
     @Override
     public void setShardingKey(ShardingKey shardingKey, ShardingKey superShardingKey) throws SQLException {
-        throw new UnsupportedOperationException();
+        activate();
+
+        try {
+            // Setters are not permitted when multiple handles are sharing the same ManagedConnection,
+            // except when the specified value is the same as the current value, which is a no-op.
+            if (managedConn.getHandleCount() > 1 &&
+                (!AdapterUtil.match(shardingKey, managedConn.getCurrentShardingKey()) ||
+                 !AdapterUtil.match(superShardingKey, managedConn.getCurrentSuperShardingKey())))
+                throw createSharingException("setShardingKey");
+
+            managedConn.setShardingKeys(shardingKey, superShardingKey);
+
+            // Update the connection request information with the new value, so that
+            // requests for shared connections will match based on the updated criteria.
+            if (managedConn.connectionSharing == ConnectionSharing.MatchCurrentState) {
+                WSConnectionRequestInfoImpl cri = (WSConnectionRequestInfoImpl) managedConn.getConnectionRequestInfo();
+                if (!cri.isCRIChangable())
+                    managedConn.setCRI(cri = WSConnectionRequestInfoImpl.createChangableCRIFromNon(cri));
+
+                cri.setShardingKey(shardingKey);
+                cri.setSuperShardingKey(superShardingKey);
+            }
+        } catch (SQLException x) {
+            FFDCFilter.processException(x, getClass().getName(), "104", this);
+            throw proccessSQLException(x);
+        } catch (NullPointerException x) {
+            // No FFDC code needed; we might be closed.
+            throw runtimeXIfNotClosed(x);
+        }
     }
 
 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
@@ -54,6 +54,8 @@ public interface JDBCRuntimeVersion {
     public static final Version VERSION_4_2 = new Version(4, 2, 0);
     public static final Version VERSION_4_3 = new Version(4, 3, 0);
 
+    public static final String SUPER_SHARDING_KEY_UNCHANGED = "UNCHANGED";
+
     public Version getVersion();
 
     // JDBC wrapper object constructor delegates

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -4039,11 +4039,19 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         connectionPropertyChanged = true; 
     }
 
+    public final Object getCurrentShardingKey() {
+        return currentShardingKey;
+    }
+
+    public final Object getCurrentSuperShardingKey() {
+        return currentSuperShardingKey;
+    }
+
     /**
      * Updates the value of the sharding keys.
      * 
      * @param shardingKey the new sharding key.
-     * @param superShardingKey the new super sharding key.
+     * @param superShardingKey the new super sharding key. The 'unchanged' constant can be used to avoid changing it.
      */
     public final void setShardingKeys(Object shardingKey, Object superShardingKey) throws SQLException {
         if (mcf.beforeJDBCVersion(JDBCRuntimeVersion.VERSION_4_3))
@@ -4054,7 +4062,8 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
         mcf.jdbcRuntime.doSetShardingKeys(sqlConn, shardingKey, superShardingKey);
         currentShardingKey = shardingKey;
-        currentSuperShardingKey = superShardingKey;
+        if (superShardingKey != JDBCRuntimeVersion.SUPER_SHARDING_KEY_UNCHANGED)
+            currentSuperShardingKey = superShardingKey;
         connectionPropertyChanged = true;
     }
 


### PR DESCRIPTION
Initial changes to experiment with Connection.setShardingKey, including a basic test covering sharing scopes and MatchOriginalRequest.