### PR TITLE
Update bnd files in order to remove warnings from build logs.

### DIFF
--- a/dev/com.ibm.jbatch.container/bnd.bnd
+++ b/dev/com.ibm.jbatch.container/bnd.bnd
@@ -81,8 +81,7 @@ Import-Package: com.ibm.jbatch.spi,\
 	javax.batch.*,\
 	org.xml.sax,\
 	*
-Private-Package: com.ibm.jbatch.container.*,\
-	com.ibm.jbatch.container.modelresolver.impl
+Private-Package: com.ibm.jbatch.container.*
 
 instrument.classesExcludes: com/ibm/jbatch/container/internal/resources/*.class
 

--- a/dev/com.ibm.jbatch.jsl.model/bnd.bnd
+++ b/dev/com.ibm.jbatch.jsl.model/bnd.bnd
@@ -41,7 +41,6 @@ Import-Package: com.ibm.jbatch.spi,\
 	javax.enterprise.inject.spi;resolution:=optional,\
 	javax.enterprise.inject;resolution:=optional,\
 	javax.inject;resolution:=optional,\
-	javax.batch.*,\
 	org.xml.sax,\
 	*
 

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
@@ -26,7 +26,6 @@ Export-Package: \
             org.eclipse.persistence.javax.persistence.osgi;version="2.0.16", \
             org.eclipse.persistence.jpa.config;version="2.0.16", \
             org.eclipse.persistence.sessions.serializers.kryo;version="2.0.16", \
-            org.eclipse.persistence.javax.*;version="2.0.16", \
             org.eclipse.persistence.internal.jpa.config.*;version="2.0.16", \
             org.eclipse.persistence.internal.jpa.metadata.graphs;version="2.0.16", \
             org.eclipse.persistence.internal.jpa.metadata.sop;version="2.0.16", \

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
@@ -26,7 +26,6 @@ Export-Package: \
             org.eclipse.persistence.javax.persistence.osgi;version="1.0.16", \
             org.eclipse.persistence.jpa.config;version="1.0.16", \
             org.eclipse.persistence.sessions.serializers.kryo;version="1.0.16", \
-            org.eclipse.persistence.javax.*;version="1.0.16", \
             org.eclipse.persistence.internal.jpa.config.*;version="1.0.16", \
             org.eclipse.persistence.internal.jpa.metadata.graphs;version="1.0.16", \
             org.eclipse.persistence.internal.jpa.metadata.sop;version="1.0.16", \

--- a/dev/com.ibm.websphere.javaee.jsf.2.2/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jsf.2.2/bnd.bnd
@@ -34,8 +34,7 @@ Export-Package: \
     javax.faces.validator;version="1.0.16", \
     javax.faces.view;version="1.0.16", \
     javax.faces.view.facelets;version="1.0.16", \
-    javax.faces.webapp;version="1.0.16", \
-    javax.faces.*
+    javax.faces.webapp;version="1.0.16"
 
 Include-Resource: \
     javax/faces=resources/javax/faces, \

--- a/dev/com.ibm.websphere.javaee.jsonb.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jsonb.1.0/bnd.bnd
@@ -34,5 +34,4 @@ instrument.disabled: true
 publish.wlp.jar.suffix: dev/api/spec
 
 -buildpath: \
-	${javac.bootclasspath.java6}, \
 	 javax.json.bind:javax.json.bind-api;version=1.0

--- a/dev/com.ibm.websphere.javaee.jsp.2.3/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jsp.2.3/bnd.bnd
@@ -33,6 +33,5 @@ instrument.disabled: true
 publish.wlp.jar.suffix: dev/api/spec
 
 -buildpath: \
-	${javac.bootclasspath.java6}, \
 	com.ibm.ws.javax.j2ee:servlet.jsp.resources;version=2.3, \
     javax.servlet.jsp-api;version=2.3.2.b01

--- a/dev/com.ibm.websphere.security/bnd.bnd
+++ b/dev/com.ibm.websphere.security/bnd.bnd
@@ -91,4 +91,4 @@ Service-Component: \
     commons-logging:commons-logging;version=1.1.1, \
     commons-codec:commons-codec;version=1.4, \
 	org.jmock:jmock-legacy;version=2.5.0, \
-	cglib:cglib-nodep;version=3.2.7, \
+	cglib:cglib-nodep;version=3.2.7

--- a/dev/com.ibm.ws.app.manager.lifecycle/bnd.bnd
+++ b/dev/com.ibm.ws.app.manager.lifecycle/bnd.bnd
@@ -16,8 +16,6 @@ Bundle-Name: WebSphere Application Manager Lifecycle
 Bundle-SymbolicName: com.ibm.ws.app.manager.lifecycle
 Bundle-Description: WebSphere Application Manager Lifecycle, version ${bVersion}
 
-Private-Package: com.ibm.ws.app.manager.lifecycle.internal
-
 Export-Package: com.ibm.wsspi.application.lifecycle
 
 -buildpath: \

--- a/dev/com.ibm.ws.app.manager_fat/bnd.bnd
+++ b/dev/com.ibm.ws.app.manager_fat/bnd.bnd
@@ -28,7 +28,6 @@ fat.project: true
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
 	com.ibm.ws.app.manager;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.cm;version=latest,\

--- a/dev/com.ibm.ws.clientcontainer.8.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.clientcontainer.8.0_fat/bnd.bnd
@@ -18,7 +18,7 @@ src: \
 	test-applications/CallbackHandlerNoDefaultConstructor.jar/src,\
 	test-applications/InAppClientContainer.jar/src,\
 	test-applications/SystemExitClient.jar/src,\
-	test-applications/SystemExitClientNoDD.jar/src,\
+	test-applications/SystemExitClientNoDD.jar/src
 
 javac.source: 1.8
 javac.target: 1.8

--- a/dev/com.ibm.ws.componenttest/bnd.bnd
+++ b/dev/com.ibm.ws.componenttest/bnd.bnd
@@ -58,8 +58,6 @@ test.project: true
     org.jboss.shrinkwrap:shrinkwrap-spi;version=1.2.3,\
     com.ibm.ws.componenttest:fat.util;version=1.0.0,\
     org.jmock:jmock;strategy=exact;version=2.5.1,\
-    org.hamcrest:hamcrest-all;version=1.3,\
-    com.ibm.ws.junit.extensions;version=latest,\
     com.ibm.websphere.javaee.servlet.3.0;version=latest,\
     com.ibm.websphere.org.osgi.core;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.config_fat/bnd.bnd
+++ b/dev/com.ibm.ws.config_fat/bnd.bnd
@@ -42,7 +42,6 @@ fat.project: true
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest, \
-	com.ibm.ws.componenttest:public.api;version=1.0.0, \
 	com.ibm.websphere.filetransfer;version=latest, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.wsspi.org.osgi.service.metatype;version=latest, \

--- a/dev/com.ibm.ws.dynamic.bundle/bnd.bnd
+++ b/dev/com.ibm.ws.dynamic.bundle/bnd.bnd
@@ -20,8 +20,6 @@ WS-TraceGroup: dynamicBundle
 
 Export-Package: com.ibm.ws.dynamic.bundle;provide:=true
 
-Private-Package: com.ibm.ws.dynamic.bundle.internal
-
 -buildpath: \
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.component,\

--- a/dev/com.ibm.ws.ejbcontainer.fat_tools/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.fat_tools/bnd.bnd
@@ -51,7 +51,6 @@ generate.replacement: true
 	com.ibm.ws.ejbcontainer.core; version=latest, \
 	com.ibm.ws.logging; version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations; version=latest, \
-	com.ibm.ws.ejbcontainer.core; version=latest, \
 	com.ibm.websphere.javaee.transaction.1.1; version=latest, \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.websphere.security; version=latest, \

--- a/dev/com.ibm.ws.el.3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.el.3.0_fat/bnd.bnd
@@ -13,7 +13,7 @@ bVersion=1.0
 
 src: \
     fat/src,\
-    test-applications/TestEL3.0.war/src,\
+    test-applications/TestEL3.0.war/src
 
 fat.project: true
 
@@ -27,4 +27,4 @@ fat.minimum.java.level: 1.7
 # fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
 -buildpath: \
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-    com.ibm.websphere.javaee.el.3.0;version=latest, 
+    com.ibm.websphere.javaee.el.3.0;version=latest

--- a/dev/com.ibm.ws.javamail.1.6_fat/bnd.bnd
+++ b/dev/com.ibm.ws.javamail.1.6_fat/bnd.bnd
@@ -22,7 +22,6 @@ javac.target: 1.8
 fat.project: true
 
 -buildpath: \
-  com.ibm.ws.componenttest:public.api;version=1.0.0,\
   com.ibm.websphere.javaee.servlet.4.0;version=latest,\
   com.ibm.websphere.javaee.mail.1.6;version=latest, \
   com.ibm.websphere.appserver.thirdparty.mail-1.6;version=latest, \

--- a/dev/com.ibm.ws.jaxrs.2.0.beanvalidation/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.beanvalidation/bnd.bnd
@@ -30,9 +30,7 @@ Import-Package: \
   javax.validation.executable.*;resolution:=optional;version="[1.1,2.1)", \
   javax.validation.*;version="[1.0,2.1)", \
   com.ibm.ws.jaxrs20.api, \
-  com.ibm.ws.jaxrs20.api.*, \
   com.ibm.ws.ffdc, \
-  com.ibm.ws.ffdc.*, \
   com.ibm.ws.beanvalidation.service, \
   com.ibm.ejs.util, \
   com.ibm.ws.runtime.metadata, \

--- a/dev/com.ibm.ws.jaxrs.2.0.security/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.security/bnd.bnd
@@ -31,8 +31,7 @@ Import-Package: \
   javax.net.ssl.*, \
   com.ibm.wsspi.ssl, \
   com.ibm.wsspi.kernel.service.utils, \
-  com.ibm.ws.jaxrs20.api, \
-  com.ibm.ws.jaxrs20.api.*, \
+  com.ibm.ws.jaxrs20.api
   
 # If you need use MESSAGE, you must enable this Private-Package, or message will translate wrong
 Private-Package:\

--- a/dev/com.ibm.ws.jaxrs.2.0.server/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/bnd.bnd
@@ -40,8 +40,7 @@ Include-Resource: OSGI-INF=resources/OSGI-INF
 IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 Private-Package:\
-   com.ibm.ws.jaxrs20.server.*, \
-   com.ibm.ws.jaxrs20.server
+   com.ibm.ws.jaxrs20.server.*
 
 -dsannotations: com.ibm.ws.jaxrs20.server.component.*
 

--- a/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.cdi.2.0_fat/bnd.bnd
@@ -14,7 +14,7 @@ bVersion=1.0
 src: \
   fat/src,\
   test-applications/atinjectapp/src,\
-  test-applications/interceptorapp/src,\
+  test-applications/interceptorapp/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.jaxrs.2.x.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.x.concurrent/bnd.bnd
@@ -24,11 +24,9 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 # but to maintain backwards compatibility we will allow it 
 Import-Package: \
   org.apache.cxf.*;version="[3.0.2,4)", \
-  com.ibm.websphere.*, \
-  javax.ws.rs.*, \
+  com.ibm.websphere.ras.*, \
   com.ibm.ws.jaxrs20.client, \
   com.ibm.ws.ffdc, \
-  com.ibm.ws.ffdc.*, \
   com.ibm.ws.concurrent, \
   com.ibm.wsspi.kernel.service.utils, \
   com.ibm.wsspi.threadcontext, \

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/bnd.bnd
@@ -24,4 +24,4 @@ javac.target: 1.8
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2;version=latest,\
   com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
-  com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+  com.ibm.websphere.javaee.servlet.3.1;version=latest

--- a/dev/com.ibm.ws.jaxws.ejb/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.ejb/bnd.bnd
@@ -47,13 +47,12 @@ Service-Component: \
      implementation:=com.ibm.ws.jaxws.ejb.EJBHandlerResolver; \
      provide:='com.ibm.wsspi.ejbcontainer.WSEJBHandlerResolver'; \
      configuration-policy:=optional; \
-     properties:="service.vendor=IBM", \
+     properties:="service.vendor=IBM"
 
 Export-Package: \
     com.ibm.ws.jaxws.ejb
 
 Import-Package: \
-   javax.xml.bind.*;version="[2.2,3)", \
    javax.xml.ws.*;version="[2.2,3)", \
    org.apache.cxf.*;version="[2.6.2,2.6.3)", \
    *

--- a/dev/com.ibm.ws.jaxws.security/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.security/bnd.bnd
@@ -35,7 +35,7 @@ Service-Component: \
   com.ibm.ws.jaxws.security.internal.JaxWsWebAppSecurityConfigurator; \
      implementation:=com.ibm.ws.jaxws.security.internal.JaxWsWebAppSecurityConfigurator; \
      provide:='com.ibm.ws.jaxws.webcontainer.JaxWsWebAppConfigurator'; \
-     properties:="service.vendor=IBM", \
+     properties:="service.vendor=IBM"
 
 Private-Package: com.ibm.ws.jaxws.security.internal, \
  com.ibm.ws.jaxws.security.internal.resources

--- a/dev/com.ibm.ws.jaxws.web/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.web/bnd.bnd
@@ -38,7 +38,7 @@ Service-Component: \
   com.ibm.ws.jaxws.web.jaxwsServletEndpointConfigurator; \
      implementation:=com.ibm.ws.jaxws.web.JaxWsServletEndpointConfigurator; \
      provide:='com.ibm.ws.jaxws.endpoint.JaxWsEndpointConfigurator'; \
-     properties:="service.vendor=IBM", \
+     properties:="service.vendor=IBM"
 
 Export-Package: \
     com.ibm.ws.jaxws.web
@@ -47,7 +47,6 @@ Import-Package: \
    com.ibm.wsspi.adaptable.module.adapters, \
    com.ibm.wsspi.webcontainer.collaborator, \
    com.ibm.ws.container.service.metadata, \
-   javax.xml.bind.*;version="[2.2,3)", \
    javax.xml.ws.*;version="[2.2,3)", \
    org.apache.cxf.*;version="[2.6.2,2.6.3)", \
    *

--- a/dev/com.ibm.ws.jaxws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.webcontainer/bnd.bnd
@@ -47,7 +47,6 @@ Export-Package: \
     com.ibm.ws.jaxws.webcontainer
 
 Import-Package: \
-   javax.xml.bind.*;version="[2.2,3)", \
    javax.xml.ws.*;version="[2.2,3)", \
    org.apache.cxf.*;version="[2.6.2,2.6.3)", \
    *

--- a/dev/com.ibm.ws.jaxws.wsat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.wsat/bnd.bnd
@@ -28,7 +28,6 @@ Import-Package: \
    javax.xml,\
    javax.xml.namespace,\
    org.osgi.framework;version="1.5.0",\
-   javax.xml.bind.*;version="[2.2,3)", \
    javax.xml.ws.*;version="[2.2,3)", \
    org.apache.cxf.*;version="[2.6.2,2.6.3)", \
    com.ibm.websphere.ras, \

--- a/dev/com.ibm.ws.jca.cm/bnd.bnd
+++ b/dev/com.ibm.ws.jca.cm/bnd.bnd
@@ -30,12 +30,9 @@ Import-Package: \
 
 Private-Package: \
     com.ibm.ejs.cm.logger, \
-	com.ibm.ejs.cm.pool, \
-	com.ibm.ejs.cm.portability, \
     com.ibm.ejs.j2c, \
 	com.ibm.websphere.ce.j2c, \
 	com.ibm.websphere.j2c, \
-	com.ibm.websphere.pmi.reqmetrics, \
 	com.ibm.ws.j2c, \
 	com.ibm.ws.j2c.poolmanager, \
 	com.ibm.ws.j2c.resources, \

--- a/dev/com.ibm.ws.jca_fat_example_anno/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_example_anno/bnd.bnd
@@ -20,12 +20,7 @@ fat.project: true
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	com.ibm.ws.junit.extensions;version=latest, \
-	org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3,\
-	fattest.simplicity;version=latest, \
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.websphere.javaee.connector.1.7;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
-	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-	com.ibm.ws.componenttest;version=latest
+	com.ibm.websphere.javaee.servlet.3.1;version=latest

--- a/dev/com.ibm.ws.jdbc/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc/bnd.bnd
@@ -37,7 +37,6 @@ Private-Package: \
     com.ibm.ejs.cm.logger, \
     com.ibm.websphere.ce.cm, \
     com.ibm.ws.jdbc.internal, \
-    com.ibm.ws.jdbc.internal.resources, \
     com.ibm.ws.jdbc.*, \
     com.ibm.ws.rsadapter.exceptions, \
     com.ibm.ws.rsadapter.resources

--- a/dev/com.ibm.ws.jmx.connector.client.rest/bnd.bnd
+++ b/dev/com.ibm.ws.jmx.connector.client.rest/bnd.bnd
@@ -27,8 +27,6 @@ Export-Package: \
 Import-Package: \
   javax.management.*, \
   com.ibm.json.java.*, \
-  com.ibm.ws.ffdc.*, \
-  com.ibm.websphere.ras.*, \
   com.ibm.ws.ssl.protocol, \
   javax.net.ssl
   

--- a/dev/com.ibm.ws.jndi.iiop/bnd.bnd
+++ b/dev/com.ibm.ws.jndi.iiop/bnd.bnd
@@ -30,8 +30,6 @@ Import-Package: \
  javax.rmi.*;version="[2.4,3.0)", \
  *
 
-Private-Package: com.ibm.ws.jndi.iiop.internal.*
-
 -dsannotations-inherit: true
 -dsannotations: com.ibm.ws.jndi.iiop.*UrlContextFactory
 

--- a/dev/com.ibm.ws.jpa.container.eclipselink/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.container.eclipselink/bnd.bnd
@@ -25,7 +25,6 @@ Export-Package: com.ibm.ws.jpa.container.eclipselink, \
 -buildpath: \
 	com.ibm.ws.jpa.container.core;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
-	com.ibm.ws.ras.instrument;version=latest,\
 	com.ibm.websphere.javaee.persistence.2.1;version=latest,\
 	com.ibm.websphere.appserver.thirdparty.eclipselink;version=latest,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\

--- a/dev/com.ibm.ws.jsf.2.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsf.2.3_fat/bnd.bnd
@@ -31,7 +31,6 @@ src: \
     test-applications/JSF23SelectOneRadioGroup.war/src,\
     test-applications/JSF23ViewParameters.war/src,\
     test-applications/StartupShutdownExternalContext.war/src,\
-    test-applications/ImportConstantsTag.war/src,\
     test-applications/PostRenderViewEvent.war/src,\
     test-applications/CDIManagedProperty.war/src,\
     test-applications/ELImplicitObjectsViaCDI.war/src,\
@@ -47,7 +46,7 @@ src: \
     test-applications/CDIInjectionTests.war/src,\
     test-applications/CDICommon/src,\
     test-applications/CDIConfigByACP.war/src,\
-    test-applications/CDIConfigByACP.jar/src,\
+    test-applications/CDIConfigByACP.jar/src
 
 fat.project: true
 
@@ -61,4 +60,4 @@ javac.target: 1.8
     com.ibm.websphere.javaee.jsf.2.3;version=latest,\
     com.ibm.websphere.javaee.validation.2.0;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
-    com.ibm.websphere.javaee.el.3.0;version=latest,\
+    com.ibm.websphere.javaee.el.3.0;version=latest

--- a/dev/com.ibm.ws.jsp.2.3/bnd.bnd
+++ b/dev/com.ibm.ws.jsp.2.3/bnd.bnd
@@ -85,7 +85,6 @@ instrument.classesIncludes: com/ibm/ws/jsp23/**/*.class
 instrument.classesExcludes: org/apache/**/*.class
 
 -buildpath: \
