### PR TITLE
prerequisite context removed from the MP concurrency spec

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
@@ -12,10 +12,7 @@ package com.ibm.ws.concurrent.mp;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.ServiceLoader;
-import java.util.Set;
 
 import org.eclipse.microprofile.concurrent.ManagedExecutorBuilder;
 import org.eclipse.microprofile.concurrent.ThreadContext;
@@ -41,17 +38,20 @@ public class ConcurrencyManagerImpl implements ConcurrencyManager {
      */
     private final ArrayList<ThreadContextProvider> contextProviders = new ArrayList<ThreadContextProvider>();
 
+    /**
+     * Merge built-in thread context providers from the container with those found
+     * on the class loader, detecting any duplicate provider types.
+     *
+     * @param concurrencyProvider the registered concurrency provider
+     * @param classloader the class loader from which to discover thread context providers
+     */
     ConcurrencyManagerImpl(ConcurrencyProviderImpl concurrencyProvider, ClassLoader classloader) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
-        // Thread context types for which providers with satisfied prerequisites are found.
+        // Thread context types for which providers are available
         HashSet<String> available = new HashSet<String>();
 
-        // Thread context providers whose prerequisites are unmet
-        LinkedList<ThreadContextProvider> unsatisfied = new LinkedList<ThreadContextProvider>();
-
         // Built-in thread context providers (always available)
-
         contextProviders.add(concurrencyProvider.applicationContextProvider);
         available.add(ThreadContext.APPLICATION);
         contextProviders.add(concurrencyProvider.securityContextProvider);
@@ -62,49 +62,18 @@ public class ConcurrencyManagerImpl implements ConcurrencyManager {
         available.add(WLMContextProvider.WORKLOAD);
 
         // Thread context providers for the supplied class loader
-
         for (ThreadContextProvider provider : ServiceLoader.load(ThreadContextProvider.class, classloader)) {
             String type = provider.getThreadContextType();
-            Set<String> prereqs = provider.getPrerequisites();
 
             if (trace && tc.isDebugEnabled())
-                Tr.debug(this, tc, "context type " + type + " with prereqs " + prereqs + " provided by " + provider);
+                Tr.debug(this, tc, "context type " + type + " provided by " + provider);
 
-            if (available.containsAll(prereqs)) {
-                if (available.add(type))
-                    contextProviders.add(provider);
-                else
-                    // TODO message: "Duplicate type of thread context, " + type + ", is provided by " + provider + " and " + getProvider(type));
-                    throw new IllegalStateException();
-            } else {
-                unsatisfied.add(provider);
-            }
+            if (available.add(type))
+                contextProviders.add(provider);
+            else
+                // TODO message: "Duplicate type of thread context, " + type + ", is provided by " + provider + " and " + getProvider(type));
+                throw new IllegalStateException();
         }
-
-        // Additional passes through the unsatisfied providers list until all are satisfied or no changes are made
-
-        for (boolean changed = true; changed && !unsatisfied.isEmpty();) {
-            changed = false;
-            for (Iterator<ThreadContextProvider> providers = unsatisfied.iterator(); providers.hasNext();) {
-                ThreadContextProvider provider = providers.next();
-
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "previously unsatisfied provider " + provider);
-
-                if (available.containsAll(provider.getPrerequisites())) {
-                    providers.remove();
-                    if (available.add(provider.getThreadContextType()))
-                        contextProviders.add(provider);
-                    else
-                        throw new IllegalStateException(); // TODO same message from earlier
-                    changed = true;
-                }
-            }
-        }
-
-        // TODO should unsatisfied providers be an error, or defer to later & only if the builder wants to enable them?
-        if (!unsatisfied.isEmpty())
-            throw new IllegalStateException(unsatisfied.toString()); // TODO message with better detail
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CityContextProvider.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CityContextProvider.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.test.context.location;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -22,15 +21,9 @@ import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
  * This context associates a city name with a thread, such that the applicable
  * sales tax rate for the corresponding city (and state that it is in) is included
  * when the getTotalSalesTax() methods is invoked from the thread.
- *
- * As a way of testing prerequisites, this context type declares the "State" context
- * to be a prerequisite and relies on it having already been established on the
- * thread when City context is applied. CityContextSnapshot.begin validates this.
  */
 public class CityContextProvider implements ThreadContextProvider {
     static ThreadLocal<String> cityName = ThreadLocal.withInitial(() -> "");
-
-    private static final Set<String> PREREQ_STATE_CONTEXT = Collections.singleton(TestContextTypes.STATE);
 
     @Override
     public ThreadContextSnapshot clearedContext(Map<String, String> props) {
@@ -42,9 +35,9 @@ public class CityContextProvider implements ThreadContextProvider {
         return new CityContextSnapshot(cityName.get());
     }
 
-    @Override
+    @Override // TODO remove this method once we pick up the binaries where prerequisite context is removed from the spec
     public Set<String> getPrerequisites() {
-        return PREREQ_STATE_CONTEXT;
+        return null;
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CityContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CityContextSnapshot.java
@@ -29,12 +29,6 @@ public class CityContextSnapshot implements ThreadContextSnapshot {
     @Override
     public ThreadContextController begin() {
         ThreadContextController cityContextRestorer = new CityContextRestorer(CityContextProvider.cityName.get());
-
-        // Validate that the city/state combination is valid before applying context.
-        // This introduces a dependency on the State context, so that we can test prerequisites.
-        if (cityName.length() > 0)
-            CurrentLocation.getTotalTaxRate(cityName, StateContextProvider.stateName.get());
-
         CityContextProvider.cityName.set(cityName);
         return cityContextRestorer;
     }


### PR DESCRIPTION
The concept of prerequisite context has been removed from the MicroProfile Concurrency spec.  While we don't have a refresh of the spec binary yet, we can prepare for this by removing our implementation and updating our tests.