### PR TITLE
test MP Config override of array type attribute for unqualified injection point without ManagedExecutorConfig

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018,2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -24,20 +24,31 @@ WS-TraceGroup: concurrent
 
 Private-Package:\
   com.ibm.ws.concurrent.mp.cdi.*
-  
+
+Import-Package: \
+  !org.eclipse.microprofile.config,\
+  !org.eclipse.microprofile.config.spi,\
+  *
+
+DynamicImport-Package: \
+  org.eclipse.microprofile.config,\
+  org.eclipse.microprofile.config.spi
+
 Include-Resource: \
   META-INF=resources/META-INF
     
 instrument.classesExcludes: com/ibm/ws/concurrent/mp/cdi/resources/*.class
 
 -dsannotations: \
-  com.ibm.ws.concurrent.mp.cdi.ConcurrencyCDIExtension
+  com.ibm.ws.concurrent.mp.cdi.ConcurrencyCDIExtension,\
+  com.ibm.ws.concurrent.mp.cdi.MPConfigAccessorImpl
 
 -buildpath: \
   com.ibm.websphere.appserver.spi.logging,\
   com.ibm.websphere.javaee.cdi.2.0;version=latest,\
   com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
   com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0,\
+  com.ibm.websphere.org.eclipse.microprofile.config.1.4;version=latest,\
   com.ibm.websphere.org.osgi.core,\
   com.ibm.websphere.org.osgi.service.component,\
   com.ibm.ws.app.manager.lifecycle;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/MPConfigAccessor.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/MPConfigAccessor.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.cdi;
+
+/**
+ * This interface abstracts away usage of MicroProfile Config so that values can be
+ * conditionally read from MicroProfile Config if available. The only data types
+ * needed are String[] and Integer.
+ */
+public interface MPConfigAccessor {
+    /**
+     * Reads a String[] or Integer property value from MicroProfile Config.
+     *
+     * @param name config property name.
+     * @param defaultValue value to use if a config property with the specified name is not found.
+     * @return value from MicroProfile Config. Otherwise the default value.
+     */
+    <T> T get(String name, T defaultValue);
+}

--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/MPConfigAccessorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/MPConfigAccessorImpl.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.cdi;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * This class abstracts away usage of MicroProfile Config so that values can be
+ * conditionally read from MicroProfile Config if available. The only data types
+ * needed are String[] and Integer.
+ */
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE)
+public class MPConfigAccessorImpl implements MPConfigAccessor {
+    @Reference
+    protected ConfigProviderResolver configProviderResolver;
+
+    /**
+     * Reads a String[] or Integer property value from MicroProfile Config.
+     *
+     * @param name config property name.
+     * @param defaultValue value to use if a config property with the specified name is not found.
+     * @return value from MicroProfile Config. Otherwise the default value.
+     */
+    @Override
+    public <T> T get(String name, T defaultValue) {
+        Config config = configProviderResolver.getConfig();
+        Class<?> cl = defaultValue == null ? String[].class : defaultValue.getClass();
+        @SuppressWarnings("unchecked")
+        Optional<T> configuredValue = (Optional<T>) config.getOptionalValue(name, cl);
+        return configuredValue.orElse(defaultValue);
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ManagedExecutorBean.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ManagedExecutorBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,23 +38,29 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
     private static final Type[] TYPE_ARR = { ManagedExecutor.class, ExecutorService.class, Executor.class };
     private static final Set<Type> TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(TYPE_ARR)));
 
+    // This instance is used as a marker for when no configured is specified for a String[]. The reference is compared; its content does not matter.
+    private static final String[] UNSPECIFIED_ARRAY = new String[] {};
+
     private final String name;
     private final Set<Annotation> qualifiers;
     private final ManagedExecutorConfig config;
+    private final MPConfigAccessor mpConfig;
 
