### PR TITLE
ft_fat smooth over outlier timing glitch

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/faulttolerance.jar/src/com/ibm/ws/microprofile/faulttolerance_fat/util/ConnectRuntimeException.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/faulttolerance.jar/src/com/ibm/ws/microprofile/faulttolerance_fat/util/ConnectRuntimeException.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance_fat.util;
+
+/**
+ * Added to enable more flexibility to use Lambdas for Supplier<Connections>
+ */
+public class ConnectRuntimeException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ConnectRuntimeException(Exception e) {
+        super("ConnectException: " + e);
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Gordon Hutchison <gordon.hutchison@gmail.com>

This change is an attempt to discount errors that arise from a slow
period in underlying test hardware.

The basic idea is that is a timeout takes too long, the test will wait for a little
while and then take 10 timing measurements. Only if they take too long on
average will a test fail and a defect be raised.