### PR TITLE
Add post invoke delay before checking if timer is deleted in fat test

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/bnd.bnd
@@ -27,4 +27,5 @@ tested.features: \
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
-	com.ibm.websphere.javaee.servlet.3.1;version=latest
+	com.ibm.websphere.javaee.servlet.3.1;version=latest, \
+	com.ibm.ws.ejbcontainer.fat_tools; version=latest

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/build.gradle
@@ -17,3 +17,22 @@ repositories {
    }
 
 }
+
+configurations {
+  ejbTools
+}
+
+dependencies {
+  ejbTools 'test:com.ibm.ws.ejbcontainer.fat_tools:1.+'
+}
+
+task addEJBTools << {
+  copy {
+    from configurations.ejbTools
+  	into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.timer.persistent.fat.NoDatasourceServer/lib/global"
+  }
+}
+
+addRequiredLibraries {
+  dependsOn addEJBTools
+}

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/NoDBProgrammaticTimerEJB.jar/src/com/ibm/ws/ejbcontainer/timer/nodb/programmatic/ejb/ProgrammaticTimerBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/NoDBProgrammaticTimerEJB.jar/src/com/ibm/ws/ejbcontainer/timer/nodb/programmatic/ejb/ProgrammaticTimerBean.java
@@ -26,6 +26,8 @@ import javax.ejb.Timeout;
 import javax.ejb.Timer;
 import javax.ejb.TimerService;
 
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
+
 /**
  * A simple stateless bean with programmatically created timers and methods
  * to verify the timers run as expected.
@@ -37,6 +39,7 @@ public class ProgrammaticTimerBean {
     private static final Logger logger = Logger.getLogger(ProgrammaticTimerBean.class.getName());
 
     private static final CountDownLatch timerLatch = new CountDownLatch(1);
+    private static long POST_INVOKE_FUDGE_FACTOR = 400; //ms
 
     @Resource
     private TimerService ts;
@@ -92,6 +95,7 @@ public class ProgrammaticTimerBean {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
+        FATHelper.sleep(POST_INVOKE_FUDGE_FACTOR);
         boolean timedout = timerLatch.getCount() == 0;
         logger.info("< waitForTimer : " + timedout);
         return timedout;


### PR DESCRIPTION
Test checks that a single action timer is cancelled after running. Test correctly uses a CountDownLatch to wait for timeout before checking, but because of a slight timing window from postinvoke the timer might be in the middle of being cancelled when the test asserts that it's deleted.

Adding a slight sleep to account for post invoke.