### PR TITLE
Create FAT test case for jwtSso and mpJwt problem with subject creation

### DIFF
--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
@@ -373,9 +373,10 @@ public class ReplayCookieTests extends CommonSecurityFat {
      * Tests:
      * - Configure mpJwt element with mapToUserRegistry=true
      * - Invoke a protected resource and log in, obtaining a JWT cookie
-     * - Re-access the protected resource with the JWT cookie value that was just obtained, but included the JWT in the Authorization header
+     * - Re-access the protected resource with the JWT cookie value that was just obtained, but include the JWT in the Authorization header
      * Expects:
-     * - TODO
+     * - Should successfully obtain a JWT cookie
+     * - Should successfully reach the protected resource on the second invocation
      */
     @Test
     public void test_obtainJwt_reaccessResourceWithJwtInHeader() throws Exception {
@@ -388,7 +389,13 @@ public class ReplayCookieTests extends CommonSecurityFat {
         String currentAction = TestActions.ACTION_INVOKE_PROTECTED_RESOURCE;
 
         Expectations expectations = new Expectations();
-        expectations.addExpectations(CommonExpectations.successfullyReachedLoginPage(currentAction));
+        expectations.addExpectations(CommonExpectations.successfullyReachedUrl(currentAction, protectedUrl));
+        expectations.addExpectations(CommonExpectations.responseTextMissingCookie(currentAction, JwtFatConstants.LTPA_COOKIE_NAME));
+        expectations.addExpectations(CommonExpectations.responseTextMissingCookie(currentAction, JwtFatConstants.JWT_COOKIE_NAME));
+        expectations.addExpectations(CommonExpectations.responseTextIncludesExpectedRemoteUser(currentAction, defaultUser));
+        expectations.addExpectations(CommonExpectations.responseTextIncludesJwtPrincipal(currentAction));
+        expectations.addExpectations(CommonExpectations.responseTextIncludesExpectedAccessId(currentAction, JwtFatConstants.BASIC_REALM, defaultUser));
+        expectations.addExpectations(CommonExpectations.getJwtPrincipalExpectations(currentAction, defaultUser, JwtFatConstants.DEFAULT_ISS_REGEX));
 
         Page response = actions.invokeUrlWithBearerToken(_testName, actions.createWebClient(), protectedUrl, jwtCookie.getValue());
         validationUtils.validateResult(response, currentAction, expectations);


### PR DESCRIPTION
Updates the `test_obtainJwt_reaccessResourceWithJwtInHeader` test in `com.ibm.ws.security.jwtsso.fat.ReplayCookieTests` to have the correct expectations.