### PR TITLE
built-in container-provided context types

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.concurrent.mp.context.WLMContextProvider;
 
 /**
  * Concurrency manager, which includes the collection of ThreadContextProviders
@@ -48,14 +49,16 @@ public class ConcurrencyManagerImpl implements ConcurrencyManager {
         // Thread context providers whose prerequisites are unmet
         LinkedList<ThreadContextProvider> unsatisfied = new LinkedList<ThreadContextProvider>();
 
-        // Built-in thread context providers
+        // Built-in thread context providers (always available)
 
-        contextProviders.add(concurrencyProvider.applicationContextProvider); // always available
+        contextProviders.add(concurrencyProvider.applicationContextProvider);
         available.add(ThreadContext.APPLICATION);
-
-        // TODO add other container-provided ThreadContextProviders
-        // TODO some of these will vary in availability which can change based on server config.
-        // Look into using ContainerContextProvider.toContainerProviders returning a NULL to indicate this.
+        contextProviders.add(concurrencyProvider.securityContextProvider);
+        available.add(ThreadContext.SECURITY);
+        contextProviders.add(concurrencyProvider.transactionContextProvider);
+        available.add(ThreadContext.TRANSACTION);
+        contextProviders.add(concurrencyProvider.wlmContextProvider);
+        available.add(WLMContextProvider.WORKLOAD);
 
         // Thread context providers for the supplied class loader
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextOp.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextOp.java
@@ -16,7 +16,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
  * Describes an operation that is performed with regard to establishing context on a thread.
  */
 @Trivial
