### PR TITLE
Cancel lease timer at shutdown

### DIFF
--- a/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/TxRecoveryAgentImpl.java
+++ b/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/TxRecoveryAgentImpl.java
@@ -517,6 +517,9 @@ public class TxRecoveryAgentImpl implements RecoveryAgent {
     }
 
     public void stop(boolean immediate) {
+        // Stop lease timeout alarm popping when server is on its way down
+        LeaseTimeoutManager.stopTimeout();
+
         // The entire server is shutting down. All recovery/peer recovery processing must be stopped. Sping
         // through all known failure scope controllers (which includes the local failure scope if we started
         // processing recovery for it) and tell them to shutdown.


### PR DESCRIPTION
Cancel lease timers at shutdown so db accesses don't occur as connection pools are disappearing.

fixes #5949 

#build 