### PR TITLE
 Make Asynchronous methods return when they timeout

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIAsyncTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIAsyncTest.java
@@ -13,7 +13,6 @@ package com.ibm.websphere.microprofile.faulttolerance_fat.tests;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.ibm.ws.fat.util.LoggingTest;
@@ -65,7 +64,13 @@ public class CDIAsyncTest extends LoggingTest {
     }
 
     @Test
-    @Ignore // Known issues, reenable under #937
+    public void testAsyncTimoutNoInterrupt() throws Exception {
+        WebBrowser browser = createWebBrowserForTestCase();
+        getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/async?testMethod=testAsyncTimeoutNoInterrupt",
+                                         "SUCCESS");
+    }
+
+    @Test
     public void testAsyncDoubleJump() throws Exception {
         WebBrowser browser = createWebBrowserForTestCase();
         getSharedServer().verifyResponse(browser, "/CDIFaultTolerance/async?testMethod=testAsyncDoubleJump",

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/AsyncBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/AsyncBean.java
@@ -12,6 +12,7 @@ package com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import javax.enterprise.context.RequestScoped;
 
@@ -62,6 +63,26 @@ public class AsyncBean {
         System.out.println(System.currentTimeMillis() + " - " + CONNECT_C_DATA + " started");
         Thread.sleep(TestConstants.WORK_TIME);
         System.out.println(System.currentTimeMillis() + " - " + CONNECT_C_DATA + " returning");
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Asynchronous
+    @Timeout(TestConstants.TIMEOUT)
+    public Future<Void> waitNoInterrupt() {
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(TestConstants.WORK_TIME);
+        long startTime = System.nanoTime();
+
+        // This is a loop which will not respond to a thread interruption
+        // This is necessary to test that the future returned to the caller completes when
+        // the timeout expires, even if the method running doesn't respect it.
+        while (System.nanoTime() - startTime < waitNanos) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                // Ignore
+            }
+        }
+
         return CompletableFuture.completedFuture(null);
     }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
@@ -167,6 +167,9 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
             }
         }
 
+        QueuedFuture<R> queuedFuture = new QueuedFuture<>(context);
+        context.setQueuedFuture(queuedFuture);
+
         return super.execute(callable, executionContext);
     }
 
@@ -221,18 +224,18 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
                 if (contextService != null) {
                     threadContext = contextService.captureThreadContext(new HashMap<String, String>(), THREAD_CONTEXT_PROVIDERS);
                 }
-                QueuedFuture<R> queuedFuture = new QueuedFuture<>(innerTask, executionContext, threadContext);
+                QueuedFuture<R> queuedFuture = (QueuedFuture<R>) executionContext.getQueuedFuture();
 
                 try {
                     //begin the queuedFuture execution
                     executionContext.onQueued();
-                    queuedFuture.start(executorService);
+                    queuedFuture.start(executorService, innerTask, threadContext);
                     metricRecorder.incrementBulkeadAcceptedCount();
                 } catch (RejectedExecutionException e) {
                     //if the execution was rejected then end the execution and throw a BulkheadException
                     //TODO there might not really have been a bulkhead?? but it's pretty unlikely that the execution would
                     //be rejected otherwise!
-                    executionContext.close();
+                    executionContext.end();
 
                     metricRecorder.incrementBulkheadRejectedCount();
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
@@ -167,7 +167,7 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
             }
         }
 
-        QueuedFuture<R> queuedFuture = new QueuedFuture<>(context);
+        QueuedFuture<R> queuedFuture = new QueuedFuture<>();
         context.setQueuedFuture(queuedFuture);
 
         return super.execute(callable, executionContext);

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/QueuedFuture.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/QueuedFuture.java
@@ -12,7 +12,7 @@ package com.ibm.ws.microprofile.faulttolerance.impl.async;
 
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -31,58 +31,76 @@ import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 /**
  *
  */
