### PR TITLE
Upgrade to ASM 7.0-beta

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -260,12 +260,11 @@ org.osgi:org.osgi.service.subsystem:1.1.0
 org.osgi:osgi.core:5.0.0
 org.ow2.asm:asm-all:5.0.3
 org.ow2.asm:asm-all:5.2
-org.ow2.asm:asm:6.2.1
-org.ow2.asm:asm-analysis:6.2.1
-org.ow2.asm:asm-commons:6.2.1
-org.ow2.asm:asm-tree:6.2.1
-org.ow2.asm:asm-util:6.2.1
-org.ow2.asm:asm-xml:6.2.1
+org.ow2.asm:asm:7.0-beta
+org.ow2.asm:asm-analysis:7.0-beta
+org.ow2.asm:asm-commons:7.0-beta
+org.ow2.asm:asm-tree:7.0-beta
+org.ow2.asm:asm-util:7.0-beta
 org.powermock:powermock-core:1.5
 org.slf4j:slf4j-api:1.7.7
 org.slf4j:slf4j-jdk14:1.7.7

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/anno/info/internal/InfoVisitor.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/anno/info/internal/InfoVisitor.java
@@ -132,7 +132,7 @@ public class InfoVisitor extends ClassVisitor {
         private List<AnnotationInfoImpl>[] paramAnnotations;
 
         public InfoMethodVisitor() {
-            super(Opcodes.ASM7_EXPERIMENTAL);
+            super(Opcodes.ASM7);
         }
 
         void setMethodInfo(MethodInfoImpl mii) {
@@ -238,7 +238,7 @@ public class InfoVisitor extends ClassVisitor {
         private List<AnnotationInfoImpl> annotations;
 
         public InfoFieldVisitor() {
-            super(Opcodes.ASM7_EXPERIMENTAL);
+            super(Opcodes.ASM7);
         }
 
         void setFieldInfo(FieldInfoImpl fii) {
@@ -308,7 +308,7 @@ public class InfoVisitor extends ClassVisitor {
     //
 
     public InfoVisitor(InfoStoreImpl infoStore, String externalName) {
-        super(Opcodes.ASM7_EXPERIMENTAL);
+        super(Opcodes.ASM7);
 
         this.infoStore = infoStore;
         this.externalName = externalName;

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/anno/info/internal/InfoVisitor_Annotation.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/anno/info/internal/InfoVisitor_Annotation.java
@@ -105,7 +105,7 @@ public abstract class InfoVisitor_Annotation extends AnnotationVisitor {
     // annotation class name.  (This is not validated.)
 
     protected InfoVisitor_Annotation(InfoStoreImpl iStore) {
-        super(Opcodes.ASM7_EXPERIMENTAL);
+        super(Opcodes.ASM7);
 
         this.infoStore = iStore;
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/anno/targets/internal/AnnotationTargetsVisitor.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/anno/targets/internal/AnnotationTargetsVisitor.java
@@ -132,7 +132,7 @@ public class AnnotationTargetsVisitor extends ClassVisitor {
     // an entire scan sweep.
 
     public AnnotationTargetsVisitor(AnnotationTargetsImpl_Targets annotationTargets) {
-        super(Opcodes.ASM7_EXPERIMENTAL);
+        super(Opcodes.ASM7);
 
         this.hashText = AnnotationServiceImpl_Logging.getBaseHash(this);
 
@@ -512,7 +512,7 @@ public class AnnotationTargetsVisitor extends ClassVisitor {
 
     protected class AnnoFieldVisitor extends FieldVisitor {
         public AnnoFieldVisitor() {
-            super(Opcodes.ASM7_EXPERIMENTAL);
+            super(Opcodes.ASM7);
         }
 
         // A field annotation.  Needs to be recorded.
@@ -555,7 +555,7 @@ public class AnnotationTargetsVisitor extends ClassVisitor {
 
     protected class AnnoMethodVisitor extends MethodVisitor {
         public AnnoMethodVisitor() {
-            super(Opcodes.ASM7_EXPERIMENTAL);
+            super(Opcodes.ASM7);
         }
 
         // A method annotation.  Needs to be recorded.

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/ByteCodeMetaData.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/ByteCodeMetaData.java
@@ -123,7 +123,7 @@ public class ByteCodeMetaData extends ClassVisitor {
      * @param publicMethods all public methods on the implementation class
      */
     ByteCodeMetaData(Class<?> implClass, Method[] publicMethods) {
-        super(Opcodes.ASM7_EXPERIMENTAL);
+        super(Opcodes.ASM7);
         ivClass = implClass;
         ivPublicMethods = publicMethods;
     }
@@ -328,7 +328,7 @@ public class ByteCodeMetaData extends ClassVisitor {
 
     private abstract class AbstractMethodVisitor extends MethodVisitor {
         public AbstractMethodVisitor() {
-            super(Opcodes.ASM7_EXPERIMENTAL);
+            super(Opcodes.ASM7);
         }
 
         @Override

--- a/dev/com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/MonitoringProxyActivator.java
+++ b/dev/com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/MonitoringProxyActivator.java
@@ -316,7 +316,7 @@ public class MonitoringProxyActivator {
         InputStream inputStream = classUrl.openStream();
 
         ClassReader reader = new ClassReader(inputStream);
-        reader.accept(new ClassVisitor(Opcodes.ASM7_EXPERIMENTAL) {}, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+        reader.accept(new ClassVisitor(Opcodes.ASM7) {}, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
         inputStream.close();
 
         return reader.getClassName();

--- a/dev/com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/bci/ClassAvailableHookClassAdapter.java
+++ b/dev/com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/bci/ClassAvailableHookClassAdapter.java
@@ -42,7 +42,7 @@ public class ClassAvailableHookClassAdapter extends ClassVisitor {
      * @param delegate the class adapter to delegate to
      */
     public ClassAvailableHookClassAdapter(ClassVisitor delegate) {
-        super(Opcodes.ASM7_EXPERIMENTAL, delegate);
+        super(Opcodes.ASM7, delegate);
     }
 
     @Override
@@ -88,7 +88,7 @@ class ProcessCandidateHookMethodAdapter extends MethodVisitor {
     boolean supportsClassLiterals;
 
     protected ProcessCandidateHookMethodAdapter(MethodVisitor visitor, Type classType, boolean supportsClassLiterals) {
-        super(Opcodes.ASM7_EXPERIMENTAL, visitor);
+        super(Opcodes.ASM7, visitor);
         this.classType = classType;
         this.supportsClassLiterals = supportsClassLiterals;
     }

--- a/dev/com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/bci/ProbeInjectionClassAdapter.java
+++ b/dev/com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/bci/ProbeInjectionClassAdapter.java
@@ -51,7 +51,7 @@ public class ProbeInjectionClassAdapter extends ClassVisitor {
     Set<ProbeListener> interestedListeners;
 
     public ProbeInjectionClassAdapter(ClassVisitor delegate, ProbeManagerImpl probeManager, final Class<?> clazz) {
-        super(Opcodes.ASM7_EXPERIMENTAL, delegate);
+        super(Opcodes.ASM7, delegate);
         this.probeManager = probeManager;
         this.probedClasses = clazz;
         this.interestedListeners = probeManager.getInterestedByClass(clazz);

--- a/dev/com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/bci/ProbeMethodAdapter.java
+++ b/dev/com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/bci/ProbeMethodAdapter.java
@@ -186,7 +186,7 @@ public class ProbeMethodAdapter extends MethodVisitor {
      * @param methodInfo
      */
     ProbeMethodAdapter(MethodVisitor visitor, MethodInfo methodInfo) {
-        super(Opcodes.ASM7_EXPERIMENTAL, visitor);
+        super(Opcodes.ASM7, visitor);
         this.visitor = visitor;
         this.methodInfo = methodInfo;
     }
@@ -195,7 +195,7 @@ public class ProbeMethodAdapter extends MethodVisitor {
      * Create an instance of a {@code ProbeMethodAdapter}.
      */
     protected ProbeMethodAdapter(ProbeMethodAdapter probeMethodAdapter, MethodInfo methodInfo) {
-        super(Opcodes.ASM7_EXPERIMENTAL, probeMethodAdapter);
+        super(Opcodes.ASM7, probeMethodAdapter);
         this.probeMethodAdapter = probeMethodAdapter;
         this.visitor = probeMethodAdapter.getVisitor();
         this.methodInfo = methodInfo;

--- a/dev/com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/bci/remap/AddVersionFieldClassAdapter.java
+++ b/dev/com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/bci/remap/AddVersionFieldClassAdapter.java
@@ -48,7 +48,7 @@ public class AddVersionFieldClassAdapter extends ClassVisitor {
      * @param versionFieldValue the value to associate with the version field
      */
     public AddVersionFieldClassAdapter(ClassVisitor delegate, String versionFieldName, String versionFieldValue) {
-        super(Opcodes.ASM7_EXPERIMENTAL, delegate);
+        super(Opcodes.ASM7, delegate);
         this.versionFieldName = versionFieldName;
         this.versionFieldValue = versionFieldValue;
     }

--- a/dev/com.ibm.ws.org.apache.cxf.jaxws/cxf-api.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.jaxws/cxf-api.bnd
@@ -28,7 +28,7 @@ Import-Package: \
  org.slf4j.*;resolution:=optional;version="[1.5,2)", \
  org.apache.log4j.*;resolution:=optional, \
  net.sf.cglib.*;resolution:=optional;version="[2.1.3,3.0.0)", \
- org.objectweb.asm.*;resolution:=optional;version="[2.0,7)", \
+ org.objectweb.asm.*;resolution:=optional;version="[2.0,8)", \
  javax.activation, \
  javax.annotation;version="[0.0,2)", \
  javax.xml.bind.*;version="[2.2,3)", \

--- a/dev/com.ibm.ws.org.objectweb.asm/bnd.bnd
+++ b/dev/com.ibm.ws.org.objectweb.asm/bnd.bnd
@@ -8,22 +8,20 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.objectweb.asm;6.2.1}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.objectweb.asm.tree.analysis;6.2.1}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.objectweb.asm.commons;6.2.1}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.objectweb.asm.tree;6.2.1}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.objectweb.asm.util;6.2.1}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.objectweb.asm.xml;6.2.1}}!/META-INF/MANIFEST.MF,\
+-include= jar:${fileuri;${repo;org.objectweb.asm;7.0.0.beta}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.objectweb.asm.tree.analysis;7.0.0.beta}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.objectweb.asm.commons;7.0.0.beta}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.objectweb.asm.tree;7.0.0.beta}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.objectweb.asm.util;7.0.0.beta}}!/META-INF/MANIFEST.MF,\
           bnd.overrides
 
 instrument.disabled: true
 
-asmVersion=6.2.1
+asmVersion=7.0.0.beta
 
 -buildpath: \
 	org.objectweb.asm;version=${asmVersion},\
 	org.objectweb.asm.tree.analysis;version=${asmVersion},\
 	org.objectweb.asm.commons;version=${asmVersion},\
 	org.objectweb.asm.tree;version=${asmVersion},\
-	org.objectweb.asm.util;version=${asmVersion},\
-	org.objectweb.asm.xml;version=${asmVersion}
+	org.objectweb.asm.util;version=${asmVersion}

--- a/dev/com.ibm.ws.org.objectweb.asm/bnd.overrides
+++ b/dev/com.ibm.ws.org.objectweb.asm/bnd.overrides
@@ -8,4 +8,4 @@ Implementation-Title: ASM all classes
 DynamicImport-Package: *
 
 Export-Package: \
-  org.objectweb.asm.*;version="6.2.1"
+  org.objectweb.asm.*;version="7.0.0.beta"

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/CheckInstrumentableClassAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/CheckInstrumentableClassAdapter.java
@@ -42,7 +42,7 @@ public class CheckInstrumentableClassAdapter extends ClassVisitor {
      *            the visitor to delegate to
      */
     public CheckInstrumentableClassAdapter(ClassVisitor visitor) {
-        super(Opcodes.ASM7_EXPERIMENTAL, visitor);
+        super(Opcodes.ASM7, visitor);
     }
 
     /**

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/DeferConstructorProcessingMethodAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/DeferConstructorProcessingMethodAdapter.java
@@ -89,7 +89,7 @@ public class DeferConstructorProcessingMethodAdapter extends MethodVisitor {
      * Create an instance of a {@code ProbeMethodAdapter}.
      */
     DeferConstructorProcessingMethodAdapter(MethodVisitor visitor) {
-        super(Opcodes.ASM7_EXPERIMENTAL, visitor);
+        super(Opcodes.ASM7, visitor);
     }
 
     private void push(Object stackElement, int count) {

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/RasMethodAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/RasMethodAdapter.java
@@ -21,7 +21,7 @@ import org.objectweb.asm.Type;
 public abstract class RasMethodAdapter extends MethodVisitor {
 
     public RasMethodAdapter(MethodVisitor visitor) {
-        super(Opcodes.ASM7_EXPERIMENTAL, visitor);
+        super(Opcodes.ASM7, visitor);
     }
 
     /**

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/FFDCIgnoreAnnotationVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/FFDCIgnoreAnnotationVisitor.java
@@ -25,7 +25,7 @@ public class FFDCIgnoreAnnotationVisitor extends AnnotationVisitor {
     private final Set<Type> ignoredExceptionTypes = new HashSet<Type>();
 
     public FFDCIgnoreAnnotationVisitor(AnnotationVisitor delegate) {
-        super(Opcodes.ASM7_EXPERIMENTAL, delegate);
+        super(Opcodes.ASM7, delegate);
     }
 
     @Override
@@ -46,7 +46,7 @@ class IgnoredExceptionVisitor extends AnnotationVisitor {
     Set<Type> ignoredExceptionTypes;
 
     IgnoredExceptionVisitor(AnnotationVisitor delegate, Set<Type> ignoredExceptionTypes) {
-        super(Opcodes.ASM7_EXPERIMENTAL, delegate);
+        super(Opcodes.ASM7, delegate);
         this.ignoredExceptionTypes = ignoredExceptionTypes;
     }
 

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/InjectedTraceAnnotationVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/InjectedTraceAnnotationVisitor.java
@@ -26,15 +26,15 @@ public class InjectedTraceAnnotationVisitor extends AnnotationVisitor {
     private boolean visitedValueArray = false;
 
     public InjectedTraceAnnotationVisitor() {
-        super(Opcodes.ASM7_EXPERIMENTAL);
+        super(Opcodes.ASM7);
     }
 
     public InjectedTraceAnnotationVisitor(AnnotationVisitor av) {
-        super(Opcodes.ASM7_EXPERIMENTAL, av);
+        super(Opcodes.ASM7, av);
     }
 
     public <T extends RasMethodAdapter> InjectedTraceAnnotationVisitor(AnnotationVisitor av, Class<T> currentMethodVisitor) {
-        super(Opcodes.ASM7_EXPERIMENTAL, av);
+        super(Opcodes.ASM7, av);
         this.currentMethodVisitor = currentMethodVisitor;
     }
 
@@ -54,7 +54,7 @@ public class InjectedTraceAnnotationVisitor extends AnnotationVisitor {
 
     private class ValueArrayVisitor extends AnnotationVisitor {
         private ValueArrayVisitor(AnnotationVisitor av) {
-            super(Opcodes.ASM7_EXPERIMENTAL, av);
+            super(Opcodes.ASM7, av);
         }
 
         @Override

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceConfigClassVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceConfigClassVisitor.java
@@ -44,7 +44,7 @@ public class TraceConfigClassVisitor extends ClassVisitor {
     protected TraceObjectFieldAnnotationVisitor traceObjectFieldAnnotationVisitor;
 
     public TraceConfigClassVisitor(ClassVisitor cv) {
-        super(Opcodes.ASM7_EXPERIMENTAL, cv);
+        super(Opcodes.ASM7, cv);
     }
 
     @Override
@@ -92,7 +92,7 @@ public class TraceConfigClassVisitor extends ClassVisitor {
         private final MethodInfo methodInfo;
 
         private MethodInfoMethodVisitor(MethodVisitor mv, MethodInfo methodInfo) {
-            super(Opcodes.ASM7_EXPERIMENTAL, mv);
+            super(Opcodes.ASM7, mv);
             this.methodInfo = methodInfo;
         }
 
@@ -113,7 +113,7 @@ public class TraceConfigClassVisitor extends ClassVisitor {
             private final MethodInfo methodInfo;
 
             private FFDCIgnoreAnnotationVisitor(AnnotationVisitor av, MethodInfo methodInfo) {
-                super(Opcodes.ASM7_EXPERIMENTAL, av);
+                super(Opcodes.ASM7, av);
                 this.methodInfo = methodInfo;
             }
 
@@ -131,7 +131,7 @@ public class TraceConfigClassVisitor extends ClassVisitor {
             private final MethodInfo methodInfo;
 
             private FFDCIgnoreValueArrayVisitor(AnnotationVisitor av, MethodInfo methodInfo) {
-                super(Opcodes.ASM7_EXPERIMENTAL, av);
+                super(Opcodes.ASM7, av);
                 this.methodInfo = methodInfo;
             }
 

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceConfigPackageVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceConfigPackageVisitor.java
@@ -28,11 +28,11 @@ public class TraceConfigPackageVisitor extends ClassVisitor {
     protected TraceOptionsAnnotationVisitor traceOptionsAnnotationVisitor;
 
     public TraceConfigPackageVisitor() {
-        super(Opcodes.ASM7_EXPERIMENTAL);
+        super(Opcodes.ASM7);
     }
 
     public TraceConfigPackageVisitor(ClassVisitor visitor) {
-        super(Opcodes.ASM7_EXPERIMENTAL, visitor);
+        super(Opcodes.ASM7, visitor);
     }
 
     @Override

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceObjectFieldAnnotationVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceObjectFieldAnnotationVisitor.java
@@ -20,11 +20,11 @@ public class TraceObjectFieldAnnotationVisitor extends AnnotationVisitor {
     private String fieldDescriptor;
 
     public TraceObjectFieldAnnotationVisitor() {
-        super(Opcodes.ASM7_EXPERIMENTAL);
+        super(Opcodes.ASM7);
     }
 
     public TraceObjectFieldAnnotationVisitor(AnnotationVisitor av) {
-        super(Opcodes.ASM7_EXPERIMENTAL, av);
+        super(Opcodes.ASM7, av);
     }
 
     @Override

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceOptionsAnnotationVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceOptionsAnnotationVisitor.java
@@ -26,11 +26,11 @@ public class TraceOptionsAnnotationVisitor extends AnnotationVisitor {
     protected boolean traceExceptionHandling;
 
     public TraceOptionsAnnotationVisitor() {
-        super(Opcodes.ASM7_EXPERIMENTAL);
+        super(Opcodes.ASM7);
     }
 
     public TraceOptionsAnnotationVisitor(AnnotationVisitor av) {
-        super(Opcodes.ASM7_EXPERIMENTAL, av);
+        super(Opcodes.ASM7, av);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class TraceOptionsAnnotationVisitor extends AnnotationVisitor {
     private final class TraceGroupsValueArrayVisitor extends AnnotationVisitor {
 
         private TraceGroupsValueArrayVisitor(AnnotationVisitor av) {
-            super(Opcodes.ASM7_EXPERIMENTAL, av);
+            super(Opcodes.ASM7, av);
         }
 
         @Override

--- a/dev/com.ibm.ws.ras.instrument_test/test/com/ibm/ws/ras/RasTransformTest.java
+++ b/dev/com.ibm.ws.ras.instrument_test/test/com/ibm/ws/ras/RasTransformTest.java
@@ -85,7 +85,7 @@ public class RasTransformTest extends LibertyRuntimeTransformer {
         StringWriter sw = null;
         sw = new StringWriter();
         ClassReader reader = new ClassReader(classBytes);
-        ClassNode directory = new ClassNode(Opcodes.ASM7_EXPERIMENTAL);
+        ClassNode directory = new ClassNode(Opcodes.ASM7);
         ClassVisitor visitor = new TraceClassVisitor(directory, new PrintWriter(sw));
         
         try {

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/bci/internal/RequestProbeClassVisitor.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/bci/internal/RequestProbeClassVisitor.java
@@ -35,7 +35,7 @@ public class RequestProbeClassVisitor extends ClassVisitor {
 	 * @param arg0
 	 */
 	public RequestProbeClassVisitor(ClassVisitor cv, String clsName) {
-		super(Opcodes.ASM7_EXPERIMENTAL, cv);
+		super(Opcodes.ASM7, cv);
 		this.classname = clsName;
 	}
 


### PR DESCRIPTION
Upgrade from ASM 6.2.1 to 7.0-beta.  The ASM 7.X releases officially support JDK 11, and have the new `ASM7` added and the `ASM7_EXPERIMENTAL` removed.

Also, we are removing the asm-xml module since it was deprecated in ASM 6.X and finally removed in 7.X.