### PR TITLE
CompletableFuture unaware of executor shutdown and other abort paths

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletionStage.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletionStage.java
@@ -13,10 +13,8 @@ package com.ibm.ws.concurrent.mp;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import com.ibm.websphere.ras.Tr;
@@ -53,7 +51,7 @@ class ManagedCompletionStage<T> extends ManagedCompletableFuture<T> {
      * @param executor default asynchronous execution facility for this stage
      * @param futureRef reference to a policy executor Future that will be submitted if requested to run async. Otherwise null.
      */
-    ManagedCompletionStage(CompletableFuture<T> completableFuture, Executor executor, AtomicReference<Future<?>> futureRef) {
+    ManagedCompletionStage(CompletableFuture<T> completableFuture, Executor executor, FutureRefExecutor futureRef) {
         super(completableFuture, executor, futureRef);
     }
 
@@ -152,7 +150,7 @@ class ManagedCompletionStage<T> extends ManagedCompletableFuture<T> {
     @Override
     @SuppressWarnings("hiding")
     @Trivial
-    <T> CompletableFuture<T> newInstance(CompletableFuture<T> completableFuture, Executor managedExecutor, AtomicReference<Future<?>> futureRef) {
+    <T> CompletableFuture<T> newInstance(CompletableFuture<T> completableFuture, Executor managedExecutor, FutureRefExecutor futureRef) {
         return new ManagedCompletionStage<T>(completableFuture, managedExecutor, futureRef);
     }
 

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -3429,7 +3429,8 @@ public class MPConcurrentTestServlet extends FATServlet {
                 fail("second task from executor 2 should be canceled/interrupted due to shutdown. Instead result is: " + cf2b.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
             } catch (CancellationException x) {
             } catch (ExecutionException x) {
-                if (!(x.getCause() instanceof InterruptedException))
+                if (!(x.getCause() instanceof InterruptedException) &&
+                    !(x.getCause() instanceof CancellationException)) // behavior of java.util.concurrent.CompletableFuture
                     throw x;
             }
 

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -16,8 +16,10 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 
@@ -281,6 +283,20 @@ public interface PolicyExecutor extends ExecutorService {
      * @throws IllegalStateException if the executor has been shut down.
      */
     PolicyExecutor startTimeout(long ms);
+
+    /**
+     * Submit a Runnable task that performs a CompletableFuture action.
+     * The CompletableFuture might be unavailable when this method is invoked and can be
+     * supplied at a later time by setting the value of the AtomicReference.
+     * The PolicyExecutor automatically cancels the CompeletableFuture if it is
+     * available at the time when the PolicyTaskFuture is canceled.
+     *
+     * @param completableFutureRef reference to a CompletableFuture that the PolicyExecutor should
+     *            automatically cancel upon cancellation of the returned future.
+     * @param task the task to run
+     * @return future for the task.
+     */
+    PolicyTaskFuture<Void> submit(AtomicReference<Future<?>> completableFutureRef, Runnable task);
 
     /**
      * Submit a Callable task with a callback to be invoked at various points in the task's life cycle.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -1238,6 +1238,13 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     }
 
     @Override
+    public PolicyTaskFuture<Void> submit(AtomicReference<Future<?>> completableFutureRef, Runnable task) {
+        PolicyTaskFutureImpl<Void> policyTaskFuture = new PolicyTaskFutureImpl<Void>(this, task, completableFutureRef, startTimeout);
+        enqueue(policyTaskFuture, maxWaitForEnqueueNS.get(), null);
+        return policyTaskFuture;
+    }
+
+    @Override
     public <T> Future<T> submit(Callable<T> task) {
         PolicyTaskFutureImpl<T> policyTaskFuture = new PolicyTaskFutureImpl<T>(this, task, null, startTimeout);
         enqueue(policyTaskFuture, maxWaitForEnqueueNS.get(), null);
@@ -1416,5 +1423,4 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         }
         out.println();
     }
-
 }


### PR DESCRIPTION
CompletableFutures created by a ManagedExecutor which are still queued for execution are unaware when shutdownNow is invoked on the executor.  This causes the CompletableFutures (plus dependent stages) to remain incomplete even though they will never be able to run.  This pull adds the necessary code so that these CompletableFutures can be reliably canceled/aborted for the Java 11 implementation, and cancel/aborted on a best effort basis for the Java 8 implementation.