### PR TITLE
should not assume that JDBC driver will allow reuse of connection builders

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ConnectionBuilder.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43ConnectionBuilder.java
@@ -17,6 +17,8 @@ import java.sql.SQLException;
 import java.sql.ShardingKey;
 
 public class D43ConnectionBuilder implements ConnectionBuilder {
+    private boolean built;
+
     private final D43DataSource d43DataSource;
 
     private String password;
@@ -30,6 +32,11 @@ public class D43ConnectionBuilder implements ConnectionBuilder {
 
     @Override
     public Connection build() throws SQLException {
+        if (built)
+            throw new IllegalStateException();
+        else
+            built = true;
+
         Connection con;
         if (user == null && password == null)
             con = d43DataSource.ds.getConnection();
@@ -44,24 +51,32 @@ public class D43ConnectionBuilder implements ConnectionBuilder {
 
     @Override
     public D43ConnectionBuilder password(String value) {
+        if (built)
+            throw new IllegalStateException();
         password = value;
         return this;
     }
 
     @Override
     public D43ConnectionBuilder shardingKey(ShardingKey value) {
+        if (built)
+            throw new IllegalStateException();
         shardingKey = value;
         return this;
     }
 
     @Override
     public D43ConnectionBuilder superShardingKey(ShardingKey value) {
+        if (built)
+            throw new IllegalStateException();
         superShardingKey = value;
         return this;
     }
 
     @Override
     public D43ConnectionBuilder user(String value) {
+        if (built)
+            throw new IllegalStateException();
         user = value;
         return this;
     }

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43PooledConnectionBuilder.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43PooledConnectionBuilder.java
@@ -18,6 +18,8 @@ import javax.sql.PooledConnection;
 import javax.sql.PooledConnectionBuilder;
 
 public class D43PooledConnectionBuilder implements PooledConnectionBuilder {
+    private boolean built;
+
     private final D43ConnectionPoolDataSource d43PoolDataSource;
 
     private String password;
@@ -31,6 +33,11 @@ public class D43PooledConnectionBuilder implements PooledConnectionBuilder {
 
     @Override
     public PooledConnection build() throws SQLException {
+        if (built)
+            throw new IllegalStateException();
+        else
+            built = true;
+
         PooledConnection con;
         if (user == null && password == null)
             con = d43PoolDataSource.ds.getPooledConnection();
@@ -45,24 +52,32 @@ public class D43PooledConnectionBuilder implements PooledConnectionBuilder {
 
     @Override
     public D43PooledConnectionBuilder password(String value) {
+        if (built)
+            throw new IllegalStateException();
         password = value;
         return this;
     }
 
     @Override
     public D43PooledConnectionBuilder shardingKey(ShardingKey value) {
+        if (built)
+            throw new IllegalStateException();
         shardingKey = value;
         return this;
     }
 
     @Override
     public D43PooledConnectionBuilder superShardingKey(ShardingKey value) {
+        if (built)
+            throw new IllegalStateException();
         superShardingKey = value;
         return this;
     }
 
     @Override
     public D43PooledConnectionBuilder user(String value) {
+        if (built)
+            throw new IllegalStateException();
         user = value;
         return this;
     }

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43XAConnectionBuilder.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/d43driver/src/org/test/d43/jdbc/D43XAConnectionBuilder.java
@@ -18,6 +18,8 @@ import javax.sql.XAConnection;
 import javax.sql.XAConnectionBuilder;
 
 public class D43XAConnectionBuilder implements XAConnectionBuilder {
+    private boolean built;
+
     private final D43XADataSource d43XADataSource;
 
     private String password;
@@ -31,6 +33,11 @@ public class D43XAConnectionBuilder implements XAConnectionBuilder {
 
     @Override
     public XAConnection build() throws SQLException {
+        if (built)
+            throw new IllegalStateException();
+        else
+            built = true;
+
         XAConnection con;
         if (user == null && password == null)
             con = d43XADataSource.ds.getXAConnection();
@@ -45,24 +52,32 @@ public class D43XAConnectionBuilder implements XAConnectionBuilder {
 
     @Override
     public D43XAConnectionBuilder password(String value) {
+        if (built)
+            throw new IllegalStateException();
         password = value;
         return this;
     }
 
     @Override
     public D43XAConnectionBuilder shardingKey(ShardingKey value) {
+        if (built)
+            throw new IllegalStateException();
         shardingKey = value;
         return this;
     }
 
     @Override
     public D43XAConnectionBuilder superShardingKey(ShardingKey value) {
+        if (built)
+            throw new IllegalStateException();
         superShardingKey = value;
         return this;
     }
 
     @Override
     public D43XAConnectionBuilder user(String value) {
+        if (built)
+            throw new IllegalStateException();
         user = value;
         return this;
     }


### PR DESCRIPTION
We should not be making the assumption that a JDBC driver will allow reuse of ConnectionBuilder/PooledConnectionBuilder/XAConnectionBuilder after it has been used to create a connection.  The JDBC 4.3 spec is silent in this area and so the behavior is left to the JDBC driver.  To enforce that we are not assume any particular behavior when using the JDBC driver's connection builders to create connections, I'll be updating our Mock JDBC 4.3 driver under this pull to reject build operations as well as mutator operations after build has been invoked for the first time. This will ensure we only use a connection builder instance once and that we have not (and will not in the future) coded any dependencies on vendor-specific JDBC driver behavior around connection builders.