### PR TITLE
Set Default Read Timeout to 1min

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/metatype/metatype.xml
@@ -67,7 +67,7 @@
         <AD id="connectTimeout" name="%connectTimeout" description="%connectTimeout.desc"
             required="false" type="String" ibm:type="duration" default="1m"/>
         <AD id="readTimeout" name="%readTimeout" description="%readTimeout.desc"
-            required="false" type="String" ibm:type="duration" default="0m"/>
+            required="false" type="String" ibm:type="duration" default="1m"/>
         <AD id="failoverServers" name="%ldap.failoverServers" description="%ldap.failoverServers.desc"
             ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.security.registry.ldap.config.failoverServers"
             required="false" type="String" cardinality="2147483647" />

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/context/ContextManager.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/context/ContextManager.java
@@ -88,10 +88,10 @@ public class ContextManager {
     private static final int DEFAULT_PREF_POOL_SIZE = 3;
 
     /** The default connect time limit - 1 minute. */
-    private static final long DEFAULT_CONNECT_TIMEOUT = 600000;
+    private static final long DEFAULT_CONNECT_TIMEOUT = 60000;
 
-    /** The default read time limit - infinite. */
-    private static final long DEFAULT_READ_TIMEOUT = 0;
+    /** The default read time limit - 1 minute. */
+    private static final long DEFAULT_READ_TIMEOUT = 60000L;
 
     /** Key to use for accessing the active URL from the JNDI environment table. */
     private static final String ENVKEY_ACTIVE_URL = "_ACTIVE_URL_";
@@ -1389,7 +1389,7 @@ public class ContextManager {
      * @param prefPoolSize The preferred context pool size. Not required when <code>enableContextPool == false</code>.
      * @param maxPoolSize The maximum context pool size. A size of '0' means the maximum size is unlimited. Not required when <code>enableContextPool == false</code>.
      * @param poolTimeOut The context pool timeout in milliseconds. This is the amount of time a context is valid for in
-     *            the context pool is valid for until it is discarded. Not required when <code>enableContextPool == false</code>.
+     *           the context pool is valid for until it is discarded. Not required when <code>enableContextPool == false</code>.
      * @param poolWaitTime The context pool wait time in milliseconds. This is the amount of time to wait when getDirContext() is called
      *            and no context is available from the pool before checking again. Not required when <code>enableContextPool == false</code>.
      * @throws InvalidInitPropertyException If <code>initPoolSize > maxPoolSize</code> or <code>prefPoolSize > maxPoolSize</code> when <code>maxPoolSize != 0</code>.

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegistryContextPoolNoConfigTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegistryContextPoolNoConfigTest.java
@@ -149,6 +149,10 @@ public class LDAPRegistryContextPoolNoConfigTest {
         tr = "CacheResultSizeLimit: 2000";
         errMsgs = server.findStringsInLogsAndTrace(tr);
         assertFalse("Should have found, " + tr, errMsgs.isEmpty());
+
+        tr = "iReadTimeout=60000";
+        errMsgs = server.findStringsInLogsAndTrace(tr);
+        assertFalse("Should have found, " + tr, errMsgs.isEmpty());
     }
 
 }

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/wim/LdapRegistry.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/wim/LdapRegistry.java
@@ -34,6 +34,7 @@ public class LdapRegistry extends ConfigElement {
     private String certificateFilter;
     private String certificateMapMode;
     private String connectTimeout;
+    private String readTimeout;
     private ContextPool contextPool;
     private LdapFilters customFilters;
     private LdapFilters domino50Filters;
@@ -125,6 +126,13 @@ public class LdapRegistry extends ConfigElement {
      */
     public String getConnectTimeout() {
         return connectTimeout;
+    }
+
+    /**
+     * @return the readTimeout
+     */
+    public String getReadTimeout() {
+        return readTimeout;
     }
 
     /**
@@ -396,6 +404,14 @@ public class LdapRegistry extends ConfigElement {
     }
 
     /**
+     * @param connectTimeout the connectTimeout to set
+     */
+    @XmlAttribute(name = "")
+    public void setReadTimeout(String readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    /**
      * @param contextPool the contextPool to set
      */
     @XmlElement(name = "contextPool")
@@ -661,6 +677,9 @@ public class LdapRegistry extends ConfigElement {
         }
         if (connectTimeout != null) {
             sb.append("connectTimeout=\"").append(connectTimeout).append("\" ");;
+        }
+        if (readTimeout != null) {
+            sb.append("readTimeout=\"").append(readTimeout).append("\" ");;
         }
         if (contextPool != null) {
             sb.append("contextPool=\"").append(contextPool).append("\" ");;


### PR DESCRIPTION
fixes #5341.

Updated default readTimeout in metatype.xml. Updated LDAPRegistry ReadTimeout constant to be set to 1 min. Added Fat Test to test for Default Value