### PR TITLE
Set default ldapRegistry-3.0 read timeout to be 1 minute

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/metatype/metatype.xml
@@ -67,7 +67,7 @@
         <AD id="connectTimeout" name="%connectTimeout" description="%connectTimeout.desc"
             required="false" type="String" ibm:type="duration" default="1m"/>
         <AD id="readTimeout" name="%readTimeout" description="%readTimeout.desc"
-            required="false" type="String" ibm:type="duration" default="0m"/>
+            required="false" type="String" ibm:type="duration" default="1m"/>
         <AD id="failoverServers" name="%ldap.failoverServers" description="%ldap.failoverServers.desc"
             ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.security.registry.ldap.config.failoverServers"
             required="false" type="String" cardinality="2147483647" />

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/context/ContextManager.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/context/ContextManager.java
@@ -88,10 +88,10 @@ public class ContextManager {
     private static final int DEFAULT_PREF_POOL_SIZE = 3;
 
     /** The default connect time limit - 1 minute. */
-    private static final long DEFAULT_CONNECT_TIMEOUT = 600000;
+    private static final long DEFAULT_CONNECT_TIMEOUT = 60000;
 
-    /** The default read time limit - infinite. */
-    private static final long DEFAULT_READ_TIMEOUT = 0;
+    /** The default read time limit - 1 minute. */
+    private static final long DEFAULT_READ_TIMEOUT = 60000;
 
     /** Key to use for accessing the active URL from the JNDI environment table. */
     private static final String ENVKEY_ACTIVE_URL = "_ACTIVE_URL_";
@@ -231,7 +231,7 @@ public class ContextManager {
      * Add a fail-over LDAP server hostname and port.
      *
      * @param hostname The hostname for the primary LDAP server.
-     * @param port The port for the primary LDAP server.
+     * @param port     The port for the primary LDAP server.
      */
     public void addFailoverServer(String hostname, int port) {
         iFailoverServers.add(new HostPort(hostname, port));
@@ -243,7 +243,7 @@ public class ContextManager {
      *
      * @param ctx The context with a connection to the current LDAP server.
      * @throws OperationNotSupportedException If write to secondary is disabled and the context
-     *             is not connected to the primary LDAP server.
+     *                                            is not connected to the primary LDAP server.
      */
     public void checkWritePermission(TimedDirContext ctx) throws OperationNotSupportedException {
         if (!iWriteToSecondary) {
@@ -283,7 +283,7 @@ public class ContextManager {
     /**
      * Create a directory context pool of the specified size.
      *
-     * @param poolSize The initial size of the pool.
+     * @param poolSize    The initial size of the pool.
      * @param providerURL The URL of the LDAP provider.
      * @throws NamingException If there was an error connecting while creating the context pool.
      */
@@ -383,7 +383,7 @@ public class ContextManager {
     /**
      * Create a directory context.
      *
-     * @param env The JNDI environment to create the context with.
+     * @param env             The JNDI environment to create the context with.
      * @param createTimestamp The timestamp to use as the creation timestamp for the {@link TimedDirContext}.
      * @return The {@link TimedDirContext}.
      * @throws NamingException If there was an issue binding to the LDAP server.
@@ -439,7 +439,7 @@ public class ContextManager {
     /**
      * Create a directory context.
      *
-     * @param principal The principal name to bind with.
+     * @param principal  The principal name to bind with.
      * @param credential The password / credential.
      * @return The {@link TimedDirContext} of the new connection.
      * @throws NamingException If the bind failed.
@@ -511,13 +511,13 @@ public class ContextManager {
     /**
      * Creates and binds a new context, along with associated attributes.
      *
-     * @param name The name to bind the new context.
+     * @param name  The name to bind the new context.
      * @param attrs The attributes to bind on the new context.
      * @return The new context.
      * @throws OperationNotSupportedException If connected to a fail-over server and write to secondary is disabled.
-     * @throws EntityAlreadyExistsException If the entity already exists.
-     * @throws EntityNotFoundException If part of the name cannot be found to create the entity.
-     * @throws WIMSystemException If any other {@link NamingException} occurs or the context cannot be released.
+     * @throws EntityAlreadyExistsException   If the entity already exists.
+     * @throws EntityNotFoundException        If part of the name cannot be found to create the entity.
+     * @throws WIMSystemException             If any other {@link NamingException} occurs or the context cannot be released.
      */
     public DirContext createSubcontext(String name,
                                        Attributes attrs) throws OperationNotSupportedException, WIMSystemException, EntityAlreadyExistsException, EntityNotFoundException {
@@ -573,8 +573,8 @@ public class ContextManager {
      *
      * @param name The distinguished name to delete.
      * @throws EntityHasDescendantsException The context being destroyed is not empty.
-     * @throws EntityNotFoundException If part of the name cannot be found to destroy the entity.
-     * @throws WIMSystemException If any other {@link NamingException} occurs or the context cannot be released.
+     * @throws EntityNotFoundException       If part of the name cannot be found to destroy the entity.
+     * @throws WIMSystemException            If any other {@link NamingException} occurs or the context cannot be released.
      */
     public void destroySubcontext(String name) throws EntityHasDescendantsException, EntityNotFoundException, WIMSystemException {
         TimedDirContext ctx = getDirContext();
@@ -838,7 +838,7 @@ public class ContextManager {
     /**
      * Returns LDAP environment containing specified URL sequence.
      *
-     * @param type Single or sequence
+     * @param type        Single or sequence
      * @param startingURL Starting URL
      * @return Environment containing specified URL sequence
      */
@@ -925,7 +925,7 @@ public class ContextManager {
     /**
      * Returns URL index in the URL list.
      *
-     * @param url URL
+     * @param url     URL
      * @param urlList List of URLs
      * @return URL index
      */
@@ -1178,7 +1178,7 @@ public class ContextManager {
     /**
      * Recreate a Directory context, where the oldContext failed with the given error message.
      *
-     * @param oldCtx The context that failed.
+     * @param oldCtx       The context that failed.
      * @param errorMessage The error message from the failure.
      * @return The new {@link TimedDirContext}. It is possible this context is connected to another LDAP server than the
      *         old context was.
@@ -1349,7 +1349,7 @@ public class ContextManager {
      * using {@link AccessController#doPrivileged(PrivilegedAction)}.
      *
      * @param clazz The class to get the {@link ClassLoader} to set when calling.
-     *            {@link Thread#currentThread()#setContextClassLoader(ClassLoader)}.
+     *                  {@link Thread#currentThread()#setContextClassLoader(ClassLoader)}.
      */
     private static void setContextClassLoader(final Class<?> clazz) {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
@@ -1366,7 +1366,7 @@ public class ContextManager {
      * using {@link AccessController#doPrivileged(PrivilegedAction)}.
      *
      * @param classLoader The {@link ClassLoader} to set when calling.
-     *            {@link Thread#currentThread()#setContextClassLoader(ClassLoader)}.
+     *                        {@link Thread#currentThread()#setContextClassLoader(ClassLoader)}.
      */
     private static void setContextClassLoader(final ClassLoader classLoader) {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
@@ -1385,13 +1385,13 @@ public class ContextManager {
      * are null, that parameter will be set to the default value.
      *
      * @param enableContextPool Whether the context pool is enabled.
-     * @param initPoolSize The initial context pool size.
-     * @param prefPoolSize The preferred context pool size. Not required when <code>enableContextPool == false</code>.
-     * @param maxPoolSize The maximum context pool size. A size of '0' means the maximum size is unlimited. Not required when <code>enableContextPool == false</code>.
-     * @param poolTimeOut The context pool timeout in milliseconds. This is the amount of time a context is valid for in
-     *            the context pool is valid for until it is discarded. Not required when <code>enableContextPool == false</code>.
-     * @param poolWaitTime The context pool wait time in milliseconds. This is the amount of time to wait when getDirContext() is called
-     *            and no context is available from the pool before checking again. Not required when <code>enableContextPool == false</code>.
+     * @param initPoolSize      The initial context pool size.
+     * @param prefPoolSize      The preferred context pool size. Not required when <code>enableContextPool == false</code>.
+     * @param maxPoolSize       The maximum context pool size. A size of '0' means the maximum size is unlimited. Not required when <code>enableContextPool == false</code>.
+     * @param poolTimeOut       The context pool timeout in milliseconds. This is the amount of time a context is valid for in
+     *                              the context pool is valid for until it is discarded. Not required when <code>enableContextPool == false</code>.
+     * @param poolWaitTime      The context pool wait time in milliseconds. This is the amount of time to wait when getDirContext() is called
+     *                              and no context is available from the pool before checking again. Not required when <code>enableContextPool == false</code>.
      * @throws InvalidInitPropertyException If <code>initPoolSize > maxPoolSize</code> or <code>prefPoolSize > maxPoolSize</code> when <code>maxPoolSize != 0</code>.
      */
     public void setContextPool(boolean enableContextPool, Integer initPoolSize, Integer prefPoolSize, Integer maxPoolSize, Long poolTimeOut,
@@ -1429,7 +1429,7 @@ public class ContextManager {
      * Set the primary LDAP server hostname and port.
      *
      * @param hostname The hostname for the primary LDAP server.
-     * @param port The port for the primary LDAP server.
+     * @param port     The port for the primary LDAP server.
      */
     public void setPrimaryServer(String hostname, int port) {
         this.iPrimaryServer = new HostPort(hostname, port);
@@ -1478,7 +1478,7 @@ public class ContextManager {
     /**
      * Set the administrative credentials used for simple authentication.
      *
-     * @param bindDn The administrative bind DN.
+     * @param bindDn       The administrative bind DN.
      * @param bindPassword The administrative bind password.
      */
     public void setSimpleCredentials(String bindDn, SerializableProtectedString bindPassword) {

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/context/ContextManagerTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/context/ContextManagerTest.java
@@ -795,6 +795,7 @@ public class ContextManagerTest {
         long time = System.currentTimeMillis();
         try {
             ctx.search(BASE_ENTRY, "objectclass=*", null);
+            time = System.currentTimeMillis() - time;
         } catch (NamingException e) {
             time = System.currentTimeMillis() - time;
             assertTrue("Expected connect timeout to be " + expectedTimeout + " millisecond.", time >= expectedTimeout && time <= (expectedTimeout + 100));
@@ -806,6 +807,22 @@ public class ContextManagerTest {
          */
         expectedTimeout = 500L;
         cm.setReadTimeout(expectedTimeout);
+        cm.initialize();
+
+        ctx = cm.createDirContext(USER_DN, "password".getBytes());
+        time = System.currentTimeMillis();
+        try {
+            ctx.search(BASE_ENTRY, "objectclass=*", null);
+        } catch (NamingException e) {
+            time = System.currentTimeMillis() - time;
+            assertTrue("Expected connect timeout to be " + expectedTimeout + " millisecond.", time >= expectedTimeout && time <= (expectedTimeout + 100));
+        }
+
+        /*
+         * Configure the context manager with a default 1min read timeout.
+         */
+        expectedTimeout = 60000L;
+        cm.setReadTimeout(null);
         cm.initialize();
 
         ctx = cm.createDirContext(USER_DN, "password".getBytes());

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/wim/LdapRegistry.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/wim/LdapRegistry.java
@@ -34,6 +34,7 @@ public class LdapRegistry extends ConfigElement {
     private String certificateFilter;
     private String certificateMapMode;
     private String connectTimeout;
+    private String readTimeout;
     private ContextPool contextPool;
     private LdapFilters customFilters;
     private LdapFilters domino50Filters;
@@ -125,6 +126,13 @@ public class LdapRegistry extends ConfigElement {
      */
     public String getConnectTimeout() {
         return connectTimeout;
+    }
+
+    /**
+     * @return the readTimeout
+     */
+    public String getReadTimeout() {
+        return readTimeout;
     }
 
     /**
@@ -396,6 +404,14 @@ public class LdapRegistry extends ConfigElement {
     }
 
     /**
+     * @param connectTimeout the connectTimeout to set
+     */
+    @XmlAttribute(name = "")
+    public void setReadTimeout(String readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    /**
      * @param contextPool the contextPool to set
      */
     @XmlElement(name = "contextPool")
@@ -661,6 +677,9 @@ public class LdapRegistry extends ConfigElement {
         }
         if (connectTimeout != null) {
             sb.append("connectTimeout=\"").append(connectTimeout).append("\" ");;
+        }
+        if (readTimeout != null) {
+            sb.append("readTimeout=\"").append(readTimeout).append("\" ");;
         }
         if (contextPool != null) {
             sb.append("contextPool=\"").append(contextPool).append("\" ");;


### PR DESCRIPTION
fixes #5341.

Updated default readTimeout in metatype.xml. Updated LDAPRegistry ReadTimeout constant to be set to 1 min. Added Fat Test to test for Default Value