### PR TITLE
Longer timeout windows on attributeCache and searchCache

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
@@ -211,4 +211,6 @@ task certificateMapper_JAR(type: Jar, dependsOn: classes) {
 assemble { 
   dependsOn \
   certificateMapper_JAR
+  
+  dependsOn ':com.ibm.ws.security.registry_test.servlet:assemble' 
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/VMMAPIs_EmbeddedLdapTests.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/VMMAPIs_EmbeddedLdapTests.java
@@ -165,7 +165,7 @@ public class VMMAPIs_EmbeddedLdapTests {
         ldap.setBindPassword(EmbeddedApacheDS.getBindPassword());
         ldap.setLdapType("Custom");
         // The cache time outs are short because we need to timeout within the test. SearchCache needs to be shorter than the AttributesCache for regression testing.
-        ldap.setLdapCache(new LdapCache(new AttributesCache(true, 4444, 2222, "6s"), new SearchResultsCache(true, 5555, 3333, "2s")));
+        ldap.setLdapCache(new LdapCache(new AttributesCache(true, 4444, 2222, "7s"), new SearchResultsCache(true, 5555, 3333, "5s")));
         serverConfig.getLdapRegistries().add(ldap);
         LDAPFatUtils.createFederatedRepository(serverConfig, "LDAPRealmAttr", new String[] { LDAP_BASE_ENTRY });
         updateConfigDynamically(server, serverConfig);


### PR DESCRIPTION
fixes #5624 

checking to see if test server is timing out before search is completed in LDAP server