### PR TITLE
Offer feature suggestions for CNFEs on removed JDK APIs

### DIFF
--- a/dev/com.ibm.ws.classloading/bnd.bnd
+++ b/dev/com.ibm.ws.classloading/bnd.bnd
@@ -27,7 +27,7 @@ Export-Package: \
   com.ibm.wsspi.classloading;provide:=true, \
   com.ibm.wsspi.library;provide:=true
 
- Include-Resource: \
+Include-Resource: \
     OSGI-INF=resources/OSGI-INF
 
 # catch any packages not explicitly exported and make sure they are private
@@ -51,6 +51,7 @@ instrument.classesExcludes: com/ibm/ws/classloading/internal/resources/*.class
 	com.ibm.ws.artifact.url;version=latest,\
 	com.ibm.ws.kernel.security.thread,\
 	com.ibm.ws.kernel.metatype.helper,\
+	com.ibm.ws.kernel.service,\
 	com.ibm.ws.artifact;version=latest,\
 	com.ibm.ws.artifact.overlay;version=latest,\
 	com.ibm.ws.org.eclipse.equinox.region,\

--- a/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
+++ b/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2014 IBM Corporation and others.
+# Copyright (c) 2011, 2018 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -155,3 +155,9 @@ cls.classloader.config.typo.useraction=Check the server configuration for invali
 cls.classloader.config.typo2=CWWKL0083E: When using prefix + or -, [{0}] API type is not valid in this [{1}] list.  All API type must have a prefix of + or -
 cls.classloader.config.typo2.explanation=Change the invalid API type to a valid API type with + or -.
 cls.classloader.config.typo2.useraction=Check the server configuration for invalid API type to ensure that the API type are correct.
+
+# {0} - class name
+# {1} - suggested feature
+cls.classloader.suggested.feature=CWWKL0084W: The {0} class could not be loaded. Try enabling the {1} feature or a newer version of the feature in the server.xml file.
+cls.classloader.suggested.feature.explanation=A class that is typically provided by one or more server features could not be loaded.
+cls.classloader.suggested.feature.useraction=Try enabling the specified feature or a newer version of the feature in the server.xml file.

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
@@ -47,6 +47,7 @@ import com.ibm.ws.artifact.url.WSJarURLConnection;
 import com.ibm.ws.classloading.ClassGenerator;
 import com.ibm.ws.classloading.internal.providers.Providers;
 import com.ibm.ws.classloading.internal.util.ClassRedefiner;
+import com.ibm.ws.classloading.internal.util.FeatureSuggestion;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.wsspi.adaptable.module.Container;
@@ -69,7 +70,7 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
     };
 
     static final List<SearchLocation> PARENT_FIRST_SEARCH_ORDER = freeze(list(PARENT, SELF, DELEGATES));
-
+    
     static final String CLASS_LOADING_TRACE_PREFIX = "com.ibm.ws.class.load.";
     static final String DEFAULT_PACKAGE = "default.package";
     /** per class loader collection of per-package trace components */
@@ -342,6 +343,7 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
         return clazz;
     }
 
