### PR TITLE
test sharding keys and handle reassociation

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
@@ -157,6 +157,11 @@ public class JDBC40Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
+    public boolean doSetShardingKeysIfValid(Connection con, Object shardingKey, Object superShardingKey, int timeout) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
     public void beginRequest(Connection con) {}
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
@@ -183,6 +183,11 @@ public class JDBC41Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
+    public boolean doSetShardingKeysIfValid(Connection con, Object shardingKey, Object superShardingKey, int timeout) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
     public void beginRequest(Connection con) {}
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
@@ -183,6 +183,11 @@ public class JDBC42Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
+    public boolean doSetShardingKeysIfValid(Connection con, Object shardingKey, Object superShardingKey, int timeout) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
     public void beginRequest(Connection con) {}
 
     @Override

--- a/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
@@ -228,6 +228,18 @@ public class JDBC43Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
+    public boolean doSetShardingKeysIfValid(Connection con, Object shardingKey, Object superShardingKey, int timeout) throws SQLException {
+        try {
+            if (superShardingKey == SUPER_SHARDING_KEY_UNCHANGED)
+                return con.setShardingKeyIfValid((ShardingKey) shardingKey, timeout);
+            else
+                return con.setShardingKeyIfValid((ShardingKey) shardingKey, (ShardingKey) superShardingKey, timeout);
+        } catch (IncompatibleClassChangeError e) { // pre-4.3 driver
+            throw new SQLFeatureNotSupportedException(e);
+        }
+    }
+
+    @Override
     public void beginRequest(Connection con) throws SQLException {
         con.beginRequest();
     }

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Connection.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43Connection.java
@@ -40,12 +40,69 @@ public class WSJdbc43Connection extends WSJdbc41Connection implements Connection
 
     @Override
     public boolean setShardingKeyIfValid(ShardingKey shardingKey, int timeout) throws SQLException {
-        throw new UnsupportedOperationException();
+        activate();
+
+        try {
+            // Setters are not permitted when multiple handles are sharing the same ManagedConnection,
+            // except when the specified value is the same as the current value, which is a no-op.
+            if (managedConn.getHandleCount() > 1 && !AdapterUtil.match(shardingKey, managedConn.getCurrentShardingKey()))
+                throw createSharingException("setShardingKeyIfValid");
+
+            boolean updated = managedConn.setShardingKeysIfValid(shardingKey, JDBCRuntimeVersion.SUPER_SHARDING_KEY_UNCHANGED, timeout);
+
+            // Update the connection request information with the new value, so that
+            // requests for shared connections will match based on the updated criteria.
+            if (updated && managedConn.connectionSharing == ConnectionSharing.MatchCurrentState) {
+                WSConnectionRequestInfoImpl cri = (WSConnectionRequestInfoImpl) managedConn.getConnectionRequestInfo();
+                if (!cri.isCRIChangable())
+                    managedConn.setCRI(cri = WSConnectionRequestInfoImpl.createChangableCRIFromNon(cri));
+
+                cri.setShardingKey(shardingKey);
+            }
+
+            return updated;
+        } catch (SQLException x) {
+            FFDCFilter.processException(x, getClass().getName(), "65", this);
+            throw proccessSQLException(x);
+        } catch (NullPointerException x) {
+            // No FFDC code needed; we might be closed.
+            throw runtimeXIfNotClosed(x);
+        }
     }
 
     @Override
     public boolean setShardingKeyIfValid(ShardingKey shardingKey, ShardingKey superShardingKey, int timeout) throws SQLException {
-        throw new UnsupportedOperationException();
+        activate();
+
+        try {
+            // Setters are not permitted when multiple handles are sharing the same ManagedConnection,
+            // except when the specified value is the same as the current value, which is a no-op.
+            if (managedConn.getHandleCount() > 1 &&
+                (!AdapterUtil.match(shardingKey, managedConn.getCurrentShardingKey()) ||
+                 !AdapterUtil.match(superShardingKey, managedConn.getCurrentSuperShardingKey())))
+                throw createSharingException("setShardingKey");
+
+            boolean updated = managedConn.setShardingKeysIfValid(shardingKey, superShardingKey, timeout);
+
+            // Update the connection request information with the new value, so that
+            // requests for shared connections will match based on the updated criteria.
+            if (updated && managedConn.connectionSharing == ConnectionSharing.MatchCurrentState) {
+                WSConnectionRequestInfoImpl cri = (WSConnectionRequestInfoImpl) managedConn.getConnectionRequestInfo();
+                if (!cri.isCRIChangable())
+                    managedConn.setCRI(cri = WSConnectionRequestInfoImpl.createChangableCRIFromNon(cri));
+
+                cri.setShardingKey(shardingKey);
+                cri.setSuperShardingKey(superShardingKey);
+            }
+
+            return updated;
+        } catch (SQLException x) {
+            FFDCFilter.processException(x, getClass().getName(), "100", this);
+            throw proccessSQLException(x);
+        } catch (NullPointerException x) {
+            // No FFDC code needed; we might be closed.
+            throw runtimeXIfNotClosed(x);
+        }
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
@@ -102,6 +102,7 @@ public interface JDBCRuntimeVersion {
     public PooledConnection buildPooledConnection(ConnectionPoolDataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException;
     public XAConnection buildXAConnection(XADataSource ds, String user, String password, WSConnectionRequestInfoImpl cri) throws SQLException;
     public void doSetShardingKeys(Connection con, Object shardingKey, Object superShardingKey) throws SQLException;
+    public boolean doSetShardingKeysIfValid(Connection con, Object shardingKey, Object superShardingKey, int timeout) throws SQLException;
     public void beginRequest(Connection con) throws SQLException;
     public void endRequest(Connection con) throws SQLException;
 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -4068,6 +4068,35 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
     }
 
     /**
+     * Updates the value of the sharding keys after validating them.
+     *
+     * @param shardingKey the new sharding key.
+     * @param superShardingKey the new super sharding key. The 'unchanged' constant can be used to avoid changing it.
+     * @param timeout number of seconds within which validation must be done. 0 indicates no timeout.
+     * @return true if the sharding keys are valid and were successfully set on the connection. Otherwise, false.
+     */
+    public final boolean setShardingKeysIfValid(Object shardingKey, Object superShardingKey, int timeout) throws SQLException {
+        if (mcf.beforeJDBCVersion(JDBCRuntimeVersion.VERSION_4_3))
+            throw new SQLFeatureNotSupportedException();
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "Set sharding key/super sharding key to " + shardingKey + "/" + superShardingKey + " within " + timeout + " seconds");
+
+        boolean updated = mcf.jdbcRuntime.doSetShardingKeysIfValid(sqlConn, shardingKey, superShardingKey, timeout);
+
+        if (updated) {
+            currentShardingKey = shardingKey;
+            if (superShardingKey != JDBCRuntimeVersion.SUPER_SHARDING_KEY_UNCHANGED)
+                currentSuperShardingKey = superShardingKey;
+            connectionPropertyChanged = true;
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "successful? " + updated);
+        return updated;
+    }
+
+    /**
      * Returns the connectionRequestInfo passed in during the construction of the object.
      * This ConnectionRequestInfo object contains the updated values for Connection properties
      * due to any modificiations made to the ManagedConnection.

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
@@ -176,11 +176,13 @@ public class D43Handler implements InvocationHandler, Supplier<AtomicInteger[]> 
             return null;
         }
         if ("setShardingKeyIfValid".equals(methodName)) {
-            boolean valid = (args[0] instanceof D43ShardingKey || args[0] == null)
-                            && (args.length == 2 || args[1] instanceof D43ShardingKey || args[1] == null);
+            boolean valid = (args[0] == null || args[0] instanceof D43ShardingKey && !args[0].toString().contains("BOOLEAN:INVALID"))
+                            && (args.length == 2
+                                || args[1] == null
+                                || args[1] instanceof D43ShardingKey && !args[1].toString().contains("BOOLEAN:INVALID"));
             if (valid) {
                 shardingKey = (ShardingKey) args[0];
-                if (args.length == 2)
+                if (args.length == 3)
                     superShardingKey = (ShardingKey) args[1];
             }
             return valid;


### PR DESCRIPTION
Automated test coverage of connection handle reassociation scenarios involving sharding key and sharing based on MatchOriginalRequest, and an additional test of setShardingKeyIfValid in combination with sharing based on MatchCurrentState.