### PR TITLE
Fix issue where timeout.stop() can be called before timeout.start()

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/SyncExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/SyncExecutor.java
@@ -118,7 +118,8 @@ public class SyncExecutor<R> implements Executor<R> {
 
             // If the circuit breaker gave permission to execute the result hasn't yet been set and we should run the execution
             if (result == null) {
-                timeoutState.start(() -> runningThread.interrupt());
+                timeoutState.setTimeoutCallback(() -> runningThread.interrupt());
+                timeoutState.start();
 
                 // The call to the application code happens here
                 result = bulkhead.run(callable);

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/package-info.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/package-info.java
@@ -11,7 +11,7 @@
 /**
  * The Fault Tolerance 2.0 providers, builders and executors
  */
-@TraceOptions(traceGroup = "FAULTTOLERANCE")
+@TraceOptions(traceGroup = "FAULTTOLERANCE", messageBundle = "com.ibm.ws.microprofile.faulttolerance.resources.FaultTolerance")
 package com.ibm.ws.microprofile.faulttolerance20.impl;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/TimeoutState.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/TimeoutState.java
@@ -46,13 +46,20 @@ public interface TimeoutState {
     /**
      * Start an execution attempt.
      * <p>
+     * If {@link #setTimeoutCallback(Runnable)} is called before {@link #stop()} is called, the timeout callback will be called if the execution times out.
+     */
+    public void start();
+
+    /**
+     * Set the callback to call if the execution attempt times out
+     * <p>
      * If the execution attempt times out before {@link #stop()} is called, {@code timeoutCallback} will be called.
      * <p>
      * {@code timeoutCallback} will not be called after {@link #stop()} has returned.
      *
-     * @param timeoutCallback the callback to call if the execution attempt times out
+     * @param timeoutCallback the callback to call if execution times out
      */
-    public void start(Runnable timeoutCallback);
+    public void setTimeoutCallback(Runnable timeoutCallback);
 
     /**
      * Stop an execution attempt

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/DurationUtils.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/DurationUtils.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance20.state.impl;
+
+import java.time.Duration;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+/**
+ * Utilities for working with {@link Duration}
+ */
+public class DurationUtils {
+
+    // No public constructor, static utility methods only
+    private DurationUtils() {}
+
+    /**
+     * Convert a duration to nanoseconds, clamping between MIN_VALUE and MAX_LONG
+     * <p>
+     * Needed in case a user specifies something silly like delay = 5 MILLENNIA
+     * <p>
+     * protected only to allow unit testing
+     *
+     * @param duration the duration to convert
+     * @return duration as nanoseconds, clamped if required
+     */
+    @FFDCIgnore(ArithmeticException.class)
+    public static long asClampedNanos(Duration duration) {
+        try {
+            return duration.toNanos();
+        } catch (ArithmeticException e) {
+            // Treat long overflow as an exceptional case
+            if (duration.isNegative()) {
+                return Long.MIN_VALUE;
+            } else {
+                return Long.MAX_VALUE;
+            }
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/RetryStateImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/RetryStateImpl.java
@@ -10,13 +10,14 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance20.state.impl;
 
+import static com.ibm.ws.microprofile.faulttolerance20.state.impl.DurationUtils.asClampedNanos;
+
 import java.time.Duration;
 import java.util.PrimitiveIterator;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
 
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.microprofile.faulttolerance.spi.RetryPolicy;
 import com.ibm.ws.microprofile.faulttolerance20.impl.MethodResult;
 import com.ibm.ws.microprofile.faulttolerance20.state.RetryState;
@@ -108,30 +109,6 @@ public class RetryStateImpl implements RetryState {
             result.delay = 0;
         }
         result.delayUnit = TimeUnit.NANOSECONDS;
-    }
-
-    /**
-     * Convert a duration to nanoseconds, clamping between MIN_VALUE and MAX_LONG
-     * <p>
-     * Needed in case a user specifies something silly like delay = 5 MILLENNIA
-     * <p>
-     * protected only to allow unit testing
-     *
-     * @param duration the duration to convert
-     * @return duration as nanoseconds, clamped if required
-     */
-    @FFDCIgnore(ArithmeticException.class)
-    protected static long asClampedNanos(Duration duration) {
-        try {
-            return duration.toNanos();
-        } catch (ArithmeticException e) {
-            // Treat long overflow as an exceptional case
-            if (duration.isNegative()) {
-                return Long.MIN_VALUE;
-            } else {
-                return Long.MAX_VALUE;
-            }
-        }
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/TimeoutStateNullImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/TimeoutStateNullImpl.java
@@ -15,7 +15,10 @@ import com.ibm.ws.microprofile.faulttolerance20.state.TimeoutState;
 public class TimeoutStateNullImpl implements TimeoutState {
 
     @Override
-    public void start(Runnable timeoutCallback) {}
+    public void start() {}
+
+    @Override
+    public void setTimeoutCallback(Runnable timeoutCallback) {}
 
     @Override
     public void stop() {}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/DurationUtilsTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/DurationUtilsTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance20.state.impl;
+
+import static java.time.temporal.ChronoUnit.MILLENNIA;
+import static java.time.temporal.ChronoUnit.YEARS;
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+public class DurationUtilsTest {
+
+    @Test
+    public void testClampedNanos() {
+        Duration tinyDuration = Duration.ofNanos(100);
+        assertEquals(tinyDuration.toNanos(), DurationUtils.asClampedNanos(tinyDuration));
+
+        Duration smallDuration = Duration.ofSeconds(5);
+        assertEquals(smallDuration.toNanos(), DurationUtils.asClampedNanos(smallDuration));
+
+        Duration mediumDuration = Duration.ofDays(5000);
+        assertEquals(mediumDuration.toNanos(), DurationUtils.asClampedNanos(mediumDuration));
+
+        // Note: Duration.of(500, YEARS) is not permitted because years don't have an exact duration
+        // We're happy with an estimated duration, so we're using this alternative construction for our very large durations
+        Duration largeDuration = YEARS.getDuration().multipliedBy(500);
+        assertEquals(Long.MAX_VALUE, DurationUtils.asClampedNanos(largeDuration));
+
+        Duration hugeDuration = MILLENNIA.getDuration().multipliedBy(7000);
+        assertEquals(Long.MAX_VALUE, DurationUtils.asClampedNanos(hugeDuration));
+
+        Duration negativeDuration = Duration.ofSeconds(-5);
+        assertEquals(negativeDuration.toNanos(), DurationUtils.asClampedNanos(negativeDuration));
+
+        Duration largeNegativeDuration = YEARS.getDuration().multipliedBy(-500);
+        assertEquals(Long.MIN_VALUE, DurationUtils.asClampedNanos(largeNegativeDuration));
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/RetryStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/RetryStateImplTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance20.state.impl;
 
-import static java.time.temporal.ChronoUnit.MILLENNIA;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -216,32 +215,6 @@ public class RetryStateImplTest {
 
         // Assert that getDelay didn't always return the same result
         assertThat(delayTimes.size(), greaterThan(1));
-    }
-
-    @Test
-    public void testClampedNanos() {
-        Duration tinyDuration = Duration.ofNanos(100);
-        assertEquals(tinyDuration.toNanos(), RetryStateImpl.asClampedNanos(tinyDuration));
-
-        Duration smallDuration = Duration.ofSeconds(5);
-        assertEquals(smallDuration.toNanos(), RetryStateImpl.asClampedNanos(smallDuration));
-
-        Duration mediumDuration = Duration.ofDays(5000);
-        assertEquals(mediumDuration.toNanos(), RetryStateImpl.asClampedNanos(mediumDuration));
-
-        // Note: Duration.of(500, YEARS) is not permitted because years don't have an exact duration
-        // We're happy with an estimated duration, so we're using this alternative construction for our very large durations
-        Duration largeDuration = YEARS.getDuration().multipliedBy(500);
-        assertEquals(Long.MAX_VALUE, RetryStateImpl.asClampedNanos(largeDuration));
-
-        Duration hugeDuration = MILLENNIA.getDuration().multipliedBy(7000);
-        assertEquals(Long.MAX_VALUE, RetryStateImpl.asClampedNanos(hugeDuration));
-
-        Duration negativeDuration = Duration.ofSeconds(-5);
-        assertEquals(negativeDuration.toNanos(), RetryStateImpl.asClampedNanos(negativeDuration));
-
-        Duration largeNegativeDuration = YEARS.getDuration().multipliedBy(-500);
-        assertEquals(Long.MIN_VALUE, RetryStateImpl.asClampedNanos(largeNegativeDuration));
     }
 
     @Test


### PR DESCRIPTION
Previously, the AsyncExecutor could not start the timeout until after it
had submitted the task, because the timeout callback requires the
ExecutionReference for the running task.

However, this meant that in rare cases the task could run, finish and
timeout.stop() could be called before timeout.start() was called.

To prevent this, we split the starting of the timeout and the setting of
the timeout callback. This allows the timeout to be started before
submitting the task and the callback to be set afterwards.

Also took the opportunity to tighten up the state handling logic in
Timeout to help ensure that any more incorrect handling of timeout
states will be caught.

Also fix message output from FT 2.0