### PR TITLE
re-add jaxrs FAT test change

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTest.java
@@ -100,6 +100,7 @@ public class JAXRSClientSSLTest extends AbstractTest {
     public void testClientBasicSSL_CustomizedSSLContext() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "alex");
+        p.put("SERVER_CONFIG_DIR", server.getServerRoot());
         this.runTestOnServer(target, "testClientBasicSSL_CustomizedSSLContext", p, "unable to find valid certification path to requested target");
     }
 


### PR DESCRIPTION
somehow, even tho git shows the change made it, the change to com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTest.java was lost causing a jaxrs test to fail when moved to OpenLiberty