### PR TITLE
Allow for FFDC from intentional exception raised by test

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/fat/src/com/ibm/ws/concurrent/mp/fat/tck/MPConcurrencyTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/fat/src/com/ibm/ws/concurrent/mp/fat/tck/MPConcurrencyTCKLauncher.java
@@ -15,6 +15,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -36,6 +37,7 @@ public class MPConcurrencyTCKLauncher {
         server.stopServer();
     }
 
+    @AllowedFFDC("java.lang.NegativeArraySizeException") // intentionally raised by test case to simulate failure during completion stage action
     @Test
     public void launchMPConcurrency10Tck() throws Exception {
         // TODO: Run this all the time once the MP Concurrency 1.0 TCK is finalized


### PR DESCRIPTION
The MP Concurrency TCK includes coverage of a tasks/actions that intentionally raises an exception, and this is causing an FFDC in the Liberty server logs, which is detected as a test failure.  Need to add the proper annotation indicating that FFDC for this exception should be allowed.