### PR TITLE
tests with jdbc-4.3 feature and older JDBC driver

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -59,6 +59,13 @@
     <containerAuthData user="user43" password="{xor}Lyg7a2w="/>
   </dataSource>
 
+  <!-- JDBC driver that only supports the 4.2 spec level -->
+  <dataSource jndiName="jdbc/xaDerby42" containerAuthDataRef="user43Auth"
+              enableBeginEndRequest="true"> <!-- Not a supported property. Only for internal testing/experimentation. -->
+    <jdbcDriver libraryRef="D43Lib"/>
+    <properties.derby.embedded databaseName="memory:testdb;create=true"/>
+  </dataSource>
+
   <!-- This is a Derby driver with custom implementations added for certain JDBC 4.3 methods -->
   <library id="D43Lib" fat.modify="true">
     <file name="${server.config.dir}/drivers/d43driver.jar"/>


### PR DESCRIPTION
Update the automated test bucket for the JDBC 4.3 feature to also use a JDBC driver that is of a spec level earlier than 4.3, such that it runs with the jdbc-4.3 feature enabled.  This will help verify that the jdbc-4.3 feature allows drivers at prior spec levels, as its intent is to support JDBC drivers up to and including 4.3.