### PR TITLE
test case with custom thread context provider

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualCallable.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualCallable.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+
+import com.ibm.wsspi.threadcontext.ThreadContext;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
+
+/**
+ * Proxy for Callable that applies thread context before running and removes it afterward
+ *
+ * @param <T> type of the result that is returned by the Callable
+ */
+class ContextualCallable<T> implements Callable<T> {
+    private final Callable<T> action;
+    private final ThreadContextDescriptor threadContextDescriptor;
+
+    ContextualCallable(ThreadContextDescriptor threadContextDescriptor, Callable<T> action) {
+        this.action = action;
+        this.threadContextDescriptor = threadContextDescriptor;
+    }
+
+    @Override
+    public T call() throws Exception {
+        ArrayList<ThreadContext> contextApplied = threadContextDescriptor.taskStarting();
+        try {
+            return action.call();
+        } finally {
+            threadContextDescriptor.taskStopping(contextApplied);
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
@@ -79,7 +79,8 @@ class ThreadContextImpl implements ThreadContext, WSContextService { // TODO add
 
     @Override
     public <R> Callable<R> withCurrentContext(Callable<R> callable) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualCallable<R>(contextDescriptor, callable);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextProvider.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextProvider.java
@@ -36,6 +36,6 @@ public class StateContextProvider implements ThreadContextProvider {
 
     @Override
     public String getThreadContextType() {
-        return "State";
+        return TestContextTypes.STATE;
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/TestContextTypes.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/TestContextTypes.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.context.location;
+
+/**
+ * Fake third-party context types created by the tests
+ */
+public class TestContextTypes {
+    public static final String STATE = "State";
+}


### PR DESCRIPTION
Basic test of ThreadContextBuilder, including one built-in container context type (APPLICATION) and one custom context provider type (TestContextTypes.STATE). Build a MicroProfile ThreadContext instance and use it to contextualize a task based on current context of the servlet thread. Change the custom "State" context of the servlet thread and run the contextualized task, verifying that the originally captured context is used. After the task ends, verify that the custom "State" context on the servlet thread has been restored to what we most recently set. Submit the same contextual task to an asynchronous unmanaged executor thread (lacking context) and verify that it runs with the context that was originally captured.
