### PR TITLE
Add unsafe method from Oracle 18c Driver

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcProxyMethod.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcProxyMethod.java
@@ -181,6 +181,8 @@ public abstract class WSJdbcProxyMethod
         // oracle.jdbc.OracleConnection.setAutoClose(boolean)
         // oracle.jdbc.internal.OracleConnection.setAutoClose(boolean)
         unsafeMethods.add("setCurrentUser"); 
+        unsafeMethods.add("setSafelyClosed");
+        //oracle.jdbc.internal.OracleConnection.setSafelyClosed(boolean)
         unsafeMethods.add("setShardingKeyIfValid");
         //  oracle.jdbc.OracleConnection.setShardingKeyIfValid
         //  oracle.jdbc.internal.OracleConnection.setShardingKeyIfValid


### PR DESCRIPTION
Block access to the new `setSafelyClosed` method on the new Oracle 18c driver on an unwrapped connection, as this methods may close out underlying resources from under Liberty.
