### PR TITLE
refresh snapshot of microprofile concurrency spec jar

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -68,7 +68,7 @@ com.ibm.ws.org.objenesis:objenesis:1.0
 com.ibm.ws.commons-collections:commons-collections:3.2.1
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 com.ibm.ws.org.eclipse.jdt.core.compiler:ecj:4.4.2
-com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api:0.20181004.214427.5-2
+com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api:0.20181025.204434.10
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.antlr:2.6.8.WAS-71e88a9
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.asm:2.6.8.WAS-71e88a9
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.core:2.6.8.WAS-71e88a9

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.concurrent.mp-1.0
 visibility=private
 singleton=true
 -bundles=\
-  com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api:0.20181004.214427.5-2",\
+  com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api:0.20181025.204434.10",\
   com.ibm.ws.concurrent.mp.1.0
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0/bnd.bnd
@@ -24,7 +24,7 @@ Export-Package: \
   org.eclipse.microprofile.concurrent.spi;version=1.0
 
 Include-Resource: \
-  @${repo;com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api;0.20181004.214427.5-2;EXACT}
+  @${repo;com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api;0.20181025.204434.10;EXACT}
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyProviderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyProviderImpl.java
@@ -12,6 +12,8 @@ package com.ibm.ws.concurrent.mp;
 
 import org.eclipse.microprofile.concurrent.ManagedExecutorBuilder;
 import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
+import org.eclipse.microprofile.concurrent.spi.ConcurrencyManager;
+import org.eclipse.microprofile.concurrent.spi.ConcurrencyManagerBuilder;
 import org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider;
 import org.eclipse.microprofile.concurrent.spi.ConcurrencyProviderRegistration;
 import org.osgi.framework.ServiceReference;
@@ -48,15 +50,38 @@ public class ConcurrencyProviderImpl implements ConcurrencyProvider {
     }
 
     @Override
