### PR TITLE
Add group validation for operational attributes

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapAdapter.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapAdapter.java
@@ -1459,8 +1459,10 @@ public class LdapAdapter extends BaseRepository implements ConfiguredRepository 
                     while (groups.hasMore()) {
                         if (entity != null) {
                             String groupDN = String.valueOf(groups.next());
-                            LdapEntry grpEntry = iLdapConn.getEntityByIdentifier(groupDN, null, null, iLdapConfigMgr.getGroupTypes(), propNames, false, false);
-                            createEntityFromLdapEntry(entity, SchemaConstants.DO_GROUP, grpEntry, supportedProps);
+                            if (LdapHelper.isUnderBases(groupDN, bases)) {
+                                LdapEntry grpEntry = iLdapConn.getEntityByIdentifier(groupDN, null, null, iLdapConfigMgr.getGroupTypes(), propNames, false, false);
+                                createEntityFromLdapEntry(entity, SchemaConstants.DO_GROUP, grpEntry, supportedProps);
+                            }
                         }
                     }
                 } catch (NamingException e) {

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
@@ -121,6 +121,7 @@ autoFVT.doLast {
     'com.ibm.ws.security.wim.adapter.ldap.fat.tds.emptyInput',
     'com.ibm.ws.security.wim.adapter.ldap.fat.tds.propertynotsupported',
     'com.ibm.ws.security.wim.adapter.ldap.fat.tds.nested',
+    'com.ibm.ws.security.wim.adapter.ldap.fat.tds.searchbase',
     'com.ibm.ws.security.wim.adapter.ldap.fat.tds.ssl',
     'com.ibm.ws.security.wim.adapter.ldap.fat.tds.sslref',
     'com.ibm.ws.security.wim.adapter.ldap.fat.tds.sslref.badssl',

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({ URAPIs_TDSLDAPTest.class,
+                URAPIs_TDSLDAP_SearchBaseTest.class,
                 URAPIs_ADLDAPTest.class,
                 URAPIs_TDSLDAP_SSLTest.class,
                 URAPIs_ADLDAP_SSLTest.class,

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAP_SearchBaseTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAP_SearchBaseTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.wim.adapter.ldap.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.registry.test.UserRegistryServletConnection;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.LDAPUtils;
+
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class URAPIs_TDSLDAP_SearchBaseTest {
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.adapter.ldap.fat.tds.searchbase");
+    private static final Class<?> c = URAPIs_TDSLDAP_SearchBaseTest.class;
+    private static UserRegistryServletConnection servlet;
+
+    /**
+     * Updates the sample, which is expected to be at the hard-coded path.
+     * If this test is failing, check this path is correct.
+     */
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Add LDAP variables to bootstrap properties file
+        LDAPUtils.addLDAPVariables(server);
+        Log.info(c, "setUp", "Starting the server... (will wait for userRegistry servlet to start)");
+        server.copyFileToLibertyInstallRoot("lib/features", "internalfeatures/securitylibertyinternals-1.0.mf");
+        server.addInstalledAppForValidation("userRegistry");
+        server.startServer(c.getName() + ".log");
+
+        //Make sure the application has come up before proceeding
+        assertNotNull("Application userRegistry does not appear to have started.",
+                      server.waitForStringInLog("CWWKZ0001I:.*userRegistry"));
+        assertNotNull("Security service did not report it was ready",
+                      server.waitForStringInLog("CWWKS0008I"));
+        assertNotNull("Server did not came up",
+                      server.waitForStringInLog("CWWKF0011I"));
+
+        Log.info(c, "setUp", "Creating servlet connection the server");
+        servlet = new UserRegistryServletConnection(server.getHostname(), server.getHttpDefaultPort());
+
+        if (servlet.getRealm() == null) {
+            Thread.sleep(5000);
+            servlet.getRealm();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        Log.info(c, "tearDown", "Stopping the server...");
+        try {
+            server.stopServer("CWIML4529E", "CWIML4537E");
+        } finally {
+            server.deleteFileFromLibertyInstallRoot("lib/features/internalfeatures/securitylibertyinternals-1.0.mf");
+        }
+    }
+
+    /**
+     * Hit the test servlet to see if getGroupsForUser works when supplied with a valid user.
+     */
+    @Test
+    public void getGroupsForUser() throws Exception {
+        String user = "eddard_vmmUser";
+        Log.info(c, "getGroupsForUser", "Checking with a valid user.");
+        List<String> list = servlet.getGroupsForUser(user);
+        assertTrue(list.contains("stark_vmmGroup"));
+    }
+
+    /**
+     * Hit the test servlet to see if getGroupsForUser works when supplied with a valid user
+     * that is part of groups outside of the group search base. It should find the user, but
+     * not any groups.
+     */
+    @Test
+    public void getGroupsForUserWithInvalidUser() throws Exception {
+        String user = "vmmtestuser";
+        Log.info(c, "getGroupsForUserWithInvalidUser", "Checking with an invalid user.");
+        List<String> list = servlet.getGroupsForUser(user);
+        assertTrue(list.isEmpty());
+    }
+
+    /**
+     * Hit the test servlet to see if getUniqueGroupIdsForUser works when supplied with a valid user.
+     */
+    @Test
+    public void getUniqueGroupIds() throws Exception {
+        String user = "uid=eddard_vmmUser,ou=jUsers,o=ibm,c=us";
+        Log.info(c, "getUniqueGroupIds", "Checking with a valid user.");
+        List<String> list = servlet.getUniqueGroupIdsForUser(user);
+        assertTrue(list.contains("cn=stark_vmmGroup,ou=jGroups,o=ibm,c=us"));
+        assertEquals("The number of entries did not match.", 1, list.size());
+    }
+
+    /**
+     * Hit the test servlet to see if getUniqueGroupIdsForUser works when supplied
+     * with a valid uniqueName. The groups associated with this user are outside
+     * the group search base and should return an empty list.
+     */
+    @Test
+    public void getUniqueGroupIdsOutsideSearchBase() throws Exception {
+        String user = "vmmtestuser";
+        Log.info(c, "getUniqueGroupIdsForUser", "Checking with a valid user.");
+        List<String> list = servlet.getUniqueGroupIdsForUser(user);
+        assertTrue(list.isEmpty());
+    }
+}

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.searchbase/bootstrap.properties
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.searchbase/bootstrap.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.ws.security.*=all=enabled
+com.ibm.ws.logging.max.file.size=0
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.searchbase/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.searchbase/server.xml
@@ -1,0 +1,57 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="com.ibm.ws.wim.adapter.ldap.fat.tds.searchbase">
+	<featureManager>
+		<feature>appSecurity-2.0</feature>
+		<feature>ldapRegistry-3.0</feature>
+		<feature>servlet-3.1</feature>
+		<feature>securitylibertyinternals-1.0</feature>
+	</featureManager>
+
+	<!-- Test with the nested group filters and membershipAttribute for scope nested-->
+	<ldapRegistry id="LDAP" realm="TDSRealm" host="${ldap.server.4.name}" port="${ldap.server.4.port}" ignoreCase="true"
+		baseDN="o=ibm,c=us"
+		ldapType="IBM Tivoli Directory Server"
+		searchTimeout="8m">
+	  <ldapEntityType name="PersonAccount">
+        <objectClass>inetOrgPerson</objectClass>
+      </ldapEntityType>
+	  <ldapEntityType name="Group">
+        <objectClass>groupOfNames</objectClass>
+		<searchBase>ou=jgroups,o=ibm,c=us</searchBase> 
+      </ldapEntityType>
+      <loginProperty>uid</loginProperty>
+		<idsFilters
+			userFilter="(&amp;(uid=%v)(objectclass=ePerson))"
+			groupFilter="(&amp;(cn=%v)(|(objectclass=groupOfNames)(objectclass=groupOfUniqueNames)(objectclass=groupOfURLs)))"
+			userIdMap="*:uid"
+			groupIdMap="*:cn"
+			groupMemberIdMap="ibm-allGroups:member;ibm-allGroups:uniqueMember;groupOfNames:member;groupOfUniqueNames:uniqueMember" />
+		<failoverServers name="failoverLdapServers">
+      		<server host="${ldap.server.7.name}" port="${ldap.server.7.port}"/>
+			<server host="${ldap.server.8.name}" port="${ldap.server.8.port}"/>
+       </failoverServers>	
+	</ldapRegistry> 
+	    <federatedRepository>
+        <primaryRealm name="TDSRealm">
+            <participatingBaseEntry name="o=ibm,c=us"/>
+            <uniqueUserIdMapping inputProperty="uniqueName" outputProperty="uniqueName"/>
+        	<userSecurityNameMapping inputProperty="principalName" outputProperty="principalName"/>
+        	<userDisplayNameMapping inputProperty="principalName" outputProperty="principalName"/>
+        	<uniqueGroupIdMapping inputProperty="uniqueName" outputProperty="uniqueName"/>
+        	<groupSecurityNameMapping inputProperty="cn" outputProperty="cn"/>
+        	<groupDisplayNameMapping inputProperty="cn" outputProperty="cn"/>
+        </primaryRealm>
+    </federatedRepository>
+
+	<include location="../fatTestPorts.xml"/>
+
+</server>


### PR DESCRIPTION
When LDAP uses operational attributes, eg. ibm-allgroups, to resolve group membership, we should take into account the group base entry as defined by the user. Now, we will only return groups that are defined under the group base entry.