### PR TITLE
clear microprofile context types when unspecified and clean up tracing of context

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
@@ -22,6 +22,10 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 WS-TraceGroup: concurrent
 
+Import-Package:\
+  javax.inject;resolution:=optional,\
+  *
+
 Private-Package:\
   com.ibm.ws.concurrent.mp.*
     
@@ -31,7 +35,8 @@ instrument.classesExcludes: com/ibm/ws/concurrent/mp/resources/*.class
   com.ibm.ws.concurrent.mp.ConcurrencyProviderImpl,\
   com.ibm.ws.concurrent.mp.ContextServiceImpl,\
   com.ibm.ws.concurrent.mp.ManagedExecutorImpl,\
-  com.ibm.ws.concurrent.mp.ManagedScheduledExecutorImpl
+  com.ibm.ws.concurrent.mp.ManagedScheduledExecutorImpl,\
+  com.ibm.ws.concurrent.mp.MicroProfileClearedContextProvider
 
 -buildpath: \
   com.ibm.websphere.appserver.spi.logging,\

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
@@ -34,11 +34,12 @@ public class ConcurrencyManagerImpl implements ConcurrencyManager {
     private final ConcurrencyProviderImpl concurrencyProvider;
 
     /**
-     * List of available thread context providers, ordered according to their prerequisites.
+     * List of available thread context providers.
+     * Container-implemented context providers are ordered according to their prerequisites.
      * This is the order in which thread context should be captured and applied to threads.
      * It is the reverse of the order in which thread context is restored on threads.
      */
-    private final ArrayList<ThreadContextProvider> contextProviders = new ArrayList<ThreadContextProvider>();
+    final ArrayList<ThreadContextProvider> contextProviders = new ArrayList<ThreadContextProvider>();
 
     /**
      * Merge built-in thread context providers from the container with those found

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextSnapshotProxy.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextSnapshotProxy.java
@@ -24,6 +24,7 @@ import com.ibm.wsspi.threadcontext.ThreadContext;
  * Proxies a MicroProfile ThreadContextSnapshot as a com.ibm.wsspi.threadcontext.ThreadContext
  * which is used internally for compatibility with container-provided context types.
  */
+@Trivial
 public class ContextSnapshotProxy implements com.ibm.wsspi.threadcontext.ThreadContext {
     private static final long serialVersionUID = 1L;
 
@@ -51,10 +52,11 @@ public class ContextSnapshotProxy implements com.ibm.wsspi.threadcontext.ThreadC
     }
 
     @Override
