### PR TITLE
Update the path to the java.policy file for JDK 9+

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/PrivHelper.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/PrivHelper.java
@@ -65,7 +65,13 @@ public class PrivHelper {
         if (!server.isJava2SecurityEnabled() || permissionsToAdd == null || permissionsToAdd.length == 0)
             return;
 
-        String policyPath = JavaInfo.forServer(server).javaHome() + "/lib/security/java.policy";
+        String policyPath;
+        if (JavaInfo.JAVA_VERSION >= 9) {
+            policyPath = JavaInfo.forServer(server).javaHome() + "/conf/security/java.policy";
+        } else {
+            policyPath = JavaInfo.forServer(server).javaHome() + "/lib/security/java.policy";
+        }
+        //String policyPath = JavaInfo.forServer(server).javaHome() + "/lib/security/java.policy";
         String policyContents = FileUtils.readFile(policyPath);
 
         // Add in our custom policy for JAX-B permissions:

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/PrivHelper.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/PrivHelper.java
@@ -71,7 +71,6 @@ public class PrivHelper {
         } else {
             policyPath = JavaInfo.forServer(server).javaHome() + "/lib/security/java.policy";
         }
-        //String policyPath = JavaInfo.forServer(server).javaHome() + "/lib/security/java.policy";
         String policyContents = FileUtils.readFile(policyPath);
 
         // Add in our custom policy for JAX-B permissions:


### PR DESCRIPTION
When testing on JDK 11 with Java2Security enabled...

java.io.FileNotFoundException: /home/nmittles/jdks/adoptOpenJDK/jdk-11+28/lib/securitty/java.policy
at componenttest.topology.uutils.FileUtils.readFile(FileUtils.java:84)
at componenttest.topology.utils.PrivHelper.generateCustomPolicy(PrivHelper.java:69)
at com.ibm.ws.beanvalidation.fat.basic.BasicValidation11Test.setUp(BasicValidation11Testt.java:33)
at componenttest.custom.jjunit.runner.FATRunner$2.evaluate(FATRunner.java:323)
at componenttest.custom.junit.runneer.FATRunner.run(FATRunner.java:167)