### PR TITLE
updated failover servers to be synchronized with the primary servers

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.custom/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.custom/server.xml
@@ -23,8 +23,8 @@
 		recursiveSearch="true"
 		customFilters="mycustom">
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
-           <server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
+		   <server host="${ldap.server.7.name}" port="${ldap.server.7.port}"/>
+           <server host="${ldap.server.8.name}" port="${ldap.server.8.port}"/>
         </failoverServers>	
 	</ldapRegistry> 
 	

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.extremeFailover/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.extremeFailover/server.xml
@@ -27,7 +27,6 @@
 			<server host="${ldap.server.1.port}" port="379"/>
 		</failoverServers>
 		<failoverServers name="failoverLdapServersGroup2">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 			<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
 		</failoverServers>
 		<failoverServers name="emptyFailover" />

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.failover/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.failover/server.xml
@@ -22,8 +22,8 @@
 		searchTimeout="8m"
 		idsFilters="ibm_dir_server">
 		<failoverServers name="failoverLdapServers">
-           <server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
-           <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
+           <server host="${ldap.server.7.name}" port="${ldap.server.7.port}"/>
+           <server host="${ldap.server.8.name}" port="${ldap.server.8.port}"/>
         </failoverServers>
         
     </ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.nofilters/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.nofilters/server.xml
@@ -23,7 +23,6 @@
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
-           <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
         </failoverServers>	
 	</ldapRegistry>		
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.reuseConnection/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.reuseConnection/server.xml
@@ -30,7 +30,6 @@
 			groupMemberIdMap="ibm-allGroups:member;ibm-allGroups:uniqueMember;groupOfNames:member;groupOfUniqueNames:uniqueMember" />
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
-           <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
         </failoverServers>	
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.ssl.trustonly/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.ssl.trustonly/server.xml
@@ -29,6 +29,7 @@
 		idsFilters="ibm_dir_server">
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.7.name}" port="${ldap.server.7.ssl.port}"/>
+		   <server host="${ldap.server.8.name}" port="${ldap.server.8.ssl.port}"/>
         </failoverServers>
 	</ldapRegistry>
 	

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.ssl/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.ssl/server.xml
@@ -28,6 +28,7 @@
 		idsFilters="ibm_dir_server">
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.7.name}" port="${ldap.server.7.ssl.port}"/>
+		   <server host="${ldap.server.8.name}" port="${ldap.server.8.ssl.port}"/>
         </failoverServers>
 	</ldapRegistry>
 	

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids/server.xml
@@ -30,8 +30,8 @@
 			groupIdMap="*:cn"
 			groupMemberIdMap="groupOfNames:member;groupOfUniqueNames:uniqueMember" />
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
-           <server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
+		   <server host="${ldap.server.7.name}" port="${ldap.server.7.port}"/>
+           <server host="${ldap.server.8.name}" port="${ldap.server.8.port}"/>
         </failoverServers>	
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ldapname/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ldapname/server.xml
@@ -30,7 +30,6 @@
 			groupMemberIdMap="ibm-allGroups:member;ibm-allGroups:uniqueMember;groupOfNames:member;groupOfUniqueNames:uniqueMember" />
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
-           <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
         </failoverServers>	
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.performance/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.performance/server.xml
@@ -29,7 +29,6 @@
 			groupMemberIdMap="ibm-allGroups:member;ibm-allGroups:uniqueMember;groupOfNames:member;groupOfUniqueNames:uniqueMember" />
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
-           <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
         </failoverServers>	
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.federation/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.federation/server.xml
@@ -56,7 +56,6 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.multipleldaps/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.multipleldaps/server.xml
@@ -42,7 +42,6 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
     </ldapRegistry>   

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.searchbase/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.searchbase/server.xml
@@ -61,7 +61,7 @@
       </ldapCache>
       <failoverServers name="failoverLdapServers">
       	<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
-		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+		<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar1/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar1/server.xml
@@ -56,7 +56,6 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar2/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar2/server.xml
@@ -56,7 +56,7 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+      		<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry> 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin/server.xml
@@ -35,7 +35,7 @@
 		searchTimeout="8m"
 		loginProperty="cn">
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+		   <server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin_SBInFilter/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin_SBInFilter/server.xml
@@ -35,7 +35,7 @@
 		searchTimeout="8m"
 		loginProperty="cn">
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+		   <server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.emptyInput/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.emptyInput/server.xml
@@ -23,7 +23,7 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+      		<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry> 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.fedcertlogin/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.fedcertlogin/server.xml
@@ -35,7 +35,7 @@
 		searchTimeout="8m"
 		loginProperty="cn">
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+		   <server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.nested/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.nested/server.xml
@@ -28,8 +28,8 @@
 			groupIdMap="*:cn"
 			groupMemberIdMap="ibm-allGroups:member;ibm-allGroups:uniqueMember;groupOfNames:member;groupOfUniqueNames:uniqueMember" />
 		<failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
