### PR TITLE
reduce references to internals in test code

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/bnd.bnd
@@ -17,6 +17,10 @@ Bundle-Description: Placeholder that indicates the lack of a MicroProfile Concur
 
 WS-TraceGroup: concurrent
 
+Import-Package:\
+  com.ibm.ws.context.service.serializable,*
+# TODO the above is a temporary workaround for a test case that accesses internals. Remove once the test is updated
+
 Private-Package:\
   com.ibm.ws.concurrent.ee.*
 

--- a/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/bnd.bnd
@@ -17,11 +17,27 @@ Bundle-Description: Placeholder that indicates the lack of a MicroProfile Concur
 
 WS-TraceGroup: concurrent
 
-Export-Package:\
-  com.ibm.ws.concurrent.mp
-    
-instrument.classesExcludes: com/ibm/ws/concurrent/mp/resources/*.class
+Private-Package:\
+  com.ibm.ws.concurrent.ee.*
+
+instrument.classesExcludes: com/ibm/ws/concurrent/ee/resources/*.class
+
+-dsannotations: \
+  com.ibm.ws.concurrent.ee.ContextServiceImpl,\
+  com.ibm.ws.concurrent.ee.ManagedExecutorServiceImpl,\
+  com.ibm.ws.concurrent.ee.ManagedScheduledExecutorServiceImpl
 
 -buildpath: \
   com.ibm.websphere.appserver.spi.logging,\
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest
+  com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
+  com.ibm.websphere.org.osgi.core,\
+  com.ibm.websphere.org.osgi.service.component,\
+  com.ibm.ws.app.manager.lifecycle;version=latest,\
+  com.ibm.ws.bnd.annotations;version=latest, \
+  com.ibm.ws.concurrency.policy;version=latest,\
+  com.ibm.ws.concurrent;version=latest,\
+  com.ibm.ws.context;version=latest,\
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+  com.ibm.ws.resource;version=latest,\
+  com.ibm.wsspi.org.osgi.service.component.annotations,\
+  com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest

--- a/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ContextServiceImpl.java
@@ -8,21 +8,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.concurrent.mp;
+package com.ibm.ws.concurrent.ee;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.Dictionary;
 
 import javax.enterprise.concurrent.ContextService;
 
-import org.eclipse.microprofile.concurrent.ThreadContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -37,32 +28,29 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.service.AbstractContextService;
+import com.ibm.ws.context.service.serializable.ThreadContextManager;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
 import com.ibm.wsspi.resource.ResourceFactory;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
- * Super class of ContextServiceImpl to be used with Java 8 and above.
- * This class provides implementation of the MicroProfile Concurrency methods.
- * These methods can be collapsed into ContextServiceImpl once there is
- * no longer a need for OpenLiberty to support Java 7.
+ * Subclass of com.ibm.ws.concurrent.internal.ContextServiceImpl to be used with Java 7,
+ * where the MicroProfile Concurrency interfaces (which require Java 8) are unavailable.
+ *
+ * The purpose of this class is to define ContextServiceImpl as an OSGi service component
+ * that provides only the EE Concurrency spec and not MicroProfile Concurrency.
  */
 @Component(name = "com.ibm.ws.context.service",
            configurationPolicy = ConfigurationPolicy.REQUIRE,
-           service = { ResourceFactory.class, ContextService.class, ThreadContext.class, WSContextService.class, ApplicationRecycleComponent.class },
-           property = { "creates.objectClass=javax.enterprise.concurrent.ContextService",
-                        "creates.objectClass=org.eclipse.microprofile.concurrent.ThreadContext" })
-public class ThreadContextImpl extends AbstractContextService implements ThreadContext {
+           service = { ResourceFactory.class, ContextService.class, WSContextService.class, ApplicationRecycleComponent.class },
+           property = { "creates.objectClass=javax.enterprise.concurrent.ContextService" })
+@Trivial
+public class ContextServiceImpl extends AbstractContextService {
     @Activate
     @Override
     @Trivial
     protected void activate(ComponentContext context) {
         super.activate(context);
-    }
-
-    @Override
-    public Executor currentContextExecutor() {
-        return null; // TODO
     }
 
     @Deactivate
@@ -112,50 +100,5 @@ public class ThreadContextImpl extends AbstractContextService implements ThreadC
     @Trivial
     protected void unsetThreadContextManager(WSContextService svc) {
         super.unsetThreadContextManager(svc);
-    }
-
-    @Override
-    public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> stage) {
-        return null; // TODO
-    }
-
-    @Override
-    public <T> CompletionStage<T> withContextCapture(CompletionStage<T> stage) {
-        return null; // TODO
-    }
-
-    @Override
-    public <T, U> BiConsumer<T, U> withCurrentContext(BiConsumer<T, U> consumer) {
-        return null; // TODO
-    }
-
-    @Override
-    public <T, U, R> BiFunction<T, U, R> withCurrentContext(BiFunction<T, U, R> function) {
-        return null; // TODO
-    }
-
-    @Override
-    public <R> Callable<R> withCurrentContext(Callable<R> callable) {
-        return null; // TODO
-    }
-
-    @Override
-    public <T> Consumer<T> withCurrentContext(Consumer<T> consumer) {
-        return null; // TODO
-    }
-
-    @Override
-    public <T, R> Function<T, R> withCurrentContext(Function<T, R> function) {
-        return null; // TODO
-    }
-
-    @Override
-    public Runnable withCurrentContext(Runnable runnable) {
-        return null; // TODO
-    }
-
-    @Override
-    public <R> Supplier<R> withCurrentContext(Supplier<R> supplier) {
-        return null; // TODO
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ContextServiceImpl.java
@@ -43,10 +43,13 @@ import com.ibm.wsspi.threadcontext.WSContextService;
            property = { "creates.objectClass=javax.enterprise.concurrent.ContextService" })
 @Trivial
 public class ContextServiceImpl extends AbstractContextService {
+    private String name; // TODO temporarily exists to accommodate test case
+
     @Activate
     @Override
     protected void activate(ComponentContext context) {
         super.activate(context);
+        name = super.name;
     }
 
     @Deactivate
@@ -59,6 +62,7 @@ public class ContextServiceImpl extends AbstractContextService {
     @Override
     protected void modified(ComponentContext context) {
         super.modified(context);
+        name = super.name;
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ContextServiceImpl.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.ee;
 
-import java.util.Dictionary;
-
 import javax.enterprise.concurrent.ContextService;
 
 import org.osgi.framework.ServiceReference;
@@ -28,7 +26,6 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.service.AbstractContextService;
-import com.ibm.ws.context.service.serializable.ThreadContextManager;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
 import com.ibm.wsspi.resource.ResourceFactory;
 import com.ibm.wsspi.threadcontext.WSContextService;
@@ -48,21 +45,18 @@ import com.ibm.wsspi.threadcontext.WSContextService;
 public class ContextServiceImpl extends AbstractContextService {
     @Activate
     @Override
-    @Trivial
     protected void activate(ComponentContext context) {
         super.activate(context);
     }
 
     @Deactivate
     @Override
-    @Trivial
     protected void deactivate(ComponentContext context) {
         super.deactivate(context);
     }
 
     @Modified
     @Override
-    @Trivial
     protected void modified(ComponentContext context) {
         super.modified(context);
     }
@@ -74,7 +68,6 @@ public class ContextServiceImpl extends AbstractContextService {
                policy = ReferencePolicy.DYNAMIC,
                policyOption = ReferencePolicyOption.GREEDY,
                target = "(id=unbound)")
-    @Trivial
     protected void setBaseInstance(ServiceReference<ContextService> ref) {
         super.setBaseInstance(ref);
     }
@@ -85,19 +78,16 @@ public class ContextServiceImpl extends AbstractContextService {
                cardinality = ReferenceCardinality.MANDATORY,
                policy = ReferencePolicy.STATIC,
                target = "(component.name=com.ibm.ws.context.manager)")
-    @Trivial
     protected void setThreadContextManager(WSContextService svc) {
         super.setThreadContextManager(svc);
     }
 
     @Override
-    @Trivial
     protected void unsetBaseInstance(ServiceReference<ContextService> ref) {
         super.unsetBaseInstance(ref);
     }
 
     @Override
-    @Trivial
     protected void unsetThreadContextManager(WSContextService svc) {
         super.unsetThreadContextManager(svc);
     }

--- a/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ManagedExecutorServiceImpl.java
@@ -43,63 +43,63 @@ import com.ibm.wsspi.threadcontext.WSContextService;
 @Trivial
 public class ManagedExecutorServiceImpl extends AbstractManagedExecutorService {
     @Activate
-    @Trivial
+    @Override
     protected void activate(ComponentContext context, Map<String, Object> properties) {
         super.activate(context, properties);
     }
 
     @Deactivate
-    @Trivial
+    @Override
     protected void deactivate(ComponentContext context) {
         super.deactivate(context);
     }
 
     @Modified
-    @Trivial
+    @Override
     protected void modified(final ComponentContext context, Map<String, Object> properties) {
         super.modified(context, properties);
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
-    @Trivial
+    @Override
     protected void setConcurrencyPolicy(ConcurrencyPolicy svc) {
         super.setConcurrencyPolicy(svc);
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
-    @Trivial
+    @Override
     protected void setContextService(ServiceReference<WSContextService> ref) {
         super.setContextService(ref);
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(id=unbound)")
-    @Trivial
+    @Override
     protected void setLongRunningPolicy(ConcurrencyPolicy svc) {
         super.setLongRunningPolicy(svc);
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(component.name=com.ibm.ws.transaction.context.provider)")
-    @Trivial
+    @Override
     protected void setTransactionContextProvider(ServiceReference<ThreadContextProvider> ref) {
         super.setTransactionContextProvider(ref);
     }
 
-    @Trivial
+    @Override
     protected void unsetConcurrencyPolicy(ConcurrencyPolicy svc) {
         super.unsetConcurrencyPolicy(svc);
     }
 
-    @Trivial
+    @Override
     protected void unsetContextService(ServiceReference<WSContextService> ref) {
         super.unsetContextService(ref);
     }
 
-    @Trivial
+    @Override
     protected void unsetLongRunningPolicy(ConcurrencyPolicy svc) {
         super.unsetLongRunningPolicy(svc);
     }
 
-    @Trivial
+    @Override
     protected void unsetTransactionContextProvider(ServiceReference<ThreadContextProvider> ref) {
         super.unsetTransactionContextProvider(ref);
     }

--- a/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ManagedExecutorServiceImpl.java
@@ -8,17 +8,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.concurrent.mp;
+package com.ibm.ws.concurrent.ee;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
-import java.util.function.Supplier;
 
 import javax.enterprise.concurrent.ManagedExecutorService;
 
-import org.eclipse.microprofile.concurrent.ManagedExecutor;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -32,7 +28,6 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrency.policy.ConcurrencyPolicy;
-import com.ibm.ws.concurrent.rx.ManagedCompletableFuture;
 import com.ibm.ws.concurrent.service.AbstractManagedExecutorService;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleCoordinator;
@@ -40,33 +35,17 @@ import com.ibm.wsspi.resource.ResourceFactory;
 import com.ibm.wsspi.threadcontext.ThreadContextProvider;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
-/**
- * Super class of ManagedExecutorServiceImpl to be used with Java 8 and above.
- * This class provides implementation of the MicroProfile Concurrency methods.
- * These methods can be collapsed into ManagedExecutorServiceImpl once there is
- * no longer a need for OpenLiberty to support Java 7.
- */
 @Component(configurationPid = "com.ibm.ws.concurrent.managedExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
-           service = { ExecutorService.class, ManagedExecutor.class, ManagedExecutorService.class, ResourceFactory.class, ApplicationRecycleComponent.class },
+           service = { ExecutorService.class, ManagedExecutorService.class, ResourceFactory.class, ApplicationRecycleComponent.class },
            reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class),
            property = { "creates.objectClass=java.util.concurrent.ExecutorService",
-                        "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
-                        "creates.objectClass=org.eclipse.microprofile.concurrent.ManagedExecutor" })
-public class ManagedExecutorImpl extends AbstractManagedExecutorService implements ManagedExecutor {
+                        "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService" })
+@Trivial
+public class ManagedExecutorServiceImpl extends AbstractManagedExecutorService {
     @Activate
     @Trivial
     protected void activate(ComponentContext context, Map<String, Object> properties) {
         super.activate(context, properties);
-    }
-
-    @Override
-    public <U> CompletableFuture<U> completedFuture(U value) {
-        return ManagedCompletableFuture.completedFuture(value, this);
-    }
-
-    @Override
-    public <U> CompletionStage<U> completedStage(U value) {
-        return ManagedCompletableFuture.completedStage(value, this);
     }
 
     @Deactivate
@@ -75,30 +54,10 @@ public class ManagedExecutorImpl extends AbstractManagedExecutorService implemen
         super.deactivate(context);
     }
 
-    @Override
-    public <U> CompletableFuture<U> failedFuture(Throwable ex) {
-        return ManagedCompletableFuture.failedFuture(ex, this);
-    }
-
-    @Override
-    public <U> CompletionStage<U> failedStage(Throwable ex) {
-        return ManagedCompletableFuture.failedStage(ex, this);
-    }
-
     @Modified
     @Trivial
     protected void modified(final ComponentContext context, Map<String, Object> properties) {
         super.modified(context, properties);
-    }
-
-    @Override
-    public <U> CompletableFuture<U> newIncompleteFuture() {
-        return null; // TODO
-    }
-
-    @Override
-    public CompletableFuture<Void> runAsync(Runnable runnable) {
-        return ManagedCompletableFuture.runAsync(runnable, this);
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
@@ -123,11 +82,6 @@ public class ManagedExecutorImpl extends AbstractManagedExecutorService implemen
     @Trivial
     protected void setTransactionContextProvider(ServiceReference<ThreadContextProvider> ref) {
         super.setTransactionContextProvider(ref);
-    }
-
-    @Override
-    public <U> CompletableFuture<U> supplyAsync(Supplier<U> supplier) {
-        return ManagedCompletableFuture.supplyAsync(supplier, this);
     }
 
     @Trivial

--- a/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ManagedScheduledExecutorServiceImpl.java
@@ -52,38 +52,34 @@ import com.ibm.wsspi.threadcontext.WSContextService;
                         "creates.objectClass=java.util.concurrent.ScheduledExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedScheduledExecutorService" })
+@Trivial
 public class ManagedScheduledExecutorServiceImpl extends AbstractManagedScheduledExecutorService {
     @Activate
     @Override
-    @Trivial
     protected void activate(ComponentContext context, Map<String, Object> properties) {
         super.activate(context, properties);
     }
 
     @Deactivate
     @Override
-    @Trivial
     protected void deactivate(ComponentContext context) {
         super.deactivate(context);
     }
 
     @Modified
     @Override
-    @Trivial
     protected void modified(ComponentContext context, Map<String, Object> properties) {
         super.modified(context, properties);
     }
 
     @Override
     @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
-    @Trivial
     protected void setConcurrencyPolicy(ConcurrencyPolicy svc) {
         super.setConcurrencyPolicy(svc);
     }
 
     @Override
     @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
-    @Trivial
     protected void setContextService(ServiceReference<WSContextService> ref) {
         super.setContextService(ref);
     }
@@ -97,44 +93,37 @@ public class ManagedScheduledExecutorServiceImpl extends AbstractManagedSchedule
 
     @Override
     @Reference(target = "(deferrable=false)")
-    @Trivial
     protected void setScheduledExecutor(ScheduledExecutorService svc) {
         super.setScheduledExecutor(svc);
     }
 
     @Override
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(component.name=com.ibm.ws.transaction.context.provider)")
-    @Trivial
     protected void setTransactionContextProvider(ServiceReference<ThreadContextProvider> ref) {
         super.setTransactionContextProvider(ref);
     }
 
     @Override
-    @Trivial
     protected void unsetConcurrencyPolicy(ConcurrencyPolicy svc) {
         super.unsetConcurrencyPolicy(svc);
     }
 
     @Override
-    @Trivial
     protected void unsetContextService(ServiceReference<WSContextService> ref) {
         super.unsetContextService(ref);
     }
 
     @Override
-    @Trivial
     protected void unsetLongRunningPolicy(ConcurrencyPolicy svc) {
         super.unsetLongRunningPolicy(svc);
     }
 
     @Override
-    @Trivial
     protected void unsetScheduledExecutor(ScheduledExecutorService svc) {
         super.unsetScheduledExecutor(svc);
     }
 
     @Override
-    @Trivial
     protected void unsetTransactionContextProvider(ServiceReference<ThreadContextProvider> ref) {
         super.unsetTransactionContextProvider(ref);
     }

--- a/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/ManagedScheduledExecutorServiceImpl.java
@@ -8,17 +8,15 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.concurrent.mp;
+package com.ibm.ws.concurrent.ee;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
-import java.util.function.Supplier;
+import java.util.concurrent.ScheduledExecutorService;
 
 import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 
-import org.eclipse.microprofile.concurrent.ManagedExecutor;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -32,8 +30,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrency.policy.ConcurrencyPolicy;
-import com.ibm.ws.concurrent.rx.ManagedCompletableFuture;
-import com.ibm.ws.concurrent.service.AbstractManagedExecutorService;
+import com.ibm.ws.concurrent.service.AbstractManagedScheduledExecutorService;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleCoordinator;
 import com.ibm.wsspi.resource.ResourceFactory;
@@ -41,84 +38,71 @@ import com.ibm.wsspi.threadcontext.ThreadContextProvider;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
- * Super class of ManagedExecutorServiceImpl to be used with Java 8 and above.
- * This class provides implementation of the MicroProfile Concurrency methods.
- * These methods can be collapsed into ManagedExecutorServiceImpl once there is
- * no longer a need for OpenLiberty to support Java 7.
+ * All declarative services annotations on this class are ignored.
+ * The annotations on
+ * com.ibm.ws.concurrent.ee.ManagedScheduledExecutorServiceImpl and
+ * com.ibm.ws.concurrent.mp.ManagedScheduledExecutorImpl
+ * apply instead.
  */
-@Component(configurationPid = "com.ibm.ws.concurrent.managedExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
-           service = { ExecutorService.class, ManagedExecutor.class, ManagedExecutorService.class, ResourceFactory.class, ApplicationRecycleComponent.class },
+@Component(configurationPid = "com.ibm.ws.concurrent.managedScheduledExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
+           service = { ExecutorService.class, ManagedExecutorService.class, ResourceFactory.class, ApplicationRecycleComponent.class, ScheduledExecutorService.class,
+                       ManagedScheduledExecutorService.class },
            reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class),
            property = { "creates.objectClass=java.util.concurrent.ExecutorService",
+                        "creates.objectClass=java.util.concurrent.ScheduledExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
-                        "creates.objectClass=org.eclipse.microprofile.concurrent.ManagedExecutor" })
-public class ManagedExecutorImpl extends AbstractManagedExecutorService implements ManagedExecutor {
+                        "creates.objectClass=javax.enterprise.concurrent.ManagedScheduledExecutorService" })
+public class ManagedScheduledExecutorServiceImpl extends AbstractManagedScheduledExecutorService {
     @Activate
+    @Override
     @Trivial
     protected void activate(ComponentContext context, Map<String, Object> properties) {
         super.activate(context, properties);
     }
 
-    @Override
-    public <U> CompletableFuture<U> completedFuture(U value) {
-        return ManagedCompletableFuture.completedFuture(value, this);
-    }
-
-    @Override
-    public <U> CompletionStage<U> completedStage(U value) {
-        return ManagedCompletableFuture.completedStage(value, this);
-    }
-
     @Deactivate
+    @Override
     @Trivial
     protected void deactivate(ComponentContext context) {
         super.deactivate(context);
     }
 
-    @Override
-    public <U> CompletableFuture<U> failedFuture(Throwable ex) {
-        return ManagedCompletableFuture.failedFuture(ex, this);
-    }
-
-    @Override
-    public <U> CompletionStage<U> failedStage(Throwable ex) {
-        return ManagedCompletableFuture.failedStage(ex, this);
-    }
-
     @Modified
+    @Override
     @Trivial
-    protected void modified(final ComponentContext context, Map<String, Object> properties) {
+    protected void modified(ComponentContext context, Map<String, Object> properties) {
         super.modified(context, properties);
     }
 
     @Override
-    public <U> CompletableFuture<U> newIncompleteFuture() {
-        return null; // TODO
-    }
-
-    @Override
-    public CompletableFuture<Void> runAsync(Runnable runnable) {
-        return ManagedCompletableFuture.runAsync(runnable, this);
-    }
-
     @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
     @Trivial
     protected void setConcurrencyPolicy(ConcurrencyPolicy svc) {
         super.setConcurrencyPolicy(svc);
     }
 
+    @Override
     @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
     @Trivial
     protected void setContextService(ServiceReference<WSContextService> ref) {
         super.setContextService(ref);
     }
 
+    @Override
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(id=unbound)")
     @Trivial
     protected void setLongRunningPolicy(ConcurrencyPolicy svc) {
         super.setLongRunningPolicy(svc);
     }
 
+    @Override
+    @Reference(target = "(deferrable=false)")
+    @Trivial
+    protected void setScheduledExecutor(ScheduledExecutorService svc) {
+        super.setScheduledExecutor(svc);
+    }
+
+    @Override
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(component.name=com.ibm.ws.transaction.context.provider)")
     @Trivial
     protected void setTransactionContextProvider(ServiceReference<ThreadContextProvider> ref) {
@@ -126,25 +110,30 @@ public class ManagedExecutorImpl extends AbstractManagedExecutorService implemen
     }
 
     @Override
-    public <U> CompletableFuture<U> supplyAsync(Supplier<U> supplier) {
-        return ManagedCompletableFuture.supplyAsync(supplier, this);
-    }
-
     @Trivial
     protected void unsetConcurrencyPolicy(ConcurrencyPolicy svc) {
         super.unsetConcurrencyPolicy(svc);
     }
 
+    @Override
     @Trivial
     protected void unsetContextService(ServiceReference<WSContextService> ref) {
         super.unsetContextService(ref);
     }
 
+    @Override
     @Trivial
     protected void unsetLongRunningPolicy(ConcurrencyPolicy svc) {
         super.unsetLongRunningPolicy(svc);
     }
 
+    @Override
+    @Trivial
+    protected void unsetScheduledExecutor(ScheduledExecutorService svc) {
+        super.unsetScheduledExecutor(svc);
+    }
+
+    @Override
     @Trivial
     protected void unsetTransactionContextProvider(ServiceReference<ThreadContextProvider> ref) {
         super.unsetTransactionContextProvider(ref);

--- a/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/package-info.java
+++ b/dev/com.ibm.ws.concurrent.mp.0.0.0.noImpl/src/com/ibm/ws/concurrent/ee/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "concurrent")
+package com.ibm.ws.concurrent.ee;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
@@ -25,6 +25,9 @@ WS-TraceGroup: concurrent
 Export-Package:\
   com.ibm.ws.concurrent.rx
   # TODO remove the above export once ManagedCompletableFuture is fully transitioned to MicroProfile Concurrency interfaces
+
+Private-Package:\
+  com.ibm.ws.concurrent.mp
     
 instrument.classesExcludes: com/ibm/ws/concurrent/mp/resources/*.class
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
@@ -23,19 +23,31 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 WS-TraceGroup: concurrent
 
 Export-Package:\
-  com.ibm.ws.concurrent.mp,\
   com.ibm.ws.concurrent.rx
   # TODO remove the above export once ManagedCompletableFuture is fully transitioned to MicroProfile Concurrency interfaces
     
 instrument.classesExcludes: com/ibm/ws/concurrent/mp/resources/*.class
 
+-dsannotations: \
+  com.ibm.ws.concurrent.mp.ManagedExecutorImpl,\
+  com.ibm.ws.concurrent.mp.ManagedScheduledExecutorImpl,\
+  com.ibm.ws.concurrent.mp.ThreadContextImpl
+
 -buildpath: \
   com.ibm.websphere.appserver.spi.logging,\
   com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
   com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0,\
-  com.ibm.websphere.org.osgi.core;version=latest,\
+  com.ibm.websphere.org.osgi.core,\
+  com.ibm.websphere.org.osgi.service.component,\
+  com.ibm.ws.app.manager.lifecycle;version=latest,\
+  com.ibm.ws.bnd.annotations;version=latest, \
+  com.ibm.ws.concurrency.policy;version=latest,\
   com.ibm.ws.concurrent;version=latest,\
   com.ibm.ws.context;version=latest,\
   com.ibm.ws.kernel.service;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+  com.ibm.ws.resource;version=latest,\
+  com.ibm.wsspi.org.osgi.service.component.annotations,\
+  com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest,\
   com.ibm.ws.threading;version=latest
+  

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
@@ -42,7 +42,7 @@ import com.ibm.wsspi.resource.ResourceFactory;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
- * Super class of ContextServiceImpl to be used with Java 8 and above.
+ * Subclass of ContextServiceImpl to be used with Java 8 and above.
  * This class provides implementation of the MicroProfile Concurrency methods.
  * These methods can be collapsed into ContextServiceImpl once there is
  * no longer a need for OpenLiberty to support Java 7.

--- a/dev/com.ibm.ws.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent/bnd.bnd
@@ -20,7 +20,8 @@ WS-TraceGroup: concurrent
 IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 Export-Package:\
-  com.ibm.ws.concurrent
+  com.ibm.ws.concurrent,\
+  com.ibm.ws.concurrent.service
     
 Private-Package:\
   com.ibm.ws.concurrent.internal.*,\
@@ -51,11 +52,6 @@ Service-Component:\
     immediate:=true;\
     deferrableScheduledExecutor='java.util.concurrent.ScheduledExecutorService(deferrable=true)';\
     metadataIdentifierService=com.ibm.ws.container.service.metadata.extended.MetaDataIdentifierService
-    
--dsannotations: \
-  com.ibm.ws.concurrent.internal.ContextServiceImpl,\
-  com.ibm.ws.concurrent.internal.ManagedExecutorServiceImpl,\
-  com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl
 
 instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 
@@ -68,7 +64,6 @@ instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 	com.ibm.ws.app.manager.lifecycle;version=latest,\
 	com.ibm.ws.bnd.annotations;version=latest, \
 	com.ibm.ws.concurrency.policy;version=latest,\
-	com.ibm.ws.concurrent.mp.0.0.0.noImpl;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.context;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -52,7 +52,6 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.concurrent.mp.ThreadContextImpl;
 import com.ibm.ws.context.service.serializable.ContextualCallable;
 import com.ibm.ws.context.service.serializable.ContextualInvocationHandler;
 import com.ibm.ws.context.service.serializable.ContextualObject;
@@ -71,12 +70,18 @@ import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
  * Captures and propagates thread context.
+ *
+ * All declarative services annotations on this class are ignored.
+ * The annotations on
+ * com.ibm.ws.concurrent.ee.ContextServiceImpl and
+ * com.ibm.ws.concurrent.mp.ThreadContextImpl
+ * apply instead.
  */
 @Component(name = "com.ibm.ws.context.service",
            configurationPolicy = ConfigurationPolicy.REQUIRE,
            service = { ResourceFactory.class, ContextService.class, WSContextService.class, ApplicationRecycleComponent.class },
            property = { "creates.objectClass=javax.enterprise.concurrent.ContextService" })
-public class ContextServiceImpl extends ThreadContextImpl implements ContextService, ResourceFactory, WSContextService, ApplicationRecycleComponent {
+public class ContextServiceImpl implements ContextService, ResourceFactory, WSContextService, ApplicationRecycleComponent {
     private static final TraceComponent tc = Tr.register(ContextServiceImpl.class);
 
     // Names of references

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -125,7 +125,7 @@ public class ContextServiceImpl implements ContextService, ResourceFactory, WSCo
      * Name of this thread context service.
      * The name is the jndiName if specified, otherwise the config id.
      */
-    private String name;
+    protected String name; // TODO this is temporarily switched from private to protected in order to accommodate test case
 
     /**
      * Service properties.

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -49,7 +49,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrency.policy.ConcurrencyPolicy;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
-import com.ibm.ws.concurrent.mp.ManagedExecutorImpl;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.ws.threading.PolicyExecutor;
@@ -62,12 +61,19 @@ import com.ibm.wsspi.resource.ResourceInfo;
 import com.ibm.wsspi.threadcontext.ThreadContextProvider;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
+/**
+ * All declarative services annotations on this class are ignored.
+ * The annotations on
+ * com.ibm.ws.concurrent.ee.ManagedExecutorServiceImpl and
+ * com.ibm.ws.concurrent.mp.ManagedExecutorImpl
+ * apply instead.
+ */
 @Component(configurationPid = "com.ibm.ws.concurrent.managedExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
            service = { ExecutorService.class, ManagedExecutorService.class, ResourceFactory.class, ApplicationRecycleComponent.class },
            reference = @Reference(name = ManagedExecutorServiceImpl.APP_RECYCLE_SERVICE, service = ApplicationRecycleCoordinator.class),
            property = { "creates.objectClass=java.util.concurrent.ExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService" })
-public class ManagedExecutorServiceImpl extends ManagedExecutorImpl implements ExecutorService, ManagedExecutorService, ResourceFactory, ApplicationRecycleComponent, WSManagedExecutorService {
+public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecutorService, ResourceFactory, ApplicationRecycleComponent, WSManagedExecutorService {
     private static final TraceComponent tc = Tr.register(ManagedExecutorServiceImpl.class);
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
@@ -45,6 +45,13 @@ import com.ibm.wsspi.resource.ResourceFactory;
 import com.ibm.wsspi.threadcontext.ThreadContextProvider;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
+/**
+ * All declarative services annotations on this class are ignored.
+ * The annotations on
+ * com.ibm.ws.concurrent.ee.ManagedScheduledExecutorServiceImpl and
+ * com.ibm.ws.concurrent.mp.ManagedScheduledExecutorImpl
+ * apply instead.
+ */
 @Component(configurationPid = "com.ibm.ws.concurrent.managedScheduledExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
            service = { ExecutorService.class, ManagedExecutorService.class, ResourceFactory.class, ApplicationRecycleComponent.class, ScheduledExecutorService.class,
                        ManagedScheduledExecutorService.class },
@@ -76,7 +83,6 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     /**
      * Reference to the (unmanaged) scheduled executor service for this managed scheduled executor service.
      */
-    @Reference(target = "(deferrable=false)")
     ScheduledExecutorService scheduledExecSvc;
 
     @Activate
@@ -221,6 +227,12 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
         super.setLongRunningPolicy(svc);
     }
 
+    @Reference(target = "(deferrable=false)")
+    @Trivial
+    protected void setScheduledExecutor(ScheduledExecutorService svc) {
+        scheduledExecSvc = svc;
+    }
+
     @Override
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(component.name=com.ibm.ws.transaction.context.provider)")
     @Trivial
@@ -244,6 +256,11 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     @Trivial
     protected void unsetLongRunningPolicy(ConcurrencyPolicy svc) {
         super.unsetLongRunningPolicy(svc);
+    }
+
+    @Trivial
+    protected void unsetScheduledExecutor(ScheduledExecutorService svc) {
+        scheduledExecSvc = null;
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/service/AbstractContextService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/service/AbstractContextService.java
@@ -8,13 +8,17 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.concurrent.mp;
+package com.ibm.ws.concurrent.service;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.internal.ContextServiceImpl;
 
 /**
- * Super class of ManagedExecutorServiceImpl to be used with Java 7, where
- * the MicroProfile Concurrency interfaces (which require Java 8) are unavailable.
+ * Extension point that enables MicroProfile and EE-only implementations to
+ * define the OSGi service component differently.
+ * This model is only needed to preserve support for Java 7.
+ * Once Java 7 is no longer supported, this should all be collapsed
+ * back into ContextServiceImpl.
  */
 @Trivial
-public class ManagedExecutorImpl {}
+public class AbstractContextService extends ContextServiceImpl {}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/service/AbstractManagedExecutorService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/service/AbstractManagedExecutorService.java
@@ -8,13 +8,17 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.concurrent.mp;
+package com.ibm.ws.concurrent.service;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.internal.ManagedExecutorServiceImpl;
 
 /**
- * Super class of ContextServiceImpl to be used with Java 7, where
- * the MicroProfile Concurrency interfaces (which require Java 8) are unavailable.
+ * Extension point that enables MicroProfile and EE-only implementations to
+ * define the OSGi service component differently.
+ * This model is only needed to preserve support for Java 7.
+ * Once Java 7 is no longer supported, this should all be collapsed
+ * back into ManagedExecutorServiceImpl.
  */
 @Trivial
-public class ThreadContextImpl {}
+public class AbstractManagedExecutorService extends ManagedExecutorServiceImpl {}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/service/AbstractManagedScheduledExecutorService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/service/AbstractManagedScheduledExecutorService.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.service;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl;
+
+/**
+ * Extension point that enables MicroProfile and EE-only implementations to
+ * define the OSGi service component differently.
+ * This model is only needed to preserve support for Java 7.
+ * Once Java 7 is no longer supported, this should all be collapsed
+ * back into ManagedScheduledExecutorServiceImpl.
+ */
+@Trivial
+public class AbstractManagedScheduledExecutorService extends ManagedScheduledExecutorServiceImpl {}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/service/package-info.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/service/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2012 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,8 @@
  * @version 1.0
  */
 @org.osgi.annotation.versioning.Version("1.0")
-@TraceOptions(traceGroup = "concurrent")
-package com.ibm.ws.concurrent.mp;
+@TraceOptions(traceGroup = "concurrent", messageBundle = "com.ibm.ws.concurrent.resources.CWWKCMessages")
+package com.ibm.ws.concurrent.service;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;
+

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
@@ -3249,7 +3249,7 @@ public class ConcurrentRxTestServlet extends FATServlet {
         String result;
         assertNotNull(result = cf.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
         assertTrue(result, result.startsWith("100,"));
-        assertTrue(result, result.indexOf("ManagedExecutor") > 0);
+        assertTrue(result, result.indexOf("ManagedExecutorImpl@") > 0);
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
@@ -82,17 +82,16 @@ public class ConcurrentRxTestServlet extends FATServlet {
         AT_LEAST_JAVA_9 = atLeastJava9;
     }
 
-    // TODO remove type once it is possible to inject as ThreadContext/ManagedExecutor
-    @Resource(type = ContextService.class)
+    @Resource
     private ThreadContext defaultThreadContext;
 
-    @Resource(name = "java:comp/env/executorRef", type = ManagedExecutorService.class)
+    @Resource(name = "java:comp/env/executorRef")
     private ManagedExecutor defaultManagedExecutor;
 
-    @Resource(name = "java:module/noContextExecutorRef", lookup = "concurrent/noContextExecutor", type = ManagedExecutorService.class)
+    @Resource(name = "java:module/noContextExecutorRef", lookup = "concurrent/noContextExecutor")
     private ManagedExecutor noContextExecutor;
 
-    @Resource(name = "java:app/oneContextExecutorRef", lookup = "concurrent/oneContextExecutor", type = ManagedExecutorService.class)
+    @Resource(name = "java:app/oneContextExecutorRef", lookup = "concurrent/oneContextExecutor")
     private ManagedExecutor oneContextExecutor; // the single enabled context is jeeMetadataContext
 
     // Executor that runs everything on the invoker's thread instead of submitting tasks to run asynchronously.
@@ -1595,7 +1594,12 @@ public class ConcurrentRxTestServlet extends FATServlet {
 
         // Verify the value, and the thread:
         CompletableFuture<String> cf2 = cs1.toCompletableFuture();
-        String result = cf2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+
+        // await completion before invoking get so that get doesn't trigger the task to run on the current thread if not started yet
+        for (long start = System.nanoTime(); !cf2.isDone() && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(200));
+        assertTrue(cf2.isDone());
+
+        String result = cf2.get();
         assertTrue(result, result.endsWith(":5f"));
         assertTrue(result, result.startsWith("Default Executor-thread-"));
         assertTrue(result, !result.startsWith(Thread.currentThread().getName()));
@@ -3245,7 +3249,7 @@ public class ConcurrentRxTestServlet extends FATServlet {
         String result;
         assertNotNull(result = cf.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
         assertTrue(result, result.startsWith("100,"));
-        assertTrue(result, result.indexOf("ManagedExecutorService") > 0);
+        assertTrue(result, result.indexOf("ManagedExecutor") > 0);
     }
 
     /**


### PR DESCRIPTION
ConcurrentRxTestServlet currently has a pattern where it directly references ManagedCompletableFuture (product internals) to work around the fact that the test code must run on both Java 11 as well as Java 8 and so is unable to use Java 9+ methods, despite needing to test some of them.  This pull will update the tests to access many of these methods reflectively, hopefully in a somewhat clean way so that we can eventually stop exporting the product internals.

This pull will cover maybe half of the occurrences, although the majority of unique Java 9+ methods that are needed by the tests.