### PR TITLE
change withCurrentContext completion stages to run on same thread, per spec

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorImpl.java
@@ -68,8 +68,6 @@ public class ManagedExecutorImpl extends AbstractManagedExecutorService implemen
 
     /**
      * Constructor for MicroProfile Concurrency (ManagedExecutorBuilder and CDI injected ManagedExecutor).
-     * Also used to construct a managed executor for use by the ManagedCompletableFuture returned from
-     * ThreadContext.withContextCapture.
      */
     public ManagedExecutorImpl(String name, PolicyExecutor policyExecutor, WSContextService mpThreadContext,
                                AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> tranContextProviderRef) {

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/SameThreadExecutor.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/SameThreadExecutor.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp;
+
+import java.util.concurrent.Executor;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.WSManagedExecutorService;
+import com.ibm.ws.threading.PolicyExecutor;
+import com.ibm.wsspi.threadcontext.WSContextService;
+
+/**
+ * Executor that runs tasks on the same thread that invokes execute.
+ * WSManagedExecutorService is implemented to store a context service instance
+ * as a convenience to the managed completable future implementation.
+ */
+class SameThreadExecutor implements Executor, WSManagedExecutorService {
+    private final WSContextService contextService;
+
+    @Trivial
+    SameThreadExecutor(WSContextService contextService) {
+        this.contextService = contextService;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        command.run();
+    }
+
+    @Override
+    @Trivial
+    public WSContextService getContextService() {
+        return contextService;
+    }
+
+    @Override
+    @Trivial
+    public PolicyExecutor getNormalPolicyExecutor() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Trivial
+    public int hashCode() {
+        return contextService.hashCode(); // for easy correlation in trace with the context service that created it
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
@@ -16,7 +16,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -24,12 +23,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.concurrent.ThreadContext;
-import org.eclipse.microprofile.concurrent.spi.ConcurrencyProvider;
 import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.threading.PolicyExecutor;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
@@ -57,14 +54,6 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
      * thread UNCHANGED are omitted from this map.
      */
     private final LinkedHashMap<ThreadContextProvider, ContextOp> configPerProvider;
-
-    /**
-     * Lazily initialized reference to a cached managed executor instance, which is
-     * backed by the Liberty global thread pool without concurrency constraints,
-     * propagates the type of context configured for this thread context service, and
-     * clears all other types of context.
-     */
-    private final AtomicReference<ManagedExecutorImpl> managedExecutorRef = new AtomicReference<ManagedExecutorImpl>();
 
     /**
      * Construct a new instance to be used directly as a MicroProfile ThreadContext service or by a ManagedExecutor.
@@ -136,54 +125,11 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
         return new ContextualExecutor(contextDescriptor);
     }
 
-    /**
-     * Obtain a ManagedExecutor backed by the Liberty global thread pool, without constraints,
-     * and propagating the same types as this ThreadContext service, clearing those which are
-     * configured to be cleared.
-     * If possible, a cached instance is returned. If it doesn't exist yet, then an instance
-     * is lazily created by this method.
-     *
-     * @return ManagedExecutor instance.
-     */
-    private ManagedExecutorImpl getManagedExecutor() {
-        ManagedExecutorImpl executor = managedExecutorRef.get();
-
-        if (executor == null) {
-            StringBuilder nameBuilder = new StringBuilder("ManagedExecutor_-1_-1_");
-
-            // Identify the propagated context types for the name
-            for (Map.Entry<ThreadContextProvider, ContextOp> entry : configPerProvider.entrySet())
-                if (entry.getValue() == ContextOp.PROPAGATED) {
-                    String contextType = entry.getKey().getThreadContextType();
-                    if (contextType != null && contextType.matches("\\w*")) // one or more of a-z, A-Z, _, 0-9
-                        nameBuilder.append(contextType).append("_");
-                }
-
-            String name = nameBuilder.append(ManagedExecutorBuilderImpl.instanceCount.incrementAndGet()).toString();
-
-            ConcurrencyProviderImpl concurrencyProvider = (ConcurrencyProviderImpl) ConcurrencyProvider.instance();
-            PolicyExecutor policyExecutor = concurrencyProvider.policyExecutorProvider.create(name);
-            policyExecutor.maxConcurrency(-1).maxQueueSize(-1);
-            // TODO these policy executor instances, as well as those created via ManagedExecutorBuilder are never shut down
-            // and removed from PolicyExecutorProvider's list. This is a memory leak and needs to be fixed.
-
-            executor = new ManagedExecutorImpl(name, policyExecutor, this, concurrencyProvider.transactionContextProvider.transactionContextProviderRef);
-
-            if (!managedExecutorRef.compareAndSet(null, executor)) {
-                // Another thread updated the reference first. Discard the instance we created and use the other.
-                policyExecutor.shutdown();
-                executor = managedExecutorRef.get();
-            }
-        }
-
-        return executor;
-    }
-
     @Override
     public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> stage) {
         CompletableFuture<T> newCompletableFuture;
 
-        ManagedExecutorImpl executor = getManagedExecutor();
+        SameThreadExecutor executor = new SameThreadExecutor(this);
         if (ManagedCompletableFuture.JAVA8)
             newCompletableFuture = new ManagedCompletableFuture<T>(new CompletableFuture<T>(), executor, null);
         else
@@ -205,7 +151,7 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
     public <T> CompletionStage<T> withContextCapture(CompletionStage<T> stage) {
         ManagedCompletionStage<T> newStage;
 
-        ManagedExecutorImpl executor = getManagedExecutor();
+        SameThreadExecutor executor = new SameThreadExecutor(this);
         if (ManagedCompletableFuture.JAVA8)
             newStage = new ManagedCompletionStage<T>(new CompletableFuture<T>(), executor, null);
         else


### PR DESCRIPTION
Update our implementation of completion stages returned by withCurrentContext to match a recent change to the spec that requires them to be backed by the ThreadContext rather than a managed executor so that they must run actions on the same thread.