### PR TITLE
Support operation name provider and revise skip pattern

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingConfiguration.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingConfiguration.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.opentracing;
 
-import java.util.Optional;
-
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -21,21 +19,25 @@ import org.eclipse.microprofile.config.ConfigProvider;
 public class OpentracingConfiguration {
 
     public static final String MP_OT_SERVER_SKIP_PATTERN_KEY = "mp.opentracing.server.skip-pattern";
-    public static final String MP_OT_SERVER_SKIP_PATTERN_DEFAULT_VALUE = "/health|/metrics|/metrics/base/.*|/metrics/vendor/.*|/metrics/application/.*|/openapi";
     public static final String MP_OT_SERVER_OPERATION_NAME_PROVIDER_KEY = "mp.opentracing.server.operation-name-provider";
+    public static final String MP_OT_SERVER_OPERATION_NAME_PROVIDER_HTTP_PATH = "http-path";
 
-    static String getServerSkipPattern() {
+    public static String getServerSkipPattern() {
         Config config = ConfigProvider.getConfig(Thread.currentThread().getContextClassLoader());
-        Optional<String> optValue = config.getOptionalValue(MP_OT_SERVER_SKIP_PATTERN_KEY, String.class);
-        if (optValue.isPresent()) {
-            return MP_OT_SERVER_SKIP_PATTERN_DEFAULT_VALUE + "|" + optValue.toString();
-        } else {
-            return MP_OT_SERVER_SKIP_PATTERN_DEFAULT_VALUE;
-        }
+        return config.getOptionalValue(MP_OT_SERVER_SKIP_PATTERN_KEY, String.class).orElse(null);
     }
 
     static String getOpertionNameProvider() {
         Config config = ConfigProvider.getConfig(Thread.currentThread().getContextClassLoader());
         return config.getOptionalValue(MP_OT_SERVER_OPERATION_NAME_PROVIDER_KEY, String.class).orElse(null);
+    }
+
+    public static boolean isOperationNameProviderHttpPath() {
+        String providerName = getOpertionNameProvider();
+        if (providerName != null) {
+            return MP_OT_SERVER_OPERATION_NAME_PROVIDER_HTTP_PATH.equals(providerName);
+        } else {
+            return false;
+        }
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -87,6 +87,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
         }
 
         URI incomingUri = incomingRequestContext.getUriInfo().getRequestUri();
+        String incomingPath = incomingRequestContext.getUriInfo().getPath();
+        if (!incomingPath.startsWith("/")) {
+            incomingPath = "/" + incomingPath;
+        }
 
         String incomingURL = incomingUri.toURL().toString();
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -100,7 +104,7 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
             Tr.debug(tc, methodName + " priorContext", priorOutgoingContext);
         }
 
-        boolean process = OpentracingService.process(incomingUri, SpanFilterType.INCOMING);
+        boolean process = OpentracingService.process(incomingUri, incomingPath, SpanFilterType.INCOMING);
 
         String buildSpanName;
         if (helper != null) {

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/filters/ExcludeFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/filters/ExcludeFilter.java
@@ -20,10 +20,10 @@ public class ExcludeFilter extends SpanFilterBase {
      * Create a new filter with a pattern, filter type, and whether to ignore case on the pattern match.
      * If the URI and type match, then exclude the request.
      *
-     * @param pattern The pattern for which this filter matches.
-     * @param type The filter types for which this filter matches.
+     * @param pattern    The pattern for which this filter matches.
+     * @param type       The filter types for which this filter matches.
      * @param ignoreCase Whether to ignore case on the pattern match.
-     * @param regex If true, pattern is treated as a regular expression.
+     * @param regex      If true, pattern is treated as a regular expression.
      */
     public ExcludeFilter(String pattern, SpanFilterType type, boolean ignoreCase, boolean regex) {
         super(pattern, type, ignoreCase, regex);
@@ -33,7 +33,7 @@ public class ExcludeFilter extends SpanFilterBase {
      * {@inheritDoc}
      */
     @Override
-    protected final boolean matchAction(final boolean previousState, final URI uri, final SpanFilterType contextType) {
+    protected final boolean matchAction(final boolean previousState, final URI uri, final String path, final SpanFilterType contextType) {
         return false;
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/filters/ExcludePathFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/filters/ExcludePathFilter.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.opentracing.filters;
+
+import java.net.URI;
+
+/**
+ *
+ */
+public class ExcludePathFilter extends ExcludeFilter {
+
+    /**
+     * @param pattern
+     * @param type
+     * @param ignoreCase
+     * @param regex
+     */
+    public ExcludePathFilter(String pattern, SpanFilterType type, boolean ignoreCase, boolean regex) {
+        super(pattern, type, ignoreCase, regex);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean process(boolean previousState, URI uri, String path, SpanFilterType contextType) {
+        if (contextApplies(contextType) && match(path)) {
+            return matchAction(previousState, uri, path, contextType);
+        }
+        return previousState;
+    }
+
+}

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/filters/IncludeFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/filters/IncludeFilter.java
@@ -20,10 +20,10 @@ public class IncludeFilter extends SpanFilterBase {
      * Create a new filter with a pattern, filter type, and whether to ignore case on the pattern match.
      * If the URI and type match, then include the request.
      *
-     * @param pattern The pattern for which this filter matches.
-     * @param type The filter types for which this filter matches.
+     * @param pattern    The pattern for which this filter matches.
+     * @param type       The filter types for which this filter matches.
      * @param ignoreCase Whether to ignore case on the pattern match.
-     * @param regex If true, pattern is treated as a regular expression.
+     * @param regex      If true, pattern is treated as a regular expression.
      */
     public IncludeFilter(String pattern, SpanFilterType type, boolean ignoreCase, boolean regex) {
         super(pattern, type, ignoreCase, regex);
@@ -33,7 +33,7 @@ public class IncludeFilter extends SpanFilterBase {
      * {@inheritDoc}
      */
     @Override
-    protected final boolean matchAction(final boolean previousState, final URI uri, final SpanFilterType contextType) {
+    protected final boolean matchAction(final boolean previousState, final URI uri, final String path, final SpanFilterType contextType) {
         return true;
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/filters/SpanFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/filters/SpanFilter.java
@@ -93,9 +93,10 @@ public interface SpanFilter {
      * Process a filter in sequence and return true if a span should be created for this request.
      *
      * @param previousState It is expected that filters are called in sequence, so this is the result of the previous filter, or a default.
-     * @param uri The full URI of this request.
-     * @param contextType The type of request.
+     * @param uri           The full URI of this request.
+     * @param path          The path of this request.
+     * @param contextType   The type of request.
      * @return True if a span should be created for this request; otherwise, false.
      */
-    boolean process(final boolean previousState, final URI uri, final SpanFilterType contextType);
+    boolean process(final boolean previousState, final URI uri, final String path, final SpanFilterType contextType);
 }

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/filters/SpanFilterBase.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/filters/SpanFilterBase.java
@@ -35,10 +35,10 @@ public abstract class SpanFilterBase implements SpanFilter {
     /**
      * Create a new filter with a pattern, filter type, and whether to ignore case on the pattern match.
      *
-     * @param pattern The pattern for which this filter matches.
-     * @param type The filter types for which this filter matches.
+     * @param pattern    The pattern for which this filter matches.
+     * @param type       The filter types for which this filter matches.
      * @param ignoreCase Whether to ignore case on the pattern match.
-     * @param regex If true, pattern is treated as a regular expression.
+     * @param regex      If true, pattern is treated as a regular expression.
      */
     public SpanFilterBase(String pattern, SpanFilterType type, boolean ignoreCase, boolean regex) {
 
@@ -122,31 +122,42 @@ public abstract class SpanFilterBase implements SpanFilter {
      */
     protected boolean match(final URI uri) {
 
-        final String methodName = "match";
         final String uriStr = prepareUri(uri);
+        return match(uriStr);
+    }
+
+    /**
+     * Check if the URI matches the pattern.
+     *
+     * @param uri The URI to check against our pattern.
+     * @return Whether or not the URI matches our pattern.
+     */
+    protected boolean match(final String path) {
+
+        final String methodName = "match";
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, methodName, this, uriStr, ignoreCase, wildcard);
+            Tr.debug(tc, methodName, this, path, ignoreCase, wildcard);
         }
 
         if (this.matcher == null) {
             if (ignoreCase) {
-                if (pattern.equalsIgnoreCase(uriStr)) {
+                if (pattern.equalsIgnoreCase(path)) {
                     return true;
                 }
-                if (wildcard && uriStr.toLowerCase().startsWith(pattern)) {
+                if (wildcard && path.toLowerCase().startsWith(pattern)) {
                     return true;
                 }
             } else {
-                if (pattern.equals(uriStr)) {
+                if (pattern.equals(path)) {
                     return true;
                 }
-                if (wildcard && uriStr.startsWith(pattern)) {
+                if (wildcard && path.startsWith(pattern)) {
                     return true;
                 }
             }
         } else {
-            return this.matcher.matcher(uriStr).matches();
+            return this.matcher.matcher(path).matches();
         }
 
         return false;
@@ -191,10 +202,10 @@ public abstract class SpanFilterBase implements SpanFilter {
      * {@inheritDoc}
      */
     @Override
-    public boolean process(final boolean previousState, final URI uri, final SpanFilterType contextType) {
+    public boolean process(final boolean previousState, final URI uri, final String path, final SpanFilterType contextType) {
 
         if (contextApplies(contextType) && match(uri)) {
-            return matchAction(previousState, uri, contextType);
+            return matchAction(previousState, uri, path, contextType);
         }
 
         return previousState;
@@ -205,9 +216,10 @@ public abstract class SpanFilterBase implements SpanFilter {
      * exclude the request (contingent on subsequent filters).
      *
      * @param previousState It is expected that filters are called in sequence, so this is the result of the previous filter, or a default.
-     * @param uri The full URI of this request.
-     * @param contextType The type of request.
+     * @param uri           The full URI of this request.
+     * @param path          The path of this request.
+     * @param contextType   The type of request.
      * @return True to include or false to exclude.
      */
-    protected abstract boolean matchAction(final boolean previousState, final URI uri, final SpanFilterType contextType);
+    protected abstract boolean matchAction(final boolean previousState, final URI uri, final String path, final SpanFilterType contextType);
 }


### PR DESCRIPTION
Fixes #5446 

1.  Add support of operation name provider
2. Revise the support of skip pattern to skip just the path from UriInfo.getPath(). (i.e. context root is ignored due to limitation of the spec)