### PR TITLE
allow external builds to find pre-release mp concurrency binary

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -187,7 +187,6 @@ org.eclipse.jetty.websocket:websocket-client:9.4.5.v20170502
 org.eclipse.jetty.websocket:websocket-client:9.4.7.RC0
 org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502
 org.eclipse.jetty.websocket:websocket-common:9.4.7.RC0
-org.eclipse.microprofile.concurrency:microprofile-concurrency-api:1.0-SNAPSHOT
 org.eclipse.microprofile.config:microprofile-config-api:1.1
 org.eclipse.microprofile.config:microprofile-config-api:1.2.1
 org.eclipse.microprofile.config:microprofile-config-api:1.3

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -68,6 +68,7 @@ com.ibm.ws.org.objenesis:objenesis:1.0
 com.ibm.ws.commons-collections:commons-collections:3.2.1
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 com.ibm.ws.org.eclipse.jdt.core.compiler:ecj:4.4.2
+com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api:0.20181004.214427.5-2
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.antlr:2.6.8.WAS-71e88a9
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.asm:2.6.8.WAS-71e88a9
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.core:2.6.8.WAS-71e88a9

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.concurrent.mp-1.0
 visibility=private
 singleton=true
 -bundles=\
-  com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.concurrency:microprofile-concurrency-api:1.0",\
+  com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api:0.20181004.214427.5-2",\
   com.ibm.ws.concurrent.mp.1.0
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0/bnd.bnd
@@ -24,7 +24,7 @@ Export-Package: \
   org.eclipse.microprofile.concurrent.spi;version=1.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.concurrency:microprofile-concurrency-api;1.0}
+  @${repo;com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api;0.20181004.214427.5-2;EXACT}
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 


### PR DESCRIPTION
The pre-release MicroProfile Concurrency binary that we are using to build against was only available internally.  This pull should make it possible to build this code externally as well.