-			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
+      		<server host="${ldap.server.7.name}" port="${ldap.server.7.port}"/>
+			<server host="${ldap.server.8.name}" port="${ldap.server.8.port}"/>
        </failoverServers>	
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.ssl/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.ssl/server.xml
@@ -67,6 +67,7 @@
       </ldapCache>
       <failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.7.name}" port="${ldap.server.7.ssl.port}"/>
+		   <server host="${ldap.server.8.name}" port="${ldap.server.8.ssl.port}"/>
         </failoverServers>
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.sslref.badssl/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.sslref.badssl/server.xml
@@ -68,6 +68,8 @@
       </ldapCache>
       <failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.7.name}" port="${ldap.server.7.ssl.port}"/>
+		   <server host="${ldap.server.8.name}" port="${ldap.server.8.ssl.port}"/>
+		   
         </failoverServers>
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.sslref/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.sslref/server.xml
@@ -67,6 +67,7 @@
       </ldapCache>
       <failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.7.name}" port="${ldap.server.7.ssl.port}"/>
+		   <server host="${ldap.server.8.name}" port="${ldap.server.8.ssl.port}"/>
         </failoverServers>
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds/server.xml
@@ -57,7 +57,6 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry> 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tworealms/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tworealms/server.xml
@@ -56,7 +56,7 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+      		<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/vmm.apis.tds.ldap/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/vmm.apis.tds.ldap/server.xml
@@ -29,7 +29,7 @@
       </attributeConfiguration>
       
       <failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+      		<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry> 

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.dynamic/server.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.dynamic/server.xml
@@ -12,7 +12,7 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
 	</ldapRegistry>	
     

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.invalidBaseEntryInRealm/server.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.invalidBaseEntryInRealm/server.xml
@@ -12,7 +12,7 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
 	</ldapRegistry>
     

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.maxSearchResult/server.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.maxSearchResult/server.xml
@@ -12,7 +12,7 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
 	</ldapRegistry>   		
     

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.noreg/server.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.noreg/server.xml
@@ -12,7 +12,7 @@
 		ldapType="BadLdapType"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
 	</ldapRegistry>   		
     

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/wim/LdapRegistry.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/wim/LdapRegistry.java
@@ -63,6 +63,7 @@ public class LdapRegistry extends ConfigElement {
     private String sslRef;
     private Integer searchPageSize; // PRIVATE
     private String certificateMapperId;
+    private String timestampFormat; // PRIVATE
 
     /**
      * @return the activedFilters
@@ -321,6 +322,13 @@ public class LdapRegistry extends ConfigElement {
      */
     public String getSslRef() {
         return sslRef;
+    }
+
+    /**
+     * @return the timestampFormat
+     */
+    public String getTimestampFormat() {
+        return timestampFormat;
     }
 
     /**
@@ -629,6 +637,14 @@ public class LdapRegistry extends ConfigElement {
         this.sslRef = sslRef;
     }
 
+    /**
+     * @param timestampFormat the timestampFormat to set
+     */
+    @XmlAttribute(name = "timestampFormat")
+    public void setTimestampFormat(String timestampFormat) {
+        this.timestampFormat = timestampFormat;
+    }
+
     @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();
@@ -742,6 +758,9 @@ public class LdapRegistry extends ConfigElement {
         }
         if (sslRef != null) {
             sb.append("sslRef=\"").append(sslRef).append("\" ");;
+        }
+        if (timestampFormat != null) {
+            sb.append("timestampFormat=\"").append(timestampFormat).append("\" ");;
         }
 
         sb.append("}");

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/LDAPUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/LDAPUtils.java
@@ -1,4 +1,5 @@
 /*******************************************************************************
+
  * Copyright (c) 2011, 2014 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
fixes #5424 

Failover servers need to be synchronized with primary ldap servers in case of failure. The synchronized servers will be able to retrieve the data if the primary server goes down