### PR TITLE
OSGi service component for MP ConcurrencyProvider

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
@@ -28,9 +28,10 @@ Private-Package:\
 instrument.classesExcludes: com/ibm/ws/concurrent/mp/resources/*.class
 
 -dsannotations: \
+  com.ibm.ws.concurrent.mp.ConcurrencyProviderImpl,\
+  com.ibm.ws.concurrent.mp.ContextServiceImpl,\
   com.ibm.ws.concurrent.mp.ManagedExecutorImpl,\
-  com.ibm.ws.concurrent.mp.ManagedScheduledExecutorImpl,\
-  com.ibm.ws.concurrent.mp.ThreadContextImpl
+  com.ibm.ws.concurrent.mp.ManagedScheduledExecutorImpl
 
 -buildpath: \
   com.ibm.websphere.appserver.spi.logging,\

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyProviderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyProviderImpl.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import org.eclipse.microprofile.concurrent.ManagedExecutorBuilder;
+import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
+import org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider;
+import org.eclipse.microprofile.concurrent.spi.ConcurrencyProviderRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * Registers this implementation as the provider of MicroProfile Concurrency.
+ */
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true)
+public class ConcurrencyProviderImpl implements ConcurrencyProvider {
+    private ConcurrencyProviderRegistration registration;
+
+    @Activate
+    protected void activate() {
+        registration = ConcurrencyProvider.register(this);
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        registration.unregister();
+    }
+
+    @Override
+    public ManagedExecutorBuilder newManagedExecutorBuilder() {
+        // TODO ThreadContextProvider implementations are discovered here? Or upon builder.build()? Or upon using the executor (awkward).
+        return null; // TODO
+    }
+
+    @Override
+    public ThreadContextBuilder newThreadContextBuilder() {
+        // TODO ThreadContextProvider implementations are discovered here?
+        return new ThreadContextBuilderImpl();
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextServiceImpl.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.enterprise.concurrent.ContextService;
+
+import org.eclipse.microprofile.concurrent.ThreadContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.service.AbstractContextService;
+import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
+import com.ibm.wsspi.resource.ResourceFactory;
+import com.ibm.wsspi.threadcontext.WSContextService;
+
+/**
+ * Subclass of ContextServiceImpl to be used with Java 8 and above.
+ * This class provides implementation of the MicroProfile Concurrency methods.
+ * These methods can be collapsed into ContextServiceImpl once there is
+ * no longer a need for OpenLiberty to support Java 7.
+ */
+@Component(name = "com.ibm.ws.context.service",
+           configurationPolicy = ConfigurationPolicy.REQUIRE,
+           service = { ResourceFactory.class, ContextService.class, ThreadContext.class, WSContextService.class, ApplicationRecycleComponent.class },
+           property = { "creates.objectClass=javax.enterprise.concurrent.ContextService",
+                        "creates.objectClass=org.eclipse.microprofile.concurrent.ThreadContext" })
+public class ContextServiceImpl extends AbstractContextService implements ThreadContext {
+    @Activate
+    @Override
+    @Trivial
+    protected void activate(ComponentContext context) {
+        super.activate(context);
+    }
+
+    @Override
+    public Executor currentContextExecutor() {
+        return null; // TODO
+    }
+
+    @Deactivate
+    @Override
+    @Trivial
+    protected void deactivate(ComponentContext context) {
+        super.deactivate(context);
+    }
+
+    @Modified
+    @Override
+    @Trivial
+    protected void modified(ComponentContext context) {
+        super.modified(context);
+    }
+
+    @Override
+    @Reference(name = "baseInstance",
+               service = ContextService.class,
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.DYNAMIC,
+               policyOption = ReferencePolicyOption.GREEDY,
+               target = "(id=unbound)")
+    @Trivial
+    protected void setBaseInstance(ServiceReference<ContextService> ref) {
+        super.setBaseInstance(ref);
+    }
+
+    @Override
+    @Reference(name = "threadContextManager",
+               service = WSContextService.class,
+               cardinality = ReferenceCardinality.MANDATORY,
+               policy = ReferencePolicy.STATIC,
+               target = "(component.name=com.ibm.ws.context.manager)")
+    @Trivial
+    protected void setThreadContextManager(WSContextService svc) {
+        super.setThreadContextManager(svc);
+    }
+
+    @Override
+    @Trivial
+    protected void unsetBaseInstance(ServiceReference<ContextService> ref) {
+        super.unsetBaseInstance(ref);
+    }
+
+    @Override
+    @Trivial
+    protected void unsetThreadContextManager(WSContextService svc) {
+        super.unsetThreadContextManager(svc);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> stage) {
+        return null; // TODO
+    }
+
+    @Override
+    public <T> CompletionStage<T> withContextCapture(CompletionStage<T> stage) {
+        return null; // TODO
+    }
+
+    @Override
+    public <T, U> BiConsumer<T, U> withCurrentContext(BiConsumer<T, U> consumer) {
+        return null; // TODO
+    }
+
+    @Override
+    public <T, U, R> BiFunction<T, U, R> withCurrentContext(BiFunction<T, U, R> function) {
+        return null; // TODO
+    }
+
+    @Override
+    public <R> Callable<R> withCurrentContext(Callable<R> callable) {
+        return null; // TODO
+    }
+
+    @Override
+    public <T> Consumer<T> withCurrentContext(Consumer<T> consumer) {
+        return null; // TODO
+    }
+
+    @Override
+    public <T, R> Function<T, R> withCurrentContext(Function<T, R> function) {
+        return null; // TODO
+    }
+
+    @Override
+    public Runnable withCurrentContext(Runnable runnable) {
+        return null; // TODO
+    }
+
+    @Override
+    public <R> Supplier<R> withCurrentContext(Supplier<R> supplier) {
+        return null; // TODO
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import org.eclipse.microprofile.concurrent.ThreadContext;
+import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
+
+/**
+ * Builder that programmatically configures and creates ThreadContext instances.
+ */
+class ThreadContextBuilderImpl implements ThreadContextBuilder {
+    private String[] cleared;
+    private String[] propagated;
+    private String[] unchanged;
+
+    @Override
+    public ThreadContext build() {
+        return new ThreadContextImpl(cleared, propagated, unchanged); // TODO
+    }
+
+    // TODO @Override
+    public ThreadContextBuilder cleared(String... types) {
+        // TODO
+        return this;
+    }
+
+    @Override
+    public ThreadContextBuilder propagated(String... types) {
+        // TODO
+        return this;
+    }
+
+    @Override
+    public ThreadContextBuilder unchanged(String... types) {
+        // TODO
+        return this;
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.mp;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -20,98 +22,31 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import javax.enterprise.concurrent.ContextService;
-
 import org.eclipse.microprofile.concurrent.ThreadContext;
-import org.osgi.framework.ServiceReference;
-import org.osgi.service.component.ComponentContext;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Modified;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
-import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.concurrent.service.AbstractContextService;
-import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
-import com.ibm.wsspi.resource.ResourceFactory;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
- * Subclass of ContextServiceImpl to be used with Java 8 and above.
- * This class provides implementation of the MicroProfile Concurrency methods.
- * These methods can be collapsed into ContextServiceImpl once there is
- * no longer a need for OpenLiberty to support Java 7.
+ * Programmatically built ThreadContext instance - either via ThreadContextBuilder
+ * or injected by CDI and possibly annotated by <code>@ThreadContextConfig</code>
  */
-@Component(name = "com.ibm.ws.context.service",
-           configurationPolicy = ConfigurationPolicy.REQUIRE,
-           service = { ResourceFactory.class, ContextService.class, ThreadContext.class, WSContextService.class, ApplicationRecycleComponent.class },
-           property = { "creates.objectClass=javax.enterprise.concurrent.ContextService",
-                        "creates.objectClass=org.eclipse.microprofile.concurrent.ThreadContext" })
-public class ThreadContextImpl extends AbstractContextService implements ThreadContext {
-    @Activate
-    @Override
-    @Trivial
-    protected void activate(ComponentContext context) {
-        super.activate(context);
+class ThreadContextImpl implements ThreadContext, WSContextService { // TODO add ContextService?
+    ThreadContextImpl(String[] cleared, String[] propagated, String[] unchanged) {
+        // TODO
+    }
+
+    public ThreadContextDescriptor captureThreadContext(Map<String, String> executionProperties, Map<String, ?>... additionalThreadContextConfig) {
+        return null; // TODO
+    }
+
+    public <T> T createContextualProxy(ThreadContextDescriptor threadContextDescriptor, T instance, Class<T> intf) {
+        return null; // TODO
     }
 
     @Override
     public Executor currentContextExecutor() {
         return null; // TODO
-    }
-
-    @Deactivate
-    @Override
-    @Trivial
-    protected void deactivate(ComponentContext context) {
-        super.deactivate(context);
-    }
-
-    @Modified
-    @Override
-    @Trivial
-    protected void modified(ComponentContext context) {
-        super.modified(context);
-    }
-
-    @Override
-    @Reference(name = "baseInstance",
-               service = ContextService.class,
-               cardinality = ReferenceCardinality.OPTIONAL,
-               policy = ReferencePolicy.DYNAMIC,
-               policyOption = ReferencePolicyOption.GREEDY,
-               target = "(id=unbound)")
-    @Trivial
-    protected void setBaseInstance(ServiceReference<ContextService> ref) {
-        super.setBaseInstance(ref);
-    }
-
-    @Override
-    @Reference(name = "threadContextManager",
-               service = WSContextService.class,
-               cardinality = ReferenceCardinality.MANDATORY,
-               policy = ReferencePolicy.STATIC,
-               target = "(component.name=com.ibm.ws.context.manager)")
-    @Trivial
-    protected void setThreadContextManager(WSContextService svc) {
-        super.setThreadContextManager(svc);
-    }
-
-    @Override
-    @Trivial
-    protected void unsetBaseInstance(ServiceReference<ContextService> ref) {
-        super.unsetBaseInstance(ref);
-    }
-
-    @Override
-    @Trivial
-    protected void unsetThreadContextManager(WSContextService svc) {
-        super.unsetThreadContextManager(svc);
     }
 
     @Override
@@ -126,12 +61,14 @@ public class ThreadContextImpl extends AbstractContextService implements ThreadC
 
     @Override
     public <T, U> BiConsumer<T, U> withCurrentContext(BiConsumer<T, U> consumer) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualBiConsumer<T, U>(contextDescriptor, consumer);
     }
 
     @Override
     public <T, U, R> BiFunction<T, U, R> withCurrentContext(BiFunction<T, U, R> function) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualBiFunction<T, U, R>(contextDescriptor, function);
     }
 
     @Override
@@ -141,21 +78,25 @@ public class ThreadContextImpl extends AbstractContextService implements ThreadC
 
     @Override
     public <T> Consumer<T> withCurrentContext(Consumer<T> consumer) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualConsumer<T>(contextDescriptor, consumer);
     }
 
     @Override
     public <T, R> Function<T, R> withCurrentContext(Function<T, R> function) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualFunction<T, R>(contextDescriptor, function);
     }
 
     @Override
     public Runnable withCurrentContext(Runnable runnable) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualRunnable(contextDescriptor, runnable);
     }
 
     @Override
     public <R> Supplier<R> withCurrentContext(Supplier<R> supplier) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualSupplier<R>(contextDescriptor, supplier);
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
@@ -60,6 +60,7 @@ import javax.servlet.annotation.WebServlet;
 
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
 import org.eclipse.microprofile.concurrent.ThreadContext;
+import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
@@ -3455,6 +3456,20 @@ public class ConcurrentRxTestServlet extends FATServlet {
             throw new Exception((Throwable) lookupResult);
         else
             fail("Unexpected result of lookup: " + lookupResult);
+    }
+
+    /**
+     * Basic test of ThreadContextBuilder used to create a ThreadContext with customized context propagation.
+     * TODO finish writing this test after ThreadContext is more fully implemented.
+     */
+    @Test
+    public void testThreadContextBuilder() throws Exception {
+        ThreadContext contextSvc = ThreadContextBuilder.instance().propagated(ThreadContext.APPLICATION).build();
+        Supplier<Object> supplier = contextSvc.withCurrentContext((Supplier<Object>) () -> { // TODO remove cast
+            return true; // TODO InitialContext.doLookup("java:comp/env/executorRef"); // requires application context
+        });
+        //Object result = supplier.get(); // TODO
+        //assertNotNull(result);
     }
 
     /**


### PR DESCRIPTION
Create an OSGi service component that registers Liberty as a ConcurrencyProvider.  Add just enough stubbed out interfaces to be able to obtain a ThreadContext instance (albeit unusable) from ThreadContextBuilder.instance() which will prove that our ConcurrencyProvider implementation was successfully registered.  Include a test case that demonstrates this.