### PR TITLE
only add java permissions if they exist

### DIFF
--- a/dev/com.ibm.ws.app.manager.module/src/com/ibm/ws/app/manager/module/internal/DeployedAppInfoBase.java
+++ b/dev/com.ibm.ws.app.manager.module/src/com/ibm/ws/app/manager/module/internal/DeployedAppInfoBase.java
@@ -512,8 +512,10 @@ public abstract class DeployedAppInfoBase extends SimpleDeployedAppInfoBase impl
 
             ArrayList<Permission> mergedPermissions = permissionManager.getEffectivePermissions(applicationInformation.getLocation());
             int count = mergedPermissions.size();
-            for (int i = 0; i < count; i++)
-                perms.add(mergedPermissions.get(i));
+            if (count > 0) {
+                for (int i = 0; i < count; i++)
+                    perms.add(mergedPermissions.get(i));
+            }
         }
 
         CodeSource codesource;


### PR DESCRIPTION
#6067 
Fix NPE that occurs when we attempt to add an empty list of permissions.