-enum ContextOp {
+public enum ContextOp {
     /**
      * Thread context of the specified type is cleared from the thread of execution
      * before performing the action/task.

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
@@ -34,7 +34,7 @@ class ThreadContextBuilderImpl implements ThreadContextBuilder {
         this.contextProviders = contextProviders;
 
         // built-in defaults from spec:
-        // cleared.add(ThreadContext.TRANSACTION); // TODO haven't added support for transaction context yet
+        cleared.add(ThreadContext.TRANSACTION);
         propagated.add(ThreadContext.ALL_REMAINING);
     }
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextDescriptorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextDescriptorImpl.java
@@ -47,12 +47,7 @@ class ThreadContextDescriptorImpl implements ThreadContextDescriptor {
         for (Map.Entry<ThreadContextProvider, ContextOp> entry : configPerProvider.entrySet()) {
             ThreadContextProvider provider = entry.getKey();
             if (provider instanceof ContainerContextProvider) {
-                for (com.ibm.wsspi.threadcontext.ThreadContextProvider cp : ((ContainerContextProvider) provider).toContainerProviders()) {
-                    com.ibm.wsspi.threadcontext.ThreadContext tc = entry.getValue() == ContextOp.CLEARED //
-                                    ? cp.createDefaultThreadContext(EMPTY_MAP) //
-                                    : cp.captureThreadContext(EMPTY_MAP, EMPTY_MAP); // PROPAGATED
-                    contextSnapshots.add(tc);
-                }
+                ((ContainerContextProvider) provider).addContextSnapshot(entry.getValue(), contextSnapshots);
             } else {
                 ThreadContextSnapshot contextSnapshot = entry.getValue() == ContextOp.CLEARED //
                                 ? provider.clearedContext(EMPTY_MAP) // CLEARED
@@ -78,7 +73,7 @@ class ThreadContextDescriptorImpl implements ThreadContextDescriptor {
     @Override
     @Trivial
     public Map<String, String> getExecutionProperties() {
-        return Collections.emptyMap();
+        return EMPTY_MAP;
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/ContainerContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/ContainerContextProvider.java
@@ -10,28 +10,41 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.mp.context;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.mp.ContextOp;
 
 /**
- * This interface allows for the conversion from MicroProfile ThreadContextProvider
- * back to one or more instances of com.ibm.wsspi.threadcontext.ThreadContextProvider.
+ * This interface allows container-provided thread context types to be used
+ * alongside MicroProfile ThreadContextProviders.
  */
 @Trivial
 public abstract class ContainerContextProvider implements ThreadContextProvider {
-    public abstract com.ibm.wsspi.threadcontext.ThreadContextProvider[] toContainerProviders();
+    static final Map<String, String> EMPTY_MAP = Collections.emptyMap();
+
+    /**
+     * Appends thread context snapshot(s) of the type provided by this provider to the specified list.
+     *
+     * @param op the CLEARED or PROPAGATED operation.
+     * @param contextSnapshots list to which to add context snapshot(s).
+     */
+    public abstract void addContextSnapshot(ContextOp op, ArrayList<com.ibm.wsspi.threadcontext.ThreadContext> contextSnapshots);
 
     @Override
     public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        // never used, because this class is converted to the internal container provider type
         throw new UnsupportedOperationException();
     }
 
     @Override
     public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        // never used, because this class is converted to the internal container provider type
         throw new UnsupportedOperationException();
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/DeferredClearedContext.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/DeferredClearedContext.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.context;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectOutputStream;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
+import com.ibm.wsspi.threadcontext.ThreadContext;
+
+/**
+ * In Liberty, the container-provided context types are considered always available
+ * even if the feature supplying the container internal com.ibm.wsspi.threadcontext.ThreadContextProvider
+ * type isn't available. This class allows for the possibility that the feature could become
+ * available at a later time, by deferring the creation of the cleared thread context snapshot
+ * until the action or task is about to start.
+ */
+public class DeferredClearedContext implements com.ibm.wsspi.threadcontext.ThreadContext {
+    private static final long serialVersionUID = 1L;
+
+    private com.ibm.wsspi.threadcontext.ThreadContext clearedContextController;
+    public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> contextProviderRef;
+
+    DeferredClearedContext(AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> contextProviderRef) {
+        this.contextProviderRef = contextProviderRef;
+    }
+
+    @Override
+    public ThreadContext clone() {
+        return new DeferredClearedContext(contextProviderRef);
+    }
+
+    @Override
+    public void taskStarting() {
+        com.ibm.wsspi.threadcontext.ThreadContextProvider provider = contextProviderRef.getService();
+        if (provider != null) {
+            clearedContextController = provider.createDefaultThreadContext(ContainerContextProvider.EMPTY_MAP);
+            clearedContextController.taskStarting();
+        }
+    }
+
+    @Override
+    public void taskStopping() {
+        if (clearedContextController != null) {
+            clearedContextController.taskStopping();
+            clearedContextController = null;
+        }
+    }
+
+    @Override
+    @Trivial
+    public String toString() {
+        StringBuilder sb = new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())) //
+                        .append(" for ").append(contextProviderRef).append(" clearedContextController: ").append(clearedContextController);
+        return sb.toString();
+    }
+
+    private void writeObject(ObjectOutputStream outStream) throws IOException {
+        throw new NotSerializableException();
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/SecurityContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/SecurityContextProvider.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.context;
+
+import java.util.ArrayList;
+
+import org.eclipse.microprofile.concurrent.ThreadContext;
+
+import com.ibm.ws.concurrent.mp.ContextOp;
+import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
+
+/**
+ * Partial implementation of MicroProfile Security context,
+ * backed by Liberty's Security context.
+ */
+public class SecurityContextProvider extends ContainerContextProvider {
+    public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> securityContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("SecurityContextProvider");
+    public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> threadIdentityContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("ThreadIdentityContextProvider");
+
+    @Override
+    public void addContextSnapshot(ContextOp op, ArrayList<com.ibm.wsspi.threadcontext.ThreadContext> contextSnapshots) {
+        com.ibm.wsspi.threadcontext.ThreadContext snapshot;
+
+        com.ibm.wsspi.threadcontext.ThreadContextProvider securityProvider = securityContextProviderRef.getService();
+        if (securityProvider == null)
+            snapshot = new DeferredClearedContext(securityContextProviderRef);
+        else if (op == ContextOp.PROPAGATED)
+            snapshot = securityProvider.captureThreadContext(EMPTY_MAP, EMPTY_MAP);
+        else
+            snapshot = securityProvider.createDefaultThreadContext(EMPTY_MAP);
+        contextSnapshots.add(snapshot);
+
+        com.ibm.wsspi.threadcontext.ThreadContextProvider threadIdentityProvider = threadIdentityContextProviderRef.getService();
+        if (threadIdentityProvider == null)
+            snapshot = new DeferredClearedContext(threadIdentityContextProviderRef);
+        else if (op == ContextOp.PROPAGATED)
+            snapshot = threadIdentityProvider.captureThreadContext(EMPTY_MAP, EMPTY_MAP);
+        else
+            snapshot = threadIdentityProvider.createDefaultThreadContext(EMPTY_MAP);
+        contextSnapshots.add(snapshot);
+    }
+
+    @Override
+    public final String getThreadContextType() {
+        return ThreadContext.SECURITY;
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/TransactionContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/TransactionContextProvider.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.context;
+
+import java.util.ArrayList;
+
+import org.eclipse.microprofile.concurrent.ThreadContext;
+
+import com.ibm.ws.concurrent.mp.ContextOp;
+import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
+
+/**
+ * Partial implementation of MicroProfile Transaction context,
+ * backed by Liberty's Transaction context.
+ */
+public class TransactionContextProvider extends ContainerContextProvider {
+    public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> transactionContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("TransactionContextProvider");
+
+    @Override
+    public void addContextSnapshot(ContextOp op, ArrayList<com.ibm.wsspi.threadcontext.ThreadContext> contextSnapshots) {
+        com.ibm.wsspi.threadcontext.ThreadContext snapshot;
+        com.ibm.wsspi.threadcontext.ThreadContextProvider transactionProvider = transactionContextProviderRef.getService();
+        if (transactionProvider == null)
+            snapshot = new DeferredClearedContext(transactionContextProviderRef);
+        else if (op == ContextOp.PROPAGATED)
+            // TODO it is reasonable to reject this when someone explicitly asks for transaction propagation,
+            // but will it be a problem to reject this when the user specifies ALL_REMAINING ?
+            throw new UnsupportedOperationException();
+        else
+            snapshot = transactionProvider.createDefaultThreadContext(EMPTY_MAP);
+
+        contextSnapshots.add(snapshot);
+    }
+
+    @Override
+    public final String getThreadContextType() {
+        return ThreadContext.TRANSACTION;
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/WLMContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/WLMContextProvider.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.context;
+
+import java.util.ArrayList;
+
+import com.ibm.ws.concurrent.mp.ContextOp;
+import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
+
+/**
+ * Partial implementation of MicroProfile thread context provider,
+ * backed by Liberty's z/OS WLM context.
+ */
+public class WLMContextProvider extends ContainerContextProvider {
+    public static final String WORKLOAD = "Workload";
+
+    public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> wlmContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("WLMContextProvider");
+
+    @Override
+    public void addContextSnapshot(ContextOp op, ArrayList<com.ibm.wsspi.threadcontext.ThreadContext> contextSnapshots) {
+        com.ibm.wsspi.threadcontext.ThreadContext snapshot;
+        com.ibm.wsspi.threadcontext.ThreadContextProvider wlmProvider = wlmContextProviderRef.getService();
+        if (wlmProvider == null)
+            snapshot = new DeferredClearedContext(wlmContextProviderRef);
+        // TODO currently, there is no way to configure execution properties that are necessary for propagate
+        //else if (op == ContextOp.PROPAGATED)
+        //    snapshot = wlmProvider.captureThreadContext(...);
+        else
+            snapshot = wlmProvider.createDefaultThreadContext(EMPTY_MAP);
+
+        contextSnapshots.add(snapshot);
+    }
+
+    @Override
+    public final String getThreadContextType() {
+        return WORKLOAD;
+    }
+}


### PR DESCRIPTION
Enable the remaining thread context types that are provided internally by the container.