### PR TITLE
Verify application component availability before applying context

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
@@ -48,6 +48,8 @@ instrument.classesExcludes: com/ibm/ws/concurrent/mp/resources/*.class
   com.ibm.ws.bnd.annotations;version=latest, \
   com.ibm.ws.concurrency.policy;version=latest,\
   com.ibm.ws.concurrent;version=latest,\
+  com.ibm.ws.container.service;version=latest,\
+  com.ibm.ws.container.service.compat;version=latest,\
   com.ibm.ws.context;version=latest,\
   com.ibm.ws.kernel.service;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyManagerImpl.java
@@ -87,6 +87,6 @@ public class ConcurrencyManagerImpl implements ConcurrencyManager {
 
     @Override
     public ThreadContext.Builder newThreadContextBuilder() {
-        return new ThreadContextBuilderImpl(contextProviders);
+        return new ThreadContextBuilderImpl(concurrencyProvider, contextProviders);
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyProviderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyProviderImpl.java
@@ -35,6 +35,7 @@ import com.ibm.ws.concurrent.mp.context.ApplicationContextProvider;
 import com.ibm.ws.concurrent.mp.context.SecurityContextProvider;
 import com.ibm.ws.concurrent.mp.context.TransactionContextProvider;
 import com.ibm.ws.concurrent.mp.context.WLMContextProvider;
+import com.ibm.ws.container.service.metadata.extended.MetaDataIdentifierService;
 import com.ibm.ws.kernel.service.util.SecureAction;
 import com.ibm.ws.threading.PolicyExecutorProvider;
 
@@ -55,6 +56,9 @@ public class ConcurrencyProviderImpl implements ConcurrencyProvider {
     private static final String NO_CONTEXT_CLASSLOADER = "NO_CONTEXT_CLASSLOADER";
 
     private static final SecureAction priv = AccessController.doPrivileged(SecureAction.get());
+
+    @Reference
+    protected MetaDataIdentifierService metadataIdentifierService;
 
     @Reference
     protected PolicyExecutorProvider policyExecutorProvider;

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
@@ -107,7 +107,7 @@ class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
                         .maxConcurrency(maxAsync) //
                         .maxQueueSize(maxQueued);
 
-        ThreadContextImpl mpThreadContext = new ThreadContextImpl(configPerProvider);
+        ThreadContextImpl mpThreadContext = new ThreadContextImpl(concurrencyProvider, configPerProvider);
 
         return new ManagedExecutorImpl(name, policyExecutor, mpThreadContext, concurrencyProvider.transactionContextProvider.transactionContextProviderRef);
     }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
@@ -23,13 +23,15 @@ import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
  * Builder that programmatically configures and creates ThreadContext instances.
  */
 class ThreadContextBuilderImpl implements ThreadContext.Builder {
+    private final ConcurrencyProviderImpl concurrencyProvider;
     private final ArrayList<ThreadContextProvider> contextProviders;
 
     private final HashSet<String> cleared = new HashSet<String>();
     private final HashSet<String> propagated = new HashSet<String>();
     private final HashSet<String> unchanged = new HashSet<String>();
 
-    ThreadContextBuilderImpl(ArrayList<ThreadContextProvider> contextProviders) {
+    ThreadContextBuilderImpl(ConcurrencyProviderImpl concurrencyProvider, ArrayList<ThreadContextProvider> contextProviders) {
+        this.concurrencyProvider = concurrencyProvider;
         this.contextProviders = contextProviders;
 
         // built-in defaults from spec:
@@ -77,7 +79,7 @@ class ThreadContextBuilderImpl implements ThreadContext.Builder {
         if (unknown.size() > 0)
             throw new IllegalArgumentException(unknown.toString());
 
-        return new ThreadContextImpl(configPerProvider);
+        return new ThreadContextImpl(concurrencyProvider, configPerProvider);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
@@ -56,6 +56,11 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
     };
 
     /**
+     * The concurrency provider.
+     */
+    private final ConcurrencyProviderImpl concurrencyProvider;
+
+    /**
      * Map of thread context provider to type of instruction for applying context to threads.
      * The values are either PROPAGATED or CLEARED. Contexts types that should be left on the
      * thread UNCHANGED are omitted from this map.
@@ -73,58 +78,59 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
     /**
      * Construct a new instance to be used directly as a MicroProfile ThreadContext service or by a ManagedExecutor.
      *
-     * @param concurrencyManager
+     * @param concurrencyProvider
      * @param configPerProvider
      */
-    ThreadContextImpl(LinkedHashMap<ThreadContextProvider, ContextOp> configPerProvider) {
+    ThreadContextImpl(ConcurrencyProviderImpl concurrencyProvider, LinkedHashMap<ThreadContextProvider, ContextOp> configPerProvider) {
+        this.concurrencyProvider = concurrencyProvider;
         this.configPerProvider = configPerProvider;
     }
 
     @Override
     public ThreadContextDescriptor captureThreadContext(Map<String, String> executionProperties,
                                                         @SuppressWarnings("unchecked") Map<String, ?>... additionalThreadContextConfig) {
-        return new ThreadContextDescriptorImpl(configPerProvider);
+        return new ThreadContextDescriptorImpl(concurrencyProvider, configPerProvider);
     }
 
     @Override
     public <R> Callable<R> contextualCallable(Callable<R> callable) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(concurrencyProvider, configPerProvider);
         return new ContextualCallable<R>(contextDescriptor, callable);
     }
 
     @Override
     public <T, U> BiConsumer<T, U> contextualConsumer(BiConsumer<T, U> consumer) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(concurrencyProvider, configPerProvider);
         return new ContextualBiConsumer<T, U>(contextDescriptor, consumer);
     }
 
     @Override
     public <T> Consumer<T> contextualConsumer(Consumer<T> consumer) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(concurrencyProvider, configPerProvider);
         return new ContextualConsumer<T>(contextDescriptor, consumer);
     }
 
     @Override
     public <T, U, R> BiFunction<T, U, R> contextualFunction(BiFunction<T, U, R> function) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(concurrencyProvider, configPerProvider);
         return new ContextualBiFunction<T, U, R>(contextDescriptor, function);
     }
 
     @Override
     public <T, R> Function<T, R> contextualFunction(Function<T, R> function) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(concurrencyProvider, configPerProvider);
         return new ContextualFunction<T, R>(contextDescriptor, function);
     }
 
     @Override
     public Runnable contextualRunnable(Runnable runnable) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(concurrencyProvider, configPerProvider);
         return new ContextualRunnable(contextDescriptor, runnable);
     }
 
     @Override
     public <R> Supplier<R> contextualSupplier(Supplier<R> supplier) {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(concurrencyProvider, configPerProvider);
         return new ContextualSupplier<R>(contextDescriptor, supplier);
     }
 
@@ -135,7 +141,7 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
 
     @Override
     public Executor currentContextExecutor() {
-        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(configPerProvider);
+        ThreadContextDescriptor contextDescriptor = new ThreadContextDescriptorImpl(concurrencyProvider, configPerProvider);
         return new ContextualExecutor(contextDescriptor);
     }
 


### PR DESCRIPTION
Verify that the application component that submitted a task/action is still available before applying context to run the task or action.

This will comply with EE Concurrency 3.3.4, which states:
"All invocations to any of the proxied interface methods will fail with a java.lang.IllegalStateException exception if the application component is not started or deployed."