-    @Trivial
     public String toString() {
-        StringBuilder sb = new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())) //
-                        .append(" for ").append(snapshot).append(" ThreadContextController: ").append(contextRestorer);
+        StringBuilder sb = new StringBuilder("proxy@").append(Integer.toHexString(hashCode())) //
+                        .append(" for ").append(snapshot);
+        if (contextRestorer != null)
+            sb.append(" with ").append(contextRestorer);
         return sb.toString();
     }
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/MicroProfileClearedContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/MicroProfileClearedContextProvider.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.wsspi.threadcontext.ThreadContextDeserializationInfo;
+
+/**
+ * Context provider that clears MicroProfile context types when server config is used to
+ * define EE Concurrency context types.
+ */
+@Component(name = "com.ibm.ws.concurrent.mp.cleared.context.provider",
+           configurationPolicy = ConfigurationPolicy.IGNORE,
+           property = "alwaysCaptureThreadContext:Boolean=true")
+@Trivial
+public class MicroProfileClearedContextProvider implements com.ibm.wsspi.threadcontext.ThreadContextProvider {
+    /**
+     * Reference to the concurrency provider.
+     */
+    @Reference
+    private ConcurrencyProvider concurrencyProvider;
+
+    @Override
+    public com.ibm.wsspi.threadcontext.ThreadContext captureThreadContext(Map<String, String> execProps, Map<String, ?> threadContextConfig) {
+        return createDefaultThreadContext(null);
+    }
+
+    @Override
+    public com.ibm.wsspi.threadcontext.ThreadContext createDefaultThreadContext(Map<String, String> execProps) {
+        return new MicroProfileClearedContextSnapshot((ConcurrencyManagerImpl) concurrencyProvider.getConcurrencyManager());
+    }
+
+    @Override
+    public com.ibm.wsspi.threadcontext.ThreadContext deserializeThreadContext(ThreadContextDeserializationInfo info, byte[] bytes) throws ClassNotFoundException, IOException {
+        return createDefaultThreadContext(null);
+    }
+
+    @Override
+    public List<com.ibm.wsspi.threadcontext.ThreadContextProvider> getPrerequisites() {
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/MicroProfileClearedContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/MicroProfileClearedContextSnapshot.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.eclipse.microprofile.concurrent.ThreadContext;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextController;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.mp.context.WLMContextProvider;
+
+/**
+ * Multi-context snapshot that clears MicroProfile context types when server config is used.
+ */
+@Trivial // this class does its own tracing when clearing and restoring context
+public class MicroProfileClearedContextSnapshot implements com.ibm.wsspi.threadcontext.ThreadContext {
+    private static final long serialVersionUID = 1L;
+
+    private static final TraceComponent tc = Tr.register(MicroProfileClearedContextSnapshot.class);
+
+    private static final HashSet<String> DO_NOT_CLEAR = new HashSet<String>(Arrays.asList //
+    (
+     ThreadContext.APPLICATION,
+     ThreadContext.CDI,
+     ThreadContext.SECURITY,
+     ThreadContext.TRANSACTION,
+     WLMContextProvider.WORKLOAD //
+    ));
+
+    private final ArrayList<ThreadContextController> contextRestorers = new ArrayList<ThreadContextController>();
+    private final ArrayList<ThreadContextSnapshot> contextSnapshots = new ArrayList<ThreadContextSnapshot>();
+
+    MicroProfileClearedContextSnapshot(ConcurrencyManagerImpl concurrencyMgr) {
+        for (ThreadContextProvider provider : concurrencyMgr.contextProviders)
+            if (!DO_NOT_CLEAR.contains(provider.getThreadContextType()))
+                contextSnapshots.add(provider.clearedContext(Collections.emptyMap()));
+    }
+
+    @Override
+    public com.ibm.wsspi.threadcontext.ThreadContext clone() {
+        try {
+            return (com.ibm.wsspi.threadcontext.ThreadContext) super.clone();
+        } catch (CloneNotSupportedException x) {
+            throw new Error(x); // should be impossible
+        }
+    }
+
+    @Override
+    public void taskStarting() throws RejectedExecutionException {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+        try {
+            for (ThreadContextSnapshot snapshot : contextSnapshots) {
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "clearing " + snapshot);
+
+                contextRestorers.add(snapshot.begin());
+            }
+        } catch (Error | RuntimeException x) {
+            taskStopping();
+            throw x;
+        }
+    }
+
+    @Override
+    public void taskStopping() {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+        Throwable failure = null;
+        for (int i = contextRestorers.size() - 1; i >= 0; i--)
+            try {
+                ThreadContextController contextRestorer = contextRestorers.remove(i);
+
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "restoring " + contextRestorer);
+
+                contextRestorer.endContext();
+            } catch (Error | RuntimeException x) {
+                if (failure != null)
+                    failure = x;
+            }
+
+        if (failure instanceof Error)
+            throw (Error) failure;
+        if (failure instanceof RuntimeException)
+            throw (RuntimeException) failure;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())).toString();
+    }
+
+    private void writeObject(ObjectOutputStream outStream) throws IOException {
+        outStream.putFields();
+        // nothing to write because the clearing context is recreated at deserialization time
+        outStream.writeFields();
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/ApplicationContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/ApplicationContextProvider.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 
 import org.eclipse.microprofile.concurrent.ThreadContext;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.mp.ContextOp;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 
@@ -21,6 +22,7 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
  * Partial implementation of MicroProfile Application context, backed by Liberty's
  * Classloader Context and JEE Metadata Context.
  */
+@Trivial
 public class ApplicationContextProvider extends ContainerContextProvider {
     public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> classloaderContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("ClassloaderContextProvider");
     public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> jeeMetadataContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("JeeMetadataContextProvider");

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/DeferredClearedContext.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/DeferredClearedContext.java
@@ -25,10 +25,11 @@ import com.ibm.wsspi.threadcontext.ThreadContext;
  * available at a later time, by deferring the creation of the cleared thread context snapshot
  * until the action or task is about to start.
  */
+@Trivial
 public class DeferredClearedContext implements com.ibm.wsspi.threadcontext.ThreadContext {
     private static final long serialVersionUID = 1L;
 
-    private com.ibm.wsspi.threadcontext.ThreadContext clearedContextController;
+    public com.ibm.wsspi.threadcontext.ThreadContext clearedContextController;
     public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> contextProviderRef;
 
     DeferredClearedContext(AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> contextProviderRef) {
@@ -58,10 +59,9 @@ public class DeferredClearedContext implements com.ibm.wsspi.threadcontext.Threa
     }
 
     @Override
-    @Trivial
     public String toString() {
         StringBuilder sb = new StringBuilder(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())) //
-                        .append(" for ").append(contextProviderRef).append(" clearedContextController: ").append(clearedContextController);
+                        .append(" for ").append(contextProviderRef);
         return sb.toString();
     }
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/SecurityContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/SecurityContextProvider.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 
 import org.eclipse.microprofile.concurrent.ThreadContext;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.mp.ContextOp;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 
@@ -21,6 +22,7 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
  * Partial implementation of MicroProfile Security context,
  * backed by Liberty's Security context.
  */
+@Trivial
 public class SecurityContextProvider extends ContainerContextProvider {
     public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> securityContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("SecurityContextProvider");
     public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> threadIdentityContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("ThreadIdentityContextProvider");

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/TransactionContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/TransactionContextProvider.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 
 import org.eclipse.microprofile.concurrent.ThreadContext;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.mp.ContextOp;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 
@@ -21,6 +22,7 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
  * Partial implementation of MicroProfile Transaction context,
  * backed by Liberty's Transaction context.
  */
+@Trivial
 public class TransactionContextProvider extends ContainerContextProvider {
     public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> transactionContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("TransactionContextProvider");
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/WLMContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/WLMContextProvider.java
@@ -12,6 +12,7 @@ package com.ibm.ws.concurrent.mp.context;
 
 import java.util.ArrayList;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.mp.ContextOp;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 
@@ -19,6 +20,7 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
  * Partial implementation of MicroProfile thread context provider,
  * backed by Liberty's z/OS WLM context.
  */
+@Trivial
 public class WLMContextProvider extends ContainerContextProvider {
     public static final String WORKLOAD = "Workload";
 

--- a/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/SerializableContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent_fat_rx/test-applications/concurrentrxfat/src/web/SerializableContextSnapshot.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import java.io.Serializable;
+import java.util.concurrent.Executor;
+
+public class SerializableContextSnapshot implements Executor, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void execute(Runnable runnable) {
+        runnable.run();
+    }
+}


### PR DESCRIPTION
When the user uses the old server-configuration based method of defining contextServer/managed executors, we should be clearing/restoring MicroProfile-supplied context types because the user's tasks/actions will not expect to see these new types remain on threads.  This will also enforce a more predictable, consistent behavior because these context types will always be cleared rather than sometimes having one value vs another or not being present at all.

Also, looking of the trace output for context propagation, it has so many trace points that it is nearly unreadable.  In this pull, I'm reducing/improving trace to more concisely show the most important and useful information.