### PR TITLE
Update test case to behave like other tests in the suite.

### DIFF
--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/AutoExtractTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/AutoExtractTest.java
@@ -134,6 +134,7 @@ public class AutoExtractTest extends AbstractAppManagerTest {
             con.disconnect();
 
             // remove file
+            server.setMarkToEndOfLog();
 
             boolean deleted = deleteFile(server.getMachine(),
                                          server.getServerRoot() + "/" + DROPINS_DIR + "/testWarApplication.war");
@@ -162,6 +163,7 @@ public class AutoExtractTest extends AbstractAppManagerTest {
             //if we failed to delete file before, try to delete it now.
             pathsToCleanup.add(server.getServerRoot() + "/" + DROPINS_DIR);
             server.removeAllInstalledAppsForValidation();
+            server.stopServer(COULD_NOT_FIND_APP_WARNING);
         }
 
     }


### PR DESCRIPTION
I have hit the testAutoExtractWarDropins() test failing in 3 personal
builds.  The change to the test is to ignore a warning that is possible
when stopping the server for the type of scenarios done by this test.
The other tests in the suite already have this logic.  Only this one was
missing it.
