### PR TITLE
Fix for Issue #5886: Additional cleanup to avoid quiesce errors

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BroadcasterApp/src/io/openliberty/sse/broadcaster/BroadcasterTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BroadcasterApp/src/io/openliberty/sse/broadcaster/BroadcasterTestServlet.java
@@ -123,6 +123,10 @@ public class BroadcasterTestServlet extends FATServlet {
             for (ClientListener clientListener : clients) {
                 clientListener.close();
             }
+            while (latch.getCount() > 0) {
+                latch.countDown();
+            }           
+            client.close();
         }
     }
 

--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BroadcasterApp/src/io/openliberty/sse/broadcaster/ClientListener.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/BroadcasterApp/src/io/openliberty/sse/broadcaster/ClientListener.java
@@ -35,6 +35,7 @@ public class ClientListener implements Runnable, Closeable {
     private final AtomicReference<CountDownLatch> sharedLatch = new AtomicReference<>();
     private CountDownLatch privateLatch;
     private final List<String> receivedEvents = new ArrayList<>();
+    private final Holder<SseEventSource> holder = new Holder<SseEventSource>();
 
     ClientListener(WebTarget target, CountDownLatch latch) {
         this.target = target;
@@ -51,6 +52,7 @@ public class ClientListener implements Runnable, Closeable {
         privateLatch = new CountDownLatch(1);
 
         try (SseEventSource source = SseEventSource.target(target).build()) {
+            holder.value = source;
             source.register(event -> {
                 _log.info("listener id " + id + " received event " + event);
                 String msg = event.readData();
@@ -87,5 +89,10 @@ public class ClientListener implements Runnable, Closeable {
     @Override
     public void close() throws IOException {
         privateLatch.countDown();
+        holder.value.close();
+    }
+    
+    private class Holder<T> {
+        public volatile T value;
     }
 }


### PR DESCRIPTION
Seeing the following in the logs:

java.lang.Exception: Errors/warnings were found in server io.openliberty.sse.broadcaster logs:
 <br>[12/3/18 7:58:35:049 GMT] 00000045 com.ibm.ws.runtime.update.internal.RuntimeUpdateManagerImpl  W CWWKE1102W: The quiesce operation did not complete. The server will now stop.
 <br>[12/3/18 7:58:35:051 GMT] 00000045 com.ibm.ws.runtime.update.internal.RuntimeUpdateManagerImpl  W CWWKE1106W: 1 shutdown operations did not complete during the quiesce period. 