### PR TITLE
use in mem derby for around_timeout test

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.interceptor_fat/publish/servers/com.ibm.ws.ejbcontainer.interceptor.fat.AroundTimeoutServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.interceptor_fat/publish/servers/com.ibm.ws.ejbcontainer.interceptor.fat.AroundTimeoutServer/server.xml
@@ -29,9 +29,12 @@
         <properties.wasJms queueName="InterceptorMDBReqQueue"/>
     </jmsQueue>
 
+	<!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
+	+    is required beyond a single server start, configure the databaseName with a file location such as:
+	+    databaseName="${shared.config.dir}/data/derbydb" --> 
 	<databaseStore id="defaultDatabaseStore" keyGenerationStrategy="SEQUENCE"/>
     <dataSource id="DefaultDataSource" jdbcDriverRef="DerbyEmbedded">
-        <properties.derby.embedded createDatabase="create" databaseName="${server.config.dir}/data/EJBTimerDB"/>
+        <properties.derby.embedded createDatabase="create" databaseName="memory:EJBTimerDB"/>
     </dataSource>
 
     <jdbcDriver id="DerbyEmbedded" libraryRef="DerbyLib"/>


### PR DESCRIPTION
to reduce database i/o during fat runs