### PR TITLE
CXF-7860: Reprocess `@FormParam`s prior to resource method invocation

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
@@ -6,6 +6,7 @@
 	<classpathentry kind="src" path="test-applications/classSubResApp/src"/>
 	<classpathentry kind="src" path="test-applications/cdiApp/src"/>
 	<classpathentry kind="src" path="test-applications/jsonbapp/src"/>
+	<classpathentry kind="src" path="test-applications/formApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
@@ -18,6 +18,7 @@ src: \
   test-applications/classSubResApp/src,\
   test-applications/cdiApp/src,\
   test-applications/jsonbapp/src,\
+  test-applications/formApp/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 ClassSubResTest.class,
                 CDITest.class,
                 PackageJsonBTestNoFeature.class,
-                PackageJsonBTestWithFeature.class
+                PackageJsonBTestWithFeature.class,
+                FormBehaviorTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FormBehaviorTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FormBehaviorTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs21.fat.extended;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import jaxrs21.fat.form.FormBehaviorTestServlet;
+
+@RunWith(FATRunner.class)
+public class FormBehaviorTest extends FATServletClient {
+
+    private static final String appName = "formApp";
+
+    @Server("jaxrs21.fat.form")
+    @TestServlet(servlet = FormBehaviorTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, appName, "jaxrs21.fat.form");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.form/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.form/bootstrap.properties
@@ -1,0 +1,8 @@
+com.ibm.ws.logging.trace.specification=*=info:\
+com.ibm.ws.jaxrs20.*=all:\
+com.ibm.websphere.jaxrs20.*=all:\
+org.apache.cxf.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.form/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.form/server.xml
@@ -1,0 +1,10 @@
+<server>
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+  <javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormBehaviorTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormBehaviorTestServlet.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.form;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/FormBehaviorTestServlet")
+public class FormBehaviorTestServlet extends FATServlet {
+
+    private Client client;
+
+    
+    @Override
+    public void init() throws ServletException {
+        client = ClientBuilder.newClient();
+    }
+
+    @Override
+    public void destroy() {
+        client.close();
+    }
+
+    @Test
+    public void testInterceptorInvokedOnFormAndFormParamMatchesFormValue(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        
+        String uri = "http://localhost:" + req.getServerPort() + "/formApp/form";
+        Form f = new Form("value", "ORIGINAL");
+        Response r = client.target(uri)
+                           .request(MediaType.APPLICATION_FORM_URLENCODED)
+                           .post(Entity.form(f));
+        assertEquals("MODIFIED", r.getHeaderString("FromFormParam"));
+        assertEquals("MODIFIED", r.getHeaderString("FromForm"));
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormReaderInterceptor.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormReaderInterceptor.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.form;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.logging.Logger;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.ReaderInterceptor;
+import javax.ws.rs.ext.ReaderInterceptorContext;
+
+@Provider
+public class FormReaderInterceptor implements ReaderInterceptor {
+    private static final Logger LOG = Logger.getLogger(FormReaderInterceptor.class.getName());
+
+    @Override
+    public Object aroundReadFrom(ReaderInterceptorContext ctx) throws IOException, WebApplicationException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(ctx.getInputStream()));
+        String line;
+        while ((line = br.readLine()) != null) {
+            LOG.info("readLine: " + line);
+        }
+
+        ByteArrayInputStream bais = new ByteArrayInputStream("value=MODIFIED".getBytes());
+        LOG.info("set value=MODIFIED");
+        ctx.setInputStream(bais);
+        return ctx.proceed();
+    }
+
+}
+

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormResource.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.form;
+
+
+import java.util.logging.Logger;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.Response;
+
+@ApplicationPath("/")
+@Path("/form")
+public class FormResource extends Application {
+    private static final Logger LOG = Logger.getLogger(FormResource.class.getName());
+
+    @POST
+    public Response processForm( @FormParam("value") String value, Form form ) {
+        String fromForm = form.asMap().getFirst( "value" );
+        LOG.info("FromFormParam: " + value);
+        LOG.info("FromForm: " + fromForm);
+        return Response.ok()
+                        .header("FromFormParam", value)
+                        .header("FromForm", fromForm)
+                        .build();
+      }
+}
+

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/JAXRSInvoker.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/JAXRSInvoker.java
@@ -1,0 +1,507 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxrs;
+
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionStage;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.ResourceContext;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+import org.apache.cxf.common.classloader.ClassLoaderUtils;
+import org.apache.cxf.common.classloader.ClassLoaderUtils.ClassLoaderHolder;
+import org.apache.cxf.common.i18n.BundleUtils;
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.common.util.ClassHelper;
+import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.InterceptorChain.State;
+import org.apache.cxf.jaxrs.impl.AsyncResponseImpl;
+import org.apache.cxf.jaxrs.impl.MetadataMap;
+import org.apache.cxf.jaxrs.impl.ResourceContextImpl;
+import org.apache.cxf.jaxrs.lifecycle.ResourceProvider;
+import org.apache.cxf.jaxrs.model.ClassResourceInfo;
+import org.apache.cxf.jaxrs.model.OperationResourceInfo;
+import org.apache.cxf.jaxrs.model.ParameterType;
+import org.apache.cxf.jaxrs.model.ProviderInfo;
+import org.apache.cxf.jaxrs.model.URITemplate;
+import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
+import org.apache.cxf.jaxrs.utils.ExceptionUtils;
+import org.apache.cxf.jaxrs.utils.InjectionUtils;
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageContentsList;
+import org.apache.cxf.service.invoker.AbstractInvoker;
+
+public class JAXRSInvoker extends AbstractInvoker {
+    private static final Logger LOG = LogUtils.getL7dLogger(JAXRSInvoker.class);
+    private static final ResourceBundle BUNDLE = BundleUtils.getBundle(JAXRSInvoker.class);
+    private static final String SERVICE_LOADER_AS_CONTEXT = "org.apache.cxf.serviceloader-context";
+    private static final String SERVICE_OBJECT_SCOPE = "org.apache.cxf.service.scope";
+    private static final String REQUEST_SCOPE = "request";
+    private static final String LAST_SERVICE_OBJECT = "org.apache.cxf.service.object.last";
+    private static final String PROXY_INVOCATION_ERROR_FRAGMENT
+        = "object is not an instance of declaring class";
+
+    public JAXRSInvoker() {
+    }
+
+    @FFDCIgnore({Throwable.class, WebApplicationException.class})
+    public Object invoke(Exchange exchange, Object request) {
+        MessageContentsList responseList = checkExchangeForResponse(exchange);
+        if (responseList != null) {
+            return responseList;
+        }
+        AsyncResponse asyncResp = exchange.get(AsyncResponse.class);
+        if (asyncResp != null) {
+            AsyncResponseImpl asyncImpl = (AsyncResponseImpl)asyncResp;
+            asyncImpl.prepareContinuation();
+            try {
+                asyncImpl.handleTimeout();
+                return handleAsyncResponse(exchange, asyncImpl);
+            } catch (Throwable t) {
+                return handleAsyncFault(exchange, asyncImpl, t);
+            }
+        }
+
+        ResourceProvider provider = getResourceProvider(exchange);
+        Object rootInstance = null;
+        Message inMessage = exchange.getInMessage();
+        try {
+            rootInstance = getServiceObject(exchange);
+            Object serviceObject = getActualServiceObject(exchange, rootInstance);
+
+            return invoke(exchange, request, serviceObject);
+        } catch (WebApplicationException ex) {
+            responseList = checkExchangeForResponse(exchange);
+            if (responseList != null) {
+                return responseList;
+            }
+            return handleFault(ex, inMessage);
+        } finally {
+            boolean suspended = isSuspended(exchange);
+            if (suspended || exchange.isOneWay() || inMessage.get(Message.THREAD_CONTEXT_SWITCHED) != null) {
+                ServerProviderFactory.clearThreadLocalProxies(inMessage);
+            }
+            if (suspended || isServiceObjectRequestScope(inMessage)) {
+                persistRoots(exchange, rootInstance, provider);
+            } else {
+                provider.releaseInstance(inMessage, rootInstance);
+            }
+        }
+    }
+
+    private boolean isSuspended(Exchange exchange) {
+        return exchange.getInMessage().getInterceptorChain().getState() == State.SUSPENDED;
+    }
+
+    private Object handleAsyncResponse(Exchange exchange, AsyncResponseImpl ar) {
+        Object asyncObj = ar.getResponseObject();
+        if (asyncObj instanceof Throwable) {
+            return handleAsyncFault(exchange, ar, (Throwable)asyncObj);
+        }
+        setResponseContentTypeIfNeeded(exchange.getInMessage(), asyncObj);
+        return new MessageContentsList(asyncObj);
+    }
+
+    @FFDCIgnore(Fault.class)
+    private Object handleAsyncFault(Exchange exchange, AsyncResponseImpl ar, Throwable t) {
+        try {
+            return handleFault(new Fault(t), exchange.getInMessage(), null, null);
+        } catch (Fault ex) {
+            ar.setUnmappedThrowable(ex.getCause() == null ? ex : ex.getCause());
+            if (isSuspended(exchange)) {
+                ar.reset();
+                exchange.getInMessage().getInterceptorChain().unpause();
+            }
+            return new MessageContentsList(Response.serverError().build());
+        }
+    }
+
+    private void persistRoots(Exchange exchange, Object rootInstance, Object provider) {
+        exchange.put(JAXRSUtils.ROOT_INSTANCE, rootInstance);
+        exchange.put(JAXRSUtils.ROOT_PROVIDER, provider);
+    }
+
+    @FFDCIgnore({Fault.class, IOException.class, WebApplicationException.class})
+    @SuppressWarnings("unchecked")
+    public Object invoke(Exchange exchange, Object request, Object resourceObject) {
+
+        final OperationResourceInfo ori = exchange.get(OperationResourceInfo.class);
+        final ClassResourceInfo cri = ori.getClassResourceInfo();
+        final Message inMessage = exchange.getInMessage();
+        final ServerProviderFactory providerFactory = ServerProviderFactory.getInstance(inMessage);
+        cri.injectContexts(resourceObject, ori, inMessage);
+
+        if (cri.isRoot()) {
+            ProviderInfo<Application> appProvider = providerFactory.getApplicationProvider();
+            if (appProvider != null) {
+                InjectionUtils.injectContexts(appProvider.getProvider(),
+                                              appProvider,
+                                              inMessage);
+            }
+        }
+
+
+        Method methodToInvoke = getMethodToInvoke(cri, ori, resourceObject);
+
+        List<Object> params = null;
+        if (request instanceof List) {
+            params = CastUtils.cast((List<?>)request);
+        } else if (request != null) {
+            params = new MessageContentsList(request);
+        }
+
+        params = reprocessFormParams(methodToInvoke, params, inMessage); //Liberty change - CXF-7860
+
+        Object result = null;
+        ClassLoaderHolder contextLoader = null;
+        AsyncResponseImpl asyncResponse = null;
+        try {
+            if (setServiceLoaderAsContextLoader(inMessage)) {
+                contextLoader = ClassLoaderUtils
+                    .setThreadContextClassloader(resourceObject.getClass().getClassLoader());
+            }
+            if (!ori.isSubResourceLocator()) {
+                asyncResponse = (AsyncResponseImpl)inMessage.get(AsyncResponse.class);
+            }
+            result = invoke(exchange, resourceObject, methodToInvoke, params);
+            if (asyncResponse == null && !ori.isSubResourceLocator()) {
+                asyncResponse = checkFutureResponse(inMessage, checkResultObject(result));
+            }
+            if (asyncResponse != null) {
+                if (!asyncResponse.suspendContinuationIfNeeded()) {
+                    result = handleAsyncResponse(exchange, asyncResponse);
+                } else {
+                    providerFactory.clearThreadLocalProxies();
+                }
+            }
+        } catch (Fault ex) {
+            Object faultResponse;
+            if (asyncResponse != null) {
+                faultResponse = handleAsyncFault(exchange, asyncResponse,
+                                                 ex.getCause() == null ? ex : ex.getCause());
+            } else {
+                faultResponse = handleFault(ex, inMessage, cri, methodToInvoke);
+            }
+            return faultResponse;
+        } finally {
+            exchange.put(LAST_SERVICE_OBJECT, resourceObject);
+            if (contextLoader != null) {
+                contextLoader.reset();
+            }
+        }
+        ClassResourceInfo subCri = null;
+        if (ori.isSubResourceLocator()) {
+            try {
+                MultivaluedMap<String, String> values = getTemplateValues(inMessage);
+                String subResourcePath = values.getFirst(URITemplate.FINAL_MATCH_GROUP);
+                String httpMethod = (String)inMessage.get(Message.HTTP_REQUEST_METHOD);
+                String contentType = (String)inMessage.get(Message.CONTENT_TYPE);
+                if (contentType == null) {
+                    contentType = "*/*";
+                }
+                List<MediaType> acceptContentType =
+                    (List<MediaType>)exchange.get(Message.ACCEPT_CONTENT_TYPE);
+
+                result = checkSubResultObject(result, subResourcePath);
+
+                Class<?> subResponseType = null;
+                if (result.getClass() == Class.class) {
+                    ResourceContext rc = new ResourceContextImpl(inMessage, ori);
+                    result = rc.getResource((Class<?>)result);
+                    subResponseType = InjectionUtils.getActualType(methodToInvoke.getGenericReturnType());
+                } else {
+                    subResponseType = methodToInvoke.getReturnType();
+                }
+                
+                subCri = cri.getSubResource(subResponseType,
+                    ClassHelper.getRealClass(exchange.getBus(), result), result);
+                if (subCri == null) {
+                    org.apache.cxf.common.i18n.Message errorM =
+                        new org.apache.cxf.common.i18n.Message("NO_SUBRESOURCE_FOUND",
+                                                               BUNDLE,
+                                                               subResourcePath);
+                    LOG.severe(errorM.toString());
+                    throw ExceptionUtils.toNotFoundException(null, null);
+                }
+
+                OperationResourceInfo subOri = JAXRSUtils.findTargetMethod(
+                                                         Collections.singletonMap(subCri, values),
+                                                         inMessage,
+                                                         httpMethod,
+                                                         values,
+                                                         contentType,
+                                                         acceptContentType);
+                exchange.put(OperationResourceInfo.class, subOri);
+                inMessage.put(URITemplate.TEMPLATE_PARAMETERS, values);
+
+                if (!subOri.isSubResourceLocator()
+                    && JAXRSUtils.runContainerRequestFilters(providerFactory,
+                                                             inMessage,
+                                                             false,
+                                                             subOri.getNameBindings())) {
+                    return new MessageContentsList(exchange.get(Response.class));
+                }
+
+                // work out request parameters for the sub-resource class. Here we
+                // presume InputStream has not been consumed yet by the root resource class.
+                List<Object> newParams = JAXRSUtils.processParameters(subOri, values, inMessage);
+                inMessage.setContent(List.class, newParams);
+
+                return this.invoke(exchange, newParams, result);
+            } catch (IOException ex) {
+                Response resp = JAXRSUtils.convertFaultToResponse(ex, inMessage);
+                if (resp == null) {
+                    resp = JAXRSUtils.convertFaultToResponse(ex, inMessage);
+                }
+                return new MessageContentsList(resp);
+            } catch (WebApplicationException ex) {
+                Response excResponse;
+                if (JAXRSUtils.noResourceMethodForOptions(ex.getResponse(),
+                        (String)inMessage.get(Message.HTTP_REQUEST_METHOD))) {
+                    excResponse = JAXRSUtils.createResponse(Collections.singletonList(subCri),
+                                                            null, null, 200, true);
+                } else {
+                    excResponse = JAXRSUtils.convertFaultToResponse(ex, inMessage);
+                }
+                return new MessageContentsList(excResponse);
+            }
+        }
+        setResponseContentTypeIfNeeded(inMessage, result);
+        return result;
+    }
+
+    // Liberty change start - CXF-7860
+    private List<Object> reprocessFormParams(Method method, List<Object> origParams, Message m) {
+        Form form = null;
+        boolean hasFormParamAnnotations = false;
+        Object[] newValues = new Object[origParams.size()];
+        java.lang.reflect.Parameter[] methodParams = method.getParameters();
+        for (int i = 0; i < methodParams.length; i++) {
+            if (Form.class.equals(methodParams[i].getType())) {
+                form = (Form) origParams.get(i);
+            }
+            if (methodParams[i].getAnnotation(FormParam.class) != null) {
+                hasFormParamAnnotations = true;
+            } else {
+                newValues[i] = origParams.get(i);
+            }
+        }
+
+        if (!hasFormParamAnnotations || form == null) {
+            return origParams;
+        }
+
+        for (int i = 0; i < newValues.length; i++) {
+            if (newValues[i] == null) {
+                String formFieldName = methodParams[i].getAnnotation(FormParam.class).value();
+                List<String> values = form.asMap().get(formFieldName);
+                newValues[i] = InjectionUtils.createParameterObject(values, 
+                                                                    methodParams[i].getType(),
+                                                                    methodParams[i].getParameterizedType(),
+                                                                    methodParams[i].getAnnotations(),
+                                                                    (String) origParams.get(i),
+                                                                    false,
+                                                                    ParameterType.FORM,
+                                                                    m);
+                if (LOG.isLoggable(Level.FINEST)) {
+                    LOG.log(Level.FINEST, "replacing @FormParam value of {0} with {1}",
+                        new Object[]{origParams.get(i), newValues[i]});
+                }
+            }
+        }
+        return Arrays.asList(newValues);
+    }
+    //Liberty change end
+
+    protected AsyncResponseImpl checkFutureResponse(Message inMessage, Object result) {
+        if (result instanceof CompletionStage) {
+            final CompletionStage<?> stage = (CompletionStage<?>)result;
+            final AsyncResponseImpl asyncResponse = new AsyncResponseImpl(inMessage);
+            stage.whenComplete((v, t) -> {
+                if (t instanceof CancellationException) {
+                    asyncResponse.cancel();
+                } else {
+                    asyncResponse.resume(v != null ? v : t);
+                }
+            });
+            return asyncResponse;
+        }
+        return null;
+    }
+
+    protected Method getMethodToInvoke(ClassResourceInfo cri, OperationResourceInfo ori, Object resourceObject) {
+        Method resourceMethod = cri.getMethodDispatcher().getMethod(ori);
+
+        Method methodToInvoke = null;
+        if (Proxy.class.isInstance(resourceObject)) {
+            methodToInvoke = cri.getMethodDispatcher().getProxyMethod(resourceMethod);
+            if (methodToInvoke == null) {
+                methodToInvoke = InjectionUtils.checkProxy(resourceMethod, resourceObject);
+                cri.getMethodDispatcher().addProxyMethod(resourceMethod, methodToInvoke);
+            }
+        } else {
+            methodToInvoke = resourceMethod;
+        }
+        return methodToInvoke;
+    }
+
+    private MessageContentsList checkExchangeForResponse(Exchange exchange) {
+        Response r = exchange.get(Response.class);
+        if (r != null) {
+            JAXRSUtils.setMessageContentType(exchange.getInMessage(), r);
+            return new MessageContentsList(r);
+        }
+        return null;
+    }
+
+    private void setResponseContentTypeIfNeeded(Message inMessage, Object response) {
+        if (response instanceof Response) {
+            JAXRSUtils.setMessageContentType(inMessage, (Response)response);
+        }
+    }
+    private Object handleFault(Throwable ex, Message inMessage) {
+        return handleFault(new Fault(ex), inMessage, null, null);
+    }
+    private Object handleFault(Fault ex, Message inMessage,
+                               ClassResourceInfo cri, Method methodToInvoke) {
+        String errorMessage = ex.getMessage();
+        if (errorMessage != null && cri != null
+            && errorMessage.contains(PROXY_INVOCATION_ERROR_FRAGMENT)) {
+            org.apache.cxf.common.i18n.Message errorM =
+                new org.apache.cxf.common.i18n.Message("PROXY_INVOCATION_FAILURE",
+                                                       BUNDLE,
+                                                       methodToInvoke,
+                                                       cri.getServiceClass().getName());
+            LOG.severe(errorM.toString());
+        }
+        Response excResponse =
+            JAXRSUtils.convertFaultToResponse(ex.getCause() == null ? ex : ex.getCause(), inMessage);
+        if (excResponse == null) {
+            inMessage.getExchange().put(Message.PROPOGATE_EXCEPTION,
+                                        ExceptionUtils.propogateException(inMessage));
+            throw ex;
+        }
+        return new MessageContentsList(excResponse);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected MultivaluedMap<String, String> getTemplateValues(Message msg) {
+        MultivaluedMap<String, String> values = new MetadataMap<String, String>();
+        MultivaluedMap<String, String> oldValues =
+            (MultivaluedMap<String, String>)msg.get(URITemplate.TEMPLATE_PARAMETERS);
+        if (oldValues != null) {
+            values.putAll(oldValues);
+        }
+        return values;
+    }
+
+    private boolean setServiceLoaderAsContextLoader(Message inMessage) {
+        Object en = inMessage.getContextualProperty(SERVICE_LOADER_AS_CONTEXT);
+        return Boolean.TRUE.equals(en) || "true".equals(en);
+    }
+
+    private boolean isServiceObjectRequestScope(Message inMessage) {
+        Object scope = inMessage.getContextualProperty(SERVICE_OBJECT_SCOPE);
+        return REQUEST_SCOPE.equals(scope);
+    }
+
+    private ResourceProvider getResourceProvider(Exchange exchange) {
+        Object provider = exchange.remove(JAXRSUtils.ROOT_PROVIDER);
+        if (provider == null) {
+            OperationResourceInfo ori = exchange.get(OperationResourceInfo.class);
+            ClassResourceInfo cri = ori.getClassResourceInfo();
+            return cri.getResourceProvider();
+        }
+        return (ResourceProvider)provider;
+    }
+
+    public Object getServiceObject(Exchange exchange) {
+
+        Object root = exchange.remove(JAXRSUtils.ROOT_INSTANCE);
+        if (root != null) {
+            return root;
+        }
+
+        OperationResourceInfo ori = exchange.get(OperationResourceInfo.class);
+        ClassResourceInfo cri = ori.getClassResourceInfo();
+
+        return cri.getResourceProvider().getInstance(exchange.getInMessage());
+    }
+
+    protected Object getActualServiceObject(Exchange exchange, Object rootInstance) {
+
+        Object last = exchange.get(LAST_SERVICE_OBJECT);
+        return last !=  null ? last : rootInstance;
+    }
+
+
+
+    private static Object checkResultObject(Object result) {
+
+        if (result != null) {
+            if (result instanceof MessageContentsList) {
+                result = ((MessageContentsList)result).get(0);
+            } else if (result instanceof List) {
+                result = ((List<?>)result).get(0);
+            } else if (result.getClass().isArray()) {
+                result = ((Object[])result)[0];
+            }
+        }
+        return result;
+    }
+    private static Object checkSubResultObject(Object result, String subResourcePath) {
+        result = checkResultObject(result);
+        if (result == null) {
+            org.apache.cxf.common.i18n.Message errorM =
+                new org.apache.cxf.common.i18n.Message("NULL_SUBRESOURCE",
+                                                       BUNDLE,
+                                                       subResourcePath);
+            LOG.info(errorM.toString());
+            throw ExceptionUtils.toNotFoundException(null, null);
+        }
+
+        return result;
+    }
+
+
+}
+


### PR DESCRIPTION
This is a temporary fix (until [CXF-7860](
https://issues.apache.org/jira/browse/CXF-7860) is pulled into a Liberty release).  This fixes the issue documented in JAX-RS API Issue [659](
https://github.com/eclipse-ee4j/jaxrs-api/issues/659) - where a parameter annotated with `@FormParam("value")` might have an injected value that does not match a `Form` parameter's value.

This PR includes the same change submitted to the CXF community, and also a test case.
