### PR TITLE
Added -Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.ssl.trustonly/jvm.options
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.ssl.trustonly/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.ssl/jvm.options
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.ssl/jvm.options
@@ -11,3 +11,4 @@
 
 # JSSE trace
 -Djavax.net.debug=true
+-Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.ad.ssl/jvm.options
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.ad.ssl/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.outbound.ssl/jvm.options
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.outbound.ssl/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true


### PR DESCRIPTION


This fixes the following error:
javax.naming.CommunicationException: localhost:10636 [Root exception is javax.net.ssl.SSLHandshakeException: No name matching localhost found]
	at com.sun.jndi.ldap.Connection.<init>(java.naming@11-adoptopenjdk/Connection.java:237)
	at com.sun.jndi.ldap.LdapClient.<init>(java.naming@11-adoptopenjdk/LdapClient.java:137)
	at com.sun.jndi.ldap.LdapClient.getInstance(java.naming@11-adoptopenjdk/LdapClient.java:1616)