### PR TITLE
Support other URL ptcols other than wsjpa:

### DIFF
--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -26,5 +26,7 @@ import com.ibm.ws.jpa.jpa22.JPA22FATSuite;
                 JPAAppClientTest.class
 })
 public class FATSuite {
+    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";" };
 
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/CallbackTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/CallbackTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.jpa.FATSuite;
 import com.ibm.ws.jpa.JPAFATServletClient;
 
 import componenttest.annotation.Server;
@@ -72,7 +73,7 @@ public class CallbackTest extends JPAFATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server1, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server1, FATSuite.JAXB_PERMS);
         bannerStart(CallbackTest.class);
         timestart = System.currentTimeMillis();
 
@@ -131,6 +132,8 @@ public class CallbackTest extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
+            server1.dumpServer("callback");
+
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/Relationships_ManyXMany_EJB.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/Relationships_ManyXMany_EJB.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.jpa.FATSuite;
 import com.ibm.ws.jpa.JPAFATServletClient;
 import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.ejb.TestManyXManyBidirectional_EJB_SFEX_Servlet;
 import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.ejb.TestManyXManyBidirectional_EJB_SF_Servlet;
@@ -80,7 +81,7 @@ public class Relationships_ManyXMany_EJB extends JPAFATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server1, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server1, FATSuite.JAXB_PERMS);
         bannerStart(CallbackTest.class);
         timestart = System.currentTimeMillis();
 
@@ -163,6 +164,7 @@ public class Relationships_ManyXMany_EJB extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
+            server1.dumpServer("relationships_manyXmany_ejb");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/Relationships_ManyXMany_Web.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/Relationships_ManyXMany_Web.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.Application;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.jpa.FATSuite;
 import com.ibm.ws.jpa.JPAFATServletClient;
 import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.web.TestManyXManyBidirectionalServlet;
 import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.web.TestManyXManyCollectionTypeServlet;
@@ -65,7 +66,7 @@ public class Relationships_ManyXMany_Web extends JPAFATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server1, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server1, FATSuite.JAXB_PERMS);
         bannerStart(CallbackTest.class);
         timestart = System.currentTimeMillis();
 
@@ -144,6 +145,7 @@ public class Relationships_ManyXMany_Web extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
+            server1.dumpServer("relationships_manyXmany_web");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22BeanValidation.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22BeanValidation.java
@@ -18,6 +18,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jpa.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -40,7 +41,7 @@ public class JPA22BeanValidation extends FATServletClient {
     public static void setUp() throws Exception {
         final String resPath = "test-applications/jpa22/" + APP_NAME + "/resources/";
 
-        PrivHelper.generateCustomPolicy(server1, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server1, FATSuite.JAXB_PERMS);
 
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war");
         app.addPackage("jpa22bval.web");
@@ -54,6 +55,7 @@ public class JPA22BeanValidation extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        server1.dumpServer("beanval");
         server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22Injection.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22Injection.java
@@ -18,6 +18,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jpa.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -44,7 +45,7 @@ public class JPA22Injection extends FATServletClient {
     public static void setUp() throws Exception {
         final String resPath = "test-applications/jpa22/" + APP_NAME + "/resources/";
 
-        PrivHelper.generateCustomPolicy(server1, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server1, FATSuite.JAXB_PERMS);
 
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war");
         app.addPackage("jpa22injection.web");
@@ -58,6 +59,7 @@ public class JPA22Injection extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        server1.dumpServer("injection");
         server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22QueryTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22QueryTest.java
@@ -18,6 +18,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jpa.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -44,7 +45,7 @@ public class JPA22QueryTest extends FATServletClient {
     public static void setUp() throws Exception {
         final String resPath = "test-applications/jpa22/" + APP_NAME + "/resources/";
 
-        PrivHelper.generateCustomPolicy(server1, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server1, FATSuite.JAXB_PERMS);
 
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war");
         app.addPackage("jpa22query.web");
@@ -58,6 +59,7 @@ public class JPA22QueryTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        server1.dumpServer("query");
         server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22TimeAPITest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22TimeAPITest.java
@@ -18,6 +18,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jpa.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -44,7 +45,7 @@ public class JPA22TimeAPITest extends FATServletClient {
     public static void setUp() throws Exception {
         final String resPath = "test-applications/jpa22/" + APP_NAME + "/resources/";
 
-        PrivHelper.generateCustomPolicy(server1, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server1, FATSuite.JAXB_PERMS);
 
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war");
         app.addPackage("jpa22timeapi.web");
@@ -58,6 +59,7 @@ public class JPA22TimeAPITest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        server1.dumpServer("timeapi");
         server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPACDIIntegrationTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPACDIIntegrationTest.java
@@ -18,6 +18,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jpa.FATSuite;
 
 import cdi.web.ELIServlet;
 import componenttest.annotation.Server;
@@ -44,7 +45,7 @@ public class JPACDIIntegrationTest {
     public static void setUp() throws Exception {
         final String resPath = "test-applications/jpa22/" + APP_NAME + "/resources/";
 
-        PrivHelper.generateCustomPolicy(server1, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server1, FATSuite.JAXB_PERMS);
 
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war");
         app.addPackage("cdi.web");
@@ -58,6 +59,7 @@ public class JPACDIIntegrationTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        server1.dumpServer("cdi");
         server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }


### PR DESCRIPTION
Update to JPA ORM Diagnostic collector to include support for jar:file URLs, unexploded jar file: URLs, and exploded jar file: URLs.

