### PR TITLE
currentContextExecutor for reusable thread context snapshots

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextServiceImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.mp;
 
+import java.util.Collections;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -39,6 +40,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.service.AbstractContextService;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
 import com.ibm.wsspi.resource.ResourceFactory;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
@@ -62,7 +64,8 @@ public class ContextServiceImpl extends AbstractContextService implements Thread
 
     @Override
     public Executor currentContextExecutor() {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualExecutor(contextDescriptor);
     }
 
     @Deactivate
@@ -126,36 +129,43 @@ public class ContextServiceImpl extends AbstractContextService implements Thread
 
     @Override
     public <T, U> BiConsumer<T, U> withCurrentContext(BiConsumer<T, U> consumer) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualBiConsumer<T, U>(contextDescriptor, consumer);
     }
 
     @Override
     public <T, U, R> BiFunction<T, U, R> withCurrentContext(BiFunction<T, U, R> function) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualBiFunction<T, U, R>(contextDescriptor, function);
     }
 
     @Override
     public <R> Callable<R> withCurrentContext(Callable<R> callable) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualCallable<R>(contextDescriptor, callable);
     }
 
     @Override
     public <T> Consumer<T> withCurrentContext(Consumer<T> consumer) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualConsumer<T>(contextDescriptor, consumer);
     }
 
     @Override
     public <T, R> Function<T, R> withCurrentContext(Function<T, R> function) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualFunction<T, R>(contextDescriptor, function);
     }
 
     @Override
     public Runnable withCurrentContext(Runnable runnable) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualRunnable(contextDescriptor, runnable);
     }
 
     @Override
     public <R> Supplier<R> withCurrentContext(Supplier<R> supplier) {
-        return null; // TODO
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualSupplier<R>(contextDescriptor, supplier);
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualExecutor.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualExecutor.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import java.util.ArrayList;
+import java.util.concurrent.Executor;
+
+import com.ibm.wsspi.threadcontext.ThreadContext;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
+
+/**
+ * Executor that serves as a reusable snapshot of thread context.
+ */
+class ContextualExecutor implements Executor {
+    private final ThreadContextDescriptor threadContextDescriptor;
+
+    ContextualExecutor(ThreadContextDescriptor threadContextDescriptor) {
+        this.threadContextDescriptor = threadContextDescriptor;
+    }
+
+    @Override
+    public void execute(Runnable action) {
+        ThreadContextDescriptor tcd = threadContextDescriptor.clone();
+        ArrayList<ThreadContext> contextApplied = tcd.taskStarting();
+        try {
+            action.run();
+        } finally {
+            tcd.taskStopping(contextApplied);
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CurrentLocation.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/customcontext/src/org/test/context/location/CurrentLocation.java
@@ -22,6 +22,14 @@ public class CurrentLocation {
         setLocation("", "");
     }
 
+    public static String getCity() {
+        return CityContextProvider.cityName.get();
+    }
+
+    public static String getState() {
+        return StateContextProvider.stateName.get();
+    }
+
     public static double getStateSalesTax(double purchaseAmount) {
         String stateName = StateContextProvider.stateName.get();
         return getStateTaxRate(stateName) * purchaseAmount;
@@ -98,12 +106,9 @@ public class CurrentLocation {
                         return 0.07375;
                     case "Saint Paul":
                         return 0.07625;
-                    case "Byron":
-                    case "Stewartville":
-                    case "Winona":
+                    default:
                         return getStateTaxRate(state);
                 }
-                break;
             case "Wisconsin":
                 switch (city) {
                     case "Madison":


### PR DESCRIPTION
Implement ThreadContext.currentContextExecutor to provide reusable snapshots of thread context.
Add a test case.