### PR TITLE
append 'JAXRS-2.1' to jaxrs 2.1 FAT tests

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/FATSuite.java
@@ -43,5 +43,5 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"));
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/FATSuite.java
@@ -73,5 +73,5 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"));
 }


### PR DESCRIPTION
append "JAXRS-2.1" to each test in com.ibm.ws.jaxrs.2.0.cdi.1.2_fat and com.ibm.ws.jaxrs.2.0.client_fat ran with via RepeatAction with the jaxrs-2.1 feature