### PR TITLE
add custom parameters to the oidc authz and token requests

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandler.java
@@ -115,7 +115,7 @@ public class AuthorizationCodeHandler {
                     sslSocketFactory,
                     clientConfig.isHostNameVerificationEnabled(),
                     clientConfig.getTokenEndpointAuthMethod(),
-                    OIDCClientAuthenticatorUtil.getResources(clientConfig));
+                    OIDCClientAuthenticatorUtil.getResources(clientConfig), clientConfig.getTokenRequestParams());
 
             oidcClientRequest.setTokenType(ClientConstants.TYPE_ID_TOKEN);
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
@@ -16,8 +16,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.servlet.http.Cookie;
@@ -374,6 +376,9 @@ public class OIDCClientAuthenticatorUtil {
                 query += resources;
             }
         }
+        // look for custom params to send to the authorization ep
+        handleCustomParams(clientConfig, query);
+        
 
         // in case the AuthorizationEndpoint already has set up its own parameters
         String s = clientConfig.getAuthorizationEndpointUrl();
@@ -382,6 +387,27 @@ public class OIDCClientAuthenticatorUtil {
             queryMark = "&";
         }
         return s + queryMark + query;
+    }
+
+    /**
+     * @param clientConfig
+     * @param query
+     */
+    private void handleCustomParams(ConvergedClientConfig clientConfig, String query) {
+        HashMap<String, String> customParams = clientConfig.getAuthzRequestParams();
+        if (customParams!= null && customParams.isEmpty()) {
+            Set<Entry<String, String>> entries =  customParams.entrySet();
+            for (Entry<String, String>entry : entries) {
+                if (entry.getKey() != null && entry.getValue() != null) {
+                    try {
+                        query = String.format("%s&%s=%s", query, URLEncoder.encode(entry.getKey(), ClientConstants.CHARSET),
+                                URLEncoder.encode(entry.getValue(), ClientConstants.CHARSET));
+                    } catch (UnsupportedEncodingException e) {
+                        
+                    }
+                }
+            }
+        }       
     }
 
     /**

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
@@ -12,6 +12,7 @@ package com.ibm.ws.security.openidconnect.clients.common;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -81,7 +82,7 @@ public class OidcClientUtil {
             SSLSocketFactory sslSocketFactory,
             boolean isHostnameVerification,
             String authMethod,
-            String resources) throws Exception {
+            String resources, HashMap<String, String> customParams) throws Exception {
         // List<String> result = new ArrayList<String>();
         List<NameValuePair> params = new ArrayList<NameValuePair>();
         params.add(new BasicNameValuePair(ClientConstants.GRANT_TYPE, grantType));
@@ -95,6 +96,7 @@ public class OidcClientUtil {
             params.add(new BasicNameValuePair(Constants.CLIENT_ID, clientId));
             params.add(new BasicNameValuePair(Constants.CLIENT_SECRET, clientSecret));
         }
+        handleCustomParams(params, customParams); // custom token ep params
         Map<String, Object> postResponseMap = postToTokenEndpoint(tokenEnpoint, params, clientId, clientSecret, sslSocketFactory, isHostnameVerification, authMethod);
 
         String tokenResponse = oidcHttpUtil.extractTokensFromResponse(postResponseMap);
@@ -118,6 +120,22 @@ public class OidcClientUtil {
         }
 
         return tokens;
+    }
+    
+    /**
+     * @param params
+     * @param customParams
+     */
+    public void handleCustomParams(List<NameValuePair> params, HashMap<String, String> customParams) {
+        //HashMap<String, String> customParams = clientConfig.getAuthzRequestParams();
+        if (customParams!= null && customParams.isEmpty()) {
+            Set<Entry<String, String>> entries =  customParams.entrySet();
+            for (Entry<String, String>entry : entries) {
+                if (entry.getKey() != null && entry.getValue() != null) {
+                    params.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
+                }
+            }
+        }             
     }
 
     public Map<String, Object> checkToken(String tokenInfor, String clientId, @Sensitive String clientSecret,

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandlerTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/AuthorizationCodeHandlerTest.java
@@ -290,7 +290,7 @@ public class AuthorizationCodeHandlerTest {
                 SSLSocketFactory sslSocketFactory,
                 boolean b,
                 String authMethod,
-                String resources) throws HttpException, IOException {
+                String resources, HashMap<String, String> customParams) throws HttpException, IOException {
             if (ioe != null) {
                 throw ioe;
             }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
@@ -1528,7 +1528,7 @@ public class OIDCClientAuthenticatorUtilTest {
                 SSLSocketFactory sslSocketFactory,
                 boolean b,
                 String authMethod,
-                String resources) throws HttpException, IOException {
+                String resources, HashMap<String, String> customParams) throws HttpException, IOException {
             if (ioe != null) {
                 throw ioe;
             }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
@@ -900,7 +900,7 @@ public class OIDCClientAuthenticatorUtilTest {
             {
                 one(oidcClientUtil).getTokensFromAuthzCode(TEST_TOKEN_ENDPOINT, CLIENT01, SHARED_KEY,
                         TEST_REDIRECT_URL, TEST_AUTHORIZATION_CODE,
-                        TEST_GRANT_TYPE, sslSocketFactory, false, authMethod, null);
+                        TEST_GRANT_TYPE, sslSocketFactory, false, authMethod, null, null);
                 will(returnValue(tokens));
             }
         });
@@ -1076,7 +1076,7 @@ public class OIDCClientAuthenticatorUtilTest {
             {
                 one(oidcClientUtil).getTokensFromAuthzCode(TEST_TOKEN_ENDPOINT, CLIENT01, SHARED_KEY,
                         TEST_REDIRECT_URL, TEST_AUTHORIZATION_CODE,
-                        TEST_GRANT_TYPE, sslSocketFactory, false, authMethod, null);
+                        TEST_GRANT_TYPE, sslSocketFactory, false, authMethod, null, null);
                 will(throwException(throwable));
             }
         });

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtilTest.java
@@ -290,7 +290,7 @@ public class OidcClientUtilTest extends CommonTestClass {
                     sslSocketFactory,
                     false,
                     authMethod,
-                    null);
+                    null, null);
             Set<String> keys = results.keySet();
             boolean bAccessToken = false;
             boolean bTokenType = false;

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -221,3 +221,6 @@ oidcClientCustomRequestParamName.desc=Specifies the name of the additional param
 
 oidcClientCustomRequestParamValue=Custom request parameter value
 oidcClientCustomRequestParamValue.desc=Specifies the value of the additional parameter.
