### PR TITLE
prerequisite thread context providers

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
@@ -12,6 +12,7 @@ package com.ibm.ws.concurrent.mp;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -67,7 +68,7 @@ public class ConcurrencyManagerImpl implements ConcurrencyManager {
             Set<String> prereqs = provider.getPrerequisites();
 
             if (trace && tc.isDebugEnabled())
-                Tr.debug(this, tc, "context type " + type + " with prereqs " + prereqs + " provided by ");
+                Tr.debug(this, tc, "context type " + type + " with prereqs " + prereqs + " provided by " + provider);
 
             if (available.containsAll(prereqs)) {
                 if (available.add(type))
@@ -84,18 +85,19 @@ public class ConcurrencyManagerImpl implements ConcurrencyManager {
 
         for (boolean changed = true; changed && !unsatisfied.isEmpty();) {
             changed = false;
-            for (ThreadContextProvider provider : unsatisfied) {
+            for (Iterator<ThreadContextProvider> providers = unsatisfied.iterator(); providers.hasNext();) {
+                ThreadContextProvider provider = providers.next();
+
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "previously unsatisfied provider " + provider);
 
                 if (available.containsAll(provider.getPrerequisites())) {
+                    providers.remove();
                     if (available.add(provider.getThreadContextType()))
                         contextProviders.add(provider);
                     else
                         throw new IllegalStateException(); // TODO same message from earlier
                     changed = true;
-                } else {
-                    unsatisfied.add(provider);
                 }
             }
         }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualCallable.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualCallable.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+
+import com.ibm.wsspi.threadcontext.ThreadContext;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
+
+/**
+ * Proxy for Callable that applies thread context before running and removes it afterward
+ *
+ * @param <T> type of the result that is returned by the Callable
+ */
+class ContextualCallable<T> implements Callable<T> {
+    private final Callable<T> action;
+    private final ThreadContextDescriptor threadContextDescriptor;
+
+    ContextualCallable(ThreadContextDescriptor threadContextDescriptor, Callable<T> action) {
+        this.action = action;
+        this.threadContextDescriptor = threadContextDescriptor;
+    }
+
+    @Override
+    public T call() throws Exception {
+        ArrayList<ThreadContext> contextApplied = threadContextDescriptor.taskStarting();
+        try {
+            return action.call();
+        } finally {
+            threadContextDescriptor.taskStopping(contextApplied);
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
@@ -79,7 +79,8 @@ class ThreadContextImpl implements ThreadContext, WSContextService { // TODO add
 
     @Override
     public <R> Callable<R> withCurrentContext(Callable<R> callable) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualCallable<R>(contextDescriptor, callable);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_rx/fat/src/com/ibm/ws/concurrent/rx/ConcurrentRxTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/fat/src/com/ibm/ws/concurrent/rx/ConcurrentRxTest.java
@@ -19,6 +19,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
+import org.test.context.location.CityContextProvider;
 import org.test.context.location.StateContextProvider;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -48,7 +49,7 @@ public class ConcurrentRxTest extends FATServletClient {
 
         JavaArchive customContextProviders = ShrinkWrap.create(JavaArchive.class, "customContextProviders.jar")
                         .addPackage("org.test.context.location")
-                        .addAsServiceProvider(ThreadContextProvider.class, StateContextProvider.class);
+                        .addAsServiceProvider(ThreadContextProvider.class, CityContextProvider.class, StateContextProvider.class);
         ShrinkHelper.exportToServer(server1, "lib", customContextProviders);
 
         server1.startServer();

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CityContextProvider.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CityContextProvider.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.context.location;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * Example third-party thread context provider, to be used for testing purposes.
+ * This context associates a city name with a thread, such that the applicable
+ * sales tax rate for the corresponding city (and state that it is in) is included
+ * when the getTotalSalesTax() methods is invoked from the thread.
+ *
+ * As a way of testing prerequisites, this context type declares the "State" context
+ * to be a prerequisite and relies on it having already been established on the
+ * thread when City context is applied. CityContextSnapshot.begin validates this.
+ */
+public class CityContextProvider implements ThreadContextProvider {
+    static ThreadLocal<String> cityName = ThreadLocal.withInitial(() -> "");
+
+    private static final Set<String> PREREQ_STATE_CONTEXT = Collections.singleton(TestContextTypes.STATE);
+
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return new CityContextSnapshot("");
+    }
+
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        return new CityContextSnapshot(cityName.get());
+    }
+
+    @Override
+    public Set<String> getPrerequisites() {
+        return PREREQ_STATE_CONTEXT;
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return TestContextTypes.CITY;
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CityContextRestorer.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CityContextRestorer.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.context.location;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+
+/**
+ * Example third-party thread context restorer, to be used for testing purposes.
+ * This context associates a city name with a thread, such that the applicable
+ * sales tax rate (also including the state reported by the State context)
+ * is included when the getTotalSalesTax() method is invoked from the thread.
+ */
+public class CityContextRestorer implements ThreadContextController {
+    private boolean restored = false;
+    private final String cityNameToRestore;
+
+    CityContextRestorer(String cityNameToRestore) {
+        this.cityNameToRestore = cityNameToRestore;
+    }
+
+    @Override
+    public void endContext() {
+        if (restored)
+            throw new IllegalStateException("thread context was already restored");
+        CityContextProvider.cityName.set(cityNameToRestore);
+        restored = true;
+    }
+
+    @Override
+    public String toString() {
+        return "CityContextRestorer@" + Integer.toHexString(hashCode()) + "(" + cityNameToRestore + ")";
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CityContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CityContextSnapshot.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.context.location;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * Example third-party thread context snapshot, to be used for testing purposes.
+ * This context associates a city name with a thread, such that the applicable
+ * sales tax rate (also including the state reported by the State context)
+ * is included when the getTotalSalesTax() method is invoked from the thread.
+ */
+public class CityContextSnapshot implements ThreadContextSnapshot {
+    private final String cityName;
+
+    CityContextSnapshot(String cityName) {
+        this.cityName = cityName;
+    }
+
+    @Override
+    public ThreadContextController begin() {
+        ThreadContextController cityContextRestorer = new CityContextRestorer(CityContextProvider.cityName.get());
+
+        // Validate that the city/state combination is valid before applying context.
+        // This introduces a dependency on the State context, so that we can test prerequisites.
+        if (cityName.length() > 0)
+            CurrentLocation.getTotalTaxRate(cityName, StateContextProvider.stateName.get());
+
+        CityContextProvider.cityName.set(cityName);
+        return cityContextRestorer;
+    }
+
+    @Override
+    public String toString() {
+        return "CityContextSnapshot@" + Integer.toHexString(hashCode()) + "(" + cityName + ")";
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CurrentLocation.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CurrentLocation.java
@@ -18,18 +18,27 @@ package org.test.context.location;
  * running thread.
  */
 public class CurrentLocation {
+    public static void clear() {
+        setLocation("", "");
+    }
+
     public static double getStateSalesTax(double purchaseAmount) {
         String stateName = StateContextProvider.stateName.get();
         return getStateTaxRate(stateName) * purchaseAmount;
     }
 
     public static double getTotalSalesTax(double purchaseAmount) {
-        String cityName = null; // TODO CityContextProvider.cityName.get();
+        String cityName = CityContextProvider.cityName.get();
         String stateName = StateContextProvider.stateName.get();
         return getTotalTaxRate(cityName, stateName) * purchaseAmount;
     }
 
     public static void setLocation(String state) {
+        StateContextProvider.stateName.set(state);
+    }
+
+    public static void setLocation(String city, String state) {
+        CityContextProvider.cityName.set(city);
         StateContextProvider.stateName.set(state);
     }
 
@@ -61,7 +70,7 @@ public class CurrentLocation {
         throw new IllegalArgumentException(state + " is an unkown location");
     }
 
-    private static double getTotalTaxRate(String city, String state) {
+    static double getTotalTaxRate(String city, String state) {
         switch (state) {
             case "Iowa":
                 switch (city) {
@@ -89,6 +98,12 @@ public class CurrentLocation {
                     case "Stewartville":
                     case "Winona":
                         return getStateTaxRate(state);
+                }
+                break;
+            case "Wisconsin":
+                switch (city) {
+                    case "Madison":
+                        return 0.055;
                 }
                 break;
         }

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextProvider.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/StateContextProvider.java
@@ -36,6 +36,6 @@ public class StateContextProvider implements ThreadContextProvider {
 
     @Override
     public String getThreadContextType() {
-        return "State";
+        return TestContextTypes.STATE;
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/TestContextTypes.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/TestContextTypes.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.context.location;
+
+/**
+ * Fake third-party context types created by the tests
+ */
+public class TestContextTypes {
+    public static final String STATE = "State";
+}

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/TestContextTypes.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/TestContextTypes.java
@@ -14,5 +14,6 @@ package org.test.context.location;
  * Fake third-party context types created by the tests
  */
 public class TestContextTypes {
+    public static final String CITY = "City";
     public static final String STATE = "State";
 }


### PR DESCRIPTION
Complete the code that allows for and enforces the ordering of prerequisite thread context providers, and add a test case to verify.