### PR TITLE
Added jvm.options to allow for certificate verification in ldap.fat.tds.ssl

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.ssl/bootstrap.properties
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.ssl/bootstrap.properties
@@ -8,6 +8,6 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.ws.security.*=all=enabled
+com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.ws.security.*=all=enabled:componenttest.topology.ldap=all
 com.ibm.ws.logging.max.file.size=0
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.ssl/jvm.options
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.ssl/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true

--- a/dev/fattest.simplicity/src/componenttest/topology/ldap/LocalLDAPServerSuite.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/ldap/LocalLDAPServerSuite.java
@@ -43,11 +43,11 @@ public class LocalLDAPServerSuite {
     public static void setUp() throws Exception {
         String method = "setUp";
         Log.entering(c, method);
-
+        System.setProperty("com.sun.jndi.ldap.object.disableEndpointIdentification", "true");
+        Log.info(c, method, "Endpoint identification was set to true");
         // Check if physical LDAP servers are up, if not then use in-memory LDAP
         if (!LDAPUtils.USE_LOCAL_LDAP_SERVER || !isInMemoryAllowed) {
             // Workaround property for OpenJDKs sun JNDI implementation
-            System.setProperty("com.sun.jndi.ldap.object.disableEndpointIdentification", "true");
             boolean isLdapServersAvailable = false;
             if (testServers != null) {
                 Set<String> primaryServers = testServers.keySet();


### PR DESCRIPTION
fixes #5233 

Added jvm.options to disable endpoint verification