### PR TITLE
Remove ant dependency

### DIFF
--- a/dev/com.ibm.ws.install.map/bnd.bnd
+++ b/dev/com.ibm.ws.install.map/bnd.bnd
@@ -33,8 +33,7 @@ Require-Bundle: com.ibm.ws.install; version="[1,1.0.100)", \
   com.ibm.ws.repository; version="[1,1.0.100)", \
   com.ibm.websphere.javaee.jaxb.2.2; location="dev/api/spec/"; version="[1, 1.0.100)", \
   com.ibm.websphere.javaee.jsonp.1.0; location="dev/api/spec/"; version="[1, 1.0.100)", \
-  com.ibm.ws.org.glassfish.json.1.0; version="[1,1.0.100)",\
-  com.ibm.ws.org.apache.ant;version="[1,1.0.100)"
+  com.ibm.ws.org.glassfish.json.1.0; version="[1,1.0.100)"
 
 Private-Package: \
   com.ibm.ws.install.map, \

--- a/dev/com.ibm.ws.install/bnd.bnd
+++ b/dev/com.ibm.ws.install/bnd.bnd
@@ -42,8 +42,7 @@ instrument.disabled: true
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.kernel.feature.cmdline;version=latest,\
 	com.ibm.ws.kernel.feature.core;version=latest,\
-	wlp.lib.extract;version=latest,\
-	com.ibm.ws.org.apache.ant;version=latest	
+	wlp.lib.extract;version=latest
 
 -testpath: \
     com.ibm.websphere.javaee.jaxb.2.2;version=latest,\

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -33,7 +33,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.apache.aries.util.manifest.ManifestProcessor;
-import org.apache.tools.ant.BuildException;
 
 import com.ibm.ws.install.CancelException;
 import com.ibm.ws.install.InstallConstants;
@@ -840,11 +839,10 @@ public class InstallKernelMap implements Map {
      * @param shortNameMap contains features parsed from individual esa files
      * @return singleJson file
      * @throws IOException
-     * @throws BuildException
      * @throws RepositoryException
      * @throws InstallException
      */
-    private File generateJsonFromIndividualESAs(Path jsonDirectory, Map<String, String> shortNameMap) throws IOException, BuildException, RepositoryException, InstallException {
+    private File generateJsonFromIndividualESAs(Path jsonDirectory, Map<String, String> shortNameMap) throws IOException, RepositoryException, InstallException {
         String dir = jsonDirectory.toString();
         List<File> esas = (List<File>) data.get(INDIVIDUAL_ESAS);
         File singleJson = new File(dir + "/SingleJson.json");


### PR DESCRIPTION
InstallKernelMap has a dependency on the library `com.ibm.ws.org.apache.ant`, which doesn't exist in the runtime.  This dependency can be removed, since the code does not actually depend on any of its classes.