### PR TITLE
Don't path normalize variables in JDBC/JCA annos

### DIFF
--- a/dev/com.ibm.ws.jca.1.7/src/com/ibm/ws/jca17/processor/service/AdministeredObjectResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jca.1.7/src/com/ibm/ws/jca17/processor/service/AdministeredObjectResourceFactoryBuilder.java
@@ -149,7 +149,7 @@ public class AdministeredObjectResourceFactoryBuilder implements ResourceFactory
         for (Map.Entry<String, Object> prop : props.entrySet()) {
             Object value = prop.getValue();
             if (value instanceof String)
-                value = variableRegistry.resolveString((String) value);
+                value = variableRegistry.resolveRawString((String) value);
             annotationProps.put(prop.getKey(), value);
         }
 

--- a/dev/com.ibm.ws.jca.1.7/src/com/ibm/ws/jca17/processor/service/ConnectionFactoryResourceBuilder.java
+++ b/dev/com.ibm.ws.jca.1.7/src/com/ibm/ws/jca17/processor/service/ConnectionFactoryResourceBuilder.java
@@ -150,7 +150,7 @@ public class ConnectionFactoryResourceBuilder implements ResourceFactoryBuilder 
         for (Map.Entry<String, Object> prop : props.entrySet()) {
             Object value = prop.getValue();
             if (value instanceof String)
-                value = variableRegistry.resolveString((String) value);
+                value = variableRegistry.resolveRawString((String) value);
             annotationProps.put(prop.getKey(), value);
         }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
@@ -145,7 +145,7 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
         for (Map.Entry<String, Object> prop : props.entrySet()) {
             Object value = prop.getValue();
             if (value instanceof String)
-                value = variableRegistry.resolveString((String) value);
+                value = variableRegistry.resolveRawString((String) value);
             vendorProps.put(prop.getKey(), value);
         }
 


### PR DESCRIPTION
The variables in the `@DataSourceDefinition`, `@ConnectionFactoryDefinition`, and `@AdministeredObjectDefinition` annos were being incorrectly path normalized.  Fix for #5963.