### PR TITLE
Align Java EE API features with corresponding EE versions

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.1.feature
@@ -3,6 +3,9 @@ symbolicName=com.ibm.websphere.appserver.javax.annotation-1.1
 singleton=true
 IBM-Process-Types: server, \
  client
--bundles=com.ibm.websphere.javaee.annotation.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.2"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-6.0
+-bundles=\
+  com.ibm.websphere.javaee.annotation.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.2.feature
@@ -3,6 +3,9 @@ symbolicName=com.ibm.websphere.appserver.javax.annotation-1.2
 singleton=true
 IBM-Process-Types: server, \
  client
--bundles=com.ibm.websphere.javaee.annotation.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.2"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-7.0
+-bundles=\
+  com.ibm.websphere.javaee.annotation.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.3.feature
@@ -3,6 +3,9 @@ symbolicName=com.ibm.websphere.appserver.javax.annotation-1.3
 singleton=true
 IBM-Process-Types: server, \
  client
--bundles=com.ibm.websphere.javaee.annotation.1.3; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.3.2"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-8.0
+-bundles=\
+  com.ibm.websphere.javaee.annotation.1.3; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.3.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.cdi-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.cdi-1.2.feature
@@ -1,8 +1,11 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.cdi-1.2
 singleton=true
--features=com.ibm.websphere.appserver.javax.el-3.0; apiJar=false, \
- com.ibm.websphere.appserver.javax.interceptor-1.2
--bundles=com.ibm.websphere.javaee.cdi.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise:cdi-api:1.2"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-7.0,\
+  com.ibm.websphere.appserver.javax.el-3.0; apiJar=false, \
+  com.ibm.websphere.appserver.javax.interceptor-1.2
+-bundles=\
+  com.ibm.websphere.javaee.cdi.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise:cdi-api:1.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.cdi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.cdi-2.0.feature
@@ -1,8 +1,11 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.cdi-2.0
 singleton=true
--features=com.ibm.websphere.appserver.javax.el-3.0; apiJar=false, \
- com.ibm.websphere.appserver.javax.interceptor-1.2
--bundles=com.ibm.websphere.javaee.cdi.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise:cdi-api:2.0"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-8.0,\
+  com.ibm.websphere.appserver.javax.el-3.0; apiJar=false, \
+  com.ibm.websphere.appserver.javax.interceptor-1.2
+-bundles=\
+  com.ibm.websphere.javaee.cdi.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise:cdi-api:2.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.connector.internal-1.6.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.connector.internal-1.6.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.connector.internal-1.6
 singleton=true
--bundles=com.ibm.websphere.javaee.connector.1.6; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.resource:javax.resource-api:1.7"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-6.0
+-bundles=\
+  com.ibm.websphere.javaee.connector.1.6; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.resource:javax.resource-api:1.7"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.connector.internal-1.7.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.connector.internal-1.7.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.connector.internal-1.7
 singleton=true
--bundles=com.ibm.websphere.javaee.connector.1.7; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.resource:javax.resource-api:1.7"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-7.0; ibm.tolerates:=8.0
+-bundles=\
+  com.ibm.websphere.javaee.connector.1.7; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.resource:javax.resource-api:1.7"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.ejb-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.ejb-3.1.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.ejb-3.1
 singleton=true
--bundles=com.ibm.websphere.javaee.ejb.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="org.glassfish:javax.ejb:3.1"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-6.0
+-bundles=\
+  com.ibm.websphere.javaee.ejb.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="org.glassfish:javax.ejb:3.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.ejb-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.ejb-3.2.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.ejb-3.2
 singleton=true
--bundles=com.ibm.websphere.javaee.ejb.3.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ejb:javax.ejb-api:3.2"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-7.0; ibm.tolerates:=8.0
+-bundles=\
+  com.ibm.websphere.javaee.ejb.3.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ejb:javax.ejb-api:3.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.el-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.el-2.2.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.el-2.2
 singleton=true
--bundles=com.ibm.websphere.javaee.el.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.el:el-api:2.2"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-6.0
+-bundles=\
+  com.ibm.websphere.javaee.el.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.el:el-api:2.2"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.el-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.el-3.0.feature
@@ -1,6 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.el-3.0
 singleton=true
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-7.0; ibm.tolerates:=8.0
 -bundles=com.ibm.websphere.javaee.el.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.el:javax.el-api:3.0.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsf-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsf-2.2.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.jsf-2.2
 singleton=true
--bundles=com.ibm.websphere.javaee.jsf.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="org.apache.myfaces.core:myfaces-api:2.2.12"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-7.0
+-bundles=\
+  com.ibm.websphere.javaee.jsf.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="org.apache.myfaces.core:myfaces-api:2.2.12"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsf-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsf-2.3.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.jsf-2.3
 singleton=true