+    @Trivial // injected trace calls ProtectedDomain.toString() which requires privileged access
     private ProtectionDomain getClassSpecificProtectionDomain(final String name, final URL resourceUrl) {
         ProtectionDomain pd = config.getProtectionDomain();
         try {
@@ -449,7 +451,7 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
                 return generatedClass;
 
             // could not generate class - throw CNFE
-            throw e;
+            throw FeatureSuggestion.getExceptionWithSuggestion(e);
         } finally {
             ThreadIdentityManager.reset(token);
         }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderConfigurationImpl.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderConfigurationImpl.java
@@ -164,23 +164,15 @@ class ClassLoaderConfigurationImpl implements ClassLoaderConfiguration {
         return sb.toString();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.ibm.wsspi.classloading.ClassLoaderConfiguration#setProtectionDomain(java.security.ProtectionDomain)
-     */
     @Override
+    @Trivial // injected trace calls ProtectedDomain.toString() which requires privileged access
     public ClassLoaderConfiguration setProtectionDomain(ProtectionDomain domain) {
         this.protectionDomain = domain;
         return this;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.ibm.wsspi.classloading.ClassLoaderConfiguration#getProtectionDomain()
-     */
     @Override
+    @Trivial // injected trace calls ProtectedDomain.toString() which requires privileged access
     public ProtectionDomain getProtectionDomain() {
         return protectionDomain;
     }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoadingServiceImpl.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoadingServiceImpl.java
@@ -59,6 +59,7 @@ import org.osgi.service.url.URLStreamHandlerService;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.classloading.ClassGenerator;
 import com.ibm.ws.classloading.ClassLoaderIdentifierService;
 import com.ibm.ws.classloading.LibertyClassLoadingService;
@@ -433,6 +434,7 @@ public class ClassLoadingServiceImpl implements LibertyClassLoadingService, Clas
         }
     }
 
+    @Trivial // injected trace calls ProtectedDomain.toString() which requires privileged access
     public Map<String, ProtectionDomain> getProtectionDomainMap() {
         return protectionDomainMap;
     }
@@ -701,6 +703,7 @@ public class ClassLoadingServiceImpl implements LibertyClassLoadingService, Clas
      * @see com.ibm.wsspi.classloading.ClassLoadingService#setSharedLibraryProtectionDomains(java.util.Map)
      */
     @Override
+    @Trivial // injected trace calls ProtectedDomain.toString() which requires privileged access
     public void setSharedLibraryProtectionDomains(Map<String, ProtectionDomain> protectionDomainMap) {
         this.protectionDomainMap = protectionDomainMap;
     }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/util/FeatureSuggestion.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/util/FeatureSuggestion.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.classloading.internal.util;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.FFDCFilter;
+import com.ibm.ws.kernel.service.util.JavaInfo;
+
+public class FeatureSuggestion {
+    
+    private static final TraceComponent tc = Tr.register(FeatureSuggestion.class);
+    
+    private static final String FEATURE_JAXB = "jaxb-2.2";
+    private static final String FEAUTRE_CORBA = "corba-2.4";
+    private static final String FEATURE_JDBC = "jdbc-4.0";
+    private static final String FEAUTRE_JAXWS = "jaxws-2.2";
+    
+    private static final Map<String, String> pkgToFeature = new HashMap<>();
+    private static final Set<String> suggestedFeatures = new HashSet<>();
+    
+    static {
+        // Packages from java.activation
+        pkgToFeature.put("javax.activation", FEATURE_JAXB);
+
+        // Packages from java.corba module
+        pkgToFeature.put("javax.activity", FEAUTRE_CORBA);
+        pkgToFeature.put("javax.rmi", FEAUTRE_CORBA);
+        pkgToFeature.put("javax.rmi.CORBA", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.CORBA", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.CORBA_2_3", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.CORBA_2_3.portable", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.CORBA.DynAnyPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.CORBA.ORBPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.CORBA.portable", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.CORBA.TypeCodePackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.CosNaming", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.CosNaming.NamingContextExtPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.CosNaming.NamingContextPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.Dynamic", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.DynamicAny", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.DynamicAny.DynAnyFactoryPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.DynamicAny.DynAnyPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.IOP", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.IOP.CodecFactoryPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.IOP.CodecPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.Messaging", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.PortableInterceptor", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.PortableInterceptor.ORBInitInfoPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.PortableServer", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.PortableServer.CurrentPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.PortableServer.POAManagerPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.PortableServer.POAPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.PortableServer.portable", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.PortableServer.ServantLocatorPackage", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.SendingContext", FEAUTRE_CORBA);
+        pkgToFeature.put("org.omg.stub.java.rmi", FEAUTRE_CORBA);
+
+        // Packages from java.transaction module
+        pkgToFeature.put("javax.transaction", FEATURE_JDBC);
+
+        // Packages from java.xml.bind module
+        pkgToFeature.put("javax.xml.bind", FEATURE_JAXB);
+        pkgToFeature.put("javax.xml.bind.annotation", FEATURE_JAXB);
+        pkgToFeature.put("javax.xml.bind.annotation.adapters", FEATURE_JAXB);
+        pkgToFeature.put("javax.xml.bind.attachment", FEATURE_JAXB);
+        pkgToFeature.put("javax.xml.bind.helpers", FEATURE_JAXB);
+        pkgToFeature.put("javax.xml.bind.util", FEATURE_JAXB);
+
+        // Packages from java.xml.ws module
+        pkgToFeature.put("javax.jws", FEAUTRE_JAXWS);
+        pkgToFeature.put("javax.jws.soap", FEAUTRE_JAXWS);
+        pkgToFeature.put("javax.xml.soap", FEAUTRE_JAXWS);
+        pkgToFeature.put("javax.xml.ws", FEAUTRE_JAXWS);
+        pkgToFeature.put("javax.xml.ws.handler", FEAUTRE_JAXWS);
+        pkgToFeature.put("javax.xml.ws.handler.soap", FEAUTRE_JAXWS);
+        pkgToFeature.put("javax.xml.ws.http", FEAUTRE_JAXWS);
+        pkgToFeature.put("javax.xml.ws.soap", FEAUTRE_JAXWS);
+        pkgToFeature.put("javax.xml.ws.spi", FEAUTRE_JAXWS);
+        pkgToFeature.put("javax.xml.ws.spi.http", FEAUTRE_JAXWS);
+        pkgToFeature.put("javax.xml.ws.wsaddressing", FEAUTRE_JAXWS);
+    }
+    
+    public static ClassNotFoundException getExceptionWithSuggestion(ClassNotFoundException original) {
+        String suggestedFeature = getFeatureSuggestion(original.getMessage());
+        if (suggestedFeature == null)
+            return original;
+
+        String warnMsg = Tr.formatMessage(tc, "cls.classloader.suggested.feature", original.getMessage(), suggestedFeature);
+        ClassNotFoundException toThrow = new ClassNotFoundException(warnMsg, original);
+        if (!suggestedFeatures.contains(suggestedFeature)) {
+            suggestedFeatures.add(suggestedFeature);
+            Tr.warning(tc, warnMsg);
+            FFDCFilter.processException(toThrow, "com.ibm.ws.classloading.internal.util.FeatureSuggestion", "106");
+        }
+        return toThrow;
+    }
+
+    private static String getFeatureSuggestion(String name) {
+        // Currently feature suggestions only apply to Java SE APIs removed in JDK 9
+        if (JavaInfo.majorVersion() < 9)
+            return null;
+        
+        if (name == null)
+            return null;
+        
+        if (!name.startsWith("javax.") &&
+            !name.startsWith("org.omg."))
+            return null;
+        
+        String pkg = name.substring(0, name.lastIndexOf('.'));
+        return pkgToFeature.get(pkg);
+    }
+
+}

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/util/package-info.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/util/package-info.java
@@ -8,15 +8,8 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.java11_fat;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+@TraceOptions(traceGroup = "ClassLoadingService", messageBundle = "com.ibm.ws.classloading.internal.resources.ClassLoadingServiceMessages")
+package com.ibm.ws.classloading.internal.util;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                Java11Test.class,
-                Java11CNFETest.class
-})
-public class FATSuite {}
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.classloading_test/bnd.bnd
+++ b/dev/com.ibm.ws.classloading_test/bnd.bnd
@@ -32,6 +32,7 @@ test.project: true
 	com.ibm.ws.kernel.equinox.module;version=latest,\
 	com.ibm.ws.kernel.metatype.helper;version=latest,\
 	com.ibm.ws.kernel.security.thread;version=latest,\
