### PR TITLE
Ensure MP Rest Client providers can be registered via MP Config

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/.classpath
@@ -9,6 +9,7 @@
 	<classpathentry kind="src" path="test-applications/asyncApp/src"/>
 	<classpathentry kind="src" path="test-applications/produceConsumeApp/src"/>
 	<classpathentry kind="src" path="test-applications/propsApp/src"/>
+	<classpathentry kind="src" path="test-applications/cdiPropsAndProvidersApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
@@ -17,6 +17,7 @@ src: \
   test-applications/basicClientApp/src,\
   test-applications/basicCdiClientApp/src,\
   test-applications/basicRemoteApp/src,\
+  test-applications/cdiPropsAndProvidersApp/src,\
   test-applications/headerPropagationApp/src,\
   test-applications/multiClientCdiApp/src,\
   test-applications/produceConsumeApp/src,\

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CdiPropsAndProvidersTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CdiPropsAndProvidersTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.rest.client.fat;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import mpRestClient11.cdiPropsAndProviders.CdiPropsAndProvidersTestServlet;
+
+@RunWith(FATRunner.class)
+public class CdiPropsAndProvidersTest extends FATServletClient {
+
+    private static final String appName = "cdiPropsAndProvidersApp";
+
+
+    @Server("mpRestClient11.cdiPropsAndProviders")
+    @TestServlet(servlet = CdiPropsAndProvidersTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @Server("mpRestClient10.remoteServer")
+    public static LibertyServer remoteAppServer;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(remoteAppServer, "basicRemoteApp", "remoteApp.basic");
+        remoteAppServer.startServer();
+
+        ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient11.cdiPropsAndProviders");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer();
+        remoteAppServer.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
@@ -23,6 +23,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 MultiClientCdiTest.class,
                 AsyncMethodTest.class,
                 ProduceConsumeTest.class,
-                PropsTest.class
+                PropsTest.class,
+                CdiPropsAndProvidersTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.cdiPropsAndProviders/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.cdiPropsAndProviders/bootstrap.properties
@@ -1,0 +1,10 @@
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+bootstrap.include=../testports.properties
+
+# enable the mpConfig for RestClient's baseURL
+mpRestClient11.cdiPropsAndProviders.CdiPropsAndProvidersClient/mp-rest/url=http://localhost:${bvt.prop.HTTP_secondary}/basicRemoteApp/basic
+
+org.jboss.weld.probe.allowRemoteAddress=.*
+org.jboss.weld.development=true

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.cdiPropsAndProviders/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.cdiPropsAndProviders/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+com.ibm.ws.logging.trace.specification=*=info
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.cdiPropsAndProviders/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.cdiPropsAndProviders/server.xml
@@ -1,0 +1,23 @@
+<server>
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>mpRestClient-1.1</feature>
+    <feature>mpConfig-1.3</feature>
+    <feature>cdi-2.0</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+  <variable name="mpRestClient11.cdiPropsAndProviders.CdiPropsAndProvidersClient/mp-rest/uri"
+            value="http://localhost:8020/basicRemoteApp/basic"/>
+
+  <variable name="mpRestClient11.cdiPropsAndProviders.CdiPropsAndProvidersClient/mp-rest/providers"
+            value="mpRestClient11.cdiPropsAndProviders.MyExceptionMapper,mpRestClient11.cdiPropsAndProviders.Filter1,mpRestClient11.cdiPropsAndProviders.Filter2,mpRestClient11.cdiPropsAndProviders.Filter3"/>
+
+  <variable name="mpRestClient11.cdiPropsAndProviders.CdiPropsAndProvidersClient/mp-rest/providers/mpRestClient11.cdiPropsAndProviders.Filter1/priority"
+            value="5000"/> <!-- Priorities.USER -->
+  <variable name="mpRestClient11.cdiPropsAndProviders.CdiPropsAndProvidersClient/mp-rest/providers/mpRestClient11.cdiPropsAndProviders.Filter2/priority"
+            value="4995"/> <!-- Priorities.USER - 5 -->
+  <variable name="mpRestClient11.cdiPropsAndProviders.CdiPropsAndProvidersClient/mp-rest/providers/mpRestClient11.cdiPropsAndProviders.Filter3/priority"
+            value="5005"/> <!-- Priorities.USER + 5 -->
+</server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/Bag.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/Bag.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.cdiPropsAndProviders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class Bag {
+
+    private static Bag INSTANCE;
+
+    synchronized static Bag getBag() {
+        if (INSTANCE == null) {
+            INSTANCE = new Bag();
+        }
+        return INSTANCE;
+    }
+
+    synchronized static void clear() {
+        INSTANCE = null;
+    }
+
+    final List<Class<?>> filtersInvoked = new ArrayList<>();
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/CdiPropsAndProvidersClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/CdiPropsAndProvidersClient.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.cdiPropsAndProviders;
+
+import java.util.Set;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@RegisterRestClient
+@RegisterProvider(value=Filter4.class, priority=Priorities.USER+10)
+@Path("/")
+public interface CdiPropsAndProvidersClient {
+    @GET
+    String get() throws MyException;
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/CdiPropsAndProvidersTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/CdiPropsAndProvidersTestServlet.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.cdiPropsAndProviders;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import mpRestClient10.basicCdi.BasicClientTestServlet;
+import mpRestClient10.basicCdi.BasicServiceClient;
+import mpRestClient10.basicCdi.DuplicateWidgetException;
+import mpRestClient10.basicCdi.MyFilter;
+import mpRestClient10.basicCdi.UnknownWidgetException;
+import mpRestClient10.basicCdi.Widget;
+
+@SuppressWarnings("serial")
+@ApplicationScoped
+@WebServlet(urlPatterns = "/CdiPropsAndProvidersTestServlet")
+public class CdiPropsAndProvidersTestServlet extends FATServlet {
+    Logger LOG = Logger.getLogger(CdiPropsAndProvidersTestServlet.class.getName());
+
+    @Inject
+    @RestClient
+    private CdiPropsAndProvidersClient client;
+
+    @Test
+    public void testProvidersAndPropertiesFromMPConfig(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        try {
+            client.get();
+            fail("Did not throw expected MyException from MyExceptionMapper specified in MP Config in server.xml");
+        } catch (MyException ex) {
+            // expected
+        } catch (WebApplicationException ex) {
+            Response r = ex.getResponse();
+            if (r != null && r.getStatus() == 409) {
+                // processed Filter4, but failed to go through MyExceptionMapper
+                fail("MyExceptionMapper provider (registered via MP Config in server.xml) was not invoked");
+            }
+            ex.printStackTrace();
+            fail("Unexpected web application exception - response code: " + r.getStatus());
+        }
+
+        Bag bag = Bag.getBag();
+        // 3 filters specified in MP Config + 1 specified on client interface
+        assertEquals(4, bag.filtersInvoked.size());
+
+        // priority order specified in same place as filters themselves
+        assertEquals("Filter2", bag.filtersInvoked.get(0).getSimpleName());
+        assertEquals("Filter1", bag.filtersInvoked.get(1).getSimpleName());
+        assertEquals("Filter3", bag.filtersInvoked.get(2).getSimpleName());
+        assertEquals("Filter4", bag.filtersInvoked.get(3).getSimpleName());
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/Filter1.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/Filter1.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.cdiPropsAndProviders;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+
+public class Filter1 implements ClientRequestFilter {
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.ws.rs.client.ClientRequestFilter#filter(javax.ws.rs.client.ClientRequestContext)
+     */
+    @Override
+    public void filter(ClientRequestContext crc) throws IOException {
+        Bag.getBag().filtersInvoked.add(this.getClass());
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/Filter2.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/Filter2.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.cdiPropsAndProviders;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+
+public class Filter2 implements ClientRequestFilter {
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.ws.rs.client.ClientRequestFilter#filter(javax.ws.rs.client.ClientRequestContext)
+     */
+    @Override
+    public void filter(ClientRequestContext crc) throws IOException {
+        Bag.getBag().filtersInvoked.add(this.getClass());
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/Filter3.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/Filter3.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.cdiPropsAndProviders;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+
+public class Filter3 implements ClientRequestFilter {
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.ws.rs.client.ClientRequestFilter#filter(javax.ws.rs.client.ClientRequestContext)
+     */
+    @Override
+    public void filter(ClientRequestContext crc) throws IOException {
+        Bag.getBag().filtersInvoked.add(this.getClass());
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/Filter4.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/Filter4.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.cdiPropsAndProviders;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Priority(Priorities.USER-10) // this should be overridden by the config in the client interface annotation
+public class Filter4 implements ClientRequestFilter {
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see javax.ws.rs.client.ClientRequestFilter#filter(javax.ws.rs.client.ClientRequestContext)
+     */
+    @Override
+    public void filter(ClientRequestContext crc) throws IOException {
+        Bag.getBag().filtersInvoked.add(this.getClass());
+        crc.abortWith(Response.status(409).build());
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/MyException.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/MyException.java
@@ -28,7 +28,6 @@ public class MyException extends Exception {
      */
     public MyException(String message) {
         super(message);
-        // TODO Auto-generated constructor stub
     }
 
     /**
@@ -36,7 +35,6 @@ public class MyException extends Exception {
      */
     public MyException(Throwable cause) {
         super(cause);
-        // TODO Auto-generated constructor stub
     }
 
     /**
@@ -45,7 +43,6 @@ public class MyException extends Exception {
      */
     public MyException(String message, Throwable cause) {
         super(message, cause);
-        // TODO Auto-generated constructor stub
     }
 
     /**
@@ -56,7 +53,6 @@ public class MyException extends Exception {
      */
     public MyException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
-        // TODO Auto-generated constructor stub
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/MyException.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/MyException.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.cdiPropsAndProviders;
+
+/**
+ *
+ */
+public class MyException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     *
+     */
+    public MyException() {
+        super();
+    }
+
+    /**
+     * @param message
+     */
+    public MyException(String message) {
+        super(message);
+        // TODO Auto-generated constructor stub
+    }
+
+    /**
+     * @param cause
+     */
+    public MyException(Throwable cause) {
+        super(cause);
+        // TODO Auto-generated constructor stub
+    }
+
+    /**
+     * @param message
+     * @param cause
+     */
+    public MyException(String message, Throwable cause) {
+        super(message, cause);
+        // TODO Auto-generated constructor stub
+    }
+
+    /**
+     * @param message
+     * @param cause
+     * @param enableSuppression
+     * @param writableStackTrace
+     */
+    public MyException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        // TODO Auto-generated constructor stub
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/MyExceptionMapper.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/cdiPropsAndProvidersApp/src/mpRestClient11/cdiPropsAndProviders/MyExceptionMapper.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient11.cdiPropsAndProviders;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+import mpRestClient10.basicCdi.DuplicateWidgetException;
+
+public class MyExceptionMapper implements ResponseExceptionMapper<MyException> {
+
+    @Override
+    public boolean handles(int status, MultivaluedMap<String, Object> headers) {
+        return status == 409; //Conflict
+    }
+
+    @Override
+    public MyException toThrowable(Response response) {
+        return new MyException();
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/bnd.bnd
@@ -20,11 +20,14 @@ javac.target: 1.8
 -buildpath: \
   org.apache.cxf:cxf-rt-rs-mp-client;version=3.2.6,\
   com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
+  com.ibm.websphere.javaee.cdi.1.2;version=latest,\
+  com.ibm.websphere.javaee.annotation.1.3;version=latest,\
   com.ibm.websphere.org.eclipse.microprofile.rest.client.1.1;version=latest,\
   com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
   com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+  com.ibm.ws.org.apache.cxf.cxf.core.3.2,\
   com.ibm.ws.jaxrs.2.0.common;version=latest,\
   com.ibm.ws.jaxrs.2.0.client;version=latest,\
   com.ibm.ws.logging.core;version=latest

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
@@ -1,0 +1,230 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.cdi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.PassivationCapable;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.ws.rs.Priorities;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+import org.apache.cxf.common.classloader.ClassLoaderUtils;
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.microprofile.client.CxfTypeSafeClientBuilder;
+import org.apache.cxf.microprofile.client.config.ConfigFacade;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+public class RestClientBean implements Bean<Object>, PassivationCapable {
+    private static final Logger LOG = LogUtils.getL7dLogger(RestClientBean.class); //Liberty change
+    public static final String REST_URL_FORMAT = "%s/mp-rest/url";
+    public static final String REST_URI_FORMAT = "%s/mp-rest/uri";
+    public static final String REST_SCOPE_FORMAT = "%s/mp-rest/scope";
+    public static final String REST_PROVIDERS_FORMAT = "%s/mp-rest/providers"; //Liberty change
+    public static final String REST_PROVIDERS_PRIORITY_FORMAT = "%s/mp-rest/providers/%s/priority"; //Liberty change
+    private static final Default DEFAULT_LITERAL = new DefaultLiteral();
+    private final Class<?> clientInterface;
+    private final Class<? extends Annotation> scope;
+    private final BeanManager beanManager;
+
+    public RestClientBean(Class<?> clientInterface, BeanManager beanManager) {
+        this.clientInterface = clientInterface;
+        this.beanManager = beanManager;
+        this.scope = this.readScope();
+    }
+    @Override
+    public String getId() {
+        return clientInterface.getName();
+    }
+
+    @Override
+    public Class<?> getBeanClass() {
+        return clientInterface;
+    }
+
+    @Override
+    public Set<InjectionPoint> getInjectionPoints() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
+    @Override
+    public Object create(CreationalContext<Object> creationalContext) {
+        //Liberty change start
+        RestClientBuilder builder = new CxfTypeSafeClientBuilder();
+        String baseUri = getBaseUri();
+        builder = ((CxfTypeSafeClientBuilder)builder).baseUri(URI.create(baseUri));
+        List<Class<?>> providers = getConfiguredProviders();
+        Map<Class<?>,Integer> providerPriorities = getConfiguredProviderPriorities(providers);
+        for (Class<?> providerClass : providers){
+            builder = builder.register(providerClass, 
+                                       providerPriorities.getOrDefault(providerClass, Priorities.USER));
+        }
+        return builder.build(clientInterface);
+        //Liberty change end
+    }
+
+    @Override
+    public void destroy(Object instance, CreationalContext<Object> creationalContext) {
+
+    }
+
+    @Override
+    public Set<Type> getTypes() {
+        return Collections.singleton(clientInterface);
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return new HashSet<>(Arrays.asList(DEFAULT_LITERAL, RestClient.RestClientLiteral.LITERAL));
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return scope;
+    }
+
+    @Override
+    public String getName() {
+        return clientInterface.getName();
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getStereotypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @FFDCIgnore(NoSuchElementException.class)
+    private String getBaseUri() {
+        String interfaceName = clientInterface.getName();
+        String property = String.format(REST_URI_FORMAT, interfaceName);
+        String baseURI = null;
+        try {
+            baseURI = ConfigFacade.getValue(property, String.class);
+        } catch (NoSuchElementException ex) {
+            // no-op - will revert to baseURL config value (as opposed to baseURI)
+        }
+        if (baseURI == null) {
+            // revert to baseUrl
+            property = String.format(REST_URL_FORMAT, interfaceName);
+            baseURI = ConfigFacade.getValue(property, String.class);
+            if (baseURI == null) {
+                throw new IllegalStateException("Unable to determine base URI from configuration");
+            }
+        }
+        return baseURI;
+    }
+
+    @FFDCIgnore(Exception.class)
+    private Class<? extends Annotation> readScope() {
+        // first check to see if the value is set
+        String property = String.format(REST_SCOPE_FORMAT, clientInterface.getName());
+        String configuredScope = ConfigFacade.getOptionalValue(property, String.class).orElse(null);
+        if (configuredScope != null) {
+            try {
+                return ClassLoaderUtils.loadClass(configuredScope, getClass(), Annotation.class);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("The scope " + configuredScope + " is invalid", e);
+            }
+        }
+
+        List<Annotation> possibleScopes = new ArrayList<>();
+        Annotation[] annotations = clientInterface.getDeclaredAnnotations();
+        for (Annotation annotation : annotations) {
+            if (beanManager.isScope(annotation.annotationType())) {
+                possibleScopes.add(annotation);
+            }
+        }
+        if (possibleScopes.isEmpty()) {
+            return Dependent.class;
+        } else if (possibleScopes.size() == 1) {
+            return possibleScopes.get(0).annotationType();
+        } else {
+            throw new IllegalArgumentException("The client interface " + clientInterface
+                    + " has multiple scopes defined " + possibleScopes);
+        }
+    }
+
+    //Liberty change start
+    @FFDCIgnore(ClassNotFoundException.class)
+    private List<Class<?>> getConfiguredProviders() {
+        String property = String.format(REST_PROVIDERS_FORMAT, clientInterface.getName());
+        String providersList = ConfigFacade.getOptionalValue(property, String.class).orElse("");
+        String[] providerClassNames = providersList.split(",");
+        List<Class<?>> providers = new ArrayList<>();
+        for (int i=0; i<providerClassNames.length; i++) {
+            try {
+                providers.add(ClassLoaderUtils.loadClass(providerClassNames[i], RestClientBean.class));
+            } catch (ClassNotFoundException e) {
+                LOG.log(Level.WARNING,
+                        "Could not load provider, {0}, configured for Rest Client interface, {1} ",
+                        new Object[]{providerClassNames[i], clientInterface.getName()});
+            }
+        }
+        return providers;
+    }
+
+    private Map<Class<?>, Integer> getConfiguredProviderPriorities(List<Class<?>> providers) {
+        Map<Class<?>, Integer> map = new HashMap<>();
+        for (Class<?> providerClass : providers) {
+            String property = String.format(REST_PROVIDERS_PRIORITY_FORMAT, 
+                                            clientInterface.getName(),
+                                            providerClass.getName());
+            Integer priority = ConfigFacade.getOptionalValue(property, Integer.class).orElse(Priorities.USER);
+            map.put(providerClass, priority);
+        }
+        return map;
+    }
+    //Liberty change end
+
+    private static final class DefaultLiteral extends AnnotationLiteral<Default> implements Default {
+        private static final long serialVersionUID = 1L;
+
+    }
+}


### PR DESCRIPTION
Fixes and tests that when a user registers/prioritizes providers via MP Config that the MP Rest Client honors that. This resolves issue #5363.