### PR TITLE
Update .classpath and bnd.bnd files to remove nonexistent source paths.

### DIFF
--- a/dev/com.ibm.websphere.org.eclipse.microprofile.opentracing.1.0/.classpath
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.opentracing.1.0/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.opentracing.1.1/.classpath
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.opentracing.1.1/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.opentracing.1.2/.classpath
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.opentracing.1.2/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.app.manager_fat/.classpath
+++ b/dev/com.ibm.ws.app.manager_fat/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-resourceadapters/SimpleRA/src"/>
 	<classpathentry kind="src" path="test-applications/DataSourceApp.ear/DataSourceEJB.jar/src"/>
 	<classpathentry kind="src" path="test-applications/snoop.war/src"/>
 	<classpathentry kind="src" path="test-applications/testWarApplication.war/src"/>

--- a/dev/com.ibm.ws.app.manager_fat/bnd.bnd
+++ b/dev/com.ibm.ws.app.manager_fat/bnd.bnd
@@ -18,8 +18,7 @@ src: \
 	test-applications/app-j2ee.ear/src, \
 	test-applications/snoop.war/src, \
 	test-applications/DataSourceApp.ear/DataSourceEJB.jar/src, \
-	test-bundles/test.app.notifications/src, \
-	test-resourceadapters/SimpleRA/src
+	test-bundles/test.app.notifications/src
 
 -sub: *.bnd
 

--- a/dev/com.ibm.ws.cdi.beansxml_fat/.classpath
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/.classpath
@@ -6,7 +6,6 @@
 	<classpathentry kind="src" path="test-applications/afterTypeDiscoveryApp.war/src"/>
 	<classpathentry kind="src" path="test-applications/aroundConstructApp.war/src"/>
 	<classpathentry kind="src" path="test-applications/utilLib.jar/src"/>
-	<classpathentry kind="src" path="test-applications/ejbConstructorInjection.war/src"/>
 	<classpathentry kind="src" path="test-applications/beanDiscoveryModeNone.war/src"/>
 	<classpathentry kind="src" path="test-applications/multipleEJBsSingleClass.war/src"/>
 	<classpathentry kind="src" path="test-applications/multipleWarEmbeddedJar.jar/src"/>

--- a/dev/com.ibm.ws.cdi.beansxml_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.beansxml_fat/bnd.bnd
@@ -19,7 +19,6 @@ src: \
         test-applications/aroundConstructApp.war/src,\
         test-applications/beanDiscoveryModeNone.war/src,\
         test-applications/classExclusion.war/src,\
-        test-applications/ejbConstructorInjection.war/src,\
         test-applications/ejbDiscovery.war/src,\
         test-applications/ejbMisc.war/src,\
         test-applications/ejbScope.war/src,\

--- a/dev/com.ibm.ws.cdi.jndi_fat/.classpath
+++ b/dev/com.ibm.ws.cdi.jndi_fat/.classpath
@@ -2,11 +2,9 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/jndiLookup.jar/src"/>
-	<classpathentry kind="src" path="test-applications/appClientAdvanced.jar"/>
 	<classpathentry kind="src" path="test-applications/jndiLookup.war/src"/>
 	<classpathentry kind="src" path="test-applications/HelloAppClient.jar/src"/>
 	<classpathentry kind="src" path="test-applications/cdi12helloworldtest.war/src"/>
-	<classpathentry kind="src" path="test-applications/appClientSecurity.jar"/>
 	<classpathentry kind="src" path="test-applications/beanManagerLookupApp.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>

--- a/dev/com.ibm.ws.cdi.jndi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.jndi_fat/bnd.bnd
@@ -15,8 +15,6 @@ bVersion=1.0
 
 src: \
 	fat/src,\
-	test-applications/appClientAdvanced.jar,\
-	test-applications/appClientSecurity.jar,\
 	test-applications/beanManagerLookupApp.war/src,\
 	test-applications/cdi12helloworldtest.war/src,\
 	test-applications/HelloAppClient.jar/src,\

--- a/dev/com.ibm.ws.cdi.noncontextual_fat/.classpath
+++ b/dev/com.ibm.ws.cdi.noncontextual_fat/.classpath
@@ -2,10 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/appNonContextual.war/src"/>
-	<classpathentry kind="src" path="test-applications/beanManagerLookupApp.war/src"/>
-	<classpathentry kind="src" path="test-applications/appClientAdvanced.jar/src"/>
 	<classpathentry kind="src" path="test-applications/nonContextual.war/src"/>
-	<classpathentry kind="src" path="test-applications/appClientSecurity.jar/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.cdi.noncontextual_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.noncontextual_fat/bnd.bnd
@@ -15,10 +15,7 @@ bVersion=1.0
 
 src: \
 	fat/src,\
-	test-applications/appClientAdvanced.jar/src,\
-	test-applications/appClientSecurity.jar/src,\
 	test-applications/appNonContextual.war/src,\
-	test-applications/beanManagerLookupApp.war/src,\
 	test-applications/nonContextual.war/src,\
 	test-applications/vetoAndExtendNonContextual.war/src
 	

