### PR TITLE
Move java dump into a debug block

### DIFF
--- a/dev/com.ibm.ws.runtime.update/src/com/ibm/ws/runtime/update/internal/RuntimeUpdateManagerImpl.java
+++ b/dev/com.ibm.ws.runtime.update/src/com/ibm/ws/runtime/update/internal/RuntimeUpdateManagerImpl.java
@@ -387,10 +387,10 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
                 Tr.info(tc, "client.quiesce.end");
         } else {
 
-            // Dump threads to show what's still running. This should normally only be done when
-            // debug is enabled, but it's always on for now. Once we're sure we've flushed out most
-            // sources of quiesce failures we can move this into a debug block.
-            libertyProcess.createJavaDump(Collections.singleton("thread"));
+            if (tc.isDebugEnabled()) {
+                // If debug is enabled we will dump threads so that we can determine what was still running
+                libertyProcess.createJavaDump(Collections.singleton("thread"));
+            }
 
             int count = tq.getActiveThreads();
 


### PR DESCRIPTION
We should only generate a javacore on quiesce failures when debug is enabled for com.ibm.ws.runtime.update. 