### PR TITLE
fix a Java 11 build break with the jaxb-2.3 feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxb-2.3/com.ibm.websphere.appserver.jaxb-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxb-2.3/com.ibm.websphere.appserver.jaxb-2.3.feature
@@ -5,6 +5,7 @@ singleton=true
 IBM-App-ForceRestart: uninstall, \
  install
 IBM-API-Package: \
+  javax.activation; type="spec", \
   javax.xml.bind;  type="spec", \
   javax.xml.bind.annotation;  type="spec", \
   javax.xml.bind.annotation.adapters;  type="spec", \


### PR DESCRIPTION
https://github.com/OpenLiberty/open-liberty/pull/4877 caused a new Java 11 build break.