### PR TITLE
Use more performant regex to search logs for errors and warnings

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -2150,7 +2150,7 @@ public class LibertyServer implements LogMonitorClient {
         // Get all warnings and errors in logs - default to an empty list
         List<String> errorsInLogs = new ArrayList<String>();
         try {
-            errorsInLogs = this.findStringsInLogs(".*[EW] .*\\d{4}[EW]:.*");
+            errorsInLogs = this.findStringsInLogs("^.*[EW] .*\\d{4}[EW]:.*$");
             if (!errorsInLogs.isEmpty()) {
                 // There were unexpected errors in logs, print them
                 // and set an exception to return


### PR DESCRIPTION
When a FAT test produces a lot of system.out, @jgrassel noticed that a lot of time was being taken scanning the messages.log file for errors and warnings.  This turned out to be the regex string used to search the logs was not being limited a single-line search.