### PR TITLE
Add missing dependencies so all public features can start by themselves

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/distributedMap-1.0/com.ibm.websphere.appserver.distributedMap-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/distributedMap-1.0/com.ibm.websphere.appserver.distributedMap-1.0.feature
@@ -12,10 +12,13 @@ IBM-API-Package: com.ibm.websphere.cache; type="ibm-api", \
  com.ibm.wsspi.cache; type="ibm-api"
 IBM-ShortName: distributedMap-1.0
 Subsystem-Name: Distributed Map interface for Dynamic Caching 1.0
--features=com.ibm.websphere.appserver.jndi-1.0, \
- com.ibm.websphere.appserver.containerServices-1.0, \
- com.ibm.websphere.appserver.classloading-1.0
--bundles=com.ibm.ws.dynacache
+-features=\
+  com.ibm.websphere.appserver.jndi-1.0, \
+  com.ibm.websphere.appserver.containerServices-1.0, \
+  com.ibm.websphere.appserver.classloading-1.0, \
+  com.ibm.websphere.appserver.javax.servlet-3.0; ibm.tolerates:="3.1,4.0"
+-bundles=\
+  com.ibm.ws.dynacache
 -jars=com.ibm.websphere.appserver.api.distributedMap; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.distributedMap_2.0-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/federatedRegistry-1.0/com.ibm.websphere.appserver.federatedRegistry-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/federatedRegistry-1.0/com.ibm.websphere.appserver.federatedRegistry-1.0.feature
@@ -3,13 +3,17 @@ symbolicName=com.ibm.websphere.appserver.federatedRegistry-1.0
 visibility=public
 IBM-ShortName: federatedRegistry-1.0
 Subsystem-Name: Federated User Registry 1.0
-IBM-SPI-Package: com.ibm.wsspi.security.wim; type="ibm-spi", \
+IBM-SPI-Package: \
+  com.ibm.wsspi.security.wim; type="ibm-spi", \
   com.ibm.wsspi.security.wim.exception; type="ibm-spi", \
   com.ibm.wsspi.security.wim.model; type="ibm-spi"
--features=com.ibm.websphere.appserver.wimcore-1.0
--bundles=com.ibm.websphere.security, \
- com.ibm.ws.security.registry, \
- com.ibm.ws.security.wim.registry
+-features=\
+  com.ibm.websphere.appserver.securityInfrastructure-1.0,\
+  com.ibm.websphere.appserver.wimcore-1.0
+-bundles=\
+  com.ibm.websphere.security, \
+  com.ibm.ws.security.registry, \
+  com.ibm.ws.security.wim.registry
 
 -jars=com.ibm.websphere.appserver.spi.federatedRepository; location:=dev/spi/ibm/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.federatedRepository_1.2-javadoc.zip

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/ldapRegistry-3.0/com.ibm.websphere.appserver.ldapRegistry-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/ldapRegistry-3.0/com.ibm.websphere.appserver.ldapRegistry-3.0.feature
@@ -3,8 +3,8 @@ symbolicName=com.ibm.websphere.appserver.ldapRegistry-3.0
 visibility=public
 IBM-ShortName: ldapRegistry-3.0
 Subsystem-Name: LDAP User Registry 1.0
--features=com.ibm.websphere.appserver.securityInfrastructure-1.0, \
- com.ibm.websphere.appserver.federatedRegistry-1.0
+-features=\
+  com.ibm.websphere.appserver.federatedRegistry-1.0
 -bundles=com.ibm.ws.security.wim.adapter.ldap
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsSecurity-1.0/com.ibm.websphere.appserver.wasJmsSecurity-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsSecurity-1.0/com.ibm.websphere.appserver.wasJmsSecurity-1.0.feature
@@ -3,9 +3,13 @@ symbolicName=com.ibm.websphere.appserver.wasJmsSecurity-1.0
 visibility=public
 IBM-ShortName: wasJmsSecurity-1.0
 Subsystem-Name: Message Server Security 1.0
--features=com.ibm.websphere.appserver.security-1.0
--bundles=com.ibm.ws.messaging.utils, \
- com.ibm.ws.messaging.security, \
- com.ibm.ws.messaging.security.common
+-features=\
+  com.ibm.websphere.appserver.security-1.0,\
+  com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:=1.2, \
+  com.ibm.websphere.appserver.wasJmsServer-1.0
+-bundles=\
+  com.ibm.ws.messaging.utils, \
+  com.ibm.ws.messaging.security, \
+  com.ibm.ws.messaging.security.common
 kind=ga
 edition=base


### PR DESCRIPTION
All public liberty features should have their dependencies declared such that they are capable of being started on their own with no other features configured in the server.xml.

Issues with `federatedRegistry-1.0`:
```
[ERROR   ] CWWKE0702E: Could not resolve module: com.ibm.ws.security.wim.core [53]
  Unresolved requirement: Import-Package: com.ibm.ws.security; version="[1.0.0,2.0.0)"

[ERROR   ] CWWKE0702E: Could not resolve module: com.ibm.ws.security.wim.registry [56]
  Unresolved requirement: Import-Package: com.ibm.ws.security.wim.util; version="[1.0.0,2.0.0)"
    -> Export-Package: com.ibm.ws.security.wim.util; bundle-symbolic-name="com.ibm.ws.security.wim.core"; bundle-version="1.0.23.201810010226"; version="1.0.17"; uses:="com.ibm.websphere.ras.annotation,com.ibm.ws.ras.instrument.annotation,com.ibm.wsspi.security.wim.exception,com.ibm.wsspi.security.wim.model"
       com.ibm.ws.security.wim.core [53]
         Unresolved requirement: Import-Package: com.ibm.ws.security; version="[1.0.0,2.0.0)"
  Unresolved requirement: Import-Package: com.ibm.ws.security.wim; version="[1.0.0,2.0.0)"
    -> Export-Package: com.ibm.ws.security.wim; bundle-symbolic-name="com.ibm.ws.security.wim.core"; bundle-version="1.0.23.201810010226"; version="1.0.16"; uses:="com.ibm.websphere.ras.annotation,com.ibm.websphere.security.wim,com.ibm.ws.ras.instrument.annotation,com.ibm.ws.security,com.ibm.ws.security.registry,com.ibm.ws.security.wim.env,com.ibm.ws.security.wim.xpath.util,com.ibm.wsspi.security.wim,com.ibm.wsspi.security.wim.exception,com.ibm.wsspi.security.wim.model,org.osgi.framework,org.osgi.service.component"

[AUDIT   ] CWWKF0012I: The server installed the following features: [ssl-1.0, federatedRegistry-1.0].
```

Issues with `distributedMap-1.0`:
```
[ERROR   ] CWWKE0702E: Could not resolve module: com.ibm.ws.dynacache [53]
  Unresolved requirement: Import-Package: javax.servlet; version="[2.6.0,3.0.0)"
```

Issues with `wasJmsSecurity-1.0`:
```
[ERROR   ] CWWKE0702E: Could not resolve module: com.ibm.ws.messaging.security [75]
  Unresolved requirement: Import-Package: com.ibm.ws.sib.jfapchannel; version="[1.2.0,2.0.0)"
```