### PR TITLE
test connection sharing according to MatchCurrentState with sharding

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
@@ -62,6 +62,7 @@ public class JDBC43Test extends FATServletClient {
     public static void tearDown() throws Exception {
         server.stopServer("DSRA0302E.*XA_RBOTHER", // raised by mock JDBC driver for XA operations after abort
                           "DSRA8790W", // expected for begin/endRequest invoked by application being ignored
+                          "J2CA0081E", // TODO why does Derby think a transaction is still active?
                           "WLTC0018E"); // TODO remove once transactions bug is fixed
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -32,6 +32,11 @@
     <properties databaseName="memory:testdb;create=true"/>
   </dataSource>
 
+  <dataSource jndiName="jdbc/matchCurrentState" type="javax.sql.ConnectionPoolDataSource" connectionSharing="MatchCurrentState">
+    <jdbcDriver libraryRef="D43Lib"/>
+    <properties databaseName="memory:testdb;create=true"/>
+  </dataSource>
+
   <dataSource jndiName="jdbc/poolOf1" type="javax.sql.ConnectionPoolDataSource">
     <connectionManager maxPoolSize="1"/>
     <jdbcDriver libraryRef="D43Lib"/>


### PR DESCRIPTION
Write a test case that changes the sharding keys and expect connection matching to happen based on the current state of the connection rather than the original request.