+
+discoveryPollingRate=Next discovery interval
+discoveryPollingRate.desc=Duration rate in milliseconds at which the OpenID Connect client checks for updates to the discovery file. The checking is done only if there is an authentication failure.

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -390,6 +390,7 @@
         <AD id="includeCustomCacheKeyInSubject" name="internal" description="internal use only" required="false" type="Boolean" default="true" />
         <AD id="resource" name="internal" description="internal use only" required="false" type="String" cardinality="2147483647" />
         <AD id="discoveryEndpoint" name="%discoveryEndpoint" description="%discoveryEndpoint.desc" required="false" type="String" />
+        <AD id="discoveryPollingRate" name="%discoveryPollingRate" description="%discoveryPollingRate.desc" required="false" type="String" default="300s" ibm:type="duration" />
         <AD id="jwkClientId" name="%jwkClientIdentifier" description="%jwkClientIdentifier.desc" required="false"  type="String" />
         <AD id="jwkClientSecret" name="%jwkClientSecret" description="%jwkClientSecret.desc" required="false"  type="String" ibm:type="password"/>
         <AD id="authzParameter" name="%authzParameter" description="%authzParameter.desc" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.security.social.client.param" cardinality="20" />

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -82,7 +82,12 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements JwtCon
     private String discoveryEndpointUrl = null;
     private JSONObject discoveryjson = null;
     private boolean discovery = false;
-           
+    
+    public static final String KEY_DISCOVERY_POLLING_RATE = "discoveryPollingRate";
+    private long discoveryPollingRate = 5 * 60 * 1000; // 5 minutes in milliseconds
+    private String discoveryDocumentHash = null;
+    private long nextDiscoveryTime;
+    
     public static final String OPDISCOVERY_AUTHZ_EP_URL = "authorization_endpoint";
     public static final String OPDISCOVERY_TOKEN_EP_URL = "token_endpoint";
     public static final String OPDISCOVERY_INTROSPECTION_EP_URL = "introspection_endpoint";
@@ -131,9 +136,12 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements JwtCon
     protected void setOptionalConfigAttributes(Map<String, Object> props) throws SocialLoginException {
     	this.sslRef = configUtils.getConfigAttribute(props, KEY_sslRef);
     	this.discoveryEndpointUrl = configUtils.getConfigAttribute(props, KEY_DISCOVERY_ENDPOINT);
+    	discoveryPollingRate = configUtils.getLongConfigAttribute(props, KEY_DISCOVERY_POLLING_RATE, discoveryPollingRate);
     	jwkClientId = configUtils.getConfigAttribute(props, KEY_JWK_CLIENT_ID);
         jwkClientSecret = configUtils.processProtectedString(props, KEY_JWK_CLIENT_SECRET);
         this.userInfoEndpointEnabled = configUtils.getBooleanConfigAttribute(props, KEY_USERINFO_ENDPOINT_ENABLED, this.userInfoEndpointEnabled);
+        discovery = false;
+        discoveryjson = null;
     	if (discoveryEndpointUrl != null) {
     		discoveryUtil = new DiscoveryConfigUtils(getId());
             discovery = handleDiscoveryEndpoint(discoveryEndpointUrl);


### PR DESCRIPTION
New oidc client config attributes are added to get this information, Update runtime to add the custom params to authz and token requests.