### PR TITLE
Add back in support for .jar etension

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.archive/src/com/ibm/ws/kernel/boot/archive/internal/ZipArchive.java
+++ b/dev/com.ibm.ws.kernel.boot.archive/src/com/ibm/ws/kernel/boot/archive/internal/ZipArchive.java
@@ -60,7 +60,7 @@ public class ZipArchive extends AbstractArchive {
         String fileName = archiveFile.getName().toLowerCase();
         FileOutputStream fOut = new FileOutputStream(archiveFile);
 
-        if (fileName.endsWith(".zip")) {
+        if (fileName.endsWith(".zip") || fileName.endsWith(".jar")) {
           this.archiveOutputStream = new ZipArchiveOutputStream(fOut);
         } else if (fileName.endsWith(".tar.gz")) {
           this.archiveOutputStream = new TarArchiveOutputStream(new GZIPOutputStream(fOut));


### PR DESCRIPTION
Adding tar.gz support for package utility broke .jar packaging so adding the extension back in as supported.