### PR TITLE
tests to experiment with vendor-specific sharding key defaults

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -27,6 +27,12 @@
     <properties url="jdbc:d43:memory:testdb;create=true" user="user43" password="{xor}Lyg7a2w="/>
   </dataSource>
 
+  <dataSource jndiName="jdbc/defaultShardingMatchCurrentState" type="javax.sql.DataSource" connectionSharing="MatchCurrentState"
+              containerAuthDataRef="user43Auth">
+    <jdbcDriver libraryRef="D43Lib"/>
+    <properties databaseName="memory:testdb;create=true" shardingKey="CHAR:DefaultShardingKey;" superShardingKey="VARCHAR:DefaultSuperKey;"/>
+  </dataSource>
+
   <dataSource jndiName="jdbc/ds" type="javax.sql.DataSource">
     <jdbcDriver libraryRef="D43Lib"/>
     <properties databaseName="memory:testdb;create=true"/>

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43Handler.java
@@ -187,6 +187,8 @@ public class D43Handler implements InvocationHandler, Supplier<AtomicInteger[]> 
             }
             return valid;
         }
+        if ("supportsSharding".equals(methodName))
+            return true;
         try {
             Object result = method.invoke(instance, args);
             if (returnType.isInterface() && (returnType.getPackage().getName().startsWith("java.sql")


### PR DESCRIPTION
Write automated tests to experiment with how vendor-specific sharding key defaults will interact with connection matching.  In this pull, we address the scenario where a null sharding key (or super sharding key) means that a default that is configured at data source level applies.  In this case, there is no distinction between unspecified and null -- both mean use the default.