### PR TITLE
Dump and restore output streams between unit tests

### DIFF
--- a/dev/com.ibm.ws.junit.extensions/src/test/common/SharedOutputManager.java
+++ b/dev/com.ibm.ws.junit.extensions/src/test/common/SharedOutputManager.java
@@ -604,6 +604,12 @@ public class SharedOutputManager implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
+                // dump and restore streams here to print out and reset stdout and stderr.  This is
+                // done to avoid intermittent ConcurrentModificationException we have seen in the 
+                // captureStreams() call below.
+                dumpStreams();
+                restoreStreams();
+
                 // capture stdout and stderr before every test
                 // Do not set any options here: allow a separate declaration 
                 // of the SharedOutputManager (such that logTo or traceTo can be driven)


### PR DESCRIPTION
We are intermittently seeing ConcurrentModificationExceptions thrown from captureStreams() in CapturedOutputHandler called from SharedOutputHandler apply() in the automated unit tests.  

This will dump and restore the output streams between each test, which will hopefully prevent that intermittent error.