### PR TITLE
Update to convert integer to String in order to write the right thing.

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/BundleList.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/BundleList.java
@@ -542,7 +542,7 @@ public class BundleList {
                 writeTime = System.currentTimeMillis();
                 writer.write(String.valueOf(writeTime));
                 writer.write(';');
-                writer.write(JavaInfo.majorVersion());
+                writer.write(Integer.toString(JavaInfo.majorVersion()));
                 writer.write(FeatureDefinitionUtils.NL);
                 for (RuntimeFeatureResource entry : resources) {
                     if (entry.getURLString() != null) {


### PR DESCRIPTION
If you pass an int to a write method it treats it as a character and not
an integer.  In order to write it you need to confirm the integer to a
String so that it is the right character number.  This caused us to
think we were always running with a different JDK for each server
restart.
