### PR TITLE
Revert "Revert "Shutdown improvements""

### DIFF
--- a/dev/com.ibm.ws.channelfw/src/com/ibm/websphere/channelfw/ChannelUtils.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/websphere/channelfw/ChannelUtils.java
@@ -46,7 +46,7 @@ import com.ibm.wsspi.channelfw.exception.RetryableChannelException;
  * <ul>
  * <li>printDebugStackTrace - for pretty-printing a debug stack trace
  * </ul>
- * 
+ *
  * Utility methods for displaying Channel and Channel Chain configuration
  * <ul>
  * <li>displayChannels - displays all configured channels
@@ -56,10 +56,9 @@ import com.ibm.wsspi.channelfw.exception.RetryableChannelException;
  */
 public final class ChannelUtils extends ChannelUtilsBase {
     /** Trace service */
-    private static final TraceComponent tc =
-                    Tr.register(ChannelUtils.class,
-                                ChannelFrameworkConstants.BASE_TRACE_NAME,
-                                ChannelFrameworkConstants.BASE_BUNDLE);
+    private static final TraceComponent tc = Tr.register(ChannelUtils.class,
+                                                         ChannelFrameworkConstants.BASE_TRACE_NAME,
+                                                         ChannelFrameworkConstants.BASE_BUNDLE);
 
     /** Configuration items unable to be processed during loadConfig */
     private static Map<String, Object> delayedConfig = new HashMap<String, Object>();
@@ -74,7 +73,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
 
     /**
      * Print debug stacktrace using given trace component.
-     * 
+     *
      * @param logger
      * @param t
      * @param message
@@ -88,7 +87,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
 
     /**
      * Print debug stacktrace using given trace component.
-     * 
+     *
      * @param logger
      * @param thread
      */
@@ -100,7 +99,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
 
     /**
      * Print channel configuration - for debug.
-     * 
+     *
      * @param logger
      * @param cfw
      * @param message
@@ -115,7 +114,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
 
     /**
      * Display configured channel chains.
-     * 
+     *
      * @param logger
      * @param cfw
      * @param factory
@@ -132,7 +131,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
 
     /**
      * Display configured channel chains.
-     * 
+     *
      * @param logger
      * @param cfw
      * @param groupName
@@ -149,7 +148,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
 
     /**
      * Display configured channel chains (convert array of chains to list).
-     * 
+     *
      * @param logger
      * @param chains
      *            Array of chains to trace
@@ -170,7 +169,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
 
     /**
      * Display configured channel chains.
-     * 
+     *
      * @param logger
      * @param lchain
      * @param message
@@ -187,7 +186,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
 
     /**
      * Debug trace using either Tr or Logger
-     * 
+     *
      * @param logTool
      *            Caller's LogTool (should be Logger OR TraceComponent)
      * @param msg
@@ -202,7 +201,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
     /**
      * Convert the input string to a list of strings based on the
      * provided delimiter.
-     * 
+     *
      * @param input
      * @param delimiter
      * @return String[]
@@ -230,7 +229,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
      * Extract the key of a key=value pair contained withint the
      * provided string. If no equals sign is found, then the input
      * is returned with white space trimmed.
-     * 
+     *
      * @param input
      * @return String
      */
@@ -246,7 +245,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
      * Extract the value of a key=value pair contained within the
      * provided string. If no value exists, then an empty string
      * is returned.
-     * 
+     *
      * @param input
      * @return String
      */
@@ -272,7 +271,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
     /**
      * Extract the various types of objects from the full configuration into
      * separate, discrete groupings.
-     * 
+     *
      * @param config
      * @return Map<String,Map<String,String[]>>
      */
@@ -324,7 +323,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
 
     /**
      * Load and possibly start the provided configuration information.
-     * 
+     *
      * @param config
      * @param start
      * @param restart
@@ -373,13 +372,13 @@ public final class ChannelUtils extends ChannelUtilsBase {
     /**
      * Using the provided configuration, create or update channels,
      * chains, and groups within the channel framework.
-     * 
+     *
      * This will return a map containing lists of created objects. The
      * keys include "factory", "chain", "group", and "channel". The
      * lists will contains the name of the objects such as channel names,
      * chain names, etc. Each list is guarenteed to be non-null; however,
      * might easily be empty.
-     * 
+     *
      * @param config
      * @return Map<String,List<String>>
      */
@@ -493,12 +492,12 @@ public final class ChannelUtils extends ChannelUtilsBase {
      * to decide whether to stop and restart that chain. Note that some
      * configuration values would require a restart of the chain to take
      * effect (such as TCP bind information).
-     * 
+     *
      * This returns map of the started chains and groups. Each is a list
      * under either the key "chain" or the key "group". The list has the
      * names of the channel framework items, ie. channel names, chains names, etc.
      * Each list is guaranteed to be non-null but might be empty.
-     * 
+     *
      * @param config
      * @param restart
      * @return Map<String,List<String>>
@@ -536,9 +535,9 @@ public final class ChannelUtils extends ChannelUtilsBase {
      * and handle changes between the two. Deleted objects will be removed from
      * runtime and updates will stop and restart those specific chains. New chains
      * will be handled as normal.
-     * 
+     *
      * This is same as startConfig(Dictionary,boolean) as to what it returns.
-     * 
+     *
      * @param oldconfig
      * @param newconfig
      * @return Map<String,List<String>>
@@ -785,7 +784,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
             unloadChains(chainsToDelete.iterator());
         }
 
-        // first stop/quiesce the chains (AND WAIT FOR COMPLETION), 
+        // first stop/quiesce the chains (AND WAIT FOR COMPLETION),
         // then destroy them for updates to happen correctly
         stopChains(chainsToStop, -1L, null);
         for (String chainname : chainsToStop) {
@@ -839,7 +838,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
      * Utility method that stops any of the chains created by the configuration
      * that might still be running. The provided timeout is used to quiesce any
      * active connections on the chains.
-     * 
+     *
      * @param chains
      * @param timeout in milliseconds - a timeout value of -1 will use the channel framework
      *            default quiesce timeout setting
@@ -872,10 +871,12 @@ public final class ChannelUtils extends ChannelUtilsBase {
                 if (bTrace && tc.isDebugEnabled()) {
                     Tr.debug(tc, "Stopping chain: " + chain);
                 }
-                if (quiesceTimeout > 0) {
+
+                if (quiesceTimeout > 0 ) {
                     listener.watchChain(cd);
                 }
                 cf.stopChain(cd, quiesceTimeout);
+
             } catch (Throwable t) {
                 // framework already FFDCs on stopChain failure
                 if (bTrace && tc.isDebugEnabled()) {
@@ -887,7 +888,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
         if (runOnStop != null) {
             ExecutorService executorService = CHFWBundle.getExecutorService();
             if (null != executorService) {
-                // Use a different thread to wait for chain stop and then finish.. 
+                // Use a different thread to wait for chain stop and then finish..
                 Runnable runner = new Runnable() {
                     @Override
                     public void run() {
@@ -915,7 +916,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
     /**
      * Load channel factories in the framework based on the provided factory
      * configurations.
-     * 
+     *
      * @param factories
      * @return List<String> - factories created successfully
      */
@@ -967,7 +968,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
     /**
      * Define a new endpoint definition using the input name and list of
      * properties.
-     * 
+     *
      * @param name
      * @param config
      * @return EndPointInfo
@@ -989,7 +990,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
 
     /**
      * Load chain endpoints based on the provided configuration.
-     * 
+     *
      * @param endpoints
      * @return List<String> - endpoints created successfully
      */
@@ -1017,7 +1018,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
     /**
      * Load individual channels in the framework based on the provided
      * channel configurations.
-     * 
+     *
      * @param channels
      * @return List<String> - channels created succesfully
      */
@@ -1143,7 +1144,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
     /**
      * Stop and unload any of the provided chain names that might exist and be
      * currently running.
-     * 
+     *
      * @param chains
      */
     private static void unloadChains(Iterator<String> chains) {
@@ -1174,7 +1175,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
             }
         }
 
-        // Stop chains, and wait for stop to complete... 
+        // Stop chains, and wait for stop to complete...
         stopChains(runningChains, -1L, null);
         for (String name : runningChains) {
             ChainData cd = cf.getChain(name);
@@ -1197,7 +1198,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
     /**
      * Load chains within the channel framework based on the provided
      * chain configurations.
-     * 
+     *
      * @param chains
      * @param start
      * @param restart
@@ -1234,8 +1235,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
                         }
                     }
                 } else if ("flow".equalsIgnoreCase(key)) {
-                    flow = "inbound".equalsIgnoreCase(value)
-                                    ? FlowType.INBOUND : FlowType.OUTBOUND;
+                    flow = "inbound".equalsIgnoreCase(value) ? FlowType.INBOUND : FlowType.OUTBOUND;
                 }
             }
             if (null == chanList) {
@@ -1281,7 +1281,7 @@ public final class ChannelUtils extends ChannelUtilsBase {
     /**
      * Load chain groups in the framework based on the provided group
      * configurations.
-     * 
+     *
      * @param groups
      * @param start
      * @param restart

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/UtilsChainListener.java
@@ -10,153 +10,70 @@
  *******************************************************************************/
 package com.ibm.ws.channelfw.internal;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+
 import com.ibm.websphere.channelfw.ChainData;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.wsspi.channelfw.ChainEventListener;
 import com.ibm.wsspi.channelfw.ChannelFramework;
 import com.ibm.wsspi.channelfw.ChannelFrameworkFactory;
 
 /**
- * Chain lifecycle listener used by the ChannelUtils while blocking on chain
- * stops.
+ * Polls a list of chains until they're stopped or the quiesce timeout is hit.
+ *
  */
-public class UtilsChainListener implements ChainEventListener {
+public class UtilsChainListener {
     /** Trace service */
     private static final TraceComponent tc = Tr.register(UtilsChainListener.class, ChannelFrameworkConstants.BASE_TRACE_NAME, ChannelFrameworkConstants.BASE_BUNDLE);
 
-    /** Number of chains currently being monitored */
-    private int numChainsWaiting = 0;
-    /** Lock used when blocking */
-    private final Object lock = new Object()
-    {};
+    private final ArrayList<String> waitingChainNames = new ArrayList<String>();
 
     /**
      * Constructor.
      */
     public UtilsChainListener() {
-        // nothing to do
+
     }
 
     /**
      * Notify this listener to watch another chain.
-     * 
+     *
      * @param chain
      */
     public void watchChain(ChainData chain) {
-        ChannelFramework cf = ChannelFrameworkFactory.getChannelFramework();
-        try {
-            synchronized (this.lock) {
-                this.numChainsWaiting++;
-            } // end-sync
-            cf.addChainEventListener(this, chain.getName());
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(this, tc, "Watching chain; " + chain.getName());
-            }
-        } catch (Exception e) {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(this, tc, "Unable to watch chain; " + chain.getName() + "; " + e);
-            }
-        }
+        waitingChainNames.add(chain.getName());
     }
 
     /**
-     * Block waiting for all current chains being watched to be stopped fully.
-     * 
+     * Poll the list of chains until they're stopped or the quiesce timeout is hit
+     *
      * @param quiesceTimeout
      */
     public void waitOnChains(long quiesceTimeout) {
-        // if we're still waiting on chains to stop, then sync and wait
-        synchronized (this.lock) {
-            if (0 < this.numChainsWaiting) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                    Tr.event(this, tc, "Waiting on " + this.numChainsWaiting + " chain(s) to stop");
-                }
-                try {
-                    // wait for up to the quiescetimeout plus some padding
-                    this.lock.wait(quiesceTimeout + 2345L);
-                } catch (InterruptedException ie) {
-                    // ignore
-                }
-            }
-        } // end-sync
-    }
 
-    /*
-     * @see
-     * com.ibm.wsspi.channelfw.ChainEventListener#chainDestroyed(com.ibm.websphere
-     * .channelfw.ChainData)
-     */
-    @Override
-    public void chainDestroyed(ChainData chainData) {
-        // do nothing
-    }
-
-    /*
-     * @see
-     * 
-     * com.ibm.wsspi.channelfw.ChainEventListener#chainInitialized(com.ibm.websphere
-     * .channelfw.ChainData)
-     */
-    @Override
-    public void chainInitialized(ChainData chainData) {
-        // do nothing
-    }
-
-    /*
-     * @see
-     * com.ibm.wsspi.channelfw.ChainEventListener#chainQuiesced(com.ibm.websphere
-     * .channelfw.ChainData)
-     */
-    @Override
-    public void chainQuiesced(ChainData chainData) {
-        // do nothing
-    }
-
-    /*
-     * @see
-     * com.ibm.wsspi.channelfw.ChainEventListener#chainStarted(com.ibm.websphere
-     * .channelfw.ChainData)
-     */
-    @Override
-    public void chainStarted(ChainData chainData) {
-        // do nothing
-    }
-
-    /*
-     * @see
-     * com.ibm.wsspi.channelfw.ChainEventListener#chainStopped(com.ibm.websphere
-     * .channelfw.ChainData)
-     */
-    @Override
-    public void chainStopped(ChainData chainData) {
         ChannelFramework cf = ChannelFrameworkFactory.getChannelFramework();
-        synchronized (this.lock) {
-            this.numChainsWaiting--;
-            if (0 == this.numChainsWaiting) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                    Tr.event(this, tc, "Last chain has stopped");
-                }
-                this.lock.notifyAll();
-            }
-        } // end-sync
-        try {
-            cf.removeChainEventListener(this, chainData.getName());
-        } catch (Exception e) {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(this, tc, "Unable to disconnect listener from chain; " + chainData.getName());
-            }
-        }
-    }
+        int elapsedTime = 0;
+        if (waitingChainNames.size() > 0 && elapsedTime < quiesceTimeout) {
 
-    /*
-     * @see
-     * com.ibm.wsspi.channelfw.ChainEventListener#chainUpdated(com.ibm.websphere
-     * .channelfw.ChainData)
-     */
-    @Override
-    public void chainUpdated(ChainData chainData) {
-        // do nothing
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                Tr.event(this, tc, "Waiting on " + waitingChainNames.size() + " chain(s) to stop");
+            }
+
+            Iterator<String> iter = waitingChainNames.iterator();
+            while (iter.hasNext()) {
+                if (!cf.isChainRunning(iter.next()))
+                    iter.remove();
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ie) {
+                // ignore
+            }
+            elapsedTime += 1000;
+
+        }
+
     }
 
 }

--- a/dev/com.ibm.ws.concurrency.policy/bnd.bnd
+++ b/dev/com.ibm.ws.concurrency.policy/bnd.bnd
@@ -35,6 +35,7 @@ instrument.classesExcludes: com/ibm/ws/concurrency/policy/resources/*.class
 
 -buildpath: \
 	com.ibm.websphere.appserver.spi.logging,\
+    com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.wsspi.org.osgi.service.component.annotations, \

--- a/dev/com.ibm.ws.kernel.filemonitor/src/com/ibm/ws/kernel/filemonitor/internal/CoreServiceImpl.java
+++ b/dev/com.ibm.ws.kernel.filemonitor/src/com/ibm/ws/kernel/filemonitor/internal/CoreServiceImpl.java
@@ -37,6 +37,7 @@ import com.ibm.wsspi.kernel.filemonitor.FileMonitor;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.utils.MetatypeUtils;
 import com.ibm.wsspi.kernel.service.utils.PathUtils;
+import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
 
 /**
  * Core of file monitor service. Looks for registered FileMonitors (via declarative services).
@@ -44,7 +45,8 @@ import com.ibm.wsspi.kernel.service.utils.PathUtils;
  * The two required references (WsLocationAdmin and ScheduledExecutorService) are dynamic, to allow
  * those services to be refreshed/replaced without recycling the component.
  */
-public abstract class CoreServiceImpl implements CoreService, FileNotification {
+public abstract class CoreServiceImpl implements CoreService, FileNotification, ServerQuiesceListener {
+
     /**  */
     static final String MONITOR = "Monitor";
 
@@ -295,7 +297,7 @@ public abstract class CoreServiceImpl implements CoreService, FileNotification {
     @Override
     public FileMonitor getReferencedMonitor(ServiceReference<FileMonitor> monitorRef) {
         // This is done once per monitor: cached by the caller (MonitorHolder.init)
-        return (FileMonitor) cContext.locateService(MONITOR, monitorRef);
+        return cContext.locateService(MONITOR, monitorRef);
     }
 
     @Override
@@ -357,4 +359,14 @@ public abstract class CoreServiceImpl implements CoreService, FileNotification {
             }
         }
     }
+
+    @Override
+    public void serverStopping() {
+
+        for (MonitorHolder mh : fileMonitors.values()) {
+            mh.serverStopping();
+        }
+
+    }
+
 }

--- a/dev/com.ibm.ws.kernel.filemonitor/src/com/ibm/ws/kernel/filemonitor/internal/MonitorHolder.java
+++ b/dev/com.ibm.ws.kernel.filemonitor/src/com/ibm/ws/kernel/filemonitor/internal/MonitorHolder.java
@@ -545,6 +545,14 @@ public abstract class MonitorHolder implements Runnable {
         return monitorState.get() == MonitorState.DESTROYED.ordinal();
     }
 
+    private boolean isStopped = false;
+
+    // Stop scanning for changes during server quiesce period
+    void serverStopping() {
+        this.isStopped = true;
+        stop();
+    }
+
     @Override
     public void run() {
         scheduledScan();
@@ -562,6 +570,10 @@ public abstract class MonitorHolder implements Runnable {
     @Trivial
     @FFDCIgnore(InterruptedException.class)
     void scheduledScan() {
+        // Don't perform a scheduled scan if this monitor holder is paused
+        if (isStopped)
+            return;
+
         // 152229: Changed this code to get the monitor type locally.  That is, now we save the monitor type in the constructor.
         // We used to get the monitor type here by monitorRef.getProperty(FileMonitor.MONITOR_TYPE)). That caused a
         // ConcurrentModificationException because of interference from the JMocked FileMonitor in the unit test code.
@@ -749,6 +761,10 @@ public abstract class MonitorHolder implements Runnable {
      *            false = process all the files without filtering
      */
     void externalScan(Set<File> notifiedCreated, Set<File> notifiedDeleted, Set<File> notifiedModified, boolean filter) {
+        // Don't perform the external scan if this monitor holder is paused
+        if (isStopped)
+            return;
+
         // only do anything if this is an 'external' monitor
         if (!!!FileMonitor.MONITOR_TYPE_EXTERNAL.equals(monitorRef.getProperty(FileMonitor.MONITOR_TYPE)))
             return;

--- a/dev/com.ibm.ws.kernel.filemonitor/src/com/ibm/ws/kernel/filemonitor/internal/scan/ScanningCoreServiceImpl.java
+++ b/dev/com.ibm.ws.kernel.filemonitor/src/com/ibm/ws/kernel/filemonitor/internal/scan/ScanningCoreServiceImpl.java
@@ -21,11 +21,13 @@ import com.ibm.ws.kernel.filemonitor.FileNotification;
 import com.ibm.ws.kernel.filemonitor.internal.CoreServiceImpl;
 import com.ibm.ws.kernel.filemonitor.internal.MonitorHolder;
 import com.ibm.wsspi.kernel.filemonitor.FileMonitor;
+import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
 
 /**
  * The traditional core service, used when we're below Java 1.7
  */
-@Component(configurationPolicy = ConfigurationPolicy.OPTIONAL, configurationPid = "com.ibm.ws.kernel.filemonitor", service = { FileNotification.class },
+@Component(configurationPolicy = ConfigurationPolicy.OPTIONAL, configurationPid = "com.ibm.ws.kernel.filemonitor",
+           service = { FileNotification.class, ServerQuiesceListener.class },
            property = { "service.vendor=IBM" })
 public class ScanningCoreServiceImpl extends CoreServiceImpl {
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/bnd.bnd
@@ -48,6 +48,7 @@ testsrc: test/src
         com.ibm.ws.logging;version=latest, \
         com.ibm.ws.logging.core;version=latest, \
         org.eclipse.osgi;version=latest, \
+        com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
         com.ibm.websphere.org.osgi.core;version=latest, \
         com.ibm.websphere.org.osgi.service.component;version=latest, \
         com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \

--- a/dev/com.ibm.ws.runtime.update/bnd.bnd
+++ b/dev/com.ibm.ws.runtime.update/bnd.bnd
@@ -29,7 +29,8 @@ Private-Package: com.ibm.ws.runtime.update.internal*
 
 -dsannotations: \
   com.ibm.ws.runtime.update.internal.RuntimeUpdateManagerImpl, \
-  com.ibm.ws.runtime.update.internal.RuntimeUpdateNotificationMBeanImpl
+  com.ibm.ws.runtime.update.internal.RuntimeUpdateNotificationMBeanImpl, \
+  com.ibm.ws.runtime.update.internal.PauseableComponentQuiesceListener
 
 instrument.classesExcludes: com/ibm/ws/runtime/update/internal/resources/*.class
 

--- a/dev/com.ibm.ws.runtime.update/resources/com/ibm/ws/runtime/update/internal/resources/Messages.nlsprops
+++ b/dev/com.ibm.ws.runtime.update/resources/com/ibm/ws/runtime/update/internal/resources/Messages.nlsprops
@@ -48,3 +48,15 @@ client.quiesce.begin.useraction=No action is required.
 client.quiesce.end=CWWKE1104I: Client quiesce complete.
 client.quiesce.end.explanation=The quiesce operation completed successfully.
 client.quiesce.end.useraction=No action is required.
+
+notifications.not.complete=CWWKE1105W: {0} runtime updates did not complete during the quiesce period. 
+notifications.not.complete.explanation=One or more updates to features, configuration, or applications did not complete before the server shutdown.
+notifications.not.complete.useraction=No action is required. 
+
+quiesce.listeners.not.complete=CWWKE1106W: {0} shutdown operations did not complete during the quiesce period. 
+quiesce.listeners.not.complete.explanation=One or more operations that were initiated during the shutdown operation did not complete. 
+quiesce.listeners.not.complete.useraction=No action is required.
+
+quiesce.waiting.on.threads=CWWKE1107W: {0} threads did not complete during the quiesce period. 
+quiesce.waiting.on.threads.explanation=One or more threads that were active before shutting down the server were still active at the end of the quiesce period.
+quiesce.waiting.on.threads.useraction=No action is required. 

--- a/dev/com.ibm.ws.runtime.update/src/com/ibm/ws/runtime/update/internal/PauseableComponentQuiesceListener.java
+++ b/dev/com.ibm.ws.runtime.update/src/com/ibm/ws/runtime/update/internal/PauseableComponentQuiesceListener.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.runtime.update.internal;
+
+import java.util.Collection;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.launch.service.PauseableComponent;
+import com.ibm.ws.kernel.launch.service.PauseableComponentException;
+import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
+
+/**
+ * TODO Find a better place for this to live
+ * This ServerQuiesceListener implementation will pause all pausable components.
+ */
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE)
+public class PauseableComponentQuiesceListener implements ServerQuiesceListener {
+
+    private static final TraceComponent tc = Tr.register(PauseableComponentQuiesceListener.class);
+    private BundleContext bundleContext = null;
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener#serverStopping()
+     */
+    @Override
+    public void serverStopping() {
+        if (bundleContext != null) {
+            try {
+                Collection<ServiceReference<PauseableComponent>> refs = bundleContext.getServiceReferences(PauseableComponent.class, null);
+                for (ServiceReference<PauseableComponent> ref : refs) {
+
+                    PauseableComponent pc = bundleContext.getService(ref);
+                    if (!pc.isPaused()) {
+                        try {
+                            pc.pause();
+                        } catch (PauseableComponentException ex) {
+                            Tr.warning(tc, "warn.did.not.pause.on.shutdown", ex.getMessage());
+                        }
+                    }
+                }
+            } catch (InvalidSyntaxException e) {
+                // Should never happen, FFDC and return
+                return;
+            }
+        }
+
+    }
+
+    protected void activate(BundleContext ctx) {
+        this.bundleContext = ctx;
+    }
+
+}

--- a/dev/com.ibm.ws.runtime.update/src/com/ibm/ws/runtime/update/internal/RuntimeUpdateManagerImpl.java
+++ b/dev/com.ibm.ws.runtime.update/src/com/ibm/ws/runtime/update/internal/RuntimeUpdateManagerImpl.java
@@ -12,6 +12,7 @@ package com.ibm.ws.runtime.update.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -19,9 +20,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -41,12 +40,13 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.kernel.LibertyProcess;
 import com.ibm.ws.kernel.launch.service.ForcedServerStop;
 import com.ibm.ws.runtime.update.RuntimeUpdateListener;
 import com.ibm.ws.runtime.update.RuntimeUpdateManager;
 import com.ibm.ws.runtime.update.RuntimeUpdateNotification;
 import com.ibm.ws.threading.FutureMonitor;
+import com.ibm.ws.threading.ThreadQuiesce;
 import com.ibm.ws.threading.listeners.CompletionListener;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.location.WsLocationConstants;
@@ -86,11 +86,21 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
 
     private WsLocationAdmin locationService;
 
+    private LibertyProcess libertyProcess;
+
+    private ExecutorService executorService;
+
     @Activate
     protected void activate(BundleContext ctx) {
         bundleCtx = ctx;
         bundleCtx.addBundleListener(this);
 
+    }
+
+    @Reference(service = ExecutorService.class,
+               cardinality = ReferenceCardinality.MANDATORY)
+    protected void setExecutorService(ExecutorService executorService) {
+        this.executorService = executorService;
     }
 
     @Reference(service = FutureMonitor.class)
@@ -138,22 +148,9 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
         this.locationService = null;
     }
 
-    /**
-     * The ThreadFactory used by the executor to create new threads.
-     */
-    ThreadFactory threadFactory = null;
-
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL,
-               policy = ReferencePolicy.DYNAMIC,
-               target = "(com.ibm.ws.threading.defaultExecutorThreadFactory=true)")
-    protected void setThreadFactory(ThreadFactory threadFactory) {
-        this.threadFactory = threadFactory;
-    }
-
-    protected void unsetThreadFactory(ThreadFactory threadFactory) {
-        if (this.threadFactory == threadFactory) {
-            threadFactory = null;
-        }
+    @Reference(policy = ReferencePolicy.STATIC)
+    protected void setProcess(LibertyProcess process) {
+        this.libertyProcess = process;
     }
 
     protected void cleanupNotifications() {
@@ -182,14 +179,6 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
         private final FutureMonitor futureMonitor;
         private final AtomicBoolean waitForPendingNotifications;
         private final boolean ignoreOnQuiesce;
-
-        NotificationImpl(String name, Future<Boolean> future, FutureMonitor futureMonitor, AtomicBoolean waitForPendingNotifications) {
-            this.name = name;
-            this.future = future;
-            this.futureMonitor = futureMonitor;
-            this.waitForPendingNotifications = waitForPendingNotifications;
-            this.ignoreOnQuiesce = false;
-        }
 
         NotificationImpl(String name, Future<Boolean> future, FutureMonitor futureMonitor, AtomicBoolean waitForPendingNotifications, boolean ignoreQuiesce) {
             this.name = name;
@@ -306,7 +295,7 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
                 // NICE / NORMAL STOP
                 // Find all ServerQueisceListeners and notify them
                 try {
-                    queisceListeners(bundleCtx.getServiceReferences(ServerQuiesceListener.class, null));
+                    quiesceListeners(bundleCtx.getServiceReferences(ServerQuiesceListener.class, null));
                 } catch (InvalidSyntaxException e) {
                     // not going to happen with a null filter.
                 }
@@ -321,8 +310,8 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
      *
      * @param listenerRefs Collection of {@code ServiceReference}s for {@code ServerQuiesceListener}s
      */
-    @FFDCIgnore(InterruptedException.class)
-    private void queisceListeners(Collection<ServiceReference<ServerQuiesceListener>> listenerRefs) {
+
+    private void quiesceListeners(Collection<ServiceReference<ServerQuiesceListener>> listenerRefs) {
         // Make a copy of existing notifications: we can't hold the lock around notifications
         // to iterate while waiting for the existing notifications to complete because that would
         // lock-out cleanupNotifications.
@@ -334,17 +323,14 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
         if (listenerRefs.isEmpty() && existingNotifications.isEmpty())
             return;
 
-        // Thread pool for stopping bits of the server (so it doesn't compete with running work.. )
-        ExecutorService threadPool = threadFactory != null ? Executors.newFixedThreadPool(3, threadFactory) : Executors.newFixedThreadPool(3);
-
         if (isServer())
             Tr.audit(tc, "quiesce.begin");
         else
             Tr.audit(tc, "client.quiesce.begin");
 
-        // Add one more for allowing existing config operations to finish
+        // If there are RuntimeUpdateNotifications outstanding, submit a thread to wait on them
         if (!existingNotifications.isEmpty()) {
-            threadPool.execute(new Runnable() {
+            executorService.execute(new Runnable() {
                 @Override
                 public void run() {
                     try {
@@ -359,18 +345,17 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
             });
         }
 
-        //Create list of threads to check who is alive in the case of a quiesce failure
-        final ConcurrentLinkedQueue<Thread> listeners = new ConcurrentLinkedQueue<Thread>();
-
         // Queue the notification of each listener (unbounded queue)
+        final ConcurrentLinkedQueue<ServerQuiesceListener> listeners = new ConcurrentLinkedQueue<ServerQuiesceListener>();
         for (ServiceReference<ServerQuiesceListener> ref : listenerRefs) {
             final ServerQuiesceListener listener = bundleCtx.getService(ref);
             if (listener != null) {
-                threadPool.execute(new Runnable() {
+
+                executorService.execute(new Runnable() {
                     @Override
                     public void run() {
                         try {
-                            listeners.add(Thread.currentThread());
+                            listeners.add(listener);
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                 Tr.debug(tc, "Invoking serverStopping() on listener: " + listener);
                             }
@@ -378,57 +363,33 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                 Tr.debug(tc, "serverStopping() method completed on listener: " + listener);
                             }
+
                         } catch (Throwable t) {
                             // Auto-FFDC here..
+                        } finally {
+                            listeners.remove(listener);
                         }
                     }
                 });
+
             }
         }
 
-        // Now that we have notified all listeners, shutdown the executor
-        threadPool.shutdown();
-
-        boolean finished = false;
-        // And wait for all of that queued work to complete
-        try {
-            finished = threadPool.awaitTermination(30, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            // boooo. Stop waiting for notifications to finish...
-            finished = false;
-        }
-
-        if (finished) {
+        // Notify the executor service that we are quiescing
+        ThreadQuiesce tq = (ThreadQuiesce) executorService;
+        if (tq.quiesceThreads()) {
             if (isServer())
                 Tr.info(tc, "quiesce.end");
             else
                 Tr.info(tc, "client.quiesce.end");
         } else {
-            if (tc.isDebugEnabled()) {
-                // for which notifications are not done yet
-                for (RuntimeUpdateNotification notification : existingNotifications.values()) {
-                    if (!!!notification.isDone()) {
-                        Tr.debug(tc, "Notification is not done yet: " + notification);
-                    }
-                }
-                // Check which threads are still alive
-                for (Thread t : listeners) {
-                    int liveThreads = 0;
-                    if (t.isAlive()) {
-                        liveThreads++;
-                        Tr.debug(tc, "For thread " + liveThreads + " the stack trace is as follows: ");
-                        StackTraceElement stackTrace[] = t.getStackTrace();
-                        int sizeOfStack = stackTrace.length;
-                        //Print the first several traces from the stack
-                        for (int i = 0; (i < sizeOfStack) || (i < 5); i++) {
-                            Tr.debug(tc, "\t \t at " + stackTrace[i].getMethodName() + "(" + stackTrace[i].getFileName() + "" + stackTrace[i].getLineNumber() + ")");
-                        }
-                        if (sizeOfStack >= 5) {
-                            Tr.debug(tc, "...");
-                        }
-                    }
-                }
-            }
+
+            // Dump threads to show what's still running. This should normally only be done when
+            // debug is enabled, but it's always on for now. Once we're sure we've flushed out most
+            // sources of quiesce failures we can move this into a debug block.
+            libertyProcess.createJavaDump(Collections.singleton("thread"));
+
+            int count = tq.getActiveThreads();
 
             // we timed out - we now have to stop waiting for existing notifications to finish...
             // we set the normal stop to false and issue the timeout warning after the diagnostics to
@@ -436,7 +397,37 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
             // finish right after we issue the warning - then we wouldn't see them in the diagnostics).
             normalServerStop.set(false);
             Tr.warning(tc, "quiece.warning");
+
+            int notificationCount = 0;
+
+            for (RuntimeUpdateNotification notification : existingNotifications.values()) {
+                if (!!!notification.isDone()) {
+                    notificationCount++;
+                    if (tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Notification did not complete during quiesce: ", notification.getName());
+                    }
+                }
+            }
+            if (notificationCount > 0) {
+                Tr.warning(tc, "notifications.not.complete", notificationCount);
+            }
+
+            if (listeners.size() > 0) {
+                Tr.warning(tc, "quiesce.listeners.not.complete", listeners.size());
+            }
+
+            if (tc.isDebugEnabled()) {
+                for (ServerQuiesceListener sql : listeners) {
+                    Tr.debug(tc, "Quiesce listener did not complete during quiesce: ", sql.getClass().getName());
+                }
+            }
+
+            count = count - notificationCount - listeners.size();
+            if (count > 0) {
+                Tr.warning(tc, "quiesce.waiting.on.threads", count);
+            }
         }
+
     }
 
     private boolean isServer() {

--- a/dev/com.ibm.ws.runtime.update_fat/publish/files/longrunning-threads-server.xml
+++ b/dev/com.ibm.ws.runtime.update_fat/publish/files/longrunning-threads-server.xml
@@ -1,0 +1,23 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>quiescelistener-1.0</feature>
+    </featureManager>
+    
+     <testServerQuiesce startThreadsWhileRunning="true" startThreadsAfterStop="true"/>
+  
+    
+    <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.runtime.update_fat/publish/files/non-blocking-threads-server.xml
+++ b/dev/com.ibm.ws.runtime.update_fat/publish/files/non-blocking-threads-server.xml
@@ -1,0 +1,23 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>quiescelistener-1.0</feature>
+    </featureManager>
+    
+     <testServerQuiesce  startThreadsAfterStop="true"/>
+  
+    
+    <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/resources/OSGI-INF/metatype/metatype.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Licensed Materials - Property of IBM
-
-  "Restricted Materials of IBM"
-
-  Copyright IBM Corp. 2014 All Rights Reserved.
-
-  US Government Users Restricted Rights - Use, duplication or
-  disclosure restricted by GSA ADP Schedule Contract with
-  IBM Corp.
--->
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0" 
                    xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
                    localization="OSGI-INF/l10n/metatype">
@@ -22,6 +21,13 @@
     
         <AD name="internal" description="internal" 
             id="takeForever" required="false" type="Boolean" default="false" />  
+                        
+        <AD name="internal" description="internal" 
+            id="startThreadsAfterStop" required="false" type="Boolean" default="false" />  
+            
+        <AD name="internal" description="internal"
+            id="startThreadsWhileRunning" required="false" type="Boolean" default="false"/>
+            
     </OCD>
   
     <Designate pid="test.server.quiesce">

--- a/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/TestQuiesceListener.java
+++ b/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/TestQuiesceListener.java
@@ -11,9 +11,12 @@
 package test.server.quiesce;
 
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
 
 import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
 
@@ -25,6 +28,8 @@ public class TestQuiesceListener implements ServerQuiesceListener {
 
     boolean throwException = false;
     boolean takeForever = false;
+    boolean startThreadsAfterStop = false;
+    ExecutorService executorService;
 
     @Activate
     protected void activate(Map<String, Object> newConfig) {
@@ -32,6 +37,23 @@ public class TestQuiesceListener implements ServerQuiesceListener {
 
         throwException = (Boolean) newConfig.get("throwException");
         takeForever = (Boolean) newConfig.get("takeForever");
+        startThreadsAfterStop = (Boolean) newConfig.get("startThreadsAfterStop");
+
+        if ((Boolean) newConfig.get("startThreadsWhileRunning")) {
+            // Start a couple of threads. These should block shutdown
+            Runnable r = new Runnable() {
+
+                @Override
+                public void run() {
+                    while (true) {
+                    }
+
+                }
+            };
+            executorService.submit(r);
+            executorService.submit(r);
+        }
+
     }
 
     @Override
@@ -53,5 +75,27 @@ public class TestQuiesceListener implements ServerQuiesceListener {
             while (true) {
             }
         }
+
+        if (startThreadsAfterStop) {
+            // Start a couple of threads. These should not block shutdown
+            Runnable r = new Runnable() {
+
+                @Override
+                public void run() {
+                    while (true) {
+                    }
+
+                }
+            };
+            executorService.submit(r);
+            executorService.submit(r);
+        }
     }
+
+    @Reference(service = ExecutorService.class,
+               cardinality = ReferenceCardinality.MANDATORY)
+    protected void setExecutorService(ExecutorService executorService) {
+        this.executorService = executorService;
+    }
+
 }

--- a/dev/com.ibm.ws.threading/bnd.bnd
+++ b/dev/com.ibm.ws.threading/bnd.bnd
@@ -59,7 +59,8 @@ instrument.classesExcludes: com/ibm/ws/threading/internal/resources/*.class
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.logging.core;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
-	com.ibm.ws.kernel.service;version=latest
+	com.ibm.ws.kernel.service;version=latest, \
+	com.ibm.ws.kernel.boot;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ThreadQuiesce.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ThreadQuiesce.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.threading;
+
+/**
+ * Used to signal the executor service that threads should be quiesced
+ */
+public interface ThreadQuiesce {
+
+    boolean quiesceThreads();
+
+    int getActiveThreads();
+}

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
@@ -39,7 +40,9 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.CpuInfo;
+import com.ibm.ws.threading.ThreadQuiesce;
 import com.ibm.wsspi.threading.ExecutorServiceTaskInterceptor;
 import com.ibm.wsspi.threading.WSExecutorService;
 
@@ -50,7 +53,7 @@ import com.ibm.wsspi.threading.WSExecutorService;
            configurationPolicy = ConfigurationPolicy.REQUIRE,
            property = "service.vendor=IBM",
            service = { java.util.concurrent.ExecutorService.class, com.ibm.wsspi.threading.WSExecutorService.class })
-public final class ExecutorServiceImpl implements WSExecutorService {
+public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuiesce {
 
     /**
      * The target ExecutorService.
@@ -104,6 +107,8 @@ public final class ExecutorServiceImpl implements WSExecutorService {
      * The ThreadFactory used by the executor to create new threads.
      */
     ThreadFactory threadFactory = null;
+
+    private Boolean serverStopping = false;
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL,
                policy = ReferencePolicy.DYNAMIC,
@@ -206,6 +211,59 @@ public final class ExecutorServiceImpl implements WSExecutorService {
         }
     }
 
+    private class RunnableWrapper implements Runnable {
+
+        private final Runnable wrappedTask;
+
+        RunnableWrapper(Runnable r) {
+            this.wrappedTask = r;
+
+            phaser.register();
+        }
+
+        /*
+         * (non-Javadoc)
+         *
+         * @see java.lang.Runnable#run()
+         */
+        @Override
+        public void run() {
+            try {
+                this.wrappedTask.run();
+            } finally {
+
+                phaser.arriveAndDeregister();
+            }
+        }
+
+    }
+
+    // Used to keep track of the number of threads that are not finished
+    protected final Phaser phaser = new Phaser(1);
+
+    private class CallableWrapper<T> implements Callable<T> {
+        private final Callable<T> callable;
+
+        CallableWrapper(Callable<T> c) {
+            this.callable = c;
+            phaser.register();
+        }
+
+        /*
+         * (non-Javadoc)
+         *
+         * @see java.util.concurrent.Callable#call()
+         */
+        @Override
+        public T call() throws Exception {
+            try {
+                return this.callable.call();
+            } finally {
+                phaser.arriveAndDeregister();
+            }
+        }
+    }
+
     /** {@inheritDoc} */
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
@@ -269,35 +327,35 @@ public final class ExecutorServiceImpl implements WSExecutorService {
     @Override
     public <T> Future<T> submit(Callable<T> task) {
         threadPoolController.resumeIfPaused();
-        return threadPool.submit(interceptorsActive ? wrap(task) : task);
+        return threadPool.submit(createWrappedCallable(task));
     }
 
     /** {@inheritDoc} */
     @Override
     public Future<?> submit(Runnable task) {
         threadPoolController.resumeIfPaused();
-        return threadPool.submit(interceptorsActive ? wrap(task) : task);
+        return threadPool.submit(createWrappedRunnable(task));
     }
 
     /** {@inheritDoc} */
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
         threadPoolController.resumeIfPaused();
-        return threadPool.submit(interceptorsActive ? wrap(task) : task, result);
+        return threadPool.submit(createWrappedRunnable(task), result);
     }
 
     /** {@inheritDoc} */
     @Override
     public void execute(Runnable command) {
         threadPoolController.resumeIfPaused();
-        threadPool.execute(interceptorsActive ? wrap(command) : command);
+        threadPool.execute(createWrappedRunnable(command));
     }
 
     /** {@inheritDoc} */
     @Override
     public void executeGlobal(Runnable command) {
         threadPoolController.resumeIfPaused();
-        threadPool.execute(interceptorsActive ? wrap(command) : command);
+        threadPool.execute(createWrappedRunnable(command));
     }
 
     /**
@@ -386,12 +444,29 @@ public final class ExecutorServiceImpl implements WSExecutorService {
         }
     }
 
+    private Runnable createWrappedRunnable(Runnable in) {
+        Runnable r = interceptorsActive ? wrap(in) : in;
+        if (serverStopping)
+            return r;
+
+        return new RunnableWrapper(r);
+    }
+
     Runnable wrap(Runnable r) {
         Iterator<ExecutorServiceTaskInterceptor> i = interceptors.iterator();
         while (i.hasNext()) {
             r = i.next().wrap(r);
         }
+
         return r;
+    }
+
+    private <T> Callable<T> createWrappedCallable(Callable<T> in) {
+
+        Callable<T> c = interceptorsActive ? wrap(in) : in;
+        if (serverStopping)
+            return c;
+        return new CallableWrapper<T>(c);
     }
 
     <T> Callable<T> wrap(Callable<T> c) {
@@ -399,15 +474,56 @@ public final class ExecutorServiceImpl implements WSExecutorService {
         while (i.hasNext()) {
             c = i.next().wrap(c);
         }
+
         return c;
     }
 
+    // This is private, so handling both interceptors and wrapping in this method for simplicity
     private <T> Collection<? extends Callable<T>> wrap(Collection<? extends Callable<T>> tasks) {
         List<Callable<T>> wrappedTasks = new ArrayList<Callable<T>>();
         Iterator<? extends Callable<T>> i = tasks.iterator();
         while (i.hasNext()) {
-            wrappedTasks.add(wrap(i.next()));
+            Callable<T> c = wrap(i.next());
+            if (serverStopping)
+                wrappedTasks.add(c);
+            else
+                wrappedTasks.add(new CallableWrapper<T>(c));
         }
         return wrappedTasks;
     }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.ibm.ws.threading.ThreadQuiesce#quiesceThreads()
+     */
+    @Override
+    @FFDCIgnore(TimeoutException.class)
+    public boolean quiesceThreads() {
+        this.serverStopping = true;
+
+        try {
+            // Wait 30 seconds for all pre-quiesce work to complete
+            phaser.arriveAndDeregister();
+            phaser.awaitAdvanceInterruptibly(0, 30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            //FFDC and fail quiesce notification
+            return false;
+        } catch (TimeoutException e) {
+            // If we time out, quiesce has failed. This is normal, so no FFDC.
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int getActiveThreads() {
+        int count = phaser.getUnarrivedParties();
+        if (this.serverStopping)
+            return count;
+
+        return count - 1;
+    }
+
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -1416,4 +1416,5 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         }
         out.println();
     }
+
 }

--- a/dev/com.ibm.ws.threading_policy_fat/bnd.bnd
+++ b/dev/com.ibm.ws.threading_policy_fat/bnd.bnd
@@ -19,11 +19,13 @@ src: \
 fat.project: true
 
 -buildpath: \
+    com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.threading;version=latest,\
 	com.ibm.ws.resource;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest
+  
 
 -sub: *.bnd


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#5219

#5184 was reverted because of an intermittent failure that managed to fail all three attempts in the continuous build. The change that resolves the intermittent is in commercial liberty, so the easiest thing to do here is to revert the revert and redeliver when that change has been integrated. 