### PR TITLE
implement ThreadContext.withContextCapture(CompletableFuture)

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
@@ -31,7 +31,7 @@ import com.ibm.ws.concurrent.mp.context.WLMContextProvider;
 public class ConcurrencyManagerImpl implements ConcurrencyManager {
     private static final TraceComponent tc = Tr.register(ConcurrencyManagerImpl.class);
 
-    private final ConcurrencyProviderImpl concurrencyProvider;
+    final ConcurrencyProviderImpl concurrencyProvider;
 
     /**
      * List of available thread context providers.
@@ -88,6 +88,6 @@ public class ConcurrencyManagerImpl implements ConcurrencyManager {
 
     @Override
     public ThreadContextBuilder newThreadContextBuilder() {
-        return new ThreadContextBuilderImpl(contextProviders);
+        return new ThreadContextBuilderImpl(this, contextProviders);
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyProviderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyProviderImpl.java
@@ -48,12 +48,18 @@ public class ConcurrencyProviderImpl implements ConcurrencyProvider {
     final TransactionContextProvider transactionContextProvider = new TransactionContextProvider();
     final WLMContextProvider wlmContextProvider = new WLMContextProvider();
 
+    /**
+     * Key for providersPerClassLoader indicating that there is no context class loader on the thread.
+     * This is needed because ConcurrentHashMap does not allow null keys.
+     */
+    private static final String NO_CONTEXT_CLASSLOADER = "NO_CONTEXT_CLASSLOADER";
+
     private static final SecureAction priv = AccessController.doPrivileged(SecureAction.get());
 
     @Reference
     protected PolicyExecutorProvider policyExecutorProvider;
 
-    private final ConcurrentHashMap<ClassLoader, ConcurrencyManager> providersPerClassLoader = new ConcurrentHashMap<ClassLoader, ConcurrencyManager>();
+    private final ConcurrentHashMap<Object, ConcurrencyManager> providersPerClassLoader = new ConcurrentHashMap<Object, ConcurrencyManager>();
 
     private ConcurrencyProviderRegistration registration;
 
@@ -87,10 +93,11 @@ public class ConcurrencyProviderImpl implements ConcurrencyProvider {
 
     @Override
     public ConcurrencyManager getConcurrencyManager(ClassLoader classLoader) {
-        ConcurrencyManager ccmgr = providersPerClassLoader.get(classLoader);
+        Object key = classLoader == null ? NO_CONTEXT_CLASSLOADER : classLoader;
+        ConcurrencyManager ccmgr = providersPerClassLoader.get(key);
         if (ccmgr == null) {
             ConcurrencyManager ccmgrNew = new ConcurrencyManagerImpl(this, classLoader);
-            ccmgr = providersPerClassLoader.putIfAbsent(classLoader, ccmgrNew);
+            ccmgr = providersPerClassLoader.putIfAbsent(key, ccmgrNew);
             if (ccmgr == null)
                 ccmgr = ccmgrNew;
         }
@@ -112,8 +119,8 @@ public class ConcurrencyProviderImpl implements ConcurrencyProvider {
         // This is inefficient. Does the spec need to require it?
         // The container, which already knows the class loader,
         // can instead directly remove the entry based on the key.
-        for (Iterator<Map.Entry<ClassLoader, ConcurrencyManager>> entries = providersPerClassLoader.entrySet().iterator(); entries.hasNext();) {
-            Map.Entry<ClassLoader, ConcurrencyManager> entry = entries.next();
+        for (Iterator<Map.Entry<Object, ConcurrencyManager>> entries = providersPerClassLoader.entrySet().iterator(); entries.hasNext();) {
+            Map.Entry<Object, ConcurrencyManager> entry = entries.next();
             if (manager.equals(entry.getValue()))
                 entries.remove();
         }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
@@ -28,7 +28,7 @@ import com.ibm.ws.threading.PolicyExecutor;
  * Builder that programmatically configures and creates ManagedExecutor instances.
  */
 class ManagedExecutorBuilderImpl implements ManagedExecutorBuilder {
-    private static final AtomicLong instanceCount = new AtomicLong();
+    static final AtomicLong instanceCount = new AtomicLong();
 
     private final ConcurrencyProviderImpl concurrencyProvider;
     private final ArrayList<ThreadContextProvider> contextProviders;
@@ -83,8 +83,17 @@ class ManagedExecutorBuilderImpl implements ManagedExecutorBuilder {
         if (unknown.size() > 0)
             throw new IllegalStateException(unknown.toString()); // TODO meaningful error message
 
-        // TODO generate better formated identifier without commas and spaces
-        String name = "ManagedExecutor-" + maxAsync + '-' + maxQueued + '-' + propagated + "#" + instanceCount.incrementAndGet();
+        StringBuilder nameBuilder = new StringBuilder("ManagedExecutor_") //
+                        .append(maxAsync).append('_') //
+                        .append(maxQueued).append('_');
+
+        for (String propagatedType : propagated)
+            if (propagatedType.matches("\\w*")) // one or more of a-z, A-Z, _, 0-9
+                nameBuilder.append(propagatedType).append('_');
+
+        nameBuilder.append(instanceCount.incrementAndGet());
+
+        String name = nameBuilder.toString();
 
         PolicyExecutor policyExecutor = concurrencyProvider.policyExecutorProvider.create(name) //
                         .maxConcurrency(maxAsync) //

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorImpl.java
@@ -63,6 +63,8 @@ public class ManagedExecutorImpl extends AbstractManagedExecutorService implemen
 
     /**
      * Constructor for MicroProfile Concurrency (ManagedExecutorBuilder and CDI injected ManagedExecutor).
+     * Also used to construct a managed executor for use by the ManagedCompletableFuture returned from
+     * ThreadContext.withContextCapture.
      */
     public ManagedExecutorImpl(String name, PolicyExecutor policyExecutor, WSContextService mpThreadContext,
                                AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> tranContextProviderRef) {

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
@@ -24,13 +24,15 @@ import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
  * Builder that programmatically configures and creates ThreadContext instances.
  */
 class ThreadContextBuilderImpl implements ThreadContextBuilder {
+    private final ConcurrencyManagerImpl concurrencyManager;
     private final ArrayList<ThreadContextProvider> contextProviders;
 
     private final HashSet<String> cleared = new HashSet<String>();
     private final HashSet<String> propagated = new HashSet<String>();
     private final HashSet<String> unchanged = new HashSet<String>();
 
-    ThreadContextBuilderImpl(ArrayList<ThreadContextProvider> contextProviders) {
+    ThreadContextBuilderImpl(ConcurrencyManagerImpl concurrencyManager, ArrayList<ThreadContextProvider> contextProviders) {
+        this.concurrencyManager = concurrencyManager;
         this.contextProviders = contextProviders;
 
         // built-in defaults from spec:
@@ -78,7 +80,7 @@ class ThreadContextBuilderImpl implements ThreadContextBuilder {
         if (unknown.size() > 0)
             throw new IllegalArgumentException(unknown.toString());
 
-        return new ThreadContextImpl(configPerProvider);
+        return new ThreadContextImpl(concurrencyManager, configPerProvider);
     }
 
     @Override


### PR DESCRIPTION
Implement the withContextCapture method that takes a CompletableFuture on ThreadContext.  A test case for this method, although passing, is not included under this pull in order to avoid a conflict with a test bucket rename that another developer is working on.