### PR TITLE
Publish version props to repository

### DIFF
--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -297,12 +297,37 @@ task zipGradleBootstrap(type: Zip) {
     }
 }
 
+task libertyReleaseVersions {
+  inputs.file('resources/bnd/liberty-release.props')
+  outputs.file('build/liberty-versions.props')
+  doLast {
+    def libertyVersionsProps = new Properties()
+    libertyVersionsProps.setProperty('libertyBaseVersion', bnd('libertyBaseVersion'))
+    libertyVersionsProps.setProperty('libertyFixpackVersion', bnd('libertyFixpackVersion'))
+    libertyVersionsProps.setProperty('libertyServiceVersion', bnd('libertyServiceVersion'))
+    libertyVersionsProps.setProperty('libertyBetaVersion', bnd('libertyBetaVersion'))
+    libertyVersionsProps.setProperty('libertyRelease', bnd('libertyRelease'))
+    libertyVersionsProps.setProperty('libertyBundleMicroVersion', bnd('libertyBundleMicroVersion'))
+    File libertyVersionsPropsFile = file('build/liberty-versions.props')
+    libertyVersionsProps.store(libertyVersionsPropsFile.newWriter(), null)
+  }
+}
+
+publish {
+  dependsOn libertyReleaseVersions
+}
+
 publishing {
   publications {
     gradle(MavenPublication) {
         artifactId 'gradle-bootstrap'
         version project.version
         artifact zipGradleBootstrap
+    }
+    libertyVersions(MavenPublication) {
+        artifactId 'liberty-versions'
+        version project.version
+        artifact project.file('build/liberty-versions.props')
     }
   }
 }


### PR DESCRIPTION
We need to publish the product version info into the release repository, so the WebSphere Liberty build can pick up and use those same properties directly instead of having them set separately, which can cause problems with mismatches.