### PR TITLE
ManagedExecutor.newIncompleteFuture

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
@@ -22,12 +22,9 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 WS-TraceGroup: concurrent
 
-Export-Package:\
-  com.ibm.ws.concurrent.rx
-  # TODO remove the above export once ManagedCompletableFuture is fully transitioned to MicroProfile Concurrency interfaces
-
 Private-Package:\
-  com.ibm.ws.concurrent.mp
+  com.ibm.ws.concurrent.mp,\
+  com.ibm.ws.concurrent.rx
     
 instrument.classesExcludes: com/ibm/ws/concurrent/mp/resources/*.class
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorImpl.java
@@ -93,7 +93,7 @@ public class ManagedExecutorImpl extends AbstractManagedExecutorService implemen
 
     @Override
     public <U> CompletableFuture<U> newIncompleteFuture() {
-        return null; // TODO
+        return ManagedCompletableFuture.newIncompleteFuture(this);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedScheduledExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedScheduledExecutorImpl.java
@@ -101,7 +101,7 @@ public class ManagedScheduledExecutorImpl extends AbstractManagedScheduledExecut
 
     @Override
     public <U> CompletableFuture<U> newIncompleteFuture() {
-        return null; // TODO
+        return ManagedCompletableFuture.newIncompleteFuture(this);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/rx/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/rx/ManagedCompletableFuture.java
@@ -12,7 +12,6 @@ package com.ibm.ws.concurrent.rx;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -46,7 +45,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.kernel.service.util.JavaInfo;
-import com.ibm.wsspi.threadcontext.ThreadContext;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
@@ -375,6 +373,21 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
             stage.super_completeExceptionally(x);
             return stage;
         }
+    }
+
+    // TODO this method (and the other static methods that don't directly equate to static methods on CompletableFuture)
+    // should eventually be moved to a different interface. For now, this is a convenient place to allow progress to be made
+    /**
+     * Construct a new incomplete CompletableFuture that is backed by the specified executor.
+     *
+     * @param executor the default asynchronous execution facility for the new CompletableFuture.
+     * @return incomplete completable future where the specified executor is the default asynchronous execution facility.
+     */
+    public static <T> CompletableFuture<T> newIncompleteFuture(Executor executor) {
+        if (JAVA8)
+            return new ManagedCompletableFuture<T>(new CompletableFuture<T>(), executor, null);
+        else
+            return new ManagedCompletableFuture<T>(executor, null);
     }
 
     /**


### PR DESCRIPTION
Add implementation for the newIncompleteFuture method of ManagedExecutor, and update the test bucket so that it uses the MicroProfile ManagedExecutor API rather than internals. The test bucket will still require internals in one place, which is where it constructs a CompletableFuture around a non-managed executor, which is not something that MicroProfile does.  That will likely be exposed as an internal interface at some point, but for now, I'll just let the test case reflectively invoke a method to obtain it.