### PR TITLE
create new test application/server instance for testing MP Config overrides of MP Concurrency

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/.classpath
+++ b/dev/com.ibm.ws.concurrent.mp_fat/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/MPConcurrentApp/src"/>
 	<classpathentry kind="src" path="test-applications/MPConcurrentCDIApp/src"/>
+	<classpathentry kind="src" path="test-applications/MPConcurrentConfigApp/src"/>
 	<classpathentry kind="src" path="test-applications/customcontext/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
@@ -18,6 +18,7 @@ src: \
 	fat/src,\
 	test-applications/MPConcurrentApp/src,\
 	test-applications/MPConcurrentCDIApp/src,\
+	test-applications/MPConcurrentConfigApp/src,\
 	test-applications/customcontext/src
 
 fat.project: true
@@ -27,6 +28,7 @@ fat.project: true
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.concurrent.mp.1.0;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
                 MPConcurrentTest.class,
-                MPConcurrentCDITest.class
+                MPConcurrentCDITest.class,
+                MPConcurrentConfigTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentConfigTest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentConfigTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.fat;
+
+import org.eclipse.microprofile.concurrent.spi.ThreadContextProvider;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.test.context.location.CityContextProvider;
+import org.test.context.location.StateContextProvider;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet;
+
+@RunWith(FATRunner.class)
+public class MPConcurrentConfigTest extends FATServletClient {
+
+    private static final String APP_NAME = "MPConcurrentConfigApp";
+
+    @Server("MPConcurrentConfigTestServer")
+    @TestServlet(servlet = MPConcurrentConfigTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, "concurrent.mp.fat.config.web");
+
+        JavaArchive customContextProviders = ShrinkWrap.create(JavaArchive.class, "customContextProviders.jar")
+                        .addPackage("org.test.context.location")
+                        .addAsServiceProvider(ThreadContextProvider.class, CityContextProvider.class, StateContextProvider.class);
+        ShrinkHelper.exportToServer(server, "lib", customContextProviders);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentConfigTestServer/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentConfigTestServer/bootstrap.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:concurrent=all
+AppProducedExecutor.maxQueued=2

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentConfigTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentConfigTestServer/server.xml
@@ -1,0 +1,36 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>mpConfig-1.3</feature>
+        <feature>mpConcurrency-1.0</feature>
+        <feature>jndi-1.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>cdi-2.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <application location="MPConcurrentConfigApp.war">
+        <classloader commonLibraryRef="customContextProviderLib"/>
+    </application>
+
+    <library id="customContextProviderLib">
+        <file name="${server.config.dir}/lib/customContextProviders.jar"/>
+    </library>
+
+    <!-- Needed for application to use a ForkJoinPool, access the thread context class loader, and shut down an unmanaged ExecutorService that the test application creates -->
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="java.lang.RuntimePermission" name="modifyThread"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.*" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/ConcurrencyBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/ConcurrencyBean.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018,2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package concurrent.mp.fat.cdi.web;
 
 import javax.enterprise.context.ApplicationScoped;

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/ConcurrencyConfigBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/ConcurrencyConfigBean.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.config.web;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+
+import org.eclipse.microprofile.concurrent.ManagedExecutor;
+import org.eclipse.microprofile.concurrent.NamedInstance;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class ConcurrencyConfigBean {
+    @Produces
+    @ApplicationScoped
+    @NamedInstance("applicationProducedExecutor")
+    ManagedExecutor createExecutor(@ConfigProperty(name = "AppProducedExecutor.maxAsync", defaultValue = "1") Integer a,
+                                   @ConfigProperty(name = "AppProducedExecutor.maxQueued", defaultValue = "4") Integer q) {
+        return ManagedExecutor.builder().maxAsync(a).maxQueued(q).build();
+    }
+
+    // MicroProfile Concurrency automatically shuts down ManagedExecutors when the application stops.
+    // But even if the application writes its own disposer, it shouldn't get an error.
+    void shutdownExecutor(@Disposes @NamedInstance("applicationProducedExecutor") ManagedExecutor exec) {
+        System.out.println("### disposer");
+        exec.shutdownNow();
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/MPConcurrentConfigTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/MPConcurrentConfigTestServlet.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.config.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.eclipse.microprofile.concurrent.ManagedExecutor;
+import org.eclipse.microprofile.concurrent.NamedInstance;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/MPConcurrentConfigTestServlet")
+public class MPConcurrentConfigTestServlet extends FATServlet {
+    static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
+
+    @Inject
+    ConcurrencyConfigBean bean;
+
+    @Inject
+    @NamedInstance("applicationProducedExecutor")
+    ManagedExecutor appProducedExecutor;
+
+    /**
+     * Demonstrates that MicroProfile Config can be used by the application to override config properties.
+     */
+    @Test
+    public void testApplicationProducedManagedExecutorUsingMicroProfileConfig() throws Exception {
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch blocker = new CountDownLatch(1);
+        CompletableFuture<Boolean> cf0 = appProducedExecutor.supplyAsync(() -> {
+            try {
+                started.countDown();
+                return blocker.await(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException x) {
+                throw new RuntimeException(x);
+            }
+        });
+        assertTrue(started.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        CompletableFuture<Integer> cf1 = appProducedExecutor.supplyAsync(() -> 1);
+        CompletableFuture<Integer> cf2 = appProducedExecutor.supplyAsync(() -> 2);
+
+        try {
+            Future<?> future = appProducedExecutor.submit(() -> System.out.println("This should never run!"));
+            fail("Should not be able to queue third task when MicroProfile Config overrides maxQueued to be 2. " + future);
+        } catch (RejectedExecutionException x) {
+            // Pass - intentionally exceeded queue capacity in order to test maxQueued constraint
+        }
+
+        blocker.countDown();
+
+        assertEquals(cf0.get(TIMEOUT_NS, TimeUnit.NANOSECONDS), Boolean.TRUE);
+        assertEquals(cf1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS), Integer.valueOf(1));
+        assertEquals(cf2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS), Integer.valueOf(2));
+    }
+}


### PR DESCRIPTION
Create a new test application and server instance with both mpConfig and mpConcurrency enabled where we can test MicroProfile Config being used to override configuration of ManagedExecutor and ThreadContext.  For now, I'll start with a single test case, where the application uses MP Config directly, which will demonstrate everything is working before we later add the tests of MP Config being used by the MP Concurrency implementation for container produced instances.