### PR TITLE
Diagnostics for defect 249816 in the JDK

### DIFF
--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/fat/src/com/ibm/ws/webserver/plugin/utility/fat/PluginUtilityGenerateTest.java
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/fat/src/com/ibm/ws/webserver/plugin/utility/fat/PluginUtilityGenerateTest.java
@@ -77,9 +77,11 @@ public class PluginUtilityGenerateTest {
     public static void tearDown() throws Exception {
         try {
             if (localAccessServer.isStarted()) {
+                localAccessServer.dumpServer("localAccessServer");
                 localAccessServer.stopServer();
             }
             if (remoteAccessServer.isStarted()) {
+                remoteAccessServer.dumpServer("remoteAccessServer");
                 remoteAccessServer.stopServer();
             }
         } catch (Exception e) {

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/defaultServer/bootstrap.properties
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/defaultServer/bootstrap.properties
@@ -1,1 +1,3 @@
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:LogService=all:ClassLoadingService=all:SharedLibrary=all
+com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/defaultServer/jvm.options
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/defaultServer/jvm.options
@@ -1,0 +1,1 @@
+-verbose:class

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/localAccessServer/bootstrap.properties
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/localAccessServer/bootstrap.properties
@@ -1,1 +1,3 @@
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:LogService=all:ClassLoadingService=all:SharedLibrary=all
+com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/localAccessServer/jvm.options
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/localAccessServer/jvm.options
@@ -1,0 +1,1 @@
+-verbose:class

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/remoteAccessServer/bootstrap.properties
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/remoteAccessServer/bootstrap.properties
@@ -1,1 +1,3 @@
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:LogService=all:ClassLoadingService=all:SharedLibrary=all
+com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/remoteAccessServer/jvm.options
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/remoteAccessServer/jvm.options
@@ -1,0 +1,1 @@
+-verbose:class

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/remoteAccessServer/server.xml
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/publish/servers/remoteAccessServer/server.xml
@@ -27,11 +27,12 @@
 
 	<keyStore id="defaultTrustStore" password="Liberty"
 	           location="resources/security/trust.jks"/>  
-
+<!--
     <logging  traceSpecification="com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:GenericBNF=all:HTTPDispatcher=all"
                 traceFileName="trace.log"
                 maxFileSize="20"
                 maxFiles="10"
                 traceFormat="BASIC" />
+-->
 
 </server>


### PR DESCRIPTION
This enables verbose classloading, Liberty classloading trace,
and server dumps for the test where the failure is seen most often.

NOTE: these changes should be reverted once these diagnostics have
been provided to the JDK team.

Not a release bug - just diagnostics...