### PR TITLE
Allow MP Config to override ManagedExecutor injection points which are method parameters

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
@@ -1,2 +1,3 @@
+concurrent.mp.fat.config.web.ConcurrencyConfigBean.getExecutor.1.maxQueued=3
 concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.executorWithMPConfigOverride.cleared=City
 concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.executorWithMPConfigOverride.propagated=Application,State

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/ConcurrencyConfigBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/ConcurrencyConfigBean.java
@@ -15,6 +15,7 @@ import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
 
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
+import org.eclipse.microprofile.concurrent.ManagedExecutorConfig;
 import org.eclipse.microprofile.concurrent.NamedInstance;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -30,8 +31,15 @@ public class ConcurrencyConfigBean {
 
     // MicroProfile Concurrency automatically shuts down ManagedExecutors when the application stops.
     // But even if the application writes its own disposer, it shouldn't get an error.
-    void shutdownExecutor(@Disposes @NamedInstance("applicationProducedExecutor") ManagedExecutor exec) {
+    void disposeExecutor(@Disposes @NamedInstance("applicationProducedExecutor") ManagedExecutor exec) {
         System.out.println("### disposer");
         exec.shutdownNow();
+    }
+
+    @Produces
+    @ApplicationScoped
+    @NamedInstance("containerExecutorReturnedByAppProducer")
+    ManagedExecutor getExecutor(@ManagedExecutorConfig(maxAsync = 1, maxQueued = 1) ManagedExecutor exec) { // MP Config sets maxQueued=3
+        return exec;
     }
 }


### PR DESCRIPTION
Implement the code path to allow MicroProfile Config to be used to override ManagedExecutor injections which are method parameters without the NamedInstance qualifier (that combination will be a separate pull and will require some additional refactoring).  Write a test case to validate.