### PR TITLE
use ConcurrencyManager to load context providers separately per class loader

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+import org.eclipse.microprofile.concurrent.ManagedExecutorBuilder;
+import org.eclipse.microprofile.concurrent.ThreadContext;
+import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
+import org.eclipse.microprofile.concurrent.spi.ConcurrencyManager;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Concurrency manager, which includes the collection of ThreadContextProviders
+ * for a particular class loader, ordered by their prerequisites.
+ */
+public class ConcurrencyManagerImpl implements ConcurrencyManager {
+    private static final TraceComponent tc = Tr.register(ConcurrencyManagerImpl.class);
+
+    /**
+     * List of available thread context providers, ordered according to their prerequisites.
+     * This is the order in which thread context should be captured and applied to threads.
+     * It is the reverse of the order in which thread context is restored on threads.
+     */
+    private final ArrayList<ThreadContextProvider> contextProviders = new ArrayList<ThreadContextProvider>();
+
+    ConcurrencyManagerImpl(ConcurrencyProviderImpl concurrencyProvider, ClassLoader classloader) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+        // Thread context types for which providers with satisfied prerequisites are found.
+        HashSet<String> available = new HashSet<String>();
+
+        // Thread context providers whose prerequisites are unmet
+        LinkedList<ThreadContextProvider> unsatisfied = new LinkedList<ThreadContextProvider>();
+
+        // Built-in thread context providers
+
+        contextProviders.add(concurrencyProvider.applicationContextProvider); // always available
+        available.add(ThreadContext.APPLICATION);
+
+        // TODO add other container-provided ThreadContextProviders
+        // TODO some of these will vary in availability which can change based on server config.
+        // Look into using ContainerContextProvider.toContainerProviders returning a NULL to indicate this.
+
+        // Thread context providers for the supplied class loader
+
+        for (ThreadContextProvider provider : ServiceLoader.load(ThreadContextProvider.class, classloader)) {
+            String type = provider.getThreadContextType();
+            Set<String> prereqs = provider.getPrerequisites();
+
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(this, tc, "context type " + type + " with prereqs " + prereqs + " provided by ");
+
+            if (available.containsAll(prereqs)) {
+                if (available.add(type))
+                    contextProviders.add(provider);
+                else
+                    // TODO message: "Duplicate type of thread context, " + type + ", is provided by " + provider + " and " + getProvider(type));
+                    throw new IllegalStateException();
+            } else {
+                unsatisfied.add(provider);
+            }
+        }
+
+        // Additional passes through the unsatisfied providers list until all are satisfied or no changes are made
+
+        for (boolean changed = true; changed && !unsatisfied.isEmpty();) {
+            changed = false;
+            for (ThreadContextProvider provider : unsatisfied) {
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "previously unsatisfied provider " + provider);
+
+                if (available.containsAll(provider.getPrerequisites())) {
+                    if (available.add(provider.getThreadContextType()))
+                        contextProviders.add(provider);
+                    else
+                        throw new IllegalStateException(); // TODO same message from earlier
+                    changed = true;
+                } else {
+                    unsatisfied.add(provider);
+                }
+            }
+        }
+
+        // TODO should unsatisfied providers be an error, or defer to later & only if the builder wants to enable them?
+        if (!unsatisfied.isEmpty())
+            throw new IllegalStateException(unsatisfied.toString()); // TODO message with better detail
+    }
+
+    @Override
+    public ManagedExecutorBuilder newManagedExecutorBuilder() {
+        throw new UnsupportedOperationException(); // TODO
+    }
+
+    @Override
+    public ThreadContextBuilder newThreadContextBuilder() {
+        return new ThreadContextBuilderImpl(contextProviders);
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextSnapshotProxy.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextSnapshotProxy.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectOutputStream;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.wsspi.threadcontext.ThreadContext;
+
+/**
+ * Proxies a MicroProfile ThreadContextSnapshot as a com.ibm.wsspi.threadcontext.ThreadContext
+ * which is used internally for compatibility with container-provided context types.
+ */
+public class ContextSnapshotProxy implements com.ibm.wsspi.threadcontext.ThreadContext {
+    private static final long serialVersionUID = 1L;
+
+    private ThreadContextController contextRestorer;
+    private final ThreadContextSnapshot snapshot;
+
+    ContextSnapshotProxy(ThreadContextSnapshot snapshot) {
+        this.snapshot = snapshot;
+    }
+
+    @Override
+    public ThreadContext clone() {
+        return new ContextSnapshotProxy(snapshot);
+    }
+
+    @Override
+    public void taskStarting() {
+        contextRestorer = snapshot.begin();
+    }
+
+    @Override
+    public void taskStopping() {
+        contextRestorer.endContext();
+        contextRestorer = null;
+    }
+
+    @Override
+    @Trivial
+    public String toString() {
+        StringBuilder sb = new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())) //
+                        .append(" for ").append(snapshot).append(" ThreadContextController: ").append(contextRestorer);
+        return sb.toString();
+    }
+
+    private void writeObject(ObjectOutputStream outStream) throws IOException {
+        throw new NotSerializableException();
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextDescriptorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextDescriptorImpl.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
 
 import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -53,8 +54,11 @@ class ThreadContextDescriptorImpl implements ThreadContextDescriptor {
                     contextSnapshots.add(tc);
                 }
             } else {
-                // TODO support MP context types
-                throw new UnsupportedOperationException();
+                ThreadContextSnapshot contextSnapshot = entry.getValue() == ContextOp.CLEARED //
+                                ? provider.clearedContext(EMPTY_MAP) // CLEARED
+                                : provider.currentContext(EMPTY_MAP); // PROPAGATED
+                // Convert to the com.ibm.wsspi.threadcontext.ThreadContext type which the container understands
+                contextSnapshots.add(new ContextSnapshotProxy(contextSnapshot));
             }
         }
     }


### PR DESCRIPTION
Start experimenting with ConcurrencyManager from the MP Concurrency spec.  The design of the spec around ConcurrencyManager needs some improvement and it will help to experiment with how well it fits in to the Liberty implementation.  To start out with, most of the non-essential methods will be left as a no-op or exception, and we won't be concerned with clearing cached ConcurrencyManager/provider lists when a class loader goes away, although that will eventually need to be added.