### PR TITLE
Updates to reduce CPU and memory during startup.

### DIFF
--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIContainerImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIContainerImpl.java
@@ -161,7 +161,7 @@ public class CDIContainerImpl implements CDIContainer, InjectionMetaDataListener
             }
 
         } finally {
-            currentDeployment.set(null);
+            currentDeployment.remove();
         }
 
     }
@@ -173,7 +173,7 @@ public class CDIContainerImpl implements CDIContainer, InjectionMetaDataListener
                 currentDeployment.set(webSphereCDIDeployment);
                 weldBootstrap.endInitialization();
             } finally {
-                currentDeployment.set(null);
+                currentDeployment.remove();
             }
         }
     }

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/wsspi/channelfw/objectpool/LocalThreadObjectPool.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/wsspi/channelfw/objectpool/LocalThreadObjectPool.java
@@ -38,7 +38,7 @@ public class LocalThreadObjectPool implements ObjectPool {
     private int underflowCount = 0;
     private int overflowCount = 0;
     private int minElements = 0;
-    private final int adjustThreshold = 1000;
+    private static final int adjustThreshold = 1000;
     private int minPoolSize;
     private int batchSize;
     private int adjustSize;

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigEvaluator.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigEvaluator.java
@@ -293,9 +293,11 @@ class ConfigEvaluator {
         context.setAttributeName(attributeName);
         context.addProcessed(attributeName);
 
+        final String prefixedAttributeName = flatPrefix.length() == 0 ? attributeName : flatPrefix + attributeName;
+
         Object rawValue = null;
         if (attributeDef.getCopyOf() != null) {
-            AttributeValueCopy copy = new AttributeValueCopy(flatPrefix + attributeName, attributeDef.getCopyOf());
+            AttributeValueCopy copy = new AttributeValueCopy(prefixedAttributeName, attributeDef.getCopyOf());
             context.addAttributeValueCopy(copy);
         }
 
@@ -415,7 +417,7 @@ class ConfigEvaluator {
                     actualValue = pids;
                 }
                 if (actualValue != null) {
-                    context.setProperty(flatPrefix + attributeName, actualValue);
+                    context.setProperty(prefixedAttributeName, actualValue);
                 }
                 evaluateFinish(context);
                 return actualValue;
@@ -444,7 +446,7 @@ class ConfigEvaluator {
                     actualValue = pids;
                 }
                 if (actualValue != null) {
-                    context.setProperty(flatPrefix + attributeName, actualValue);
+                    context.setProperty(prefixedAttributeName, actualValue);
                 }
                 evaluateFinish(context);
                 return actualValue;
@@ -501,7 +503,7 @@ class ConfigEvaluator {
             }
 
             if (actualValue != null) {
-                context.setProperty(flatPrefix + attributeName, actualValue);
+                context.setProperty(prefixedAttributeName, actualValue);
             }
             evaluateFinish(context);
         }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigEvaluator.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigEvaluator.java
@@ -1330,36 +1330,51 @@ class ConfigEvaluator {
             }
         }
 
