### PR TITLE
Consolidate parseQueryString implementations to one.

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/RequestUtils.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/RequestUtils.java
@@ -28,32 +28,31 @@ import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
 import com.ibm.ejs.ras.TraceNLS;
 import com.ibm.wsspi.webcontainer.util.EncodingUtils;
 
-@SuppressWarnings("unchecked")
 public class RequestUtils extends com.ibm.wsspi.webcontainer.util.RequestUtils
 {
-    private static String SYSTEM_CLIENT_ENCODING;
-    private static String SYSTEM_FILE_ENCODING;
+    private static final String SYSTEM_CLIENT_ENCODING;
+    private static final String SYSTEM_FILE_ENCODING;
     public static final String SYS_PROP_FILE_ENCODING = "file.encoding";
     public static final String SYS_PROP_DFLT_CLIENT_ENCODING = "default.client.encoding";
-    private static TraceNLS nls = TraceNLS.getTraceNLS(RequestUtils.class, "com.ibm.ws.webcontainer.resources.Messages");
-protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.ws.webcontainer.servlet");
-	private static final String CLASS_NAME="com.ibm.ws.webcontainer.servlet.RequestUtils";
+    private static final TraceNLS nls = TraceNLS.getTraceNLS(RequestUtils.class, "com.ibm.ws.webcontainer.resources.Messages");
+    private static final Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.ws.webcontainer.servlet");
+    private static final String CLASS_NAME="com.ibm.ws.webcontainer.servlet.RequestUtils";
 
     static
     {
         // get the system file encoding
-        SYSTEM_FILE_ENCODING = (String)AccessController.doPrivileged(new java.security.PrivilegedAction()
+        SYSTEM_FILE_ENCODING = AccessController.doPrivileged(new java.security.PrivilegedAction<String>()
                                                                      {
-                                                                         public Object run()
+                                                                         public String run()
                                                                          {
                                                                              return(System.getProperty(SYS_PROP_FILE_ENCODING));
                                                                          }
                                                                      });
 
         // setup the override for client encoding...if specified, this property will be used as the client encoding.
-        SYSTEM_CLIENT_ENCODING = (String)AccessController.doPrivileged(new java.security.PrivilegedAction()
+        SYSTEM_CLIENT_ENCODING = AccessController.doPrivileged(new java.security.PrivilegedAction<String>()
                                                                      {
-                                                                         public Object run()
+                                                                         public String run()
                                                                          {
                                                                              return(System.getProperty(SYS_PROP_DFLT_CLIENT_ENCODING));
                                                                          }
@@ -222,68 +221,14 @@ protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.
         return encoding;
     }
        
-    static private String parseName(String s, StringBuffer sb)
-    {
-        sb.setLength(0);
-        int len = s.length();
-        for (int i = 0; i < len; i++)
-        {
-            char c = s.charAt(i);
-            switch (c)
-            {
-            case '+' :
-                sb.append(' ');
-                break;
-            case '%' :
-                try
-                {
-                    sb.append((char) Integer.parseInt(s.substring(i + 1, i + 3), 16));
-                    i += 2;
-                }
-                catch (NumberFormatException e)
-                {
-                    // XXX
-                    // need to be more specific about illegal arg
-                        com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(e, "com.ibm.ws.webcontainer.servlet.RequestUtils.parseName", "337");
-                    throw new IllegalArgumentException("Unable to parse query string name or value  [" + s +"] ");
-                }
-                catch (StringIndexOutOfBoundsException e)
-                {
-                        com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(e, "com.ibm.ws.webcontainer.servlet.RequestUtils.parseName", "342");
-                    String rest = s.substring(i);
-                    sb.append(rest);
-                    if (rest.length() == 2)
-                        i++;
-                }
-                break;
-            default :
-                sb.append(c);
-                break;
-            }
-        }
-        /* PQ44657 causes POST data parsing in non-ENglish environments to fail.
-        //Begin PQ44657 - The HttpUtils' parsePostData() method incorrectly decodes values.
-        byte[] inputBytes = null;
-        try {
-            String result = sb.toString();
-            inputBytes = result.getBytes(SHORT_ENGLISH);
-        } catch (java.io.UnsupportedEncodingException uex) {
-
-        }
-        return new String(inputBytes);
-        //End PQ44657
-        */
-        return sb.toString();
-    }
-    
-    private static byte[] getPostBytes(int len, ServletInputStream in) /* 157338 add throws */ throws IOException
+    private static String getPostBody(int len, ServletInputStream in, String encoding) /* 157338 add throws */ throws IOException
     {
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))
-            logger.logp(Level.FINE,CLASS_NAME,"getPostBytes","len = " + len);
+			logger.logp(Level.FINE,CLASS_NAME,"getPostBody","len = " + len, ", encoding = " + encoding);
         
         int inputLen, offset;
         byte[] postedBytes = null;
-        
+        String postedBody;
         if (len <= 0)
             return null;
         if (in == null)
@@ -303,69 +248,40 @@ protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.
                     String msg = nls.getString("post.body.contains.less.bytes.than.specified", "post body contains less bytes than specified by content-length");
                     throw new IOException(msg);
                 }
-                logger.logp(Level.FINE, CLASS_NAME, "getPostBytes","read of " +  inputLen + " bytes.");
-                offset += inputLen;
+                logger.logp(Level.FINE, CLASS_NAME, "getPostBody","read of " +  inputLen + " bytes.");
+               offset += inputLen;
             }
             while ((len - offset) > 0);            
             
         }
         catch (IOException e)
         {
-            com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(e, "com.ibm.ws.webcontainer.servlet.RequestUtils.getPostBytes", "398");
+            com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(e, "com.ibm.ws.webcontainer.servlet.RequestUtils.parsePostData", "398");
             // begin 157338
             throw e;
             //return new Hashtable();
             // begin 157338
         }
-        
-        return postedBytes;
-    }
-    private static String getPostBody(int len, ServletInputStream in, String encoding) /* 157338 add throws */ throws IOException
-    {
-        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {
-            logger.logp(Level.FINE,CLASS_NAME,"getPostBody","len = " + len," encoding = " + encoding);
-        }
-        
-        String postedBody;
-        byte postedBytes[] = getPostBytes(len,in);
-        
+        // XXX we shouldn't assume that the only kind of POST body
+        // is FORM data encoded using ASCII or ISO Latin/1 ... or
+        // that the body should always be treated as FORM data.
+        //
         try
-        {   
+        {
             postedBody = new String(postedBytes, encoding);
         }
         catch (UnsupportedEncodingException e)
         {
-            com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(e, "com.ibm.ws.webcontainer.servlet.RequestUtils.getPostBody", "411");
+            com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(e, "com.ibm.ws.webcontainer.servlet.RequestUtils.parsePostData", "411");
             postedBody = new String(postedBytes);
         }
-        
-        if (WCCustomProperties.PARSE_UTF8_POST_DATA && encoding.equalsIgnoreCase("UTF-8")) {
-            for (byte nextByte : postedBytes) {
-                if (nextByte < (byte)0 ) {
-                        encoding = "8859_1";                            
-                    if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))
-                                logger.logp(Level.FINE, CLASS_NAME,"parsePostData","UTF8 post data, set encoing to 8859_1 to prevent futrther encoding");
-                        break;
-                }       
-            }
-        }    
         
        return postedBody;
     }
     
+    @SuppressWarnings("rawtypes")
     public static Hashtable parsePostData(int len, ServletInputStream in, String encoding, boolean multireadPropertyEnabled) /* 157338 add throws */ throws IOException // MultiRead
     {    
-        
-        if (!WCCustomProperties.PARSE_UTF8_POST_DATA && encoding.equalsIgnoreCase("UTF-8")) {
-            byte postedBytes[] = getPostBytes(len,in);
-            
-            if (multireadPropertyEnabled) {
-                in.close();
-            }
-            
-            return parseQueryString(postedBytes, encoding);
-        }
-        
         String postedBody = getPostBody(len, in, encoding);
 
         // MultiRead Start
@@ -377,6 +293,7 @@ protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.
         return parseQueryString(postedBody, encoding);
     }
     
