### PR TITLE
begin and end request are not safe to invoke

### DIFF
--- a/dev/com.ibm.ws.jdbc/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc/resources/OSGI-INF/metatype/metatype.xml
@@ -78,6 +78,7 @@
    <Option value="commit"                         label="%commitRollbk.commit.desc"/>
    <Option value="rollback"                       label="%commitRollbk.rollback.desc"/>
   </AD>
+  <AD id="enableBeginEndRequest"                  name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="Boolean"/>
   <AD id="enableConnectionCasting"                name="%enblConCast"  description="%enblConCast.desc"  ibmui:group="Advanced" type="Boolean" default="false"/>
   <AD id="onConnect"                              name="%onConnect"    description="%onConnect.desc"    ibmui:group="Advanced" required="false" type="String"  cardinality="1000"/>
   <AD id="queryTimeout"                           name="%qryTimeout"   description="%qryTimeout.desc"   ibmui:group="Advanced" required="false" type="String"  ibm:type="duration(s)"/>

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corporation and others.
+ * Copyright (c) 2011, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,6 +44,7 @@ public class DSConfig implements FFDCSelfIntrospectable {
                     CONNECTION_MANAGER_REF = "connectionManagerRef",
                     CONNECTION_SHARING = "connectionSharing",
                     CONTAINER_AUTH_DATA_REF = "containerAuthDataRef",
+                    ENABLE_BEGIN_END_REQUEST = "enableBeginEndRequest", // Not a supported property. Only for internal testing/experimentation.
                     ENABLE_CONNECTION_CASTING = "enableConnectionCasting",
                     ENABLE_MULTITHREADED_ACCESS_DETECTION = "enableMultithreadedAccessDetection", // currently disabled in liberty profile
                     JDBC_DRIVER_REF = "jdbcDriverRef",
@@ -68,6 +69,7 @@ public class DSConfig implements FFDCSelfIntrospectable {
                                                                CONNECTION_SHARING,
                                                                CONTAINER_AUTH_DATA_REF,
                                                                DataSourceDef.isolationLevel.name(),
+                                                               ENABLE_BEGIN_END_REQUEST, // Not a supported property. Only for internal testing/experimentation.
                                                                ENABLE_CONNECTION_CASTING,
                                                                JDBC_DRIVER_REF,
                                                                ON_CONNECT,
@@ -112,6 +114,21 @@ public class DSConfig implements FFDCSelfIntrospectable {
      * Component with access to various core services needed for JDBC/connection management
      */
     public final ConnectorService connectorSvc;
+
+    /**
+     * Not a supported property. Only for internal testing/experimentation.
+     *
+     * Controls whether the Connection.beginRequest and Connection.endRequest hints are sent to the
+     * JDBC driver. These methods were introduced in JDBC 4.3, but without any guarantee that they
+     * will not lead to the JDBC driver corrupting the connection state while connections are in the
+     * pool. Therefore, beginRequest/endRequests are not supplied by the application server.
+     * This property can be used in internal development code to force the application server
+     * to send beginRequest/endRequest hints to the JDBC driver.
+     *
+     * WARNING: usage of this property can lead to unstable and unpredictable behavior.
+     * Do not enable this in production. 
+     */
+    public final boolean enableBeginEndRequest;
 
     /**
      * Indicates to automatically create a dynamic proxy for interfaces implemented by the connection. 
@@ -232,6 +249,7 @@ public class DSConfig implements FFDCSelfIntrospectable {
         beginTranForVendorAPIs = remove(BEGIN_TRAN_FOR_VENDOR_APIS, true);
         CommitOrRollbackOnCleanup commitOrRollback = remove(COMMIT_OR_ROLLBACK_ON_CLEANUP, null, CommitOrRollbackOnCleanup.class);
         connectionSharing = remove(CONNECTION_SHARING, ConnectionSharing.MatchOriginalRequest, ConnectionSharing.class);
+        enableBeginEndRequest = remove(ENABLE_BEGIN_END_REQUEST, false); // Not a supported property. Only for internal testing/experimentation.
         enableConnectionCasting = remove(ENABLE_CONNECTION_CASTING, false);
         enableMultithreadedAccessDetection = false;
         isolationLevel = remove(DataSourceDef.isolationLevel.name(), -1, -1, null, -1, 0, 1, 2, 4, 8, 16, 4096);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -543,7 +543,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
      */
     private final void addHandle(WSJdbcConnection handle) throws ResourceException {
         (numHandlesInUse < handlesInUse.length - 1 ? handlesInUse : resizeHandleList())[numHandlesInUse++] = handle;
-        if (!inRequest)
+        if (!inRequest && dsConfig.get().enableBeginEndRequest)
             try {
                 inRequest = true;
                 mcf.jdbcRuntime.beginRequest(sqlConn);

--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -22,7 +22,8 @@
 
   <authData id="user43Auth" user="user43" password="{xor}Lyg7a2w="/>
 
-  <dataSource id="DefaultDataSource">
+  <dataSource id="DefaultDataSource"
+              enableBeginEndRequest="true"> <!-- Not a supported property. Only for internal testing/experimentation. -->
     <jdbcDriver libraryRef="D43Lib"/>
     <properties url="jdbc:d43:memory:testdb;create=true" user="user43" password="{xor}Lyg7a2w="/>
   </dataSource>
@@ -43,14 +44,16 @@
     <properties databaseName="memory:testdb;create=true"/>
   </dataSource>
 
-  <dataSource jndiName="jdbc/poolOf1" type="javax.sql.ConnectionPoolDataSource">
+  <dataSource jndiName="jdbc/poolOf1" type="javax.sql.ConnectionPoolDataSource"
+              enableBeginEndRequest="true"> <!-- Not a supported property. Only for internal testing/experimentation. -->
     <connectionManager maxPoolSize="1"/>
     <jdbcDriver libraryRef="D43Lib"/>
     <properties databaseName="memory:testdb;create=true"/>
     <containerAuthData user="user43" password="{xor}Lyg7a2w="/>
   </dataSource>
 
-  <dataSource jndiName="jdbc/xa">
+  <dataSource jndiName="jdbc/xa"
+              enableBeginEndRequest="true"> <!-- Not a supported property. Only for internal testing/experimentation. -->
     <jdbcDriver libraryRef="D43Lib"/>
     <properties databaseName="memory:testdb;create=true"/>
     <containerAuthData user="user43" password="{xor}Lyg7a2w="/>


### PR DESCRIPTION
Given how we have seen JDBC driver implementations of the JDBC 4.3 spec methods Connection.beginRequest/Connection.endRequest with behavior that is contrary to the intent of the JDBC spec, and which will destabilize the connection pool and statement cache in a way that will adversely impact users, this pull updates OpenLiberty to stop invoking these optional methods.  We would be open to reintroducing invocation of these "hints" to the JDBC driver in future spec levels where the language around these methods is clarified to guarantee that connection state will not be corrupted.