### PR TITLE
Unzip app to temp directory to prevent test issue

### DIFF
--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
@@ -330,9 +330,12 @@ public class FATTest extends AbstractAppManagerTest {
             server.copyFileToLibertyServerRoot(PUBLISH_FILES, "tmp",
                                                SNOOP_WAR);
 
-            //unzip the application into the location so that we can easily modify the application in a minute
+            //unzip the application into a temp location so that we can easily modify the application in a minute
             TestUtils.unzip(new File(server.getServerRoot() + "/tmp/snoop.war"),
-                            new File(server.getServerRoot() + "/apps/snoop.war"));
+                            new File(server.getServerRoot() + "/tmp/unzip/snoop.war"));
+
+            // Copy the expanded snoop.war to "apps"
+            server.renameLibertyServerRootFile("tmp/unzip/snoop.war", "apps/snoop.war");
 
             //make sure the started message has been output twice by the server (once earlier, once now).
             assertNotNull("The snoop application never resumed running after being stopped",


### PR DESCRIPTION
We need to unzip snoop.war to a temp location rather than directly to "apps" so that we don't start the app before classes are available. Otherwise, we can get ClassNotFound exceptions until the app updates again. 