+        boolean optionFound = false;
         // Convert option value to correct case.
         String[] optionValues = attrDef.getOptionValues();
         if (optionValues != null) {
-            String[] optionLabels = attrDef.getOptionLabels();
             for (int i = 0; i < optionValues.length; i++) {
-                if (strValue.equalsIgnoreCase(optionValues[i]) || strValue.equalsIgnoreCase(optionLabels[i])) {
+                if (strValue.equalsIgnoreCase(optionValues[i])) {
                     strValue = optionValues[i];
+                    optionFound = true;
                     break;
+                }
+            }
+            // only get the labels if it isn't found in the values.  Usually it will be a value.
+            if (!optionFound) {
+                String[] optionLabels = attrDef.getOptionLabels();
+                for (int i = 0; i < optionValues.length; i++) {
+                    if (strValue.equalsIgnoreCase(optionLabels[i])) {
+                        strValue = optionValues[i];
+                        optionFound = true;
+                        break;
+                    }
                 }
             }
         }
 
-        // Special case for Boolean, since we want to validate "true" or "false" and anything is fail to validate (rather than being treated as false)
-        if (attrDef.getType() == AttributeDefinition.BOOLEAN) {
-            if (!!!("true".equalsIgnoreCase(strValue))
-                && !!!("false".equalsIgnoreCase(strValue))) {
-                Object[] inserts = new Object[] { strValue, attrDef.getID(), "false" }; // "false" is the default default
-                if (attrDef.getDefaultValue() != null && attrDef.getDefaultValue().length > 0)
-                    inserts[2] = attrDef.getDefaultValue()[0];
-                throw new AttributeValidationException(attrDef, strValue, Tr.formatMessage(tc, "error.invalid.boolean.attribute", inserts));
-            }
-        } else if (attrDef.getType() != MetaTypeFactory.PID_TYPE) {
-            // The validate method treats whitespace, commas, and
-            // backslashes specially, but we've already done all that
-            // processing and just want to validate a single value, so
-            // escape all the special characters.  (It might be less effort
-            // to just reimplement the validate method entirely.)
-            String validateResult = attrDef.validate(MetaTypeHelper.escapeValue(strValue));
-            if (validateResult != null && validateResult.length() > 0) {
-                throw new AttributeValidationException(attrDef, strValue, validateResult);
+        // If it is an option and it was found then skip the validate since it isn't needed.
+        if (!optionFound) {
+            // Special case for Boolean, since we want to validate "true" or "false" and anything is fail to validate (rather than being treated as false)
+            if (attrDef.getType() == AttributeDefinition.BOOLEAN) {
+                if (!!!("true".equalsIgnoreCase(strValue))
+                    && !!!("false".equalsIgnoreCase(strValue))) {
+                    Object[] inserts = new Object[] { strValue, attrDef.getID(), "false" }; // "false" is the default default
+                    if (attrDef.getDefaultValue() != null && attrDef.getDefaultValue().length > 0)
+                        inserts[2] = attrDef.getDefaultValue()[0];
+                    throw new AttributeValidationException(attrDef, strValue, Tr.formatMessage(tc, "error.invalid.boolean.attribute", inserts));
+                }
+            } else if (attrDef.getType() != MetaTypeFactory.PID_TYPE) {
+                // The validate method treats whitespace, commas, and
+                // backslashes specially, but we've already done all that
+                // processing and just want to validate a single value, so
+                // escape all the special characters.  (It might be less effort
+                // to just reimplement the validate method entirely.)
+                String validateResult = attrDef.validate(MetaTypeHelper.escapeValue(strValue));
+                if (validateResult != null && validateResult.length() > 0) {
+                    throw new AttributeValidationException(attrDef, strValue, validateResult);
+                }
             }
         }
 

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/MetaTypeRegistry.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/MetaTypeRegistry.java
@@ -922,8 +922,8 @@ final class MetaTypeRegistry {
             }
             if (referencingPids == null) {
                 referencingPids = new CopyOnWriteArrayList<PidReference>();
-            }
-            if (!referencingPids.contains(ref)) {
+                referencingPids.add(ref);
+            } else if (!referencingPids.contains(ref)) {
                 referencingPids.add(ref);
             }
         }

--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/jacc/EJBJaccAuthorizationHelper.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/jacc/EJBJaccAuthorizationHelper.java
@@ -24,7 +24,6 @@ import com.ibm.websphere.security.audit.AuditAuthResult;
 import com.ibm.websphere.security.audit.AuditAuthenticationResult;
 import com.ibm.websphere.security.audit.AuditEvent;
 import com.ibm.websphere.security.audit.context.AuditManager;
-import com.ibm.websphere.security.audit.context.AuditThreadContext;
 import com.ibm.ws.ejbcontainer.EJBComponentMetaData;
 import com.ibm.ws.ejbcontainer.EJBMethodMetaData;
 import com.ibm.ws.ejbcontainer.EJBRequestData;
@@ -51,8 +50,6 @@ public class EJBJaccAuthorizationHelper implements EJBAuthorizationHelper {
     public HashMap<String, Object> ejbAuditHashMap = new HashMap<String, Object>();
 
     protected AuditManager auditManager;
-
-    private static ThreadLocal<AuditThreadContext> threadLocal = new ThreadLocal<AuditThreadContext>();
 
     public void populateAuditEJBHashMap(EJBRequestData request) {
         EJBMethodMetaData methodMetaData = request.getEJBMethodMetaData();

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/service/model/EndpointInfo.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/service/model/EndpointInfo.java
@@ -33,19 +33,20 @@ public class EndpointInfo extends AbstractDescriptionElement implements NamedIte
     BindingInfo binding;
     QName name;
     private volatile EndpointReferenceType lastAddressSet; //Liberty: Maintain last address set for when threadlocal value may be null.
-    
-    // Liberty #3669:  Store address in a theadLocal to avoid issue where redirected URL is mismatched when accessed 
+
+    // Liberty #3669:  Store address in a theadLocal to avoid issue where redirected URL is mismatched when accessed
     // from both IP address and machine name.
     private static ThreadLocal<EndpointReferenceType> threadLocal = new ThreadLocal<EndpointReferenceType>();
 
     public EndpointInfo() {
     }
-    
+
     public EndpointInfo(ServiceInfo serv, String ns) {
         transportId = ns;
         service = serv;
     }
-    
+
+    @Override
     public DescriptionInfo getDescription() {
         if (service == null) {
             return null;
@@ -53,33 +54,34 @@ public class EndpointInfo extends AbstractDescriptionElement implements NamedIte
         return service.getDescription();
     }
 
-    
+
     public String getTransportId() {
         return transportId;
-    }    
-    
+    }
+
     public void setTransportId(String tid) {
         transportId = tid;
     }
-    
+
     public InterfaceInfo getInterface() {
         if (service == null) {
             return null;
         }
         return service.getInterface();
     }
-    
+
     public void setService(ServiceInfo s) {
         service = s;
     }
     public ServiceInfo getService() {
         return service;
     }
-    
+
+    @Override
     public QName getName() {
         return name;
     }
-    
+
     public void setName(QName n) {
         name = n;
     }
@@ -87,11 +89,11 @@ public class EndpointInfo extends AbstractDescriptionElement implements NamedIte
     public BindingInfo getBinding() {
         return binding;
     }
-    
+
     public void setBinding(BindingInfo b) {
         binding = b;
-    }    
-    
+    }
+
     public String getAddress() {
         EndpointReferenceType address = threadLocal.get(); //Liberty #3669
         if (address == null) {
@@ -99,7 +101,7 @@ public class EndpointInfo extends AbstractDescriptionElement implements NamedIte
         }
         return (null != address && null != address.getAddress()) ? address.getAddress().getValue() : null;
     }
-    
+
     public void setAddress(String addr) {
         EndpointReferenceType address = threadLocal.get();  //Liberty #3669
         if (null == address) {
@@ -108,37 +110,37 @@ public class EndpointInfo extends AbstractDescriptionElement implements NamedIte
         } else {
             EndpointReferenceUtils.setAddress(address, addr);
         }
-        lastAddressSet = address; //Liberty 
+        lastAddressSet = address; //Liberty
     }
-    
+
     public void setAddress(EndpointReferenceType endpointReference) {
         threadLocal.set(endpointReference);  //Liberty #3669
         lastAddressSet = endpointReference; //Liberty
     }
-    
+
     //When finished the threadlocal must be cleared. //Liberty #3669
     public void resetAddress() {
-        threadLocal.set(null); //Liberty #3669
+        threadLocal.remove(); //Liberty #3669
     }
-    
+
     @Override
     public <T> T getTraversedExtensor(T defaultValue, Class<T> type) {
         T value = getExtensor(type);
-        
+
         if (value == null) {
             if (binding != null) {
                 value = binding.getExtensor(type);
             }
-            
+
             if (service != null && value == null) {
                 value = service.getExtensor(type);
             }
-            
+
             if (value == null) {
                 value = defaultValue;
             }
         }
-        
+
         return value;
     }
 
@@ -157,11 +159,12 @@ public class EndpointInfo extends AbstractDescriptionElement implements NamedIte
         if (epInfo == null) {
             return false;
         }
-        return binding.getName().equals(epInfo.binding.getName()) 
-            && service.getName().equals(epInfo.service.getName()) 
+        return binding.getName().equals(epInfo.binding.getName())
+            && service.getName().equals(epInfo.service.getName())
             && name.equals(epInfo.name);
     }
 
+    @Override
     public String toString() {
         return "BindingQName=" + (binding == null ? "" : (binding.getName()
                 + ", ServiceQName=" + (binding.getService() == null ? "" : binding.getService().getName())))

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapManifest.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapManifest.java
@@ -198,31 +198,34 @@ public class BootstrapManifest {
                     }
                 }
 
-                //sort the files by version (high to low)
-                Collections.sort(systemPackageFileNames, new Comparator<String>() {
-                    @Override
-                    public int compare(String name1, String name2) {
-                        //elements can't be null because we don't allow
-                        //null elements to be added to the list
-                        //use OSGi versions so we can cope easily with, for example, java 10
-                        Version oneVersion = getVersion(name1);
-                        Version twoVersion = getVersion(name2);
-                        //!!NOTE reverse the comparison order to get high to low ordering
-                        return twoVersion.compareTo(oneVersion);
-                    }
-
-                    private Version getVersion(String name) {
-                        //remove the prefix
-                        String version = name.substring(SYSTEM_PKG_PREFIX.length(), name.length());
-                        //remove the suffix
-                        version = version.substring(0, version.indexOf(SYSTEM_PKG_SUFFIX, 0));
-                        return new Version(version);
-                    }
-                });
-
+                int numNames = systemPackageFileNames.size();
                 //if we found any package files then work out the appropriate one
                 //otherwise try the default which will produce a nice error message
-                if (!systemPackageFileNames.isEmpty()) {
+                if (numNames != 0) {
+                    //sort the files by version (high to low)
+                    if (numNames > 1) {
+                        Collections.sort(systemPackageFileNames, new Comparator<String>() {
+                            @Override
+                            public int compare(String name1, String name2) {
+                                //elements can't be null because we don't allow
+                                //null elements to be added to the list
+                                //use OSGi versions so we can cope easily with, for example, java 10
+                                Version oneVersion = getVersion(name1);
+                                Version twoVersion = getVersion(name2);
+                                //!!NOTE reverse the comparison order to get high to low ordering
+                                return twoVersion.compareTo(oneVersion);
+                            }
+
+                            private Version getVersion(String name) {
+                                //remove the prefix
+                                String version = name.substring(SYSTEM_PKG_PREFIX.length(), name.length());
+                                //remove the suffix
+                                version = version.substring(0, version.indexOf(SYSTEM_PKG_SUFFIX, 0));
+                                return new Version(version);
+                            }
+                        });
+                    }
+
                     //check if we have a package file for the version of Java we are using
                     int indexOfPackageFileToUse = systemPackageFileNames.indexOf(pkgListFileName);
                     //if we don't, then we should use the highest available package list instead
@@ -233,7 +236,7 @@ public class BootstrapManifest {
                         indexOfPackageFileToUse = 0;
                     //cut down the list to be from the current java version to the oldest version
                     //we will read all the files and append the properties to save maintenance effort on the package lists
-                    systemPackageFileNames = systemPackageFileNames.subList(indexOfPackageFileToUse, systemPackageFileNames.size());
+                    systemPackageFileNames = systemPackageFileNames.subList(indexOfPackageFileToUse, numNames);
                 } else {
                     //default system package file name
                     systemPackageFileNames = Arrays.asList(new String[] { pkgListFileName });

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/BootstrapChildFirstJarClassloader.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/BootstrapChildFirstJarClassloader.java
@@ -29,6 +29,7 @@ public final class BootstrapChildFirstJarClassloader extends JarFileClassLoader 
     }
     static final String KERNEL_BOOT_CLASS_PREFIX = "com.ibm.ws.kernel.boot.";
     static final String KERNEL_BOOT_RESOURCE_PREFIX = "com/ibm/ws/kernel/boot/";
+    static final int KERNEL_BOOT_PREFIX_LENGTH = KERNEL_BOOT_CLASS_PREFIX.length();
 
     static <E> Enumeration<E> compoundEnumerations(Enumeration<E> e1, Enumeration<E> e2) {
         if (e2 == null || !e2.hasMoreElements())
@@ -76,13 +77,12 @@ public final class BootstrapChildFirstJarClassloader extends JarFileClassLoader 
 
             result = findLoadedClass(name);
             if (result == null) {
-                if (name.startsWith(BootstrapChildFirstJarClassloader.KERNEL_BOOT_CLASS_PREFIX))
+                if (name.regionMatches(0, KERNEL_BOOT_CLASS_PREFIX, 0, KERNEL_BOOT_PREFIX_LENGTH)) {
                     result = super.loadClass(name, resolve);
-                else {
-                    try {
-                        // Try to load the class from this classpath
-                        result = findClass(name);
-                    } catch (ClassNotFoundException cnfe) {
+                } else {
+                    // Try to load the class from this classpath
+                    result = findClass(name, true);
+                    if (result == null) {
                         result = super.loadClass(name, resolve);
                     }
                 }
@@ -98,7 +98,7 @@ public final class BootstrapChildFirstJarClassloader extends JarFileClassLoader 
             return null;
 
         URL result = null;
-        if (name.startsWith(BootstrapChildFirstJarClassloader.KERNEL_BOOT_RESOURCE_PREFIX)) {
+        if (name.regionMatches(0, KERNEL_BOOT_RESOURCE_PREFIX, 0, KERNEL_BOOT_PREFIX_LENGTH)) {
             result = super.getResource(name);
         } else {
             // Try to get the resource from this classpath
@@ -116,10 +116,10 @@ public final class BootstrapChildFirstJarClassloader extends JarFileClassLoader 
             return Collections.<URL> enumeration(Collections.<URL> emptyList());
         Enumeration<URL> parentResources = super.getResources(name);
         Enumeration<URL> localResources = super.findResources(name);
-        if (name.startsWith(BootstrapChildFirstJarClassloader.KERNEL_BOOT_RESOURCE_PREFIX)) {
-            return BootstrapChildFirstJarClassloader.compoundEnumerations(parentResources, localResources);
+        if (name.regionMatches(0, KERNEL_BOOT_RESOURCE_PREFIX, 0, KERNEL_BOOT_PREFIX_LENGTH)) {
+            return compoundEnumerations(parentResources, localResources);
         } else {
-            return BootstrapChildFirstJarClassloader.compoundEnumerations(localResources, parentResources);
+            return compoundEnumerations(localResources, parentResources);
         }
     }
 

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/BootstrapChildFirstURLClassloader.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/BootstrapChildFirstURLClassloader.java
@@ -57,9 +57,10 @@ public final class BootstrapChildFirstURLClassloader extends URLClassLoader {
 
             result = findLoadedClass(name);
             if (result == null) {
-                if (name.startsWith(BootstrapChildFirstJarClassloader.KERNEL_BOOT_CLASS_PREFIX))
+                if (name.regionMatches(0, BootstrapChildFirstJarClassloader.KERNEL_BOOT_CLASS_PREFIX, 0,
+                                       BootstrapChildFirstJarClassloader.KERNEL_BOOT_PREFIX_LENGTH)) {
                     result = super.loadClass(name, resolve);
-                else {
+                } else {
                     try {
                         // Try to load the class from this classpath
                         result = findClass(name);
@@ -79,7 +80,8 @@ public final class BootstrapChildFirstURLClassloader extends URLClassLoader {
             return null;
 
         URL result = null;
-        if (name.startsWith(BootstrapChildFirstJarClassloader.KERNEL_BOOT_RESOURCE_PREFIX)) {
+        if (name.regionMatches(0, BootstrapChildFirstJarClassloader.KERNEL_BOOT_RESOURCE_PREFIX, 0,
+                               BootstrapChildFirstJarClassloader.KERNEL_BOOT_PREFIX_LENGTH)) {
             result = super.getResource(name);
         } else {
             // Try to get the resource from this classpath

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/DirectoryResourceEntry.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/DirectoryResourceEntry.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.security.cert.Certificate;
-import java.util.jar.Manifest;
 
 /**
  */
@@ -33,11 +32,6 @@ public class DirectoryResourceEntry implements ResourceEntry {
     @Override
     public ResourceHandler getResourceHandler() {
         return handler;
-    }
-
-    @Override
-    public Manifest getManifest() throws IOException {
-        return handler.getManifest();
     }
 
     @Override

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarFileClassLoader.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarFileClassLoader.java
@@ -23,7 +23,6 @@ import java.security.CodeSource;
 import java.security.SecureClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
@@ -61,16 +60,21 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
         }
 
         this.verify = verify;
-        this.urls = new CopyOnWriteArrayList<URL>(urls == null ? Collections.<URL> emptyList() : Arrays.asList(urls));
         hook = ClassLoaderHookFactory.getClassLoaderHook(this);
+        if (urls == null) {
+            this.urls = new CopyOnWriteArrayList<URL>();
+            this.resourceHandlers = new CopyOnWriteArrayList<ResourceHandler>();
+        } else {
+            this.urls = new CopyOnWriteArrayList<URL>(Arrays.asList(urls));
 
-        // avoid adding resource handlers one at a time to a copy on write list
-        List<ResourceHandler> tempResourceHandlers = new ArrayList<ResourceHandler>();
-        for (URL url : this.urls) {
-            tempResourceHandlers.add(createResoureHandler(url, verify));
+            // avoid adding resource handlers one at a time to a copy on write list
+            List<ResourceHandler> tempResourceHandlers = new ArrayList<ResourceHandler>(urls.length);
+            for (URL url : urls) {
+                tempResourceHandlers.add(createResoureHandler(url, verify));
+            }
+            // Create resourceHandler list in one go
+            this.resourceHandlers = new CopyOnWriteArrayList<ResourceHandler>(tempResourceHandlers);
         }
-        // Create resourceHandler list in one go
-        this.resourceHandlers = new CopyOnWriteArrayList<ResourceHandler>(tempResourceHandlers);
     }
 
     private ResourceHandler createResoureHandler(URL url, boolean verify) {
@@ -110,10 +114,17 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
 
     @Override
     protected Class<?> findClass(String className) throws ClassNotFoundException {
-        String resourceName = className.replace('.', '/') + ".class";
+        return findClass(className, false);
+    }
+
+    protected Class<?> findClass(String className, boolean returnNull) throws ClassNotFoundException {
+        String resourceName = new StringBuilder(className.replace('.', '/')).append(".class").toString();
 
         ResourceEntry entry = findResourceEntry(resourceName);
         if (entry == null) {
+            if (returnNull) {
+                return null;
+            }
             throw new ClassNotFoundException(className);
         }
 
@@ -126,21 +137,32 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
             foundInClassCache = (classBytes != null);
         }
 
+        ResourceHandler resourceHandler = entry.getResourceHandler();
+
         Manifest manifest = null;
         try {
             if (!foundInClassCache) {
                 classBytes = entry.getBytes();
             }
 
-            manifest = entry.getManifest();
+            manifest = resourceHandler.getManifest();
         } catch (IOException e) {
+            if (returnNull) {
+                throw null;
+            }
             throw new ClassNotFoundException(className, e);
         }
 
-        URL jarURL = entry.getResourceHandler().toURL();
+        URL jarURL = resourceHandler.toURL();
 
-        // define package
-        definePackage(className, jarURL, manifest);
+        int packageEnd = className.lastIndexOf('.');
+        if (packageEnd >= 0) {
+            String packageName = className.substring(0, packageEnd);
+            String packagePath = resourceName.substring(0, packageEnd + 1);
+
+            // define package
+            definePackage(packageName, packagePath, jarURL, manifest);
+        }
 
         // create code source
         CodeSource source = new CodeSource(jarURL, entry.getCertificates());
@@ -155,15 +177,7 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
         return clazz;
     }
 
-    private void definePackage(String className, URL jarURL, Manifest manifest) {
-        int packageEnd = className.lastIndexOf('.');
-        if (packageEnd < 0) {
-            return;
-        }
-
-        String packageName = className.substring(0, packageEnd);
-        String packagePath = packageName.replace('.', '/') + "/";
-
+    private void definePackage(String packageName, String packagePath, URL jarURL, Manifest manifest) {
         Package pkg = getPackage(packageName);
         if (pkg != null) {
             if (pkg.isSealed()) {
@@ -225,7 +239,7 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
 
     @Override
     public Enumeration<URL> findResources(String resourceName) throws IOException {
-        return new ResourceEntryEnumeration(resourceName);
+        return new ResourceEntryEnumeration(resourceHandlers, resourceName);
     }
 
     private ResourceEntry findResourceEntry(String resourceName) {
@@ -238,13 +252,13 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
         return null;
     }
 
-    private class ResourceEntryEnumeration implements Enumeration<URL> {
+    private static class ResourceEntryEnumeration implements Enumeration<URL> {
 
         private final String resourceName;
         private final Iterator<ResourceHandler> handlerIterator;
         private ResourceEntry entry;
 
-        public ResourceEntryEnumeration(String resourceName) {
+        public ResourceEntryEnumeration(List<ResourceHandler> resourceHandlers, String resourceName) {
             this.resourceName = resourceName;
             this.handlerIterator = resourceHandlers.iterator();
             this.entry = null;

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarFileClassLoader.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarFileClassLoader.java
@@ -15,7 +15,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -50,7 +49,6 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
     private final CopyOnWriteArrayList<ResourceHandler> resourceHandlers;
     private final boolean verify;
     private final ClassLoaderHook hook;
-    private static final PrintStream sysOut = System.out;
 
     public JarFileClassLoader(URL[] urls, boolean verify, ClassLoader parent) {
         super(parent);

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarResourceEntry.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarResourceEntry.java
@@ -16,13 +16,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.security.cert.Certificate;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.jar.Manifest;
 
 import com.ibm.ws.kernel.boot.classloader.URLEncodingUtils;
 
@@ -41,11 +37,6 @@ public class JarResourceEntry implements ResourceEntry {
     @Override
     public ResourceHandler getResourceHandler() {
         return handler;
-    }
-
-    @Override
-    public Manifest getManifest() throws IOException {
-        return handler.getManifest();
     }
 
     @Override
@@ -90,20 +81,11 @@ public class JarResourceEntry implements ResourceEntry {
         try {
             final JarEntryURLStreamHandler handler = new JarEntryURLStreamHandler(jarFile, jarEntry);
             final URL url = new URL("jarentry", "", -1, name, handler);
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
-
-                @Override
-                public Void run() throws Exception {
-                    handler.setExpectedURL(url);
-                    return null;
-                }
-            });
+            handler.setExpectedURL(url);
             return url;
         } catch (MalformedURLException e) {
             // this is very unexpected
             throw new Error(e);
-        } catch (PrivilegedActionException e) {
-            throw new Error(e.getCause());
         }
     }
 
@@ -118,7 +100,7 @@ public class JarResourceEntry implements ResourceEntry {
             this.jarEntry = jarEntry;
         }
 
-        private void setExpectedURL(URL expectedURL) {
+        void setExpectedURL(URL expectedURL) {
             this.expectedURL = expectedURL;
         }
 

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/ResourceEntry.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/ResourceEntry.java
@@ -13,15 +13,12 @@ package com.ibm.ws.kernel.internal.classloader;
 import java.io.IOException;
 import java.net.URL;
 import java.security.cert.Certificate;
-import java.util.jar.Manifest;
 
 /**
  */
 public interface ResourceEntry {
 
     ResourceHandler getResourceHandler();
-
-    Manifest getManifest() throws IOException;
 
     Certificate[] getCertificates();
 

--- a/dev/com.ibm.ws.kernel.security.thread/src/com/ibm/ws/kernel/security/thread/ThreadIdentityManager.java
+++ b/dev/com.ibm.ws.kernel.security.thread/src/com/ibm/ws/kernel/security/thread/ThreadIdentityManager.java
@@ -20,7 +20,6 @@ import javax.security.auth.Subject;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.wsspi.kernel.security.thread.ThreadIdentityService;
 
 /**
@@ -35,13 +34,7 @@ public class ThreadIdentityManager {
      * ThreadLocal used to detect potential infinite recursion in the
      * tracing code.
      */
-    private static final ThreadLocal<Boolean> recursionMarker = new ThreadLocal<Boolean>() {
-        @Override
-        @Trivial
-        protected synchronized Boolean initialValue() {
-            return Boolean.FALSE;
-        }
-    };
+    private static final ThreadLocal<Boolean> recursionMarker = new ThreadLocal<Boolean>();
 
     /**
      * The ThreadIdentityService references. The references are set by the
@@ -193,16 +186,24 @@ public class ThreadIdentityManager {
      * @throws ThreadIdentityException
      */
     public static Object setJ2CThreadIdentity(Subject subject) throws ThreadIdentityException {
-        LinkedHashMap<J2CIdentityService, Object> token = new LinkedHashMap<J2CIdentityService, Object>();
+        LinkedHashMap<J2CIdentityService, Object> token = null;
         for (J2CIdentityService j2cIdentityService : j2cIdentityServices) {
             if (j2cIdentityService.isJ2CThreadIdentityEnabled()) {
-                tryToSetJ2CIdentity(token, j2cIdentityService, subject);
+                try {
+                    Object tokenReturnedFromSet = j2cIdentityService.set(subject);
+                    if (tokenReturnedFromSet != null) {
+                        if (token == null) {
+                            token = new LinkedHashMap<J2CIdentityService, Object>();
+                        }
+                        token.put(j2cIdentityService, tokenReturnedFromSet);
+                    }
+                } catch (Exception e) {
+                    com.ibm.ws.ffdc.FFDCFilter.processException(e, thisClass, "272");
+                    resetCheckedInternal(token, e);
+                }
             }
         }
-        if (token.isEmpty() == false) {
-            return token;
-        }
-        return null;
+        return token;
     }
 
     /**
@@ -218,56 +219,24 @@ public class ThreadIdentityManager {
      * @throws ThreadIdentityException
      */
     public static Object setAppThreadIdentity(Subject subject) throws ThreadIdentityException {
-        LinkedHashMap<ThreadIdentityService, Object> token = new LinkedHashMap<ThreadIdentityService, Object>();
+        LinkedHashMap<ThreadIdentityService, Object> token = null;
         for (ThreadIdentityService tis : threadIdentityServices) {
             if (tis.isAppThreadIdentityEnabled()) {
-                tryToSetIdentity(token, tis, subject);
+                try {
+                    Object tokenReturnedFromSet = tis.set(subject);
+                    if (tokenReturnedFromSet != null) {
+                        if (token == null) {
+                            token = new LinkedHashMap<ThreadIdentityService, Object>();
+                        }
+                        token.put(tis, tokenReturnedFromSet);
+                    }
+                } catch (Exception e) {
+                    com.ibm.ws.ffdc.FFDCFilter.processException(e, thisClass, "251");
+                    resetCheckedInternal(token, e);
+                }
             }
         }
-        if (token.isEmpty() == false) {
-            return token;
-        }
-        return null;
-    }
-
-    /**
-     * Try to set the subject's identity as the thread identity.
-     * 
-     * If an identity is returned from the identity service,
-     * then it will be saved in the token map to be returned to the caller.
-     * 
-     * @throws ThreadIdentityException
-     */
-    private static void tryToSetIdentity(LinkedHashMap<ThreadIdentityService, Object> token, ThreadIdentityService tis, Subject subject) throws ThreadIdentityException {
-        try {
-            Object tokenReturnedFromSet = tis.set(subject);
-            if (tokenReturnedFromSet != null) {
-                token.put(tis, tokenReturnedFromSet);
-            }
-        } catch (Exception e) {
-            com.ibm.ws.ffdc.FFDCFilter.processException(e, thisClass, "251");
-            resetCheckedInternal(token, e);
-        }
-    }
-
-    /**
-     * Try to set the subject's identity as the J2C thread identity.
-     * 
-     * If an identity is returned from the identity service,
-     * then it will be saved in the token map to be returned to the caller.
-     * 
-     * @throws ThreadIdentityException
-     */
-    private static void tryToSetJ2CIdentity(LinkedHashMap<J2CIdentityService, Object> token, J2CIdentityService j2cIdentityService, Subject subject) throws ThreadIdentityException {
-        try {
-            Object tokenReturnedFromSet = j2cIdentityService.set(subject);
-            if (tokenReturnedFromSet != null) {
-                token.put(j2cIdentityService, tokenReturnedFromSet);
-            }
-        } catch (Exception e) {
-            com.ibm.ws.ffdc.FFDCFilter.processException(e, thisClass, "272");
-            resetCheckedInternal(token, e);
-        }
+        return token;
     }
 
     /**
@@ -311,7 +280,7 @@ public class ThreadIdentityManager {
      *         true, if we have recursed.
      */
     private static boolean checkForRecursionAndSet() {
-        if (recursionMarker.get() == Boolean.FALSE) {
+        if (recursionMarker.get() == null) {
             recursionMarker.set(Boolean.TRUE);
             return false;
         } else {
@@ -323,7 +292,7 @@ public class ThreadIdentityManager {
      * Reset the recursionMarker.
      */
     private static void resetRecursionCheck() {
-        recursionMarker.set(Boolean.FALSE);
+        recursionMarker.remove();
     }
 
     /**
@@ -333,12 +302,16 @@ public class ThreadIdentityManager {
      *         This token must be passed to the subsequent reset call.
      */
     public static Object runAsServer() {
-        LinkedHashMap<ThreadIdentityService, Object> token = new LinkedHashMap<ThreadIdentityService, Object>();
+        LinkedHashMap<ThreadIdentityService, Object> token = null;
 
         if (!checkForRecursionAndSet()) {
             try {
-                for (ThreadIdentityService tis : threadIdentityServices) {
+                for (int i = 0, size = threadIdentityServices.size(); i < size; ++i) {
+                    ThreadIdentityService tis = threadIdentityServices.get(i);
                     if (tis.isAppThreadIdentityEnabled()) {
+                        if (token == null) {
+                            token = new LinkedHashMap<ThreadIdentityService, Object>();
+                        }
                         token.put(tis, tis.runAsServer());
                     }
                 }
@@ -346,7 +319,7 @@ public class ThreadIdentityManager {
                 resetRecursionCheck();
             }
         }
-        return token;
+        return token == null ? Collections.EMPTY_MAP : token;
     }
 
     /**
@@ -374,25 +347,28 @@ public class ThreadIdentityManager {
         if (threadIdentityServices.isEmpty() == false || j2cIdentityServices.isEmpty() == false) {
             if (!checkForRecursionAndSet()) {
                 try {
-                    @SuppressWarnings("unchecked")
-                    List<Map.Entry> identityServicesToTokensMap = new ArrayList<Map.Entry>(((LinkedHashMap) token).entrySet());
+                    Map tokenMap = (Map) token;
+                    int size = tokenMap.size();
+                    if (size > 0) {
+                        @SuppressWarnings("unchecked")
+                        List<Map.Entry> identityServicesToTokensMap = new ArrayList<Map.Entry>(tokenMap.entrySet());
 
-                    int lastIdx = identityServicesToTokensMap.size() - 1;
-                    for (int idx = lastIdx; idx >= 0; idx--) {
-                        Map.Entry entry = identityServicesToTokensMap.get(idx);
-                        Object identityService = entry.getKey();
-                        Object identityServiceToken = entry.getValue();
-                        try {
-                            if (identityService instanceof ThreadIdentityService) {
-                                ((ThreadIdentityService) identityService).reset(identityServiceToken);
-                            } else if (identityService instanceof J2CIdentityService) {
-                                ((J2CIdentityService) identityService).reset(identityServiceToken);
-                            }
-                        } catch (Exception e) {
-                            com.ibm.ws.ffdc.FFDCFilter.processException(e, thisClass, "385");
-                            if (cachedException == null)
-                            {
-                                cachedException = e;
+                        for (int idx = size - 1; idx >= 0; idx--) {
+                            Map.Entry entry = identityServicesToTokensMap.get(idx);
+                            Object identityService = entry.getKey();
+                            Object identityServiceToken = entry.getValue();
+                            try {
+                                if (identityService instanceof ThreadIdentityService) {
+                                    ((ThreadIdentityService) identityService).reset(identityServiceToken);
+                                } else if (identityService instanceof J2CIdentityService) {
+                                    ((J2CIdentityService) identityService).reset(identityServiceToken);
+                                }
+                            } catch (Exception e) {
+                                com.ibm.ws.ffdc.FFDCFilter.processException(e, thisClass, "385");
+                                if (cachedException == null)
+                                {
+                                    cachedException = e;
+                                }
                             }
                         }
                     }

--- a/dev/com.ibm.ws.kernel.security.thread/src/com/ibm/ws/kernel/security/thread/ThreadIdentityManager.java
+++ b/dev/com.ibm.ws.kernel.security.thread/src/com/ibm/ws/kernel/security/thread/ThreadIdentityManager.java
@@ -347,27 +347,29 @@ public class ThreadIdentityManager {
         if (threadIdentityServices.isEmpty() == false || j2cIdentityServices.isEmpty() == false) {
             if (!checkForRecursionAndSet()) {
                 try {
-                    Map tokenMap = (Map) token;
-                    int size = tokenMap.size();
-                    if (size > 0) {
-                        @SuppressWarnings("unchecked")
-                        List<Map.Entry> identityServicesToTokensMap = new ArrayList<Map.Entry>(tokenMap.entrySet());
+                    if (token != null) {
+                        Map tokenMap = (Map) token;
+                        int size = tokenMap.size();
+                        if (size > 0) {
+                            @SuppressWarnings("unchecked")
+                            List<Map.Entry> identityServicesToTokensMap = new ArrayList<Map.Entry>(tokenMap.entrySet());
 
-                        for (int idx = size - 1; idx >= 0; idx--) {
-                            Map.Entry entry = identityServicesToTokensMap.get(idx);
-                            Object identityService = entry.getKey();
-                            Object identityServiceToken = entry.getValue();
-                            try {
-                                if (identityService instanceof ThreadIdentityService) {
-                                    ((ThreadIdentityService) identityService).reset(identityServiceToken);
-                                } else if (identityService instanceof J2CIdentityService) {
-                                    ((J2CIdentityService) identityService).reset(identityServiceToken);
-                                }
-                            } catch (Exception e) {
-                                com.ibm.ws.ffdc.FFDCFilter.processException(e, thisClass, "385");
-                                if (cachedException == null)
-                                {
-                                    cachedException = e;
+                            for (int idx = size - 1; idx >= 0; idx--) {
+                                Map.Entry entry = identityServicesToTokensMap.get(idx);
+                                Object identityService = entry.getKey();
+                                Object identityServiceToken = entry.getValue();
+                                try {
+                                    if (identityService instanceof ThreadIdentityService) {
+                                        ((ThreadIdentityService) identityService).reset(identityServiceToken);
+                                    } else if (identityService instanceof J2CIdentityService) {
+                                        ((J2CIdentityService) identityService).reset(identityServiceToken);
+                                    }
+                                } catch (Exception e) {
+                                    com.ibm.ws.ffdc.FFDCFilter.processException(e, thisClass, "385");
+                                    if (cachedException == null)
+                                    {
+                                        cachedException = e;
+                                    }
                                 }
                             }
                         }

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/TimestampUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/TimestampUtils.java
@@ -11,7 +11,6 @@
 package com.ibm.wsspi.kernel.service.utils;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -46,7 +45,6 @@ public class TimestampUtils {
         // Update last modified timestamp
         String stamp = Long.toString(timestamp);
 
-        BufferedWriter out = null;
         FileWriter fstream = null;
 
         try {
@@ -55,12 +53,10 @@ public class TimestampUtils {
                 return;
 
             fstream = new FileWriter(file);
-            out = new BufferedWriter(fstream);
-            out.write(stamp, 0, stamp.length());
+            fstream.write(stamp, 0, stamp.length());
         } catch (IOException e) {
         } finally {
-            if (!tryToClose(out))
-                tryToClose(fstream);
+            tryToClose(fstream);
         }
     }
 
@@ -74,8 +70,8 @@ public class TimestampUtils {
 
         try {
             fstream = new FileReader(file);
-            in = new BufferedReader(fstream);
-            timestamp = new Long(in.readLine()).longValue();
+            in = new BufferedReader(fstream, 32);
+            timestamp = Long.parseLong(in.readLine());
         } catch (FileNotFoundException e) {
             // Not an error: stamp might not have been created (return 0)
         } catch (NumberFormatException e) {

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/TraceComponent.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/TraceComponent.java
@@ -197,7 +197,7 @@ public class TraceComponent implements FFDCSelfIntrospectable {
                 logger = Logger.getLogger(name, bundle);
                 logger.setLevel(getLoggerLevel());
             } finally {
-                WsLogger.loggerRegistrationComponent.set(null); // clear when done.
+                WsLogger.loggerRegistrationComponent.remove(); // clear when done.
             }
         }
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/BurstDateFormat.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/BurstDateFormat.java
@@ -117,7 +117,8 @@ public class BurstDateFormat {
             String str = refTime.substring(position.getBeginIndex(), position.getEndIndex());
 
             // Make sure we are using ascii digits (The loop could be unwrapped)
-            for (char a : str.toCharArray()) {
+            for (int i = str.length() - 1; i >= 0; --i) {
+                char a = str.charAt(i);
                 if (a < 48 || a > 57) {
                     invalidFormat = true;
                     break;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/BurstDateFormat.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/BurstDateFormat.java
@@ -62,14 +62,9 @@ public class BurstDateFormat {
     private final FieldPosition position = new FieldPosition(Field.MILLISECOND);
 
     /**
-     * Forces a re-format
-     */
-    private boolean reset = false;
-
-    /**
      * Tracks whether the format is not valid. If true, the underlying SimpleDateFormat is used
      */
-    protected boolean invalidFormat = false;
+    boolean invalidFormat = false;
 
     /**
      * Constructs a BurstDateFormat
@@ -78,27 +73,10 @@ public class BurstDateFormat {
      */
     public BurstDateFormat(SimpleDateFormat formatter) {
         this.formatter = formatter;
-        setup();
-    }
 
-    /**
-     * Apply a pattern to the formatter (only new formats are applied)
-     *
-     * @param pattern
-     */
-    public void applyPattern(String pattern) {
-        if (!formatter.toPattern().equals(pattern)) {
-            formatter.applyPattern(pattern);
-            reset = true;
-            invalidFormat = false;
-            setup();
-        }
-    }
-
-    /**
-     * Setup the date formatter, determine if the format is valid
-     */
-    protected void setup() {
+        /**
+         * Setup the date formatter, determine if the format is valid
+         */
         try {
             StringBuffer refTime = new StringBuffer();
 
@@ -146,8 +124,7 @@ public class BurstDateFormat {
             long delta = timestamp - refTimestamp;
 
             // If we need to reformat
-            if (delta >= pdiff || delta < ndiff || reset) {
-                reset = false;
+            if (delta >= pdiff || delta < ndiff) {
                 StringBuffer refTime = new StringBuffer();
                 refTimestamp = timestamp;
                 formatter.format(timestamp, refTime, position);

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
@@ -156,21 +156,6 @@ public class BaseTraceFormatter extends Formatter {
         return "";
     }
 
-    //copied from BTS
-    /** Flags for suppressing traceback output to the console */
-    private static class StackTraceFlags {
-        boolean needsToOutputInternalPackageMarker = false;
-        boolean isSuppressingTraces = false;
-    }
-
-    /** Track the stack trace printing activity of the current thread */
-    private static ThreadLocal<StackTraceFlags> traceFlags = new ThreadLocal<StackTraceFlags>() {
-        @Override
-        protected StackTraceFlags initialValue() {
-            return new StackTraceFlags();
-        }
-    };
-
     final TraceFormat traceFormat;
 
     static boolean useIsoDateFormat = false;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/service/model/EndpointInfo.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/service/model/EndpointInfo.java
@@ -118,7 +118,7 @@ public class EndpointInfo extends AbstractDescriptionElement implements NamedIte
     
     //When finished the threadlocal must be cleared. //Liberty #3669
     public void resetAddress() {
-        threadLocal.set(null); //Liberty #3669
+        threadLocal.remove(); //Liberty #3669
     }
     
     @Override

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpLocalFormat.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpLocalFormat.java
@@ -26,9 +26,9 @@ import com.ibm.ws.http.dispatcher.internal.HttpDispatcher;
 public class HttpLocalFormat {
 
     /** Default tolerance range is within one second */
-    protected static final long DEFAULT_TOLERANCE = 1000L;
+    static final long DEFAULT_TOLERANCE = 1000L;
     /** Ref to the GMT timezone */
-    protected static final TimeZone gmt = TimeZone.getTimeZone("GMT");
+    static final TimeZone gmt = TimeZone.getTimeZone("GMT");
 
     /** Cached RFC 1123 format timer */
     private CachedTime c1123Time = null;
@@ -43,14 +43,43 @@ public class HttpLocalFormat {
 
     /**
      * Create an instance of this class.
-     *
+     * Create the CachedTimes lazily only if they are needed in order to reduce memory.
      */
-    public HttpLocalFormat() {
-        this.c1123Time = new CachedTime("EEE, dd MMM yyyy HH:mm:ss z", true);
-        this.c1036Time = new CachedTime("EEEEEEEEE, dd-MMM-yy HH:mm:ss z", true);
-        this.cAsciiTime = new CachedTime("EEE MMM  d HH:mm:ss yyyy", true);
-        this.cNCSATime = new CachedTime("dd/MMM/yyyy:HH:mm:ss Z", false);
-        this.c2109Time = new CachedTime("EEE, dd-MMM-yy HH:mm:ss z", true);
+    public HttpLocalFormat() {}
+
+    private CachedTime getC1123Time() {
+        if (this.c1123Time == null) {
+            this.c1123Time = new CachedTime("EEE, dd MMM yyyy HH:mm:ss z", true);
+        }
+        return this.c1123Time;
+    }
+
+    private CachedTime getC1036Time() {
+        if (this.c1036Time == null) {
+            this.c1036Time = new CachedTime("EEEEEEEEE, dd-MMM-yy HH:mm:ss z", true);
+        }
+        return this.c1036Time;
+    }
+
+    private CachedTime getCAsciiTime() {
+        if (this.cAsciiTime == null) {
+            this.cAsciiTime = new CachedTime("EEE MMM  d HH:mm:ss yyyy", true);
+        }
+        return this.cAsciiTime;
+    }
+
+    private CachedTime getCNCSATime() {
+        if (this.cNCSATime == null) {
+            this.cNCSATime = new CachedTime("dd/MMM/yyyy:HH:mm:ss Z", false);
+        }
+        return this.cNCSATime;
+    }
+
+    private CachedTime getC2109Time() {
+        if (this.c2109Time == null) {
+            this.c2109Time = new CachedTime("EEE, dd-MMM-yy HH:mm:ss z", true);
+        }
+        return this.c2109Time;
     }
 
     /**
@@ -63,7 +92,7 @@ public class HttpLocalFormat {
      * @return byte[]
      */
     public byte[] get1123TimeAsBytes(long range) {
-        return this.c1123Time.getTimeAsBytes(range);
+        return this.getC1123Time().getTimeAsBytes(range);
     }
 
     /**
@@ -76,7 +105,7 @@ public class HttpLocalFormat {
      * @return String
      */
     public String get1123TimeAsString(long range) {
-        return this.c1123Time.getTimeAsString(range);
+        return this.getC1123Time().getTimeAsString(range);
     }
 
     /**
@@ -89,7 +118,7 @@ public class HttpLocalFormat {
      * @return byte[]
      */
     public byte[] get1036TimeAsBytes(long range) {
-        return this.c1036Time.getTimeAsBytes(range);
+        return this.getC1036Time().getTimeAsBytes(range);
     }
 
     /**
@@ -102,7 +131,7 @@ public class HttpLocalFormat {
      * @return String
      */
     public String get1036TimeAsString(long range) {
-        return this.c1036Time.getTimeAsString(range);
+        return this.getC1036Time().getTimeAsString(range);
     }
 
     /**
@@ -115,7 +144,7 @@ public class HttpLocalFormat {
      * @return byte[]
      */
     public byte[] getAsciiTimeAsBytes(long range) {
-        return this.cAsciiTime.getTimeAsBytes(range);
+        return this.getCAsciiTime().getTimeAsBytes(range);
     }
 
     /**
@@ -128,7 +157,7 @@ public class HttpLocalFormat {
      * @return String
      */
     public String getAsciiTimeAsString(long range) {
-        return this.cAsciiTime.getTimeAsString(range);
+        return this.getCAsciiTime().getTimeAsString(range);
     }
 
     /**
@@ -141,7 +170,7 @@ public class HttpLocalFormat {
      * @return byte[]
      */
     public byte[] getNCSATimeAsBytes(long range) {
-        return this.cNCSATime.getTimeAsBytes(range);
+        return this.getCNCSATime().getTimeAsBytes(range);
     }
 
     /**
@@ -154,7 +183,7 @@ public class HttpLocalFormat {
      * @return String
      */
     public String getNCSATimeAsString(long range) {
-        return this.cNCSATime.getTimeAsString(range);
+        return this.getCNCSATime().getTimeAsString(range);
     }
 
     /**
@@ -167,7 +196,7 @@ public class HttpLocalFormat {
      * @return byte[]
      */
     public byte[] get2109TimeAsBytes(long range) {
-        return this.c2109Time.getTimeAsBytes(range);
+        return this.getC2109Time().getTimeAsBytes(range);
     }
 
     /**
@@ -180,7 +209,7 @@ public class HttpLocalFormat {
      * @return String
      */
     public String get2109TimeAsString(long range) {
-        return this.c2109Time.getTimeAsString(range);
+        return this.getC2109Time().getTimeAsString(range);
     }
 
     /**
@@ -190,7 +219,7 @@ public class HttpLocalFormat {
      * @return SimpleDateFormat
      */
     public SimpleDateFormat get1123Format() {
-        return this.c1123Time.getFormat();
+        return this.getC1123Time().getFormat();
     }
 
     /**
@@ -200,7 +229,7 @@ public class HttpLocalFormat {
      * @return SimpleDateFormat
      */
     public SimpleDateFormat get1036Format() {
-        return this.c1036Time.getFormat();
+        return this.getC1036Time().getFormat();
     }
 
     /**
@@ -210,7 +239,7 @@ public class HttpLocalFormat {
      * @return SimpleDateFormat
      */
     public SimpleDateFormat getAsciiFormat() {
-        return this.cAsciiTime.getFormat();
+        return this.getCAsciiTime().getFormat();
     }
 
     /**
@@ -220,7 +249,7 @@ public class HttpLocalFormat {
      * @return SimpleDateFormat
      */
     public SimpleDateFormat getNCSAFormat() {
-        return this.cNCSATime.getFormat();
+        return this.getCNCSATime().getFormat();
     }
 
     /**
@@ -229,7 +258,7 @@ public class HttpLocalFormat {
      * @return SimpleDateFormat
      */
     public SimpleDateFormat get2109Format() {
-        return this.c2109Time.getFormat();
+        return this.getC2109Time().getFormat();
     }
 
     /**
@@ -239,7 +268,7 @@ public class HttpLocalFormat {
      * @return SimpleDateFormat
      */
     public SimpleDateFormat get1123Parse() {
-        return this.c1123Time.getParse();
+        return this.getC1123Time().getParse();
     }
 
     /**
@@ -249,7 +278,7 @@ public class HttpLocalFormat {
      * @return SimpleDateFormat
      */
     public SimpleDateFormat get1036Parse() {
-        return this.c1036Time.getParse();
+        return this.getC1036Time().getParse();
     }
 
     /**
@@ -259,7 +288,7 @@ public class HttpLocalFormat {
      * @return SimpleDateFormat
      */
     public SimpleDateFormat getAsciiParse() {
-        return this.cAsciiTime.getParse();
+        return this.getCAsciiTime().getParse();
     }
 
     /**
@@ -269,7 +298,7 @@ public class HttpLocalFormat {
      * @return SimpleDateFormat
      */
     public SimpleDateFormat getNCSAParse() {
-        return this.cNCSATime.getParse();
+        return this.getCNCSATime().getParse();
     }
 
     /**
@@ -278,7 +307,7 @@ public class HttpLocalFormat {
      * @return SimpleDateFormat
      */
     public SimpleDateFormat get2109Parse() {
-        return this.c2109Time.getParse();
+        return this.getC2109Time().getParse();
     }
 
     /**
@@ -290,9 +319,13 @@ public class HttpLocalFormat {
      * level so no synchronization is required.
      *
      */
-    private class CachedTime {
+    private static class CachedTime {
+        private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+        private static final char[] EMPTY_CHAR_ARRAY = new char[0];
         /** Stored formatter */
-        private SimpleDateFormat myFormat = null;
+        private final SimpleDateFormat myFormat;
+        private final String pattern;
+        private final boolean gmtTimeZone;
         /** Stored Parser */
         private SimpleDateFormat myParse = null;
         /** Last time we formatted a value */
@@ -300,9 +333,9 @@ public class HttpLocalFormat {
         /** The stored formatted time as a string */
         private String sTime = null;
         /** The stored formatted time as byte[] */
-        private byte[] baTime = new byte[0];
+        private byte[] baTime = EMPTY_BYTE_ARRAY;
         /** The stored formatted time as a char[] */
-        private char[] caTime = new char[0];
+        private char[] caTime = EMPTY_CHAR_ARRAY;
         /** Static date object used for all conversions */
         private final Date myDate = new Date();
         /** Buffer that the formatted puts output into */
@@ -314,12 +347,12 @@ public class HttpLocalFormat {
          *
          * @param format
          */
-        protected CachedTime(String format, boolean gmtTimeZone) {
+        CachedTime(String format, boolean gmtTimeZone) {
+            this.pattern = format;
+            this.gmtTimeZone = gmtTimeZone;
             this.myFormat = new SimpleDateFormat(format, Locale.US);
-            this.myParse = new SimpleDateFormat(format, Locale.US);
             if (gmtTimeZone) {
                 this.myFormat.setTimeZone(gmt);
-                this.myParse.setTimeZone(gmt);
             }
         }
 
@@ -328,7 +361,7 @@ public class HttpLocalFormat {
          *
          * @return SimpleDateFormat
          */
-        protected SimpleDateFormat getFormat() {
+        SimpleDateFormat getFormat() {
             return this.myFormat;
         }
 
@@ -337,7 +370,13 @@ public class HttpLocalFormat {
          *
          * @return SimpleDateFormat
          */
-        protected SimpleDateFormat getParse() {
+        SimpleDateFormat getParse() {
+            if (this.myParse == null) {
+                this.myParse = new SimpleDateFormat(pattern);
+                if (gmtTimeZone) {
+                    this.myParse.setTimeZone(gmt);
+                }
+            }
             return this.myParse;
         }
 
@@ -393,7 +432,7 @@ public class HttpLocalFormat {
          *            means that this must be an exact match in time
          * @return byte[]
          */
-        protected byte[] getTimeAsBytes(long tolerance) {
+        byte[] getTimeAsBytes(long tolerance) {
             updateTime(tolerance);
             return this.baTime;
         }
@@ -409,7 +448,7 @@ public class HttpLocalFormat {
          *            means that this must be an exact match in time
          * @return String
          */
-        protected String getTimeAsString(long tolerance) {
+        String getTimeAsString(long tolerance) {
             updateTime(tolerance);
             // see if we need the delayed string creation at this point
             if (null == this.sTime) {

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -37,7 +37,6 @@ import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.security.audit.AuditConstants;
 import com.ibm.websphere.security.audit.AuditEvent;
 import com.ibm.websphere.security.audit.context.AuditManager;
-import com.ibm.websphere.security.audit.context.AuditThreadContext;
 import com.ibm.websphere.security.auth.CredentialDestroyedException;
 import com.ibm.websphere.security.cred.WSCredential;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
@@ -162,8 +161,6 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
     private boolean isJaspiEnabled = false;
     private Subject savedSubject = null;
     private boolean isActive = false;
-
-    private static ThreadLocal<AuditThreadContext> threadLocal = new ThreadLocal<AuditThreadContext>();
 
     /**
      * Zero length constructor required by DS.

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java
@@ -60,7 +60,6 @@ import com.ibm.ws.container.Container;
 import com.ibm.ws.container.DeployedModule;
 import com.ibm.ws.javaee.dd.webext.WebExt;
 import com.ibm.websphere.security.audit.context.AuditManager;
-import com.ibm.websphere.security.audit.context.AuditThreadContext;
 import com.ibm.ws.util.WSThreadLocal;
 import com.ibm.ws.webcontainer.async.AsyncContextFactory;
 import com.ibm.ws.webcontainer.async.AsyncContextImpl;
@@ -164,9 +163,6 @@ public abstract class WebContainer extends BaseContainer {
     private static ServiceLoader<ServletContainerInitializer> servletContainerInitializers;
     
     protected AuditManager auditManager;
-
-    private static ThreadLocal<AuditThreadContext> threadLocal = new ThreadLocal<AuditThreadContext>();
-
 
     private static int invocationCacheSize = 500;
     static {

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
@@ -5631,7 +5631,7 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
                 ThreadContextHelper.setClassLoader(origLoader);
             }
             if (envObjectStack.isEmpty()) {
-                envObject.set(null);
+                envObject.remove();
             }
         }
 


### PR DESCRIPTION
Clean up ThreadLocal objects that are not used.
Use ThreadLocal.remove() instead of ThreadLocal.set(null) to clean up some memory.
Do not create Comparator to do a sort when a collection is only size 0 or size 1.
Change some logic where we end up newing up Strings necessarily.
In config validation, improve performance by not doing some validation if it isn't needed.
If a collection is null do not do a contains call after newing up the collection.  Just add the new element.
Reduce some ThreadLocals that can be consolidated.
Lazily new up SimpleDateFormat objects in HttpLocalFormat in order to reduce memory.