### PR TITLE
Change acceptLicense requirement depending on feature license and runtime

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -607,8 +607,16 @@ public class InstallKernelMap implements Map {
                 for (RepositoryResource repoResrc : item) {
                     String license = repoResrc.getLicenseId();
                     if (license != null) {
-                        boolean isNDRuntime = false; // TODO check whether the current runtime is ND
+                        // determine whether the runtime is ND
+                        boolean isNDRuntime = false;
+                        for (ProductInfo productInfo : ProductInfo.getAllProductInfo().values()) {
+                            if (productInfo.getReplacedBy() == null && "com.ibm.websphere.appserver".equals(productInfo.getId()) && "ND".equals(productInfo.getEdition())) {
+                                isNDRuntime = true;
+                                break;
+                            }
+                        }
 
+                        // determine whether the license should be auto accepted
                         boolean autoAcceptLicense = license.startsWith(LICENSE_EPL_PREFIX) || license.equals(LICENSE_FEATURE_TERMS)
                                                     || (isNDRuntime && license.equals(LICENSE_FEATURE_TERMS_RESTRICTED));
 

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -610,7 +610,7 @@ public class InstallKernelMap implements Map {
                         // determine whether the runtime is ND
                         boolean isNDRuntime = false;
                         for (ProductInfo productInfo : ProductInfo.getAllProductInfo().values()) {
-                            if (productInfo.getReplacedBy() == null && "com.ibm.websphere.appserver".equals(productInfo.getId()) && "ND".equals(productInfo.getEdition())) {
+                            if ("com.ibm.websphere.appserver".equals(productInfo.getId()) && "ND".equals(productInfo.getEdition())) {
                                 isNDRuntime = true;
                                 break;
                             }

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -118,7 +118,8 @@ public class InstallKernelMap implements Map {
 
     // License identifiers
     private static final String LICENSE_EPL_PREFIX = "https://www.eclipse.org/legal/epl-";
-    private static final String LICENSE_FEATURE_TERMS_PREFIX = "http://www.ibm.com/licenses/wlp-featureterms-";
+    private static final String LICENSE_FEATURE_TERMS = "http://www.ibm.com/licenses/wlp-featureterms-v1";
+    private static final String LICENSE_FEATURE_TERMS_RESTRICTED = "http://www.ibm.com/licenses/wlp-featureterms-restricted-v1";
 
     private enum ActionType {
         install,
@@ -605,11 +606,19 @@ public class InstallKernelMap implements Map {
             for (List<RepositoryResource> item : resolveResult) {
                 for (RepositoryResource repoResrc : item) {
                     String license = repoResrc.getLicenseId();
-                    if (license != null && !(license.startsWith(LICENSE_EPL_PREFIX) || license.startsWith(LICENSE_FEATURE_TERMS_PREFIX))) {
-                        Boolean accepted = (Boolean) data.get(LICENSE_ACCEPT);
-                        if (accepted == null || !accepted) {
-                            featuresResolved.clear(); // clear the result since the licenses were not accepted
-                            throw new InstallException(Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_LICENSES_NOT_ACCEPTED"));
+                    if (license != null) {
+                        boolean isNDRuntime = false; // TODO check whether the current runtime is ND
+
+                        boolean autoAcceptLicense = license.startsWith(LICENSE_EPL_PREFIX) || license.equals(LICENSE_FEATURE_TERMS)
+                                                    || (isNDRuntime && license.equals(LICENSE_FEATURE_TERMS_RESTRICTED));
+
+                        if (!autoAcceptLicense) {
+                            // check whether the license has been accepted
+                            Boolean accepted = (Boolean) data.get(LICENSE_ACCEPT);
+                            if (accepted == null || !accepted) {
+                                featuresResolved.clear(); // clear the result since the licenses were not accepted
+                                throw new InstallException(Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_LICENSES_NOT_ACCEPTED"));
+                            }
                         }
                     }
 


### PR DESCRIPTION
Change acceptLicense to not be required if any of the following are true:
- feature license is EPL
- feature license is standard feature terms
- feature license is restricted feature terms **and** runtime is ND