### PR TITLE
minimum pool size 4

### DIFF
--- a/dev/com.ibm.ws.threading/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.threading/resources/OSGI-INF/l10n/metatype.properties
@@ -21,7 +21,7 @@ name=Name
 name.desc=The name of the Liberty kernel default executor.
 
 core.threads=Core threads
-core.threads.desc=Steady-state or core number of threads to associate with the executor. The number of threads associated with the executor will quickly grow to this number. If this value is less than 0, a default value is used. This default value is calculated based on the number of hardware threads on the system.
+core.threads.desc=Baseline or minimum number of threads to associate with the executor. The number of threads associated with the executor will quickly grow to this number. If this value is less than 0, a default value is used, calculated based on the number of hardware threads on the system. If the value is a positive number less than 4, then a default value of 4 is used.
 
 max.threads=Maximum threads
-max.threads.desc=Maximum number of threads that can be associated with the executor. If greater than 0, this value must be greater than or equal to the value of coreThreads. If the value of maxThreads is less than or equal to 0, the maximum number of threads is unbounded.  Note that the actual number of threads associated with the executor is determined dynamically by the Liberty kernel, so leaving the maximum threads unbounded does not imply that the runtime will actively create large amounts of threads; it simply lets the Liberty kernel decide how many threads to associate with the executor without having a defined upper boundary.
+max.threads.desc=Maximum number of threads that can be associated with the executor. If greater than 0, maxThreads can be a minimum of 4, and should be at least as large as coreThreads; if maxThreads is set less than coreThreads, Liberty will reduce coreThreads to the maxThreads value.  If the value of maxThreads is less than or equal to 0, the maximum number of threads is unbounded, which lets the Liberty kernel decide how many threads to associate with the executor without having a defined upper boundary.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -73,6 +73,12 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
     String poolName = null;
 
     /**
+     * The smallest size for the pool - smaller coreThreads and/or maxThreads config values
+     * are replaced with this value.
+     */
+    final static int MINIMUM_POOL_SIZE = 4;
+
+    /**
      * The most recently provided component config for the executor.
      */
     Map<String, Object> componentConfig = null;
@@ -194,8 +200,10 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
             coreThreads = 2 * CpuInfo.getAvailableProcessors();
         }
 
