### PR TITLE
Fix eclipse build that doesn't build due to jax-rs change.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/subResourceApp/src"/>
 	<classpathentry kind="src" path="test-applications/patchapp/src"/>
 	<classpathentry kind="src" path="test-applications/providerPriorityApp/src"/>
 	<classpathentry kind="src" path="test-applications/classSubResApp/src"/>


### PR DESCRIPTION
Update to add new source package to the .classpath so things build again
in eclipse.
