### PR TITLE
Improve support for installing individual ESAs

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -794,7 +794,7 @@ public class InstallKernelMap implements Map {
             if (subsystemEntry != null) {
                 Manifest m = ManifestProcessor.parseManifest(zip.getInputStream(subsystemEntry));
                 Attributes manifestAttrs = m.getMainAttributes();
-                String shortNameAttr = manifestAttrs.getValue(SHORTNAME_HEADER_NAME);
+                String shortNameAttr = manifestAttrs.getValue(SHORTNAME_HEADER_NAME); // TODO also try with Subsystem-SymbolicName
                 shortNameMap.put(esa.getCanonicalPath(), shortNameAttr);
             }
         } finally {
@@ -816,7 +816,6 @@ public class InstallKernelMap implements Map {
      * @throws InstallException
      */
     private File generateJsonFromIndividualESAs(Path jsonDirectory, Map<String, String> shortNameMap) throws IOException, BuildException, RepositoryException, InstallException {
-
         String dir = jsonDirectory.toString();
         List<File> esas = (List<File>) data.get(INDIVIDUAL_ESAS);
         File singleJson = new File(dir + "/SingleJson.json");
@@ -843,8 +842,11 @@ public class InstallKernelMap implements Map {
             RepositoryResourceWritable resource = parser.parseFileToResource(esa, null, null);
             resource.updateGeneratedFields(true);
             resource.setRepositoryConnection(mySingleFileRepo);
-            resource.uploadToMassive(new AddThenDeleteStrategy());
 
+            // Overload the Maven coordinates field with the file path, since the ESA should be installed from that path
+            resource.setMavenCoordinates(esa.getAbsolutePath());
+
+            resource.uploadToMassive(new AddThenDeleteStrategy());
         }
 
         return singleJson;

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -564,15 +565,17 @@ public class InstallKernelMap implements Map {
 
                     RepositoryConnection repo = new SingleFileRepositoryConnection(individualEsaJson);
                     repoList.add(repo);
-                    for (String feature : featureToInstall) {
-                        if (feature.endsWith(".esa")) {
-                            if (shortNameMap.containsKey(feature)) {
-                                String shortName = shortNameMap.get(feature);
-                                featureToInstall.remove(feature);
-                                featureToInstall.add(shortName);
-                            }
+
+                    List<String> shortNamesToInstall = new ArrayList<String>();
+                    Iterator<String> it = featureToInstall.iterator();
+                    while (it.hasNext()) {
+                        String feature = it.next();
+                        if (feature.endsWith(".esa") && shortNameMap.containsKey(feature)) {
+                            it.remove();
+                            shortNamesToInstall.add(shortNameMap.get(feature));
                         }
                     }
+                    featureToInstall.addAll(shortNamesToInstall);
                 }
             } catch (NullPointerException e) {
                 data.put(ACTION_RESULT, ERROR);


### PR DESCRIPTION
- Avoid ConcurrentModificationException when installing two individual ESAs, by not changing the contents of a collection while looping over its items.
- For individual ESAs that do not have Maven coordinates, set its file path instead, so that the file path can be retrieved by the plugin after features are resolved.
- For individual ESAs that do not have a short name, support using its symbolic name as the feature name instead.