### PR TITLE
FT 2.0 CompletionStage new semantics

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/TimeoutStateImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/TimeoutStateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -72,8 +72,7 @@ public class TimeoutStateImpl implements TimeoutState {
     public void stop() {
         synchronized (this) {
             switch (result) {
-                case NEW:
-                    throw new IllegalStateException("Stop called on a timeout that was never started");
+                case NEW: // If an attempt is aborted before it runs, stop() may be called without start()
                 case STARTED:
                     result = TimeoutResult.FINISHED;
                     if (timeoutFuture != null) {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/FATSuite.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.microprofile.faulttolerance_fat.tests.CDITimeoutTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.tests.FallbackMethodTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.tests.TxRetryReorderedTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.tests.TxRetryTest;
+import com.ibm.websphere.microprofile.faulttolerance_fat.tests.completionstage.CDICompletionStageTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.tests.enablement.DisableEnableTest;
 import com.ibm.websphere.microprofile.faulttolerance_fat.validation.ValidationTest;
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -52,6 +53,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
                 ValidationTest.class,
                 FallbackMethodTest.class,
                 DisableEnableTest.class,
+                CDICompletionStageTest.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/completionstage/CDICompletionStageBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/completionstage/CDICompletionStageBean.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.completionstage;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+@ApplicationScoped
+public class CDICompletionStageBean {
+
+    @Asynchronous
+    public <T> CompletionStage<T> serviceCs(CompletableFuture<Void> latch, CompletableFuture<T> returnValue) {
+        try {
+            latch.get(5, SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new RuntimeException("Error", e);
+        }
+        return returnValue;
+    }
+
+    @Asynchronous
+    @Timeout(500)
+    public CompletionStage<Void> serviceCsTimeout(CompletableFuture<Void> returnValue) {
+        return returnValue;
+    }
+
+    private int retryAlwaysFailsAttemptCount = 0;
+
+    @Asynchronous
+    @Retry(maxRetries = 3, jitter = 0)
+    public CompletionStage<Void> serviceCsRetryAlwaysFails() {
+        retryAlwaysFailsAttemptCount++;
+        CompletableFuture<Void> cf = new CompletableFuture<>();
+        cf.completeExceptionally(new RuntimeException());
+        return cf;
+    }
+
+    public int getRetryAlwaysFailsAttemptCount() {
+        return retryAlwaysFailsAttemptCount;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/completionstage/CDICompletionStageServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/completionstage/CDICompletionStageServlet.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.completionstage;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/CDICompletionStage")
+public class CDICompletionStageServlet extends FATServlet {
+
+    @Inject
+    CDICompletionStageBean bean;
+
+    private ArrayList<CompletableFuture<?>> latches;
+
+    @Override
+    protected void before() {
+        latches = new ArrayList<>();
+    }
+
+    @Override
+    protected void after() {
+        for (CompletableFuture<?> latch : latches) {
+            latch.complete(null);
+        }
+    }
+
+    @Test
+    public void testCompletionStage() throws InterruptedException {
+        CompletableFuture<Void> latch = getLatch();
+        CompletableFuture<String> returnValue = getLatch();
+
+        returnValue.complete("OK"); // Return an already complete CS
+        CompletionStage<String> result = bean.serviceCs(latch, returnValue);
+
+        assertNotCompleting(result); // Should not complete until latch is completed
+        latch.complete(null);
+        assertResult(result, "OK");
+    }
+
+    @Test
+    public void testCompletionStageLateCompletion() throws InterruptedException {
+        CompletableFuture<Void> latch = getLatch();
+        CompletableFuture<String> returnValue = getLatch();
+
+        latch.complete(null); // Allow the method to return immediately
+        CompletionStage<String> result = bean.serviceCs(latch, returnValue);
+
+        assertNotCompleting(result); // method should return but result should be complete until returnValue is completed
+        returnValue.complete("OK");
+        assertResult(result, "OK");
+    }
+
+    @Test
+    public void testCompletionStageTimeout() throws InterruptedException {
+        CompletableFuture<Void> returnValue = getLatch();
+        CompletionStage<Void> result = bean.serviceCsTimeout(returnValue);
+
+        // If we don't complete the return value, we expect a timeout exception
+        try {
+            toCompletableFuture(result).get(2, SECONDS);
+            fail("No exception thrown");
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), instanceOf(org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException.class));
+        } catch (TimeoutException e) {
+            fail("Result did not complete");
+        }
+    }
+
+    @Test
+    public void testCompletionStageRetry() throws InterruptedException {
+        CompletionStage<Void> result = bean.serviceCsRetryAlwaysFails();
+        assertCompleting(result);
+        assertEquals("Number of retry attempts", 4, bean.getRetryAlwaysFailsAttemptCount());
+    }
+
+    /**
+     * Get a CompletableFuture which will automatically be completed at the end of the test
+     * <p>
+     * Useful to ensure we don't leave anything latched in the case of an unexpected failure
+     */
+    private <T> CompletableFuture<T> getLatch() {
+        CompletableFuture<T> latch = new CompletableFuture<>();
+        latches.add(latch);
+        return latch;
+    }
+
+    private <T> void assertResult(CompletionStage<T> cs, T expected) throws InterruptedException {
+        try {
+            T result = toCompletableFuture(cs).get(2, SECONDS);
+            assertEquals(expected, result);
+        } catch (TimeoutException ex) {
+            fail("CompletionStage did not complete within 2 seconds");
+        } catch (ExecutionException ex) {
+            throw new AssertionError("Completion Stage failed with exception", ex);
+        }
+    }
+
+    private void assertCompleting(CompletionStage<?> cs) throws InterruptedException {
+        try {
+            toCompletableFuture(cs).get(2, SECONDS);
+        } catch (TimeoutException ex) {
+            fail("CompletionStage did not complete within 2 seconds");
+        } catch (ExecutionException ex) {
+            // completion with exception is still a completion...
+        }
+    }
+
+    private void assertNotCompleting(CompletionStage<?> cs) throws InterruptedException {
+        try {
+            toCompletableFuture(cs).get(2, SECONDS);
+            fail("CompletionStage completed, exepected not to complete");
+        } catch (ExecutionException e) {
+            fail("CompletionStage completed exceptionally, expected not to complete");
+        } catch (TimeoutException e) {
+            // Expected
+        }
+    }
+
+    private static <T> CompletableFuture<T> toCompletableFuture(CompletionStage<T> cs) {
+        CompletableFuture<T> cf = new CompletableFuture<>();
+        cs.handle((r, t) -> {
+            if (t == null) {
+                cf.complete(r);
+            } else {
+                cf.completeExceptionally(t);
+            }
+            return null;
+        });
+        return cf;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/completionstage/CDICompletionStageTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/completionstage/CDICompletionStageTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.completionstage;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class CDICompletionStageTest extends FATServletClient {
+
+    private static final String SERVER_NAME = "FaultToleranceMultiModule";
+    private static final String APP_NAME = "ftCompletionStage";
+
+    @Server(SERVER_NAME)
+    @TestServlet(servlet = CDICompletionStageServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackage(CDICompletionStageTest.class.getPackage());
+        ShrinkHelper.exportDropinAppToServer(server, app, SERVER_ONLY);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+        server.deleteDirectoryFromLibertyServerRoot("dropins/" + APP_NAME + ".war");
+    }
+
+}


### PR DESCRIPTION
The FT 2.0 spec has been updated to say that when an `@Asynchronous` method returns a `CompletionStage`, any other fault tolerance logic is applied when the returned `CompletionStage` completes, rather than when the method returns.

This change adds this behaviour for everything except `@Bulkhead`.

See the details in the changes under eclipse/microprofile-fault-tolerance#381

Fixes #6139 