### PR TITLE
Run tests on separate servers to prevent test failure

### DIFF
--- a/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.ConsoleFormatServer2/bootstrap.properties
+++ b/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.ConsoleFormatServer2/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.message.source=message,trace,accessLog,ffdc
+com.ibm.ws.logging.message.format=basic
+com.ibm.ws.logging.console.source=message,trace,accessLog,ffdc
+com.ibm.ws.logging.console.format=basic

--- a/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.ConsoleFormatServer2/server.xml
+++ b/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.ConsoleFormatServer2/server.xml
@@ -1,0 +1,27 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing Liberty logging in a server">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+	   <feature>jsp-2.2</feature>
+    </featureManager>
+    
+    <httpEndpoint id="defaultHttpEndpoint" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+        <accessLogging
+            filepath="${server.output.dir}/logs/http_defaultEndpoint_access.log"
+            logFormat='%h %u %t "%r" %s %b %D %{User-agent}i'>
+        </accessLogging>
+   	</httpEndpoint>
+    
+    <application location="LogstashApp.war"/>
+</server>

--- a/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.ConsoleFormatServer3/bootstrap.properties
+++ b/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.ConsoleFormatServer3/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.message.source=message,trace,accessLog,ffdc
+com.ibm.ws.logging.message.format=basic
+com.ibm.ws.logging.console.source=message,trace,accessLog,ffdc
+com.ibm.ws.logging.console.format=basic

--- a/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.ConsoleFormatServer3/server.xml
+++ b/dev/com.ibm.ws.logging.json_fat/publish/servers/com.ibm.ws.logging.json.ConsoleFormatServer3/server.xml
@@ -1,0 +1,27 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing Liberty logging in a server">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+	   <feature>jsp-2.2</feature>
+    </featureManager>
+    
+    <httpEndpoint id="defaultHttpEndpoint" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+        <accessLogging
+            filepath="${server.output.dir}/logs/http_defaultEndpoint_access.log"
+            logFormat='%h %u %t "%r" %s %b %D %{User-agent}i'>
+        </accessLogging>
+   	</httpEndpoint>
+    
+    <application location="LogstashApp.war"/>
+</server>


### PR DESCRIPTION
Console Log Format tests were failing when run out of order. Created separate servers for each test to prevent this test failure. 