-	${javac.bootclasspath.java7}, \
 	com.ibm.websphere.appserver.spi.logging,\
 	com.ibm.ws.jsp;version=latest,\
 	com.ibm.ws.webcontainer;version=latest,\

--- a/dev/com.ibm.ws.kernel.boot_fat/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.boot_fat/bnd.bnd
@@ -23,12 +23,9 @@ test.classpath.wlp.include: api/spec/*.jar,api/ibm/*.jar
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	com.ibm.ws.junit.extensions;version=latest, \
 	org.hamcrest:hamcrest-all;version=1.3, \
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
-	fattest.simplicity;version=latest, \
-	com.ibm.ws.componenttest:public.api;version=1.0.0, \
 	org.apache.commons:commons-compress;version=1.18, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.websphere.org.osgi.service.cm;version=latest,\

--- a/dev/com.ibm.ws.logging/bnd.bnd
+++ b/dev/com.ibm.ws.logging/bnd.bnd
@@ -16,7 +16,6 @@ Bundle-Description: ${Bundle-Name}, version ${bVersion}
 Bundle-SymbolicName: com.ibm.ws.logging; singleton:=true
 
 Private-Package: \
- !com.ibm.ws.logging.internal.osgi.*,\
  com.ibm.ws.logging.*,\
  com.ibm.ws.collector.manager.internal.*,\
  com.ibm.wsspi.logprovider.*

--- a/dev/com.ibm.ws.logging_fat/accesslog.source.handler.bnd
+++ b/dev/com.ibm.ws.logging_fat/accesslog.source.handler.bnd
@@ -33,6 +33,4 @@ Service-Component: \
      executor=java.util.concurrent.ExecutorService; \
     modified:='modified'; \
     immediate:='true'; \
-    properties:="service.vendor=IBM", \
-    
- 
+    properties:="service.vendor=IBM"

--- a/dev/com.ibm.ws.logging_fat/bnd.bnd
+++ b/dev/com.ibm.ws.logging_fat/bnd.bnd
@@ -33,11 +33,9 @@ fat.project: true
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	com.ibm.ws.junit.extensions;version=latest, \
 	org.hamcrest:hamcrest-all;version=1.3, \
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
-	com.ibm.ws.componenttest:public.api;version=1.0.0, \
 	org.apache.commons:commons-compress;version=1.18, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.websphere.org.osgi.service.cm;version=latest,\

--- a/dev/com.ibm.ws.logging_fat/ffdc.source.handler.bnd
+++ b/dev/com.ibm.ws.logging_fat/ffdc.source.handler.bnd
@@ -32,6 +32,4 @@ Service-Component: \
      executor=java.util.concurrent.ExecutorService; \
     modified:='modified'; \
     immediate:='true'; \
-    properties:="service.vendor=IBM", \
-    
- 
+    properties:="service.vendor=IBM"

--- a/dev/com.ibm.ws.logging_fat/message.source.handler.bnd
+++ b/dev/com.ibm.ws.logging_fat/message.source.handler.bnd
@@ -32,6 +32,4 @@ Service-Component: \
      executor=java.util.concurrent.ExecutorService; \
     modified:='modified'; \
     immediate:='true'; \
-    properties:="service.vendor=IBM", \
-    
- 
+    properties:="service.vendor=IBM"

--- a/dev/com.ibm.ws.logging_fat/sample.source.handler.bnd
+++ b/dev/com.ibm.ws.logging_fat/sample.source.handler.bnd
@@ -38,5 +38,4 @@ Service-Component: \
     executor=java.util.concurrent.ExecutorService; \
     modified:='modified'; \
     immediate:='true'; \
-    properties:="service.vendor=IBM", \
-  
+    properties:="service.vendor=IBM"

--- a/dev/com.ibm.ws.logging_test/bnd.bnd
+++ b/dev/com.ibm.ws.logging_test/bnd.bnd
@@ -22,11 +22,6 @@ Bundle-Name: WebSphere Logging (RAS/FFDC) Unit Test
 Bundle-Description: ${Bundle-Name}, version ${bVersion}
 Bundle-SymbolicName: com.ibm.ws.logging.test; singleton:=true
 
-Private-Package: \
- !com.ibm.ws.logging.internal.osgi.*,\
- com.ibm.ws.logging.*,\
- com.ibm.wsspi.logprovider.*
-
 test.project: true
 
 -buildpath: \

--- a/dev/com.ibm.ws.management.j2ee/bnd.bnd
+++ b/dev/com.ibm.ws.management.j2ee/bnd.bnd
@@ -20,9 +20,6 @@ WS-TraceGroup: applications
 Export-Package: \
   com.ibm.websphere.management.j2ee
   
-Private-Package: \
-  com.ibm.ws.management.j2ee.mbeans.internal
-    
 Import-Package: \
   !*.internal.*, \
   *

--- a/dev/com.ibm.ws.messaging.runtime/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.runtime/bnd.bnd
@@ -38,12 +38,10 @@ Private-Package: com.ibm.ws.sib.admin.internal,\
  com.ibm.ws.sib.processor.impl.store.filters,\
  com.ibm.ws.sib.processor.impl.store.items,\
  com.ibm.ws.sib.processor.impl.store.itemstreams,\
- com.ibm.ws.sib.processor.impl.store.xarecovery,\
  com.ibm.ws.sib.processor.gd,\
  com.ibm.ws.sib.processor.gd.statestream,\
  com.ibm.ws.sib.processor.io,\
  com.ibm.ws.sib.processor.matching,\
- com.ibm.ws.sib.processor.messagecontrol,\
  com.ibm.ws.sib.processor.proxyhandler,\
  com.ibm.ws.sib.processor.runtime.anycast,\
  com.ibm.ws.sib.processor.utils,\
@@ -51,7 +49,6 @@ Private-Package: com.ibm.ws.sib.admin.internal,\
  com.ibm.ws.sib.processor.utils.index,\
  com.ibm.ws.sib.processor.utils.linkedlist,\
  com.ibm.ws.sib.processor.utils.linkedlist2,\
- com.ibm.ws.sib.core.selector,\
  com.ibm.ws.sib.matchspace.impl,\
  com.ibm.ws.sib.matchspace.selector.impl,\
  com.ibm.ws.sib.matchspace.tools

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/bnd.bnd
@@ -17,7 +17,7 @@ src: \
 	test-applications/serverXMLApp/resources,\
 	test-applications/mapEnvVarApp/src,\
 	test-applications/variableServerXMLApp/src,\
-	test-applications/duplicateInServerXMLApp/src,\
+	test-applications/duplicateInServerXMLApp/src
 
 javac.source: 1.8
 javac.target: 1.8

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat/bnd.bnd
@@ -13,7 +13,7 @@ bVersion=1.0
 
 src: \
 	fat/src,\
-	test-applications/variableResolutionApp/src,
+	test-applications/variableResolutionApp/src
 
 javac.source: 1.8
 javac.target: 1.8

--- a/dev/com.ibm.ws.microprofile.config_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config_fat/bnd.bnd
@@ -57,6 +57,5 @@ tested.features: mpConfig-1.1,\
         com.ibm.ws.microprofile.config;version=latest,\
         com.ibm.ws.microprofile.config.cdi;version=latest,\
         com.ibm.websphere.javaee.annotation.1.2;version=latest,\
-	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	com.ibm.ws.microprofile.config_repeat_tests;version=latest

--- a/dev/com.ibm.ws.microprofile.config_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
@@ -32,13 +32,8 @@ fat.project: true
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	com.ibm.ws.junit.extensions;version=latest, \
-	org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-impl-base;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-spi;version=1.2.3,\
-	fattest.simplicity;version=latest, \
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
-	com.ibm.ws.componenttest;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0;version=latest,\

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
@@ -29,13 +29,8 @@ tested.features: mpFaultTolerance-1.1,\
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	com.ibm.ws.junit.extensions;version=latest, \
-	org.jboss.shrinkwrap:shrinkwrap-api;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-impl-base;version=1.2.3,\
     org.jboss.shrinkwrap:shrinkwrap-spi;version=1.2.3,\
-	fattest.simplicity;version=latest, \
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
-	com.ibm.ws.componenttest;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.1;version=latest,\
@@ -45,5 +40,4 @@ tested.features: mpFaultTolerance-1.1,\
 	com.ibm.ws.security;version=latest,\
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
-	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest

--- a/dev/com.ibm.ws.microprofile.faulttolerance.metrics/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.metrics/bnd.bnd
@@ -50,5 +50,5 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
-	org.hamcrest:hamcrest-all;version=1.3, \
+	org.hamcrest:hamcrest-all;version=1.3
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.health/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health/bnd.bnd
@@ -81,7 +81,7 @@ testsrc: test/src
         com.ibm.ws.threading;version=latest,\
         com.ibm.ws.webcontainer;version=latest,\
         com.ibm.ws.org.apache.commons.lang3;version=latest,\
-        org.eclipse.osgi;version=latest,\
+        org.eclipse.osgi;version=latest
 
 -testpath: \
         ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/bnd.bnd
@@ -34,10 +34,8 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 # fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-	com.ibm.ws.junit.extensions;version=latest, \
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
-	com.ibm.ws.componenttest:public.api;version=1.0.0, \
 	org.apache.commons:commons-compress;version=1.18, \
 	com.ibm.websphere.rest.handler;version=latest, \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest, \

--- a/dev/com.ibm.ws.microprofile.metrics_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/bnd.bnd
@@ -33,10 +33,8 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 # fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
-	com.ibm.ws.junit.extensions;version=latest,\
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
 	org.jmock:jmock;strategy=exact;version=2.5.1,\
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
 	org.apache.commons:commons-compress;version=1.18,\
 	com.ibm.websphere.rest.handler;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 tested.features:\

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators.cdi/bnd.bnd
@@ -57,7 +57,6 @@ testsrc: test/src
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.ws.com.lightbend.microprofile.reactive.streams.zerodep;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
     com.ibm.websphere.org.eclipse.microprofile.reactive.streams.operators.1.0;version=latest, \
 	com.ibm.ws.logging.core;version=latest,\
 	com.ibm.ws.microprofile.reactive.streams.operators

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators/bnd.bnd
@@ -67,7 +67,6 @@ testsrc: test/src
   com.ibm.websphere.security;version=latest, \
   com.ibm.websphere.javaee.annotation.1.2;version=latest, \
   com.ibm.websphere.javaee.concurrent.1.0;version=latest, \
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
   com.ibm.ws.threading;version=latest
   
 -testpath: \

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/bnd.bnd
@@ -15,7 +15,7 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src,\
+	fat/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.mongo/bnd.bnd
+++ b/dev/com.ibm.ws.mongo/bnd.bnd
@@ -44,7 +44,7 @@ Service-Component: \
     greedy:='ssl,keyStoreService,mongoSslHelper';\
     properties:='\
       library.target=(id=unbound),\
-      ssl.target=(id=unbound)',\
+      ssl.target=(id=unbound)'
     
 -dsannotations=com.ibm.ws.mongo.internal.MongoDBService
 

--- a/dev/com.ibm.ws.monitor/bnd.bnd
+++ b/dev/com.ibm.ws.monitor/bnd.bnd
@@ -17,8 +17,7 @@ Bundle-Description: Monitoring framework; version=${bVersion}
 Export-Package: com.ibm.websphere.monitor.*;version=1.1.0, \
 	com.ibm.wsspi.pmi.*;version=1.1.0, \
 	com.ibm.websphere.pmi.*;version=1.1.0, \
-	com.ibm.ws.pmi.*;version=1.1.0, \
-	com.ibm.ws.pmi.factory.*;version=1.1.0 \
+	com.ibm.ws.pmi.*;version=1.1.0
 
 	
 Private-Package: com.ibm.ws.monitor.internal*, \
@@ -78,4 +77,4 @@ instrument.classesExcludes: \
 	com.ibm.ws.junit.extensions;version=latest, \
 	org.hamcrest:hamcrest-all;version=1.3, \
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
-	org.jmock:jmock;strategy=exact;version=2.5.1, \
+	org.jmock:jmock;strategy=exact;version=2.5.1

--- a/dev/com.ibm.ws.opentracing.1.1_fat/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/opentracing.mock.bnd
@@ -24,8 +24,6 @@ Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:='com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation'
                 
-Private-Package: com.ibm.ws.opentracing.mock.resources
-
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"

--- a/dev/com.ibm.ws.opentracing.1.2_fat/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.opentracing.1.2_fat/opentracing.mock.bnd
@@ -23,8 +23,6 @@ Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
 Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:='com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation'
-                
-Private-Package: com.ibm.ws.opentracing.mock.resources
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 

--- a/dev/com.ibm.ws.opentracing_fat/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.opentracing_fat/opentracing.mock.bnd
@@ -23,8 +23,6 @@ Bundle-Description:Opentracing mock Tracer, version ${bVersion}
 Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:="com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation"
-                
-Private-Package: com.ibm.ws.opentracing.mock.resources
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/bnd.bnd
@@ -27,7 +27,6 @@ javac.target: 1.8
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
   com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  com.ibm.ws.org.apache.cxf.cxf.core.3.2,\
   com.ibm.ws.jaxrs.2.0.common;version=latest,\
   com.ibm.ws.jaxrs.2.0.client;version=latest,\
   com.ibm.ws.logging.core;version=latest

--- a/dev/com.ibm.ws.persistence/bnd.bnd
+++ b/dev/com.ibm.ws.persistence/bnd.bnd
@@ -66,5 +66,4 @@ instrument.classesExcludes: com/ibm/wsspi/persistence/internal/PersistenceServic
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.websphere.appserver.api.authData;version=latest,\
 	com.ibm.tx.jta;version=latest,\
-	com.ibm.websphere.appserver.spi.kernel.service;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.websphere.appserver.spi.kernel.service;version=latest

--- a/dev/com.ibm.ws.repository.liberty/bnd.bnd
+++ b/dev/com.ibm.ws.repository.liberty/bnd.bnd
@@ -23,7 +23,6 @@ Export-Package: com.ibm.ws.repository.connections.liberty
 instrument.disabled: true
 
 -buildpath: \
-	${javac.bootclasspath.java6}, \
 	com.ibm.ws.kernel.boot.core;version=latest,\
 	com.ibm.ws.repository;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.request.probes/bnd.bnd
+++ b/dev/com.ibm.ws.request.probes/bnd.bnd
@@ -46,7 +46,7 @@ Service-Component:\
      com.ibm.ws.request.probe.RequestProbeIntrospector; \
         provide:=com.ibm.wsspi.logging.IntrospectableService; \
         implementation:=com.ibm.ws.request.probe.RequestProbeIntrospector; \
-        properties:="service.vendor=IBM", \
+        properties:="service.vendor=IBM"
 
 instrument.disabled: true
 

--- a/dev/com.ibm.ws.rest.handler/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler/bnd.bnd
@@ -27,7 +27,6 @@ Private-Package: \
   com.ibm.ws.rest.handler.internal.servlet, \
   com.ibm.ws.rest.handler.internal.helper, \
   com.ibm.ws.rest.handler.internal.service, \
-  com.ibm.ws.rest.handler.internal.cors, \
   com.ibm.ws.rest.handler.internal.resources.*
   
 Export-Package: \

--- a/dev/com.ibm.ws.runtime.update_fat/bnd.bnd
+++ b/dev/com.ibm.ws.runtime.update_fat/bnd.bnd
@@ -25,8 +25,6 @@ fat.project: true
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
     com.ibm.websphere.org.osgi.service.component;version=latest, \
-	com.ibm.ws.junit.extensions;version=latest,\
-	fattest.simplicity;version=latest,\
 	com.ibm.ws.runtime.update;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.threading;version=latest

--- a/dev/com.ibm.ws.security.common.jsonwebkey/bnd.bnd
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/bnd.bnd
@@ -57,8 +57,7 @@ instrument.classesExcludes: com/ibm/ws/security/common/jwk/internal/resources/*.
     com.ibm.ws.security.common;version=latest, \
     com.ibm.json4j;version=latest, \
     org.apache.httpcomponents:httpclient;version=4.3.1, \
-    org.apache.httpcomponents:httpcore;version=4.3, \
-    com.ibm.ws.webcontainer.security;version=latest
+    org.apache.httpcomponents:httpcore;version=4.3
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.common/bnd.bnd
@@ -31,8 +31,7 @@ Import-Package: \
  
 Private-Package: \
     com.ibm.ws.common.internal.encoder.*, \
-    com.ibm.ws.security.common.internal.*, \
-    com.ibm.ws.security.common.jwk.internal.*
+    com.ibm.ws.security.common.internal.*
 
 -dsannotations: com.ibm.ws.security.common.token.propagation.TokenPropagationHelper
 -dsannotations-inherit = true

--- a/dev/com.ibm.ws.security.credentials/bnd.bnd
+++ b/dev/com.ibm.ws.security.credentials/bnd.bnd
@@ -37,7 +37,7 @@ Service-Component: \
     optional:='credentialProvider,basicAuthCredentialProvider'; \
     multiple:='credentialProvider'; \
     dynamic:='credentialProvider,basicAuthCredentialProvider'; \
-    properties:="service.vendor=IBM", \
+    properties:="service.vendor=IBM"
 
 -dsannotations=com.ibm.ws.security.credentials.wscred.BasicAuthCredentialProvider, \
   com.ibm.ws.security.jwtsso.token.proxy.JwtSSOTokenHelper

--- a/dev/com.ibm.ws.security.fat.common.jwt/bnd.bnd
+++ b/dev/com.ibm.ws.security.fat.common.jwt/bnd.bnd
@@ -61,6 +61,5 @@ javac.target: 1.8
 	com.ibm.json4j;version=latest,\
 	com.ibm.ws.org.apache.commons.codec.1.4;version=latest,\
 	com.ibm.ws.org.glassfish.json.1.1, \
-	com.ibm.ws.org.jose4j.0.5.1;version=latest, \
-	com.ibm.json4j;version=latest
+	com.ibm.ws.org.jose4j.0.5.1;version=latest
     

--- a/dev/com.ibm.ws.security.jaas.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaas.common/bnd.bnd
@@ -79,7 +79,6 @@ instrument.classesExcludes: com/ibm/ws/security/jaas/common/internal/resources/*
 	com.ibm.ws.kernel.service,\
 	com.ibm.websphere.appserver.spi.kernel.service,\
 	com.ibm.ws.logging;version=latest,\
-	com.ibm.websphere.appserver.spi.kernel.service,\
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.wsspi.org.osgi.service.component.annotations,\

--- a/dev/com.ibm.ws.security.javaeesec/bnd.bnd
+++ b/dev/com.ibm.ws.security.javaeesec/bnd.bnd
@@ -84,6 +84,5 @@ Include-Resource: \
     com.ibm.ws.container.service;version=latest,\
     com.ibm.ws.security.registry;version=latest,\
     com.ibm.ws.org.apache.jasper.el.3.0;version=latest,\
-    com.ibm.ws.container.service;version=latest,\
     com.ibm.ws.adaptable.module;version=latest
     

--- a/dev/com.ibm.ws.security.javaeesec_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.javaeesec_fat/bnd.bnd
@@ -52,8 +52,6 @@ fat.project: true
 -buildpath: \
 	org.apache.httpcomponents:httpclient;strategy=exact;version=4.1.2,\
 	org.apache.httpcomponents:httpcore;strategy=exact;version=4.1.2,\
-	fattest.simplicity;version=latest,\
-	com.ibm.ws.componenttest:public.api;version=1.0.0,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	com.ibm.websphere.javaee.el.3.0;version=latest,\

--- a/dev/com.ibm.ws.security.jwtsso.token/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwtsso.token/bnd.bnd
@@ -48,7 +48,7 @@ Private-Package: \
     com.ibm.ws.security.jwt;version=latest, \
     com.ibm.ws.security.mp.jwt;version=latest, \
 	com.ibm.ws.security.jwtsso;version=latest, \
-	com.ibm.ws.security.token;version=latest, \
+	com.ibm.ws.security.token;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.jwtsso/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwtsso/bnd.bnd
@@ -77,8 +77,6 @@ Include-Resource: \
 	com.ibm.ws.security.common;version=latest,\
 	com.ibm.ws.security.common.jsonwebkey;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest, \
-	com.ibm.websphere.org.osgi.service.component;version=latest, \
-	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.json4j;version=latest,\
     com.ibm.websphere.org.eclipse.microprofile.jwt.1.0;version=latest, \

--- a/dev/com.ibm.ws.security.quickstart/bnd.bnd
+++ b/dev/com.ibm.ws.security.quickstart/bnd.bnd
@@ -51,4 +51,4 @@ instrument.classesExcludes: com/ibm/ws/security/quickstart/internal/resources/*.
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
 	cglib:cglib-nodep;version=3.2.7, \
 	com.ibm.ws.kernel.boot;version=latest, \
-	com.ibm.ws.crypto.passwordutil;version=latest, \
+	com.ibm.ws.crypto.passwordutil;version=latest

--- a/dev/com.ibm.ws.security.registry.basic/bnd.bnd
+++ b/dev/com.ibm.ws.security.registry.basic/bnd.bnd
@@ -63,4 +63,4 @@ instrument.classesExcludes: com/ibm/ws/security/registry/basic/internal/resource
 	cglib:cglib-nodep;version=3.2.7, \
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.kernel.service;version=latest, \
-	com.ibm.ws.crypto.passwordutil;version=latest, \
+	com.ibm.ws.crypto.passwordutil;version=latest

--- a/dev/com.ibm.ws.security.registry/bnd.bnd
+++ b/dev/com.ibm.ws.security.registry/bnd.bnd
@@ -60,4 +60,4 @@ instrument.classesExcludes: com/ibm/ws/security/registry/internal/resources/*.cl
 	org.jmock:jmock-legacy;version=2.5.0, \
 	com.ibm.ws.org.objenesis:objenesis;version=1.0, \
 	cglib:cglib-nodep;version=3.2.7, \
-	com.ibm.ws.kernel.boot;version=latest, \
+	com.ibm.ws.kernel.boot;version=latest

--- a/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
+++ b/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
@@ -88,4 +88,4 @@ instrument.classesExcludes: com/ibm/ws/security/token/ltpa/internal/resources/*.
 	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.kernel.service.location;version=latest, \
-	com.ibm.ws.crypto.passwordutil;version=latest, \
+	com.ibm.ws.crypto.passwordutil;version=latest

--- a/dev/com.ibm.ws.threading/bnd.bnd
+++ b/dev/com.ibm.ws.threading/bnd.bnd
@@ -24,8 +24,7 @@ Export-Package: com.ibm.ws.threading;provide:=true, \
                 com.ibm.ws.threading.listeners
 
 Private-Package: com.ibm.ws.threading.internal, \
-    com.ibm.ws.threading.internal.resources, \
-    com.ibm.ws.threading.statistics
+    com.ibm.ws.threading.internal.resources
 
 Service-Component=com.ibm.ws.threading.internal.DeferrableScheduledExecutorImpl; \
         implementation:=com.ibm.ws.threading.internal.DeferrableScheduledExecutorImpl; \

--- a/dev/com.ibm.ws.transport.http/bnd.bnd
+++ b/dev/com.ibm.ws.transport.http/bnd.bnd
@@ -33,8 +33,6 @@ IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 Export-Package: \
     com.ibm.wsspi.genericbnf*;provide:=true, \
     com.ibm.wsspi.http*;provide:=true, \
-    com.ibm.wsspi.http.ee7*;provide:=true, \
-    com.ibm.wsspi.http.ee8*;provide:=true, \
     com.ibm.ws.transport.access*;provide:=true, \
     com.ibm.ws.genericbnf, \
     com.ibm.ws.http.dispatcher.classify, \
@@ -45,11 +43,7 @@ Export-Package: \
 
 Private-Package: \
 	com.ibm.ws.http.*, \
-	com.ibm.ws.http.dispatcher*, \
-	com.ibm.ws.http.channel*, \
-	com.ibm.ws.http.logging.internal, \
-	com.ibm.ws.genericbnf.internal, \
-	com.ibm.ws.http.dispatcher.classify
+	com.ibm.ws.genericbnf.internal
 
 -dsannotations: com.ibm.ws.http.channel.internal.inbound.HttpPipelineEventHandler,\
   com.ibm.ws.http.dispatcher.internal.HttpDispatcher,\

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1.factories/bnd.bnd
@@ -42,7 +42,7 @@ Service-Component: \
  
 Private-Package: \
  com.ibm.ws.webcontainer31.async.factory, \
- com.ibm.ws.webcontainer31.container.config.factory, \
+ com.ibm.ws.webcontainer31.osgi.container.config.factory, \
  com.ibm.ws.webcontainer31.osgi.response.factory, \
  com.ibm.ws.webcontainer31.osgi.srt.factory, \
  com.ibm.ws.webcontainer31.osgi.webapp.factory, \

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/bnd.bnd
@@ -28,7 +28,6 @@ Export-Package: !*.internal.*, \
     com.ibm.ws.webcontainer40.osgi.webapp*, \
     com.ibm.ws.webcontainer40.servlet*, \
     com.ibm.ws.webcontainer40.srt*, \
-    com.ibm.ws.webcontainer40.srt.http*, \
     com.ibm.wsspi.webcontainer40.util*
 
 Private-Package: \

--- a/dev/com.ibm.ws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer/bnd.bnd
@@ -91,7 +91,6 @@ Export-Package: !*.internal.*, \
     com.ibm.ws.webcontainer;provide:=true, \
     com.ibm.ws.webcontainer.session*;provide:=true, \
     com.ibm.ws.webcontainer.webapp;provide:=true, \
-    com.ibm.ws.webcontainer.upgrade*, \
     com.ibm.ws.webcontainer.servlet, \
     com.ibm.ws.webcontainer.spiadapter.collaborator, \
     com.ibm.ws.container
@@ -100,13 +99,10 @@ Private-Package: \
 	com.ibm.websphere.csi, \
 	com.ibm.websphere.security, \
 	com.ibm.ejs.j2c, \
-	com.ibm.servlet.util, \
-	com.ibm.ws.app.framework.webcontainer.internal*, \
 	com.ibm.ws.http, \
 	com.ibm.ws.webcontainer.osgi.container*, \
 	com.ibm.ws.webcontainer.osgi*, \
 	com.ibm.ws.security.core, \
-	com.ibm.ws.security.util, \
 	!com.ibm.ws.webcontainer.httpsession, \
 	!com.ibm.websphere.servlet.session, \
 	com.ibm.ws.webcontainer*, \

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/bnd.bnd
@@ -12,6 +12,6 @@
 bVersion=1.0
 
 src: \
-	fat/src,\
+	fat/src
 	
 fat.project: true

--- a/dev/wlp-generateRepositoryContent/bnd.bnd
+++ b/dev/wlp-generateRepositoryContent/bnd.bnd
@@ -11,22 +11,12 @@ Private-Package: \
  com.ibm.ws.wlp.repository.esa, \
  com.ibm.ws.wlp.repository.treehandler, \
  com.ibm.ws.wlp.repository.xml, \
- com.ibm.ejs.ras, \
- com.ibm.websphere.logging, \
- com.ibm.websphere.ras, \
- com.ibm.websphere.ras.annotation, \
- com.ibm.ws.ffdc, \
  com.ibm.ws.kernel.boot.cmdline, \
  com.ibm.ws.kernel.feature, \
- com.ibm.ws.kernel.feature.internal.cmdline, \
- com.ibm.ws.kernel.feature.internal.generator, \
  com.ibm.ws.kernel.feature.internal.subsystem, \
  com.ibm.ws.kernel.feature.provisioning, \
  com.ibm.ws.kernel.provisioning, \
  com.ibm.wsspi.kernel.feature, \
- com.ibm.ws.logging.internal, \
- com.ibm.wsspi.logprovider, \
- org.apache.aries.util.manifest, \
  org.osgi.framework
 
 Include-Resource: \

--- a/dev/wlp.lib.extract_fat/bnd.bnd
+++ b/dev/wlp.lib.extract_fat/bnd.bnd
@@ -21,10 +21,8 @@ fat.project: true
 	com.ibm.ws.kernel.feature
 
 -buildpath: \
-	fattest.simplicity;version=latest, \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest, \
-	com.ibm.ws.junit.extensions;version=latest, \
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.websphere.org.osgi.service.component;version=latest, \
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest


### PR DESCRIPTION
- Remove extra commas at the end of a property causing Empty clause
warnings
- Remove duplicate classpath entries in buildpath causing Duplicate name
warnings.
- Remove non existent packages for Private package, Import package and Export package to
remove Unused warnings.
