### PR TITLE
Revert "Update product and bundle version for release 19.0.0.1"

### DIFF
--- a/dev/cnf/resources/bnd/liberty-release.props
+++ b/dev/cnf/resources/bnd/liberty-release.props
@@ -1,13 +1,13 @@
 
 releaseTypeGA=true
 
-libertyBaseVersion=19.0.0
-libertyFixpackVersion=1
+libertyBaseVersion=18.0.0
+libertyFixpackVersion=4
 libertyServiceVersion=${libertyBaseVersion}.${libertyFixpackVersion}
 libertyBetaVersion=2018.12.0.0
 libertyRelease=${if;${releaseTypeGA};${libertyServiceVersion};${libertyBetaVersion}}
 
-libertyBundleMicroVersion=24
+libertyBundleMicroVersion=23
 copyrightBuildYear=2018
 buildID=${libertyRelease}-${buildLabel}
 productEdition=BASE_ILAN


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#5912

This is causing problems because some of the CL tests take the product version from a different place that hasn't been updated in master yet.  Will re-deliver when we figure out a better way.