### PR TITLE
Fixed bug in merging paths

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/jaxrs2/util/ReaderUtils.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/jaxrs2/util/ReaderUtils.java
@@ -183,8 +183,15 @@ public class ReaderUtils {
 
             b.append(parentPath);
         }
-        if (classLevelPath != null) {
-            b.append(classLevelPath.value());
+        if (classLevelPath != null && !"/".equals(classLevelPath.value())) {
+            String classPath = classLevelPath.value();
+            if (!classPath.startsWith("/") && !b.toString().endsWith("/")) {
+                b.append("/");
+            }
+            if (classPath.endsWith("/")) {
+                classPath = classPath.substring(0, classPath.length() - 1);
+            }
+            b.append(classPath);
         }
         if (methodLevelPath != null && !"/".equals(methodLevelPath.value())) {
             String methodPath = methodLevelPath.value();


### PR DESCRIPTION
Fixed bug in openapi when merging `classLevelPath` with `methodLevelPath`