### PR TITLE
Ignore svc ref warning for test svc component

### DIFF
--- a/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/JsonUserFeatureTest.java
+++ b/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/JsonUserFeatureTest.java
@@ -46,7 +46,7 @@ public class JsonUserFeatureTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKE0700W: .*ServiceThatRequiresJson"); // Sometimes DS reports this warning when it attempts to get the ref, but ultimately the svc component activates successfully
     }
 
     // Test a user feature with a service component that injects JsonProvider (from the bell)


### PR DESCRIPTION
Sometimes the jsonb_fat test gets the following error in logs:

> [5/23/18 18:23:01:635 UTC] 0000001a LogService-55-test.jsonp.bundle                              W CWWKE0700W: [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Could not get service from ref {javax.json.spi.JsonProvider}={implementation.class=org.apache.johnzon.core.JsonProviderImpl, service.id=194, service.bundleid=57, service.scope=prototype, exported.from=johnzon} Bundle:test.jsonp.bundle(id=55)   

From what I can tell, the test component is properly defined:
```java
@Component(configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true)
public class ServiceThatRequiresJsonp {

    @Reference
    private JsonProvider jsonpProvider;

    @Activate
    protected void activate(ComponentContext context) throws Exception {
        System.out.println("TEST3: JsonProvider obtained from declarative services is " + jsonpProvider.getClass().getName());
        // ...
    }
}
```

Even when we get this warning, the component eventually activates successfully and the service component is useable:
```
[5/23/18 18:23:01:628 UTC] 0000001a id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Locating field jsonpProvider in class test.jsonp.bundle.ServiceThatRequiresJsonp
[5/23/18 18:23:01:635 UTC] 0000001a id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] getReferenceClass: Looking for interface class javax.json.spi.JsonProvider through loader of test.jsonp.bundle.ServiceThatRequiresJsonp
[5/23/18 18:23:01:635 UTC] 0000001a id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] getParameterClass: Found class javax.json.spi.JsonProvider
[5/23/18 18:23:01:635 UTC] 0000001a id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Found field: private javax.json.spi.JsonProvider test.jsonp.bundle.ServiceThatRequiresJsonp.jsonpProvider
[5/23/18 18:23:01:635 UTC] 0000001a id=         LogService-55-test.jsonp.bundle                              W CWWKE0700W: [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Could not get service from ref {javax.json.spi.JsonProvider}={implementation.class=org.apache.johnzon.core.JsonProviderImpl, service.id=194, service.bundleid=57, service.scope=prototype, exported.from=johnzon} Bundle:test.jsonp.bundle(id=55)   
[5/23/18 18:23:01:635 UTC] 0000001a id=03043e72 LogService-13-com.ibm.ws.org.apache.felix.scr                3 Missing service {javax.json.spi.JsonProvider}={implementation.class=org.apache.johnzon.core.JsonProviderImpl, service.id=194, service.bundleid=57, service.scope=prototype, exported.from=johnzon} for dependency manager DependencyManager: Component [Component: test.jsonp.bundle.ServiceThatRequiresJsonp (112)] reference [jsonpProvider] is not a DS service, cannot resolve circular dependency
[5/23/18 18:23:01:635 UTC] 0000001a id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Deactivating dependency managers
[5/23/18 18:23:01:635 UTC] 0000001a id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Could not get required dependency for dependency manager: jsonpProvider
[5/23/18 18:23:01:635 UTC] 0000001a id=         LogService-55-test.jsonp.bundle                              I [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Could not obtain all required dependencies, getService returning null Bundle:test.jsonp.bundle(id=55)   

// ...

[5/23/18 18:23:01:849 UTC] 0000001e id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] This thread collected dependencies
[5/23/18 18:23:01:849 UTC] 0000001e id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] getService (single component manager) dependencies collected.
[5/23/18 18:23:01:849 UTC] 0000001e id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Querying state satisfied
[5/23/18 18:23:01:849 UTC] 0000001e id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Querying state satisfied
[5/23/18 18:23:01:849 UTC] 0000001e id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] For dependency jsonpProvider, optional: false; to bind: [[RefPair: ref: [{javax.json.spi.JsonProvider}={implementation.class=org.apache.johnzon.core.JsonProviderImpl, service.id=204, service.bundleid=57, service.scope=prototype, exported.from=johnzon}] service: [org.apache.johnzon.core.JsonProviderImpl@af820b09]]]
[5/23/18 18:23:01:849 UTC] 0000001e id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] getting activate: activate
[5/23/18 18:23:01:849 UTC] 0000001e id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Locating method activate in class test.jsonp.bundle.ServiceThatRequiresJsonp
[5/23/18 18:23:01:849 UTC] 0000001e id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] Found activate method: protected void test.jsonp.bundle.ServiceThatRequiresJsonp.activate(org.osgi.service.component.ComponentContext) throws java.lang.Exception
[5/23/18 18:23:01:849 UTC] 0000001e id=4e06db2f LogService-55-test.jsonp.bundle                              3 [test.jsonp.bundle.ServiceThatRequiresJsonp(112)] invoking activate: activate: parameters [org.apache.felix.scr.impl.manager.ComponentContextImpl@5d003340]
[5/23/18 18:23:01:849 UTC] 0000001e id=         SystemOut                                                    O TEST3: JsonProvider obtained from declarative services is org.apache.johnzon.core.JsonProviderImpl
```