### PR TITLE
Add fault tolerance 2.0 metrics

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance-metrics.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance-metrics.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.mpFaultTolerance-metrics
 singleton=true
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-1.1))", \
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-1.1)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-2.0)))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-1.1))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.microprofile.faulttolerance.metrics

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncCompletionStageExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncCompletionStageExecutor.java
@@ -19,6 +19,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.microprofile.faulttolerance.spi.BulkheadPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.CircuitBreakerPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.FallbackPolicy;
+import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance.spi.RetryPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.TimeoutPolicy;
 import com.ibm.ws.threading.PolicyExecutorProvider;
@@ -33,8 +34,8 @@ public class AsyncCompletionStageExecutor<R> extends AsyncExecutor<CompletionSta
     private static final TraceComponent tc = Tr.register(AsyncCompletionStageExecutor.class);
 
     public AsyncCompletionStageExecutor(RetryPolicy retry, CircuitBreakerPolicy cbPolicy, TimeoutPolicy timeoutPolicy, FallbackPolicy fallbackPolicy, BulkheadPolicy bulkheadPolicy,
-                                        ScheduledExecutorService executorService, PolicyExecutorProvider policyExecutorProvider) {
-        super(retry, cbPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, executorService, policyExecutorProvider);
+                                        ScheduledExecutorService executorService, PolicyExecutorProvider policyExecutorProvider, MetricRecorder metricRecorder) {
+        super(retry, cbPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, executorService, policyExecutorProvider, metricRecorder);
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncFutureExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncFutureExecutor.java
@@ -19,6 +19,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.microprofile.faulttolerance.spi.BulkheadPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.CircuitBreakerPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.FallbackPolicy;
+import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance.spi.RetryPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.TimeoutPolicy;
 import com.ibm.ws.threading.PolicyExecutorProvider;
@@ -33,8 +34,8 @@ public class AsyncFutureExecutor<R> extends AsyncExecutor<Future<R>> {
     private static final TraceComponent tc = Tr.register(AsyncFutureExecutor.class);
 
     public AsyncFutureExecutor(RetryPolicy retry, CircuitBreakerPolicy cbPolicy, TimeoutPolicy timeoutPolicy, FallbackPolicy fallbackPolicy, BulkheadPolicy bulkheadPolicy,
-                               ScheduledExecutorService executorService, PolicyExecutorProvider policyExecutorProvider) {
-        super(retry, cbPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, executorService, policyExecutorProvider);
+                               ScheduledExecutorService executorService, PolicyExecutorProvider policyExecutorProvider, MetricRecorder metricRecorder) {
+        super(retry, cbPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, executorService, policyExecutorProvider, metricRecorder);
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/ExecutorBuilderImpl20.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/ExecutorBuilderImpl20.java
@@ -27,16 +27,16 @@ public class ExecutorBuilderImpl20<T, R> extends ExecutorBuilderImpl<T, R> {
 
     @Override
     public Executor<R> build() {
-        return new SyncExecutor<>(retryPolicy, circuitBreakerPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, scheduledExecutorService);
+        return new SyncExecutor<>(retryPolicy, circuitBreakerPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, scheduledExecutorService, metricRecorder);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <W> Executor<W> buildAsync(Class<?> asyncResultWrapperType) {
         if (asyncResultWrapperType == Future.class) {
-            return (Executor<W>) new AsyncFutureExecutor<Object>(retryPolicy, circuitBreakerPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, scheduledExecutorService, policyExecutorProvider);
+            return (Executor<W>) new AsyncFutureExecutor<Object>(retryPolicy, circuitBreakerPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, scheduledExecutorService, policyExecutorProvider, metricRecorder);
         } else if (asyncResultWrapperType == CompletionStage.class) {
-            return (Executor<W>) new AsyncCompletionStageExecutor<Object>(retryPolicy, circuitBreakerPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, scheduledExecutorService, policyExecutorProvider);
+            return (Executor<W>) new AsyncCompletionStageExecutor<Object>(retryPolicy, circuitBreakerPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, scheduledExecutorService, policyExecutorProvider, metricRecorder);
         } else {
             throw new IllegalArgumentException("Invalid return type for async execution: " + asyncResultWrapperType);
         }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/FaultToleranceStateFactory.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/FaultToleranceStateFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import com.ibm.ws.microprofile.faulttolerance.spi.BulkheadPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.CircuitBreakerPolicy;
+import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance.spi.RetryPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.TimeoutPolicy;
 import com.ibm.ws.microprofile.faulttolerance20.state.impl.AsyncBulkheadStateImpl;
@@ -49,11 +50,11 @@ public class FaultToleranceStateFactory {
      * @param policy the RetryPolicy, may be {@code null}
      * @return a new RetryState
      */
-    public RetryState createRetryState(RetryPolicy policy) {
+    public RetryState createRetryState(RetryPolicy policy, MetricRecorder metricRecorder) {
         if (policy == null) {
             return new RetryStateNullImpl();
         } else {
-            return new RetryStateImpl(policy);
+            return new RetryStateImpl(policy, metricRecorder);
         }
     }
 
@@ -63,11 +64,11 @@ public class FaultToleranceStateFactory {
      * @param policy the BulkheadPolicy, may be {@code null}
      * @return a new SyncBulkheadState
      */
-    public SyncBulkheadState createSyncBulkheadState(BulkheadPolicy policy) {
+    public SyncBulkheadState createSyncBulkheadState(BulkheadPolicy policy, MetricRecorder metricRecorder) {
         if (policy == null) {
             return new SyncBulkheadStateNullImpl();
         } else {
-            return new SyncBulkheadStateImpl(policy);
+            return new SyncBulkheadStateImpl(policy, metricRecorder);
         }
     }
 
@@ -75,14 +76,14 @@ public class FaultToleranceStateFactory {
      * Create an object implementing Timeout
      *
      * @param executorService the executor to use to schedule the timeout callback
-     * @param policy the TimeoutPolicy, may be {@code null}
+     * @param policy          the TimeoutPolicy, may be {@code null}
      * @return a new TimeoutState
      */
-    public TimeoutState createTimeoutState(ScheduledExecutorService executorService, TimeoutPolicy policy) {
+    public TimeoutState createTimeoutState(ScheduledExecutorService executorService, TimeoutPolicy policy, MetricRecorder metricRecorder) {
         if (policy == null) {
             return new TimeoutStateNullImpl();
         } else {
-            return new TimeoutStateImpl(executorService, policy);
+            return new TimeoutStateImpl(executorService, policy, metricRecorder);
         }
     }
 
@@ -92,11 +93,11 @@ public class FaultToleranceStateFactory {
      * @param policy the CircuitBreakerPolicy, may be {@code null}
      * @return a new CircuitBreakerState
      */
-    public CircuitBreakerState createCircuitBreakerState(CircuitBreakerPolicy policy) {
+    public CircuitBreakerState createCircuitBreakerState(CircuitBreakerPolicy policy, MetricRecorder metricRecorder) {
         if (policy == null) {
             return new CircuitBreakerStateNullImpl();
         } else {
-            return new CircuitBreakerStateImpl(policy);
+            return new CircuitBreakerStateImpl(policy, metricRecorder);
         }
     }
 
@@ -106,15 +107,16 @@ public class FaultToleranceStateFactory {
      * If {@code null} is passed for the policy, the returned object will still run submitted tasks asynchronously, but will not apply any bulkhead logic.
      *
      * @param executorProvider the policy executor provider
-     * @param executorService the executor to use to asynchronously run tasks
-     * @param policy the BulkheadPolicy, may be {@code null}
+     * @param executorService  the executor to use to asynchronously run tasks
+     * @param policy           the BulkheadPolicy, may be {@code null}
      * @return a new AsyncBulkheadState
      */
-    public AsyncBulkheadState createAsyncBulkheadState(PolicyExecutorProvider executorProvider, ScheduledExecutorService executorService, BulkheadPolicy policy) {
+    public AsyncBulkheadState createAsyncBulkheadState(PolicyExecutorProvider executorProvider, ScheduledExecutorService executorService, BulkheadPolicy policy,
+                                                       MetricRecorder metricRecorder) {
         if (policy == null) {
             return new AsyncBulkheadStateNullImpl(executorService);
         } else {
-            return new AsyncBulkheadStateImpl(executorProvider, policy);
+            return new AsyncBulkheadStateImpl(executorProvider, policy, metricRecorder);
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/SyncBulkheadStateImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/SyncBulkheadStateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,14 +16,19 @@ import java.util.concurrent.Semaphore;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 
 import com.ibm.ws.microprofile.faulttolerance.spi.BulkheadPolicy;
+import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance20.impl.MethodResult;
 
 public class SyncBulkheadStateImpl extends SyncBulkheadStateNullImpl {
 
     private final Semaphore semaphore;
+    private final MetricRecorder metrics;
 
-    public SyncBulkheadStateImpl(BulkheadPolicy policy) {
-        semaphore = new Semaphore(policy.getMaxThreads());
+    public SyncBulkheadStateImpl(BulkheadPolicy policy, MetricRecorder metrics) {
+        final int maxThreads = policy.getMaxThreads();
+        semaphore = new Semaphore(maxThreads);
+        this.metrics = metrics;
+        metrics.setBulkheadConcurentExecutionCountSupplier(() -> maxThreads - semaphore.availablePermits());
     }
 
     /** {@inheritDoc} */
@@ -31,13 +36,19 @@ public class SyncBulkheadStateImpl extends SyncBulkheadStateNullImpl {
     public <R> MethodResult<R> run(Callable<R> callable) {
 
         if (!semaphore.tryAcquire()) {
+            metrics.incrementBulkheadRejectedCount();
             return MethodResult.failure(new BulkheadException());
         }
+
+        long startTime = System.nanoTime();
+        metrics.incrementBulkeadAcceptedCount();
 
         try {
             return super.run(callable);
         } finally {
             semaphore.release();
+            long endTime = System.nanoTime();
+            metrics.recordBulkheadExecutionTime(endTime - startTime);
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/RetryStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/RetryStateImplTest.java
@@ -29,17 +29,21 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import com.ibm.ws.microprofile.faulttolerance.impl.policy.RetryPolicyImpl;
+import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
+import com.ibm.ws.microprofile.faulttolerance.utils.DummyMetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance20.impl.MethodResult;
 import com.ibm.ws.microprofile.faulttolerance20.state.RetryState.RetryResult;
 
 public class RetryStateImplTest {
+
+    private static MetricRecorder dummyMetrics = DummyMetricRecorder.get();
 
     @Test
     public void testMaxRetries() {
         RetryPolicyImpl retryPolicy = new RetryPolicyImpl();
         retryPolicy.setMaxRetries(3);
 
-        RetryStateImpl retryState = new RetryStateImpl(retryPolicy);
+        RetryStateImpl retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
 
         // Should retry three times
@@ -54,7 +58,7 @@ public class RetryStateImplTest {
         RetryPolicyImpl retryPolicy = new RetryPolicyImpl();
         retryPolicy.setMaxRetries(3);
 
-        RetryStateImpl retryState = new RetryStateImpl(retryPolicy);
+        RetryStateImpl retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
 
         // Should not retry because execution was successful
@@ -67,19 +71,19 @@ public class RetryStateImplTest {
         retryPolicy.setMaxRetries(3);
         retryPolicy.setRetryOn(TestExceptionA.class, TestExceptionB.class);
 
-        RetryStateImpl retryState = new RetryStateImpl(retryPolicy);
+        RetryStateImpl retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertTrue(retryState.recordResult(MethodResult.failure(new TestExceptionA())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertTrue(retryState.recordResult(MethodResult.failure(new TestExceptionAsubclass())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertTrue(retryState.recordResult(MethodResult.failure(new TestExceptionB())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertFalse(retryState.recordResult(MethodResult.failure(new TestExceptionC())).shouldRetry());
     }
@@ -90,19 +94,19 @@ public class RetryStateImplTest {
         retryPolicy.setMaxRetries(3);
         retryPolicy.setAbortOn(TestExceptionA.class, TestExceptionB.class);
 
-        RetryStateImpl retryState = new RetryStateImpl(retryPolicy);
+        RetryStateImpl retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertFalse(retryState.recordResult(MethodResult.failure(new TestExceptionA())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertFalse(retryState.recordResult(MethodResult.failure(new TestExceptionAsubclass())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertFalse(retryState.recordResult(MethodResult.failure(new TestExceptionB())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertTrue(retryState.recordResult(MethodResult.failure(new TestExceptionC())).shouldRetry());
     }
@@ -117,19 +121,19 @@ public class RetryStateImplTest {
         retryPolicy.setRetryOn(TestExceptionA.class, TestExceptionB.class);
         retryPolicy.setAbortOn(TestExceptionAsubclass.class);
 
-        RetryStateImpl retryState = new RetryStateImpl(retryPolicy);
+        RetryStateImpl retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertTrue(retryState.recordResult(MethodResult.failure(new TestExceptionA())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertFalse(retryState.recordResult(MethodResult.failure(new TestExceptionAsubclass())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertTrue(retryState.recordResult(MethodResult.failure(new TestExceptionB())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertFalse(retryState.recordResult(MethodResult.failure(new TestExceptionC())).shouldRetry());
 
@@ -140,19 +144,19 @@ public class RetryStateImplTest {
         retryPolicy.setRetryOn(TestExceptionAsubclass.class, TestExceptionB.class);
         retryPolicy.setAbortOn(TestExceptionA.class);
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertFalse(retryState.recordResult(MethodResult.failure(new TestExceptionA())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertFalse(retryState.recordResult(MethodResult.failure(new TestExceptionAsubclass())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertTrue(retryState.recordResult(MethodResult.failure(new TestExceptionB())).shouldRetry());
 
-        retryState = new RetryStateImpl(retryPolicy);
+        retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertFalse(retryState.recordResult(MethodResult.failure(new TestExceptionC())).shouldRetry());
     }
@@ -163,7 +167,7 @@ public class RetryStateImplTest {
         retryPolicy.setMaxRetries(3);
         retryPolicy.setMaxDuration(Duration.ofMillis(200));
 
-        RetryStateImpl retryState = new RetryStateImpl(retryPolicy);
+        RetryStateImpl retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         assertTrue(retryState.recordResult(MethodResult.failure(new TestExceptionA())).shouldRetry());
 
@@ -178,7 +182,7 @@ public class RetryStateImplTest {
         retryPolicy.setDelay(Duration.ofMillis(200));
         retryPolicy.setJitter(Duration.ofMillis(0));
 
-        RetryStateImpl retryState = new RetryStateImpl(retryPolicy);
+        RetryStateImpl retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
         RetryResult result = retryState.recordResult(MethodResult.failure(new TestExceptionA()));
         assertTrue(result.shouldRetry());
@@ -198,7 +202,7 @@ public class RetryStateImplTest {
 
         Set<Long> delayTimes = new HashSet<>();
 
-        RetryStateImpl retryState = new RetryStateImpl(retryPolicy);
+        RetryStateImpl retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
 
         // Test 10 iterations
@@ -269,7 +273,7 @@ public class RetryStateImplTest {
         retryPolicy.setMaxRetries(-1);
         retryPolicy.setJitter(Duration.ZERO);
 
-        RetryStateImpl retryState = new RetryStateImpl(retryPolicy);
+        RetryStateImpl retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
 
         // Should retry forever
@@ -284,7 +288,7 @@ public class RetryStateImplTest {
         RetryPolicyImpl retryPolicy = new RetryPolicyImpl();
         retryPolicy.setMaxDuration(Duration.ZERO);
 
-        RetryStateImpl retryState = new RetryStateImpl(retryPolicy);
+        RetryStateImpl retryState = new RetryStateImpl(retryPolicy, dummyMetrics);
         retryState.start();
 
         assertTrue(retryState.recordResult(MethodResult.failure(new TestExceptionA())).shouldRetry());
@@ -295,12 +299,16 @@ public class RetryStateImplTest {
         assertTrue(retryState.recordResult(MethodResult.failure(new TestExceptionA())).shouldRetry());
     }
 
-    private class TestExceptionA extends Exception {}
+    private class TestExceptionA extends Exception {
+    }
 
-    private class TestExceptionB extends Exception {}
+    private class TestExceptionB extends Exception {
+    }
 
-    private class TestExceptionC extends Exception {}
+    private class TestExceptionC extends Exception {
+    }
 
-    private class TestExceptionAsubclass extends TestExceptionA {}
+    private class TestExceptionAsubclass extends TestExceptionA {
+    }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/SyncBulkheadStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/SyncBulkheadStateImplTest.java
@@ -36,11 +36,14 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 import org.junit.Test;
 
 import com.ibm.ws.microprofile.faulttolerance.impl.policy.BulkheadPolicyImpl;
+import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
+import com.ibm.ws.microprofile.faulttolerance.utils.DummyMetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance20.impl.MethodResult;
 
 public class SyncBulkheadStateImplTest {
 
     ExecutorService executor = Executors.newFixedThreadPool(10);
+    private static MetricRecorder dummyMetrics = DummyMetricRecorder.get();
 
     /**
      * Check that the bulkhead will reject executions if it's full
@@ -50,7 +53,7 @@ public class SyncBulkheadStateImplTest {
         BulkheadPolicyImpl bulkheadPolicy = new BulkheadPolicyImpl();
         bulkheadPolicy.setMaxThreads(2);
 
-        SyncBulkheadStateImpl bulkheadState = new SyncBulkheadStateImpl(bulkheadPolicy);
+        SyncBulkheadStateImpl bulkheadState = new SyncBulkheadStateImpl(bulkheadPolicy, dummyMetrics);
 
         CompletableFuture<Void> waitingFuture = new CompletableFuture<>();
 
@@ -100,7 +103,7 @@ public class SyncBulkheadStateImplTest {
         BulkheadPolicyImpl bulkheadPolicy = new BulkheadPolicyImpl();
         bulkheadPolicy.setMaxThreads(2);
 
-        SyncBulkheadStateImpl bulkheadState = new SyncBulkheadStateImpl(bulkheadPolicy);
+        SyncBulkheadStateImpl bulkheadState = new SyncBulkheadStateImpl(bulkheadPolicy, dummyMetrics);
 
         for (int i = 0; i < 100; i++) {
             MethodResult<String> result = bulkheadState.run(() -> "ok");

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/TimeoutStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/TimeoutStateImplTest.java
@@ -24,11 +24,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.ibm.ws.microprofile.faulttolerance.impl.policy.TimeoutPolicyImpl;
+import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
+import com.ibm.ws.microprofile.faulttolerance.utils.DummyMetricRecorder;
 
 public class TimeoutStateImplTest {
 
     private ScheduledExecutorService scheduledExecutorService;
     private final AtomicBoolean timeoutFlag = new AtomicBoolean(false);
+    private static MetricRecorder dummyMetrics = DummyMetricRecorder.get();
 
     @Before
     public void setup() {
@@ -46,7 +49,7 @@ public class TimeoutStateImplTest {
         TimeoutPolicyImpl policy = new TimeoutPolicyImpl();
         policy.setTimeout(Duration.ofMillis(100L));
 
-        TimeoutStateImpl state = new TimeoutStateImpl(scheduledExecutorService, policy);
+        TimeoutStateImpl state = new TimeoutStateImpl(scheduledExecutorService, policy, dummyMetrics);
         state.start();
         state.setTimeoutCallback(this::setTimeoutFlag);
         state.stop();
@@ -66,7 +69,7 @@ public class TimeoutStateImplTest {
         TimeoutPolicyImpl policy = new TimeoutPolicyImpl();
         policy.setTimeout(Duration.ofMillis(100L));
 
-        TimeoutStateImpl state = new TimeoutStateImpl(scheduledExecutorService, policy);
+        TimeoutStateImpl state = new TimeoutStateImpl(scheduledExecutorService, policy, dummyMetrics);
         state.start();
         state.setTimeoutCallback(this::setTimeoutFlag);
 
@@ -86,7 +89,7 @@ public class TimeoutStateImplTest {
         TimeoutPolicyImpl policy = new TimeoutPolicyImpl();
         policy.setTimeout(Duration.ZERO);
 
-        TimeoutStateImpl state = new TimeoutStateImpl(scheduledExecutorService, policy);
+        TimeoutStateImpl state = new TimeoutStateImpl(scheduledExecutorService, policy, dummyMetrics);
         state.start();
         state.setTimeoutCallback(this::setTimeoutFlag);
 
@@ -110,7 +113,7 @@ public class TimeoutStateImplTest {
         TimeoutPolicyImpl policy = new TimeoutPolicyImpl();
         policy.setTimeout(Duration.ofMillis(100L));
 
-        TimeoutStateImpl state = new TimeoutStateImpl(scheduledExecutorService, policy);
+        TimeoutStateImpl state = new TimeoutStateImpl(scheduledExecutorService, policy, dummyMetrics);
         state.setTimeoutCallback(this::setTimeoutFlag);
         state.start();
 
@@ -133,7 +136,7 @@ public class TimeoutStateImplTest {
         TimeoutPolicyImpl policy = new TimeoutPolicyImpl();
         policy.setTimeout(Duration.ofMillis(100L));
 
-        TimeoutStateImpl state = new TimeoutStateImpl(scheduledExecutorService, policy);
+        TimeoutStateImpl state = new TimeoutStateImpl(scheduledExecutorService, policy, dummyMetrics);
         state.start();
 
         assertFalse(timeoutFlag.get());


### PR DESCRIPTION
Adds metrics support to Fault Tolerance 2.0

Test coverage is provided by the TCK

Still missing are the execution and queuing time histograms from asynchronous bulkhead which will be added under #6147. (Currently the Async Bulkhead is broken in a fundamental way so these metrics can't be added correctly. It doesn't seem worth the effort of adding them incorrectly given that they won't pass the tests anyway.)

Fixes #5492

Ignore the first two commits, they will be removed when #6149 is merged