### PR TITLE
Add javax.jms to the eclipselink bundle's list of optional imports #5657

### DIFF
--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
@@ -47,6 +47,7 @@ Import-Package: \
             javax.enterprise.inject.spi;resolution:=optional, \
             javax.imageio;resolution:=optional, \
             javax.imageio.stream;resolution:=optional, \
+            javax.jms;resolution:=optional, \
             javax.json;resolution:=optional, \
             javax.json.stream;resolution:=optional, \
             javax.management;resolution:=optional, \

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
@@ -47,6 +47,7 @@ Import-Package: \
             javax.enterprise.inject.spi;resolution:=optional, \
             javax.imageio;resolution:=optional, \
             javax.imageio.stream;resolution:=optional, \
+            javax.jms;resolution:=optional, \
             javax.json;resolution:=optional, \
             javax.json.stream;resolution:=optional, \
             javax.management;resolution:=optional, \


### PR DESCRIPTION
Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>


