### PR TITLE
build jwk with kids even if they are created using the key information from the config

### DIFF
--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JWKProvider.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JWKProvider.java
@@ -50,6 +50,8 @@ public class JWKProvider {
 
     protected PublicKey publicKey = null;
     protected PrivateKey privateKey = null;
+    
+    protected String publicKeyKid = null;
 
     protected JWKProvider() {
         this(DEFAULT_KEY_SIZE, RS256, DEFAULT_ROTATION_TIME);
@@ -95,6 +97,15 @@ public class JWKProvider {
 
         this.publicKey = publicKey;
         this.privateKey = privateKey;
+        this.publicKeyKid = buildKidFromPublicKey(this.publicKey);
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "kid = " + this.publicKeyKid);
+        }
+    }
+    
+    private String buildKidFromPublicKey(PublicKey cert) {
+        JwkKidBuilder kidbuilder = new JwkKidBuilder();
+        return kidbuilder.buildKeyId(cert);
     }
 
     public JSONWebKey getJWK() {
@@ -118,7 +129,7 @@ public class JWKProvider {
         JWK jwk = null;
         if (RS256.equals(alg)) {
             if (publicKey != null && privateKey != null) {
-                jwk = Jose4jRsaJWK.getInstance(alg, use, publicKey, privateKey);
+                jwk = Jose4jRsaJWK.getInstance(alg, use, publicKey, privateKey, publicKeyKid);
                 jwk.generateKey();
             } else {
                 jwk = generateRsaJWK(alg, size);

--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/Jose4jRsaJWK.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/Jose4jRsaJWK.java
@@ -115,7 +115,7 @@ public class Jose4jRsaJWK extends RsaJsonWebKey implements JWK {
     }
 
     // alg, use, publicKey, privateKey
-    public static Jose4jRsaJWK getInstance(String alg, String use, PublicKey publicKey, PrivateKey privateKey) {
+    public static Jose4jRsaJWK getInstance(String alg, String use, PublicKey publicKey, PrivateKey privateKey, String kid) {
 
         //String kid = RandomUtils.getRandomAlphaNumeric(KID_LENGTH);
         RSAPublicKey pubKey = (RSAPublicKey) publicKey;
@@ -124,7 +124,7 @@ public class Jose4jRsaJWK extends RsaJsonWebKey implements JWK {
 
         jwk.setPrivateKey(priKey);
         jwk.setAlgorithm(alg);
-        //jwk.setKeyId(kid);
+        jwk.setKeyId(kid);
         jwk.setUse(use == null ? JwkConstants.sig : use);
 
         return jwk;

--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwkKidBuilder.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwkKidBuilder.java
@@ -1,0 +1,26 @@
+package com.ibm.ws.security.common.jwk.impl;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+
+public class JwkKidBuilder {
+
+    public JwkKidBuilder() {
+
+    }
+
+    public String buildKeyId(PublicKey cert) {
+        if (cert != null && cert.getEncoded() != null) {
+            byte[] certhash = null;
+            try {
+                certhash = MessageDigest.getInstance("SHA-256").digest(cert.getEncoded());
+            } catch (NoSuchAlgorithmException e) {
+            }
+            if (certhash != null) {
+                return org.jose4j.base64url.Base64Url.encode(certhash);
+            }
+        }
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtData.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtData.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.security.jwt.utils;
 
 import java.security.Key;
+import java.security.PublicKey;
 import java.security.interfaces.RSAPrivateKey;
 
 import org.jose4j.keys.HmacKey;
@@ -20,6 +21,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.jwk.impl.JWKProvider;
+import com.ibm.ws.security.common.jwk.impl.JwkKidBuilder;
 import com.ibm.ws.security.jwt.config.JwtConfig;
 import com.ibm.ws.security.jwt.internal.BuilderImpl;
 import com.ibm.ws.security.jwt.internal.JwtTokenException;
@@ -115,8 +117,9 @@ public class JwtData {
                         keyAlias = jwtConfig.getKeyAlias();
                         keyStoreRef = jwtConfig.getKeyStoreRef();
                         _signingKey = JwtUtils.getPrivateKey(keyAlias, keyStoreRef);
+                        _keyId = buildKidFromPublicKey(JwtUtils.getPublicKey(keyAlias, keyStoreRef));
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "Key alias: " + keyAlias + ", Keystore: " + keyStoreRef);
+                            Tr.debug(tc, "Key alias: " + keyAlias + ", Keystore: " + keyStoreRef+ ", kid: " + _keyId);
                         }
                     }
 
@@ -129,6 +132,7 @@ public class JwtData {
                         // Object[] objs = new Object[] { signatureAlgorithm, errorMsg };
                         // noKeyException = JWTTokenException.newInstance(false, "JWT_BAD_SIGNING_KEY", objs);
                         _signingKey = null; // we will catch this later in jwtSigner
+                        _keyId = null;
                     }
                 }
             }
@@ -150,6 +154,11 @@ public class JwtData {
             throw JwtTokenException.newInstance(true, "JWT_NO_SIGNING_KEY_WITH_ERROR", objs);
         }
     }
+    
+    private String buildKidFromPublicKey(PublicKey cert)  {
+    	JwkKidBuilder kidbuilder = new JwkKidBuilder();
+        return kidbuilder.buildKeyId(cert);
+	}
 
     public String getSignatureAlgorithm() {
         return signatureAlgorithm;

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/BuilderTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/BuilderTests.java
@@ -134,8 +134,8 @@ public class BuilderTests extends CommonSecurityFat {
         response = actions.doFormLogin(response, defaultUser, defaultPassword);
         validationUtils.validateResult(response, currentAction, expectations);
 
-        Cookie jwtCookie = webClient.getCookieManager().getCookie(JwtFatConstants.JWT_COOKIE_NAME);
-        verifyJwtHeaderDoesNotContainKey(jwtCookie.getValue(), "kid");
+        //Cookie jwtCookie = webClient.getCookieManager().getCookie(JwtFatConstants.JWT_COOKIE_NAME);
+        //verifyJwtHeaderDoesNotContainKey(jwtCookie.getValue(), "kid");
     }
 
     private void verifyJwtHeaderContainsKey(String jwt, String key) throws UnsupportedEncodingException {


### PR DESCRIPTION
I fixed the failing webcontainer security fat. Try to deliver these changes again.