### PR TITLE
create custom thread context provider for tests

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_rx/.classpath
+++ b/dev/com.ibm.ws.concurrent_fat_rx/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/concurrentrxfat/src"/>
+	<classpathentry kind="src" path="test-applications/customcontext/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.concurrent_fat_rx/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_rx/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2018 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,7 +16,8 @@ javac.target: 1.8
 
 src: \
 	fat/src,\
-	test-applications/concurrentrxfat/src
+	test-applications/concurrentrxfat/src,\
+	test-applications/customcontext/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.concurrent_fat_rx/fat/src/com/ibm/ws/concurrent/rx/ConcurrentRxTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/fat/src/com/ibm/ws/concurrent/rx/ConcurrentRxTest.java
@@ -12,11 +12,14 @@ package com.ibm.ws.concurrent.rx;
 
 import java.io.File;
 
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
+import org.test.context.location.StateContextProvider;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
@@ -42,6 +45,11 @@ public class ConcurrentRxTest extends FATServletClient {
                         .addPackages(true, "web")//
                         .addAsWebInfResource(new File("test-applications/concurrentrxfat/resources/index.jsp"));
         ShrinkHelper.exportAppToServer(server1, app);
+
+        JavaArchive customContextProviders = ShrinkWrap.create(JavaArchive.class, "customContextProviders.jar")
+                        .addPackage("org.test.context.location")
+                        .addAsServiceProvider(ThreadContextProvider.class, StateContextProvider.class);
+        ShrinkHelper.exportToServer(server1, "lib", customContextProviders);
 
         server1.startServer();
     }

--- a/dev/com.ibm.ws.concurrent_fat_rx/publish/servers/com.ibm.ws.concurrent.fat.rx/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_rx/publish/servers/com.ibm.ws.concurrent.fat.rx/server.xml
@@ -20,7 +20,13 @@
     
     <include location="../fatTestPorts.xml"/>
     
-    <application location="concurrentrxfat.war" />
+    <application location="concurrentrxfat.war">
+        <classloader commonLibraryRef="customContextProviderLib"/>
+    </application>
+
+    <library id="customContextProviderLib">
+        <file name="${server.config.dir}/lib/customContextProviders.jar"/>
+    </library>
 
     <!-- Do not change the concurrency policies associated with the following executors. Tests make assumptions based on this configuration -->
 

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/ConcurrentRxTestServlet.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -62,6 +63,7 @@ import org.eclipse.microprofile.concurrent.ManagedExecutor;
 import org.eclipse.microprofile.concurrent.ThreadContext;
 import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
 import org.junit.Test;
+import org.test.context.location.CurrentLocation;
 
 import componenttest.app.FATServlet;
 