-        // If coreThreads is greater than maxThreads, automatically lower it and proceed
-        coreThreads = Math.min(coreThreads, maxThreads);
+        // Make sure coreThreads is not bigger than maxThreads, subject to MINIMUM_POOL_SIZE limit
+        coreThreads = Math.max(MINIMUM_POOL_SIZE, Math.min(coreThreads, maxThreads));
+        // ... and then make sure maxThreads is not smaller than coreThreads ...
+        maxThreads = Math.max(coreThreads, maxThreads);
 
         BlockingQueue<Runnable> workQueue = new BoundedBuffer<Runnable>(java.lang.Runnable.class, 1000, 1000);
 

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ThreadPoolController.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ThreadPoolController.java
@@ -1402,6 +1402,10 @@ public final class ThreadPoolController {
         sb.append(String.format(" poolDecrement = %2d", Integer.valueOf(poolDecrement)));
         sb.append(String.format(" compareRange = %2d", Integer.valueOf(compareRange)));
 
+        sb.append("\nConfig:");
+        sb.append(String.format(" coreThreads = %2d", Integer.valueOf(coreThreads)));
+        sb.append(String.format(" maxThreads = %2d", Integer.valueOf(maxThreads)));
+
         sb.append("\nStatistics:\n");
 
         Integer[] poolSizes = new Integer[2 * RANGE + 1];

--- a/dev/com.ibm.ws.threading/test/com/ibm/ws/threading/internal/PolicyExecutorTest.java
+++ b/dev/com.ibm.ws.threading/test/com/ibm/ws/threading/internal/PolicyExecutorTest.java
@@ -76,24 +76,30 @@ public class PolicyExecutorTest {
     public void testExpedite() throws Exception {
         ExecutorServiceImpl globalExecutor = new ExecutorServiceImpl();
         Map<String, Object> globalExecutorConfig = new HashMap<String, Object>();
-        globalExecutorConfig.put("coreThreads", 1);
-        globalExecutorConfig.put("maxThreads", 1);
-        globalExecutorConfig.put("keepAlive", TimeUnit.MINUTES.toMillis(5));
+        globalExecutorConfig.put("coreThreads", ExecutorServiceImpl.MINIMUM_POOL_SIZE);
+        globalExecutorConfig.put("maxThreads", ExecutorServiceImpl.MINIMUM_POOL_SIZE);
         globalExecutor.activate(globalExecutorConfig);
-        globalExecutor.threadPoolController.deactivate(); // disable autonomic tuning to guarantee maxThreads stays the same
 
         ConcurrentHashMap<String, PolicyExecutorImpl> policyExecutors = new ConcurrentHashMap<String, PolicyExecutorImpl>();
 
-        PolicyExecutor executor0 = new PolicyExecutorImpl(globalExecutor, "testExpedite-0", null, policyExecutors).expedite(0).maxConcurrency(4).maxQueueSize(3);
-        PolicyExecutor executor2 = new PolicyExecutorImpl(globalExecutor, "testExpedite-2", "myApp", policyExecutors).expedite(2).maxConcurrency(4).maxQueueSize(4);
+        PolicyExecutor executor0 = new PolicyExecutorImpl(globalExecutor, "testExpedite-0", null, policyExecutors);
+        executor0.expedite(0).maxConcurrency(ExecutorServiceImpl.MINIMUM_POOL_SIZE + 3).maxQueueSize(ExecutorServiceImpl.MINIMUM_POOL_SIZE + 2);
+        PolicyExecutor executor2 = new PolicyExecutorImpl(globalExecutor, "testExpedite-2", "myApp", policyExecutors);
+        executor2.expedite(2).maxConcurrency(4).maxQueueSize(4);
 
         // Share a counter between all tasks to record the order in which they run
         AtomicInteger sharedCounter = new AtomicInteger(0);
 
-        // Use up the single thread in the global pool
-        CountDownLatch blockerStartedLatch = new CountDownLatch(1);
+        // Use up the thread(s) in the global pool
+        CountDownLatch blockerStartedLatch = new CountDownLatch(ExecutorServiceImpl.MINIMUM_POOL_SIZE);
+        // The first latch blocks one thread and will be released to let the other queued tasks execute
         CountDownLatch blockerLatch = new CountDownLatch(1);
         Future<Integer> future0a = executor0.submit(new CommonTask("blocker", blockerStartedLatch, blockerLatch, sharedCounter));
+        // The second latch blocks the other threads in the pool, so that the queued tasks execute in order
+        CountDownLatch blockerLatch2 = new CountDownLatch(1);
+        for (int x = 1; x < ExecutorServiceImpl.MINIMUM_POOL_SIZE; x++) {
+            executor0.submit(new CommonTask("blocker", blockerStartedLatch, blockerLatch2, sharedCounter));
+        }
         assertTrue(blockerStartedLatch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 
         // Submit 3 non-expedited tasks that will be blocked from running
@@ -109,7 +115,7 @@ public class PolicyExecutorTest {
         Future<Integer> future2c = executor2.submit(new CommonTask("2c", null, null, sharedCounter));
         Future<Integer> future2d = executor2.submit(new CommonTask("2d", null, null, sharedCounter));
 
-        // Release the blocker, allowing all tasks to run
+        // Release the single thread blocker, allowing queued tasks to run in order
         blockerLatch.countDown();
 
         // Verify the ordering (first the blocker task which had started, then the 2 expedited tasks, then the remaining tasks in order of submit)
@@ -124,6 +130,10 @@ public class PolicyExecutorTest {
 
         assertEquals(Collections.emptyList(), executor0.shutdownNow());
         assertEquals(Collections.emptyList(), executor2.shutdownNow());
+
+        // Release the other threads blocker, so that the executor has no tasks remaining
+        blockerLatch2.countDown();
+
         globalExecutor.deactivate(0);
     }
 


### PR DESCRIPTION
Add a 'minimum pool size' for the default executor pool, to avoid app startup problems if the pool is too small.

