### PR TITLE
Update QuickStartSecurity to support hashed passwords

### DIFF
--- a/dev/com.ibm.ws.security.quickstart/src/com/ibm/ws/security/quickstart/internal/Password.java
+++ b/dev/com.ibm.ws.security.quickstart/src/com/ibm/ws/security/quickstart/internal/Password.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.quickstart.internal;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
+
+import com.ibm.websphere.crypto.PasswordUtil;
+import com.ibm.wsspi.kernel.service.utils.SerializableProtectedString;
+import com.ibm.websphere.ras.annotation.Sensitive;
+
+/**
+ * A base class defining behaviour and creation methods for doing
+ * password checks. This allows the client to do a password check
+ * using plain text, xor, aes or hash (recommended) without needing
+ * to know the details.
+ */
+public abstract class Password {
+  protected final SerializableProtectedString pwd;
+  private final boolean isEmpty;
+
+  public Password(SerializableProtectedString pwd) {
+    this.pwd = pwd;
+    isEmpty = new String(pwd.getChars()).trim().isEmpty();
+  }
+
+  public abstract boolean checkPassword(String pwd);
+
+  public final boolean isEmpty() {
+    return isEmpty;
+  }
+
+  public static Password create(SerializableProtectedString pwd) {
+    String pwdStr = new String(pwd.getChars());
+    if (PasswordUtil.getCryptoAlgorithm(pwdStr) == null) {
+      return new PlainTextPassword(pwd);
+    } else if (PasswordUtil.isHashed(pwdStr)) {
+      return new HashedPassword(pwd);
+    } else {
+      return new ReversablePassword(pwd);
+    }
+  }
+
+  /**
+   * Performs a simple equals check on the password. The password needs
+   * to be stored in plain text. A bad production practice, but in dev
+   * this is quite common.
+   */
+  private static class PlainTextPassword extends Password {
+    public PlainTextPassword(SerializableProtectedString pwd) {
+      super(pwd);
+    }
+
+    public boolean checkPassword(@Sensitive String password) {
+      if (pwd != null) {
+        return Arrays.equals(pwd.getChars(), password.toCharArray());
+      } else {
+        return password == null;
+      }
+    }
+  }
+
+  /**
+   * Performs a password check for xor or aes encrypted passwords.
+   * Essentially decrepts/decodes the password and does an equal check.
+   */
+  private static class ReversablePassword extends Password {
+
+    public ReversablePassword(SerializableProtectedString pwd) {
+      super(pwd);
+    }
+
+    public boolean checkPassword(@Sensitive String password) {
+      if (pwd != null) {
+        return Arrays.equals(decodePassword(pwd).getChars(), password.toCharArray());
+      } else {
+        return password == null;
+      }
+    }
+
+    private static SerializableProtectedString decodePassword(SerializableProtectedString pw) {
+      if (pw != null) {
+          String password = new String(pw.getChars());
+          password = PasswordUtil.passwordDecode(password.trim());
+          char[] passswordArray = new char[password.length()];
+          password.getChars(0, password.length(), passswordArray, 0);
+          return new SerializableProtectedString(passswordArray);
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Performs a password check on a hashed password. Works by
+   * recomputing the hash and comparing the hash.
+   */
+  private static class HashedPassword extends Password {
+    private String hashAlgorithm;
+
+    public HashedPassword(SerializableProtectedString pwd) {
+      super(pwd);
+      String pwdStr = new String(pwd.getChars());
+      hashAlgorithm = PasswordUtil.getCryptoAlgorithm(pwdStr);
+    }
+
+    public boolean checkPassword(@Sensitive String password) {
+      HashMap<String, String> props = new HashMap<String, String>();
+      props.put(PasswordUtil.PROPERTY_HASH_ENCODED, new String(pwd.getChars()));
+      String inPass = null;
+      try {
+          inPass = PasswordUtil.encode(password, hashAlgorithm, props);
+          return Arrays.equals(pwd.getChars(), inPass.toCharArray());
+      } catch (Exception e) {
+          //fail to encode password.
+          throw new IllegalArgumentException("password encoding failure : " + e.getMessage());
+      }
+    }
+  }
+}

--- a/dev/com.ibm.ws.security.quickstart/src/com/ibm/ws/security/quickstart/internal/QuickStartSecurity.java
+++ b/dev/com.ibm.ws.security.quickstart/src/com/ibm/ws/security/quickstart/internal/QuickStartSecurity.java
@@ -59,7 +59,7 @@ interface QuickStartSecurityConfig {
     String userName();
 
     @AttributeDefinition(name = "%quickStartSecurity.userPassword", description = "%quickStartSecurity.userPassword.desc", required = false)
-    @Ext.Type("password")
+    @Ext.Type("passwordHash")
     SerializableProtectedString userPassword();
 
     @AttributeDefinition(name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, defaultValue = "*")
@@ -260,7 +260,6 @@ public class QuickStartSecurity {
         properties.put("id", QUICK_START_SECURITY_REGISTRY_ID);
         properties.put(UserRegistryService.REGISTRY_TYPE, QUICK_START_SECURITY_REGISTRY_TYPE);
         properties.put(CFG_KEY_USER, config.userName());
-        properties.put(CFG_KEY_PASSWORD, getPasswordValue(config.userPassword()));
         properties.put("service.vendor", "IBM");
         return properties;
     }
@@ -304,7 +303,7 @@ public class QuickStartSecurity {
         }
         Dictionary<String, Object> props = buildUserRegistryConfigProps();
 
-        quickStartRegistry = new QuickStartSecurityRegistry(config.userName(), getPasswordValue(config.userPassword()));
+        quickStartRegistry = new QuickStartSecurityRegistry(config.userName(), Password.create(config.userPassword()));
         urConfigReg = bc.registerService(UserRegistry.class,
                                          quickStartRegistry,
                                          props);
@@ -325,7 +324,7 @@ public class QuickStartSecurity {
         if (!isStringValueUndefined(config.userName()) && !isStringValueUndefined(config.userPassword())
             && (config.UserRegistry() == null || config.UserRegistry().length == 0)
             && (config.ManagementRole() == null || config.ManagementRole().length == 0)) {
-            quickStartRegistry.update(config.userName(), getPasswordValue(config.userPassword()));
+            quickStartRegistry.update(config.userName(), Password.create(config.userPassword()));
 
             // Update the service registration with the new configuration
             Dictionary<String, Object> newConfigProps = buildUserRegistryConfigProps();
@@ -413,25 +412,6 @@ public class QuickStartSecurity {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "QuickStartSecurityAdministratorRole is not registered.");
             }
-        }
-    }
-
-    /**
-     * Get the password value from the list of properties
-     *
-     * @param props
-     * @return the password
-     */
-    private ProtectedString getPasswordValue(SerializableProtectedString pw) {
-        if (pw != null) {
-            String password = new String(pw.getChars());
-            // The password may have been encoded, if so we need to decode it first before we store it
-            password = PasswordUtil.passwordDecode(password.trim());
-            char[] passswordArray = new char[password.length()];
-            password.getChars(0, password.length(), passswordArray, 0);
-            return new ProtectedString(passswordArray);
-        } else {
-            return null;
         }
     }
 }

--- a/dev/com.ibm.ws.security.quickstart/src/com/ibm/ws/security/quickstart/internal/QuickStartSecurityRegistry.java
+++ b/dev/com.ibm.ws.security.quickstart/src/com/ibm/ws/security/quickstart/internal/QuickStartSecurityRegistry.java
@@ -34,7 +34,7 @@ class QuickStartSecurityRegistry implements UserRegistry {
     static final String REALM_NAME = "QuickStartSecurityRealm";
     private volatile String user;
     @Sensitive
-    private volatile ProtectedString password;
+    private volatile Password password;
 
     /**
      * Create QuickStartSecurityRegistry instance.
@@ -43,7 +43,7 @@ class QuickStartSecurityRegistry implements UserRegistry {
      * @param password
      * @throws IllegalArgumentException
      */
-    QuickStartSecurityRegistry(String user, ProtectedString password) {
+    QuickStartSecurityRegistry(String user, Password password) {
         update(user, password);
     }
 
@@ -51,7 +51,7 @@ class QuickStartSecurityRegistry implements UserRegistry {
      * @param user
      * @param password
      */
-    void update(String user, ProtectedString password) {
+    void update(String user, Password password) {
         if (user == null) {
             throw new IllegalArgumentException("user must not be null");
         }
@@ -61,7 +61,7 @@ class QuickStartSecurityRegistry implements UserRegistry {
         if (password == null) {
             throw new IllegalArgumentException("password must not be null");
         }
-        if (new String(password.getChars()).trim().isEmpty()) {
+        if (password.isEmpty()) {
             throw new IllegalArgumentException("password must not be empty");
         }
         this.user = user;
@@ -89,8 +89,7 @@ class QuickStartSecurityRegistry implements UserRegistry {
         if (password.isEmpty()) {
             throw new IllegalArgumentException("password is an empty String");
         }
-        String savedPassword = new String(this.password.getChars());
-        if (this.user.equals(userSecurityName) && savedPassword.equals(password)) {
+        if (this.user.equals(userSecurityName) && this.password.checkPassword(password)) {
             return user;
         } else {
             return null;

--- a/dev/com.ibm.ws.security.quickstart/test/com/ibm/ws/security/quickstart/internal/QuickStartSecurityRegistryIllegalArgumentTest.java
+++ b/dev/com.ibm.ws.security.quickstart/test/com/ibm/ws/security/quickstart/internal/QuickStartSecurityRegistryIllegalArgumentTest.java
@@ -12,6 +12,7 @@ package com.ibm.ws.security.quickstart.internal;
 
 import com.ibm.websphere.ras.ProtectedString;
 import com.ibm.ws.security.registry.UserRegistryIllegalArgumentTemplate;
+import com.ibm.wsspi.kernel.service.utils.SerializableProtectedString;
 
 /**
  * @see UserRegistryIllegalArgumentTemplate
@@ -19,6 +20,6 @@ import com.ibm.ws.security.registry.UserRegistryIllegalArgumentTemplate;
 public class QuickStartSecurityRegistryIllegalArgumentTest extends UserRegistryIllegalArgumentTemplate {
 
     public QuickStartSecurityRegistryIllegalArgumentTest() {
-        super(new QuickStartSecurityRegistry("user", new ProtectedString("pwd".toCharArray())));
+         super(new QuickStartSecurityRegistry("user", Password.create(new SerializableProtectedString("pwd".toCharArray()))));
     }
 }

--- a/dev/com.ibm.ws.security.quickstart/test/com/ibm/ws/security/quickstart/internal/QuickStartSecurityRegistryTest.java
+++ b/dev/com.ibm.ws.security.quickstart/test/com/ibm/ws/security/quickstart/internal/QuickStartSecurityRegistryTest.java
@@ -33,6 +33,7 @@ import com.ibm.ws.security.registry.CertificateMapFailedException;
 import com.ibm.ws.security.registry.EntryNotFoundException;
 import com.ibm.ws.security.registry.SearchResult;
 import com.ibm.ws.security.registry.UserRegistry;
+import com.ibm.wsspi.kernel.service.utils.SerializableProtectedString;
 
 /**
  *
@@ -40,7 +41,7 @@ import com.ibm.ws.security.registry.UserRegistry;
 public class QuickStartSecurityRegistryTest {
     private static final String DEFAULT_ADMIN_USER = "bob";
     private static final String DEFAULT_ADMIN_PASSWORD = "bobpwd";
-    private static final ProtectedString DEFAULT_ADMIN_PASSWORD_PROTECTED = new ProtectedString(DEFAULT_ADMIN_PASSWORD.toCharArray());
+    private static final Password DEFAULT_ADMIN_PASSWORD_PROTECTED = createPassword(DEFAULT_ADMIN_PASSWORD);
     private final Mockery mock = new JUnit4Mockery() {
         {
             setImposteriser(ClassImposteriser.INSTANCE);
@@ -90,7 +91,7 @@ public class QuickStartSecurityRegistryTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void ctor_passwordCanNotBeEmpty() throws Exception {
-        new QuickStartSecurityRegistry(DEFAULT_ADMIN_USER, new ProtectedString("".toCharArray()));
+        new QuickStartSecurityRegistry(DEFAULT_ADMIN_USER,  createPassword(""));
     }
 
     /**
@@ -98,7 +99,7 @@ public class QuickStartSecurityRegistryTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void ctor_passwordCanNotBeOnlyWhiteSpace() throws Exception {
-        new QuickStartSecurityRegistry(DEFAULT_ADMIN_USER, new ProtectedString("  ".toCharArray()));
+        new QuickStartSecurityRegistry(DEFAULT_ADMIN_USER, createPassword("  "));
     }
 
     /**
@@ -605,4 +606,7 @@ public class QuickStartSecurityRegistryTest {
         assertEquals(0, groups.size());
     }
 
+    private static Password createPassword(String pwd) {
+        return Password.create(new SerializableProtectedString(pwd.toCharArray()));
+    }
 }

--- a/dev/com.ibm.ws.security.quickstart/test/com/ibm/ws/security/quickstart/internal/QuickStartSecurityTest.java
+++ b/dev/com.ibm.ws.security.quickstart/test/com/ibm/ws/security/quickstart/internal/QuickStartSecurityTest.java
@@ -155,7 +155,6 @@ public class QuickStartSecurityTest {
         configProps.put(UserRegistryService.REGISTRY_TYPE, QuickStartSecurity.QUICK_START_SECURITY_REGISTRY_TYPE);
         configProps.put("service.vendor", "IBM");
         configProps.put(QuickStartSecurity.CFG_KEY_USER, user);
-        configProps.put(QuickStartSecurity.CFG_KEY_PASSWORD, new ProtectedString(password.toCharArray()));
 
         mock.checking(new Expectations() {
             {
@@ -652,7 +651,6 @@ public class QuickStartSecurityTest {
         newProps.put(UserRegistryService.REGISTRY_TYPE, QuickStartSecurity.QUICK_START_SECURITY_REGISTRY_TYPE);
         newProps.put("service.vendor", "IBM");
         newProps.put(QuickStartSecurity.CFG_KEY_USER, "adminUser2");
-        newProps.put(QuickStartSecurity.CFG_KEY_PASSWORD, new ProtectedString("adminPassword2".toCharArray()));
         mock.checking(new Expectations() {
             {
                 one(mgmtURConfigReg).setProperties(with(equal(newProps)));


### PR DESCRIPTION
Security best practices says passwords stored for encryption should
be one way hashed so add this to quick start security. No expectation
anyone is using this in production since function is really limited and
we have always said this is for prototype and development use.