### PR TITLE
Increase timeout for slow test machines.

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicClientApp/src/mpRestClient10/basic/BasicClientTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicClientApp/src/mpRestClient10/basic/BasicClientTestServlet.java
@@ -60,6 +60,8 @@ public class BasicClientTestServlet extends FATServlet {
                         .register(DuplicateWidgetExceptionMapper.class)
                         .register(UnknownWidgetExceptionMapper.class)
                         .property("com.ibm.ws.jaxrs.client.ssl.config", "mySSLConfig")
+                        .property("com.ibm.ws.jaxrs.client.receive.timeout", "120000")
+                        .property("com.ibm.ws.jaxrs.client.connection.timeout", "120000")
                         .baseUrl(baseUrl);
     }
 


### PR DESCRIPTION
Not a release bug - only adjusting the read/connect timeouts for a test case to accommodate slower test machines.