### PR TITLE
Add cnf:checkForUpdates task to check for artifact updates on Maven Central

### DIFF
--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -401,6 +401,81 @@ task printProjectDependencies() {
     }
 }
 
+task checkForUpdates() {
+  doLast {
+    def xmlParser = new XmlSlurper()
+    int totalArtifacts = 0
+    int possibleUpdates = 0
+    file('oss_dependencies.maven').eachLine { line ->
+      line = line.trim()
+      if (line.startsWith('#'))
+        return;
+      totalArtifacts++
+      def (g,a,v) = line.split(':').collect { it.trim() }
+      g = g.replace('.','/')
+      println '### g=' + g + '   a=' + a + '  v=' + v
+      println '  checking http://central.maven.org/maven2/' + g + '/' + a + '/maven-metadata.xml'
+      def response = new URL('http://central.maven.org/maven2/' + g + '/' + a + '/maven-metadata.xml').text
+      def mavenMetadata = xmlParser.parseText(response)
+      VersionString currentVersion = new VersionString(v)
+      VersionString possibleUpdate = currentVersion;
+      // Look for a MINOR or MICRO version update (within current MAJOR version)
+      mavenMetadata.versioning.versions.version.each { rawVersion ->
+         VersionString version = new VersionString(rawVersion.text())
+         if (currentVersion.major == version.major && version.isNewerThan(possibleUpdate)) {
+           possibleUpdate = version;
+         }
+      }
+      if (!possibleUpdate.raw.equals(currentVersion.raw)) {
+        println '  current version: ' + v
+        println '  latest released: ' + mavenMetadata.versioning.release
+        println '  found possible update at version=' + possibleUpdate.raw
+        possibleUpdates++;
+      }
+    }
+    println 'Found ' + possibleUpdates + ' possible MINOR/MICRO version updates out of ' + totalArtifacts + ' total artifacts.'
+  }
+}
+
+class VersionString {
+
+  String raw
+  Integer major = 0
+  Integer minor = 0
+  Integer micro = 0
+  String qualifier = ''
+
+  VersionString(String version) {
+    raw = version
+    def versionParts = version.split('\\.')
+    major = parseVersion(versionParts[0])
+    if (versionParts.length > 1)
+      minor = parseVersion(versionParts[1])
+    if (versionParts.length > 2)
+      micro = parseVersion(versionParts[2])
+    if (versionParts.length > 3)
+      qualifier = versionParts[3]
+  }
+
+  Integer parseVersion(String versionPart) {
+    try {
+      return Integer.valueOf(versionPart)
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  boolean isNewerThan(VersionString other) {
+    if (major > other.major)
+      return true;
+    if (major == other.major && minor > other.minor)
+      return true;
+    if (major == other.major && minor == other.minor && micro > other.micro)
+      return true;
+    return false;
+  }
+}
+
 List nextPivot(Map dependencyMap, Set seenProjects) {
     List buildableProjects = new ArrayList()
     dependencyMap.keySet().each { item ->

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -437,6 +437,32 @@ task checkForUpdates() {
   }
 }
 
+task updateArtifact() {
+  doLast {
+    String mavenCoords = System.getProperty('mavenCoords');
+    String toVersion = System.getProperty('toVersion');
+     if (mavenCoords == null || System.getProperty('toVersion') == null) {
+       throw new InvalidUserDataException('Missing required arguments.\nExample usage:\n' +
+         './gradlew cnf:updateArtifact -DmavenCoords=org.apache.commons:commons-lang3:1.0 -DtoVersion=2.0');
+     }
+     def (group, artifact, version) = mavenCoords.split(':').collect { it.trim() }
+     println 'Updating GROUP=' + group + '  ARTIFACT=' + artifact + '  VERSION=' + version + ' --> ' + toVersion
+     // Update maven, gradle, and bnd files
+     String regex = '((' + group + '[\\.:]' + artifact + '):?;?(version=)?)(' + version + ')'
+     println 'Using regex: ' + regex
+     rootProject.fileTree(dir: '.', includes: ['**/*.maven', '**/*.gradle', '**/*.bnd', '**/bnd.*']).each{file ->
+       ant.replaceregexp(match: regex,
+                         replace: '\\1' + toVersion, 
+                         file: file, flags: 'g', byline: true)
+     }
+     // Update BND files
+     //rootProject.fileTree(dir: '.', includes: []).each{file ->
+     //  ant.replaceregexp(match: group + ':' + artifact + ';' + version, replace: group + ':' + artifact + ';' + toVersion, file: file, flags: 'g', byline: true)
+     //  ant.replaceregexp(match: group + ':' + artifact + ';version=' + version, replace: group + ':' + artifact + ';version=' + toVersion, file: file, flags: 'g', byline: true)
+    // }
+  }
+}
+
 class VersionString {
 
   String raw


### PR DESCRIPTION
Adds a gradle task `cnf:checkForUpdates` which reads `cnf/oss_dependencies.maven` and scrapes Maven Central for potential updates.

Currently the update policy only looks for MINOR/MICRO version updates (e.g. 1.0 -> 1.1, but not 1.0 -> 2.0).

Example output:

```
$ ./gradlew :cnf:checkForUpdates
<snipped >
### g=xalan   a=xalan  v=2.7.2
  checking http://central.maven.org/maven2/xalan/xalan/maven-metadata.xml
### g=xerces   a=xercesImpl  v=2.11.0
  checking http://central.maven.org/maven2/xerces/xercesImpl/maven-metadata.xml
  current version: 2.11.0
  latest released: 2.12.0
  found possible update at version=2.12.0
### g=commons-collections   a=commons-collections  v=3.2.2
  checking http://central.maven.org/maven2/commons-collections/commons-collections/maven-metadata.xml
### g=org/mock-server   a=mockserver-client-java  v=3.10.7
  checking http://central.maven.org/maven2/org/mock-server/mockserver-client-java/maven-metadata.xml
  current version: 3.10.7
  latest released: 5.5.1
  found possible update at version=3.12
### g=org/mock-server   a=mockserver-core  v=3.10.7
  checking http://central.maven.org/maven2/org/mock-server/mockserver-core/maven-metadata.xml
  current version: 3.10.7
  latest released: 5.5.1
  found possible update at version=3.12
### g=org/mock-server   a=mockserver-netty  v=3.10.7
  checking http://central.maven.org/maven2/org/mock-server/mockserver-netty/maven-metadata.xml
  current version: 3.10.7
  latest released: 5.5.1
  found possible update at version=3.12
Found 246 possible MINOR/MICRO version updates out of 336 total artifacts.
```