### PR TITLE
Temporarily downgrade feature suggestion from WARN to INFO

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/util/FeatureSuggestion.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/util/FeatureSuggestion.java
@@ -103,8 +103,9 @@ public class FeatureSuggestion {
         ClassNotFoundException toThrow = new ClassNotFoundException(warnMsg, original);
         if (!suggestedFeatures.contains(suggestedFeature)) {
             suggestedFeatures.add(suggestedFeature);
-            Tr.warning(tc, warnMsg);
-            FFDCFilter.processException(toThrow, "com.ibm.ws.classloading.internal.util.FeatureSuggestion", "106");
+            // TODO: Temporarily disable the FFDC and downgrade to INFO message
+            Tr.info(tc, warnMsg);
+            //FFDCFilter.processException(toThrow, "com.ibm.ws.classloading.internal.util.FeatureSuggestion", "106");
         }
         return toThrow;
     }
@@ -121,6 +122,12 @@ public class FeatureSuggestion {
             !name.startsWith("org.omg."))
             return null;
         
+        // Weld will try to load javax.xml.ws.WebServiceRef to detect if JAX-WS API is available,
+        // so don't issue a feature suggestion for this specific class
+        // TODO: Figure out a more generic solution for internal components that do try-loads using the AppCL
+        if (name.equals("javax.xml.ws.WebServiceRef"))
+            return null;
+
         String pkg = name.substring(0, name.lastIndexOf('.'));
         return pkgToFeature.get(pkg);
     }


### PR DESCRIPTION
Delivering the feature suggestion message at WARN level has caused many test failures in the Java 11 builds (because a FAT will fail if we find unexpected errors/warnings in server logs).

This delivery will be followed up with another delivery that will move the message back to WARN (after the expected warnings have been mapped out for the effected FATs).