### PR TITLE
Fix publishWLPJars for -sub bnd files

### DIFF
--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -44,6 +44,27 @@ task publishWLPJars(type: Copy) {
       rename '(.*).jar', '$1' + "_${bnd.bFullVersion}.${qualifier}.jar"
     }
   }
+  if (!bnd('-sub', '').empty) {
+    def hasIFIXHeaders = [:]
+    fileTree(dir: projectDir, include: bnd('-sub', '')).each { subBndFile ->
+      Properties subBndProperties = new Properties()
+      subBndFile.withInputStream { subBndProperties.load(it) }
+      if (subBndProperties.getProperty("IBM-Interim-Fixes") != null
+          || subBndProperties.getProperty("IBM-Test-Fixes") != null) {
+        hasIFIXHeaders.put(subBndProperties.getProperty("Bundle-SymbolicName"), true)
+      }
+    }
+
+    eachFile {
+      // If the sub.bnd that built this jar contains iFix headers, rename it with a qualifer.
+      def symbolicName = it.getSourceName().substring(0, it.getSourceName().lastIndexOf("."))
+      if (!hasIFIXHeaders.get(symbolicName)) {
+        it.setName(symbolicName + "_${bnd.bFullVersion}.jar")
+      } else {
+        it.setName(symbolicName + "_${bnd.bFullVersion}.${qualifier}.jar")
+      }
+    }
+  }
 }
 
 task apiSpiJavadoc(type: Javadoc) {


### PR DESCRIPTION
Delivers a service fix so bundles created by sub Bnd builders get renamed properly in iFix builds.

Changes were also tested in:
https://github.ibm.com/was-liberty/open-liberty-service/pull/153