### PR TITLE
Update OIDC RP certification tests to run in full mode

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.social/src/com/ibm/ws/security/fat/common/social/oidc/certification/OidcCertificationRPBasicProfileTests.java
+++ b/dev/com.ibm.ws.security.fat.common.social/src/com/ibm/ws/security/fat/common/social/oidc/certification/OidcCertificationRPBasicProfileTests.java
@@ -60,7 +60,7 @@ import componenttest.topology.impl.LibertyServer;
  * 
  * This class should encompass all tests required for the minimal certification for the Basic RP profile.
  */
-@Mode(TestMode.LITE)
+@Mode(TestMode.FULL)
 public abstract class OidcCertificationRPBasicProfileTests extends CommonSecurityFat {
 
     public static Class<?> thisClass = OidcCertificationRPBasicProfileTests.class;


### PR DESCRIPTION
Move tests to run in FULL mode to lessen the load on the OIDC certification servers.