-    public ManagedExecutorBean() {
+    public ManagedExecutorBean(MPConfigAccessor mpConfig) {
         this.name = getClass().getCanonicalName();
         this.config = null;
+        this.mpConfig = mpConfig;
         Set<Annotation> qualifiers = new HashSet<>(2);
         qualifiers.add(Any.Literal.INSTANCE);
         qualifiers.add(Default.Literal.INSTANCE);
         this.qualifiers = Collections.unmodifiableSet(qualifiers);
     }
 
-    public ManagedExecutorBean(String name, ManagedExecutorConfig config) {
+    public ManagedExecutorBean(String name, ManagedExecutorConfig config, MPConfigAccessor mpConfig) {
         Objects.requireNonNull(name);
         this.name = name;
         this.config = config;
+        this.mpConfig = mpConfig;
         Set<Annotation> qualifiers = new HashSet<>(2);
         qualifiers.add(Any.Literal.INSTANCE);
         qualifiers.add(NamedInstance.Literal.of(this.name));
@@ -64,12 +70,41 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
     @Override
     public ManagedExecutor create(CreationalContext<ManagedExecutor> cc) {
         Builder b = ManagedExecutor.builder();
-        if (config != null) {
-            b.maxAsync(config.maxAsync());
-            b.maxQueued(config.maxQueued());
-            b.propagated(config.propagated());
-            b.cleared(config.cleared());
+        if (mpConfig == null) {
+            if (config != null) {
+                b.maxAsync(config.maxAsync());
+                b.maxQueued(config.maxQueued());
+                b.propagated(config.propagated());
+                b.cleared(config.cleared());
+            }
+        } else {
+            int start = name.length() + 1;
+            int len = start + 10;
+            StringBuilder propName = new StringBuilder(len).append(name).append('.');
+
+            // In order to efficiently reuse StringBuilder, properties are added in the order of the length of their names,
+
+            propName.append("cleared");
+            String[] c = mpConfig.get(propName.toString(), config == null ? UNSPECIFIED_ARRAY : config.cleared());
+            if (c != UNSPECIFIED_ARRAY)
+                b.cleared(c);
+
+            propName.replace(start, len, "maxAsync");
+            Integer a = mpConfig.get(propName.toString(), config == null ? null : config.maxAsync());
+            if (a != null)
+                b.maxAsync(a);
+
+            propName.replace(start, len, "maxQueued");
+            Integer q = mpConfig.get(propName.toString(), config == null ? null : config.maxQueued());
+            if (q != null)
+                b.maxQueued(q);
+
+            propName.replace(start, len, "propagated");
+            String[] p = mpConfig.get(propName.toString(), config == null ? UNSPECIFIED_ARRAY : config.propagated());
+            if (p != UNSPECIFIED_ARRAY)
+                b.propagated(p);
         }
+
         return b.build();
     }
 

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentConfigTestServer/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentConfigTestServer/bootstrap.properties
@@ -11,3 +11,5 @@
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:concurrent=all
 AppProducedExecutor.maxQueued=2
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.annotatedExecutorWithMPConfigOverride.maxAsync=2
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.annotatedExecutorWithMPConfigOverride.maxQueued=3

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,2 @@
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.executorWithMPConfigOverride.cleared=City
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.executorWithMPConfigOverride.propagated=Application,State

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/ConcurrencyConfigBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/ConcurrencyConfigBean.java
@@ -24,7 +24,7 @@ public class ConcurrencyConfigBean {
     @ApplicationScoped
     @NamedInstance("applicationProducedExecutor")
     ManagedExecutor createExecutor(@ConfigProperty(name = "AppProducedExecutor.maxAsync", defaultValue = "1") Integer a,
-                                   @ConfigProperty(name = "AppProducedExecutor.maxQueued", defaultValue = "4") Integer q) {
+                                   @ConfigProperty(name = "AppProducedExecutor.maxQueued", defaultValue = "4") Integer q) { // MP Config sets maxQueued=2
         return ManagedExecutor.builder().maxAsync(a).maxQueued(q).build();
     }
 


### PR DESCRIPTION
This test covers both override of array type attributes via MicroProfile Config as well as MicroProfile Config override of ManagedExecutor injection points that have neither qualifiers nor the ManagedExecutorConfig annotation.