### PR TITLE
cleared context improperly cloned

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/MicroProfileClearedContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/MicroProfileClearedContextSnapshot.java
@@ -47,21 +47,23 @@ public class MicroProfileClearedContextSnapshot implements com.ibm.wsspi.threadc
     ));
 
     private final ArrayList<ThreadContextController> contextRestorers = new ArrayList<ThreadContextController>();
-    private final ArrayList<ThreadContextSnapshot> contextSnapshots = new ArrayList<ThreadContextSnapshot>();
+    private final ArrayList<ThreadContextSnapshot> contextSnapshots;
 
     MicroProfileClearedContextSnapshot(ConcurrencyManagerImpl concurrencyMgr) {
+        contextSnapshots = new ArrayList<ThreadContextSnapshot>();
         for (ThreadContextProvider provider : concurrencyMgr.contextProviders)
             if (!DO_NOT_CLEAR.contains(provider.getThreadContextType()))
                 contextSnapshots.add(provider.clearedContext(Collections.emptyMap()));
     }
 
+    // constructor for clone method
+    private MicroProfileClearedContextSnapshot(ArrayList<ThreadContextSnapshot> contextSnapshots) {
+        this.contextSnapshots = contextSnapshots; // shallow copy is okay here
+    }
+
     @Override
     public com.ibm.wsspi.threadcontext.ThreadContext clone() {
-        try {
-            return (com.ibm.wsspi.threadcontext.ThreadContext) super.clone();
-        } catch (CloneNotSupportedException x) {
-            throw new Error(x); // should be impossible
-        }
+        return new MicroProfileClearedContextSnapshot(contextSnapshots);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/servers/MPConcurrencyTCKServer/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/servers/MPConcurrencyTCKServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.trace.specification=*=info:concurrent=all


### PR DESCRIPTION
There is a bug in the clone method of 
com/ibm/ws/concurrent/mp/MicroProfileClearedContextSnapshot.java
where it makes a shallow copy of the restore context types, which are not supposed to be shared across snapshots.