### PR TITLE
Revert "fix a Java 11 build break with the jaxb-2.3 feature"

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxb-2.3/com.ibm.websphere.appserver.jaxb-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxb-2.3/com.ibm.websphere.appserver.jaxb-2.3.feature
@@ -5,7 +5,6 @@ singleton=true
 IBM-App-ForceRestart: uninstall, \
  install
 IBM-API-Package: \
-  javax.activation; type="spec", \
   javax.xml.bind;  type="spec", \
   javax.xml.bind.annotation;  type="spec", \
   javax.xml.bind.annotation.adapters;  type="spec", \


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#6122

Appears to have caused the following failure in the continuous build:

com.ibm.ws.jaxb_fat FAT tests
com.ibm.ws.jaxb.fat.LibertyJAXBTest
testActivationLoaded_JAXB-2.3

```junit.framework.AssertionFailedError: 2019-01-09-08:28:20:140 The response did not contain "[SUCCESS]".  Full output is:"
ERROR: Caught exception attempting to call test method testActivationLoaded on servlet jaxb.web.JAXBTestServlet
java.lang.AssertionError: Expected javax.activation to come from JDK classloader, but it came from: org.eclipse.osgi.internal.loader.EquinoxClassLoader@e1d7f92e[com.ibm.websphere.javaee.activation.1.1:1.0.24.201901090216(id=76)]
    at jaxb.web.JAXBTestServlet.testActivationLoaded(JAXBTestServlet.java:71)
    at componenttest.app.FATServlet.doGet(FATServlet.java:71)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1255)```