### PR TITLE
Fail startup if tmp dir is full.

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -161,7 +161,13 @@ safeEcho()
   cat <<EOF
 $*
 EOF
+
+  return $?
 }
+
+# Starting the server with a full tmp directory may prevent the server from
+# reading server.env during startup.
+safeEcho "" || exit $?
 
 # Define escapeForEval functions using ${var//find/replace} and ${var#suffix}
 # if possible since those constructs are significantly faster than safeEcho+sed


### PR DESCRIPTION
It was reported that starting the server with a full tmp directory
prevents the server from reading server.env causing the server to start
with the wrong environment vars.

fixes #4132 