### PR TITLE
test case is missing code to wait for termination before verifying the state

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -3551,6 +3551,7 @@ public class MPConcurrentTestServlet extends FATServlet {
         }
 
         assertTrue(executor1.isShutdown());
+        assertTrue(executor1.awaitTermination(TIMEOUT_NS, TimeUnit.NANOSECONDS));
         assertTrue(executor1.isTerminated());
     }
 


### PR DESCRIPTION
Inserted a line to await termination before the test case validates that the executor has reached the terminated state.