### PR TITLE
refresh mp concurrency binary

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -68,7 +68,7 @@ com.ibm.ws.org.objenesis:objenesis:1.0
 com.ibm.ws.commons-collections:commons-collections:3.2.1
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 com.ibm.ws.org.eclipse.jdt.core.compiler:ecj:4.4.2
-com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api:0.20181025.204434.10
+com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api:0.20181117.144439.14
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.antlr:2.6.8.WAS-71e88a9
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.asm:2.6.8.WAS-71e88a9
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.core:2.6.8.WAS-71e88a9

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0/bnd.bnd
@@ -24,7 +24,7 @@ Export-Package: \
   org.eclipse.microprofile.concurrent.spi;version=1.0
 
 Include-Resource: \
-  @${repo;com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api;0.20181025.204434.10;EXACT}
+  @${repo;com.ibm.ws.org.eclipse.microprofile.concurrency:microprofile-concurrency-api;0.20181117.144439.14;EXACT}
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
@@ -14,9 +14,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.ServiceLoader;
 
-import org.eclipse.microprofile.concurrent.ManagedExecutorBuilder;
+import org.eclipse.microprofile.concurrent.ManagedExecutor;
 import org.eclipse.microprofile.concurrent.ThreadContext;
-import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
 import org.eclipse.microprofile.concurrent.spi.ConcurrencyManager;
 import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 
