### PR TITLE
Ensure dynamic source polling tasks are cleaned up

### DIFF
--- a/dev/com.ibm.ws.microprofile.config/.classpath
+++ b/dev/com.ibm.ws.microprofile.config/.classpath
@@ -2,8 +2,16 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="resources"/>
-  <classpathentry kind="src" output="bin_test" path="test/src"/>
-  <classpathentry kind="src" output="bin_test" path="test/resources"/>
+	<classpathentry kind="src" output="bin_test" path="test/src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="bin_test" path="test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.config/test/src/com/ibm/ws/microprofile/config/classloader/test/ConfigCacheTest.java
+++ b/dev/com.ibm.ws.microprofile.config/test/src/com/ibm/ws/microprofile/config/classloader/test/ConfigCacheTest.java
@@ -71,12 +71,37 @@ public class ConfigCacheTest extends AbstractConfigTest {
             ConfigProviderResolver.instance().releaseConfig(configA);
             configB = ConfigProviderResolver.instance().getConfig();
             assertNotSame(configA, configB);
+            try {
+                configA.getPropertyNames();
+                fail("Released config not closed");
+            } catch (IllegalStateException e) {
+                // Expected
+            }
         } finally {
             if (configA != null) {
                 ConfigProviderResolver.instance().releaseConfig(configA);
             }
             if (configB != null && configB != configA) {
                 ConfigProviderResolver.instance().releaseConfig(configB);
+            }
+        }
+    }
+
+    @Test
+    public void testReleaseUnregisteredConfig() {
+        Config configA = null;
+        try {
+            configA = ConfigProviderResolver.instance().getBuilder().build();
+            ConfigProviderResolver.instance().releaseConfig(configA);
+            try {
+                configA.getPropertyNames();
+                fail("Released config not closed");
+            } catch (IllegalStateException e) {
+                // Expected
+            }
+        } finally {
+            if (configA != null) {
+                ConfigProviderResolver.instance().releaseConfig(configA);
             }
         }
     }

