### PR TITLE
Update connection wait timeout exception to include number of waiting requests and the total connection count

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
@@ -367,9 +367,9 @@ public final class FreePool implements JCAPMIHelper {
      * - If removeFromFreePool is false, the mcWrapper do not exist in the free pool
      *
      * @param Managed connection wrapper
-     * @param Remove from free pool
-     * @param Are we already synchronized on the freeLockObject
-     * @param Skip waiter notify
+     * @param Remove  from free pool
+     * @param Are     we already synchronized on the freeLockObject
+     * @param Skip    waiter notify
      * @param Cleanup and Destroy MCWrapper
      * @pre mcWrapper != null
      * @throws ClassCastException
@@ -1182,7 +1182,9 @@ public final class FreePool implements JCAPMIHelper {
                                      tc,
                                      "POOL_MANAGER_EXCP_CCF2_0001_J2CA0045",
                                      new Object[] { "createOrWaitForConnection", gConfigProps.cfName });
-                            ConnectionWaitTimeoutException cwte = new ConnectionWaitTimeoutException("Connection not available, Timed out waiting for " + totalTimeWaited);
+                            ConnectionWaitTimeoutException cwte = new ConnectionWaitTimeoutException("Connection not available, Timed out waiting for " + totalTimeWaited +
+                                                                                                     " with current waiting requests " + pm.waiterCount +
+                                                                                                     " and current total connections used " + pm.totalConnectionCount.get());
                             /*
                              * The new ffdc prossException has a dependency on the DiagnosticModuleForJ2C and should not
                              * be changed without making the same changes in the Dia...J2C.


### PR DESCRIPTION
For improved serviceability and consumability providing the number of waiting threads with the total connection count may avoid requiring trace for tuning recommendations.   If only a few connection wait timeouts are occurring, if the waiting threads numbers are low, increasing the maximum connections by just a few connections may be enough to avoid the connection wait timeouts.  If the waiting threads numbers are high relative to the total connections, then several considerations may be required to fix the problem correctly.  When the waiting thread numbers are high, database performance, network performance, number of threads using the datasource and any other performance related issue around connections will need to be reviewed.