@@ -26,7 +25,7 @@ import com.ibm.ws.concurrent.mp.context.WLMContextProvider;
 
 /**
  * Concurrency manager, which includes the collection of ThreadContextProviders
- * for a particular class loader, ordered by their prerequisites.
+ * for a particular class loader.
  */
 public class ConcurrencyManagerImpl implements ConcurrencyManager {
     private static final TraceComponent tc = Tr.register(ConcurrencyManagerImpl.class);
@@ -82,12 +81,12 @@ public class ConcurrencyManagerImpl implements ConcurrencyManager {
     }
 
     @Override
-    public ManagedExecutorBuilder newManagedExecutorBuilder() {
+    public ManagedExecutor.Builder newManagedExecutorBuilder() {
         return new ManagedExecutorBuilderImpl(concurrencyProvider, contextProviders);
     }
 
     @Override
-    public ThreadContextBuilder newThreadContextBuilder() {
+    public ThreadContext.Builder newThreadContextBuilder() {
         return new ThreadContextBuilderImpl(contextProviders);
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextServiceImpl.java
@@ -78,6 +78,55 @@ public class ContextServiceImpl extends AbstractContextService implements Thread
     }
 
     @Override
+    public <R> Callable<R> contextualCallable(Callable<R> callable) {
+        @SuppressWarnings("unchecked")
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualCallable<R>(contextDescriptor, callable);
+    }
+
+    @Override
+    public <T, U> BiConsumer<T, U> contextualConsumer(BiConsumer<T, U> consumer) {
+        @SuppressWarnings("unchecked")
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualBiConsumer<T, U>(contextDescriptor, consumer);
+    }
+
+    @Override
+    public <T> Consumer<T> contextualConsumer(Consumer<T> consumer) {
+        @SuppressWarnings("unchecked")
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualConsumer<T>(contextDescriptor, consumer);
+    }
+
+    @Override
+    public <T, U, R> BiFunction<T, U, R> contextualFunction(BiFunction<T, U, R> function) {
+        @SuppressWarnings("unchecked")
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualBiFunction<T, U, R>(contextDescriptor, function);
+    }
+
+    @Override
+    public <T, R> Function<T, R> contextualFunction(Function<T, R> function) {
+        @SuppressWarnings("unchecked")
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualFunction<T, R>(contextDescriptor, function);
+    }
+
+    @Override
+    public Runnable contextualRunnable(Runnable runnable) {
+        @SuppressWarnings("unchecked")
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualRunnable(contextDescriptor, runnable);
+    }
+
+    @Override
+    public <R> Supplier<R> contextualSupplier(Supplier<R> supplier) {
+        @SuppressWarnings("unchecked")
+        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
+        return new ContextualSupplier<R>(contextDescriptor, supplier);
+    }
+
+    @Override
     public Executor currentContextExecutor() {
         @SuppressWarnings("unchecked")
         ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
@@ -208,54 +257,5 @@ public class ContextServiceImpl extends AbstractContextService implements Thread
         });
 
         return newStage;
-    }
-
-    @Override
-    public <T, U> BiConsumer<T, U> withCurrentContext(BiConsumer<T, U> consumer) {
-        @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
-        return new ContextualBiConsumer<T, U>(contextDescriptor, consumer);
-    }
-
-    @Override
-    public <T, U, R> BiFunction<T, U, R> withCurrentContext(BiFunction<T, U, R> function) {
-        @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
-        return new ContextualBiFunction<T, U, R>(contextDescriptor, function);
-    }
-
-    @Override
-    public <R> Callable<R> withCurrentContext(Callable<R> callable) {
-        @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
-        return new ContextualCallable<R>(contextDescriptor, callable);
-    }
-
-    @Override
-    public <T> Consumer<T> withCurrentContext(Consumer<T> consumer) {
-        @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
-        return new ContextualConsumer<T>(contextDescriptor, consumer);
-    }
-
-    @Override
-    public <T, R> Function<T, R> withCurrentContext(Function<T, R> function) {
-        @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
-        return new ContextualFunction<T, R>(contextDescriptor, function);
-    }
-
-    @Override
-    public Runnable withCurrentContext(Runnable runnable) {
-        @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
-        return new ContextualRunnable(contextDescriptor, runnable);
-    }
-
-    @Override
-    public <R> Supplier<R> withCurrentContext(Supplier<R> supplier) {
-        @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(Collections.emptyMap());
-        return new ContextualSupplier<R>(contextDescriptor, supplier);
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextServiceImpl.java
@@ -116,7 +116,7 @@ public class ContextServiceImpl extends AbstractContextService implements Thread
 
             if (!managedExecutorRef.compareAndSet(null, executor)) {
                 // Another thread updated the reference first. Discard the instance we created and use the other.
-                executor.shutdown();
+                policyExecutor.shutdown();
                 executor = managedExecutorRef.get();
             }
         }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
-import org.eclipse.microprofile.concurrent.ManagedExecutorBuilder;
 import org.eclipse.microprofile.concurrent.ThreadContext;
 import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 
@@ -28,7 +27,7 @@ import com.ibm.ws.threading.PolicyExecutor;
 /**
  * Builder that programmatically configures and creates ManagedExecutor instances.
  */
-class ManagedExecutorBuilderImpl implements ManagedExecutorBuilder {
+class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
     static final AtomicLong instanceCount = new AtomicLong();
 
     private final ConcurrencyProviderImpl concurrencyProvider;
@@ -114,14 +113,14 @@ class ManagedExecutorBuilderImpl implements ManagedExecutorBuilder {
     }
 
     @Override
-    public ManagedExecutorBuilder cleared(String... types) {
+    public ManagedExecutor.Builder cleared(String... types) {
         cleared.clear();
         Collections.addAll(cleared, types);
         return this;
     }
 
     @Override
-    public ManagedExecutorBuilder maxAsync(int max) {
+    public ManagedExecutor.Builder maxAsync(int max) {
         if (max == 0 || max < -1)
             throw new IllegalArgumentException(Integer.toString(max));
         maxAsync = max;
@@ -129,7 +128,7 @@ class ManagedExecutorBuilderImpl implements ManagedExecutorBuilder {
     }
 
     @Override
-    public ManagedExecutorBuilder maxQueued(int max) {
+    public ManagedExecutor.Builder maxQueued(int max) {
         if (max == 0 || max < -1)
             throw new IllegalArgumentException(Integer.toString(max));
         maxQueued = max;
@@ -137,7 +136,7 @@ class ManagedExecutorBuilderImpl implements ManagedExecutorBuilder {
     }
 
     @Override
-    public ManagedExecutorBuilder propagated(String... types) {
+    public ManagedExecutor.Builder propagated(String... types) {
         propagated.clear();
         Collections.addAll(propagated, types);
         return this;

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
@@ -17,13 +17,12 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 
 import org.eclipse.microprofile.concurrent.ThreadContext;
-import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
 import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 
 /**
  * Builder that programmatically configures and creates ThreadContext instances.
  */
-class ThreadContextBuilderImpl implements ThreadContextBuilder {
+class ThreadContextBuilderImpl implements ThreadContext.Builder {
     private final ArrayList<ThreadContextProvider> contextProviders;
 
     private final HashSet<String> cleared = new HashSet<String>();
@@ -82,21 +81,21 @@ class ThreadContextBuilderImpl implements ThreadContextBuilder {
     }
 
     @Override
-    public ThreadContextBuilder cleared(String... types) {
+    public ThreadContext.Builder cleared(String... types) {
         cleared.clear();
         Collections.addAll(cleared, types);
         return this;
     }
 
     @Override
-    public ThreadContextBuilder propagated(String... types) {
+    public ThreadContext.Builder propagated(String... types) {
         propagated.clear();
         Collections.addAll(propagated, types);
         return this;
     }
 
     @Override
-    public ThreadContextBuilder unchanged(String... types) {
+    public ThreadContext.Builder unchanged(String... types) {
         unchanged.clear();
         Collections.addAll(unchanged, types);
         return this;

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextDescriptorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextDescriptorImpl.java
@@ -39,7 +39,6 @@ class ThreadContextDescriptorImpl implements ThreadContextDescriptor {
 
     /**
      * List of thread context snapshots (either captured from the requesting thread or cleared/empty)
-     * which is ordered based on thread context provider prerequisites.
      */
     private ArrayList<com.ibm.wsspi.threadcontext.ThreadContext> contextSnapshots = new ArrayList<com.ibm.wsspi.threadcontext.ThreadContext>();
 

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
@@ -87,6 +87,48 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
     }
 
     @Override
+    public <R> Callable<R> contextualCallable(Callable<R> callable) {
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        return new ContextualCallable<R>(contextDescriptor, callable);
+    }
+
+    @Override
+    public <T, U> BiConsumer<T, U> contextualConsumer(BiConsumer<T, U> consumer) {
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        return new ContextualBiConsumer<T, U>(contextDescriptor, consumer);
+    }
+
+    @Override
+    public <T> Consumer<T> contextualConsumer(Consumer<T> consumer) {
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        return new ContextualConsumer<T>(contextDescriptor, consumer);
+    }
+
+    @Override
+    public <T, U, R> BiFunction<T, U, R> contextualFunction(BiFunction<T, U, R> function) {
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        return new ContextualBiFunction<T, U, R>(contextDescriptor, function);
+    }
+
+    @Override
+    public <T, R> Function<T, R> contextualFunction(Function<T, R> function) {
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        return new ContextualFunction<T, R>(contextDescriptor, function);
+    }
+
+    @Override
+    public Runnable contextualRunnable(Runnable runnable) {
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        return new ContextualRunnable(contextDescriptor, runnable);
+    }
+
+    @Override
+    public <R> Supplier<R> contextualSupplier(Supplier<R> supplier) {
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        return new ContextualSupplier<R>(contextDescriptor, supplier);
+    }
+
+    @Override
     public <T> T createContextualProxy(ThreadContextDescriptor threadContextDescriptor, T instance, Class<T> intf) {
         throw new UnsupportedOperationException(); // not needed by ManagedCompletableFuture or ManagedExecutorServiceImpl
     }
@@ -182,47 +224,5 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
         });
 
         return newStage;
-    }
-
-    @Override
-    public <T, U> BiConsumer<T, U> withCurrentContext(BiConsumer<T, U> consumer) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
-        return new ContextualBiConsumer<T, U>(contextDescriptor, consumer);
-    }
-
-    @Override
-    public <T, U, R> BiFunction<T, U, R> withCurrentContext(BiFunction<T, U, R> function) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
-        return new ContextualBiFunction<T, U, R>(contextDescriptor, function);
-    }
-
-    @Override
-    public <R> Callable<R> withCurrentContext(Callable<R> callable) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
-        return new ContextualCallable<R>(contextDescriptor, callable);
-    }
-
-    @Override
-    public <T> Consumer<T> withCurrentContext(Consumer<T> consumer) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
-        return new ContextualConsumer<T>(contextDescriptor, consumer);
-    }
-
-    @Override
-    public <T, R> Function<T, R> withCurrentContext(Function<T, R> function) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
-        return new ContextualFunction<T, R>(contextDescriptor, function);
-    }
-
-    @Override
-    public Runnable withCurrentContext(Runnable runnable) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
-        return new ContextualRunnable(contextDescriptor, runnable);
-    }
-
-    @Override
-    public <R> Supplier<R> withCurrentContext(Supplier<R> supplier) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
-        return new ContextualSupplier<R>(contextDescriptor, supplier);
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
@@ -132,7 +132,7 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
 
             if (!managedExecutorRef.compareAndSet(null, executor)) {
                 // Another thread updated the reference first. Discard the instance we created and use the other.
-                executor.shutdown();
+                policyExecutor.shutdown();
                 executor = managedExecutorRef.get();
             }
         }

--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ManagedExecutorProducer.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ManagedExecutorProducer.java
@@ -17,7 +17,6 @@ import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
 
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
-import org.eclipse.microprofile.concurrent.ManagedExecutorBuilder;
 import org.eclipse.microprofile.concurrent.ManagedExecutorConfig;
 
 import com.ibm.websphere.ras.Tr;
@@ -43,7 +42,7 @@ public class ManagedExecutorProducer {
     private ManagedExecutor createManagedExecutor(ManagedExecutorConfigContainer config) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "Building a new ManagedExecutor for the requested configuration: " + config);
-        return ManagedExecutorBuilder.instance()
+        return ManagedExecutor.builder()
                         .maxAsync(config.maxAsync)
                         .maxQueued(config.maxQueued)
                         .propagated(config.propagated.toArray(new String[config.propagated.size()]))

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -4327,7 +4327,7 @@ public class MPConcurrentTestServlet extends FATServlet {
      * Liberty global thread pool.
      */
     @Test
-    public void testWithContextCapture_CompletableFuture() throws Exception {
+    public void testWithContextCapture_CompletableFuture_builder() throws Exception {
         ThreadContext contextSvc = ThreadContextBuilder.instance()
                         .propagated(ThreadContext.APPLICATION)
                         .cleared(TestContextTypes.CITY)
@@ -4380,13 +4380,65 @@ public class MPConcurrentTestServlet extends FATServlet {
     }
 
     /**
+     * Use testWithContextCapture on a ContextService configured in server.xml
+     * to create a contextualized CompletableFuture based on one that isn't context aware.
+     * Verify that its dependent actions run with the configured context of the ContextService
+     * instance and that Async operations run on the Liberty global thread pool.
+     */
+    @Test
+    public void testWithContextCapture_CompletableFuture_serverConfig() throws Exception {
+        CompletableFuture<Integer> cf1 = CompletableFuture.supplyAsync(() -> 122, testThreads);
+
+        CurrentLocation.setLocation("Mankato", "Minnesota");
+        try {
+            CompletableFuture<Integer> cf2 = defaultThreadContext.withContextCapture(cf1);
+            CompletableFuture<Integer> cf3 = cf2.thenApplyAsync(i -> {
+                try {
+                    assertNotNull(InitialContext.doLookup("java:comp/env/executorRef"));
+                } catch (NamingException x) {
+                    throw new RuntimeException(x);
+                }
+                String threadName = Thread.currentThread().getName();
+                assertEquals("", CurrentLocation.getCity());
+                assertEquals("", CurrentLocation.getState());
+                assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // Liberty executor thread
+                return i + 1;
+            });
+
+            assertEquals(Integer.valueOf(123), cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+            CompletableFuture<Integer> cf4 = cf3.thenApply(i -> {
+                try {
+                    assertNotNull(InitialContext.doLookup("java:comp/env/executorRef"));
+                } catch (NamingException x) {
+                    throw new RuntimeException(x);
+                }
+                String threadName = Thread.currentThread().getName();
+                assertEquals("", CurrentLocation.getCity()); // context of servlet thread is cleared
+                assertEquals("", CurrentLocation.getState()); // context of servlet thread is cleared
+                assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // Liberty executor thread
+                CurrentLocation.setLocation("Onalaska", "Wisconsin");
+                return i + 1;
+            });
+
+            assertEquals(Integer.valueOf(124), cf4.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+            // context restored on current thread
+            assertEquals("Mankato", CurrentLocation.getCity());
+            assertEquals("Minnesota", CurrentLocation.getState());
+        } finally {
+            CurrentLocation.clear();
+        }
+    }
+
+    /**
      * Use ThreadContext.testWithContextCapture to create a contextualized CompletionStage
      * based on one that isn't context aware. Verify that its dependent actions run with the
      * configured context of the ThreadContext instance and that Async operations run on the
      * Liberty global thread pool.
      */
     @Test
-    public void testWithContextCapture_CompletionStage() throws Exception {
+    public void testWithContextCapture_CompletionStage_builder() throws Exception {
         ThreadContext contextSvc = ThreadContextBuilder.instance()
                         .propagated(ThreadContext.APPLICATION)
                         .cleared(TestContextTypes.CITY)
@@ -4464,6 +4516,90 @@ public class MPConcurrentTestServlet extends FATServlet {
 
             // context not restored on current thread
             assertEquals("Iowa", CurrentLocation.getState());
+        } finally {
+            CurrentLocation.clear();
+        }
+    }
+
+    /**
+     * Use ThreadContext.testWithContextCapture on a ContextService configured in server.xml
+     * to create a contextualized CompletionStage based on one that isn't context aware.
+     * Verify that its dependent actions run with the configured context of the ContextService
+     * instance and that Async operations run on the Liberty global thread pool.
+     */
+    @Test
+    public void testWithContextCapture_CompletionStage_serverConfig() throws Exception {
+        // Ensure that our CompletionStage runs on an unmanaged thread by blocking execution of the
+        // stage it will depend on until after we create it.
+        CountDownLatch continueLatch = new CountDownLatch(1);
+        CompletableFuture<Integer> cf1 = CompletableFuture.supplyAsync(new BlockableSupplier<Integer>(125, null, continueLatch), testThreads);
+        CompletionStage<Integer> cs1 = new MinimalSingleCompletionStage<Integer>(cf1);
+        continueLatch.countDown();
+
+        CurrentLocation.setLocation("Grand Marais", "Minnesota");
+        try {
+            CompletionStage<Integer> cs2 = defaultThreadContext.withContextCapture(cs1);
+
+            // verify that cs2 is a CompletionStage or limited to CompletionStage methods
+            if (cs2 instanceof CompletableFuture)
+                try {
+                    fail("CompletionStage.complete returned " + ((CompletableFuture<Integer>) cs2).complete(-125));
+                } catch (UnsupportedOperationException x) {
+                    // expected
+                }
+
+            CompletionStage<Integer> cs3 = cs2.thenApplyAsync(i -> {
+                try {
+                    assertNotNull(InitialContext.doLookup("java:comp/env/executorRef"));
+                } catch (NamingException x) {
+                    throw new RuntimeException(x);
+                }
+                String threadName = Thread.currentThread().getName();
+                assertEquals("", CurrentLocation.getCity());
+                assertEquals("", CurrentLocation.getState());
+                assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // Liberty executor thread
+                return i + 1;
+            });
+
+            // verify that cs3 is a CompletionStage or limited to CompletionStage methods
+            if (cs3 instanceof CompletableFuture)
+                try {
+                    fail("CompletionStage.completeExceptionally returned " + ((CompletableFuture<Integer>) cs3).completeExceptionally(new ArrayIndexOutOfBoundsException()));
+                } catch (UnsupportedOperationException x) {
+                    // expected
+                }
+
+            assertEquals(Integer.valueOf(126), cs3.toCompletableFuture().get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+            CompletionStage<Integer> cs4 = cs3.thenApply(i -> {
+                try {
+                    assertNotNull(InitialContext.doLookup("java:comp/env/executorRef"));
+                } catch (NamingException x) {
+                    throw new RuntimeException(x);
+                }
+                String threadName = Thread.currentThread().getName();
+                assertEquals("", CurrentLocation.getCity()); // context of servlet thread is cleared
+                assertEquals("", CurrentLocation.getState()); // context of servlet thread is cleared
+                assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // Liberty executor thread
+                CurrentLocation.setLocation("Superior", "Wisconsin");
+                return i + 1;
+            });
+
+            // verify that cs4 is a CompletionStage or limited to CompletionStage methods
+            if (cs4 instanceof CompletableFuture)
+                try {
+                    fail("CompletionStage.cancel returned " + ((CompletableFuture<Integer>) cs4).cancel(true));
+                } catch (UnsupportedOperationException x) {
+                    // expected
+                }
+
+            assertEquals(Integer.valueOf(127), cs4.toCompletableFuture().get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+            // context restored on current thread
+            assertEquals("Grand Marais", CurrentLocation.getCity());
+
+            // context not restored on current thread
+            assertEquals("Minnesota", CurrentLocation.getState());
         } finally {
             CurrentLocation.clear();
         }

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -64,9 +64,7 @@ import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
-import org.eclipse.microprofile.concurrent.ManagedExecutorBuilder;
 import org.eclipse.microprofile.concurrent.ThreadContext;
-import org.eclipse.microprofile.concurrent.ThreadContextBuilder;
 import org.junit.Test;
 import org.test.context.location.CurrentLocation;
 import org.test.context.location.TestContextTypes;
@@ -153,7 +151,7 @@ public class MPConcurrentTestServlet extends FATServlet {
 
     @Override
     public void init(ServletConfig config) throws ServletException {
-        stateContextPropagator = ThreadContextBuilder.instance()
+        stateContextPropagator = ThreadContext.builder()
                         .propagated(ThreadContext.SECURITY, TestContextTypes.STATE)
                         .unchanged(ThreadContext.APPLICATION)
                         .cleared(ThreadContext.ALL_REMAINING)
@@ -1947,7 +1945,7 @@ public class MPConcurrentTestServlet extends FATServlet {
     public void testManagedExecutorBuilder() throws Exception {
         ClassLoader original = Thread.currentThread().getContextClassLoader();
 
-        ManagedExecutor executor = ManagedExecutorBuilder.instance()
+        ManagedExecutor executor = ManagedExecutor.builder()
                         .propagated(ThreadContext.APPLICATION, TestContextTypes.STATE)
                         .build();
 
@@ -2516,7 +2514,7 @@ public class MPConcurrentTestServlet extends FATServlet {
 
         CurrentLocation.setLocation("Des Moines", "Iowa");
         try {
-            ManagedExecutorBuilder builder = ManagedExecutorBuilder.instance()
+            ManagedExecutor.Builder builder = ManagedExecutor.builder()
                             .maxAsync(1)
                             .maxQueued(1);
 
@@ -2805,16 +2803,16 @@ public class MPConcurrentTestServlet extends FATServlet {
         Function<Double, Double> totalCostInRochesterMN;
         Function<Double, Double> totalCostInAmesIA;
 
-        ThreadContext contextSvc = ThreadContextBuilder.instance()
+        ThreadContext contextSvc = ThreadContext.builder()
                         .propagated(TestContextTypes.CITY, TestContextTypes.STATE)
                         .build();
 
         try {
             CurrentLocation.setLocation("Rochester", "Minnesota");
-            totalCostInRochesterMN = contextSvc.withCurrentContext(totalCost);
+            totalCostInRochesterMN = contextSvc.contextualFunction(totalCost);
 
             CurrentLocation.setLocation("Ames", "Iowa");
-            totalCostInAmesIA = contextSvc.withCurrentContext(totalCost);
+            totalCostInAmesIA = contextSvc.contextualFunction(totalCost);
 
             CurrentLocation.setLocation("Madison", "Wisconsin");
 
@@ -3954,7 +3952,7 @@ public class MPConcurrentTestServlet extends FATServlet {
      */
     @Test
     public void testThreadContextBuilder() throws Exception {
-        ThreadContext contextSvc = ThreadContextBuilder.instance()
+        ThreadContext contextSvc = ThreadContext.builder()
                         .propagated(ThreadContext.APPLICATION, TestContextTypes.STATE)
                         .build();
 
@@ -3963,7 +3961,7 @@ public class MPConcurrentTestServlet extends FATServlet {
 
         CurrentLocation.setLocation("Minnesota");
         try {
-            task = contextSvc.withCurrentContext((Callable<Object[]>) () -> { // TODO remove cast
+            task = contextSvc.contextualCallable(() -> {
                 try {
                     return new Object[] {
                                           InitialContext.doLookup("java:comp/env/executorRef"), // requires Application context
@@ -4328,7 +4326,7 @@ public class MPConcurrentTestServlet extends FATServlet {
      */
     @Test
     public void testWithContextCapture_CompletableFuture_builder() throws Exception {
-        ThreadContext contextSvc = ThreadContextBuilder.instance()
+        ThreadContext contextSvc = ThreadContext.builder()
                         .propagated(ThreadContext.APPLICATION)
                         .cleared(TestContextTypes.CITY)
                         .unchanged(TestContextTypes.STATE)
@@ -4439,7 +4437,7 @@ public class MPConcurrentTestServlet extends FATServlet {
      */
     @Test
     public void testWithContextCapture_CompletionStage_builder() throws Exception {
-        ThreadContext contextSvc = ThreadContextBuilder.instance()
+        ThreadContext contextSvc = ThreadContext.builder()
                         .propagated(ThreadContext.APPLICATION)
                         .cleared(TestContextTypes.CITY)
                         .unchanged(TestContextTypes.STATE)

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/customcontext/src/org/test/context/location/CityContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/customcontext/src/org/test/context/location/CityContextProvider.java
@@ -11,7 +11,6 @@
 package org.test.context.location;
 
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 import org.eclipse.microprofile.concurrent.spi.ThreadContextSnapshot;
@@ -33,11 +32,6 @@ public class CityContextProvider implements ThreadContextProvider {
     @Override
     public ThreadContextSnapshot currentContext(Map<String, String> props) {
         return new CityContextSnapshot(cityName.get());
-    }
-
-    @Override // TODO remove this method once we pick up the binaries where prerequisite context is removed from the spec
-    public Set<String> getPrerequisites() {
-        return null;
     }
 
     @Override


### PR DESCRIPTION
Refresh MicroProfile Concurrency spec binary to latest snapshot build.
This will require updating some method and interface names in our source code and tests to align with the latest.