### PR TITLE
Swap EmbeddedApacheDS stopServer calls for stopService in WIM tests

### DIFF
--- a/dev/com.ibm.ws.org.apache.directory.server/src/com/ibm/ws/apacheds/EmbeddedApacheDS.java
+++ b/dev/com.ibm.ws.org.apache.directory.server/src/com/ibm/ws/apacheds/EmbeddedApacheDS.java
@@ -402,7 +402,7 @@ public class EmbeddedApacheDS {
     }
 
     /**
-     * Stop the LdapServer.
+     * Stop the LdapServer. Use stopService for JUnit teardown.
      */
     public void stopServer() {
         this.server.stop();

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/AttributeCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/AttributeCacheTimeoutTest.java
@@ -101,7 +101,7 @@ public class AttributeCacheTimeoutTest {
         }
         if (ldapServer != null) {
             try {
-                ldapServer.stopServer();
+                ldapServer.stopService();
             } catch (Exception e) {
                 Log.error(c, "teardown", e, "LDAP server threw error while stopping. " + e.getMessage());
             }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_IDMapping_Test.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_IDMapping_Test.java
@@ -97,7 +97,7 @@ public class URAPIs_IDMapping_Test {
         }
         if (ldapServer != null) {
             try {
-                ldapServer.stopServer();
+                ldapServer.stopService();
             } catch (Exception e) {
                 // Ignore
             }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_RealmPropertyMappingTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_RealmPropertyMappingTest.java
@@ -134,7 +134,7 @@ public class URAPIs_RealmPropertyMappingTest {
         }
         if (ldapServer != null) {
             try {
-                ldapServer.stopServer();
+                ldapServer.stopService();
             } catch (Exception e) {
                 Log.error(c, "teardown", e, "LDAP server threw error while stopping. " + e.getMessage());
             }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_UserGroupSearchBases.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_UserGroupSearchBases.java
@@ -100,7 +100,7 @@ public class URAPIs_UserGroupSearchBases {
         }
         if (ldapServer != null) {
             try {
-                ldapServer.stopServer();
+                ldapServer.stopService();
             } catch (Exception e) {
                 Log.error(c, "teardown", e, "LDAP server threw error while stopping. " + e.getMessage());
             }


### PR DESCRIPTION
Fixes #5852 

Swapped 4 wim/ldap tests to use stopService on EmbeddedApacheDS from stopServer. This should help avoid this type of issue:

com.ibm.ws.security.wim.adapter.ldap.fat.AttributeCacheTimeoutTest
java.io.IOException: Unable to delete file: apacheDS\instances\myLDAP\partitions\users\master.lg
at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:2279)
at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1653)
at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1535)
at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:2270)
at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1653)
at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1535)
at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:2270)
at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1653)
at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1535)
at com.ibm.ws.apacheds.EmbeddedApacheDS.<init>(EmbeddedApacheDS.java:93)
at com.ibm.ws.security.wim.adapter.ldap.fat.AttributeCacheTimeoutTest.setupldapServer(AttributeCacheTimeoutTest.java:159)
at com.ibm.ws.security.wim.adapter.ldap.fat.AttributeCacheTimeoutTest.setupClass(AttributeCacheTimeoutTest.java:87)
at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:323)
at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:167)