--- a/dev/com.ibm.ws.cdi.visibility_fat/.classpath
+++ b/dev/com.ibm.ws.cdi.visibility_fat/.classpath
@@ -8,7 +8,6 @@
 	<classpathentry kind="src" path="test-applications/visTestEjbAsEjbLib.jar/src"/>
 	<classpathentry kind="src" path="test-applications/visTestEjbWarLib.jar/src"/>
 	<classpathentry kind="src" path="test-applications/visTestWarLib.jar/src"/>
-	<classpathentry kind="src" path="test-applications/maskedClass.ear/src"/>
 	<classpathentry kind="src" path="test-applications/jarInRar.jar/src"/>
 	<classpathentry kind="src" path="test-applications/visTestFramework.jar/src"/>
 	<classpathentry kind="src" path="test-applications/multiModuleAppLib2.jar/src"/>
@@ -17,7 +16,6 @@
 	<classpathentry kind="src" path="test-applications/warLibAccessBeansInWarJar.jar/src"/>
 	<classpathentry kind="src" path="test-applications/TestValidatorInJar.jar/src"/>
 	<classpathentry kind="src" path="test-applications/TestValidatorInJar.war/src"/>
-	<classpathentry kind="src" path="test-applications/jarInRar.rar/src"/>
 	<classpathentry kind="src" path="test-applications/visTestAppClientAsEjbLib.jar/src"/>
 	<classpathentry kind="src" path="test-applications/packagePrivateAccessApp.war/src"/>
 	<classpathentry kind="src" path="test-applications/visTestAppClientAsWarLib.jar/src"/>
@@ -26,7 +24,6 @@
 	<classpathentry kind="src" path="test-applications/maskedClassLib.jar/src"/>
 	<classpathentry kind="src" path="test-applications/visTestNonLib.jar/src"/>
 	<classpathentry kind="src" path="test-applications/sharedLibrary.jar/src"/>
-	<classpathentry kind="src" path="test-applications/TestValidatorInJar.ear/src"/>
 	<classpathentry kind="src" path="test-applications/visTestWar2.war/src"/>
 	<classpathentry kind="src" path="test-applications/rootClassLoaderExtension.jar/src"/>
 	<classpathentry kind="src" path="test-applications/multiModuleAppWeb2.war/src"/>
@@ -43,7 +40,6 @@
 	<classpathentry kind="src" path="test-applications/visTestEjbLib.jar/src"/>
 	<classpathentry kind="src" path="test-applications/maskedClassEjb.jar/src"/>
 	<classpathentry kind="src" path="test-applications/sharedLibraryNoInjectionApp.war/src"/>
-	<classpathentry kind="src" path="test-applications/warLibAccessBeansInWar.ear/src"/>
 	<classpathentry kind="src" path="test-applications/TestClassLoadPrereqLogger.war/src"/>
 	<classpathentry kind="src" path="test-applications/multiModuleAppWeb1.war/src"/>
 	<classpathentry kind="src" path="test-applications/warLibAccessBeansInWar.war/src"/>

--- a/dev/com.ibm.ws.config_fat/.classpath
+++ b/dev/com.ibm.ws.config_fat/.classpath
@@ -6,7 +6,6 @@
 	<classpathentry kind="src" path="test-applications/configdropins/src"/>
 	<classpathentry kind="src" path="test" output="bin_test"/>
 	<classpathentry kind="src" path="test-applications/mergedconfig/src"/>
-	<classpathentry kind="src" path="test-bundles/test.config.childalias.b/src"/>
 	<classpathentry kind="src" path="test-bundles/test.config.extensions.schema.generator/src"/>
 	<classpathentry kind="src" path="test-bundles/test.metatype.provider/src"/>
 	<classpathentry kind="src" path="test-applications/childalias/src"/>
@@ -14,10 +13,8 @@
 	<classpathentry kind="src" path="test-applications/confighelper/src"/>
 	<classpathentry kind="src" path="test-applications/varmerge/src"/>
 	<classpathentry kind="src" path="test-applications/mbeans/src"/>
-	<classpathentry kind="src" path="test-bundles/test.config.childalias.c/src"/>
 	<classpathentry kind="src" path="test-bundles/test.prod.extensions/src"/>
 	<classpathentry kind="src" path="test-bundles/test.user.prod.extensions/src"/>
-	<classpathentry kind="src" path="test-bundles/test.config.childalias/src"/>
 	<classpathentry kind="src" path="test-applications/restart/src"/>
 	<classpathentry kind="src" path="test-applications/metatypeprovider/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.javaee.persistence.api.2.1/.classpath
+++ b/dev/com.ibm.ws.javaee.persistence.api.2.1/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.javaee.persistence.api.2.2/.classpath
+++ b/dev/com.ibm.ws.javaee.persistence.api.2.2/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.javamail.config/.classpath
+++ b/dev/com.ibm.ws.javamail.config/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/.classpath
@@ -3,8 +3,6 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/baseclient/src"/>
 	<classpathentry kind="src" path="test-applications/bookstore/src"/>