--- a/dev/com.ibm.ws.microprofile.config/test/src/com/ibm/ws/microprofile/config/dynamic/test/DynamicSourceCleanupTest.java
+++ b/dev/com.ibm.ws.microprofile.config/test/src/com/ibm/ws/microprofile/config/dynamic/test/DynamicSourceCleanupTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config.dynamic.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertNull;
+
+import java.lang.ref.WeakReference;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigBuilder;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.config.interfaces.ConfigConstants;
+import com.ibm.ws.microprofile.test.AbstractConfigTest;
+
+public class DynamicSourceCleanupTest extends AbstractConfigTest {
+
+    /**
+     * Test that a dynamic source stops being refreshed after it is no longer referenced
+     */
+    @Test
+    public void testDynamicSourceCleanup() throws InterruptedException {
+        long refreshInterval = 1000; //milliseconds
+        long extraInterval = 1000; //milliseconds
+
+        String key1 = "key1";
+        String value1 = "value1";
+
+        //create a config with a single entry and a polling interval of [refreshInterval] seconds
+        System.setProperty(ConfigConstants.DYNAMIC_REFRESH_INTERVAL_PROP_NAME, "" + refreshInterval);
+        TestDynamicConfigSource configSource = new TestDynamicConfigSource();
+        configSource.put(key1, value1);
+        configSource.getProperties();
+
+        ConfigBuilder builder = ConfigProviderResolver.instance().getBuilder();
+        builder.withSources(configSource);
+        Config config = builder.build();
+
+        long lastGetPropertiesTime = TestDynamicConfigSource.getPropertiesLastCalled;
+
+        // Ensure that the source is being refreshed
+        Thread.sleep(refreshInterval + extraInterval);
+        assertThat("Config source was not refreshed", TestDynamicConfigSource.getPropertiesLastCalled, not(equalTo(lastGetPropertiesTime)));
+
+        // Remove references to the config and wait for it to be garbage collected
+        WeakReference<Config> weakConfig = new WeakReference<>(config);
+        builder = null;
+        config = null;
+        long startGcTime = System.nanoTime();
+        long timeToWait = 10 * 1000 * 1000 * 1000; // Wait up to 10 seconds
+        while (weakConfig.get() != null && System.nanoTime() - startGcTime < timeToWait) {
+            System.gc();
+        }
+
+        assertNull("Config object was not garbage collected, likely memory leak", weakConfig.get());
+
+        // Check that once the config has been GC'd, the config source is no longer being periodically updated
+        Thread.sleep(refreshInterval);
+        lastGetPropertiesTime = TestDynamicConfigSource.getPropertiesLastCalled;
+
+        Thread.sleep(refreshInterval + extraInterval);
+        assertThat("Config source was refreshed after config was GC'd", TestDynamicConfigSource.getPropertiesLastCalled, equalTo(lastGetPropertiesTime));
+
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config/test/src/com/ibm/ws/microprofile/config/dynamic/test/TestDynamicConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config/test/src/com/ibm/ws/microprofile/config/dynamic/test/TestDynamicConfigSource.java
@@ -18,9 +18,12 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 @SuppressWarnings("serial")
 public class TestDynamicConfigSource extends ConcurrentHashMap<String, String> implements ConfigSource {
 
+    public static long getPropertiesLastCalled = 0L;
+
     /** {@inheritDoc} */
     @Override
     public ConcurrentMap<String, String> getProperties() {
+        getPropertiesLastCalled = System.nanoTime();
         return this;
     }
 

--- a/dev/com.ibm.ws.microprofile.config_fat/test-applications/dynamicSources.war/src/com/ibm/ws/microprofile/appConfig/dynamicSources/test/DynamicSourcesTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/test-applications/dynamicSources.war/src/com/ibm/ws/microprofile/appConfig/dynamicSources/test/DynamicSourcesTestServlet.java
@@ -10,6 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.appConfig.dynamicSources.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.fail;
+
 import javax.servlet.annotation.WebServlet;
 
 import org.eclipse.microprofile.config.Config;
@@ -167,6 +172,50 @@ public class DynamicSourcesTestServlet extends FATServlet {
             TestUtils.assertContains(config, "server_env_property", "server.env.value");
         } finally {
             ConfigProviderResolver.instance().releaseConfig(config);
+        }
+    }
+
+    @Test
+    public void testClosedConfigStopsRefreshing() throws Exception {
+        // Remember that the mimimum refresh is currently 500
+        System.setProperty(DYNAMIC_REFRESH_INTERVAL_PROP_NAME, "" + 1);
+        ConfigBuilder b = ConfigProviderResolver.instance().getBuilder();
+
+        MySource s1 = new MySource("MySource S1");
+        s1.setOrdinal(600);
+        s1.put("1", "1");
+
+        b.withSources(s1);
+        b.addDefaultSources();
+        Config config = b.build();
+
+        try {
+            TestUtils.assertContains(config, "1", "1");
+            TestUtils.assertContains(config, "server_env_property", "server.env.value");
+
+            long lastRefresh = s1.lastRefresh;
+
+            // Remember that the mimimum refresh is currently 500 ... so wait longer than that
+            Thread.sleep(1500);
+
+            // Check that config source is currently being refreshed
+            assertThat(s1.lastRefresh, not(equalTo(lastRefresh)));
+
+        } finally {
+            ConfigProviderResolver.instance().releaseConfig(config);
+        }
+
+        // Check that now that config has been closed, the config source is no longer being refreshed
+        long lastRefresh = s1.lastRefresh;
+        Thread.sleep(1500);
+        assertThat(s1.lastRefresh, equalTo(lastRefresh));
+
+        // Check that the config itself is actually closed
+        try {
+            config.getValue("1", String.class);
+            fail("get() on a released config should fail");
+        } catch (IllegalStateException e) {
+            // Expected
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.config_fat/test-applications/dynamicSources.war/src/com/ibm/ws/microprofile/appConfig/dynamicSources/test/DynamicSourcesTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/test-applications/dynamicSources.war/src/com/ibm/ws/microprofile/appConfig/dynamicSources/test/DynamicSourcesTestServlet.java
@@ -25,6 +25,7 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.junit.Test;
 
 import com.ibm.ws.microprofile.appConfig.test.utils.TestUtils;
+import com.ibm.ws.microprofile.config.interfaces.ConfigConstants;
 
 import componenttest.app.FATServlet;
 
@@ -196,7 +197,7 @@ public class DynamicSourcesTestServlet extends FATServlet {
             long lastRefresh = s1.lastRefresh;
 
             // Remember that the mimimum refresh is currently 500 ... so wait longer than that
-            Thread.sleep(1500);
+            Thread.sleep(ConfigConstants.MINIMUM_DYNAMIC_REFRESH_INTERVAL + 1000);
 
             // Check that config source is currently being refreshed
             assertThat(s1.lastRefresh, not(equalTo(lastRefresh)));

--- a/dev/com.ibm.ws.microprofile.config_fat/test-applications/dynamicSources.war/src/com/ibm/ws/microprofile/appConfig/dynamicSources/test/MySource.java
+++ b/dev/com.ibm.ws.microprofile.config_fat/test-applications/dynamicSources.war/src/com/ibm/ws/microprofile/appConfig/dynamicSources/test/MySource.java
@@ -24,6 +24,7 @@ public class MySource implements org.eclipse.microprofile.config.spi.ConfigSourc
     public ConcurrentMap<String, String> props;
     public int ordinal = 700;
     public String id = "mySource";
+    public long lastRefresh = 0L;
 
     public ConcurrentMap<String, String> getProps() {
         return props;
@@ -54,6 +55,7 @@ public class MySource implements org.eclipse.microprofile.config.spi.ConfigSourc
     /** {@inheritDoc} */
     @Override
     public ConcurrentMap<String, String> getProperties() {
+        lastRefresh = System.nanoTime();
         return props;
     }
 


### PR DESCRIPTION
1) Ensure that if a config is passed to releaseConfig(), it is closed
2) Ensure that if a config is GC'd, we cancel its polling tasks

Fixes #6036 