### PR TITLE
Update Guava to 27.0.1-android for Java 7 support

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -16,6 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.1
 com.google.code.gson:gson:2.2.4
 com.google.guava:guava:14.0.1
 com.google.guava:guava:26.0-jre
+com.google.guava:guava:27.0.1-android
 com.google.inject:guice:2.0
 com.ibm.ws.componenttest:com.ibm.componenttest.common:1.0.0
 com.ibm.ws.componenttest:com.ibm.ws.topology.helper:1.0.0

--- a/dev/com.ibm.ws.com.google.guava.26.0/bnd.bnd
+++ b/dev/com.ibm.ws.com.google.guava.26.0/bnd.bnd
@@ -8,9 +8,9 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;com.google.guava:guava;26.0}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;com.google.guava:guava;27.0.1}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 -includeresource: \
-   @${repo;com.google.guava:guava;26.0}!/!META-INF/*
+   @${repo;com.google.guava:guava;27.0.1}!/!META-INF/*
 
--buildpath: com.google.guava:guava;version=26.0
+-buildpath: com.google.guava:guava;version=27.0.1

--- a/dev/com.ibm.ws.com.google.guava.26.0/bnd.overrides
+++ b/dev/com.ibm.ws.com.google.guava.26.0/bnd.overrides
@@ -2,17 +2,17 @@
 bVersion=1.0
 
 Bundle-Name: google.concurrent
-Bundle-Description: google.concurrent; version=26.0
+Bundle-Description: google.concurrent; version=27.0.1
 Bundle-SymbolicName: com.ibm.ws.com.google.guava
 
 WS-TraceGroup: OPENIDCONNECT
 
 Export-Package: \
-  com.google.common.base;version="26.0", \
-  com.google.common.cache;version="26.0", \
-  com.google.common.collect;version="26.0", \
-  com.google.common.primitives;version="26.0", \
-  com.google.common.util.concurrent;version="26.0"
+  com.google.common.base;version="27.0.1", \
+  com.google.common.cache;version="27.0.1", \
+  com.google.common.collect;version="27.0.1", \
+  com.google.common.primitives;version="27.0.1", \
+  com.google.common.util.concurrent;version="27.0.1"
 
 Private-Package: com.google.common.*
 


### PR DESCRIPTION
The 27.0.1-jre version of Guava is compiled with Java 8 so will not work on systems running Java 7. The x.x.x-android artifacts are built with Java 7, so I'm updating the library to use that version.