@@ -1440,6 +1442,21 @@ public class ConcurrentRxTestServlet extends FATServlet {
         assertEquals(Long.valueOf(100), cf0.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
         assertTrue(cf0.isDone());
         assertFalse(cf0.isCompletedExceptionally());
+    }
+
+    // TODO replace this test with one that expects the custom thread context to be propagated to completion stage actions
+    @Test
+    public void testCustomContextProvider() throws Exception {
+        CurrentLocation.setLocation("Minnesota");
+        try {
+            assertEquals(6.875, CurrentLocation.getStateSalesTax(100.0), 0.000001);
+        } finally {
+            CurrentLocation.setLocation("");
+        }
+
+        ServiceLoader<org.eclipse.microprofile.concurrent.spi.ThreadContextProvider> providers = ServiceLoader
+                        .load(org.eclipse.microprofile.concurrent.spi.ThreadContextProvider.class);
+        providers.iterator().next();
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CurrentLocation.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CurrentLocation.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.context.location;
+
+/**
+ * Utility class for tests that relies on a location (US state and city)
+ * being associated with the current thread, which it uses to compute sales tax.
+ * This can be used to validate that the custom thread context types
+ * "StateContext" and "CityContext" have been correctly propagated to the
+ * running thread.
+ */
+public class CurrentLocation {
+    public static double getStateSalesTax(double purchaseAmount) {
+        String stateName = StateContextProvider.stateName.get();
+        return getStateTaxRate(stateName) * purchaseAmount;
+    }
+
+    public static double getTotalSalesTax(double purchaseAmount) {
+        String cityName = null; // TODO CityContextProvider.cityName.get();
+        String stateName = StateContextProvider.stateName.get();
+        return getTotalTaxRate(cityName, stateName) * purchaseAmount;
+    }
+
+    public static void setLocation(String state) {
+        StateContextProvider.stateName.set(state);
+    }
+
+    private static double getStateTaxRate(String state) {
+        switch (StateContextProvider.stateName.get()) {
+            case "Illinois":
+                return 0.0625;
+            case "Indiana":
+                return 0.07;
+            case "Iowa":
+                return 0.06;
+            case "Kansas":
+                return 0.065;
+            case "Michigan":
+                return 0.0600;
+            case "Minnesota":
+                return 0.06875;
+            case "Missouri":
+                return 0.04225;
+            case "Nebraska":
+                return 0.055;
+            case "North Dakota":
+                return 0.05;
+            case "South Dakota":
+                return 0.04;
+            case "Wisconsin":
+                return 0.05;
+        }
+        throw new IllegalArgumentException(state + " is an unkown location");
+    }
+
+    private static double getTotalTaxRate(String city, String state) {
+        switch (state) {
+            case "Iowa":
+                switch (city) {
+                    case "Ames":
+                    case "Cedar Rapids":
+                    case "Davenport":
+                    case "Dubuque":
+                        return 0.07;
+                    case "Des Moines":
+                    case "Iowa City":
+                        return 0.06;
+                }
+                break;
+            case "Minnesota":
+                switch (city) {
+                    case "Duluth":
+                        return 0.07875;
+                    case "Minneapolis":
+                        return 0.07775;
+                    case "Rochester":
+                        return 0.07375;
+                    case "Saint Paul":
+                        return 0.07625;
+                    case "Byron":
+                    case "Stewartville":
+                    case "Winona":
+                        return getStateTaxRate(state);
+                }
+                break;
+        }
+        throw new IllegalArgumentException(city + ", " + state + " is an unknown location");
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextProvider.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextProvider.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.context.location;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * Example third-party thread context provider, to be used for testing purposes.
+ * This context associates a US state name with a thread, such that the applicable
+ * sales tax rate for the corresponding state is included when either of the
+ * getStateSalesTax() or getTotalSalesTax() methods is invoked from the thread.
+ */
+public class StateContextProvider implements ThreadContextProvider {
+    static ThreadLocal<String> stateName = ThreadLocal.withInitial(() -> "");
+
+    public ThreadContextSnapshot defaultContext(Map<String, String> props) {
+        return new StateContextSnapshot("");
+    }
+
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        return new StateContextSnapshot(stateName.get());
+    }
+
+    // TODO remove the following method once default implementation is added
+    public Set<String> getPrerequisites() {
+        return Collections.emptySet();
+    }
+
+    public String getThreadContextType() {
+        return "State";
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextRestorer.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextRestorer.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.context.location;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+
+/**
+ * Example third-party thread context restorer, to be used for testing purposes.
+ * This context associates a US state name with a thread, such that the applicable
+ * sales tax rate for the corresponding state is included when either of the
+ * getStateSalesTax() or getTotalSalesTax() methods is invoked from the thread.
+ */
+public class StateContextRestorer implements ThreadContextController {
+    private boolean restored = false;
+    private final String stateNameToRestore;
+
+    StateContextRestorer(String stateNameToRestore) {
+        this.stateNameToRestore = stateNameToRestore;
+    }
+
+    public void endContext() {
+        if (restored)
+            throw new IllegalStateException("thread context was already restored");
+        StateContextProvider.stateName.set(stateNameToRestore);
+        restored = true;
+    }
+
+    @Override
+    public String toString() {
+        return "StateContextRestorer@" + Integer.toHexString(hashCode()) + "(" + stateNameToRestore + ")";
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextSnapshot.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.context.location;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * Example third-party thread context snapshot, to be used for testing purposes.
+ * This context associates a US state name with a thread, such that the applicable
+ * sales tax rate for the corresponding state is included when either of the
+ * getStateSalesTax() or getTotalSalesTax() methods is invoked from the thread.
+ */
+public class StateContextSnapshot implements ThreadContextSnapshot {
+    private final String stateName;
+
+    StateContextSnapshot(String stateName) {
+        this.stateName = stateName;
+    }
+
+    public ThreadContextController begin() {
+        ThreadContextController stateContextRestorer = new StateContextRestorer(StateContextProvider.stateName.get());
+        StateContextProvider.stateName.set(stateName);
+        return stateContextRestorer;
+    }
+
+    @Override
+    public String toString() {
+        return "StateContextSnapshot@" + Integer.toHexString(hashCode()) + "(" + stateName + ")";
+    }
+}


### PR DESCRIPTION
Create a custom thread context provider that we can use for tests.
It should be possible to include it within a shared library, made available to the application.