+    @SuppressWarnings("rawtypes")
     public static Hashtable parsePostDataLong(long len, ServletInputStream in, String encoding, boolean multireadPropertyEnabled) throws IOException // MultiRead
     {
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))
@@ -431,6 +348,7 @@ protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.
     }
     
     // begin 231634    Support posts with query parms in chunked body    WAS.webcontainer    
+    @SuppressWarnings("rawtypes")
     public static Hashtable parsePostData(ServletInputStream in, String encoding, boolean multireadPropertyEnabled) /* 157338 add throws */ throws IOException
     {
         int inputLen;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/RequestUtils.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/RequestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2006 IBM Corporation and others.
+ * Copyright (c) 1997, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package com.ibm.wsspi.webcontainer.util;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.nio.charset.Charset;
 import java.text.MessageFormat;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -39,22 +38,20 @@ import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
  *
  */
 public class RequestUtils {
-	protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.ws.webcontainer.util");
-	private static final String CLASS_NAME="com.ibm.wsspi.webcontainer.util.RequestUtils";
-	private static TraceNLS nls = TraceNLS.getTraceNLS(RequestUtils.class, "com.ibm.ws.webcontainer.resources.Messages"); //724365.4
+    private static final Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.ws.webcontainer.util");
+    private static final String CLASS_NAME="com.ibm.wsspi.webcontainer.util.RequestUtils";
+    private static final TraceNLS nls = TraceNLS.getTraceNLS(RequestUtils.class, "com.ibm.ws.webcontainer.resources.Messages"); //724365.4
 
-	private static final String SHORT_ENGLISH = "8859_1"; //a shortened ASCII encoding
+    private static final String SHORT_ENGLISH = "8859_1"; //a shortened ASCII encoding
 	
-	private static boolean ignoreInvalidQueryString = WCCustomProperties.IGNORE_INVALID_QUERY_STRING;       //PK75617
-    private static boolean allowQueryParamWithNoEqual = WCCustomProperties.ALLOW_QUERY_PARAM_WITH_NO_EQUAL;       //PM35450
+    private static final boolean ignoreInvalidQueryString = WCCustomProperties.IGNORE_INVALID_QUERY_STRING;       //PK75617
+    private static final boolean allowQueryParamWithNoEqual = WCCustomProperties.ALLOW_QUERY_PARAM_WITH_NO_EQUAL;       //PM35450
     private static final String EMPTY_STRING = ""; //PM35450
-    private static int maxParamPerRequest = WCCustomProperties.MAX_PARAM_PER_REQUEST; // PM53930 (724365)
+    private static final int maxParamPerRequest = WCCustomProperties.MAX_PARAM_PER_REQUEST; // PM53930 (724365)
     private static final int maxDuplicateHashKeyParams = WCCustomProperties.MAX_DUPLICATE_HASHKEY_PARAMS; // PM58495 (728397)
-    private static boolean decodeParamViaReqEncoding = WCCustomProperties.DECODE_PARAM_VIA_REQ_ENCODING; // PM92940
+    private static final boolean decodeParamViaReqEncoding = WCCustomProperties.DECODE_PARAM_VIA_REQ_ENCODING; // PM92940
     private static final boolean printbyteValueandcharParamdata = WCCustomProperties.PRINT_BYTEVALUE_AND_CHARPARAMDATA; //PM92940
 
-
-    
    /**
     *
     * Parses a query string passed from the client to the
@@ -86,12 +83,14 @@ public class RequestUtils {
     *						is invalid
     *
     */
+    @SuppressWarnings("rawtypes")
     static public Hashtable parseQueryString(String s) {
-        return parseQueryString(s.toCharArray(), SHORT_ENGLISH);
+        return parseQueryString(new StringQueryString(s), SHORT_ENGLISH);
     }
 
+    @SuppressWarnings("rawtypes")
     static public Hashtable parseQueryString(String s, String encoding) {
-        return parseQueryString(s.toCharArray(), encoding);
+        return parseQueryString(new StringQueryString(s), encoding);
     }
 
     private static String lastShortEnglishEncoding = null;
@@ -111,17 +110,401 @@ public class RequestUtils {
         return false;
     }
 
-    /**
-     * This method is an optimized version of the parseQueryString(char[][], String)
-     * method for use when there is only one char[].
-     * 
-     * @param ch
-     * @param encoding
-     * @return
-     */
-    static private Hashtable parseQueryString(char[] ch, String encoding) {
+    private static abstract class QueryString {
+        protected int pair_start = 0, equalSign = -1, i = -1;
+        protected boolean isKeySingleByteString = true;
+        protected boolean isValueSingleByteString = true;
+        protected boolean equalsFound = false;
+
+        abstract protected boolean lessThanEqualLength();
+
+        abstract protected boolean isEqualLength();
+
+        abstract protected char getNextChar();
+
+        protected void setEqualSign() {
+            equalSign = i;
+        }
+
+        boolean findNextPair() {
+            pair_start = ++i;
+            isKeySingleByteString = true;
+            isValueSingleByteString = true;
+            equalsFound = false;
+            for (; lessThanEqualLength(); i++) {
+                if (isEqualLength()) {
+                    if (!equalsFound) {
+                        setEqualSign();
+                    }
+                    return true;
+                }
+                char c = getNextChar();
+                if (c == '&') {
+                    if (!equalsFound) {
+                        setEqualSign();
+                    }
+                    return true;
+                }
+                // Only record the first = after pair_start so we handle if a value has an = in it.
+                if (c == '=' && !equalsFound) {
+                    setEqualSign();
+                    equalsFound = true;
+                }
+                if (!decodeParamViaReqEncoding && c > '\u007F') {
+                    if (equalsFound) {
+                        isValueSingleByteString = false;
+                    } else {
+                        isKeySingleByteString = false;
+                    }
+                }
+            }
+            return false;
+        }
+
+        final boolean isKeySingleByteString() {
+            return isKeySingleByteString;
+        }
+
+        final boolean isValueSingleByteString() {
+            return isValueSingleByteString;
+        }
+
+        final boolean hasEquals() {
+            return equalsFound;
+        }
+
+        abstract String getKey();
+
+        abstract String getValue();
+
+        abstract String parseKey();
+
+        abstract String parseValue();
+
+        /*
+         * Parse a name in the query string.
+         */
+        // @MD17415 begin part 3 of 3 New Loop for finding key and value
+        protected String parseName(final char[] ch, final int startOffset, final int endOffset, boolean isKey) {
+            int j = 0;
+            char[] c = null;
+            for (int i = startOffset; i < endOffset; i++) {
+                switch (ch[i]) {
+                    case '+':
+                        if (c == null) {
+                            c = new char[endOffset - startOffset];
+                            j = i - startOffset;
+                            if (j != 0) {
+                                System.arraycopy(ch, startOffset, c, 0, j);
+                            }
+                        }
+                        c[j++] = ' ';
+                        break;
+                    case '%':
+                        if (i + 2 < endOffset) { // @RWS2
+                            if (c == null) {
+                                c = new char[endOffset - startOffset];
+                                j = i - startOffset;
+                                if (j != 0) {
+                                    System.arraycopy(ch, startOffset, c, 0, j);
+                                }
+                            }
+                            int num1 = Character.digit(ch[++i], 16); //@RWS7
+                            int num2 = Character.digit(ch[++i], 16); //@RWS7
+                            if (num1 == -1 || num2 == -1) //@RWS5
+                            { //PK75617 starts
+                                if (ignoreInvalidQueryString) {
+                                    logger.logp(Level.WARNING, CLASS_NAME, "parseName", "invalid.query.string");
+                                    return null;
+                                } //PK75617 ends
+                                throw new IllegalArgumentException(); //@RWS5
+                            } //PK75617
+                            // c[j++] = (char)(num1*16 + num2);       //@RWS5
+                            char newChar = (char) ((num1 << 4) | num2); //@RWS8
+                            if (!decodeParamViaReqEncoding && newChar > '\u007F') {
+                                if (isKey) {
+                                    isKeySingleByteString = false;
+                                } else {
+                                    isValueSingleByteString = false;
+                                }
+                            }
+                            c[j++] = newChar;
+                        } else { // allow '%' at end of value or second to last character (as original code does)
+                            if (c != null) {
+                                for (; i < endOffset; i++) // @RWS2
+                                    c[j++] = ch[i]; // @RWS7
+                            } else {
+                                i = endOffset;
+                            }
+                        }
+                        break;
+                    default:
+                        if (c != null) {
+                            c[j++] = ch[i];
+                        }
+                        break;
+                }
+            }
+            String returnValue = c != null ? new String(c, 0, j) : new String(ch, startOffset, endOffset - startOffset);
+            if (printbyteValueandcharParamdata && com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE))
+                printValues(returnValue, "parseNameOUT");
+            return returnValue;
+        }
+        // @MD17415 end part 3 of 3 New Loop for finding key and value
+    }
+
+    private static class StringQueryString extends QueryString {
+        private final String queryString;
+        private final int lgth;
+
+        StringQueryString(String queryString) {
+            this.queryString = queryString;
+            lgth = queryString.length();
+        }
+
+        protected boolean lessThanEqualLength() {
+            return i <= lgth;
+        }
+
+        protected boolean isEqualLength() {
+            return i == lgth;
+        }
+
+        protected char getNextChar() {
+            return queryString.charAt(i);
+        }
+
+        String getKey() {
+            return queryString.substring(pair_start, equalSign);
+        }
+
+        String getValue() {
+            return queryString.substring(equalSign + 1, i);
+        }
+
+        String parseKey() {
+            return parseName(pair_start, equalSign, true);
+        }
+
+        String parseValue() {
+            return parseName(equalSign + 1, i, false);
+        }
+
+        private String parseName(final int startOffset, final int endOffset, boolean isKey) {
+            StringBuilder sb = null;
+            for (int i = startOffset; i < endOffset; i++) {
+                char c = queryString.charAt(i);
+                switch (c) {
+                    case '+':
+                        if (sb == null) {
+                            sb = new StringBuilder(endOffset - startOffset);
+                            if (i != startOffset) {
+                                sb.append(queryString, startOffset, i);
+                            }
+                        }
+                        sb.append(' ');
+                        break;
+                    case '%':
+                        if (i + 2 < endOffset) { // @RWS2
+                            if (sb == null) {
+                                sb = new StringBuilder(endOffset - startOffset);
+                                if (i != startOffset) {
+                                    sb.append(queryString, startOffset, i);
+                                }
+                            }
+                            int num1 = Character.digit(queryString.charAt(++i), 16); //@RWS7
+                            int num2 = Character.digit(queryString.charAt(++i), 16); //@RWS7
+                            if (num1 == -1 || num2 == -1) //@RWS5
+                            { //PK75617 starts
+                                if (ignoreInvalidQueryString) {
+                                    logger.logp(Level.WARNING, CLASS_NAME, "parseName", "invalid.query.string");
+                                    return null;
+                                } //PK75617 ends
+                                throw new IllegalArgumentException(); //@RWS5
+                            } //PK75617
+                              // c[j++] = (char)(num1*16 + num2);       //@RWS5
+                            char newChar = (char) ((num1 << 4) | num2); //@RWS8
+                            if (!decodeParamViaReqEncoding && newChar > '\u007F') {
+                                if (isKey) {
+                                    isKeySingleByteString = false;
+                                } else {
+                                    isValueSingleByteString = false;
+                                }
+                            }
+                            sb.append(newChar);
+                        } else { // allow '%' at end of value or second to last character (as original code does)
+                            if (sb != null) {
+                                if (i < endOffset) {
+                                    sb.append(queryString, i, endOffset);
+                                }
+                            } else {
+                                i = endOffset;
+                            }
+                        }
+                        break;
+                    default:
+                        if (sb != null) {
+                            sb.append(c);
+                        }
+                        break;
+                }
+            }
+            String returnValue = sb != null ? sb.toString() : queryString.substring(startOffset, endOffset);
+            if (printbyteValueandcharParamdata && com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE))
+                printValues(returnValue, "parseNameOUT");
+            return returnValue;
+        }
+    }
+
+    private static class CharArrayQueryString extends QueryString {
+        private final char[] queryString;
+        private final int lgth;
+
+        CharArrayQueryString(char[] queryString) {
+            this.queryString = queryString;
+            lgth = queryString.length;
+        }
+
+        protected boolean lessThanEqualLength() {
+            return i <= lgth;
+        }
+
+        protected boolean isEqualLength() {
+            return i == lgth;
+        }
+
+        protected char getNextChar() {
+            return queryString[i];
+        }
+
+        String getKey() {
+            return new String(queryString, pair_start, equalSign - pair_start);
+        }
+
+        String getValue() {
+            return new String(queryString, equalSign + 1, i - equalSign - 1);
+        }
+
+        String parseKey() {
+            return parseName(queryString, pair_start, equalSign, true);
+        }
+
+        String parseValue() {
+            return parseName(queryString, equalSign + 1, i, false);
+        }
+    }
+
+    private static class CharArrayArrayQueryString extends QueryString {
+
+        private final char[][] queryString;
+        private int pair_start_index = 0;
+        private int k = 0, equalSign_index = 0;
+
+        CharArrayArrayQueryString(char[][] cha) {
+            this.queryString = cha;
+        }
+
+        protected boolean lessThanEqualLength() {
+            return k < queryString.length && i <= queryString[k].length;
+        }
+
+        protected boolean isEqualLength() {
+            return k == queryString.length - 1 && i == queryString[queryString.length - 1].length;
+        }
+
+        protected char getNextChar() {
+            if (i >= queryString[k].length) {
+                i = 0;
+                k++;
+            }
+            return queryString[k][i];
+        }
+
+        @Override
+        protected void setEqualSign() {
+            super.setEqualSign();
+            equalSign_index = k;
+        }
+
+        @Override
+        boolean findNextPair() {
+            if (i + 1 >= queryString[k].length) {
+                i = -1;
+                k++;
+            }
+            pair_start_index = k;
+            return super.findNextPair();
+        }
+
+        String getKey() {
+            char[] nameChars;
+            int nameStart;
+            int nameLen;
+            if (pair_start_index != equalSign_index) {
+                nameChars = getSingleBuffer(queryString, pair_start, pair_start_index, equalSign, equalSign_index);
+                nameStart = 0;
+                nameLen = nameChars.length;
+            } else {
+                nameChars = queryString[pair_start_index];
+                nameStart = pair_start;
+                nameLen = equalSign - pair_start;
+            }
+            return new String(nameChars, nameStart, nameLen);
+        }
+
+        String getValue() {
+            char[] valueChars;
+            int valueStart;
+            int valueLen;
+            if (equalSign_index != k) {
+                valueChars = getSingleBuffer(queryString, equalSign + 1, equalSign_index, i, k);
+                valueStart = 0;
+                valueLen = valueChars.length;
+            } else {
+                valueChars = queryString[k];
+                valueStart = equalSign + 1;
+                valueLen = i - valueStart;
+            }
+            return new String(valueChars, valueStart, valueLen);
+        }
+
+        String parseKey() {
+            char[] nameChars;
+            int nameStart;
+            int nameEnd;
+            if (pair_start_index != equalSign_index) {
+                nameChars = getSingleBuffer(queryString, pair_start, pair_start_index, equalSign, equalSign_index);
+                nameStart = 0;
+                nameEnd = nameChars.length;
+            } else {
+                nameChars = queryString[pair_start_index];
+                nameStart = pair_start;
+                nameEnd = equalSign;
+            }
+            return parseName(nameChars, nameStart, nameEnd, true);
+        }
+
+        String parseValue() {
+            char[] valueChars;
+            int valueStart;
+            int valueEnd;
+            if (equalSign_index != k) {
+                valueChars = getSingleBuffer(queryString, equalSign + 1, equalSign_index, i, k);
+                valueStart = 0;
+                valueEnd = valueChars.length;
+            } else {
+                valueChars = queryString[k];
+                valueStart = equalSign + 1;
+                valueEnd = i;
+            }
+            return parseName(valueChars, valueStart, valueEnd, false);
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    static private Hashtable parseQueryString(QueryString qs, String encoding) {
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
-            logger.entering(CLASS_NAME, "parseQueryString( char[] , encoding --> [" + encoding + "])"); //PM35450.1
+            logger.entering(CLASS_NAME, "parseQueryString( QueryString , encoding --> [" + encoding + "])"); //PM35450.1
         } //PK75617
         int totalSize = 0; //PM53930
         int dupSize = 0; // 728397
@@ -130,27 +513,12 @@ public class RequestUtils {
         // PK23256 begin
         boolean encoding_is_ShortEnglish = isShortEnglishEncoding(encoding);
         // PK23256 end
-        int pair_start = 0, equalSign = -1;
-        int lgth = ch.length;
 
-        for (int i = 0; i <= lgth; i++) {
-            if (i == lgth || ch[i] == '&') {
-                if (equalSign < pair_start) {
-                    equalSign = i;
-                }
-            } else {
-                if (ch[i] == '=') {
-                    // Only record the first = after pair_start so we handle if a value has an = in it.
-                    if (equalSign < pair_start) {
-                        equalSign = i;
-                    }
-                }
-                continue;
-            }
+        while (qs.findNextPair()) {
 
             //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "equalSign =" + equalSign);
 
-            if ((equalSign < i) || (allowQueryParamWithNoEqual && equalSign == i)) //PM35450 , parameter is blah and not blah=
+            if (qs.hasEquals() || allowQueryParamWithNoEqual) //PM35450 , parameter is blah and not blah=
             { // equal sign found at offset equalSign
                 String key = null; //PM92940 Start
                 String value = null;
@@ -158,41 +526,40 @@ public class RequestUtils {
                 if (decodeParamViaReqEncoding && (!encoding_is_ShortEnglish)) {
 
                     // data, start, (end-start),encoding, string
-                    key = parse_decode_Parameter(ch, pair_start, equalSign - pair_start, encoding, "paramKey");
+                    key = parse_decode_Parameter(qs.getKey(), encoding, "paramKey");
 
-                    if (equalSign == i) {
+                    if (!qs.hasEquals()) {
                         value = key != null ? EMPTY_STRING : null;
                     } else {
-                        int valueStart = equalSign + 1, valueLen = i - valueStart;
-                        value = parse_decode_Parameter(ch, valueStart, valueLen, encoding, "paramValue");
+                        value = parse_decode_Parameter(qs.getValue(), encoding, "paramValue");
                     }
 
                     if (ignoreInvalidQueryString && ((value == null) || (key == null))) {
-                        pair_start = i + 1;
-                        equalSign = i;
                         continue;
                     }
 
                 } else {
-                    key = parseName(ch, pair_start, equalSign);
+                    key = qs.parseKey();
                     //PM35450 Start
                     //String value = null;
-                    if (equalSign == i) {
+                    if (!qs.hasEquals()) {
                         value = key != null ? EMPTY_STRING : null;
                     } else {
-                        value = parseName(ch, equalSign + 1, i);
+                        value = qs.parseValue();
                     }
                     //PM35450 End
 
                     if (ignoreInvalidQueryString && ((value == null) || (key == null))) { //PK75617
-                        pair_start = i + 1;
-                        equalSign = i;
                         continue;
                     } //PK75617
                     if (!encoding_is_ShortEnglish) {
                         try {
-                            key = new String(key.getBytes(SHORT_ENGLISH), encoding);
-                            value = new String(value.getBytes(SHORT_ENGLISH), encoding);
+                            if (!qs.isKeySingleByteString()) {
+                                key = new String(key.getBytes(SHORT_ENGLISH), encoding);
+                            }
+                            if (!qs.isValueSingleByteString()) {
+                                value = new String(value.getBytes(SHORT_ENGLISH), encoding);
+                            }
                         } catch (UnsupportedEncodingException uee) {
                             //No need to nls. SHORT_ENGLISH will always be supported
                             logger.logp(Level.SEVERE, CLASS_NAME, "parseQueryString", "unsupported exception", uee);
@@ -226,686 +593,38 @@ public class RequestUtils {
                 }
             }
             // 724365(PM53930) Start
-            totalSize++;
-            if (maxParamPerRequest != -1 && totalSize >= maxParamPerRequest) {
+            if (maxParamPerRequest != -1 && ++totalSize >= maxParamPerRequest) {
                 // possibly 10000 big enough, will never be here 
                 logger.logp(Level.SEVERE, CLASS_NAME, "parseQueryString",
                             MessageFormat.format(nls.getString("Exceeding.maximum.parameters"), new Object[] { maxParamPerRequest, totalSize }));
                 throw new IllegalArgumentException();
             } // 724365 End
-            pair_start = i + 1;
-            equalSign = i;
         }
 
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
-            logger.exiting(CLASS_NAME, "parseQueryString(char[], String)");
+            logger.exiting(CLASS_NAME, "parseQueryString(QueryString, String)");
         } //PK75617
         return ht;
     }
 
-   @SuppressWarnings("unchecked") 
-   static public Hashtable parseQueryString(char[][] cha, String encoding)
-   {
-       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)){	//PK75617
-           logger.entering(CLASS_NAME, "parseQueryString( query , encoding --> [" +  encoding +"])"); //PM35450.1
-       }																							//PK75617
-       if (cha == null || cha.length==0)
-       {
-           throw new IllegalArgumentException("query string or post data is null");
-       }
+    @SuppressWarnings("rawtypes")
+    static public Hashtable parseQueryString(char[][] cha, String encoding) {
+        if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
+            logger.entering(CLASS_NAME, "parseQueryString( query , encoding --> [" + encoding + "])"); //PM35450.1
+        }                                                                                            //PK75617
 
-       // Call optimized version if there is only 1 char[]
-       if (cha.length == 1) {
-           return parseQueryString(cha[0], encoding);
-       }
+        if (cha == null || cha.length == 0) {
+            throw new IllegalArgumentException("query string or post data is null");
+        }
 
-       String valArray[] = null;
-       int totalSize = 0; //PM53930
-       int dupSize = 0; // 728397
-       Hashtable ht = new Hashtable();
-       HashSet<Integer> key_hset = new HashSet<Integer>(); // 728397
-       // @MD17415 Start 1 of 3: New Loop for finding key and value           @RWS1
-       int lgth;
-       // PK23256 begin
-       boolean encoding_is_ShortEnglish = isShortEnglishEncoding(encoding);                  // @RWS9
-       // PK23256 end
-       int pair_start=0,pair_start_index=0,pair_end=0,pair_end_index=0;
-       int i = 0, j=0, k=0, equalSign=0,equalSign_index=0;
+        // Call optimized version if there is only 1 char[]
+        if (cha.length == 1) {
+            return parseQueryString(new CharArrayQueryString(cha[0]), encoding);
+        }
 
-       for (k=0; k < cha.length ; k++) {
+        return parseQueryString(new CharArrayArrayQueryString(cha), encoding);
+    }
 
-           //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "process buffer " + k + " : " + Arrays.toString(cha[k]) );
-
-
-           lgth = cha[k].length;
-
-           for (i=0; i<lgth; i++) {
-               if (cha[k][i] == '&') {
-
-                   //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "found an &  - pair start =" + pair_start + ", pair_start_index="+pair_start_index);
-
-                   boolean equalFound=false;
-                   for (int count = pair_start_index ; count<= k; count++) {                  
-                       int start = 0, end = cha[k].length;
-                       equalSign_index=count;
-                       if (count == pair_start_index) start=pair_start;
-                       if (count==k) end=i;
-                       for (equalSign=start; equalSign<end; equalSign++) {
-                           if (cha[count][equalSign] == '=') {
-                               equalFound=true;
-                               break;
-                           }
-                       } 
-                       if (equalFound) break;
-                   }
-
-                   //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "equalSign =" + equalSign + ", equalSign_index="+equalSign_index);
-
-                   if ((equalSign < i || equalSign_index < k) || (allowQueryParamWithNoEqual && equalSign == i && equalSign_index ==k )) //PM35450 , parameter is blah and not blah=
-                   {   // equal sign found at offset equalSign
-                       String key = null; //PM92940 Start
-                       String value = null;
-
-                       char[] nameChars,valueChars;
-                       int nameStart=0,nameLen=0;
-                       int valueStart=0,valueLen=0;
-
-                       if (pair_start_index != equalSign_index) { 
-                           nameChars = getSingleBuffer(cha,pair_start,pair_start_index,equalSign, equalSign_index);
-                           nameStart = 0;
-                           nameLen = nameChars.length;
-                       } else {
-                           nameChars=cha[pair_start_index];
-                           nameStart = pair_start;
-                           nameLen = equalSign-pair_start;
-                       }
-
-                       //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "nameStart = " + nameStart + ", nameLen = " + nameLen + ", from buffer :" + Arrays.toString(nameChars));
-
-                       if (equalSign_index != k) { 
-                           valueChars = getSingleBuffer(cha,equalSign+1,equalSign_index,i,k);
-                           valueStart = 0;
-                           valueLen = valueChars.length;
-                       } else {
-                           valueChars=cha[k];
-                           valueStart = equalSign+1;
-                           valueLen = i-valueStart;
-                       }
-
-                       //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "valueStart = " + valueStart + ", valueLen = " + valueLen + ", from buffer :" + Arrays.toString(valueChars));
-
-                       if(decodeParamViaReqEncoding && (!encoding_is_ShortEnglish)){
-
-                           // data, start, (end-start),encoding, string
-                           key = parse_decode_Parameter(nameChars,nameStart,nameLen, encoding,"paramKey");
-
-                           if (equalSign == i && equalSign_index == k){
-                               if(key != null) 
-                                   value = EMPTY_STRING;
-                               else value = null;
-                           }
-                           else {
-
-
-                               value = parse_decode_Parameter(valueChars,valueStart,valueLen,encoding ,"paramValue");
-                           }
-
-                           valueChars=null;
-                           nameChars=null;
-
-                           if (ignoreInvalidQueryString && ((value == null) || (key ==null))){             
-                               pair_start = i+1;
-                               pair_start_index = k;
-                               continue;
-                           }
-
-                       }
-                       else{
-                           key = parseName(nameChars,nameStart,nameStart+nameLen);
-                           //PM35450 Start
-                           //String value = null;
-                           if (equalSign == i && equalSign_index == k){
-                               if(key != null) value = EMPTY_STRING;
-                               else value = null;
-                           }
-                           else value = parseName(valueChars,valueStart,valueStart+valueLen);
-                           //PM35450 End
-
-                           valueChars=null;
-                           nameChars=null;
-
-                           if (ignoreInvalidQueryString && ((value == null) || (key ==null))){      //PK75617
-                               pair_start = i +1;
-                               pair_start_index = k;
-                               continue;
-                           }                                                                                                                                                //PK75617
-                           if ( !encoding_is_ShortEnglish) {
-                               try {
-                                   key = new String(key.getBytes(SHORT_ENGLISH),encoding);
-                                   value = new String(value.getBytes(SHORT_ENGLISH),encoding);
-                               } catch ( UnsupportedEncodingException uee ) {
-                                   //No need to nls. SHORT_ENGLISH will always be supported
-                                   logger.logp(Level.SEVERE, CLASS_NAME,"parseQueryString", "unsupported exception", uee);
-                                   throw new IllegalArgumentException();
-                               }
-                           }
-                       }//PM92940 End
-
-                       //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "key="+key+", value="+value);
-
-                       if (ht.containsKey(key)) {
-                           String oldVals[] = (String []) ht.get(key);
-                           valArray = new String[oldVals.length + 1];
-                           for (j = 0; j < oldVals.length; j++)
-                               valArray[j] = oldVals[j];
-                           valArray[oldVals.length] = value;
-                       } else {
-                           // 728397 Start                        
-                           if(!(key_hset.add(key.hashCode()))){ 
-                               dupSize++;// if false then count as duplicate hashcodes for unique keys
-                               if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  
-                                   logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "duplicate hashCode generated by key --> " + key);
-                               }
-                               if( dupSize > maxDuplicateHashKeyParams){							 
-                                   logger.logp(Level.SEVERE, CLASS_NAME,"parseQueryString", MessageFormat.format(nls.getString("Exceeding.maximum.hash.collisions"), new Object[]{maxDuplicateHashKeyParams}));
-
-                                   throw new IllegalArgumentException();
-                               }
-                           } // 728397 End 
-                           valArray = new String[1];
-                           valArray[0] = value;
-                       }
-                       // 724365(PM53930) Start
-                       totalSize++;
-                       if((maxParamPerRequest == -1) || ( totalSize < maxParamPerRequest)){
-                           ht.put(key, valArray);
-                       }
-                       else{
-                           // possibly 10000 big enough, will never be here 
-                           logger.logp(Level.SEVERE, CLASS_NAME,"parseQueryString", MessageFormat.format(nls.getString("Exceeding.maximum.parameters"), new Object[]{maxParamPerRequest, totalSize}));
-
-                           throw new IllegalArgumentException();
-                       }// 724365 End
-                   }
-                   pair_start = i+1;
-                   pair_start_index = k;
-                   //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "new pair start =" + pair_start + ", pair_start_index="+pair_start_index);
-               }
-               pair_end = i;
-               pair_end_index = k;
-               //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "new pair end =" + pair_end + ", pair_end_index="+pair_end_index);
-           }
-       }
-
-       boolean equalFound=false;
-
-       //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "k=" + k + ", pair_start_index="+pair_start_index+", cha[pair_start_index].length="+cha[pair_start_index].length);
-       //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "pair_start =" +pair_start+ " ,cha[pair_start_index] = "+ Arrays.toString(cha[pair_start_index]));
-       for (int count = pair_start_index ; count < cha.length; count++) {  
-           //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "loop count=" + count);
-           int start = 0, end = cha[count].length;
-           if (count == pair_start_index) start=pair_start;
-           equalSign_index=count;
-           for (equalSign=start; equalSign<end; equalSign++) {
-               //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "equalSign="+equalSign+", cha[count][equalSign]=" + cha[count][equalSign]);
-               if (cha[count][equalSign] == '=') {
-                   equalSign_index=count;
-                   equalFound=true;
-                   break;
-               }
-           } 
-           if (equalFound) break;
-       }
-
-
-       //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "pair_start="+pair_start+", pair_start_index="+pair_start_index+", pair_end="+pair_end+", pair_end_index="+pair_end_index+", equal_sign="+equalSign+", equalSign_Index="+equalSign_index);
-
-       if (pair_start < equalSign || pair_start_index < equalSign_index) { 
-           if ((equalSign <= pair_end || equalSign_index < pair_end_index) || (allowQueryParamWithNoEqual && equalSign > pair_end && equalSign_index == pair_end_index )) //PM35450 , parameter is blah and not blah=
-           {   // equal sign found at offset equalSign
-               String key = null; //PM92940 Start
-               String value = null;
-               char[] nameChars,valueChars;
-               int nameStart=0,nameLen=0;
-               int valueStart=0,valueLen=0;
-
-               if (pair_start_index != equalSign_index) { 
-                   nameChars = getSingleBuffer(cha,pair_start,pair_start_index,equalSign, equalSign_index);
-                   nameStart = 0;
-                   nameLen = nameChars.length;
-               } else {
-                   nameChars=cha[pair_start_index];
-                   nameStart = pair_start;
-                   nameLen = equalSign-pair_start;
-               }
-
-               if (equalSign_index != pair_end_index) { 
-                   valueChars = getSingleBuffer(cha,equalSign+1,equalSign_index,pair_end+1,pair_end_index);
-                   valueStart = 0;
-                   valueLen = valueChars.length;
-               } else {
-                   valueChars=cha[pair_end_index];
-                   valueStart = equalSign+1;
-                   valueLen = pair_end-equalSign;
-               }
-
-               if(decodeParamViaReqEncoding && (!encoding_is_ShortEnglish)){
-
-                   key = parse_decode_Parameter(nameChars,nameStart,nameLen, encoding,"paramKey");
-                   if (equalSign > pair_end && equalSign_index == pair_end_index){
-                       if(key != null) 
-                           value = EMPTY_STRING;
-                       else value = null;
-                   }
-                   else
-                       value = parse_decode_Parameter(valueChars,valueStart,valueLen,encoding ,"paramValue");
-
-                   valueChars=null;
-                   nameChars=null;
-
-                   if (ignoreInvalidQueryString && ((value == null) || (key ==null))){                                             
-                       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)){      
-                           logger.exiting(CLASS_NAME, "parseQueryString(String, String)");
-                       }
-                       return ht;
-                   }          
-               }
-               else{
-                   key = parseName(nameChars,nameStart,nameStart+nameLen);
-                   //PM35450 Start
-                   //String value = null;
-                   if (equalSign > pair_end && equalSign_index == pair_end_index){
-                       if(key != null) value = EMPTY_STRING;
-                       else value = null;
-                   }
-                   else value = parseName(valueChars,valueStart,valueStart+valueLen);
-                   //PM35450 End
-
-                   valueChars=null;
-                   nameChars=null;
-
-                   if (ignoreInvalidQueryString && ((value == null) || (key ==null))){                                      //PK75617 - start
-                       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)){   
-                           logger.exiting(CLASS_NAME, "parseQueryString(String, String)");
-                       }                                                                                                                                                                            
-                       return ht;
-                   }                                                                                                                                                                                //PK75617 -end
-                   if ( !encoding_is_ShortEnglish ) {
-                       try {
-                           key = new String(key.getBytes(SHORT_ENGLISH),encoding);
-                           value = new String(value.getBytes(SHORT_ENGLISH),encoding);
-                       } catch ( UnsupportedEncodingException uee ) {
-                           logger.logp(Level.SEVERE, CLASS_NAME,"parseQueryString", "unsupported exception", uee);
-                           throw new IllegalArgumentException();
-                       }
-                   }
-               } //PM92940 End
-
-               //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "key="+key+", value="+value);
-
-               if (ht.containsKey(key)) {
-                   String oldVals[] = (String []) ht.get(key);
-                   valArray = new String[oldVals.length + 1];
-                   for (j = 0; j < oldVals.length; j++)
-                       valArray[j] = oldVals[j];
-                   valArray[oldVals.length] = value;
-               } else {
-                   // 728397 Start               
-                   if(!(key_hset.add(key.hashCode()))){
-                       dupSize++;	// if false then count as duplicate hashcodes for unique keys
-                       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  
-                           logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "duplicate hashCode generated by key --> " + key);
-                       }
-                       if( dupSize > maxDuplicateHashKeyParams){							 
-                           logger.logp(Level.SEVERE, CLASS_NAME,"parseQueryString", MessageFormat.format(nls.getString("Exceeding.maximum.hash.collisions"), new Object[]{maxDuplicateHashKeyParams}));
-
-                           throw new IllegalArgumentException();
-                       }
-                   } // 728397 End 
-                   valArray = new String[1];
-                   valArray[0] = value;
-               }
-               // 724365(PM53930) Start
-               totalSize++;
-               if((maxParamPerRequest == -1) || ( totalSize < maxParamPerRequest)){
-                   ht.put(key, valArray);
-               }
-               else{
-                   // possibly 10000 big enough, will never be here 
-                   logger.logp(Level.SEVERE, CLASS_NAME,"parseQueryString", MessageFormat.format(nls.getString("Exceeding.maximum.parameters"), new Object[]{maxParamPerRequest, totalSize}));
-
-                   throw new IllegalArgumentException();
-               }// 724365 End
-           }
-       }
-       // @MD17415 End 1 of 3: New Loop for finding key and value           @RWS1
-
-//@MD17415 begin part 2 of 3 New Loop for finding key and value
-//@MD17415 
-//@MD17415         StringBuffer sb = new StringBuffer();
-//@MD17415         StringTokenizer st = new StringTokenizer(s, "&");
-//@MD17415         while (st.hasMoreTokens())
-//@MD17415         {
-//@MD17415             String pair = (String) st.nextToken();
-//@MD17415             int pos = pair.indexOf('=');
-//@MD17415             if (pos == -1)
-//@MD17415             {
-//@MD17415                 // XXX
-//@MD17415                 // should give more detail about the illegal argument
-//@MD17415                 // ignore invalid parameter value (eg) http://localhost/servlet/snoop?name&age=9 (ignore name)
-//@MD17415                 //don't throw new IllegalArgumentException();
-//@MD17415             }
-//@MD17415             else
-//@MD17415             {
-//@MD17415                 String key = parseName(pair.substring(0, pos), sb);
-//@MD17415                 String val = parseName(pair.substring(pos + 1, pair.length()), sb);
-//@MD17415                 /**
-//@MD17415                  * ajg
-//@MD17415                  * convert post data to right format
-//@MD17415                  * skip if client is ASCII (english)
-//@MD17415                 *
-//@MD17415                 * Performance enhancement:
-//@MD17415                 *   added 1st condition, if !encoding.equals("ISO-8859-1"), to avoid
-//@MD17415                 *   the costly conversion.
-//@MD17415                 *   (Keith Smith)
-//@MD17415                  */
-//@MD17415                 if ((!encoding.equals("ISO-8859-1")) && (encoding.indexOf(SHORT_ENGLISH) == -1))
-//@MD17415                 {
-//@MD17415                     try
-//@MD17415                     {
-//@MD17415                         key = new String(key.getBytes(SHORT_ENGLISH), encoding);
-//@MD17415                         val = new String(val.getBytes(SHORT_ENGLISH), encoding);
-//@MD17415                     }
-//@MD17415                     catch (UnsupportedEncodingException uee)
-//@MD17415                     {
-//      @MD17415                         com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(uee, "com.ibm.ws.webcontainer.servlet.RequestUtils.parseQueryString", "289");
-
-//@MD17415                         throw new IllegalArgumentException();
-//@MD17415                     }
-//@MD17415                 }
-//@MD17415                 if (ht.containsKey(key))
-//@MD17415                 {
-//@MD17415                     String oldVals[] = (String[]) ht.get(key);
-//@MD17415                     valArray = new String[oldVals.length + 1];
-//@MD17415                     for (int i = 0; i < oldVals.length; i++)
-//@MD17415                         valArray[i] = oldVals[i];
-//@MD17415                     valArray[oldVals.length] = val;
-//@MD17415                 }
-//@MD17415                 else
-//@MD17415                 {
-//@MD17415                     valArray = new String[1];
-//@MD17415                     valArray[0] = val;
-//@MD17415                 }
-//@MD17415                 ht.put(key, valArray);
-//@MD17415             }
-//@MD17415         }
-//@MD17415 end part 2 of 3 New Loop for finding key and value
-       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)){		//PK75617
-           logger.exiting(CLASS_NAME, "parseQueryString(String, String)");
-       }																								//PK75617
-       return ht;
-   }
-   
-       
-   static public Hashtable parseQueryString(byte b[], String encoding) {
-       
-       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
-           logger.entering(CLASS_NAME, "parseQueryString( byte[] , encoding --> [" + encoding + "])"); //PM35450.1
-       } 
-    
-       Charset charset = Charset.forName(encoding);
-       
-       int totalSize = 0; //PM53930
-       int dupSize = 0; // 728397
-       Hashtable<String, String[]> ht = new Hashtable<>();
-       HashSet<Integer> key_hset = new HashSet<>(); // 728397
-       // PK23256 begin
-       boolean encoding_is_ShortEnglish = isShortEnglishEncoding(encoding);
-       // PK23256 end
-       int pair_start = 0, equalSign = -1;
-       int lgth = b.length;
-
-       for (int i = 0; i <= lgth; i++) {
-           if (i == lgth || b[i] == '&') {
-               if (equalSign < pair_start) {
-                   equalSign = i;
-               }
-           } else {
-               if (b[i] == '=') {
-                   // Only record the first = after pair_start so we handle if a value has an = in it.
-                   if (equalSign < pair_start) {
-                       equalSign = i;
-                   }
-               }
-               continue;
-           }
-
-           //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "equalSign =" + equalSign);
-
-           if ((equalSign < i) || (allowQueryParamWithNoEqual && equalSign == i)) //PM35450 , parameter is blah and not blah=
-           { // equal sign found at offset equalSign
-               String key = null; //PM92940 Start
-               String value = null;             
-                  
-               if (decodeParamViaReqEncoding && (!encoding_is_ShortEnglish)) {
-
-                   // data, start, (end-start),encoding, string
-                   key = parse_decode_Parameter(b, pair_start, equalSign - pair_start, encoding, "paramKey");
-
-                   if (equalSign == i) {
-                       value = key != null ? EMPTY_STRING : null;
-                   } else {
-                       int valueStart = equalSign + 1, valueLen = i - valueStart;
-                       value = parse_decode_Parameter(b, valueStart, valueLen, encoding, "paramValue");
-                   }
-
-                   if (ignoreInvalidQueryString && ((value == null) || (key == null))) {
-                       pair_start = i + 1;
-                       equalSign = i;
-                       continue;
-                   }
-
-               } else {
-                   key = parseName(b, pair_start, equalSign, charset);
-                   //PM35450 Start
-                   if (equalSign == i) {
-                       value = key != null ? EMPTY_STRING : null;
-                   } else {
-                       value = parseName(b, equalSign + 1, i, charset);
-                   }
-                   //PM35450 End
-
-                   if (ignoreInvalidQueryString && ((value == null) || (key == null))) { //PK75617
-                       pair_start = i + 1;
-                       equalSign = i;
-                       continue;
-                   } //PK75617
-                                         
-               } //PM92940 End
-
-               //logger.logp(Level.FINE, CLASS_NAME,"parseQueryString", "key="+key+", value="+value);
-               String valArray[] = new String[] { value };
-               String[] oldVals = (String[]) ht.put(key, valArray);
-               if (oldVals != null) {
-                   valArray = new String[oldVals.length + 1];
-                   System.arraycopy(oldVals, 0, valArray, 0, oldVals.length);
-                   valArray[oldVals.length] = value;
-                   ht.put(key, valArray);
-               } else {
-                   // 728397 Start 
-                   if (!(key_hset.add(key.hashCode()))) {
-                       dupSize++;// if false then count as duplicate hashcodes for unique keys
-                       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
-                           logger.logp(Level.FINE, CLASS_NAME, "parseQueryString", "duplicate hashCode generated by key --> " + key);
-                       }
-                       if (dupSize > maxDuplicateHashKeyParams) {
-                           logger.logp(Level.SEVERE, CLASS_NAME, "parseQueryString",
-                                       MessageFormat.format(nls.getString("Exceeding.maximum.hash.collisions"), new Object[] { maxDuplicateHashKeyParams }));
-
-                           throw new IllegalArgumentException();
-                       }
-                   } // 728397 End 
-               }
-           }
-           // 724365(PM53930) Start
-           totalSize++;
-           if (maxParamPerRequest != -1 && totalSize >= maxParamPerRequest) {
-               // possibly 10000 big enough, will never be here 
-               logger.logp(Level.SEVERE, CLASS_NAME, "parseQueryString",
-                           MessageFormat.format(nls.getString("Exceeding.maximum.parameters"), new Object[] { maxParamPerRequest, totalSize }));
-               throw new IllegalArgumentException();
-           } // 724365 End
-           pair_start = i + 1;
-           equalSign = i;
-       }
-
-       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
-           logger.exiting(CLASS_NAME, "parseQueryString(byte[], String)");
-       } //PK75617
-       return ht;  
-   }
-   
-   /*
-        * Parse a name in the query string.
-        */
-   // @MD17415 begin part 3 of 3 New Loop for finding key and value
-   static private String parseName(final char [] ch, final int startOffset, final int endOffset) {
-       
-       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
-           logger.entering(CLASS_NAME, "parseName( char[] , startOffset --> [" + startOffset + "], endOffset  --> [" + endOffset + "])");
-       } 
-       
-       int j = 0;
-       char [] c = null;
-       for (int i = startOffset; i < endOffset; i++) {
-           switch (ch[i]) {
-           case '+' :
-               if (c == null) {
-                   c = new char [endOffset-startOffset];
-                   j = i - startOffset;
-                   if (j != 0) {
-                       System.arraycopy(ch, startOffset, c, 0, j);
-                   }
-               }
-               c[j++] = ' ';
-               break;
-           case '%' :
-               if (i+2 < endOffset) {   // @RWS2
-                   if (c == null) {
-                       c = new char [endOffset-startOffset];
-                       j = i - startOffset;
-                       if (j != 0) {
-                           System.arraycopy(ch, startOffset, c, 0, j);
-                       }
-                   }
-                   int num1 = Character.digit(ch[++i],16);   //@RWS7
-                   int num2 = Character.digit(ch[++i],16);   //@RWS7
-                   if (num1 == -1 || num2 == -1)             //@RWS5
-                   {																	//PK75617 starts
-                	   if (ignoreInvalidQueryString)									
-                	   {
-                		   logger.logp(Level.WARNING, CLASS_NAME,"parseName", "invalid.query.string");
-                		   return null;
-                	   }																//PK75617 ends
-                       throw new IllegalArgumentException(); //@RWS5
-                   }																	//PK75617
-                   // c[j++] = (char)(num1*16 + num2);       //@RWS5
-                   c[j++] = (char)((num1<<4) | num2);       //@RWS8
-               } else {   // allow '%' at end of value or second to last character (as original code does)
-                   if (c != null) {
-                       for (; i<endOffset; i++)   // @RWS2
-                           c[j++] = ch[i];        // @RWS7
-                   } else {
-                       i = endOffset;
-                   }
-               }
-               break;
-           default :
-               if (c != null) {
-                   c[j++] = ch[i];
-               }
-               break;
-           } 
-       }
-       String returnValue = c != null ? new String(c, 0, j) : new String(ch, startOffset, endOffset - startOffset);
-       if (printbyteValueandcharParamdata && com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))  
-           printValues(returnValue, "parseNameOUT");
-       return returnValue;
-   }
-   
-   static private String parseName(final byte [] bytes, final int startOffset, final int endOffset, Charset charset) {
-       
-       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
-           logger.entering(CLASS_NAME, "parseName( byte[] , startOffset --> [" + startOffset + "], endOffset  --> [" + endOffset + "])");
-       } 
-       
-       int j = 0;
-       byte [] b = null;
-       for (int i = startOffset; i < endOffset; i++) {
-           switch (bytes[i]) {
-           case '+' :
-               if (b == null) {
-                   b = new byte [endOffset-startOffset];
-                   j = i - startOffset;
-                   if (j != 0) {
-                       System.arraycopy(bytes, startOffset, b, 0, j);
-                   }
-               }
-               b[j++] = ' ';
-               break;
-           case '%' :
-               if (i+2 < endOffset) {   // @RWS2
-                   if (b == null) {
-                       b = new byte [endOffset-startOffset];
-                       j = i - startOffset;
-                       if (j != 0) {
-                           System.arraycopy(bytes, startOffset, b, 0, j);
-                       }
-                   }
-                   
-                   int num1 = Character.digit(bytes[++i],16);   //@RWS7
-                   int num2 = Character.digit(bytes[++i],16);   //@RWS7
-                   
-                   if (num1 == -1 || num2 == -1)             //@RWS5
-                   {                                                                                                                                    //PK75617 starts
-                           if (ignoreInvalidQueryString)                                                                        
-                           {
-                                   logger.logp(Level.WARNING, CLASS_NAME,"parseName", "invalid.query.string");
-                                   return null;
-                           }                                                                                                                            //PK75617 ends
-                       throw new IllegalArgumentException(); //@RWS5
-                   }                                                                                                                                    //PK75617
-                   // c[j++] = (char)(num1*16 + num2);       //@RWS5
-                   b[j++] = (byte)((num1<<4) | num2);       //@RWS8
-                  
-               } else {   // allow '%' at end of value or second to last character (as original code does)
-                   if (b != null) {
-                       for (; i<endOffset; i++)   // @RWS2
-                           b[j++] = bytes[i];        // @RWS7
-                   } else {
-                       i = endOffset;
-                   }
-               }
-               break;
-           default :
-               if (b != null) {
-                   b[j++] = bytes[i];
-               }
-               break;
-           } 
-       }
-       
-       String returnValue = b != null ?  new String(b, 0 , j , charset) : new String(bytes, startOffset, endOffset - startOffset , charset); 
-           
-       if (printbyteValueandcharParamdata && com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))  
-           printValues(returnValue, "parseNameOUT");
-       
-       return returnValue;
-   }
-   
-   
-   // @MD17415 end part 3 of 3 New Loop for finding key and value
-   
    /**
     * Used to retrive the "true" uri that represents the current request.
     * If include request_uri attribute is set, it returns that value.
@@ -930,15 +649,8 @@ public class RequestUtils {
     * @param val
     * @return
     */