+	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	org.hamcrest:hamcrest-all;version=1.3, \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.java11_fat/.classpath
+++ b/dev/com.ibm.ws.java11_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/cnfeApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.java11_fat/bnd.bnd
+++ b/dev/com.ibm.ws.java11_fat/bnd.bnd
@@ -12,8 +12,12 @@
 bVersion=1.0
 
 src: \
-	fat/src
+	fat/src,\
+	test-applications/cnfeApp/src
 
 fat.project: true
 
 fat.minimum.java.level: 11
+
+-buildpath: \
+    com.ibm.websphere.javaee.servlet.4.0;version=latest

--- a/dev/com.ibm.ws.java11_fat/fat/src/com/ibm/ws/java11_fat/Java11CNFETest.java
+++ b/dev/com.ibm.ws.java11_fat/fat/src/com/ibm/ws/java11_fat/Java11CNFETest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.java11_fat;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import java11.cnfe.web.CNFETestServlet;
+
+@RunWith(FATRunner.class)
+@AllowedFFDC("java.lang.ClassNotFoundException")
+public class Java11CNFETest extends FATServletClient {
+
+    private static final String APP_NAME = "cnfeApp";
+
+    @Server("server_Java11CNFETest")
+    @TestServlet(servlet = CNFETestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, APP_NAME, "java11.cnfe.web");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer("CWWKL0084W");
+    }
+
+    @Test
+    public void testClassForName() throws Exception {
+        runTest();
+        findStringInLog("CWWKL0084W: .* javax\\.jws\\.WebService.*jaxws-2\\.2");
+    }
+
+    @Test
+    public void testClassForNameTCCL() throws Exception {
+        runTest();
+        // Don't look for a specific JAX-B class, since a different test may have triggered the message first
+        findStringInLog("CWWKL0084W: .* javax\\.xml\\.bind.*jaxb-2\\.2");
+    }
+
+    private void runTest() throws Exception {
+        runTest(server, APP_NAME + "/" + CNFETestServlet.class.getSimpleName(), testName.getMethodName());
+    }
+
+    private void findStringInLog(String regex) throws Exception {
+        List<String> matches = server.findStringsInLogs(regex);
+        assertTrue("Did not find expected string in logs: " + regex, matches.size() > 0);
+    }
+
+}

