### PR TITLE
Reapply "Dump and restore output streams between unit tests""

### DIFF
--- a/dev/com.ibm.ws.junit.extensions/src/test/common/SharedOutputManager.java
+++ b/dev/com.ibm.ws.junit.extensions/src/test/common/SharedOutputManager.java
@@ -604,6 +604,12 @@ public class SharedOutputManager implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
+                // dump and restore streams here to print out and reset stdout and stderr.  This is
+                // done to avoid intermittent ConcurrentModificationException we have seen in the 
+                // captureStreams() call below.
+                dumpStreams();
+                restoreStreams();
+
                 // capture stdout and stderr before every test
                 // Do not set any options here: allow a separate declaration 
                 // of the SharedOutputManager (such that logTo or traceTo can be driven)


### PR DESCRIPTION
This reverts commit 8b4d54ae1d3ebbf17a4b285990481c3368a6cb42.

Reapplying #6030, which was reverted under #6091 because it was thought to be causing a unit test OOM in the builds.  It turned out to not be the problem.