### PR TITLE
tolerate empty array or empty string within array

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/MPConfigAccessorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/MPConfigAccessorImpl.java
@@ -41,7 +41,21 @@ public class MPConfigAccessorImpl implements MPConfigAccessor {
         Class<?> cl = defaultValue == null ? String[].class : defaultValue.getClass();
         @SuppressWarnings("unchecked")
         Optional<T> configuredValue = (Optional<T>) ((Config) config).getOptionalValue(name, cl);
-        return configuredValue.orElse(defaultValue);
+        T value = configuredValue.orElse(defaultValue);
+
+        // MicroProfile Config is unclear about whether empty value for String[] results in
+        // an empty String array or a size 1 String array where the element is the empty string.
+        // Allow for both possibilities,
+        if (value instanceof String[]) {
+            String[] arr = ((String[]) value);
+            if (arr.length == 1 && arr[0].length() == 0) {
+                @SuppressWarnings("unchecked")
+                T emptyArray = (T) new String[0];
+                value = emptyArray;
+            }
+        }
+
+        return value;
     }
 
     /**


### PR DESCRIPTION
Update our MP Concurrency implementation's code that processes config values from MP Config such that both empty array as well as size 1 array with empty string are valid and mean the same thing.  This is done in order to tolerate an ambiguity in the MP Config spec.