### PR TITLE
ConcurrencyProvider initial support for container context starting with application context

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
@@ -23,7 +23,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 WS-TraceGroup: concurrent
 
 Private-Package:\
-  com.ibm.ws.concurrent.mp
+  com.ibm.ws.concurrent.mp.*
     
 instrument.classesExcludes: com/ibm/ws/concurrent/mp/resources/*.class
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextOp.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextOp.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Describes an operation that is performed with regard to establishing context on a thread.
+ */
+@Trivial
+enum ContextOp {
+    /**
+     * Thread context of the specified type is cleared from the thread of execution
+     * before performing the action/task.
+     */
+    CLEARED,
+
+    /**
+     * Thread context of the specified type is captured from the requesting thread
+     * and propagated to the thread of execution before performing the action/task.
+     */
+    PROPAGATED,
+
+    /**
+     * Thread context of the specified type is ignored and left unchanged.
+     */
+    UNCHANGED
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
@@ -10,37 +10,105 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.mp;
 
+import java.util.ConcurrentModificationException;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.function.Consumer;
+
 import org.eclipse.microprofile.concurrent.ThreadContext;
 import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 
 /**
  * Builder that programmatically configures and creates ThreadContext instances.
  */
 class ThreadContextBuilderImpl implements ThreadContextBuilder {
-    private String[] cleared;
-    private String[] propagated;
-    private String[] unchanged;
+    private final ConcurrencyProviderImpl concurrencyProvider;
+
+    private final HashSet<String> cleared = new HashSet<String>();
+    private final HashSet<String> propagated = new HashSet<String>();
+    private final HashSet<String> unchanged = new HashSet<String>();
+
+    ThreadContextBuilderImpl(ConcurrencyProviderImpl concurrencyProvider) {
+        this.concurrencyProvider = concurrencyProvider;
+
+        // built-in defaults from spec:
+        // cleared.add(ThreadContext.TRANSACTION); // TODO add this once we pull in newer spec jar
+        propagated.add(ThreadContext.ALL); // TODO ALL is renamed to ALL_REMAINING once we update spec binaries
+    }
 
     @Override
     public ThreadContext build() {
-        return new ThreadContextImpl(cleared, propagated, unchanged); // TODO
+        // For detection of unknown and overlapping types,
+        HashSet<String> unknown = new HashSet<String>(cleared);
+        unknown.addAll(propagated);
+        unknown.addAll(unchanged);
+
+        if (unknown.size() < cleared.size() + propagated.size() + unchanged.size())
+            throw new IllegalArgumentException(/* TODO findOverlapping(configured) */);
+
+        // Determine what to with remaining context types that are not explicitly configured
+        ContextOp remaining;
+        if (unknown.remove(ThreadContext.ALL)) {
+            remaining = propagated.contains(ThreadContext.ALL) ? ContextOp.PROPAGATED //
+                            : cleared.contains(ThreadContext.ALL) ? ContextOp.CLEARED //
+                                            : unchanged.contains(ThreadContext.ALL) ? ContextOp.UNCHANGED //
+                                                            : null;
+            if (remaining == null) // only possible if builder is concurrently modified during build
+                throw new ConcurrentModificationException();
+        } else
+            remaining = ContextOp.CLEARED;
+
+        LinkedHashMap<ThreadContextProvider, ContextOp> configPerProvider = new LinkedHashMap<ThreadContextProvider, ContextOp>();
+
+        Consumer<ThreadContextProvider> addProvider = provider -> {
+            String contextType = provider.getThreadContextType();
+            unknown.remove(contextType);
+
+            ContextOp op = propagated.contains(contextType) ? ContextOp.PROPAGATED //
+                            : cleared.contains(contextType) ? ContextOp.CLEARED //
+                                            : unchanged.contains(contextType) ? ContextOp.UNCHANGED //
+                                                            : remaining;
+            if (op != ContextOp.UNCHANGED)
+                configPerProvider.put(provider, op);
+        };
+
+        // thread context providers from the container
+        addProvider.accept(concurrencyProvider.applicationContextProvider);
+        // TODO other container providers
+
+        // TODO obtain providers from ServiceLoader, preferably from cache based on class loader (can also do duplicate provider check there)
+
+        // TODO process in an order that keeps prereqs satisfied
+
+        // unknown thread context types
+        if (unknown.size() > 0)
+            throw new IllegalArgumentException(unknown.toString());
+
+        return new ThreadContextImpl(configPerProvider);
     }
 
     // TODO @Override
     public ThreadContextBuilder cleared(String... types) {
-        // TODO
+        cleared.clear();
+        for (String type : types)
+            cleared.add(type);
         return this;
     }
 
     @Override
     public ThreadContextBuilder propagated(String... types) {
-        // TODO
+        propagated.clear();
+        for (String type : types)
+            propagated.add(type);
         return this;
     }
 
     @Override
     public ThreadContextBuilder unchanged(String... types) {
-        // TODO
+        unchanged.clear();
+        for (String type : types)
+            unchanged.add(type);
         return this;
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextDescriptorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextDescriptorImpl.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.mp.context.ContainerContextProvider;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
+
+/**
+ * Programmatically built ThreadContext instance - either via ThreadContextBuilder
+ * or injected by CDI and possibly annotated by <code>@ThreadContextConfig</code>
+ */
+class ThreadContextDescriptorImpl implements ThreadContextDescriptor {
+    private static final TraceComponent tc = Tr.register(ThreadContextDescriptorImpl.class);
+
+    private final Map<String, String> EMPTY_MAP = Collections.emptyMap();
+
+    /**
+     * List of thread context snapshots (either captured from the requesting thread or cleared/empty)
+     * which is ordered based on thread context provider prerequisites.
+     */
+    private ArrayList<com.ibm.wsspi.threadcontext.ThreadContext> contextSnapshots = new ArrayList<com.ibm.wsspi.threadcontext.ThreadContext>();
+
+    ThreadContextDescriptorImpl(LinkedHashMap<ThreadContextProvider, ContextOp> configPerProvider) {
+        // create snapshots of captured or cleared context here, per the configured instructions for each type
+        for (Map.Entry<ThreadContextProvider, ContextOp> entry : configPerProvider.entrySet()) {
+            ThreadContextProvider provider = entry.getKey();
+            if (provider instanceof ContainerContextProvider) {
+                for (com.ibm.wsspi.threadcontext.ThreadContextProvider cp : ((ContainerContextProvider) provider).toContainerProviders()) {
+                    com.ibm.wsspi.threadcontext.ThreadContext tc = entry.getValue() == ContextOp.CLEARED //
+                                    ? cp.createDefaultThreadContext(EMPTY_MAP) //
+                                    : cp.captureThreadContext(EMPTY_MAP, EMPTY_MAP); // PROPAGATED
+                    contextSnapshots.add(tc);
+                }
+            } else {
+                // TODO support MP context types
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+    @Override
+    public ThreadContextDescriptor clone() {
+        try {
+            ThreadContextDescriptorImpl clone = (ThreadContextDescriptorImpl) super.clone();
+            clone.contextSnapshots = new ArrayList<com.ibm.wsspi.threadcontext.ThreadContext>(contextSnapshots);
+            return clone;
+        } catch (CloneNotSupportedException x) {
+            throw new RuntimeException(x); // should never occur
+        }
+
+    }
+
+    @Override
+    @Trivial
+    public Map<String, String> getExecutionProperties() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    @Trivial
+    public byte[] serialize() throws IOException {
+        throw new NotSerializableException();
+    }
+
+    @Override
+    public void set(String providerName, com.ibm.wsspi.threadcontext.ThreadContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Establish context on a thread before a contextual operation is started.
+     *
+     * @return list of thread context matching the order in which context has been applied to the thread.
+     * @throws IllegalStateException if the application component is not started or deployed.
+     * @throws RejectedExecutionException if context cannot be established on the thread.
+     */
+    @Override
+    public ArrayList<com.ibm.wsspi.threadcontext.ThreadContext> taskStarting() throws RejectedExecutionException {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+        // TODO enforce application availability
+
+        ArrayList<com.ibm.wsspi.threadcontext.ThreadContext> contextAppliedToThread = new ArrayList<com.ibm.wsspi.threadcontext.ThreadContext>(contextSnapshots.size());
+        try {
+            for (com.ibm.wsspi.threadcontext.ThreadContext contextSnapshot : contextSnapshots) {
+                contextSnapshot = contextSnapshot.clone();
+
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "begin context " + toString(contextSnapshot));
+                contextSnapshot.taskStarting();
+
+                contextAppliedToThread.add(contextSnapshot);
+            }
+        } catch (RuntimeException | Error x) {
+            // In the event of failure, undo all context propagation up to this point.
+
+            for (int c = contextAppliedToThread.size() - 1; c >= 0; c--)
+                try {
+                    if (trace && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "end context " + toString(contextAppliedToThread.get(c)));
+                    contextAppliedToThread.get(c).taskStopping();
+                } catch (Throwable stopX) {
+                }
+
+            throw x;
+        }
+
+        return contextAppliedToThread;
+    }
+
+    /**
+     * Remove context from the thread (in reverse of the order in which is was applied) after a contextual operation completes.
+     *
+     * @param threadContext list of context previously applied to thread, ordered according to the order in which it was applied to the thread.
+     */
+    @Override
+    public void taskStopping(ArrayList<com.ibm.wsspi.threadcontext.ThreadContext> contextAppliedToThread) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+        Throwable failure = null;
+        for (int c = contextAppliedToThread.size() - 1; c >= 0; c--)
+            try {
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "end context " + toString(contextAppliedToThread.get(c)));
+                contextAppliedToThread.get(c).taskStopping();
+            } catch (Throwable x) {
+                if (failure == null)
+                    failure = x;
+            }
+
+        if (failure != null)
+            if (failure instanceof RuntimeException)
+                throw (RuntimeException) failure;
+            else if (failure instanceof Error)
+                throw (Error) failure;
+            else
+                throw new RuntimeException(failure); // should never happen
+    }
+
+    /**
+     * Returns text that uniquely identifies a context instance. This is only used for tracing.
+     *
+     * @param c a context
+     * @return text formatted to include the class name and hashcode.
+     */
+    @Trivial
+    private static String toString(com.ibm.wsspi.threadcontext.ThreadContext c) {
+        if (c == null)
+            return null;
+        String s = c.toString();
+        if (s.indexOf('@') < 0)
+            s = c.getClass().getSimpleName() + '@' + Integer.toHexString(System.identityHashCode(c)) + ':' + s;
+        return s;
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.concurrent.mp;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -23,6 +24,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.concurrent.ThreadContext;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
@@ -32,16 +34,20 @@ import com.ibm.wsspi.threadcontext.WSContextService;
  * or injected by CDI and possibly annotated by <code>@ThreadContextConfig</code>
  */
 class ThreadContextImpl implements ThreadContext, WSContextService { // TODO add ContextService?
-    ThreadContextImpl(String[] cleared, String[] propagated, String[] unchanged) {
-        // TODO
+    private final LinkedHashMap<ThreadContextProvider, ContextOp> configPerProvider;
+
+    ThreadContextImpl(LinkedHashMap<ThreadContextProvider, ContextOp> configPerProvider) {
+        this.configPerProvider = configPerProvider;
     }
 
+    @Override
     public ThreadContextDescriptor captureThreadContext(Map<String, String> executionProperties, Map<String, ?>... additionalThreadContextConfig) {
-        return null; // TODO
+        return new ThreadContextDescriptorImpl(configPerProvider);
     }
 
+    @Override
     public <T> T createContextualProxy(ThreadContextDescriptor threadContextDescriptor, T instance, Class<T> intf) {
-        return null; // TODO
+        throw new UnsupportedOperationException(); // not needed by ManagedCompletableFuture or ManagedExecutorServiceImpl
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/ApplicationContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/ApplicationContextProvider.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.context;
+
+import org.eclipse.microprofile.concurrent.ThreadContext;
+
+import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
+
+/**
+ * Partial implementation of MicroProfile Application context, backed by Liberty's
+ * Classloader Context and JEE Metadata Context.
+ */
+public class ApplicationContextProvider extends ContainerContextProvider {
+    public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> classloaderContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("ClassloaderContextProvider");
+    public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> jeeMetadataContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("JeeMetadataContextProvider");
+
+    @Override
+    public com.ibm.wsspi.threadcontext.ThreadContextProvider[] toContainerProviders() {
+        return new com.ibm.wsspi.threadcontext.ThreadContextProvider[] { classloaderContextProviderRef.getServiceWithException(),
+                                                                         jeeMetadataContextProviderRef.getServiceWithException()
+        };
+    }
+
+    @Override
+    public final String getThreadContextType() {
+        return ThreadContext.APPLICATION;
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/ContainerContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/ContainerContextProvider.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.context;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * This interface allows for the conversion from MicroProfile ThreadContextProvider
+ * back to one or more instances of com.ibm.wsspi.threadcontext.ThreadContextProvider.
+ */
+@Trivial
+public abstract class ContainerContextProvider implements ThreadContextProvider {
+    public abstract com.ibm.wsspi.threadcontext.ThreadContextProvider[] toContainerProviders();
+
+    @Override
+    public ThreadContextSnapshot defaultContext(Map<String, String> props) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        throw new UnsupportedOperationException();
+    }
+
+    // TODO remove once default impl provided by spec
+    @Override
+    public Set<String> getPrerequisites() {
+        return Collections.emptySet();
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/package-info.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "concurrent")
+package com.ibm.ws.concurrent.mp.context;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
Add some initial code around interpreting the configured context settings (cleared/propagated/unchanged) and loading one of the container supplied thread context providers: the application context.  Also, need to create this container-supplied context based on the existing JEE Metadata context and classloader context.