### PR TITLE
FIX added a check to make sure jax-ws components are not tested with Java version above Java8

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
@@ -83,7 +83,7 @@ public class MetricsMonitorTest {
     @After
     public void tearDown() throws Exception {
         if (server != null && server.isStarted()) {
-            server.stopServer("CWWKS4000E");
+            server.stopServer("CWWKS4000E", "CWWKZ0014W");
             server.removeAllInstalledAppsForValidation();
         }
     }
@@ -231,22 +231,22 @@ public class MetricsMonitorTest {
        		new String[] {});
        	
        	Log.info(c, testName, "------- Remove JAX-WS application ------");
-       	boolean rc1 = server.removeDropinsApplications("testJaxWsApp.war");
+       	boolean rc1 = server.removeAndStopDropinsApplications("testJaxWsApp.war");
        	Log.info(c, testName, "------- " + (rc1 ? "successfully removed" : "failed to remove") + " JAX-WS application ------");
        	server.setMarkToEndOfLog();
        	server.setServerConfigurationFile("server_noJaxWs.xml");
-       	Log.info(c, testName, server.waitForStringInLogUsingMark("CWWKF0007I"));
+       	Log.info(c, testName, server.waitForStringInLogUsingMark("CWWKG0017I"));
        	Log.info(c, testName, "------- jax-ws metrics should not be available ------");
       	checkStrings(getHttpsServlet("/metrics/vendor"), 
       		new String[] { "vendor:" }, 
       		new String[] { "vendor:jaxws_client", "vendor:jaxws_server"});
        	
        	Log.info(c, testName, "------- Remove JDBC application ------");
-       	boolean rc2 = server.removeDropinsApplications("testJDBCApp.war");
+       	boolean rc2 = server.removeAndStopDropinsApplications("testJDBCApp.war");
        	Log.info(c, testName, "------- " + (rc2 ? "successfully removed" : "failed to remove") + " JDBC application ------");
        	server.setMarkToEndOfLog();
        	server.setServerConfigurationFile("server_noJDBC.xml");
-       	Log.info(c, testName, server.waitForStringInLogUsingMark("CWWKF0007I"));
+       	Log.info(c, testName, server.waitForStringInLogUsingMark("CWWKG0017I"));
        	Log.info(c, testName, "------- connectionpool metrics should not be available ------");
       	checkStrings(getHttpsServlet("/metrics/vendor"), 
       		new String[] { "vendor:" }, 

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/files/server_monitorFilter1.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/files/server_monitorFilter1.xml
@@ -1,5 +1,6 @@
 <server>
     <featureManager>
+        <feature>jaxws-2.2</feature>
     	<feature>servlet-3.1</feature>
     	<feature>jdbc-4.0</feature>
     	<feature>mpMetrics-1.1</feature>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/files/server_monitorFilter2.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/files/server_monitorFilter2.xml
@@ -1,5 +1,6 @@
 <server>
     <featureManager>
+        <feature>jaxws-2.2</feature>
     	<feature>servlet-3.1</feature>
     	<feature>jdbc-4.0</feature>
     	<feature>mpMetrics-1.1</feature>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/files/server_monitorFilter3.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/files/server_monitorFilter3.xml
@@ -1,5 +1,6 @@
 <server>
     <featureManager>
+        <feature>jaxws-2.2</feature>
     	<feature>servlet-3.1</feature>
     	<feature>jdbc-4.0</feature>
     	<feature>mpMetrics-1.1</feature>

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/files/server_monitorFilter4.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/publish/files/server_monitorFilter4.xml
@@ -1,5 +1,6 @@
 <server>
     <featureManager>
+        <feature>jaxws-2.2</feature>
     	<feature>servlet-3.1</feature>
     	<feature>jdbc-4.0</feature>
     	<feature>mpMetrics-1.1</feature>


### PR DESCRIPTION
Last PR was not working with all versions of Java but this amended one was tested for all locally. Will see result of personal build for java 8 and manual rtc build for java 11
Issue #5757 