-public class QueuedFuture<R> implements Future<R>, Callable<Future<R>> {
+public class QueuedFuture<R> implements Future<R>, Callable<Void> {
 
     private static final TraceComponent tc = Tr.register(QueuedFuture.class);
 
     //innerTask is the task which will be run on the new thread
-    private final Callable<Future<R>> innerTask;
-    //outerFuture is the Future which represents the execution of the innerTask
-    private Future<Future<R>> outerFuture;
+    private Callable<Future<R>> innerTask;
+
+    /**
+     * Future which will be completed with either the result or an exception
+     * <p>
+     * This will either complete when the task ends or when {@link #abort(Throwable)} is called
+     */
+    private CompletableFuture<Future<R>> resultFuture;
+
+    /**
+     * Future which controls the asynchronous execution of {@link #innerTask}
+     * <p>
+     * It's the future we got back from the execution service and can be used to cancel the execution.
+     * <p>
+     * Don't use it to get the result, use {@link #resultFuture} instead.
+     */
+    private Future<Void> taskFuture;
+
     //threadContext is the context retrieved from the originating thread
-    private final ThreadContextDescriptor threadContext;
+    private ThreadContextDescriptor threadContext;
     //executionContext is the overall FT execution context, covering both synchronous halves of the asynchronous execution
     private final ExecutionContextImpl executionContext;
-    //has the user called the cancel method
-    private boolean cancelled = false;
-    private boolean internallyCancelled = false;
 
-    public QueuedFuture(Callable<Future<R>> innerTask, ExecutionContextImpl executionContext, ThreadContextDescriptor threadContext) {
-        this.innerTask = innerTask;
+    public QueuedFuture(ExecutionContextImpl executionContext) {
         this.executionContext = executionContext;
-        this.threadContext = threadContext;
     }
 
     /** {@inheritDoc} */
     @Override
+    @FFDCIgnore({ ExecutionException.class })
     public boolean cancel(boolean mayInterruptIfRunning) {
-        synchronized (this) {
-            if (this.cancelled) {
-                return false; //if already cancelled then this call should fail
-            } else if (this.internallyCancelled) {
-                this.cancelled = true; //if this was internally cancelled then just set the flag and return true
-                return true;
-            } else {
-                //go ahead and cancel, return the result, setting the flags accordingly
-                boolean outerCancelled = getOuterFuture().cancel(mayInterruptIfRunning);
-                this.cancelled = outerCancelled;
-                this.internallyCancelled = outerCancelled;
-                return outerCancelled;
-            }
+        Future<Future<R>> resultFuture = getResultFuture();
+        boolean cancellationResult = resultFuture.cancel(false); // Result will always be a cancellation exception
 
+        if (cancellationResult) {
+            getTaskFuture().cancel(mayInterruptIfRunning); // Attempt to cancel the queued/running task
+        } else if (resultFuture.isDone()) {
+            try {
+                Future<R> innerFuture = resultFuture.get();
+                cancellationResult = innerFuture.cancel(mayInterruptIfRunning);
+            } catch (InterruptedException e) {
+                //outerFuture was done so we should never get an interrupted exception
+                throw new FaultToleranceException(e);
+            } catch (ExecutionException e) {
+                //this is most likely to be caused if an exception is thrown from the business method ... or a TimeoutException
+                //either way, the future cannot be cancelled
+                cancellationResult = false;
+            }
         }
+
+        return cancellationResult;
     }
 
     /**
-     * Cancel the inner future and interrupt if running but do not set the cancelled flag for this QueuedFuture.
+     * Complete the result future with the given exception and attempt to cancel the task.
+     * <p>
      * This is typically used as part of timeout.
      */
-    public void internalCancel() {
-        synchronized (this) {
-            if (!this.internallyCancelled) {
-                boolean outerCancelled = getOuterFuture().cancel(true);
-                this.internallyCancelled = outerCancelled;
-            }
+    public void abort(Throwable t) {
+        // Set the result to the given exception
+        boolean abortSuccessful = getResultFuture().completeExceptionally(t);
+
+        if (abortSuccessful) {
+            // Attempt to abort the task
+            getTaskFuture().cancel(true);
         }
     }
 
@@ -90,13 +108,13 @@ public class QueuedFuture<R> implements Future<R>, Callable<Future<R>> {
     @Override
     @FFDCIgnore({ ExecutionException.class })
     public boolean isCancelled() {
-        Future<Future<R>> outerFuture = getOuterFuture();
-        if (outerFuture.isDone()) {
-            if (outerFuture.isCancelled()) {
+        Future<Future<R>> resultFuture = getResultFuture();
+        if (resultFuture.isDone()) {
+            if (resultFuture.isCancelled()) {
                 return true;
             } else {
                 try {
-                    Future<R> innerFuture = outerFuture.get();
+                    Future<R> innerFuture = resultFuture.get();
                     return innerFuture.isCancelled();
                 } catch (InterruptedException e) {
                     //outerFuture was done so we should never get an interrupted exception
@@ -116,13 +134,13 @@ public class QueuedFuture<R> implements Future<R>, Callable<Future<R>> {
     @Override
     @FFDCIgnore({ ExecutionException.class })
     public boolean isDone() {
-        Future<Future<R>> outerFuture = getOuterFuture();
-        if (outerFuture.isDone()) {
-            if (outerFuture.isCancelled()) {
+        Future<Future<R>> resultFuture = getResultFuture();
+        if (resultFuture.isDone()) {
+            if (resultFuture.isCancelled()) {
                 return true;
             } else {
                 try {
-                    Future<R> innerFuture = outerFuture.get();
+                    Future<R> innerFuture = resultFuture.get();
                     return innerFuture.isDone();
                 } catch (InterruptedException e) {
                     //outerFuture was done so we should never get an interrupted exception
@@ -140,28 +158,13 @@ public class QueuedFuture<R> implements Future<R>, Callable<Future<R>> {
 
     /** {@inheritDoc} */
     @Override
-    @FFDCIgnore({ CancellationException.class, ExecutionException.class, org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException.class })
+    @FFDCIgnore({ ExecutionException.class })
     public R get() throws InterruptedException, ExecutionException {
         R result = null;
-        Future<Future<R>> outerFuture = getOuterFuture();
+        Future<Future<R>> resultFuture = getResultFuture();
 
         try {
-            executionContext.check();
-        } catch (org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException te) {
-            throw new ExecutionException(te);
-        }
-
-        try {
-            result = outerFuture.get().get();
-        } catch (InterruptedException | CancellationException e) {
-            //if the future was interrupted or cancelled, check if it was because the FT Timeout popped
-            try {
-                executionContext.check();
-            } catch (org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException te) {
-                throw new ExecutionException(te);
-            }
-
-            throw e;
+            result = resultFuture.get().get();
         } catch (ExecutionException e) {
             if (e.getCause() instanceof com.ibm.ws.microprofile.faulttolerance.spi.ExecutionException) {
                 throw new ExecutionException(e.getCause().getCause());
@@ -174,34 +177,19 @@ public class QueuedFuture<R> implements Future<R>, Callable<Future<R>> {
 
     /** {@inheritDoc} */
     @Override
-    @FFDCIgnore({ CancellationException.class, ExecutionException.class, org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException.class })
+    @FFDCIgnore({ ExecutionException.class })
     public R get(long methodTimeout, TimeUnit methodUnit) throws InterruptedException, ExecutionException, TimeoutException {
         R result = null;
-        Future<Future<R>> outerFuture = getOuterFuture();
-
-        try {
-            executionContext.check();
-        } catch (org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException te) {
-            throw new ExecutionException(te);
-        }
+        Future<Future<R>> resultFuture = getResultFuture();
 
         try {
             long start = System.nanoTime();
             long methodNanos = TimeUnit.NANOSECONDS.convert(methodTimeout, methodUnit);
-            Future<R> innerFuture = outerFuture.get(methodNanos, TimeUnit.NANOSECONDS);
+            Future<R> innerFuture = resultFuture.get(methodNanos, TimeUnit.NANOSECONDS);
             long middle = System.nanoTime();
             long diff = middle - start;
             long remaining = methodNanos - diff;
             result = innerFuture.get(remaining, TimeUnit.NANOSECONDS);
-        } catch (InterruptedException | CancellationException e) {
-            //if the future was interrupted or cancelled, check if it was because the FT Timeout popped
-            try {
-                executionContext.check();
-            } catch (org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException te) {
-                throw new ExecutionException(te);
-            }
-
-            throw e;
         } catch (ExecutionException e) {
             if (e.getCause() instanceof com.ibm.ws.microprofile.faulttolerance.spi.ExecutionException) {
                 throw new ExecutionException(e.getCause().getCause());
@@ -218,44 +206,78 @@ public class QueuedFuture<R> implements Future<R>, Callable<Future<R>> {
      * @throws Exception
      */
     @Override
-    public Future<R> call() throws Exception {
+    @FFDCIgnore(Throwable.class)
+    public Void call() throws Exception {
         Future<R> result = null;
+        Throwable thrownException = null;
 
-        ArrayList<ThreadContext> contextAppliedToThread = null;
-        if (this.threadContext != null) {
-            //apply the JEE contexts to the thread before calling the inner task
-            contextAppliedToThread = this.threadContext.taskStarting();
-        }
         try {
-            result = innerTask.call();
+            ArrayList<ThreadContext> contextAppliedToThread = null;
+            if (this.threadContext != null) {
+                //apply the JEE contexts to the thread before calling the inner task
+                contextAppliedToThread = this.threadContext.taskStarting();
+            }
+            try {
+                result = innerTask.call();
+            } finally {
+                if (contextAppliedToThread != null) {
+                    //remove the JEE contexts again since the thread will be re-used
+                    this.threadContext.taskStopping(contextAppliedToThread);
+                }
+            }
+        } catch (Throwable e) {
+            if (e instanceof com.ibm.ws.microprofile.faulttolerance.spi.ExecutionException) {
+                thrownException = e.getCause();
+            } else {
+                thrownException = e;
+            }
         } finally {
-            if (contextAppliedToThread != null) {
-                //remove the JEE contexts again since the thread will be re-used
-                this.threadContext.taskStopping(contextAppliedToThread);
+            // We've finished running and caught any exceptions that occurred, now store the result in the resultFuture
+            // If abort() has already been called then the result future will already be completed and the result (or exception) here is discarded.
+            if (thrownException == null) {
+                resultFuture.complete(result);
+            } else {
+                resultFuture.completeExceptionally(thrownException);
             }
         }
-        return result;
+        return null;
     }
 
-    private Future<Future<R>> getOuterFuture() {
+    private CompletableFuture<Future<R>> getResultFuture() {
         synchronized (this) {
-            if (this.outerFuture == null) {
+            if (this.resultFuture == null) {
                 //shouldn't be possible unless the QueuedFuture was created but not started
                 throw new IllegalStateException(Tr.formatMessage(tc, "internal.error.CWMFT4999E"));
             }
         }
-        return this.outerFuture;
+        return this.resultFuture;
+    }
+
+    private Future<Void> getTaskFuture() {
+        synchronized (this) {
+            if (this.taskFuture == null) {
+                //shouldn't be possible unless the QueuedFuture was created but not started
+                throw new IllegalStateException(Tr.formatMessage(tc, "internal.error.CWMFT4999E"));
+            }
+        }
+        return this.taskFuture;
     }
 
     /**
      * Submit this task for execution by the given executor service.
      *
-     * @param executorService
+     * @param executorService the executor service to use
+     * @param innerTask the task to run
+     * @param threadContext the thread context to apply when running the task
      */
-    public void start(ExecutorService executorService) {
+    public void start(ExecutorService executorService, Callable<Future<R>> innerTask, ThreadContextDescriptor threadContext) {
         synchronized (this) {
+            this.innerTask = innerTask;
+            this.threadContext = threadContext;
+            //set up the future to hold the result
+            this.resultFuture = new CompletableFuture<Future<R>>();
             //submit the innerTask (wrapped by this) for execution
-            this.outerFuture = executorService.submit(this);
+            this.taskFuture = executorService.submit(this);
         }
     }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/QueuedFutureTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/QueuedFutureTest.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance.test;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.faulttolerance.impl.async.QueuedFuture;
+import com.ibm.ws.microprofile.faulttolerance.test.util.TestException;
+
+/**
+ * Tests for basic functionality for QueuedFuture
+ */
+public class QueuedFutureTest {
+
+    private static ExecutorService executor;
+
+    private final List<CompletableFuture<?>> latches = new ArrayList<>();
+
+    @BeforeClass
+    public static void setupExecutor() {
+        executor = Executors.newFixedThreadPool(10);
+    }
+
+    @AfterClass
+    public static void cleanupExecutor() throws InterruptedException {
+        executor.shutdownNow();
+        executor.awaitTermination(5, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void testCancellation() {
+        QueuedFuture<Void> qf = new QueuedFuture<>();
+
+        CompletableFuture<Void> latch = newLatch();
+
+        qf.start(executor, waitOnLatch(latch), null);
+        assertFalse("Queued future cancelled", qf.isCancelled());
+        assertFalse("Queued future done", qf.isDone());
+
+        assertTrue("Failed to cancel queued future", qf.cancel(true));
+
+        assertTrue("Queued future not cancelled", qf.isCancelled());
+        assertTrue("Queued future not done", qf.isDone());
+
+        // Reading the contract for Future.cancel(), I thought this should return false.
+        // However, all implementations I could find return true when canceling an already cancelled future.
+        assertTrue("Cancelling already cancelled future should return true", qf.cancel(true));
+    }
+
+    @Test
+    public void testGet() throws InterruptedException, ExecutionException, TimeoutException {
+        QueuedFuture<String> qf = new QueuedFuture<>();
+
+        CompletableFuture<String> latch = newLatch();
+
+        qf.start(executor, waitOnLatch(latch), null);
+        assertFalse("Queued future cancelled", qf.isCancelled());
+        assertFalse("Queued future done", qf.isDone());
+
+        latch.complete("OK");
+        assertEquals("Incorrect result returned", "OK", qf.get(2, TimeUnit.MINUTES));
+        assertTrue("Queued future not done", qf.isDone());
+        assertFalse("Queued future cancelled", qf.isCancelled());
+
+        assertFalse("Succeeded in cancelling already completed future", qf.cancel(true));
+    }
+
+    @Test
+    public void testAbort() {
+        QueuedFuture<String> qf = new QueuedFuture<>();
+
+        CompletableFuture<String> latch = newLatch();
+
+        qf.start(executor, waitOnLatch(latch), null);
+        assertFalse("Queued future cancelled", qf.isCancelled());
+        assertFalse("Queued future done", qf.isDone());
+
+        qf.abort(new TestException());
+        assertThrows(qf, TestException.class);
+        assertTrue("Queued future not done", qf.isDone());
+        assertFalse("Queued future cancelled", qf.isCancelled());
+
+        assertFalse("Succeeded in cancelling aborted future", qf.cancel(true));
+
+        // The task completing should not change the queued future result
+        latch.complete("OK");
+        assertTrue("Queued future not done", qf.isDone());
+        assertFalse("Queued future cancelled", qf.isCancelled());
+        assertFalse("Succeeded in cancelling aborted future", qf.cancel(true));
+        assertThrows(qf, TestException.class);
+    }
+
+    private void assertThrows(Future<?> future, Class<? extends Exception> expectedException) {
+        try {
+            future.get(2, TimeUnit.MINUTES);
+            fail("Future did not throw expected exception");
+        } catch (ExecutionException e) {
+            assertThat("Thrown exception is the wrong type", e.getCause(), instanceOf(expectedException));
+        } catch (InterruptedException e) {
+            throw new AssertionError("Getting future result was interrupted", e);
+        } catch (CancellationException e) {
+            throw new AssertionError("Future was cancelled", e);
+        } catch (TimeoutException e) {
+            throw new AssertionError("Timed out waiting for future to complete", e);
+        }
+    }
+
+    private <T> Callable<Future<T>> waitOnLatch(Future<T> latch) {
+        return () -> CompletableFuture.completedFuture(latch.get());
+    }
+
+    private <T> CompletableFuture<T> newLatch() {
+        CompletableFuture<T> latch = new CompletableFuture<>();
+        latches.add(latch);
+        return latch;
+    }
+
+}


### PR DESCRIPTION
Fixes #3919 

Make Asynchronous methods as soon as they timeout, rather than waiting for the method to actually return.

This change adds the ability to abort the execution of an asynchronous method and set its result immediately.

We can then use this to abort execution of an asynchronous method when a timeout occurs.

However, we can't do this if Retry or Fallback are in use as they need to capture and handle the exception and return a different result.

In addition, some refactoring of ExecutionContextImpl and QueuedFuture was required to ensure that we take the correct code paths when starting execution of an asynchronous method. The exising code could cause the calling thread to be interrupted if the timeout occurred before the asynchronous method started running.

I think this also makes the async double call scenario work (either way, the test now passes so I've enabled it).