### PR TITLE
update MP Concurrency TCK bucket for running tests that use MP Config

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ManagedExecutorBean.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ManagedExecutorBean.java
@@ -41,13 +41,16 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
     // This instance is used as a marker for when no configured is specified for a String[]. The reference is compared; its content does not matter.
     private static final String[] UNSPECIFIED_ARRAY = new String[] {};
 
-    private final String name;
+    private final String injectionPointName;
+    private final String instanceName;
     private final Set<Annotation> qualifiers;
     private final ManagedExecutorConfig config;
     private final ConcurrencyCDIExtension cdiExtension;
 
+    // TODO remove this constructor given the decision not to supply unqualified instance for programmatic lookup
     public ManagedExecutorBean(ConcurrencyCDIExtension cdiExtension) {
-        this.name = getClass().getCanonicalName();
+        this.injectionPointName = getClass().getCanonicalName();
+        this.instanceName = getClass().getCanonicalName();
         this.config = null;
         this.cdiExtension = cdiExtension;
         Set<Annotation> qualifiers = new HashSet<>(2);
@@ -56,14 +59,16 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
         this.qualifiers = Collections.unmodifiableSet(qualifiers);
     }
 
-    public ManagedExecutorBean(String name, ManagedExecutorConfig config, ConcurrencyCDIExtension cdiExtension) {
-        Objects.requireNonNull(name);
-        this.name = name;
+    public ManagedExecutorBean(String injectionPointName, String instanceName, ManagedExecutorConfig config, ConcurrencyCDIExtension cdiExtension) {
+        Objects.requireNonNull(injectionPointName);
+        Objects.requireNonNull(instanceName);
+        this.injectionPointName = injectionPointName;
+        this.instanceName = instanceName;
         this.config = config;
         this.cdiExtension = cdiExtension;
         Set<Annotation> qualifiers = new HashSet<>(2);
         qualifiers.add(Any.Literal.INSTANCE);
-        qualifiers.add(NamedInstance.Literal.of(this.name));
+        qualifiers.add(NamedInstance.Literal.of(instanceName));
         this.qualifiers = Collections.unmodifiableSet(qualifiers);
     }
 
@@ -81,9 +86,9 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
         } else {
             Object mpConfig = cdiExtension.mpConfig;
 
-            int start = name.length() + 1;
+            int start = injectionPointName.length() + 1;
             int len = start + 10;
-            StringBuilder propName = new StringBuilder(len).append(name).append('.');
+            StringBuilder propName = new StringBuilder(len).append(injectionPointName).append('.');
 
             // In order to efficiently reuse StringBuilder, properties are added in the order of the length of their names,
 
@@ -118,7 +123,7 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
 
     @Override
     public String getName() {
-        return name;
+        return instanceName; // TODO should change this to null because @Named qualifier is not present ?
     }
 
     @Override
@@ -148,7 +153,7 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
 
     @Override
     public String getId() {
-        return name;
+        return injectionPointName;
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
@@ -1,3 +1,5 @@
 concurrent.mp.fat.config.web.ConcurrencyConfigBean.getExecutor.1.maxQueued=3
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.containerExecutorWithNameAndConfig.maxAsync=1
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.containerExecutorWithNameAndConfig.maxQueued=2
 concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.executorWithMPConfigOverride.cleared=City
 concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.executorWithMPConfigOverride.propagated=Application,State

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/ConcurrencyConfigBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/ConcurrencyConfigBean.java
@@ -32,7 +32,6 @@ public class ConcurrencyConfigBean {
     // MicroProfile Concurrency automatically shuts down ManagedExecutors when the application stops.
     // But even if the application writes its own disposer, it shouldn't get an error.
     void disposeExecutor(@Disposes @NamedInstance("applicationProducedExecutor") ManagedExecutor exec) {
-        System.out.println("### disposer");
         exec.shutdownNow();
     }
 

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/servers/MPConcurrencyTCKServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/servers/MPConcurrencyTCKServer/server.xml
@@ -5,6 +5,7 @@
         <feature>localConnector-1.0</feature>
         <feature>cdi-2.0</feature>
         <feature>mpConcurrency-1.0</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml" />


### PR DESCRIPTION
MicroProfile Config needs to be enabled in the MicroProfile Concurrency TCK test bucket because some of the TCK tests rely on it.