### PR TITLE
Allow projects to build on Java 11 bytecode

### DIFF
--- a/dev/build.gradle
+++ b/dev/build.gradle
@@ -38,7 +38,7 @@ subprojects {
     doFirst {
       if(JavaVersion.current().isJava9Compatible() && !'off'.equals(bnd('javac.args.release'))) {
         def release = sourceCompatibility
-        if(sourceCompatibility < '9')
+        if(sourceCompatibility.startsWith('1.'))
           release = sourceCompatibility.substring(2);
         if('current'.equals(bnd('javac.args.release')))
           release = JavaVersion.current().getMajorVersion() 

--- a/dev/cnf/build.bnd
+++ b/dev/cnf/build.bnd
@@ -145,6 +145,9 @@ javac.bootclasspath.1.4: ${defaultjdklib.bootclasspath}
 javac.bootclasspath.1.6: ${defaultjdklib.bootclasspath}
 javac.bootclasspath.1.7: ${defaultjdklib.bootclasspath}
 javac.bootclasspath.1.8: ${defaultjdklib.bootclasspath}
+javac.bootclasspath.9:
+javac.bootclasspath.10:
+javac.bootclasspath.11:
 	
 javac.bootclasspath.java6:
 javac.bootclasspath.java7:

--- a/dev/com.ibm.ws.ras.instrument/HOW_TO_BUILD_LOCALLY.txt
+++ b/dev/com.ibm.ws.ras.instrument/HOW_TO_BUILD_LOCALLY.txt
@@ -1,0 +1,4 @@
+This is a primordial project that does not build in the same way as the rest of the Liberty bundles.
+If you are making a change in this project, run the following command to get your change included in your local Liberty install:
+
+  ./gradlew :com.ibm.ws.ras.instrument:build :com.ibm.ws.logging.osgi:build

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyJava8WorkaroundRuntimeTransformer.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyJava8WorkaroundRuntimeTransformer.java
@@ -56,7 +56,8 @@ public class LibertyJava8WorkaroundRuntimeTransformer implements ClassFileTransf
     /**
      * Indication that the host is an IBM VM.
      */
-    private final static boolean isIBMVirtualMachine = System.getProperty("java.vm.name", "unknown").contains("IBM J9");
+    private final static boolean isIBMVirtualMachine = System.getProperty("java.vm.name", "unknown").contains("IBM J9") ||
+                                                       System.getProperty("java.vm.name", "unknown").contains("OpenJ9");
 
 	/**
 	 * Trace instrumentation force. Due to performance concerns with up-front instrumentation of all 1.8 bytecode classes,

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyRuntimeTransformer.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyRuntimeTransformer.java
@@ -53,7 +53,8 @@ public class LibertyRuntimeTransformer implements ClassFileTransformer {
      * Indication that the host is an IBM VM.
      */
     @SuppressWarnings("unused")
-    private final static boolean isIBMVirtualMachine = System.getProperty("java.vm.name", "unknown").contains("IBM J9");
+    private final static boolean isIBMVirtualMachine = System.getProperty("java.vm.name", "unknown").contains("IBM J9") ||
+                                                       System.getProperty("java.vm.name", "unknown").contains("OpenJ9");
 
     /**
      * Indication that the host is a Sun VM.
@@ -197,9 +198,9 @@ public class LibertyRuntimeTransformer implements ClassFileTransformer {
         //If we have issues here, 1.8 classes will be instead handled by a separate
         //transformer that only does those classes.
         if (isJDK8WithHotReplaceBug)
-        	return classFileVersion <= Opcodes.V1_7;
+            return classFileVersion <= Opcodes.V1_7;
         else
-        	return classFileVersion <= Opcodes.V1_8;
+            return classFileVersion <= Opcodes.V11;
     }
 
     /**


### PR DESCRIPTION
This PR does 2 things:
1) allows projects to set `javac.source: 11`, which will also allow them to use Java 11 APIs (once the builds and everyone's sandbox is upgrade to use JDK 11)
2) enables trace injection for JDK 11 bytecode