--- a/dev/com.ibm.ws.java11_fat/publish/servers/server_Java11CNFETest/bootstrap.properties
+++ b/dev/com.ibm.ws.java11_fat/publish/servers/server_Java11CNFETest/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:ClassLoadingService=all

--- a/dev/com.ibm.ws.java11_fat/publish/servers/server_Java11CNFETest/jvm.options
+++ b/dev/com.ibm.ws.java11_fat/publish/servers/server_Java11CNFETest/jvm.options
@@ -1,0 +1,1 @@
+-verbose:class

--- a/dev/com.ibm.ws.java11_fat/publish/servers/server_Java11CNFETest/server.xml
+++ b/dev/com.ibm.ws.java11_fat/publish/servers/server_Java11CNFETest/server.xml
@@ -1,0 +1,11 @@
+<server>
+
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>servlet-4.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+</server>

--- a/dev/com.ibm.ws.java11_fat/test-applications/cnfeApp/src/java11/cnfe/web/CNFETestServlet.java
+++ b/dev/com.ibm.ws.java11_fat/test-applications/cnfeApp/src/java11/cnfe/web/CNFETestServlet.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package java11.cnfe.web;
+
+import static org.junit.Assert.assertTrue;
+
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/CNFETestServlet")
+public class CNFETestServlet extends FATServlet {
+
+    private static final String CNFE_MSGID = "CWWKL0084W";
+
+    public void testClassForNameTCCL() throws Exception {
+        try {
+            Class.forName("javax.xml.bind.annotation.DomHandler", false, Thread.currentThread().getContextClassLoader());
+            Assert.fail("Should not be able to load JAX-B class in the server.");
+        } catch (ClassNotFoundException expected) {
+            expected.printStackTrace();
+        }
+    }
+
+    public void testClassForName() throws Exception {
+        try {
+            Class.forName("javax.jws.WebService");
+            Assert.fail("Should not be able to load JAX-WS annotation in the server.");
+        } catch (ClassNotFoundException expected) {
+            expected.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testClassLoaderLoadJAXB() throws Exception {
+        try {
+            CNFETestServlet.class.getClassLoader().loadClass("javax.xml.bind.JAXBException");
+        } catch (ClassNotFoundException expected) {
+            expected.printStackTrace();
+            assertContains(expected.getMessage(), "jaxb-2.2");
+            assertContains(expected.getMessage(), CNFE_MSGID);
+        }
+    }
+
+    @Test
+    public void testUseClassThatUsesJAXB() throws Exception {
+        try {
+            new SomeJAXBClass().useJAXB();
+        } catch (NoClassDefFoundError expected) {
+            expected.printStackTrace();
+            Throwable t1 = expected.getCause();
+            assertTrue("First cause of NCDFE should have been a CNFE but was: " + t1.getClass(), t1 instanceof ClassNotFoundException);
+            ClassNotFoundException cnfe = (ClassNotFoundException) t1;
+            assertContains(cnfe.getMessage(), CNFE_MSGID);
+            assertContains(cnfe.getMessage(), "javax.xml.bind.JAXBContext");
+        }
+    }
+
+    @Test
+    public void testNewClassThatUsesTransaction() throws Exception {
+        try {
+            Class.forName("java11.cnfe.web.SomeJDBCClass");
+        } catch (NoClassDefFoundError expected) {
+            expected.printStackTrace();
+            Throwable t1 = expected.getCause();
+            assertTrue("First cause of NCDFE should have been a CNFE but was: " + t1.getClass(), t1 instanceof ClassNotFoundException);
+            ClassNotFoundException cnfe = (ClassNotFoundException) t1;
+            assertContains(cnfe.getMessage(), CNFE_MSGID);
+            assertContains(cnfe.getMessage(), "javax.transaction.InvalidTransactionException");
+        }
+    }
+
+    private void assertContains(String str, String lookFor) {
+        assertTrue("Did not find string '" + lookFor + "' in the message: " + str, str != null && str.contains(lookFor));
+    }
+
+}

--- a/dev/com.ibm.ws.java11_fat/test-applications/cnfeApp/src/java11/cnfe/web/SomeJAXBClass.java
+++ b/dev/com.ibm.ws.java11_fat/test-applications/cnfeApp/src/java11/cnfe/web/SomeJAXBClass.java
@@ -1,0 +1,14 @@
+package java11.cnfe.web;
+
+import javax.xml.bind.JAXBContext;
+
+import org.junit.Assert;
+
+public class SomeJAXBClass {
+
+    public void useJAXB() {
+        System.out.println(JAXBContext.class.toString());
+        Assert.fail("Should not get here!  JAX-B API classes should not be available since no JAX-B feature is enabled in the server");
+    }
+
+}

--- a/dev/com.ibm.ws.java11_fat/test-applications/cnfeApp/src/java11/cnfe/web/SomeJDBCClass.java
+++ b/dev/com.ibm.ws.java11_fat/test-applications/cnfeApp/src/java11/cnfe/web/SomeJDBCClass.java
@@ -1,0 +1,8 @@
+package java11.cnfe.web;
+
+public class SomeJDBCClass {
+
+    @SuppressWarnings("unused")
+    private Exception tranEx = new javax.transaction.InvalidTransactionException();
+
+}


### PR DESCRIPTION
Primary serviceability enhancement for Liberty support of Java 11.

The biggest hurdle (in my experience) in adopting Java 9+ has been the removed JDK APIs. To help customers along this path, we can add extra processing to the CNFE code path of the application classloader to wrap the CNFE with an enhanced error message that suggests enabling the corresponding feature.

For example:
> CWWKL0084W: Unable to load class javax.jws.WebService, try enabling the jaxws-2.2 (or newer) feature in your server configuration.