### PR TITLE
trackLoggedOutCookies setting cause multiple login failure

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
@@ -412,7 +412,7 @@ public class LTPAToken2 implements Token, Serializable {
      * @param expirationInMinutes the expiration limit of the LTPA2 token in minutes
      */
     private final void setExpiration(long expirationInMinutes) {
-        expirationInMilliseconds = ((System.currentTimeMillis() + expirationInMinutes * 60 * 1000 + 60000) / 60000) * 60000;
+	expirationInMilliseconds = System.currentTimeMillis()+ expirationInMinutes * 60 * 1000;
         signature = null;
         if (userData != null) {
             encryptedBytes = null;

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/AuthenticateApi.java
@@ -294,6 +294,7 @@ public class AuthenticateApi {
         authResult.setAuditOutcome(AuditEvent.OUTCOME_SUCCESS);
         Audit.audit(Audit.EventID.SECURITY_API_AUTHN_TERMINATE_01, req, authResult, Integer.valueOf(res.getStatus()));
 
+	removeEntryFromAuthCacheForUser(req, res);
         invalidateSession(req);
         ssoCookieHelper.removeSSOCookieFromResponse(res);
         ssoCookieHelper.createLogoutCookies(req, res);


### PR DESCRIPTION
trackLoggedOutCookies setting could cause multiple login failure.  

This is caused by following 2 reasons. 

1) There are cases that authCache entry not being removed when trackLoggedOutCookies setting is configured, and subsequent login hit the authCache retrieving the same cookie (that is considered logged out) 

and/or 

2) The logic of LtpaToken expiration time allows the same token to be created within 1 min login-window.   The new cookie may be the same value as the logged out cookie. 

