### PR TITLE
Revert "Switch pool implementation for webcontainer pooled objects."

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/interceptor/JAXRSInInterceptor.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/interceptor/JAXRSInInterceptor.java
@@ -177,7 +177,7 @@ public class JAXRSInInterceptor extends AbstractPhaseInterceptor<Message> {
 
         LibertyJaxRsResourceMethodCache resourceMethodCache = exchange.getBus().getExtension(LibertyJaxRsResourceMethodCache.class);
 
-        MultivaluedMap<String, String> matchedValues = null;
+        MultivaluedMap<String, String> matchedValues = new MetadataMap<String, String>();
 
         OperationResourceInfo ori = null;
 
@@ -219,7 +219,6 @@ public class JAXRSInInterceptor extends AbstractPhaseInterceptor<Message> {
             Tr.debug(tc, "shouldFind = " + shouldFind);
         }
         if (shouldFind == true) {
-            matchedValues = new MetadataMap<String, String>();
 
             Map<ClassResourceInfo, MultivaluedMap<String, String>> matchedResources = JAXRSUtils.selectResourceClass(resources, rawPath, message);
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/interceptor/JAXRSInInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/interceptor/JAXRSInInterceptor.java
@@ -175,7 +175,7 @@ public class JAXRSInInterceptor extends AbstractPhaseInterceptor<Message> {
 
         LibertyJaxRsResourceMethodCache resourceMethodCache = exchange.getBus().getExtension(LibertyJaxRsResourceMethodCache.class);
 
-        MultivaluedMap<String, String> matchedValues = null;
+        MultivaluedMap<String, String> matchedValues = new MetadataMap<String, String>();
 
         OperationResourceInfo ori = null;
 
@@ -217,7 +217,6 @@ public class JAXRSInInterceptor extends AbstractPhaseInterceptor<Message> {
             Tr.debug(tc, "shouldFind = " + shouldFind);
         }
         if (shouldFind == true) {
-            matchedValues = new MetadataMap<String, String>();
 
             Map<ClassResourceInfo, MultivaluedMap<String, String>> matchedResources = JAXRSUtils.selectResourceClass(resources, rawPath, message);
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpObjectFactory.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpObjectFactory.java
@@ -12,28 +12,30 @@ package com.ibm.ws.http.channel.internal;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.kernel.service.util.ConcurrentObjectPool;
+import com.ibm.wsspi.channelfw.objectpool.TwoTierObjectPool;
 import com.ibm.wsspi.http.channel.inbound.HttpInboundServiceContext;
 import com.ibm.wsspi.http.channel.outbound.HttpOutboundServiceContext;
 
 /**
  * Factory for all of the pooled objects used in the HTTP channel.
- *
+ * 
  */
 public class HttpObjectFactory {
 
     /** RAS tracing variable */
     private static final TraceComponent tc = Tr.register(HttpObjectFactory.class, HttpMessages.HTTP_TRACE_NAME, HttpMessages.HTTP_BUNDLE);
 
-    /** Size of the pool */
-    private static final int POOL_SIZE = 100;
+    /** Size of each thread based object pool */
+    private static final int SIZE_THREAD = 50;
+    /** Size of the main group */
+    private static final int SIZE_MAIN = 50;
 
     /** Pool of http request objects */
-    private final ConcurrentObjectPool<HttpRequestMessageImpl> reqPool = new ConcurrentObjectPool<>(POOL_SIZE);
+    private final TwoTierObjectPool reqPool = new TwoTierObjectPool(SIZE_THREAD, SIZE_MAIN);
     /** Pool of http response objects */
-    private final ConcurrentObjectPool<HttpResponseMessageImpl> respPool = new ConcurrentObjectPool<>(POOL_SIZE);
+    private final TwoTierObjectPool respPool = new TwoTierObjectPool(SIZE_THREAD, SIZE_MAIN);
     /** Pool of http trailer objects */
-    private final ConcurrentObjectPool<HttpTrailersImpl> hdrPool = new ConcurrentObjectPool<>(POOL_SIZE);
+    private final TwoTierObjectPool hdrPool = new TwoTierObjectPool(SIZE_THREAD, SIZE_MAIN);
 
     /**
      * Constructor of the object factory.
@@ -47,11 +49,11 @@ public class HttpObjectFactory {
 
     /**
      * Retrieve an uninitialized request message.
-     *
+     * 
      * @return HttpRequestMessageImpl
      */
     public HttpRequestMessageImpl getRequest() {
-        HttpRequestMessageImpl req = this.reqPool.get();
+        HttpRequestMessageImpl req = (HttpRequestMessageImpl) this.reqPool.get();
         if (null == req) {
             req = new HttpRequestMessageImpl();
         }
@@ -63,7 +65,7 @@ public class HttpObjectFactory {
 
     /**
      * Retrieve an incoming request object from the factory.
-     *
+     * 
      * @param hsc
      * @return HttpRequestMessageImpl
      */
@@ -75,7 +77,7 @@ public class HttpObjectFactory {
 
     /**
      * Retrieve an outgoing request object from the factory.
-     *
+     * 
      * @param hsc
      * @return HttpRequestMessageImpl
      */
@@ -87,7 +89,7 @@ public class HttpObjectFactory {
 
     /**
      * Return a request object to the factory for pooling.
-     *
+     * 
      * @param request
      */
     public void releaseRequest(HttpRequestMessageImpl request) {
@@ -99,11 +101,11 @@ public class HttpObjectFactory {
 
     /**
      * Retrieve an uninitialized response message.
-     *
+     * 
      * @return HttpResponseMessageImpl
      */
     public HttpResponseMessageImpl getResponse() {
-        HttpResponseMessageImpl resp = this.respPool.get();
+        HttpResponseMessageImpl resp = (HttpResponseMessageImpl) this.respPool.get();
         if (null == resp) {
             resp = new HttpResponseMessageImpl();
         }
@@ -115,7 +117,7 @@ public class HttpObjectFactory {
 
     /**
      * Retrieve an outgoing response object from the factory.
-     *
+     * 
      * @param hsc
      * @return HttpResponseMessageImpl
      */
@@ -127,7 +129,7 @@ public class HttpObjectFactory {
 
     /**
      * Retrieve an incoming response object from the factory.
-     *
+     * 
      * @param hsc
      * @return HttpResponseMessageImpl
      */
@@ -139,7 +141,7 @@ public class HttpObjectFactory {
 
     /**
      * Return a response object to the factory for pooling.
-     *
+     * 
      * @param response
      */
     public void releaseResponse(HttpResponseMessageImpl response) {
@@ -152,7 +154,7 @@ public class HttpObjectFactory {
     /**
      * Get a new trailers object. init() is not called on the object so the
      * default values for certain variables are used (byte cache size, etc).
-     *
+     * 
      * @return HttpTrailersImpl
      */
     public HttpTrailersImpl getTrailers() {
@@ -168,7 +170,7 @@ public class HttpObjectFactory {
 
     /**
      * Return a trailers object to the pool.
-     *
+     * 
      * @param h
      */
     public void releaseTrailers(HttpTrailersImpl h) {

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/bnd.bnd
@@ -64,7 +64,6 @@ instrument.disabled: true
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.container.service;version=latest,\
     com.ibm.ws.injection;version=latest,\
-    com.ibm.ws.kernel.service;version=latest,\
     com.ibm.ws.managedobject;version=latest,\
     com.ibm.ws.resource;version=latest,\
     com.ibm.ws.session;version=latest,\

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/src/com/ibm/ws/webcontainer31/osgi/srt/factory/SRTConnectionContextPool31Impl.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/src/com/ibm/ws/webcontainer31/osgi/srt/factory/SRTConnectionContextPool31Impl.java
@@ -12,8 +12,6 @@ package com.ibm.ws.webcontainer31.osgi.srt.factory;
 
 import org.osgi.service.component.annotations.Component;
 
-import com.ibm.ws.kernel.service.util.ConcurrentObjectPool;
-import com.ibm.ws.webcontainer.osgi.srt.SRTConnectionContext;
 import com.ibm.ws.webcontainer.osgi.srt.SRTConnectionContextPool;
 import com.ibm.ws.webcontainer31.osgi.srt.SRTConnectionContext31;
 
@@ -22,21 +20,29 @@ import com.ibm.ws.webcontainer31.osgi.srt.SRTConnectionContext31;
  */
 @Component(property = { "service.vendor=IBM", "service.ranking:Integer=31", "servlet.version=3.1" })
 public class SRTConnectionContextPool31Impl implements SRTConnectionContextPool {
-    private final ConcurrentObjectPool<SRTConnectionContext> pool = new ConcurrentObjectPool<>(100);
+    private final ThreadLocal<com.ibm.ws.webcontainer.osgi.srt.SRTConnectionContext> head = new ThreadLocal<com.ibm.ws.webcontainer.osgi.srt.SRTConnectionContext>();
 
     @Override
-    public final SRTConnectionContext get() {
-        SRTConnectionContext context = pool.get();
+    public final com.ibm.ws.webcontainer.osgi.srt.SRTConnectionContext get() {
+        com.ibm.ws.webcontainer.osgi.srt.SRTConnectionContext context = null;
+        com.ibm.ws.webcontainer.osgi.srt.SRTConnectionContext headContext = head.get();
+        if (headContext != null) {
+            context = headContext;
+            head.set(context.nextContext);
+        }
 
         if (context == null) {
             context = new SRTConnectionContext31();
         }
 
+        context.nextContext = null;
+
         return context;
     }
 
     @Override
-    public final void put(SRTConnectionContext context) {
-        pool.put(context);
+    public final void put(com.ibm.ws.webcontainer.osgi.srt.SRTConnectionContext context) {
+        context.nextContext = head.get();
+        head.set(context);
     }
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/srt/SRTConnectionContext31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/srt/SRTConnectionContext31.java
@@ -16,6 +16,8 @@
  */
 package com.ibm.ws.webcontainer31.osgi.srt;
 
+import java.io.IOException;
+
 import javax.servlet.http.HttpUpgradeHandler;
 
 import com.ibm.websphere.ras.Tr;
@@ -44,6 +46,11 @@ public class SRTConnectionContext31 extends com.ibm.ws.webcontainer.osgi.srt.SRT
 {
 
     private final static TraceComponent tc = Tr.register(SRTConnectionContext31.class, WebContainerConstants.TR_GROUP, WebContainerConstants.NLS_PROPS);
+
+    /**
+     * Used for pooling the SRTConnectionContext31 objects.
+     */
+    public SRTConnectionContext31 nextContext;
 
     protected SRTServletRequest newSRTServletRequest() {
         return new SRTServletRequest31(this);

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0.factories/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0.factories/bnd.bnd
@@ -70,7 +70,6 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.transport.http;version=latest,\
     com.ibm.ws.channelfw;version=latest,\
-    com.ibm.ws.kernel.service;version=latest,\
     com.ibm.ws.managedobject;version=latest,\
     com.ibm.ws.container.service;version=latest,\
     com.ibm.ws.injection;version=latest,\

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/srt/SRTConnectionContext40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/srt/SRTConnectionContext40.java
@@ -18,6 +18,11 @@ import com.ibm.ws.webcontainer40.srt.SRTServletResponse40;
 
 public class SRTConnectionContext40 extends com.ibm.ws.webcontainer31.osgi.srt.SRTConnectionContext31 {
 
+    /**
+     * Used for pooling the SRTConnectionContext31 objects.
+     */
+    public SRTConnectionContext40 nextContext;
+
     @Override
     protected void init() {
         this._dispatchContext = new WebAppDispatcherContext40(_request);

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/WebContainer.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/WebContainer.java
@@ -112,6 +112,10 @@ public class WebContainer extends com.ibm.ws.webcontainer.WebContainer implement
 
     private static final String CLASS_NAME = "com.ibm.ws.webcontainer.osgi.WebContainer";
 
+    // uncomment if the getConnectionContext() method uses it again
+    // private static ThreadLocal<SRTConnectionContext> _threadLocal =
+    // new ThreadLocal<SRTConnectionContext>();
+
     private boolean initialized;
 
     /** required dynamic reference */
@@ -795,6 +799,22 @@ public class WebContainer extends com.ibm.ws.webcontainer.WebContainer implement
      */
     @Override
     protected com.ibm.ws.webcontainer.srt.SRTConnectionContext getConnectionContext() {
+        // SRTConnectionContext srt = _threadLocal.get();
+        // if (srt == null) {
+        // srt = new SRTConnectionContext();
+        // _threadLocal.set(srt);
+        // }
+        // return srt;
+
+        /*
+         * TODO: Investigate performance impact of removing thread locals and
+         * instead creating a new connection context each time. The threadlocal
+         * approach causes problems for requests that go async as a subsequent
+         * request may use the same thread and therefore get the same
+         * SRTServletRequest instance from the SRTConnectionContext.
+         */
+
+        // return new SRTConnectionContext();
         return connContextPool.get();
     }
 


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#5698

In the LAOS Continuous build there were two unit test failures in the http transport code. PR #5698 was the only one to change that code in that build.
```
com.ibm.ws.transport.http unittests
  com.ibm.ws.http.internal.VirtualHostImplTest
    testRegenerateAliases
    testThreadedAddRemoveMultipleVHosts
```