--bundles=com.ibm.websphere.javaee.jsf.2.3; location:="dev/api/spec/,lib/"; mavenCoordinates="org.apache.myfaces.core:myfaces-api:2.3.0"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-8.0
+-bundles=\
+  com.ibm.websphere.javaee.jsf.2.3; location:="dev/api/spec/,lib/"; mavenCoordinates="org.apache.myfaces.core:myfaces-api:2.3.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsp-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jsp-2.3.feature
@@ -1,8 +1,10 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.jsp-2.3
 singleton=true
--features=com.ibm.websphere.appserver.javax.el-3.0; apiJar=false, \
- com.ibm.websphere.appserver.javax.servlet-3.1; ibm.tolerates:=4.0; apiJar=false
--bundles=com.ibm.websphere.javaee.jsp.2.3; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet.jsp:javax.servlet.jsp-api:2.3.1"
+-features=\
+  com.ibm.websphere.appserver.javax.el-3.0; apiJar=false, \
+  com.ibm.websphere.appserver.javax.servlet-3.1; ibm.tolerates:=4.0; apiJar=false
+-bundles=\
+  com.ibm.websphere.javaee.jsp.2.3; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet.jsp:javax.servlet.jsp-api:2.3.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.mail-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.mail-1.5.feature
@@ -3,6 +3,9 @@ symbolicName=com.ibm.websphere.appserver.javax.mail-1.5
 visibility=private
 singleton=true
 Subsystem-Version: 1.5
--bundles=com.ibm.ws.com.sun.mail.javax.mail.1.5
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-7.0
+-bundles=\
+  com.ibm.ws.com.sun.mail.javax.mail.1.5
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.mail-1.6.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.mail-1.6.feature
@@ -3,6 +3,9 @@ symbolicName=com.ibm.websphere.appserver.javax.mail-1.6
 visibility=private
 singleton=true
 Subsystem-Version: 1.6
--bundles=com.ibm.ws.com.sun.mail.javax.mail.1.6
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-8.0
+-bundles=\
+  com.ibm.ws.com.sun.mail.javax.mail.1.6
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.persistence.base-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.persistence.base-2.1.feature
@@ -3,6 +3,9 @@ symbolicName=com.ibm.websphere.appserver.javax.persistence.base-2.1
 singleton=true
 IBM-Process-Types: server, \
  client
--bundles=com.ibm.ws.javaee.persistence.2.1; location:=lib/
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-7.0
+-bundles=\
+  com.ibm.ws.javaee.persistence.2.1; location:=lib/
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.persistence.base-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.persistence.base-2.2.feature
@@ -3,6 +3,9 @@ symbolicName=com.ibm.websphere.appserver.javax.persistence.base-2.2
 singleton=true
 IBM-Process-Types: server, \
  client
--bundles=com.ibm.ws.javaee.persistence.2.2; location:=lib/
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-8.0
+-bundles=\
+  com.ibm.ws.javaee.persistence.2.2; location:=lib/
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-3.0.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.servlet-3.0
 singleton=true
--bundles=com.ibm.websphere.javaee.servlet.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:3.0.1"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-6.0
+-bundles=\
+  com.ibm.websphere.javaee.servlet.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:3.0.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-3.1.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.servlet-3.1
 singleton=true
--bundles=com.ibm.websphere.javaee.servlet.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:3.1.0"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-7.0
+-bundles=\
+  com.ibm.websphere.javaee.servlet.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:3.1.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-4.0.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.servlet-4.0
 singleton=true
--bundles=com.ibm.websphere.javaee.servlet.4.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:4.0.1"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-8.0
+-bundles=\
+  com.ibm.websphere.javaee.servlet.4.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:4.0.1"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.validation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.validation-1.1.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.validation-1.1
 singleton=true
--bundles=com.ibm.websphere.javaee.validation.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.validation:validation-api:1.1.0.Final"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-7.0
+-bundles=\
+  com.ibm.websphere.javaee.validation.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.validation:validation-api:1.1.0.Final"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.validation-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.validation-2.0.feature
@@ -1,6 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.javax.validation-2.0
 singleton=true
--bundles=com.ibm.websphere.javaee.validation.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.validation:validation-api:2.0.1.Final"
+-features=\
+  com.ibm.websphere.appserver.javaeeCompatible-8.0
+-bundles=\
+  com.ibm.websphere.javaee.validation.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.validation:validation-api:2.0.1.Final"
 kind=ga
 edition=core


### PR DESCRIPTION
Currently many of our private javax.* features that provide Java EE APIs are not restricted to their corresponding Java EE version(s).

@dazavala pointed out that by default we may have `servlet-4.0 -> anno-1.0 -> javax.annotations-1.1`, which means Servlet from EE8 is linking with common annotations from Java EE 6.