### PR TITLE
Reordered the testInvalidPaddingValue test to put the expected frame in

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/DataFrameTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/DataFrameTests.java
@@ -118,11 +118,13 @@ public class DataFrameTests extends H2FATDriverServlet {
         String testName = "testInvalidPaddingValue";
 
         Http2Client h2Client = getDefaultH2Client(request, response, blockUntilConnectionIsDone);
-        FrameHeaders headers = setupDefaultPreface(h2Client);
 
+        // Add expected goaway before the init sequence.
         byte[] debugData = "Error processing the payload for DATA frame on stream 5".getBytes();
         FrameGoAway errorFrame = new FrameGoAway(0, debugData, PROTOCOL_ERROR, 1, false);
         h2Client.addExpectedFrame(errorFrame);
+
+        FrameHeaders headers = setupDefaultPreface(h2Client);
 
         h2Client.addExpectedFrame(headers);
 


### PR DESCRIPTION
Need to add a goaway frame to the expected list before the start up sequence. 

Because of timing, the test will sometimes fail if the start up sequence completes before the goaway is added as expected.

