### PR TITLE
Exclude tools.jar as a maven dependency for JDK 9+

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
@@ -58,6 +58,13 @@
 			<groupId>org.eclipse.microprofile.metrics</groupId>
 			<artifactId>microprofile-metrics-api-tck</artifactId>
 			<version>${microprofile.metrics.version}</version>
+			<!-- Manually exclude the tools jar dependency because it doesn't exist on JDK 9+ and also is not needed -->
+			<exclusions>
+			    <exclusion>
+			        <groupId>com.sun</groupId>
+			        <artifactId>tools</artifactId>
+			    </exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>javax.enterprise</groupId>


### PR DESCRIPTION
Resolves the following error when running on Java 11:

> [ERROR] Failed to execute goal on project tck.runner.tck: Could not resolve dependencies for project com.ibm.ws.microprofile.metrics:tck.runner.tck:jar:1.0-SNAPSHOT: Could not find artifact com.sun:tools:jar:1.6.0 at specified path /home/jazz_build/_S1B8oMFfEei9re3pB293Wg-EBC.PROD.WASRTC-BSA-000-00-00/jbe/jvms/openj9_jdk11_20180609-sdk/../lib/tools.jar -> [Help 1]
