### PR TITLE
fix a write race condition for multiple streams writing on a connection

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2InboundLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2InboundLink.java
@@ -738,7 +738,7 @@ public class H2InboundLink extends HttpInboundLink {
         }
 
         try {
-            H2WriteQEntry e = new H2WriteQEntry(buf, bufs, numBytes, timeout, H2WriteQEntry.WRITE_TYPE.SYNC, fType, payloadLength, streamID);
+            H2WriteQEntry e = new H2WriteQEntry(buf, bufs, numBytes, timeout, fType, payloadLength, streamID);
             e.armWriteCompleteLatch();
 
             action = writeQ.writeOrAddToQ(e);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2MuxTCPWriteCallback.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2MuxTCPWriteCallback.java
@@ -64,36 +64,6 @@ public class H2MuxTCPWriteCallback implements TCPWriteCompletedCallback {
             return;
         }
 
-        // If this was an async write, then invoke the original caller's callback
-        if (qEntry.getWriteType() == H2WriteQEntry.WRITE_TYPE.ASYNC) {
-            VirtualConnection eVC = qEntry.getConnectionContext().getVC();
-            TCPWriteRequestContext eTWC = qEntry.getConnectionContext().getWriteInterface();
-
-            try {
-                if (complete) {
-
-
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "invoke complete callback vc: " + eVC + " TWC: " + eTWC);
-                    }
-                    qEntry.getCallback().complete(eVC, eTWC);
-                } else {
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "invoke error callback vc: " + eVC + " TWC: " + eTWC);
-                    }
-                    qEntry.getCallback().error(eVC, eTWC, ioe);
-                }
-            } catch (Throwable t) {
-                // debug, not much else to do with it
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "caught a Throwable. log and leave: " + t);
-                }
-            }
-        }
-
-        // Having this after the callback is not good for performance, but issue is if there can be more than one write outstanding per a stream
-        // on the write queue, then writes could finish out of order if this is before the callback.
-        // Since most writes should be sync, hopefully this will not become an issue
         // Release waiting threads, Sync writes are waiting, and/or the queue service thread is waiting so it can start another write
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "hit write complete latch for qentry: " + qEntry.hashCode());

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2WorkQInterface.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2WorkQInterface.java
@@ -42,8 +42,6 @@ public interface H2WorkQInterface {
 
     public void setToQuit(boolean inDrainQ);
 
-    public void asyncCallbackComplete(H2WriteQEntry e);
-
     public WRITE_ACTION writeOrAddToQ(H2WriteQEntry n) throws FlowControlException;
 
     public void addNewNodeToQ(int streamID, int parentStreamID, int priority, boolean exclusive);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2WriteQEntry.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2WriteQEntry.java
@@ -16,7 +16,6 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.http.channel.internal.HttpMessages;
 import com.ibm.wsspi.bytebuffer.WsByteBuffer;
-import com.ibm.wsspi.tcpchannel.TCPWriteCompletedCallback;
 
 /**
  *
@@ -25,15 +24,10 @@ public class H2WriteQEntry {
 
     private static final TraceComponent tc = Tr.register(H2WriteQEntry.class, HttpMessages.HTTP_TRACE_NAME, HttpMessages.HTTP_BUNDLE);
 
-    public static enum WRITE_TYPE {
-        NOT_SET, SYNC, ASYNC
-    };
-
     WsByteBuffer buf = null;
     WsByteBuffer[] bufs = null;
     long minToWrite;
     int timeout;
-    WRITE_TYPE wType = WRITE_TYPE.NOT_SET;
     int priority = 0;
     FrameTypes frameType = FrameTypes.UNKNOWN;
     int payloadLength = 0;
@@ -46,31 +40,14 @@ public class H2WriteQEntry {
     // that is processing this entry
     boolean servicedOnQ = true;
 
-    H2TCPConnectionContext connectionContext = null;
-    TCPWriteCompletedCallback callback = null;
-
     int streamID = 0;
 
-    boolean forceQueue = false;
-
-    public H2WriteQEntry(WsByteBuffer inBuf, WsByteBuffer[] inBufs, long inMin, int inTimeout, WRITE_TYPE inType, FrameTypes fType, int inPayloadLength, int inStreamID) {
-
-        //  For a Sync write entry, the following are not use:  callback, forceQueue, connectionContext.
-        this(inBuf, inBufs, inMin, null, false, inTimeout, null, inType, fType, inPayloadLength, inStreamID);
-
-    }
-
-    public H2WriteQEntry(WsByteBuffer inBuf, WsByteBuffer[] inBufs, long inMin, TCPWriteCompletedCallback inCallback,
-                         boolean inForceQueue, int inTimeout, H2TCPConnectionContext inConnectionContext, WRITE_TYPE inType,
-                         FrameTypes fType, int inPayloadLength, int inStreamID) {
+    public H2WriteQEntry(WsByteBuffer inBuf, WsByteBuffer[] inBufs, long inMin,
+                         int inTimeout, FrameTypes fType, int inPayloadLength, int inStreamID) {
         buf = inBuf;
         bufs = inBufs;
         minToWrite = inMin;
         timeout = inTimeout;
-        wType = inType;
-        callback = inCallback;
-        forceQueue = inForceQueue;
-        connectionContext = inConnectionContext;
         frameType = fType;
         payloadLength = inPayloadLength;
         streamID = inStreamID;
@@ -136,24 +113,8 @@ public class H2WriteQEntry {
         return minToWrite;
     }
 
-    public WRITE_TYPE getWriteType() {
-        return wType;
-    }
-
     public int getTimeout() {
         return timeout;
-    }
-
-    public boolean getForceQueue() {
-        return forceQueue;
-    }
-
-    public TCPWriteCompletedCallback getCallback() {
-        return callback;
-    }
-
-    public H2TCPConnectionContext getConnectionContext() {
-        return connectionContext;
     }
 
     public int getStreamID() {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/priority/Node.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/priority/Node.java
@@ -31,9 +31,11 @@ public class Node {
 
     static public enum NODE_STATUS {
         REQUESTING_WRITE, // Stream/Node wants to write a frame
+        WRITE_LATCHED, // thread is waiting for the write to complete
         NOT_REQUESTING, // Stream/Node is not writing, but is not closed
         CLOSED, // Stream/Node is closed
-        ACTION_NO_CHANGE // This isn't a status/state, but a signal to methods that the status is not changing
+        ACTION_NO_CHANGE, // This isn't a status/state, but a signal to methods that the status is not changing
+        ACTION_RESET_IF_LATCHED // signal to move the state to NOT_REQUESTING if the current state is WRITE_LATCHED
     }
 
     static public enum WRITE_COUNT_ACTION {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/priority/Tree.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/priority/Tree.java
@@ -153,7 +153,13 @@ public class Tree {
 
         // Change status unless told not to
         if (status != NODE_STATUS.ACTION_NO_CHANGE) {
-            nodeToUpdate.setStatus(status);
+            if (status == NODE_STATUS.ACTION_RESET_IF_LATCHED) {
+                if (nodeToUpdate.getStatus() == NODE_STATUS.WRITE_LATCHED) {
+                    nodeToUpdate.setStatus(NODE_STATUS.NOT_REQUESTING);
+                }
+            } else {
+                nodeToUpdate.setStatus(status);
+            }
         }
 
         // Do the count action, unless it is NO_ACTION

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -2378,9 +2378,16 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
         }
         if (isOutgoingBodyValid()) {
             HttpInboundServiceContextImpl hisc = null;
-            if (wsbb == null && this instanceof HttpInboundServiceContextImpl) {
-                hisc = (HttpInboundServiceContextImpl) this;
+
+            if (this instanceof HttpInboundServiceContextImpl) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "sendFullOutgoing : getContentLength(): " + this.getContentLength());
+                }
+                if (wsbb == null || this.getContentLength() == -1) {
+                    hisc = (HttpInboundServiceContextImpl) this;
+                }
             }
+
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() && hisc != null && hisc.getLink() != null) {
                 Tr.debug(tc, "sendFullOutgoing : " + hisc + ", " + hisc.getLink().toString());
             }


### PR DESCRIPTION
Also, while updating the code to fix the race condition, I remove the internal async writing code of the H2 code.  This code is not used, but was present in case it would be required by the design, which it is not.  It was removed for this PR since it would have needed a similar update as then internal sync path to fix a probable race condition.