-	<classpathentry kind="src" path="test-applications/cdiApp/src"/>
-	<classpathentry kind="src" path="test-applications/classSubResApp/src"/>
 	<classpathentry kind="src" path="test-applications/clientcontextinjection/src"/>
 	<classpathentry kind="src" path="test-applications/complexclient/src"/>
 	<classpathentry kind="src" path="test-applications/ibmjson4j/src"/>
@@ -18,11 +16,8 @@
 	<classpathentry kind="src" path="test-applications/jaxrsclientssl/src"/>
 	<classpathentry kind="src" path="test-applications/jaxrsclientstandalone/src"/>
 	<classpathentry kind="src" path="test-applications/jaxrsclienttimeout/src"/>
-	<classpathentry kind="src" path="test-applications/jsonbapp/src"/>
 	<classpathentry kind="src" path="test-applications/jsonp/src"/>
-	<classpathentry kind="src" path="test-applications/patchapp/src"/>
 	<classpathentry kind="src" path="test-applications/pathparam/src"/>
-	<classpathentry kind="src" path="test-applications/providerPriorityApp/src"/>
 	<classpathentry kind="src" path="test-applications/thirdpartyjerseyclient/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/bnd.bnd
@@ -15,8 +15,6 @@ src: \
 	fat/src,\
 	test-applications/baseclient/src,\
 	test-applications/bookstore/src,\
-    test-applications/cdiApp/src,\
-	test-applications/classSubResApp/src,\
 	test-applications/clientcontextinjection/src,\
 	test-applications/complexclient/src,\
 	test-applications/ibmjson4j/src,\
@@ -30,11 +28,8 @@ src: \
 	test-applications/jaxrsclientssl/src,\
 	test-applications/jaxrsclientstandalone/src,\
 	test-applications/jaxrsclienttimeout/src,\
-	test-applications/jsonbapp/src,\
 	test-applications/jsonp/src,\
-	test-applications/patchapp/src,\
 	test-applications/pathparam/src,\
-	test-applications/providerPriorityApp/src,\
 	test-applications/thirdpartyjerseyclient/src
 
 fat.project: true

--- a/dev/com.ibm.ws.jaxrs.2.x.config/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.x.config/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.kernel.boot_test/.classpath
+++ b/dev/com.ibm.ws.kernel.boot_test/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="bin" path="src"/>
 	<classpathentry kind="src" output="bin_test" path="test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>

--- a/dev/com.ibm.ws.microprofile.config_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.config_fat/.classpath
@@ -19,11 +19,10 @@
 	<classpathentry kind="src" path="test-applications/types.war/src"/>
 	<classpathentry kind="src" path="test-applications/converterApp/src"/>
 	<classpathentry kind="src" path="test-applications/converterApp/resources"/>
-	<classpathentry kind="src" path="test-applications/cdiConfig.war/src"/>
-	<classpathentry kind="src" path="test-applications/defaultSources.war/src"/>
-	<classpathentry kind="src" path="test-applications/earlib.jar/src"/>
-	<classpathentry kind="src" path="test-applications/warVisibility.war/src"/>
-	<classpathentry kind="src" path="test-applications/sharedLibUser.war/src"/>
+	<classpathentry kind="src" path="test-applications/defaultSources.war/resources"/>
+	<classpathentry kind="src" path="test-applications/earlib.jar/resources"/>
+	<classpathentry kind="src" path="test-applications/warVisibility.war/resources"/>
+	<classpathentry kind="src" path="test-applications/sharedLibUser.war/resources"/>
 	<classpathentry kind="src" path="test-applications/simultaneousRequests.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/.classpath
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/.classpath
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-        <classpathentry kind="src" path="resources"/>
-        <classpathentry kind="src" output="bin_test" path="test/src"/>
+	<classpathentry kind="src" output="bin_test" path="test/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.metrics/.classpath
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.metrics/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-        <classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.metrics/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.metrics/bnd.bnd
@@ -32,8 +32,6 @@ Private-Package: com.ibm.ws.microprofile.faulttolerance.metrics.integration
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
-src: src,resources
-
 -buildpath: \
         com.ibm.ws.logging;version=latest, \
         com.ibm.ws.logging.core;version=latest, \

--- a/dev/com.ibm.ws.microprofile.openapi.ui/.classpath
+++ b/dev/com.ibm.ws.microprofile.openapi.ui/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.microprofile.openapi_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/appWithAnnotations/src"/>
-	<classpathentry kind="src" path="test-applications/appWithStaticDoc/src"/>
 	<classpathentry kind="src" path="test-applications/pure-jaxrs/src"/>
 	<classpathentry kind="src" path="test-applications/complete-flow/src"/>
 	<classpathentry kind="src" path="test-applications/simpleServlet/src"/>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.service.description.3.2/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.service.description.3.2/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/wlp-rasInstrumentation/.classpath
+++ b/dev/wlp-rasInstrumentation/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
This change allows people to do a git clean -dfx and not have to build gradle in order for eclipse to be happy because gradle creates directories that don't exist in git.  It also means that someone can checkout from git fresh and import into eclipse without building gradle except to do cnf:initialize.