### PR TITLE
Add custom injection proxy classes for Servlet request and response

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/component/injection/ContextObjectFactory.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/component/injection/ContextObjectFactory.java
@@ -26,6 +26,8 @@ import javax.naming.Context;
 import javax.naming.Name;
 import javax.naming.Reference;
 import javax.naming.spi.ObjectFactory;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Application;
 
 import org.osgi.service.component.ComponentContext;
@@ -36,6 +38,8 @@ import org.osgi.service.component.annotations.Modified;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.jaxrs20.injection.ApplicationInjectionProxy;
+import com.ibm.ws.jaxrs20.injection.HttpServletRequestInjectionProxy;
+import com.ibm.ws.jaxrs20.injection.HttpServletResponseInjectionProxy;
 import com.ibm.ws.jaxrs20.injection.InjectionRuntimeContextHelper;
 import com.ibm.ws.jaxrs20.injection.metadata.InjectionRuntimeContext;
 import com.ibm.ws.kernel.service.util.SecureAction;
@@ -83,8 +87,17 @@ public class ContextObjectFactory implements ObjectFactory {
                 Tr.debug(tc, "This is an Application sub-class being injected. Injecting an instance of ApplicationInjectionProxy.");
             }
             proxy = new ApplicationInjectionProxy();
+        } else if (HttpServletRequest.class.equals(contextClass)) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "This is an HttpServletRequest sub-class being injected. Injecting an instance of HttpServletRequestInjectionProxy.");
+            }
+            proxy = new HttpServletRequestInjectionProxy();
+        } else if (HttpServletResponse.class.equals(contextClass)) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "This is an HttpServletResponse sub-class being injected. Injecting an instance of HttpServletResponseInjectionProxy.");
+            }
+            proxy = new HttpServletResponseInjectionProxy();
         } else {
-
             proxy = Proxy.newProxyInstance(priv.getClassLoader(contextClass),
                                            new Class[] { contextClass },
                                            new InvocationHandler() {

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/injection/HttpServletRequestInjectionProxy.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/injection/HttpServletRequestInjectionProxy.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.injection;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.security.AccessController;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestWrapper;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jaxrs20.injection.metadata.InjectionRuntimeContext;
+import com.ibm.ws.kernel.service.util.SecureAction;
+
+/**
+ * A proxy that can be injected for {@link HttpServletRequest}s. All method invocations on the wrapped context are handled
+ * via {@link java.lang.reflect.Proxy}. This class allows clients to access the original context
+ * using {@link ServletRequestWrapper#getRequest()}.
+ */
+public class HttpServletRequestInjectionProxy extends HttpServletRequestWrapper {
+
+    private static final TraceComponent tc = Tr.register(HttpServletRequestInjectionProxy.class);
+    final static SecureAction priv = AccessController.doPrivileged(SecureAction.get());
+    private static final Class<?> contextClass = HttpServletRequest.class;
+
+    public HttpServletRequestInjectionProxy() {
+        super((HttpServletRequest) Proxy.newProxyInstance(priv.getClassLoader(contextClass),
+                                                          new Class[] { contextClass },
+                                                          new InvocationHandler() {
+                                                              @Override
+                                                              public Object invoke(Object proxy,
+                                                                                   Method method,
+                                                                                   Object[] args) throws Throwable {
+                                                                  if (tc.isEntryEnabled()) {
+                                                                      Tr.entry(tc, "invoke");
+                                                                  }
+                                                                  Object result;
+                                                                  if ("toString".equals(method.getName()) && (method.getParameterTypes().length == 0)) {
+                                                                      result = "Injection Proxy for " + contextClass.getName();
+                                                                      if (tc.isEntryEnabled()) {
+                                                                          Tr.exit(tc, "invoke", result);
+                                                                      }
+                                                                      return result;
+                                                                  }
+                                                                  result = method.invoke(getHttpServletRequest(), args);
+                                                                  if (tc.isEntryEnabled()) {
+                                                                      Tr.exit(tc, "invoke", result);
+                                                                  }
+                                                                  return result;
+                                                              }
+                                                          }));
+    }
+
+    private static HttpServletRequest getHttpServletRequest() {
+        final String methodName = "getHttpServletRequest";
+        if (tc.isEntryEnabled()) {
+            Tr.entry(tc, methodName);
+        }
+        // use runtimeContext from TLS
+        InjectionRuntimeContext runtimeContext = InjectionRuntimeContextHelper.getRuntimeContext();
+        // get the real context from the RuntimeContext
+        Object context = runtimeContext.getRuntimeCtxObject(contextClass.getName());
+        return (HttpServletRequest) context;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Injection Proxy for " + contextClass.getName();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletRequestWrapper#getRequest()
+     */
+    @Override
+    public ServletRequest getRequest() {
+        return getHttpServletRequest();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletRequestWrapper#isWrapperFor(java.lang.Class)
+     */
+    @Override
+    public boolean isWrapperFor(@SuppressWarnings("rawtypes") Class wrappedType) {
+        if (!ServletRequest.class.isAssignableFrom(wrappedType)) {
+            throw new IllegalArgumentException("Given class " +
+                                               wrappedType.getName() + " not a subinterface of " +
+                                               ServletRequest.class.getName());
+        }
+
+        final ServletRequest request = getHttpServletRequest();
+        @SuppressWarnings("unchecked")
+        final Class<? extends ServletRequest> wrappedServletType = wrappedType;
+
+        if (wrappedServletType.isAssignableFrom(request.getClass())) {
+            return true;
+        } else if (request instanceof ServletRequestWrapper) {
+            return ((ServletRequestWrapper) request).isWrapperFor(wrappedType);
+        } else {
+            return false;
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletRequestWrapper#isWrapperFor(javax.servlet.ServletRequest)
+     */
+    @Override
+    public boolean isWrapperFor(ServletRequest wrapped) {
+        final ServletRequest request = getHttpServletRequest();
+
+        if (request == wrapped) {
+            return true;
+        } else if (request instanceof ServletRequestWrapper) {
+            return ((ServletRequestWrapper) request).isWrapperFor(wrapped);
+        } else {
+            return false;
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletRequestWrapper#setRequest(javax.servlet.ServletRequest)
+     */
+    @Override
+    public void setRequest(ServletRequest request) {
+        throw new UnsupportedOperationException("ServletRequest may not be set on this proxy");
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/injection/HttpServletResponseInjectionProxy.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/injection/HttpServletResponseInjectionProxy.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.injection;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.security.AccessController;
+
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletResponseWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jaxrs20.injection.metadata.InjectionRuntimeContext;
+import com.ibm.ws.kernel.service.util.SecureAction;
+
+/**
+ * A proxy that can be injected for {@link HttpServletResponse}s. All method invocations on the wrapped context are handled
+ * via {@link java.lang.reflect.Proxy}. This class allows clients to access the original context
+ * using {@link ServletResponseWrapper#getResponse()}.
+ */
+public class HttpServletResponseInjectionProxy extends HttpServletResponseWrapper {
+
+    private static final TraceComponent tc = Tr.register(HttpServletResponseInjectionProxy.class);
+    final static SecureAction priv = AccessController.doPrivileged(SecureAction.get());
+    private static final Class<?> contextClass = HttpServletResponse.class;
+
+    public HttpServletResponseInjectionProxy() {
+        super((HttpServletResponse) Proxy.newProxyInstance(priv.getClassLoader(contextClass),
+                                                           new Class[] { contextClass },
+                                                           new InvocationHandler() {
+                                                               @Override
+                                                               public Object invoke(Object proxy,
+                                                                                    Method method,
+                                                                                    Object[] args) throws Throwable {
+                                                                   if (tc.isEntryEnabled()) {
+                                                                       Tr.entry(tc, "invoke");
+                                                                   }
+                                                                   Object result;
+                                                                   if ("toString".equals(method.getName()) && (method.getParameterTypes().length == 0)) {
+                                                                       result = "Injection Proxy for " + contextClass.getName();
+                                                                       if (tc.isEntryEnabled()) {
+                                                                           Tr.exit(tc, "invoke", result);
+                                                                       }
+                                                                       return result;
+                                                                   }
+                                                                   result = method.invoke(getHttpServletResponse(), args);
+                                                                   if (tc.isEntryEnabled()) {
+                                                                       Tr.exit(tc, "invoke", result);
+                                                                   }
+                                                                   return result;
+                                                               }
+                                                           }));
+    }
+
+    private static HttpServletResponse getHttpServletResponse() {
+        final String methodName = "getHttpServletResponse";
+        if (tc.isEntryEnabled()) {
+            Tr.entry(tc, methodName);
+        }
+        // use runtimeContext from TLS
+        InjectionRuntimeContext runtimeContext = InjectionRuntimeContextHelper.getRuntimeContext();
+        // get the real context from the RuntimeContext
+        Object context = runtimeContext.getRuntimeCtxObject(contextClass.getName());
+        return (HttpServletResponse) context;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Injection Proxy for " + contextClass.getName();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletResponseWrapper#getResponse()
+     */
+    @Override
+    public ServletResponse getResponse() {
+        return getHttpServletResponse();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletResponseWrapper#isWrapperFor(java.lang.Class)
+     */
+    @Override
+    public boolean isWrapperFor(@SuppressWarnings("rawtypes") Class wrappedType) {
+        if (!ServletResponse.class.isAssignableFrom(wrappedType)) {
+            throw new IllegalArgumentException("Given class " +
+                                               wrappedType.getName() + " not a subinterface of " +
+                                               ServletResponse.class.getName());
+        }
+
+        final ServletResponse response = getHttpServletResponse();
+        @SuppressWarnings("unchecked")
+        final Class<? extends ServletResponse> wrappedServletType = wrappedType;
+
+        if (wrappedServletType.isAssignableFrom(response.getClass())) {
+            return true;
+        } else if (response instanceof ServletResponseWrapper) {
+            return ((ServletResponseWrapper) response).isWrapperFor(wrappedType);
+        } else {
+            return false;
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletResponseWrapper#isWrapperFor(javax.servlet.ServletResponse)
+     */
+    @Override
+    public boolean isWrapperFor(ServletResponse wrapped) {
+        final ServletResponse response = getHttpServletResponse();
+
+        if (response == wrapped) {
+            return true;
+        } else if (response instanceof ServletResponseWrapper) {
+            return ((ServletResponseWrapper) response).isWrapperFor(wrapped);
+        } else {
+            return false;
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletResponseWrapper#setResponse(javax.servlet.ServletResponse)
+     */
+    @Override
+    public void setResponse(ServletResponse response) {
+        throw new UnsupportedOperationException("ServletResponse may not be set on this proxy");
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/component/injection/ContextObjectFactory.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/component/injection/ContextObjectFactory.java
@@ -26,6 +26,8 @@ import javax.naming.Context;
 import javax.naming.Name;
 import javax.naming.Reference;
 import javax.naming.spi.ObjectFactory;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Application;
 
 import org.osgi.service.component.ComponentContext;
@@ -36,6 +38,8 @@ import org.osgi.service.component.annotations.Modified;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.jaxrs20.injection.ApplicationInjectionProxy;
+import com.ibm.ws.jaxrs20.injection.HttpServletRequestInjectionProxy;
+import com.ibm.ws.jaxrs20.injection.HttpServletResponseInjectionProxy;
 import com.ibm.ws.jaxrs20.injection.InjectionRuntimeContextHelper;
 import com.ibm.ws.jaxrs20.injection.metadata.InjectionRuntimeContext;
 import com.ibm.ws.kernel.service.util.SecureAction;
@@ -83,8 +87,17 @@ public class ContextObjectFactory implements ObjectFactory {
                 Tr.debug(tc, "This is an Application sub-class being injected. Injecting an instance of ApplicationInjectionProxy.");
             }
             proxy = new ApplicationInjectionProxy();
+        } else if (HttpServletRequest.class.equals(contextClass)) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "This is an HttpServletRequest sub-class being injected. Injecting an instance of HttpServletRequestInjectionProxy.");
+            }
+            proxy = new HttpServletRequestInjectionProxy();
+        } else if (HttpServletResponse.class.equals(contextClass)) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "This is an HttpServletResponse sub-class being injected. Injecting an instance of HttpServletResponseInjectionProxy.");
+            }
+            proxy = new HttpServletResponseInjectionProxy();
         } else {
-
             proxy = Proxy.newProxyInstance(priv.getClassLoader(contextClass),
                                            new Class[] { contextClass },
                                            new InvocationHandler() {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/injection/HttpServletRequestInjectionProxy.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/injection/HttpServletRequestInjectionProxy.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.injection;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.security.AccessController;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestWrapper;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jaxrs20.injection.metadata.InjectionRuntimeContext;
+import com.ibm.ws.kernel.service.util.SecureAction;
+
+/**
+ * A proxy that can be injected for {@link HttpServletRequest}s. All method invocations on the wrapped context are handled
+ * via {@link java.lang.reflect.Proxy}. This class allows clients to access the original context
+ * using {@link ServletRequestWrapper#getRequest()}.
+ */
+public class HttpServletRequestInjectionProxy extends HttpServletRequestWrapper {
+
+    private static final TraceComponent tc = Tr.register(HttpServletRequestInjectionProxy.class);
+    final static SecureAction priv = AccessController.doPrivileged(SecureAction.get());
+    private static final Class<?> contextClass = HttpServletRequest.class;
+
+    public HttpServletRequestInjectionProxy() {
+        super((HttpServletRequest) Proxy.newProxyInstance(priv.getClassLoader(contextClass),
+                                                          new Class[] { contextClass },
+                                                          new InvocationHandler() {
+                                                              @Override
+                                                              public Object invoke(Object proxy,
+                                                                                   Method method,
+                                                                                   Object[] args) throws Throwable {
+                                                                  if (tc.isEntryEnabled()) {
+                                                                      Tr.entry(tc, "invoke");
+                                                                  }
+                                                                  Object result;
+                                                                  if ("toString".equals(method.getName()) && (method.getParameterTypes().length == 0)) {
+                                                                      result = "Injection Proxy for " + contextClass.getName();
+                                                                      if (tc.isEntryEnabled()) {
+                                                                          Tr.exit(tc, "invoke", result);
+                                                                      }
+                                                                      return result;
+                                                                  }
+                                                                  result = method.invoke(getHttpServletRequest(), args);
+                                                                  if (tc.isEntryEnabled()) {
+                                                                      Tr.exit(tc, "invoke", result);
+                                                                  }
+                                                                  return result;
+                                                              }
+                                                          }));
+    }
+
+    private static HttpServletRequest getHttpServletRequest() {
+        final String methodName = "getHttpServletRequest";
+        if (tc.isEntryEnabled()) {
+            Tr.entry(tc, methodName);
+        }
+        // use runtimeContext from TLS
+        InjectionRuntimeContext runtimeContext = InjectionRuntimeContextHelper.getRuntimeContext();
+        // get the real context from the RuntimeContext
+        Object context = runtimeContext.getRuntimeCtxObject(contextClass.getName());
+        return (HttpServletRequest) context;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Injection Proxy for " + contextClass.getName();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletRequestWrapper#getRequest()
+     */
+    @Override
+    public ServletRequest getRequest() {
+        return getHttpServletRequest();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletRequestWrapper#isWrapperFor(java.lang.Class)
+     */
+    @Override
+    public boolean isWrapperFor(@SuppressWarnings("rawtypes") Class wrappedType) {
+        if (!ServletRequest.class.isAssignableFrom(wrappedType)) {
+            throw new IllegalArgumentException("Given class " +
+                                               wrappedType.getName() + " not a subinterface of " +
+                                               ServletRequest.class.getName());
+        }
+
+        final ServletRequest request = getHttpServletRequest();
+        @SuppressWarnings("unchecked")
+        final Class<? extends ServletRequest> wrappedServletType = wrappedType;
+
+        if (wrappedServletType.isAssignableFrom(request.getClass())) {
+            return true;
+        } else if (request instanceof ServletRequestWrapper) {
+            return ((ServletRequestWrapper) request).isWrapperFor(wrappedType);
+        } else {
+            return false;
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletRequestWrapper#isWrapperFor(javax.servlet.ServletRequest)
+     */
+    @Override
+    public boolean isWrapperFor(ServletRequest wrapped) {
+        final ServletRequest request = getHttpServletRequest();
+
+        if (request == wrapped) {
+            return true;
+        } else if (request instanceof ServletRequestWrapper) {
+            return ((ServletRequestWrapper) request).isWrapperFor(wrapped);
+        } else {
+            return false;
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletRequestWrapper#setRequest(javax.servlet.ServletRequest)
+     */
+    @Override
+    public void setRequest(ServletRequest request) {
+        throw new UnsupportedOperationException("ServletRequest may not be set on this proxy");
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/injection/HttpServletResponseInjectionProxy.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/injection/HttpServletResponseInjectionProxy.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.injection;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.security.AccessController;
+
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletResponseWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jaxrs20.injection.metadata.InjectionRuntimeContext;
+import com.ibm.ws.kernel.service.util.SecureAction;
+
+/**
+ * A proxy that can be injected for {@link HttpServletResponse}s. All method invocations on the wrapped context are handled
+ * via {@link java.lang.reflect.Proxy}. This class allows clients to access the original context
+ * using {@link ServletResponseWrapper#getResponse()}.
+ */
+public class HttpServletResponseInjectionProxy extends HttpServletResponseWrapper {
+
+    private static final TraceComponent tc = Tr.register(HttpServletResponseInjectionProxy.class);
+    final static SecureAction priv = AccessController.doPrivileged(SecureAction.get());
+    private static final Class<?> contextClass = HttpServletResponse.class;
+
+    public HttpServletResponseInjectionProxy() {
+        super((HttpServletResponse) Proxy.newProxyInstance(priv.getClassLoader(contextClass),
+                                                           new Class[] { contextClass },
+                                                           new InvocationHandler() {
+                                                               @Override
+                                                               public Object invoke(Object proxy,
+                                                                                    Method method,
+                                                                                    Object[] args) throws Throwable {
+                                                                   if (tc.isEntryEnabled()) {
+                                                                       Tr.entry(tc, "invoke");
+                                                                   }
+                                                                   Object result;
+                                                                   if ("toString".equals(method.getName()) && (method.getParameterTypes().length == 0)) {
+                                                                       result = "Injection Proxy for " + contextClass.getName();
+                                                                       if (tc.isEntryEnabled()) {
+                                                                           Tr.exit(tc, "invoke", result);
+                                                                       }
+                                                                       return result;
+                                                                   }
+                                                                   result = method.invoke(getHttpServletResponse(), args);
+                                                                   if (tc.isEntryEnabled()) {
+                                                                       Tr.exit(tc, "invoke", result);
+                                                                   }
+                                                                   return result;
+                                                               }
+                                                           }));
+    }
+
+    private static HttpServletResponse getHttpServletResponse() {
+        final String methodName = "getHttpServletResponse";
+        if (tc.isEntryEnabled()) {
+            Tr.entry(tc, methodName);
+        }
+        // use runtimeContext from TLS
+        InjectionRuntimeContext runtimeContext = InjectionRuntimeContextHelper.getRuntimeContext();
+        // get the real context from the RuntimeContext
+        Object context = runtimeContext.getRuntimeCtxObject(contextClass.getName());
+        return (HttpServletResponse) context;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Injection Proxy for " + contextClass.getName();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletResponseWrapper#getResponse()
+     */
+    @Override
+    public ServletResponse getResponse() {
+        return getHttpServletResponse();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletResponseWrapper#isWrapperFor(java.lang.Class)
+     */
+    @Override
+    public boolean isWrapperFor(@SuppressWarnings("rawtypes") Class wrappedType) {
+        if (!ServletResponse.class.isAssignableFrom(wrappedType)) {
+            throw new IllegalArgumentException("Given class " +
+                                               wrappedType.getName() + " not a subinterface of " +
+                                               ServletResponse.class.getName());
+        }
+
+        final ServletResponse response = getHttpServletResponse();
+        @SuppressWarnings("unchecked")
+        final Class<? extends ServletResponse> wrappedServletType = wrappedType;
+
+        if (wrappedServletType.isAssignableFrom(response.getClass())) {
+            return true;
+        } else if (response instanceof ServletResponseWrapper) {
+            return ((ServletResponseWrapper) response).isWrapperFor(wrappedType);
+        } else {
+            return false;
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletResponseWrapper#isWrapperFor(javax.servlet.ServletResponse)
+     */
+    @Override
+    public boolean isWrapperFor(ServletResponse wrapped) {
+        final ServletResponse response = getHttpServletResponse();
+
+        if (response == wrapped) {
+            return true;
+        } else if (response instanceof ServletResponseWrapper) {
+            return ((ServletResponseWrapper) response).isWrapperFor(wrapped);
+        } else {
+            return false;
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.servlet.ServletResponseWrapper#setResponse(javax.servlet.ServletResponse)
+     */
+    @Override
+    public void setResponse(ServletResponse response) {
+        throw new UnsupportedOperationException("ServletResponse may not be set on this proxy");
+    }
+}


### PR DESCRIPTION
fixes #5505 

This change introduces two new context proxies for JAX-RS, one for HttpServletRequest and one for HttpServletResponse. The proxies extend from the standard request/response wrapper classes and allow for retrieval of the original context objects, i.e. unwrapping.