### PR TITLE
MP Concurrency impl should use translated messages

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletableFuture.java
@@ -204,7 +204,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Trivial
     public static <U> CompletableFuture<U> completedFuture(U value) {
-        throw new UnsupportedOperationException("Use ManagedExecutor.completedFuture instead"); // TODO NLS
+        throw new UnsupportedOperationException(Tr.formatMessage(tc, "CWWKC1156.not.supported", "ManagedExecutor.completedFuture"));
     }
 
     /**
@@ -235,7 +235,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Trivial
     public static <U> CompletionStage<U> completedStage(U value) {
-        throw new UnsupportedOperationException("Use ManagedExecutor.completedStage instead"); // TODO NLS
+        throw new UnsupportedOperationException(Tr.formatMessage(tc, "CWWKC1156.not.supported", "ManagedExecutor.completedStage"));
     }
 
     /**
@@ -286,7 +286,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Trivial
     public static <U> CompletableFuture<U> failedFuture(Throwable x) {
-        throw new UnsupportedOperationException("Use ManagedExecutor.failedFuture instead"); // TODO NLS
+        throw new UnsupportedOperationException(Tr.formatMessage(tc, "CWWKC1156.not.supported", "ManagedExecutor.failedFuture"));
     }
 
     /**
@@ -319,7 +319,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Trivial
     public static <U> CompletionStage<U> failedStage(Throwable x) {
-        throw new UnsupportedOperationException("Use ManagedExecutor.failedStage instead"); // TODO NLS
+        throw new UnsupportedOperationException(Tr.formatMessage(tc, "CWWKC1156.not.supported", "ManagedExecutor.failedStage"));
     }
 
     /**
@@ -370,7 +370,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Trivial
     public static CompletableFuture<Void> runAsync(Runnable action) {
-        throw new UnsupportedOperationException("Use ManagedExecutor.runAsync instead"); // TODO NLS
+        throw new UnsupportedOperationException(Tr.formatMessage(tc, "CWWKC1156.not.supported", "ManagedExecutor.runAsync"));
     }
 
     /**
@@ -412,7 +412,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      */
     @Trivial
     public static <U> CompletableFuture<U> supplyAsync(Supplier<U> action) {
-        throw new UnsupportedOperationException("Use ManagedExecutor.supplyAsync instead"); // TODO NLS
+        throw new UnsupportedOperationException(Tr.formatMessage(tc, "CWWKC1156.not.supported", "ManagedExecutor.supplyAsync"));
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
@@ -21,12 +21,16 @@ import org.eclipse.microprofile.concurrent.ManagedExecutor;
 import org.eclipse.microprofile.concurrent.ThreadContext;
 import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.threading.PolicyExecutor;
 
 /**
  * Builder that programmatically configures and creates ManagedExecutor instances.
  */
 class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
+    private static final TraceComponent tc = Tr.register(ManagedExecutorBuilderImpl.class);
+
     static final AtomicLong instanceCount = new AtomicLong();
 
     private final ConcurrencyProviderImpl concurrencyProvider;
@@ -123,7 +127,7 @@ class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
         overlap.retainAll(propagated);
         if (overlap.isEmpty()) // only possible if builder is concurrently modified during build
             throw new ConcurrentModificationException();
-        throw new IllegalStateException(overlap.toString()); // TODO NLS translated error message
+        throw new IllegalStateException(Tr.formatMessage(tc, "CWWKC1151.context.lists.overlap", overlap));
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/package-info.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/package-info.java
@@ -12,7 +12,7 @@
  * @version 1.0
  */
 @org.osgi.annotation.versioning.Version("1.0")
-@TraceOptions(traceGroup = "concurrent")
+@TraceOptions(traceGroup = "concurrent", messageBundle = "com.ibm.ws.concurrent.mp.resources.CWWKCMessages")
 package com.ibm.ws.concurrent.mp.context;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/package-info.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/package-info.java
@@ -12,7 +12,7 @@
  * @version 1.0
  */
 @org.osgi.annotation.versioning.Version("1.0")
-@TraceOptions(traceGroup = "concurrent")
+@TraceOptions(traceGroup = "concurrent", messageBundle = "com.ibm.ws.concurrent.mp.resources.CWWKCMessages")
 package com.ibm.ws.concurrent.mp;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -1932,7 +1932,7 @@ public class MPConcurrentTestServlet extends FATServlet {
         try {
             builder.build();
         } catch (IllegalStateException x) {
-            if (x.getMessage() == null || !x.getMessage().contains(ThreadContext.APPLICATION))
+            if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1151E") || !x.getMessage().contains(ThreadContext.APPLICATION))
                 throw x;
         }
 
@@ -1941,7 +1941,8 @@ public class MPConcurrentTestServlet extends FATServlet {
         try {
             builder.build();
         } catch (IllegalStateException x) {
-            if (x.getMessage() == null || !x.getMessage().contains(TestContextTypes.CITY) || !x.getMessage().contains(TestContextTypes.STATE))
+            if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1151E") || !x.getMessage().contains(TestContextTypes.CITY)
+                || !x.getMessage().contains(TestContextTypes.STATE))
                 throw x;
         }
 
@@ -1950,7 +1951,7 @@ public class MPConcurrentTestServlet extends FATServlet {
         try {
             builder.build();
         } catch (IllegalStateException x) {
-            if (x.getMessage() == null || !x.getMessage().contains(ThreadContext.ALL_REMAINING))
+            if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1151E") || !x.getMessage().contains(ThreadContext.ALL_REMAINING))
                 throw x;
         }
 
@@ -1994,7 +1995,7 @@ public class MPConcurrentTestServlet extends FATServlet {
         try {
             builder.build();
         } catch (IllegalStateException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("Country") || !x.getMessage().contains("Planet"))
+            if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1155E") || !x.getMessage().contains("Country") || !x.getMessage().contains("Planet"))
                 throw x;
         }
 
@@ -2004,7 +2005,7 @@ public class MPConcurrentTestServlet extends FATServlet {
         try {
             builder.build();
         } catch (IllegalStateException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("Galaxy"))
+            if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1155E") || !x.getMessage().contains("Galaxy"))
                 throw x;
         }
 
@@ -2565,12 +2566,16 @@ public class MPConcurrentTestServlet extends FATServlet {
                 fail("Should not be able to build when type to propagate does not exist: " +
                      builder.propagated("ContextType1ThatDoesNotExist").build());
             } catch (IllegalStateException x) {
+                if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1155E") || !x.getMessage().contains("ContextType1ThatDoesNotExist"))
+                    throw x;
             }
 
             try {
                 fail("Should not be able to build when type to clear does not exist: " +
                      builder.propagated(ThreadContext.SECURITY).cleared("ContextType2ThatDoesNotExist").build());
             } catch (IllegalStateException x) {
+                if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1155E") || !x.getMessage().contains("ContextType2ThatDoesNotExist"))
+                    throw x;
             }
 
             // builder is still usable
@@ -4173,7 +4178,7 @@ public class MPConcurrentTestServlet extends FATServlet {
         try {
             builder.build();
         } catch (IllegalStateException x) {
-            if (x.getMessage() == null || !x.getMessage().contains(TestContextTypes.CITY))
+            if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1152E") || !x.getMessage().contains(TestContextTypes.CITY))
                 throw x;
         }
 
@@ -4183,7 +4188,7 @@ public class MPConcurrentTestServlet extends FATServlet {
         try {
             builder.build();
         } catch (IllegalStateException x) {
-            if (x.getMessage() == null || !x.getMessage().contains(ThreadContext.ALL_REMAINING))
+            if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1152E") || !x.getMessage().contains(ThreadContext.ALL_REMAINING))
                 throw x;
         }
     }
@@ -4203,7 +4208,8 @@ public class MPConcurrentTestServlet extends FATServlet {
         try {
             builder.build();
         } catch (IllegalStateException x) {
-            if (x.getMessage() == null || !x.getMessage().contains("Township") || !x.getMessage().contains("Ward") || x.getMessage().contains("Precinct"))
+            if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1155E")
+                || !x.getMessage().contains("Township") || !x.getMessage().contains("Ward") || x.getMessage().contains("Precinct"))
                 throw x;
         }
 


### PR DESCRIPTION
Update MicroProfile Concurrency implementation to use the translatable messages that we previously created for it to use.