### PR TITLE
Add support for configuring whether to suspend or not

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -50,6 +50,11 @@
 # WLP_DEBUG_ADDRESS - The port to use when running the server in debug mode.
 #              The default value is 7777.
 #
+# WLP_DEBUG_SUSPEND - Whether to suspend the jvm on startup or not. This can be
+#              set to y to suspend the jvm on startup until a debugger attaches,
+#              or set to n to startup without waiting for a debugger to attach.
+#              The default value is y. 
+#
 # WLP_SKIP_UMASK -  Skip setting the umask value to allow the default value 
 #                   to be used.
 #
@@ -1035,7 +1040,11 @@ case "$ACTION" in
         then
           WLP_DEBUG_ADDRESS=7777
         fi
-        JAVA_DEBUG="-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${WLP_DEBUG_ADDRESS}"
+        if [ -z "${WLP_DEBUG_SUSPEND}" ]
+        then
+          WLP_DEBUG_SUSPEND=y
+        fi
+        JAVA_DEBUG="-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=${WLP_DEBUG_SUSPEND},address=${WLP_DEBUG_ADDRESS}"
       fi
 
       serverWorkingDirectory

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -43,6 +43,11 @@
 @REM WLP_DEBUG_ADDRESS - The port to use when running the server in debug mode.
 @REM              The default value is 7777.
 @REM
+@REM WLP_DEBUG_SUSPEND - Whether to suspend the jvm on startup or not. This can be
+@REM              set to y to suspend the jvm on startup until a debugger attaches,
+@REM              or set to n to startup without waiting for a debugger to attach.
+@REM              The default value is y.
+@REM
 @REM ----------------------------------------------------------------------------
 
 setlocal enabledelayedexpansion
@@ -117,7 +122,8 @@ if "help" == "%ACTION%" (
   call:runServer
 ) else if "debug" == "%ACTION%" (
   if not defined WLP_DEBUG_ADDRESS set WLP_DEBUG_ADDRESS=7777
-  set JAVA_PARAMS_QUOTED=-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address="!WLP_DEBUG_ADDRESS!" !JAVA_PARAMS_QUOTED!
+  if not defined WLP_DEBUG_SUSPEND set WLP_DEBUG_SUSPEND=y
+  set JAVA_PARAMS_QUOTED=-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend="!WLP_DEBUG_SUSPEND!",address="!WLP_DEBUG_ADDRESS!" !JAVA_PARAMS_QUOTED!
   call:runServer
 ) else if "status" == "%ACTION%" (
   call:serverStatus


### PR DESCRIPTION
Add support for an env var of WLP_DEBUG_SUSPEND which can be set to n to ensure the JVM doesn't suspend on startup for a debugger to attach.