### PR TITLE
Ignore config when using Oracle UCP

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/AbstractConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/AbstractConnectionFactoryService.java
@@ -451,6 +451,12 @@ public abstract class AbstractConnectionFactoryService implements Observer, Reso
         return xa;
     }
 
+    /**
+     * Returns whether Liberty Connection Pooling should be disabled
+     *
+     */
+    public abstract boolean isLibertyConnectionPoolingDisabled();
+
     @FFDCIgnore(PrivilegedActionException.class)
     private void initPrivileged() throws Exception {
         try {

--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
@@ -504,4 +504,9 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
         }
 
     }
+
+    @Override
+    public boolean isLibertyConnectionPoolingDisabled() {
+        return false;
+    }
 }

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -271,6 +271,14 @@ DSRA4011.tran.none.iso.switch.unsupported=DSRA4011E: The JDBC driver does not su
 DSRA4011.tran.none.iso.switch.unsupported.explanation=The JDBC specification does not support switching to an isolation level of TRANSACTION_NONE.
 DSRA4011.tran.none.iso.switch.unsupported.useraction=Avoid switching to an isolation level of TRANSACTION_NONE.
 
+DSRA4012.ignored.datasource.config.used=DSRA4012I: When using Oracle UCP the following data source properties are ignored: statementCacheSize and validationTimeout. Please use the equivalent Oracle UCP functionality.
+DSRA4012.ignored.datasource.config.used.explanation=The statementCacheSize and validationTimeout data source properties are not valid when using Oracle UCP.
+DSRA4012.ignored.datasource.config.used.useraction=Remove the data source properties and instead utilize the equivalent Oracle UCP functionality.
+
+DSRA4013.ignored.connection.manager.config.used=DSRA4013I: When using Oracle UCP the following connection manager properties are ignored: agedTimeout, connectionTimeout, maxIdleTime, maxPoolSize, minPoolSize, purgePolicy, reapTime, maxConnectionsPerThread, maxConnectionsPerThreadLocal. Please use the equivalent Oracle UCP functionality.
+DSRA4013.ignored.connection.manager.config.used.explanation=The listed connection manager properties are not valid when using Oracle UCP.
+DSRA4013.ignored.connection.manager.config.used.useraction=Remove the connection manager properties and instead utilize the equivalent Oracle UCP functionality.
+
 # ----------------------------------------------------------------------------
 # 
 # Using 7000-7599 for DataStore Helper exception messages and warnings

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -271,13 +271,13 @@ DSRA4011.tran.none.iso.switch.unsupported=DSRA4011E: The JDBC driver does not su
 DSRA4011.tran.none.iso.switch.unsupported.explanation=The JDBC specification does not support switching to an isolation level of TRANSACTION_NONE.
 DSRA4011.tran.none.iso.switch.unsupported.useraction=Avoid switching to an isolation level of TRANSACTION_NONE.
 
-DSRA4012.ignored.datasource.config.used=DSRA4012I: When using Oracle UCP the following data source properties are ignored: statementCacheSize and validationTimeout. Please use the equivalent Oracle UCP functionality.
+DSRA4012.ignored.datasource.config.used=DSRA4012I: When using Oracle UCP the following data source properties are ignored: statementCacheSize and validationTimeout. Use the equivalent Oracle UCP functionality.
 DSRA4012.ignored.datasource.config.used.explanation=The statementCacheSize and validationTimeout data source properties are not valid when using Oracle UCP.
-DSRA4012.ignored.datasource.config.used.useraction=Remove the data source properties and instead utilize the equivalent Oracle UCP functionality.
+DSRA4012.ignored.datasource.config.used.useraction=Remove the data source properties and instead use the equivalent Oracle UCP functionality.
 
-DSRA4013.ignored.connection.manager.config.used=DSRA4013I: When using Oracle UCP the following connection manager properties are ignored: agedTimeout, connectionTimeout, maxIdleTime, maxPoolSize, minPoolSize, purgePolicy, reapTime, maxConnectionsPerThread, maxConnectionsPerThreadLocal. Please use the equivalent Oracle UCP functionality.
+DSRA4013.ignored.connection.manager.config.used=DSRA4013I: When using Oracle UCP the following connection manager properties are ignored: agedTimeout, connectionTimeout, maxIdleTime, maxPoolSize, minPoolSize, purgePolicy, reapTime, maxConnectionsPerThread, maxConnectionsPerThreadLocal. Use the equivalent Oracle UCP functionality.
 DSRA4013.ignored.connection.manager.config.used.explanation=The listed connection manager properties are not valid when using Oracle UCP.
-DSRA4013.ignored.connection.manager.config.used.useraction=Remove the connection manager properties and instead utilize the equivalent Oracle UCP functionality.
+DSRA4013.ignored.connection.manager.config.used.useraction=Remove the connection manager properties and instead use the equivalent Oracle UCP functionality.
 
 # ----------------------------------------------------------------------------
 # 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
@@ -285,7 +285,7 @@ public class DSConfig implements FFDCSelfIntrospectable {
         isolationLevel = remove(DataSourceDef.isolationLevel.name(), -1, -1, null, -1, 0, 1, 2, 4, 8, 16, 4096);
         onConnect = remove(ON_CONNECT, (String[]) null);
         queryTimeout = remove(QUERY_TIMEOUT, (Integer) null, 0, TimeUnit.SECONDS);
-        statementCacheSize = remove(STATEMENT_CACHE_SIZE, 10, 0, null); // If UCP support is ever added to Liberty, can document how to disable statement caching
+        statementCacheSize = remove(STATEMENT_CACHE_SIZE, 10, 0, null);
         supplementalJDBCTrace = remove(SUPPLEMENTAL_JDBC_TRACE, (Boolean) null);
         syncQueryTimeoutWithTransactionTimeout = remove(SYNC_QUERY_TIMEOUT_WITH_TRAN_TIMEOUT, false);
         transactional = remove(DataSourceDef.transactional.name(), true);


### PR DESCRIPTION
Add the initial support for handling Oracle UCP config.  This includes overriding several Liberty connection manager and datasource properties so that the Liberty connection manager is disabled.