### PR TITLE
Revert "5785-orbssltimeout2-commit1"

### DIFF
--- a/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/security/AbstractCsiv2SubsystemFactory.java
+++ b/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/security/AbstractCsiv2SubsystemFactory.java
@@ -10,6 +10,25 @@
  *******************************************************************************/
 package com.ibm.ws.transport.iiop.security;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.csiv2.config.ssl.SSLConfig;
+import com.ibm.ws.security.csiv2.util.SecurityServices;
+import com.ibm.ws.ssl.optional.SSLSupportOptional;
+import com.ibm.ws.transport.iiop.security.config.ssl.yoko.SocketFactory;
+import com.ibm.ws.transport.iiop.spi.IIOPEndpoint;
+import com.ibm.ws.transport.iiop.spi.ReadyListener;
+import com.ibm.ws.transport.iiop.spi.SubsystemFactory;
+import com.ibm.wsspi.ssl.SSLSupport;
+import org.apache.yoko.osgi.locator.LocalFactory;
+import org.apache.yoko.osgi.locator.Register;
+import org.apache.yoko.osgi.locator.ServiceProvider;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -22,31 +41,12 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.yoko.osgi.locator.LocalFactory;
-import org.apache.yoko.osgi.locator.Register;
-import org.apache.yoko.osgi.locator.ServiceProvider;
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.security.csiv2.config.ssl.SSLConfig;
-import com.ibm.ws.security.csiv2.util.SecurityServices;
-import com.ibm.ws.ssl.optional.SSLSupportOptional;
-import com.ibm.ws.transport.iiop.security.config.ssl.yoko.SocketFactory;
-import com.ibm.ws.transport.iiop.spi.IIOPEndpoint;
-import com.ibm.ws.transport.iiop.spi.ReadyListener;
-import com.ibm.ws.transport.iiop.spi.SubsystemFactory;
-import com.ibm.wsspi.ssl.SSLSupport;
-
 /**
  *
  */
 public abstract class AbstractCsiv2SubsystemFactory extends SubsystemFactory {
     private static final TraceComponent tc = Tr.register(AbstractCsiv2SubsystemFactory.class);
-    protected static long TIMEOUT_SECONDS;
+    protected static final long TIMEOUT_SECONDS = 10;
 
     private enum MyLocalFactory implements LocalFactory {
         INSTANCE;
@@ -132,13 +132,6 @@ public abstract class AbstractCsiv2SubsystemFactory extends SubsystemFactory {
     @Override
     public void register(ReadyListener listener, Map<String, Object> properties, List<IIOPEndpoint> endpoints) {
         ReadyRegistration rr = new ReadyRegistration(extractSslRefs(properties, endpoints), listener);
-        String timeoutValue = (String) properties.get("orbSSLInitTimeout");
-        if (timeoutValue != null & timeoutValue.length() > 0) {
-            TIMEOUT_SECONDS = Long.valueOf(timeoutValue);
-            Tr.debug(tc, "orbSSLInitTimeout=" + timeoutValue);
-        } else {
-            Tr.debug(tc, "orbSSLInitTimeout is invalid. orbSSLInitTimeout=" + timeoutValue);
-        }
         regs.add(rr);
         rr.check();
     }

--- a/dev/com.ibm.ws.transport.iiop/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.transport.iiop/resources/OSGI-INF/l10n/metatype.properties
@@ -23,8 +23,6 @@ orbWrapper.iiopEndpoint.desc=Optional IIOP Endpoint describing the ports open fo
 orbWrapper.name=Object Request Broker (ORB)
 orbWrapper.nameService=Naming context location for a client ORB
 orbWrapper.nameService.desc=Optional URL for the remote name service, for example corbaname::localhost:2809
-orbWrapper.orbSSLInitTimeout=Timeout that governs ORB SSL initialization
-orbWrapper.orbSSLInitTimeout.desc=ORB SSL initialization timeout specified in seconds
 
 #deprecated
 iiopClient.desc=Configuration for IIOP client

--- a/dev/com.ibm.ws.transport.iiop/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.transport.iiop/resources/OSGI-INF/metatype/metatype.xml
@@ -38,9 +38,6 @@
         <AD name="%orbWrapper.nameService" description="%orbWrapper.nameService.desc"
             id="nameService" required="false" type="String" default="corbaname::localhost:2809" />
             
-        <AD name="%orbWrapper.orbSSLInitTimeout" description="%orbWrapper.orbSSLInitTimeout.desc"
-            id="orbSSLInitTimeout" required="false" type="String" default="10" />
-            
         <AD id="iiopEndpoint" name="%orbWrapper.iiopEndpoint" description="%orbWrapper.iiopEndpoint.desc" cardinality="100"
             required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.transport.iiop.internal.IIOPEndpointImpl" default="defaultIiopEndpoint"/>
             


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#5983

Looks like there could be thread safety and timing issues around the reading of the TIMEOUT_SECONDS value from config. It is possible that the timeout task is run before the timeout has been properly read, in which case the value would be zero and the timeout would run straight away.