-   static private String parse_decode_Parameter(char[] data, int start, int length, String encoding, String val) {
+   static private String parse_decode_Parameter(String paramData, String encoding, String val) {
 
-       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
-           logger.entering(CLASS_NAME, "parse_decode_Parameter( char[] , start --> [" + start + "], length  --> [" + length + "], encoding --> [" + encoding + "], val  --> [" + val + ")");
-       } 
-       
-       String paramData = null;     
-       paramData = new String(data, start, length);
-       
        if (printbyteValueandcharParamdata && com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)){  
            printValues(paramData, "parsed " +val);                  
        } 
@@ -960,46 +672,7 @@ public class RequestUtils {
 
        return paramData;
    }
-   
-   /**
-    * @param data
-    * @param start
-    * @param length
-    * @param encoding
-    * @param val
-    * @return
-    */
-   static private String parse_decode_Parameter(byte[] data, int start, int length, String encoding, String val) {
 
-       if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
-           logger.entering(CLASS_NAME, "parse_decode_Parameter( byte[] , start --> [" + start + "], length  --> [" + length + "], encoding --> [" + encoding + "], val  --> [" + val + ")");
-       } 
-       
-       String paramData = null;     
-       paramData = new String(data, start, length);
-       
-       if (printbyteValueandcharParamdata && com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)){  
-           printValues(paramData, "parsed " +val);                  
-       } 
-       try {                   
-           paramData = URLDecoder.decode(paramData, encoding);
-           if (printbyteValueandcharParamdata && com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))  
-               printValues(paramData, "decoded " + val);                        
-       }catch ( UnsupportedEncodingException uee ) {
-           logger.logp(Level.SEVERE, CLASS_NAME,"parse_decode_Parameter", "unsupported exception--> ", uee);
-           throw new IllegalArgumentException();
-       }catch ( IllegalArgumentException ie ) {
-           if (ignoreInvalidQueryString)                                                                        
-           {
-               logger.logp(Level.WARNING, CLASS_NAME,"parse_decode_Parameter", "invalid.query.string");
-               return null;
-           }               
-           throw ie;
-       }
-
-       return paramData;
-   }
-      
   //PM92940 adds this method        
    /**
     * @param value

--- a/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/util/RequestUtilsTest.java
+++ b/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/util/RequestUtilsTest.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Hashtable;
+
+import org.junit.Test;
+
+import com.ibm.wsspi.webcontainer.util.RequestUtils;
+
+import junit.framework.Assert;
+
+public class RequestUtilsTest {
+
+    private static String qs = "a=b&c==d&e&f=&=g&=&h+i=j+k&a=c";
+    private static String[] expectedKeys = {"a", "c", "f", "", "h i"};
+    private static String[][] expectedValues = {{"b", "c"}, {"=d"}, {""}, {"g", ""}, {"j k"}};
+    
+    private static String qs2 = "key=value&key2=value=2&key3=&key4&key+5=value5&key=value2";
+    private static String[] expectedKeys2 = {"key", "key2", "key3", "key 5"};
+    private static String[][] expectedValues2 = {{"value", "value2"}, {"value=2"}, {""}, {"value5"}};
+
+    private static String qs3 = "key=И вдаль глядел. Пред ним широко";
+    private static String[] expectedKeys3 = {"key"};
+    private static String[][] expectedValues3 = {{"И вдаль глядел. Пред ним широко"}};
+
+    private static String qs4;
+    static {
+        try {
+            qs4 = "key=" + URLEncoder.encode("И вдаль глядел. Пред ним широко", "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void validateParams(Hashtable params, String[] expectedKeys, String[][] expectedValues) {
+        Assert.assertEquals(expectedKeys.length, params.size());
+        for (int i = 0; i < expectedKeys.length; ++i) {
+            String[] val = (String[]) params.get(expectedKeys[i]);
+            Assert.assertNotNull(val);
+            Assert.assertEquals(expectedValues[i].length, val.length);
+            for (int j = 0; j < expectedValues[i].length; ++j) {
+                Assert.assertEquals(expectedValues[i][j], val[j]);
+            }
+        }
+    }
+
+    private void testString(String queryString, String encoding, String[] keys, String[][] values) throws Exception {
+        Hashtable params = RequestUtils.parseQueryString(queryString, encoding);
+        validateParams(params, keys, values);
+    }
+    
+    @Test
+    public void parseStringQueryStringUTF8() throws Exception {
+        testString(qs, "UTF-8", expectedKeys, expectedValues);
+        testString(qs2, "UTF-8", expectedKeys2, expectedValues2);
+        testString(qs4, "UTF-8", expectedKeys3, expectedValues3);
+    }
+
+    @Test
+    public void parseStringQueryStringISO8859_1() throws Exception {
+        testString(qs, "8859_1", expectedKeys, expectedValues);
+        testString(qs2, "8859_1", expectedKeys2, expectedValues2);
+        testString(qs3, "8859_1", expectedKeys3, expectedValues3);
+    }
+
+    private void testCharArray(String queryString, String encoding, String[] keys, String[][] values) {
+        char[][] worstCase = new char[queryString.length()][1];
+        char[][] optimizedCase = new char[1][queryString.length()];
+        for (int i = 0, length = queryString.length(); i < length; ++i) {
+            worstCase[i][0] = queryString.charAt(i);
+            optimizedCase[0][i] = queryString.charAt(i);
+        }
+
+        Hashtable params = RequestUtils.parseQueryString(optimizedCase, encoding);
+        validateParams(params, keys, values);
+        
+        params = RequestUtils.parseQueryString(worstCase, encoding);
+        validateParams(params, keys, values);
+
+        char[][] simple2ArrayCase = new char[2][];
+        int size1 = queryString.length() / 2;
+        int size2 = queryString.length() - size1;
+        simple2ArrayCase[0] = new char[size1];
+        simple2ArrayCase[1] = new char[size2];
+        for (int i = 0; i < size1; ++i) {
+            simple2ArrayCase[0][i] = queryString.charAt(i);
+        }
+        for (int i = 0; i < size2; ++i) {
+            simple2ArrayCase[1][i] = queryString.charAt(size1 + i);
+        }
+
+        params = RequestUtils.parseQueryString(simple2ArrayCase, encoding);
+        validateParams(params, keys, values);
+    }
+
+    @Test
+    public void parseCharArrayQueryStringUTF8() {
+        testCharArray(qs, "UTF-8", expectedKeys, expectedValues);
+        testCharArray(qs2, "UTF-8", expectedKeys2, expectedValues2);
+        testCharArray(qs4, "UTF-8", expectedKeys3, expectedValues3);
+    }
+
+    @Test
+    public void parseCharArrayQueryStringISO8859_1() {
+        testCharArray(qs, "8859_1", expectedKeys, expectedValues);
+        testCharArray(qs2, "8859_1", expectedKeys2, expectedValues2);
+        testCharArray(qs3, "8859_1", expectedKeys3, expectedValues3);
+    }
+}


### PR DESCRIPTION
The code was updated to have one implementation for parseQueryString
that String, char[] and char[][] all use.  The parsing of the String,
char[] and char[][] was moved to a QueryString class so that the
processing of the keys and values in the parseQueryString method can be
the same.