-    public ManagedExecutorBuilder newManagedExecutorBuilder() {
-        // TODO ThreadContextProvider implementations are discovered here? Or upon builder.build()? Or upon using the executor (awkward).
+    public ConcurrencyManager getConcurrencyManager() {
         return null; // TODO
     }
 
     @Override
+    public ConcurrencyManager getConcurrencyManager(ClassLoader classLoader) {
+        return null; // TODO
+    }
+
+    @Override
+    public ConcurrencyManagerBuilder getConcurrencyManagerBuilder() {
+        return null; // TODO
+    }
+
+    @Override
+    public ManagedExecutorBuilder newManagedExecutorBuilder() {
+        return null; // TODO rely on default implementation to get from concurrency manager?
+    }
+
+    @Override
     public ThreadContextBuilder newThreadContextBuilder() {
-        // TODO ThreadContextProvider implementations are discovered here?
-        return new ThreadContextBuilderImpl(this);
+        return new ThreadContextBuilderImpl(this); // TODO rely on default implementation to get from concurrency manager?
+    }
+
+    @Override
+    public void registerConcurrencyManager(ConcurrencyManager manager, ClassLoader classLoader) {
+        // TODO
+    }
+
+    @Override
+    public void releaseConcurrencyManager(ConcurrencyManager manager) {
+        // TODO
     }
 
     @Reference(service = com.ibm.wsspi.threadcontext.ThreadContextProvider.class,

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.mp;
 
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -33,8 +34,8 @@ class ThreadContextBuilderImpl implements ThreadContextBuilder {
         this.concurrencyProvider = concurrencyProvider;
 
         // built-in defaults from spec:
-        // cleared.add(ThreadContext.TRANSACTION); // TODO add this once we pull in newer spec jar
-        propagated.add(ThreadContext.ALL); // TODO ALL is renamed to ALL_REMAINING once we update spec binaries
+        // cleared.add(ThreadContext.TRANSACTION); // TODO haven't added support for transaction context yet
+        propagated.add(ThreadContext.ALL_REMAINING);
     }
 
     @Override
@@ -42,17 +43,17 @@ class ThreadContextBuilderImpl implements ThreadContextBuilder {
         // For detection of unknown and overlapping types,
         HashSet<String> unknown = new HashSet<String>(cleared);
         unknown.addAll(propagated);
-        unknown.addAll(unchanged);
+        unknown.addAll(unchanged); // TODO should not cause an error if an unchanged type is not known
 
         if (unknown.size() < cleared.size() + propagated.size() + unchanged.size())
             throw new IllegalArgumentException(/* TODO findOverlapping(configured) */);
 
         // Determine what to with remaining context types that are not explicitly configured
         ContextOp remaining;
-        if (unknown.remove(ThreadContext.ALL)) {
-            remaining = propagated.contains(ThreadContext.ALL) ? ContextOp.PROPAGATED //
-                            : cleared.contains(ThreadContext.ALL) ? ContextOp.CLEARED //
-                                            : unchanged.contains(ThreadContext.ALL) ? ContextOp.UNCHANGED //
+        if (unknown.remove(ThreadContext.ALL_REMAINING)) {
+            remaining = propagated.contains(ThreadContext.ALL_REMAINING) ? ContextOp.PROPAGATED //
+                            : cleared.contains(ThreadContext.ALL_REMAINING) ? ContextOp.CLEARED //
+                                            : unchanged.contains(ThreadContext.ALL_REMAINING) ? ContextOp.UNCHANGED //
                                                             : null;
             if (remaining == null) // only possible if builder is concurrently modified during build
                 throw new ConcurrentModificationException();
@@ -88,27 +89,24 @@ class ThreadContextBuilderImpl implements ThreadContextBuilder {
         return new ThreadContextImpl(configPerProvider);
     }
 
-    // TODO @Override
+    @Override
     public ThreadContextBuilder cleared(String... types) {
         cleared.clear();
-        for (String type : types)
-            cleared.add(type);
+        Collections.addAll(cleared, types);
         return this;
     }
 
     @Override
     public ThreadContextBuilder propagated(String... types) {
         propagated.clear();
-        for (String type : types)
-            propagated.add(type);
+        Collections.addAll(propagated, types);
         return this;
     }
 
     @Override
     public ThreadContextBuilder unchanged(String... types) {
         unchanged.clear();
-        for (String type : types)
-            unchanged.add(type);
+        Collections.addAll(unchanged, types);
         return this;
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/ContainerContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/ContainerContextProvider.java
@@ -10,9 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.mp.context;
 
-import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
@@ -28,18 +26,12 @@ public abstract class ContainerContextProvider implements ThreadContextProvider 
     public abstract com.ibm.wsspi.threadcontext.ThreadContextProvider[] toContainerProviders();
 
     @Override
-    public ThreadContextSnapshot defaultContext(Map<String, String> props) {
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public ThreadContextSnapshot currentContext(Map<String, String> props) {
         throw new UnsupportedOperationException();
-    }
-
-    // TODO remove once default impl provided by spec
-    @Override
-    public Set<String> getPrerequisites() {
-        return Collections.emptySet();
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextProvider.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextProvider.java
@@ -10,9 +10,7 @@
  *******************************************************************************/
 package org.test.context.location;
 
-import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
@@ -26,19 +24,17 @@ import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
 public class StateContextProvider implements ThreadContextProvider {
     static ThreadLocal<String> stateName = ThreadLocal.withInitial(() -> "");
 
-    public ThreadContextSnapshot defaultContext(Map<String, String> props) {
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
         return new StateContextSnapshot("");
     }
 
+    @Override
     public ThreadContextSnapshot currentContext(Map<String, String> props) {
         return new StateContextSnapshot(stateName.get());
     }
 
-    // TODO remove the following method once default implementation is added
-    public Set<String> getPrerequisites() {
-        return Collections.emptySet();
-    }
-
+    @Override
     public String getThreadContextType() {
         return "State";
     }

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextRestorer.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextRestorer.java
@@ -26,6 +26,7 @@ public class StateContextRestorer implements ThreadContextController {
         this.stateNameToRestore = stateNameToRestore;
     }
 
+    @Override
     public void endContext() {
         if (restored)
             throw new IllegalStateException("thread context was already restored");

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextSnapshot.java
@@ -26,6 +26,7 @@ public class StateContextSnapshot implements ThreadContextSnapshot {
         this.stateName = stateName;
     }
 
+    @Override
     public ThreadContextController begin() {
         ThreadContextController stateContextRestorer = new StateContextRestorer(StateContextProvider.stateName.get());
         StateContextProvider.stateName.set(stateName);


### PR DESCRIPTION
Update to the latest snapshot of the MicroProfile Concurrency spec jar,
https://repo.eclipse.org/content/repositories/microprofile-snapshots/org/eclipse/microprofile/concurrency/microprofile-concurrency-api/1.0-SNAPSHOT/microprofile-concurrency-api-1.0-20181025.204434-10.jar

This will allow us to stay in sync with changes to method/constant names, and more importantly, will allow us to experiment with ConcurrencyManager