### PR TITLE
quiet down routine jwtsso cookie expiration messages

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jwtSso-1.0/com.ibm.websphere.appserver.jwtSso-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jwtSso-1.0/com.ibm.websphere.appserver.jwtSso-1.0.feature
@@ -17,6 +17,7 @@ Subsystem-Name: JSON Web Token Single Sign-On 1.0
   com.ibm.websphere.appserver.httpcommons-1.0
 -bundles= com.ibm.ws.security.jwtsso, \
   com.ibm.ws.security.common, \
+  com.ibm.ws.security.jwt, \
   com.ibm.websphere.org.eclipse.microprofile.jwt.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.0",\
   com.ibm.ws.security.mp.jwt
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jwtSso-1.0/com.ibm.websphere.appserver.jwtSso-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jwtSso-1.0/com.ibm.websphere.appserver.jwtSso-1.0.feature
@@ -17,7 +17,6 @@ Subsystem-Name: JSON Web Token Single Sign-On 1.0
   com.ibm.websphere.appserver.httpcommons-1.0
 -bundles= com.ibm.ws.security.jwtsso, \
   com.ibm.ws.security.common, \
-  com.ibm.ws.security.jwt, \
   com.ibm.websphere.org.eclipse.microprofile.jwt.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.0",\
   com.ibm.ws.security.mp.jwt
 kind=ga

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerImpl.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerImpl.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.security.jwt.InvalidConsumerException;
 import com.ibm.websphere.security.jwt.InvalidTokenException;
 import com.ibm.websphere.security.jwt.JwtToken;
 import com.ibm.ws.security.jwt.config.JwtConsumerConfig;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.ssl.KeyStoreService;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceMap;
@@ -48,149 +49,168 @@ import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceMap;
 @Component(service = Consumer.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE, property = "service.vendor=IBM", name = "consumer")
 public class ConsumerImpl implements Consumer {
 
-    private static final TraceComponent tc = Tr.register(ConsumerImpl.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
+	private static final TraceComponent tc = Tr.register(ConsumerImpl.class, TraceConstants.TRACE_GROUP,
+			TraceConstants.MESSAGE_BUNDLE);
 
-    private String configId = DEFAULT_ID;
+	private String configId = DEFAULT_ID;
 
-    private static boolean active = false;
+	private static boolean active = false;
 
-    /*********************************** Begin OSGi-related fields and methods ***********************************/
+	/***********************************
+	 * Begin OSGi-related fields and methods
+	 ***********************************/
 
-    private final static String KEY_JWT_CONSUMER_SERVICE = "jwtConsumerConfig";
-    private static final String KEY_KEYSTORE_SERVICE = "keyStoreService";
-    private static final String CFG_KEY_ID = "id";
+	private final static String KEY_JWT_CONSUMER_SERVICE = "jwtConsumerConfig";
+	private static final String KEY_KEYSTORE_SERVICE = "keyStoreService";
+	private static final String CFG_KEY_ID = "id";
 
-    private static ConcurrentServiceReferenceMap<String, JwtConsumerConfig> jwtServiceMapRef = new ConcurrentServiceReferenceMap<String, JwtConsumerConfig>(KEY_JWT_CONSUMER_SERVICE);
-    private static AtomicServiceReference<KeyStoreService> keyStoreServiceRef = new AtomicServiceReference<KeyStoreService>(KEY_KEYSTORE_SERVICE);
+	private static ConcurrentServiceReferenceMap<String, JwtConsumerConfig> jwtServiceMapRef = new ConcurrentServiceReferenceMap<String, JwtConsumerConfig>(
+			KEY_JWT_CONSUMER_SERVICE);
+	private static AtomicServiceReference<KeyStoreService> keyStoreServiceRef = new AtomicServiceReference<KeyStoreService>(
+			KEY_KEYSTORE_SERVICE);
 
-    @Reference(service = JwtConsumerConfig.class, name = KEY_JWT_CONSUMER_SERVICE, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.RELUCTANT)
-    protected void setJwtConsumerConfig(ServiceReference<JwtConsumerConfig> ref) {
-        synchronized (jwtServiceMapRef) {
-            jwtServiceMapRef.putReference((String) ref.getProperty(CFG_KEY_ID), ref);
-        }
-    }
+	@Reference(service = JwtConsumerConfig.class, name = KEY_JWT_CONSUMER_SERVICE, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.RELUCTANT)
+	protected void setJwtConsumerConfig(ServiceReference<JwtConsumerConfig> ref) {
+		synchronized (jwtServiceMapRef) {
+			jwtServiceMapRef.putReference((String) ref.getProperty(CFG_KEY_ID), ref);
+		}
+	}
 
-    protected void unsetJwtConsumerConfig(ServiceReference<JwtConsumerConfig> ref) {
-        synchronized (jwtServiceMapRef) {
-            jwtServiceMapRef.removeReference((String) ref.getProperty(CFG_KEY_ID), ref);
-        }
-    }
+	protected void unsetJwtConsumerConfig(ServiceReference<JwtConsumerConfig> ref) {
+		synchronized (jwtServiceMapRef) {
+			jwtServiceMapRef.removeReference((String) ref.getProperty(CFG_KEY_ID), ref);
+		}
+	}
 
-    @Reference(service = KeyStoreService.class, name = KEY_KEYSTORE_SERVICE, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
-    protected void setKeyStoreService(ServiceReference<KeyStoreService> ref) {
-        keyStoreServiceRef.setReference(ref);
-    }
+	@Reference(service = KeyStoreService.class, name = KEY_KEYSTORE_SERVICE, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
+	protected void setKeyStoreService(ServiceReference<KeyStoreService> ref) {
+		keyStoreServiceRef.setReference(ref);
+	}
 
-    protected void unsetKeyStoreService(ServiceReference<KeyStoreService> ref) {
-        keyStoreServiceRef.unsetReference(ref);
-    }
+	protected void unsetKeyStoreService(ServiceReference<KeyStoreService> ref) {
+		keyStoreServiceRef.unsetReference(ref);
+	}
 
-    @Activate
-    protected void activate(ComponentContext cc) {
-        jwtServiceMapRef.activate(cc);
-        keyStoreServiceRef.activate(cc);
-        active = true;
-        Tr.info(tc, "JWT_CONSUMER_SERVICE_ACTIVATED");
-    }
+	@Activate
+	protected void activate(ComponentContext cc) {
+		jwtServiceMapRef.activate(cc);
+		keyStoreServiceRef.activate(cc);
+		active = true;
+		Tr.info(tc, "JWT_CONSUMER_SERVICE_ACTIVATED");
+	}
 
-    @Modified
-    protected void modify(Map<String, Object> properties) {
+	@Modified
+	protected void modify(Map<String, Object> properties) {
 
-    }
+	}
 
-    @Deactivate
-    protected void deactivate(int reason, ComponentContext cc) {
-        jwtServiceMapRef.deactivate(cc);
-        keyStoreServiceRef.deactivate(cc);
-        active = false;
-    }
+	@Deactivate
+	protected void deactivate(int reason, ComponentContext cc) {
+		jwtServiceMapRef.deactivate(cc);
+		keyStoreServiceRef.deactivate(cc);
+		active = false;
+	}
 
-    /*********************************** End OSGi-related fields and methods ***********************************/
+	/***********************************
+	 * End OSGi-related fields and methods
+	 ***********************************/
 
-    /**
-     * Instantiates a new {@code JwtConsumer} object using the default configuration ID {@value #DEFAULT_ID}. The behavior of the
-     * instantiated object reflects the configuration of the corresponding {@code jwtConsumer} element in {@code server.xml}.
-     */
-    public ConsumerImpl() {
-        this(DEFAULT_ID);
-    }
+	/**
+	 * Instantiates a new {@code JwtConsumer} object using the default configuration
+	 * ID {@value #DEFAULT_ID}. The behavior of the instantiated object reflects the
+	 * configuration of the corresponding {@code jwtConsumer} element in
+	 * {@code server.xml}.
+	 */
+	public ConsumerImpl() {
+		this(DEFAULT_ID);
+	}
 
-    /**
-     * Instantiates a new {@code JwtConsumer} object using the configuration ID provided. The ID is expected to match the
-     * {@code id} attribute of a {@code jwtConsumer} element in the server configuration. The behavior of the instantiated object
-     * reflects the configuration of the corresponding {@code jwtConsumer} element in {@code server.xml}.
-     *
-     * @param consumerConfigId
-     *            ID of a {@code jwtConsumer} element in the server configuration to be reflected by this object. If {@code null}
-     *            is specified, the default configuration ID {@value #DEFAULT_ID} will be used.
-     */
-    public ConsumerImpl(String consumerConfigId) {
-        if (consumerConfigId == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Null config ID provided; using " + DEFAULT_ID + " instead");
-            }
-            consumerConfigId = DEFAULT_ID;
-        }
-        if (consumerConfigId.equals("")) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Blank config ID provided; using " + DEFAULT_ID + " instead");
-            }
-            consumerConfigId = DEFAULT_ID;
-        }
-        configId = consumerConfigId;
-    }
+	/**
+	 * Instantiates a new {@code JwtConsumer} object using the configuration ID
+	 * provided. The ID is expected to match the {@code id} attribute of a
+	 * {@code jwtConsumer} element in the server configuration. The behavior of the
+	 * instantiated object reflects the configuration of the corresponding
+	 * {@code jwtConsumer} element in {@code server.xml}.
+	 *
+	 * @param consumerConfigId
+	 *            ID of a {@code jwtConsumer} element in the server configuration to
+	 *            be reflected by this object. If {@code null} is specified, the
+	 *            default configuration ID {@value #DEFAULT_ID} will be used.
+	 */
+	public ConsumerImpl(String consumerConfigId) {
+		if (consumerConfigId == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Null config ID provided; using " + DEFAULT_ID + " instead");
+			}
+			consumerConfigId = DEFAULT_ID;
+		}
+		if (consumerConfigId.equals("")) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Blank config ID provided; using " + DEFAULT_ID + " instead");
+			}
+			consumerConfigId = DEFAULT_ID;
+		}
+		configId = consumerConfigId;
+	}
 
-    @Override
-    public synchronized Consumer create() throws InvalidConsumerException {
-        if (!active) {
-            String err = Tr.formatMessage(tc, "JWT_CONSUMER_SERVICE_NOT_ACTIVATED");
-            throw new InvalidConsumerException(err);
-        }
-        return create(DEFAULT_ID);
-    }
+	@Override
+	public synchronized Consumer create() throws InvalidConsumerException {
+		if (!active) {
+			String err = Tr.formatMessage(tc, "JWT_CONSUMER_SERVICE_NOT_ACTIVATED");
+			throw new InvalidConsumerException(err);
+		}
+		return create(DEFAULT_ID);
+	}
 
-    @Override
-    public synchronized Consumer create(String consumerConfigId) throws InvalidConsumerException {
-        if (!active) {
-            String err = Tr.formatMessage(tc, "JWT_CONSUMER_SERVICE_NOT_ACTIVATED");
-            throw new InvalidConsumerException(err);
-        }
-        if (consumerConfigId == null) {
-            String err = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_ID");
-            throw new InvalidConsumerException(err);
-        }
-        return new ConsumerImpl(consumerConfigId);
-    }
+	@Override
+	public synchronized Consumer create(String consumerConfigId) throws InvalidConsumerException {
+		if (!active) {
+			String err = Tr.formatMessage(tc, "JWT_CONSUMER_SERVICE_NOT_ACTIVATED");
+			throw new InvalidConsumerException(err);
+		}
+		if (consumerConfigId == null) {
+			String err = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_ID");
+			throw new InvalidConsumerException(err);
+		}
+		return new ConsumerImpl(consumerConfigId);
+	}
 
-    @Override
-    public JwtToken createJwt(String encodedTokenString) throws InvalidTokenException, InvalidConsumerException {
-        JwtConsumerConfig config = jwtServiceMapRef.getService(configId);
-        if (config == null) {
-            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_CONFIG_NOT_FOUND", new Object[] { configId });
-            throw new InvalidConsumerException(msg);
-        }
+	@Override
+	@FFDCIgnore(Exception.class)
+	public JwtToken createJwt(String encodedTokenString) throws InvalidTokenException, InvalidConsumerException {
+		JwtConsumerConfig config = jwtServiceMapRef.getService(configId);
+		if (config == null) {
+			String msg = Tr.formatMessage(tc, "JWT_CONSUMER_CONFIG_NOT_FOUND", new Object[] { configId });
+			throw new InvalidConsumerException(msg);
+		}
 
-        if (encodedTokenString == null || encodedTokenString.isEmpty()) {
-            String errorMsg = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_OR_EMPTY_STRING", new Object[] { configId, encodedTokenString });
-            throw new InvalidTokenException(errorMsg);
-        }
+		if (encodedTokenString == null || encodedTokenString.isEmpty()) {
+			String errorMsg = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_OR_EMPTY_STRING",
+					new Object[] { configId, encodedTokenString });
+			throw new InvalidTokenException(errorMsg);
+		}
 
-        ConsumerUtil util = config.getConsumerUtils();
-        if (util == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "ConsumerUtil object was not found for config [" + configId + "]");
-            }
-            return null;
-        }
+		ConsumerUtil util = config.getConsumerUtils();
+		if (util == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "ConsumerUtil object was not found for config [" + configId + "]");
+			}
+			return null;
+		}
 
-        JwtToken token = null;
-        try {
-            token = util.parseJwt(encodedTokenString, config);
-        } catch (Exception e) { // CWWKS6031E
-            String msg = Tr.formatMessage(tc, "JWT_ERROR_PROCESSING_JWT", new Object[] { configId, e.getLocalizedMessage() });
-            throw new InvalidTokenException(msg, e);
-        }
-        return token;
-    }
+		JwtToken token = null;
+		try {
+			token = util.parseJwt(encodedTokenString, config);
+		} catch (Exception e) { // CWWKS6031E
+
+			String msg = Tr.formatMessage(tc, "JWT_ERROR_PROCESSING_JWT",
+					new Object[] { configId, e.getLocalizedMessage() });
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, msg);
+			}
+			throw new InvalidTokenException(msg, e);
+		}
+		return token;
+	}
 
 }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
@@ -494,6 +494,7 @@ public class ConsumerUtil {
         // Check that expiration claim is in the future, accounting for the
         // clock skew
         if (expirationClaim == null || (!expirationClaim.isAfter(currentTimeMinusSkew))) {
+        	JwtUtils.setJwtSsoValidationPathExiredToken();
             String msg = Tr.formatMessage(tc, "JWT_TOKEN_EXPIRED", new Object[] { createDateString(expirationClaim), createDateString(currentTimeMinusSkew), (clockSkewInMilliseconds / 1000) });
             throw new InvalidClaimException(msg);
         }
@@ -519,7 +520,7 @@ public class ConsumerUtil {
         NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
 
         // Check that nbf claim is in the past, accounting for the clock skew
-        if (nbfClaim != null && (nbfClaim.isOnOrAfter(currentTimePlusSkew))) {
+        if (nbfClaim != null && (nbfClaim.isOnOrAfter(currentTimePlusSkew))) {        	
             String msg = Tr.formatMessage(tc, "JWT_TOKEN_BEFORE_NBF", new Object[] { createDateString(nbfClaim), createDateString(currentTimePlusSkew), (clockSkewInMilliseconds / 1000) });
             throw new InvalidClaimException(msg);
         }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
@@ -40,6 +40,7 @@ import com.ibm.websphere.security.jwt.InvalidTokenException;
 import com.ibm.websphere.security.jwt.JwtToken;
 import com.ibm.websphere.security.jwt.KeyException;
 import com.ibm.websphere.security.jwt.KeyStoreServiceException;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.jwk.impl.JwKRetriever;
 import com.ibm.ws.security.common.time.TimeUtils;
 import com.ibm.ws.security.jwt.config.JwtConsumerConfig;
@@ -50,605 +51,641 @@ import com.ibm.ws.ssl.KeyStoreService;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 
 public class ConsumerUtil {
-    private static final TraceComponent tc = Tr.register(ConsumerUtil.class);
-    private static final Class<?> thisClass = ConsumerUtil.class;
-
-    private AtomicServiceReference<KeyStoreService> keyStoreService = null;
-
-    private static TimeUtils timeUtils = new TimeUtils(TimeUtils.YearMonthDateHourMinSecZone);
-    private final JtiNonceCache jtiCache = new JtiNonceCache();
-    public final static String ISSUER = "mp.jwt.verify.issuer";
-    public final static String PUBLIC_KEY = "mp.jwt.verify.publickey";
-    public final static String KEY_LOCATION = "mp.jwt.verify.publickey.location";
-
-    public ConsumerUtil(AtomicServiceReference<KeyStoreService> kss) {
-        keyStoreService = kss;
-    }
-
-    public JwtToken parseJwt(String jwtString, JwtConsumerConfig config) throws Exception {
-        return parseJwt(jwtString, config, null);
-    }
-
-    public JwtToken parseJwt(String jwtString, JwtConsumerConfig config, Map properties) throws Exception {
-        JwtContext jwtContext = parseJwtAndGetJwtContext(jwtString, config, properties);
-        JwtTokenConsumerImpl jwtToken = new JwtTokenConsumerImpl(jwtContext);
-        checkForReusedJwt(jwtToken, config);
-        return jwtToken;
-    }
-
-    JwtContext parseJwtAndGetJwtContext(String jwtString, JwtConsumerConfig config, Map properties) throws Exception {
-        JwtContext jwtContext = parseJwtWithoutValidation(jwtString, config);
-        if (config.isValidationRequired()) {
-            jwtContext = getSigningKeyAndParseJwtWithValidation(jwtString, config, jwtContext, properties);
-        }
-        return jwtContext;
-    }
-
-    JwtContext getSigningKeyAndParseJwtWithValidation(String jwtString, JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws Exception {
-        Key signingKey = getSigningKey(config, jwtContext, properties);
-        return parseJwtWithValidation(jwtString, jwtContext, config, signingKey, properties);
-    }
-
-    /**
-     * Throws an exception if JWTs are not allowed to be reused (as configured
-     * by the provided config option) AND a token with a matching "jti" and
-     * "issuer" claim already exists in the cache.
-     */
-    void checkForReusedJwt(JwtTokenConsumerImpl jwt, JwtConsumerConfig config) throws InvalidTokenException {
-        // Only throw an error if tokens are not allowed to be reused
-        if (!config.getTokenReuse()) {
-            throwExceptionIfJwtReused(jwt);
-        }
-    }
-
-    void throwExceptionIfJwtReused(JwtTokenConsumerImpl jwt) throws InvalidTokenException {
-        if (jtiCache.contains(jwt)) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "JWT token can only be submitted once. The issuer is " + jwt.getClaims().getIssuer() + ", and JTI is " + jwt.getClaims().getJwtId());
-            }
-            String errorMsg = Tr.formatMessage(tc, "JWT_DUP_JTI_ERR", new Object[] { jwt.getClaims().getIssuer(), jwt.getClaims().getJwtId() });
-            throw new InvalidTokenException(errorMsg);
-        }
-    }
-
-    /**
-     * Get the appropriate signing key based on the signature algorithm
-     * specified in the config.
-     */
-    Key getSigningKey(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
-        Key signingKey = null;
-        if (config == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "JWT consumer config object is null");
-            }
-            return null;
-        }
-        signingKey = getSigningKeyBasedOnSignatureAlgorithm(config, jwtContext, properties);
-        if (signingKey == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "A signing key could not be found");
-            }
-        }
-        return signingKey;
-    }
-
-    Key getSigningKeyBasedOnSignatureAlgorithm(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
-        Key signingKey = null;
-        String sigAlg = config.getSignatureAlgorithm();
-
-        if (Constants.SIGNATURE_ALG_HS256.equals(sigAlg)) {
-            signingKey = getSigningKeyForHS256(config);
-        } else if (Constants.SIGNATURE_ALG_RS256.equals(sigAlg)) {
-            signingKey = getSigningKeyForRS256(config, jwtContext, properties);
-        }
-        return signingKey;
-    }
-
-    Key getSigningKeyForHS256(JwtConsumerConfig config) throws KeyException {
-        Key signingKey = null;
-        try {
-            signingKey = getSharedSecretKey(config);
-        } catch (Exception e) {
-            String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_SHARED_KEY", new Object[] { e.getLocalizedMessage() });
-            throw new KeyException(msg, e);
-        }
-        return signingKey;
-    }
-
-    /**
-     * Creates a Key object from the shared key specified in the provided
-     * configuration.
-     */
-    Key getSharedSecretKey(JwtConsumerConfig config) throws KeyException {
-        if (config == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "JWT consumer config object is null");
-            }
-            return null;
-        }
-        String sharedKey = config.getSharedKey();
-        return createKeyFromSharedKey(sharedKey);
-    }
-
-    Key createKeyFromSharedKey(String sharedKey) throws KeyException {
-        if (sharedKey == null || sharedKey.isEmpty()) {
-            String msg = Tr.formatMessage(tc, "JWT_MISSING_SHARED_KEY");
-            throw new KeyException(msg);
-        }
-        try {
-            return new HmacKey(sharedKey.getBytes(Constants.UTF_8));
-        } catch (UnsupportedEncodingException e) {
-            // Should not happen - UTF-8 should be supported
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Caught exception getting shared key bytes: " + e.getLocalizedMessage());
-            }
-        }
-        return null;
-    }
-
-    boolean isPublicKeyPropsPresent(Map props) {
-        if (props == null) {
-            return false;
-        }
-        return props.get(PUBLIC_KEY) != null || props.get(KEY_LOCATION) != null;
-    }
-
-    Key getSigningKeyForRS256(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
-        Key signingKey = null;
-        if (config.getJwkEnabled() ||
-                (config.getTrustedAlias() == null && isPublicKeyPropsPresent(properties))) { // need change to consider MP-Config
-            signingKey = getKeyForJwkEnabled(config, jwtContext, properties);
-        } else {
-            signingKey = getKeyForJwkDisabled(config);
-        }
-        return signingKey;
-    }
-
-    Key getKeyForJwkEnabled(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
-        Key signingKey = null;
-        try {
-            signingKey = getJwksKey(config, jwtContext, properties);
-        } catch (Exception e) {
-            String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_JWK_KEY", new Object[] { config.getJwkEndpointUrl(), e.getLocalizedMessage() });
-            throw new KeyException(msg, e);
-        }
-        return signingKey;
-    }
-
-    protected Key getJwksKey(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws Exception {
-        JsonWebStructure jwtHeader = getJwtHeader(jwtContext);
-        String kid = jwtHeader.getKeyIdHeaderValue();
-        JwKRetriever jwkRetriever = null;
-        if (properties != null) {
-            String publickey = (String) properties.get(PUBLIC_KEY);
-            String keyLocation = (String) properties.get(KEY_LOCATION);
-            if (publickey != null || keyLocation != null) {
-                jwkRetriever = new JwKRetriever(config.getId(), config.getSslRef(), config.getJwkEndpointUrl(),
-                        config.getJwkSet(), JwtUtils.getSSLSupportService(), config.isHostNameVerificationEnabled(),
-                        null, null, publickey, keyLocation);
-            }
-        }
-        if (jwkRetriever == null) {
-            jwkRetriever = new JwKRetriever(config.getId(), config.getSslRef(), config.getJwkEndpointUrl(),
-                    config.getJwkSet(), JwtUtils.getSSLSupportService(), config.isHostNameVerificationEnabled(), null, null);
-        }
-        Key signingKey = jwkRetriever.getPublicKeyFromJwk(kid, null, config.getUseSystemPropertiesForHttpClientConnections()); // only kid or x5t will work but not both
-        return signingKey;
-    }
-
-    JsonWebStructure getJwtHeader(JwtContext jwtContext) throws InvalidJwtException {
-        List<JsonWebStructure> jsonStructures = jwtContext.getJoseObjects();
-        if (jsonStructures == null || jsonStructures.isEmpty()) {
-            // TODO - NLS message
-            throw new InvalidJwtException("Invalid JsonWebStructure");
-        }
-        JsonWebStructure jwtHeader = jsonStructures.get(0);
-        debugJwtHeader(jwtHeader);
-        return jwtHeader;
-    }
-
-    void debugJwtHeader(JsonWebStructure jwtHeader) {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "JsonWebStructure class: " + jwtHeader.getClass().getName() + " data:" + jwtHeader);
-            if (jwtHeader instanceof JsonWebSignature) {
-                JsonWebSignature signature = (JsonWebSignature) jwtHeader;
-                Tr.debug(tc, "JsonWebSignature alg: " + signature.getAlgorithmHeaderValue() + " 3rd:'" + signature.getEncodedSignature() + "'");
-            }
-        }
-    }
-
-    Key getKeyForJwkDisabled(JwtConsumerConfig config) throws KeyException {
-        Key signingKey = null;
-        String trustedAlias = config.getTrustedAlias();
-        String trustStoreRef = config.getTrustStoreRef();
-        try {
-            signingKey = getPublicKey(trustedAlias, trustStoreRef, Constants.SIGNATURE_ALG_RS256);
-        } catch (Exception e) {
-            String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_PUBLIC_KEY", new Object[] { trustedAlias, trustStoreRef, e.getLocalizedMessage() });
-            throw new KeyException(msg, e);
-        }
-        return signingKey;
-    }
-
-    /**
-     * Creates a Key object from the certificate stored in the trust store and
-     * alias provided.
-     */
-    Key getPublicKey(String trustedAlias, String trustStoreRef, String signatureAlgorithm) throws KeyStoreServiceException, KeyException {
-        Key signingKey = getPublicKeyFromKeystore(trustedAlias, trustStoreRef, signatureAlgorithm);
-        if (tc.isDebugEnabled()) {
-            Tr.debug(tc, "Trusted alias: " + trustedAlias + ", Truststore: " + trustStoreRef);
-            Tr.debug(tc, "RSAPublicKey: " + (signingKey instanceof RSAPublicKey));
-        }
-        if (signingKey != null && !(signingKey instanceof RSAPublicKey)) {
-            signingKey = null;
-        }
-        return signingKey;
-    }
-
-    Key getPublicKeyFromKeystore(String trustedAlias, String trustStoreRef, String signatureAlgorithm) throws KeyException {
-        try {
-            if (keyStoreService == null) {
-                String msg = Tr.formatMessage(tc, "JWT_TRUSTSTORE_SERVICE_NOT_AVAILABLE");
-                throw new KeyStoreServiceException(msg);
-            }
-            return JwtUtils.getPublicKey(trustedAlias, trustStoreRef, keyStoreService.getService());
-        } catch (Exception e) {
-            String msg = Tr.formatMessage(tc, "JWT_NULL_SIGNING_KEY_WITH_ERROR", new Object[] { signatureAlgorithm, Constants.SIGNING_KEY_X509, e.getLocalizedMessage() });
-            throw new KeyException(msg, e);
-        }
-    }
-
-    protected JwtContext parseJwtWithoutValidation(String jwtString, JwtConsumerConfig config) throws Exception {
-        if (jwtString == null || jwtString.isEmpty()) {
-            String errorMsg = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_OR_EMPTY_STRING", new Object[] { config.getId(), jwtString });
-            throw new InvalidTokenException(errorMsg);
-        }
-        JwtConsumerBuilder builder = initializeJwtConsumerBuilderWithoutValidation(config);
-        JwtConsumer firstPassJwtConsumer = builder.build();
-        return firstPassJwtConsumer.process(jwtString);
-    }
-
-    protected JwtContext parseJwtWithValidation(String jwtString, JwtContext jwtContext, JwtConsumerConfig config, Key key, Map properties) throws Exception {
-        JwtClaims jwtClaims = jwtContext.getJwtClaims();
-
-        if (tc.isDebugEnabled()) {
-            Tr.debug(tc, "Key from config: " + key);
-        }
-
-        validateClaims(jwtClaims, jwtContext, config, properties);
-        validateSignatureAlgorithmWithKey(config, key);
-
-        JwtConsumerBuilder consumerBuilder = initializeJwtConsumerBuilderWithValidation(config, jwtClaims, key);
-        JwtConsumer jwtConsumer = consumerBuilder.build();
-        return processJwtStringWithConsumer(jwtConsumer, jwtString);
-    }
-
-    JwtConsumerBuilder initializeJwtConsumerBuilderWithoutValidation(JwtConsumerConfig config) {
-        JwtConsumerBuilder builder = new JwtConsumerBuilder();
-        builder.setSkipAllValidators();
-        builder.setDisableRequireSignature();
-        builder.setSkipSignatureVerification();
-        builder.setAllowedClockSkewInSeconds((int) ((config.getClockSkew()) / 1000));
-        return builder;
-    }
-
-    JwtConsumerBuilder initializeJwtConsumerBuilderWithValidation(JwtConsumerConfig config, JwtClaims jwtClaims, Key key) throws MalformedClaimException {
-        JwtConsumerBuilder builder = new JwtConsumerBuilder();
-        builder.setExpectedIssuer(jwtClaims.getIssuer());
-        builder.setSkipDefaultAudienceValidation();
-        builder.setRequireExpirationTime();
-        builder.setVerificationKey(key);
-        builder.setRelaxVerificationKeyValidation();
-        builder.setAllowedClockSkewInSeconds((int) (config.getClockSkew() / 1000));
-        return builder;
-    }
-
-    void validateClaims(JwtClaims jwtClaims, JwtContext jwtContext, JwtConsumerConfig config, Map properties) throws MalformedClaimException, InvalidClaimException, InvalidTokenException {
-        String issuer = config.getIssuer();
-        if (issuer == null) {
-            issuer = (properties == null) ? null : (String) properties.get(ISSUER);
-        }
-
-        validateIssuer(config.getId(), issuer, jwtClaims.getIssuer());
-
-        if (!validateAudience(config.getAudiences(), jwtClaims.getAudience())) {
-            String msg = Tr.formatMessage(tc, "JWT_AUDIENCE_NOT_TRUSTED", new Object[] { jwtClaims.getAudience(), config.getId(), config.getAudiences() });
-            throw new InvalidClaimException(msg);
-        }
-
-        // check azp
-
-        validateIatAndExp(jwtClaims, config.getClockSkew());
-
-        validateNbf(jwtClaims, config.getClockSkew());
-
-        validateAlgorithm(jwtContext, config.getSignatureAlgorithm());
-    }
-
-    /**
-     * Throws an exception if the provided key is null but the config specifies
-     * a signature algorithm other than "none".
-     */
-    void validateSignatureAlgorithmWithKey(JwtConsumerConfig config, Key key) throws InvalidClaimException {
-        String signatureAlgorithm = config.getSignatureAlgorithm();
-        if (key == null && signatureAlgorithm != null && !signatureAlgorithm.equalsIgnoreCase("none")) {
-            String msg = Tr.formatMessage(tc, "JWT_MISSING_KEY", new Object[] { signatureAlgorithm });
-            throw new InvalidClaimException(msg);
-        }
-    }
-
-    /**
-     * Verifies that tokenIssuer is one of the values specified in the
-     * comma-separated issuers string.
-     */
-    boolean validateIssuer(String consumerConfigId, String issuers, String tokenIssuer) throws InvalidClaimException {
-        boolean isIssuer = false;
-        if (issuers == null || issuers.isEmpty()) {
-            String msg = Tr.formatMessage(tc, "JWT_TRUSTED_ISSUERS_NULL", new Object[] { tokenIssuer, consumerConfigId });
-            throw new InvalidClaimException(msg);
-        }
-
-        StringTokenizer st = new StringTokenizer(issuers, ",");
-        while (st.hasMoreTokens()) {
-            String iss = st.nextToken().trim();
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Trusted issuer: " + iss);
-            }
-            if (Constants.ALL_ISSUERS.equals(iss) || (tokenIssuer != null && tokenIssuer.equals(iss))) {
-                isIssuer = true;
-                break;
-            }
-        }
-
-        if (!isIssuer) {
-            String msg = Tr.formatMessage(tc, "JWT_ISSUER_NOT_TRUSTED", new Object[] { tokenIssuer, consumerConfigId, issuers });
-            throw new InvalidClaimException(msg);
-        }
-        return isIssuer;
-    }
-
-    /**
-     * Verifies that at least one of the values specified in audiences is
-     * contained in the allowedAudiences list.
-     */
-    boolean validateAudience(List<String> allowedAudiences, List<String> audiences) {
-        boolean valid = false;
-
-        if (allowedAudiences != null && allowedAudiences.contains(Constants.ALL_AUDIENCES)) {
-            return true;
-        }
-        if (allowedAudiences != null && audiences != null) {
-            for (String audience : audiences) {
-                for (String allowedAud : allowedAudiences) {
-                    if (allowedAud.equals(audience)) {
-                        valid = true;
-                        break;
-                    }
-                }
-            }
-        } else if (allowedAudiences == null && (audiences == null || audiences.isEmpty())) {
-            valid = true;
-        }
-
-        return valid;
-    }
-
-    /**
-     * Validates the the {@value Claims#ISSUED_AT} and
-     * {@value Claims#EXPIRATION} claims are present and properly formed. Also
-     * verifies that the {@value Claims#ISSUED_AT} time is after the
-     * {@value Claims#EXPIRATION} time.
-     */
-    void validateIatAndExp(JwtClaims jwtClaims, long clockSkewInMilliseconds) throws InvalidClaimException {
-        if (jwtClaims == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Missing JwtClaims object");
-            }
-            return;
-        }
-        NumericDate issueAtClaim = getIssuedAtClaim(jwtClaims);
-        NumericDate expirationClaim = getExpirationClaim(jwtClaims);
-
-        debugCurrentTimes(clockSkewInMilliseconds, issueAtClaim, expirationClaim);
-
-        validateIssuedAtClaim(issueAtClaim, expirationClaim, clockSkewInMilliseconds);
-        validateExpirationClaim(expirationClaim, clockSkewInMilliseconds);
-
-    }
-
-    void debugCurrentTimes(long clockSkewInMilliseconds, NumericDate issueAtClaim, NumericDate expirationClaim) {
-        if (tc.isDebugEnabled()) {
-            long now = (new Date()).getTime();
-            NumericDate currentTimeMinusSkew = NumericDate.fromMilliseconds(now - clockSkewInMilliseconds);
-            NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
-            Tr.debug(tc, "Checking iat [" + createDateString(issueAtClaim) + "] and exp [" + createDateString(expirationClaim) + "]");
-            Tr.debug(tc, "Comparing against current time (minus clock skew of " + (clockSkewInMilliseconds / 1000) + " seconds) [" + createDateString(currentTimeMinusSkew) + "]");
-            Tr.debug(tc, "Comparing against current time (plus clock skew of " + (clockSkewInMilliseconds / 1000) + " seconds) [" + createDateString(currentTimePlusSkew) + "]");
-        }
-    }
-
-    void validateIssuedAtClaim(NumericDate issueAtClaim, NumericDate expirationClaim, long clockSkewInMilliseconds) throws InvalidClaimException {
-        long now = (new Date()).getTime();
-        NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
-
-        if (issueAtClaim != null && expirationClaim != null) {
-            if (issueAtClaim.isAfter(currentTimePlusSkew)) {
-                String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_CURRENT_TIME", new Object[] { createDateString(issueAtClaim), createDateString(currentTimePlusSkew), (clockSkewInMilliseconds / 1000) });
-                throw new InvalidClaimException(msg);
-            }
-            if (issueAtClaim.isOnOrAfter(expirationClaim)) {
-                String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_EXP", new Object[] { createDateString(issueAtClaim), createDateString(expirationClaim) });
-                throw new InvalidClaimException(msg);
-            }
-        } else {
-            // TODO - what if one or the other is missing? is that an error
-            // condition?
-        }
-    }
-
-    void validateExpirationClaim(NumericDate expirationClaim, long clockSkewInMilliseconds) throws InvalidClaimException {
-        long now = (new Date()).getTime();
-        NumericDate currentTimeMinusSkew = NumericDate.fromMilliseconds(now - clockSkewInMilliseconds);
-
-        // Check that expiration claim is in the future, accounting for the
-        // clock skew
-        if (expirationClaim == null || (!expirationClaim.isAfter(currentTimeMinusSkew))) {
-        	JwtUtils.setJwtSsoValidationPathExiredToken();
-            String msg = Tr.formatMessage(tc, "JWT_TOKEN_EXPIRED", new Object[] { createDateString(expirationClaim), createDateString(currentTimeMinusSkew), (clockSkewInMilliseconds / 1000) });
-            throw new InvalidClaimException(msg);
-        }
-    }
-
-    /**
-     * Validates the the {@value Claims#NOT_BEFORE} claim is present and
-     * properly formed. Also
-     */
-    void validateNbf(JwtClaims jwtClaims, long clockSkewInMilliseconds) throws InvalidClaimException {
-        if (jwtClaims == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Missing JwtClaims object");
-            }
-            return;
-        }
-        NumericDate nbf = getNotBeforeClaim(jwtClaims);
-        validateNotBeforeClaim(nbf, clockSkewInMilliseconds);
-    }
-
-    void validateNotBeforeClaim(NumericDate nbfClaim, long clockSkewInMilliseconds) throws InvalidClaimException {
-        long now = (new Date()).getTime();
-        NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
-
-        // Check that nbf claim is in the past, accounting for the clock skew
-        if (nbfClaim != null && (nbfClaim.isOnOrAfter(currentTimePlusSkew))) {        	
-            String msg = Tr.formatMessage(tc, "JWT_TOKEN_BEFORE_NBF", new Object[] { createDateString(nbfClaim), createDateString(currentTimePlusSkew), (clockSkewInMilliseconds / 1000) });
-            throw new InvalidClaimException(msg);
-        }
-    }
-
-    NumericDate getIssuedAtClaim(JwtClaims jwtClaims) throws InvalidClaimException {
-        NumericDate iatClaim = null;
-        try {
-            iatClaim = jwtClaims.getIssuedAt();
-        } catch (MalformedClaimException e) {
-            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM", new Object[] { Claims.ISSUED_AT, e.getLocalizedMessage() });
-            throw new InvalidClaimException(msg, e);
-        }
-        return iatClaim;
-    }
-
-    NumericDate getExpirationClaim(JwtClaims jwtClaims) throws InvalidClaimException {
-        NumericDate expClaim = null;
-        try {
-            expClaim = jwtClaims.getExpirationTime();
-        } catch (MalformedClaimException e) {
-            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM", new Object[] { Claims.EXPIRATION, e.getLocalizedMessage() });
-            throw new InvalidClaimException(msg, e);
-        }
-        return expClaim;
-    }
-
-    NumericDate getNotBeforeClaim(JwtClaims jwtClaims) throws InvalidClaimException {
-        NumericDate nbfClaim = null;
-        try {
-            nbfClaim = jwtClaims.getNotBefore();
-        } catch (MalformedClaimException e) {
-            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM", new Object[] { Claims.NOT_BEFORE, e.getLocalizedMessage() });
-            throw new InvalidClaimException(msg, e);
-        }
-        return nbfClaim;
-    }
-
-    void validateAlgorithm(JwtContext jwtContext, String requiredAlg) throws InvalidTokenException {
-        if (requiredAlg == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "No required signature algorithm was specified");
-            }
-            return;
-        }
-        String tokenAlg = getAlgorithmFromJwtHeader(jwtContext);
-        validateAlgorithm(requiredAlg, tokenAlg);
-    }
-
-    void validateAlgorithm(String requiredAlg, String tokenAlg) throws InvalidTokenException {
-        if (tokenAlg == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Signature algorithm was not found in the JWT");
-            }
-            String msg = Tr.formatMessage(tc, "JWT_MISSING_ALG_HEADER", new Object[] { requiredAlg });
-            throw new InvalidTokenException(msg);
-        }
-        if (tc.isDebugEnabled()) {
-            Tr.debug(tc, "JWT is signed with algorithm: ", tokenAlg);
-            Tr.debug(tc, "JWT is required to be signed with algorithm: ", requiredAlg);
-        }
-        if (!requiredAlg.equals(tokenAlg)) {
-            String msg = Tr.formatMessage(tc, "JWT_ALGORITHM_MISMATCH", new Object[] { tokenAlg, requiredAlg });
-            throw new InvalidTokenException(msg);
-        }
-    }
-
-    JwtContext processJwtStringWithConsumer(JwtConsumer jwtConsumer, String jwtString) throws InvalidTokenException, InvalidJwtException {
-        JwtContext validatedJwtContext = null;
-        try {
-            validatedJwtContext = jwtConsumer.process(jwtString);
-        } catch (InvalidJwtSignatureException e) {
-            String msg = Tr.formatMessage(tc, "JWT_INVALID_SIGNATURE", new Object[] { e.getLocalizedMessage() });
-            throw new InvalidTokenException(msg, e);
-        } catch (InvalidJwtException e) {
-            Throwable cause = getRootCause(e);
-            if (cause != null && cause instanceof InvalidKeyException) {
-                throw e;
-            } else {
-                // Don't have enough information to output a more useful error
-                // message
-                throw e;
-            }
-        }
-        return validatedJwtContext;
-    }
-
-    String getAlgorithmFromJwtHeader(JwtContext jwtContext) {
-        if (jwtContext == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "JwtContext is null");
-            }
-            return null;
-        }
-        JsonWebStructure jwtHeader = null;
-        try {
-            jwtHeader = getJwtHeader(jwtContext);
-        } catch (InvalidJwtException e) {
-            // TODO - NLS message?
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Failed to obtain JWT header");
-            }
-            return null;
-        }
-        String algHeader = jwtHeader.getAlgorithmHeaderValue();
-        if (tc.isDebugEnabled()) {
-            Tr.debug(tc, "JWT is signed with algorithm: ", algHeader);
-        }
-        return algHeader;
-    }
-
-    Throwable getRootCause(Exception e) {
-        Throwable rootCause = null;
-        Throwable tmpCause = e;
-        while (tmpCause != null) {
-            rootCause = tmpCause;
-            tmpCause = rootCause.getCause();
-        }
-        return rootCause;
-    }
-
-    String createDateString(NumericDate date) {
-        if (date == null) {
-            return null;
-        }
-        // NumericDate.getValue() returns a value in seconds, so convert to
-        // milliseconds
-        return timeUtils.createDateString(1000 * date.getValue());
-    }
+	private static final TraceComponent tc = Tr.register(ConsumerUtil.class);
+	private static final Class<?> thisClass = ConsumerUtil.class;
+
+	private AtomicServiceReference<KeyStoreService> keyStoreService = null;
+
+	private static TimeUtils timeUtils = new TimeUtils(TimeUtils.YearMonthDateHourMinSecZone);
+	private final JtiNonceCache jtiCache = new JtiNonceCache();
+	public final static String ISSUER = "mp.jwt.verify.issuer";
+	public final static String PUBLIC_KEY = "mp.jwt.verify.publickey";
+	public final static String KEY_LOCATION = "mp.jwt.verify.publickey.location";
+
+	public ConsumerUtil(AtomicServiceReference<KeyStoreService> kss) {
+		keyStoreService = kss;
+	}
+
+	public JwtToken parseJwt(String jwtString, JwtConsumerConfig config) throws Exception {
+		return parseJwt(jwtString, config, null);
+	}
+
+	public JwtToken parseJwt(String jwtString, JwtConsumerConfig config, Map properties) throws Exception {
+		JwtContext jwtContext = parseJwtAndGetJwtContext(jwtString, config, properties);
+		JwtTokenConsumerImpl jwtToken = new JwtTokenConsumerImpl(jwtContext);
+		checkForReusedJwt(jwtToken, config);
+		return jwtToken;
+	}
+
+	JwtContext parseJwtAndGetJwtContext(String jwtString, JwtConsumerConfig config, Map properties) throws Exception {
+		JwtContext jwtContext = parseJwtWithoutValidation(jwtString, config);
+		if (config.isValidationRequired()) {
+			jwtContext = getSigningKeyAndParseJwtWithValidation(jwtString, config, jwtContext, properties);
+		}
+		return jwtContext;
+	}
+
+	JwtContext getSigningKeyAndParseJwtWithValidation(String jwtString, JwtConsumerConfig config, JwtContext jwtContext,
+			Map properties) throws Exception {
+		Key signingKey = getSigningKey(config, jwtContext, properties);
+		return parseJwtWithValidation(jwtString, jwtContext, config, signingKey, properties);
+	}
+
+	/**
+	 * Throws an exception if JWTs are not allowed to be reused (as configured by
+	 * the provided config option) AND a token with a matching "jti" and "issuer"
+	 * claim already exists in the cache.
+	 */
+	void checkForReusedJwt(JwtTokenConsumerImpl jwt, JwtConsumerConfig config) throws InvalidTokenException {
+		// Only throw an error if tokens are not allowed to be reused
+		if (!config.getTokenReuse()) {
+			throwExceptionIfJwtReused(jwt);
+		}
+	}
+
+	void throwExceptionIfJwtReused(JwtTokenConsumerImpl jwt) throws InvalidTokenException {
+		if (jtiCache.contains(jwt)) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "JWT token can only be submitted once. The issuer is " + jwt.getClaims().getIssuer()
+						+ ", and JTI is " + jwt.getClaims().getJwtId());
+			}
+			String errorMsg = Tr.formatMessage(tc, "JWT_DUP_JTI_ERR",
+					new Object[] { jwt.getClaims().getIssuer(), jwt.getClaims().getJwtId() });
+			throw new InvalidTokenException(errorMsg);
+		}
+	}
+
+	/**
+	 * Get the appropriate signing key based on the signature algorithm specified in
+	 * the config.
+	 */
+	Key getSigningKey(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
+		Key signingKey = null;
+		if (config == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "JWT consumer config object is null");
+			}
+			return null;
+		}
+		signingKey = getSigningKeyBasedOnSignatureAlgorithm(config, jwtContext, properties);
+		if (signingKey == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "A signing key could not be found");
+			}
+		}
+		return signingKey;
+	}
+
+	Key getSigningKeyBasedOnSignatureAlgorithm(JwtConsumerConfig config, JwtContext jwtContext, Map properties)
+			throws KeyException {
+		Key signingKey = null;
+		String sigAlg = config.getSignatureAlgorithm();
+
+		if (Constants.SIGNATURE_ALG_HS256.equals(sigAlg)) {
+			signingKey = getSigningKeyForHS256(config);
+		} else if (Constants.SIGNATURE_ALG_RS256.equals(sigAlg)) {
+			signingKey = getSigningKeyForRS256(config, jwtContext, properties);
+		}
+		return signingKey;
+	}
+
+	Key getSigningKeyForHS256(JwtConsumerConfig config) throws KeyException {
+		Key signingKey = null;
+		try {
+			signingKey = getSharedSecretKey(config);
+		} catch (Exception e) {
+			String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_SHARED_KEY", new Object[] { e.getLocalizedMessage() });
+			throw new KeyException(msg, e);
+		}
+		return signingKey;
+	}
+
+	/**
+	 * Creates a Key object from the shared key specified in the provided
+	 * configuration.
+	 */
+	Key getSharedSecretKey(JwtConsumerConfig config) throws KeyException {
+		if (config == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "JWT consumer config object is null");
+			}
+			return null;
+		}
+		String sharedKey = config.getSharedKey();
+		return createKeyFromSharedKey(sharedKey);
+	}
+
+	Key createKeyFromSharedKey(String sharedKey) throws KeyException {
+		if (sharedKey == null || sharedKey.isEmpty()) {
+			String msg = Tr.formatMessage(tc, "JWT_MISSING_SHARED_KEY");
+			throw new KeyException(msg);
+		}
+		try {
+			return new HmacKey(sharedKey.getBytes(Constants.UTF_8));
+		} catch (UnsupportedEncodingException e) {
+			// Should not happen - UTF-8 should be supported
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Caught exception getting shared key bytes: " + e.getLocalizedMessage());
+			}
+		}
+		return null;
+	}
+
+	boolean isPublicKeyPropsPresent(Map props) {
+		if (props == null) {
+			return false;
+		}
+		return props.get(PUBLIC_KEY) != null || props.get(KEY_LOCATION) != null;
+	}
+
+	Key getSigningKeyForRS256(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
+		Key signingKey = null;
+		if (config.getJwkEnabled() || (config.getTrustedAlias() == null && isPublicKeyPropsPresent(properties))) { // need
+																													// change
+																													// to
+																													// consider
+																													// MP-Config
+			signingKey = getKeyForJwkEnabled(config, jwtContext, properties);
+		} else {
+			signingKey = getKeyForJwkDisabled(config);
+		}
+		return signingKey;
+	}
+
+	Key getKeyForJwkEnabled(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
+		Key signingKey = null;
+		try {
+			signingKey = getJwksKey(config, jwtContext, properties);
+		} catch (Exception e) {
+			String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_JWK_KEY",
+					new Object[] { config.getJwkEndpointUrl(), e.getLocalizedMessage() });
+			throw new KeyException(msg, e);
+		}
+		return signingKey;
+	}
+
+	protected Key getJwksKey(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws Exception {
+		JsonWebStructure jwtHeader = getJwtHeader(jwtContext);
+		String kid = jwtHeader.getKeyIdHeaderValue();
+		JwKRetriever jwkRetriever = null;
+		if (properties != null) {
+			String publickey = (String) properties.get(PUBLIC_KEY);
+			String keyLocation = (String) properties.get(KEY_LOCATION);
+			if (publickey != null || keyLocation != null) {
+				jwkRetriever = new JwKRetriever(config.getId(), config.getSslRef(), config.getJwkEndpointUrl(),
+						config.getJwkSet(), JwtUtils.getSSLSupportService(), config.isHostNameVerificationEnabled(),
+						null, null, publickey, keyLocation);
+			}
+		}
+		if (jwkRetriever == null) {
+			jwkRetriever = new JwKRetriever(config.getId(), config.getSslRef(), config.getJwkEndpointUrl(),
+					config.getJwkSet(), JwtUtils.getSSLSupportService(), config.isHostNameVerificationEnabled(), null,
+					null);
+		}
+		Key signingKey = jwkRetriever.getPublicKeyFromJwk(kid, null,
+				config.getUseSystemPropertiesForHttpClientConnections()); // only kid or x5t will work but not both
+		return signingKey;
+	}
+
+	JsonWebStructure getJwtHeader(JwtContext jwtContext) throws InvalidJwtException {
+		List<JsonWebStructure> jsonStructures = jwtContext.getJoseObjects();
+		if (jsonStructures == null || jsonStructures.isEmpty()) {
+			// TODO - NLS message
+			throw new InvalidJwtException("Invalid JsonWebStructure");
+		}
+		JsonWebStructure jwtHeader = jsonStructures.get(0);
+		debugJwtHeader(jwtHeader);
+		return jwtHeader;
+	}
+
+	void debugJwtHeader(JsonWebStructure jwtHeader) {
+		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+			Tr.debug(tc, "JsonWebStructure class: " + jwtHeader.getClass().getName() + " data:" + jwtHeader);
+			if (jwtHeader instanceof JsonWebSignature) {
+				JsonWebSignature signature = (JsonWebSignature) jwtHeader;
+				Tr.debug(tc, "JsonWebSignature alg: " + signature.getAlgorithmHeaderValue() + " 3rd:'"
+						+ signature.getEncodedSignature() + "'");
+			}
+		}
+	}
+
+	Key getKeyForJwkDisabled(JwtConsumerConfig config) throws KeyException {
+		Key signingKey = null;
+		String trustedAlias = config.getTrustedAlias();
+		String trustStoreRef = config.getTrustStoreRef();
+		try {
+			signingKey = getPublicKey(trustedAlias, trustStoreRef, Constants.SIGNATURE_ALG_RS256);
+		} catch (Exception e) {
+			String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_PUBLIC_KEY",
+					new Object[] { trustedAlias, trustStoreRef, e.getLocalizedMessage() });
+			throw new KeyException(msg, e);
+		}
+		return signingKey;
+	}
+
+	/**
+	 * Creates a Key object from the certificate stored in the trust store and alias
+	 * provided.
+	 */
+	Key getPublicKey(String trustedAlias, String trustStoreRef, String signatureAlgorithm)
+			throws KeyStoreServiceException, KeyException {
+		Key signingKey = getPublicKeyFromKeystore(trustedAlias, trustStoreRef, signatureAlgorithm);
+		if (tc.isDebugEnabled()) {
+			Tr.debug(tc, "Trusted alias: " + trustedAlias + ", Truststore: " + trustStoreRef);
+			Tr.debug(tc, "RSAPublicKey: " + (signingKey instanceof RSAPublicKey));
+		}
+		if (signingKey != null && !(signingKey instanceof RSAPublicKey)) {
+			signingKey = null;
+		}
+		return signingKey;
+	}
+
+	Key getPublicKeyFromKeystore(String trustedAlias, String trustStoreRef, String signatureAlgorithm)
+			throws KeyException {
+		try {
+			if (keyStoreService == null) {
+				String msg = Tr.formatMessage(tc, "JWT_TRUSTSTORE_SERVICE_NOT_AVAILABLE");
+				throw new KeyStoreServiceException(msg);
+			}
+			return JwtUtils.getPublicKey(trustedAlias, trustStoreRef, keyStoreService.getService());
+		} catch (Exception e) {
+			String msg = Tr.formatMessage(tc, "JWT_NULL_SIGNING_KEY_WITH_ERROR",
+					new Object[] { signatureAlgorithm, Constants.SIGNING_KEY_X509, e.getLocalizedMessage() });
+			throw new KeyException(msg, e);
+		}
+	}
+
+	protected JwtContext parseJwtWithoutValidation(String jwtString, JwtConsumerConfig config) throws Exception {
+		if (jwtString == null || jwtString.isEmpty()) {
+			String errorMsg = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_OR_EMPTY_STRING",
+					new Object[] { config.getId(), jwtString });
+			throw new InvalidTokenException(errorMsg);
+		}
+		JwtConsumerBuilder builder = initializeJwtConsumerBuilderWithoutValidation(config);
+		JwtConsumer firstPassJwtConsumer = builder.build();
+		return firstPassJwtConsumer.process(jwtString);
+	}
+
+	protected JwtContext parseJwtWithValidation(String jwtString, JwtContext jwtContext, JwtConsumerConfig config,
+			Key key, Map properties) throws Exception {
+		JwtClaims jwtClaims = jwtContext.getJwtClaims();
+
+		if (tc.isDebugEnabled()) {
+			Tr.debug(tc, "Key from config: " + key);
+		}
+
+		validateClaims(jwtClaims, jwtContext, config, properties);
+		validateSignatureAlgorithmWithKey(config, key);
+
+		JwtConsumerBuilder consumerBuilder = initializeJwtConsumerBuilderWithValidation(config, jwtClaims, key);
+		JwtConsumer jwtConsumer = consumerBuilder.build();
+		return processJwtStringWithConsumer(jwtConsumer, jwtString);
+	}
+
+	JwtConsumerBuilder initializeJwtConsumerBuilderWithoutValidation(JwtConsumerConfig config) {
+		JwtConsumerBuilder builder = new JwtConsumerBuilder();
+		builder.setSkipAllValidators();
+		builder.setDisableRequireSignature();
+		builder.setSkipSignatureVerification();
+		builder.setAllowedClockSkewInSeconds((int) ((config.getClockSkew()) / 1000));
+		return builder;
+	}
+
+	JwtConsumerBuilder initializeJwtConsumerBuilderWithValidation(JwtConsumerConfig config, JwtClaims jwtClaims,
+			Key key) throws MalformedClaimException {
+		JwtConsumerBuilder builder = new JwtConsumerBuilder();
+		builder.setExpectedIssuer(jwtClaims.getIssuer());
+		builder.setSkipDefaultAudienceValidation();
+		builder.setRequireExpirationTime();
+		builder.setVerificationKey(key);
+		builder.setRelaxVerificationKeyValidation();
+		builder.setAllowedClockSkewInSeconds((int) (config.getClockSkew() / 1000));
+		return builder;
+	}
+
+	void validateClaims(JwtClaims jwtClaims, JwtContext jwtContext, JwtConsumerConfig config, Map properties)
+			throws MalformedClaimException, InvalidClaimException, InvalidTokenException {
+		String issuer = config.getIssuer();
+		if (issuer == null) {
+			issuer = (properties == null) ? null : (String) properties.get(ISSUER);
+		}
+
+		validateIssuer(config.getId(), issuer, jwtClaims.getIssuer());
+
+		if (!validateAudience(config.getAudiences(), jwtClaims.getAudience())) {
+			String msg = Tr.formatMessage(tc, "JWT_AUDIENCE_NOT_TRUSTED",
+					new Object[] { jwtClaims.getAudience(), config.getId(), config.getAudiences() });
+			throw new InvalidClaimException(msg);
+		}
+
+		// check azp
+
+		validateIatAndExp(jwtClaims, config.getClockSkew());
+
+		validateNbf(jwtClaims, config.getClockSkew());
+
+		validateAlgorithm(jwtContext, config.getSignatureAlgorithm());
+	}
+
+	/**
+	 * Throws an exception if the provided key is null but the config specifies a
+	 * signature algorithm other than "none".
+	 */
+	void validateSignatureAlgorithmWithKey(JwtConsumerConfig config, Key key) throws InvalidClaimException {
+		String signatureAlgorithm = config.getSignatureAlgorithm();
+		if (key == null && signatureAlgorithm != null && !signatureAlgorithm.equalsIgnoreCase("none")) {
+			String msg = Tr.formatMessage(tc, "JWT_MISSING_KEY", new Object[] { signatureAlgorithm });
+			throw new InvalidClaimException(msg);
+		}
+	}
+
+	/**
+	 * Verifies that tokenIssuer is one of the values specified in the
+	 * comma-separated issuers string.
+	 */
+	boolean validateIssuer(String consumerConfigId, String issuers, String tokenIssuer) throws InvalidClaimException {
+		boolean isIssuer = false;
+		if (issuers == null || issuers.isEmpty()) {
+			String msg = Tr.formatMessage(tc, "JWT_TRUSTED_ISSUERS_NULL",
+					new Object[] { tokenIssuer, consumerConfigId });
+			throw new InvalidClaimException(msg);
+		}
+
+		StringTokenizer st = new StringTokenizer(issuers, ",");
+		while (st.hasMoreTokens()) {
+			String iss = st.nextToken().trim();
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Trusted issuer: " + iss);
+			}
+			if (Constants.ALL_ISSUERS.equals(iss) || (tokenIssuer != null && tokenIssuer.equals(iss))) {
+				isIssuer = true;
+				break;
+			}
+		}
+
+		if (!isIssuer) {
+			String msg = Tr.formatMessage(tc, "JWT_ISSUER_NOT_TRUSTED",
+					new Object[] { tokenIssuer, consumerConfigId, issuers });
+			throw new InvalidClaimException(msg);
+		}
+		return isIssuer;
+	}
+
+	/**
+	 * Verifies that at least one of the values specified in audiences is contained
+	 * in the allowedAudiences list.
+	 */
+	boolean validateAudience(List<String> allowedAudiences, List<String> audiences) {
+		boolean valid = false;
+
+		if (allowedAudiences != null && allowedAudiences.contains(Constants.ALL_AUDIENCES)) {
+			return true;
+		}
+		if (allowedAudiences != null && audiences != null) {
+			for (String audience : audiences) {
+				for (String allowedAud : allowedAudiences) {
+					if (allowedAud.equals(audience)) {
+						valid = true;
+						break;
+					}
+				}
+			}
+		} else if (allowedAudiences == null && (audiences == null || audiences.isEmpty())) {
+			valid = true;
+		}
+
+		return valid;
+	}
+
+	/**
+	 * Validates the the {@value Claims#ISSUED_AT} and {@value Claims#EXPIRATION}
+	 * claims are present and properly formed. Also verifies that the
+	 * {@value Claims#ISSUED_AT} time is after the {@value Claims#EXPIRATION} time.
+	 */
+	void validateIatAndExp(JwtClaims jwtClaims, long clockSkewInMilliseconds) throws InvalidClaimException {
+		if (jwtClaims == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Missing JwtClaims object");
+			}
+			return;
+		}
+		NumericDate issueAtClaim = getIssuedAtClaim(jwtClaims);
+		NumericDate expirationClaim = getExpirationClaim(jwtClaims);
+
+		debugCurrentTimes(clockSkewInMilliseconds, issueAtClaim, expirationClaim);
+
+		validateIssuedAtClaim(issueAtClaim, expirationClaim, clockSkewInMilliseconds);
+		validateExpirationClaim(expirationClaim, clockSkewInMilliseconds);
+
+	}
+
+	void debugCurrentTimes(long clockSkewInMilliseconds, NumericDate issueAtClaim, NumericDate expirationClaim) {
+		if (tc.isDebugEnabled()) {
+			long now = (new Date()).getTime();
+			NumericDate currentTimeMinusSkew = NumericDate.fromMilliseconds(now - clockSkewInMilliseconds);
+			NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
+			Tr.debug(tc, "Checking iat [" + createDateString(issueAtClaim) + "] and exp ["
+					+ createDateString(expirationClaim) + "]");
+			Tr.debug(tc, "Comparing against current time (minus clock skew of " + (clockSkewInMilliseconds / 1000)
+					+ " seconds) [" + createDateString(currentTimeMinusSkew) + "]");
+			Tr.debug(tc, "Comparing against current time (plus clock skew of " + (clockSkewInMilliseconds / 1000)
+					+ " seconds) [" + createDateString(currentTimePlusSkew) + "]");
+		}
+	}
+
+	void validateIssuedAtClaim(NumericDate issueAtClaim, NumericDate expirationClaim, long clockSkewInMilliseconds)
+			throws InvalidClaimException {
+		long now = (new Date()).getTime();
+		NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
+
+		if (issueAtClaim != null && expirationClaim != null) {
+			if (issueAtClaim.isAfter(currentTimePlusSkew)) {
+				String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_CURRENT_TIME",
+						new Object[] { createDateString(issueAtClaim), createDateString(currentTimePlusSkew),
+								(clockSkewInMilliseconds / 1000) });
+				throw new InvalidClaimException(msg);
+			}
+			if (issueAtClaim.isOnOrAfter(expirationClaim)) {
+				String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_EXP",
+						new Object[] { createDateString(issueAtClaim), createDateString(expirationClaim) });
+				throw new InvalidClaimException(msg);
+			}
+		} else {
+			// TODO - what if one or the other is missing? is that an error
+			// condition?
+		}
+	}
+
+	
+	void validateExpirationClaim(NumericDate expirationClaim, long clockSkewInMilliseconds)
+			throws InvalidClaimException {
+		long now = (new Date()).getTime();
+		NumericDate currentTimeMinusSkew = NumericDate.fromMilliseconds(now - clockSkewInMilliseconds);
+
+		// Check that expiration claim is in the future, accounting for the
+		// clock skew
+		if (expirationClaim == null || (!expirationClaim.isAfter(currentTimeMinusSkew))) {
+			JwtUtils.setJwtSsoValidationPathExiredToken();
+			String msg = Tr.formatMessage(tc, "JWT_TOKEN_EXPIRED", new Object[] { createDateString(expirationClaim),
+					createDateString(currentTimeMinusSkew), (clockSkewInMilliseconds / 1000) });
+			throw new InvalidClaimException(msg);
+		}
+	}
+
+	/**
+	 * Validates the the {@value Claims#NOT_BEFORE} claim is present and properly
+	 * formed. Also
+	 */
+	void validateNbf(JwtClaims jwtClaims, long clockSkewInMilliseconds) throws InvalidClaimException {
+		if (jwtClaims == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Missing JwtClaims object");
+			}
+			return;
+		}
+		NumericDate nbf = getNotBeforeClaim(jwtClaims);
+		validateNotBeforeClaim(nbf, clockSkewInMilliseconds);
+	}
+
+	void validateNotBeforeClaim(NumericDate nbfClaim, long clockSkewInMilliseconds) throws InvalidClaimException {
+		long now = (new Date()).getTime();
+		NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
+
+		// Check that nbf claim is in the past, accounting for the clock skew
+		if (nbfClaim != null && (nbfClaim.isOnOrAfter(currentTimePlusSkew))) {
+			String msg = Tr.formatMessage(tc, "JWT_TOKEN_BEFORE_NBF", new Object[] { createDateString(nbfClaim),
+					createDateString(currentTimePlusSkew), (clockSkewInMilliseconds / 1000) });
+			throw new InvalidClaimException(msg);
+		}
+	}
+
+	NumericDate getIssuedAtClaim(JwtClaims jwtClaims) throws InvalidClaimException {
+		NumericDate iatClaim = null;
+		try {
+			iatClaim = jwtClaims.getIssuedAt();
+		} catch (MalformedClaimException e) {
+			String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
+					new Object[] { Claims.ISSUED_AT, e.getLocalizedMessage() });
+			throw new InvalidClaimException(msg, e);
+		}
+		return iatClaim;
+	}
+
+	NumericDate getExpirationClaim(JwtClaims jwtClaims) throws InvalidClaimException {
+		NumericDate expClaim = null;
+		try {
+			expClaim = jwtClaims.getExpirationTime();
+		} catch (MalformedClaimException e) {
+			String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
+					new Object[] { Claims.EXPIRATION, e.getLocalizedMessage() });
+			throw new InvalidClaimException(msg, e);
+		}
+		return expClaim;
+	}
+
+	NumericDate getNotBeforeClaim(JwtClaims jwtClaims) throws InvalidClaimException {
+		NumericDate nbfClaim = null;
+		try {
+			nbfClaim = jwtClaims.getNotBefore();
+		} catch (MalformedClaimException e) {
+			String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
+					new Object[] { Claims.NOT_BEFORE, e.getLocalizedMessage() });
+			throw new InvalidClaimException(msg, e);
+		}
+		return nbfClaim;
+	}
+
+	void validateAlgorithm(JwtContext jwtContext, String requiredAlg) throws InvalidTokenException {
+		if (requiredAlg == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "No required signature algorithm was specified");
+			}
+			return;
+		}
+		String tokenAlg = getAlgorithmFromJwtHeader(jwtContext);
+		validateAlgorithm(requiredAlg, tokenAlg);
+	}
+
+	void validateAlgorithm(String requiredAlg, String tokenAlg) throws InvalidTokenException {
+		if (tokenAlg == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Signature algorithm was not found in the JWT");
+			}
+			String msg = Tr.formatMessage(tc, "JWT_MISSING_ALG_HEADER", new Object[] { requiredAlg });
+			throw new InvalidTokenException(msg);
+		}
+		if (tc.isDebugEnabled()) {
+			Tr.debug(tc, "JWT is signed with algorithm: ", tokenAlg);
+			Tr.debug(tc, "JWT is required to be signed with algorithm: ", requiredAlg);
+		}
+		if (!requiredAlg.equals(tokenAlg)) {
+			String msg = Tr.formatMessage(tc, "JWT_ALGORITHM_MISMATCH", new Object[] { tokenAlg, requiredAlg });
+			throw new InvalidTokenException(msg);
+		}
+	}
+
+	JwtContext processJwtStringWithConsumer(JwtConsumer jwtConsumer, String jwtString)
+			throws InvalidTokenException, InvalidJwtException {
+		JwtContext validatedJwtContext = null;
+		try {
+			validatedJwtContext = jwtConsumer.process(jwtString);
+		} catch (InvalidJwtSignatureException e) {
+			String msg = Tr.formatMessage(tc, "JWT_INVALID_SIGNATURE", new Object[] { e.getLocalizedMessage() });
+			throw new InvalidTokenException(msg, e);
+		} catch (InvalidJwtException e) {
+			Throwable cause = getRootCause(e);
+			if (cause != null && cause instanceof InvalidKeyException) {
+				throw e;
+			} else {
+				// Don't have enough information to output a more useful error
+				// message
+				throw e;
+			}
+		}
+		return validatedJwtContext;
+	}
+
+	String getAlgorithmFromJwtHeader(JwtContext jwtContext) {
+		if (jwtContext == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "JwtContext is null");
+			}
+			return null;
+		}
+		JsonWebStructure jwtHeader = null;
+		try {
+			jwtHeader = getJwtHeader(jwtContext);
+		} catch (InvalidJwtException e) {
+			// TODO - NLS message?
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Failed to obtain JWT header");
+			}
+			return null;
+		}
+		String algHeader = jwtHeader.getAlgorithmHeaderValue();
+		if (tc.isDebugEnabled()) {
+			Tr.debug(tc, "JWT is signed with algorithm: ", algHeader);
+		}
+		return algHeader;
+	}
+
+	Throwable getRootCause(Exception e) {
+		Throwable rootCause = null;
+		Throwable tmpCause = e;
+		while (tmpCause != null) {
+			rootCause = tmpCause;
+			tmpCause = rootCause.getCause();
+		}
+		return rootCause;
+	}
+
+	String createDateString(NumericDate date) {
+		if (date == null) {
+			return null;
+		}
+		// NumericDate.getValue() returns a value in seconds, so convert to
+		// milliseconds
+		return timeUtils.createDateString(1000 * date.getValue());
+	}
 
 }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtUtils.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtUtils.java
@@ -60,540 +60,561 @@ import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceMap;
 import com.ibm.wsspi.ssl.SSLSupport;
 
 public class JwtUtils {
-    private static final TraceComponent tc = Tr.register(JwtUtils.class);
-
-    public static final String CFG_KEY_ID = "id";
-    public static final String CFG_KEY_ISSUER = "issuer";
-    public static final String CFG_KEY_JWK_ENABLED = "jwkEnabled";
-    public static final String CFG_KEY_VALID = "expiry";
-    public static final String CFG_KEY_JTI = "jti"; // builder
-    public static final String CFG_KEY_JTI_CHECK_ENABLED = "jtiCheckEnabled"; // consumer
-    public static final String CFG_KEY_SCOPE = "scope";
-    public static final String CFG_KEY_AUDIENCES = "audiences";
-    public static final String CFG_KEY_SIGNATURE_ALGORITHM = "signatureAlgorithm";
-    public static final String CFG_KEY_CLAIMS = "claims";
-    public static final String CFG_KEY_KEYSTORE_REF = "keyStoreRef";
-    public static final String CFG_KEY_KEY_ALIAS_NAME = "keyAlias";
-    public static final String CFG_KEY_TRUSTSTORE_REF = "trustStoreRef";
-    public static final String CFG_KEY_TRUSTED_ALIAS = "trustedAlias";
-    public static final String CFG_KEY_SHARED_KEY = "sharedKey";
-    public static final String CFG_KEY_JWK_ROTATION_TIME = "jwkRotationTime";
-    public static final String CFG_KEY_JWK_SIGNING_KEY_SIZE = "jwkSigningKeySize";
-    public static final String CFG_KEY_JWK_ENDPOINT_URL = "jwkEndpointUrl";
-    public static final String CFG_KEY_CLOCK_SKEW = "clockSkew";
-    public static final String CFG_KEY_VALIDATION_REQUIRED = "validationRequired";
-    public static final String CFG_KEY_SSL_REF = "sslRef";
-    public static final String CFG_KEY_EXPIRES_IN_SECONDS = "expiresInSeconds";
-    public static final String CFG_KEY_USE_SYSPROPS_FOR_HTTPCLIENT_CONNECTONS = "useSystemPropertiesForHttpClientConnections";
-
-    public static final String JCEPROVIDER_IBM = "IBMJCE";
-    public static final String SECRANDOM_SHA1PRNG = "SHA1PRNG";
-    public static final String SECRANDOM_IBM = "IBMSecureRandom";
-
-    public static final String ISSUER = "iss";
-    public static final String SUBJECT = "sub";
-    public static final String AUDIENCE = "aud";
-    public static final String SCOPE = "scope";
-    public static final String EXPIRATION = "exp";
-    public static final String NOT_BEFORE = "nbf";
-    public static final String ISSUED_AT = "iat";
-    public static final String ID = "jti";
-    public static final String KEY = "signKey";
-    public static final String ALG = "signAlg";
-    public static final String KS = "KeyStore";
-    public static final String KS_ALIAS = "KeyStore_ALIAS";
-    public static final String TS = "TrustStore";
-    public static final String TS_ALIAS = "TrustStore_ALIAS";
-
-    public static final String DELIMITER = ".";
-
-    private static final String KEY_VMM_SERVICE = "vmmService";
-    public static final String KEY_KEYSTORE_SERVICE = "keyStoreService";
-    private static AtomicServiceReference<VMMService> vmmServiceRef = new AtomicServiceReference<VMMService>(
-            KEY_VMM_SERVICE);
-    private static AtomicServiceReference<KeyStoreService> keyStoreServiceRef;
-    private static ConcurrentServiceReferenceMap<String, KeyStoreService> keyStoreServiceMapRef = new ConcurrentServiceReferenceMap<String, KeyStoreService>(
-            KEY_KEYSTORE_SERVICE);
-    private static AtomicServiceReference<SSLSupport> sslSupportRef;
-
-    // private static AtomicServiceReference<VirtualHost> virtualHostRef;
-
-    public static String convertToBase64(String source) {
-        return Base64.encodeBase64URLSafeString(StringUtils.getBytesUtf8(source));
-    }
-
-    public static String decodeFromBase64String(String encoded) {
-        return new String(Base64.decodeBase64(encoded));
-    }
-
-    public static boolean isBase64Encoded(String str) {
-        if (!isNullEmpty(str)) {
-            return Base64.isArrayByteBase64(StringUtils.getBytesUtf8(str));
-        }
-        return false;
-    }
-
-    public static String fromBase64ToJsonString(String source) {
-        return StringUtils.newStringUtf8(Base64.decodeBase64(source));
-    }
-
-    public static String toJson(String source) {
-        try {
-            return StringUtils.newStringUtf8(source.getBytes("UTF8"));
-        } catch (UnsupportedEncodingException e) {
-            // TODO Auto-generated catch block
-            // e.printStackTrace();
-        }
-        return null;
-    }
-
-    public static boolean isNullEmpty(String value) {
-        return value == null || value.isEmpty();
-    }
-
-    public static boolean isJson(String tokenString) {
-        boolean result = false;
-        if (!isNullEmpty(tokenString)) {
-            if ((tokenString.startsWith("{") && tokenString.endsWith("}"))
-                    || (tokenString.startsWith("[") && tokenString.endsWith("]"))) {
-                // com.google.gson.JsonParser parser = new
-                // com.google.gson.JsonParser();
-                // parser.parse(tokenString);
-                result = true;
-            }
-        }
-        return result;
-    }
-
-    // either from header or payload
-    public static Object claimFromJsonObject(String jsonFormattedString, String claimName) throws JoseException {
-        Object claim = null;
-
-        // JSONObject jobj = JSONObject.parse(jsonFormattedString);
-        Map<String, Object> jobj = org.jose4j.json.JsonUtil.parseJson(jsonFormattedString);
-        if (jobj != null) {
-            claim = jobj.get(claimName);
-        }
-
-        return claim;
-    }
-
-    // assuming payload not the whole token string
-    public static Map claimsFromJsonObject(String jsonFormattedString) throws JoseException {
-        Map claimsMap = new ConcurrentHashMap<String, Object>();
-
-        // JSONObject jobj = JSONObject.parse(jsonFormattedString);
-        Map<String, Object> jobj = org.jose4j.json.JsonUtil.parseJson(jsonFormattedString);
-        Set<Entry<String, Object>> entries = jobj.entrySet();
-        Iterator<Entry<String, Object>> it = entries.iterator();
-
-        while (it.hasNext()) {
-            Entry<String, Object> entry = it.next();
-
-            String key = entry.getKey();
-            Object value = entry.getValue();
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Key : " + key + ", Value: " + value);
-            }
-            if (!isNullEmpty(key) && value != null) {
-                claimsMap.put(key, value);
-            }
-
-            // JsonElement jsonElem = entry.getValue();
-        }
-
-        // claims.putAll(jobj.entrySet());
-
-        return claimsMap;
-    }
-
-    public static Map<String, Object> claimsFromJson(String jsonFormattedString) throws Exception {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "JSON String =" + jsonFormattedString);
-        }
-        JSONObject object = JSONObject.parse(jsonFormattedString);
-
-        HashMap<String, Object> map = new HashMap<String, Object>();
-        Set<Entry<String, Object>> set = object.entrySet();
-        Iterator<Entry<String, Object>> iterator = set.iterator();
-
-        while (iterator.hasNext()) {
-            Entry<String, Object> entry = iterator.next();
-            String key = entry.getKey();
-            Object value = entry.getValue();
-
-            if (isJsonArray(value)) {
-                handleJsonArray(value, key, map);
-            } else if (isJsonObject(value)) {
-                map.put(key, claimsFromJson(value.toString()));
-            } else {
-                map.put(key, value.toString());
-            }
-        }
-        return map;
-    }
-
-    @FFDCIgnore(Exception.class)
-    public static void handleJsonArray(Object value, String key, HashMap<String, Object> map) {
-        if (!isJsonArray(value)) {
-            map.put(key, value.toString());
-            return;
-        }
-        JSONArray jArray = null;
-        try {
-            jArray = JSONArray.parse(value.toString());
-        } catch (Exception e) {
-            // Shouldn't happen since we verified the value should be a JSON
-            // array if we get here
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Caught exception handling provided object [" + value.toString() + "]: " + e.getMessage());
-            }
-            map.put(key, value.toString());
-            return;
-        }
-        if (jArray != null && !jArray.isEmpty()) {
-            map.put(key, jArray);
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "array list of objects, Key : " + key + ", Value: " + jArray.toString());
-            }
-        }
-    }
-
-    @FFDCIgnore(Exception.class)
-    static boolean isJsonObject(Object value) {
-        if (value == null) {
-            return false;
-        }
-        try {
-            JSONObject.parse(value.toString());
-        } catch (Exception e) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Value [" + value + "] is not a valid JSON object: " + e.getMessage());
-            }
-            return false;
-        }
-        return true;
-    }
-
-    @FFDCIgnore(Exception.class)
-    static boolean isJsonArray(Object value) {
-        if (value == null) {
-            return false;
-        }
-        try {
-            JSONArray.parse(value.toString());
-        } catch (Exception e) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Value [" + value + "] is not a valid JSON array: " + e.getMessage());
-            }
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Trims each of the strings in the array provided and returns a new list
-     * with each string added to it. If the trimmed string is empty, that string
-     * will not be added to the final array. If no entries are present in the
-     * final array, null is returned.
-     *
-     * @param strings
-     * @return
-     */
-    public static List<String> trimIt(String[] strings) {
-        if (strings == null || strings.length == 0) {
-            return null;
-        }
-
-        List<String> results = new ArrayList<String>();
-
-        for (int i = 0; i < strings.length; i++) {
-            String result = trimIt(strings[i]);
-            if (result != null) {
-                results.add(result);
-            }
-        }
-
-        if (results.size() > 0) {
-            return results;
-        } else {
-            return null;
-        }
-    }
-
-    public static String trimIt(String str) {
-        if (str == null) {
-            return null;
-        }
-        str = str.trim();
-        if (str.isEmpty()) {
-            return null;
-        }
-        return str;
-    }
-
-    public static JwtConfig getTheAtomicService(String builderConfigId,
-            ConcurrentServiceReferenceMap<String, JwtConfig> jwtServiceMapRef) {
-        Iterator<JwtConfig> jwtServices = jwtServiceMapRef.getServices();
-        while (jwtServices.hasNext()) {
-            JwtConfig jwtService = jwtServices.next();
-            if (builderConfigId.equals(jwtService.getId())) {
-                return jwtService;
-            }
-        }
-        return null;
-
-    }
-
-    public static JwtConfig getTheService(String builderConfigId,
-            ConcurrentServiceReferenceMap<String, JwtConfig> jwtServiceMapRef) {
-        Iterator<JwtConfig> jwtServices = jwtServiceMapRef.getServices();
-        while (jwtServices.hasNext()) {
-            JwtConfig jwtService = jwtServices.next();
-            if (builderConfigId.equals(jwtService.getId())) {
-                return jwtService;
-            }
-        }
-        return null;
-
-    }
-
-    public static String[] splitTokenString(String tokenString) {
-        boolean isPlainTextJWT = false;
-        if (tokenString.endsWith(".")) {
-            isPlainTextJWT = true;
-        }
-        String[] pieces = tokenString.split(Pattern.quote(DELIMITER));
-        if (!isPlainTextJWT && pieces.length != 3) {
-            // Tr.warning("Expected JWT to have 3 segments separated by '" +
-            // DELIMITER + "', but it has " + pieces.length + " segments");
-            return null;
-        }
-        return pieces;
-    }
-
-    public static String getPayload(String jwt) {
-        String[] jwtInfo = splitTokenString(jwt);
-        if (jwtInfo != null) {
-            return jwtInfo[1];
-        }
-        return null;
-    }
-
-    public static String getRandom(int length) {
-        StringBuffer result = new StringBuffer(length);
-        final char[] chars = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',
-                'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u',
-                'v', 'w', 'x', 'y', 'z' };
-        Random r = getRandom();
-
-        for (int i = 0; i < length; i++) {
-            int n = r.nextInt(62);
-            result.append(chars[n]);
-        }
-
-        return result.toString();
-    }
-
-    static Random getRandom() {
-        Random result = null;
-        try {
-            if (Security.getProvider(JCEPROVIDER_IBM) != null) {
-                result = SecureRandom.getInstance(SECRANDOM_IBM);
-            } else {
-                result = SecureRandom.getInstance(SECRANDOM_SHA1PRNG);
-            }
-        } catch (Exception e) {
-            result = new Random();
-        }
-        return result;
-    }
-
-    public static long calculate(long valid) {
-        // TODO Auto-generated method stub
-        long lifetimeSeconds = valid * 60 * 60;
-        long timeInSeconds = System.currentTimeMillis() / 1000;
-
-        return timeInSeconds + lifetimeSeconds;
-    }
-
-    public static String toJson(Map<String, Object> claimsMap) {
-        // TODO Auto-generated method stub
-        return org.jose4j.json.JsonUtil.toJson(claimsMap);
-    }
-
-    public static void setVMMService(AtomicServiceReference<VMMService> vmmServiceRef) {
-        JwtUtils.vmmServiceRef = vmmServiceRef;
-    }
-
-    public static VMMService getVMMService() {
-        return vmmServiceRef.getService();
-    }
-
-    public static Object fetch(String claim, String subject) throws Exception {
-        RegistryClaims claims = new RegistryClaims(subject);
-        return claims.fetchClaim(claim);
-    }
-
-    public static void setSSLSupportService(AtomicServiceReference<SSLSupport> sslSupportRef) {
-        // TODO Auto-generated method stub
-        JwtUtils.sslSupportRef = sslSupportRef;
-    }
-
-    public static SSLSupport getSSLSupportService() {
-        // TODO Auto-generated method stub
-        return (sslSupportRef.getService());
-    }
-
-    public static void setKeyStoreService(AtomicServiceReference<KeyStoreService> kssRef) {
-        // TODO Auto-generated method stub
-        JwtUtils.keyStoreServiceRef = kssRef;
-    }
-
-    public static void setKeyStoreService2(ConcurrentServiceReferenceMap<String, KeyStoreService> kssMapRef) {
-        // TODO Auto-generated method stub
-        JwtUtils.keyStoreServiceMapRef = kssMapRef;
-    }
-
-    public static KeyStoreService getKeyStoreService() {
-        if (keyStoreServiceRef != null) {
-            return keyStoreServiceRef.getService();
-        }
-        return null;
-    }
-
-    public static String getDefaultKeyStoreName(String propKey) {
-        String keyStoreName = null;
-        // config does not specify keystore, so try to get one from servers
-        // default ssl config.
-        SSLSupport sslSupport = getSSLSupportService();
-        JSSEHelper helper = null;
-        if (sslSupport != null) {
-            helper = sslSupport.getJSSEHelper();
-        }
-        Properties props = null;
-        final JSSEHelper jsseHelper = helper;
-        final Map<String, Object> connectionInfo = new HashMap<String, Object>();
-        connectionInfo.put(Constants.CONNECTION_INFO_DIRECTION, Constants.DIRECTION_INBOUND);
-        if (jsseHelper != null) {
-            try {
-                // props = jsseHelper.getProperties("", null, null, true);
-                props = (Properties) AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
-                    @Override
-                    public Object run() throws Exception {
-                        return jsseHelper.getProperties("", connectionInfo, null, true);
-                    }
-                });
-
-            } catch (PrivilegedActionException pae) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Exception getting properties from jssehelper!!!");
-                }
-                // throw (SSLException) pae.getCause();
-            }
-
-            if (props != null) {
-                keyStoreName = props.getProperty(propKey);
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "KeyStore name from default ssl config = " + keyStoreName);
-                }
-            }
-        }
-        return keyStoreName;
-    }
-
-    @Sensitive
-    public static PrivateKey getPrivateKey(String keyAlias, String keyStoreRef)
-            throws KeyStoreException, CertificateException {
-        return getPrivateKey(keyAlias, keyStoreRef, getKeyStoreService());
-    }
-
-    @Sensitive
-    public static PrivateKey getPrivateKey(String keyAlias, String keyStoreRef, KeyStoreService kss)
-            throws KeyStoreException, CertificateException {
-        if (kss != null) {
-            if (keyStoreRef == null) {
-                keyStoreRef = getDefaultKeyStoreName("com.ibm.ssl.keyStoreName");
-            }
-            if (keyStoreRef != null) {
-                if (keyAlias != null) {
-                    return kss.getPrivateKeyFromKeyStore(keyStoreRef, keyAlias, null);
-                } else {
-                    return kss.getPrivateKeyFromKeyStore(keyStoreRef);
-                }
-            }
-        }
-        return null;
-    }
-
-    public static PublicKey getPublicKey(String keyAlias, String trustStoreRef)
-            throws KeyStoreException, CertificateException, InvalidTokenException {
-        return getPublicKey(keyAlias, trustStoreRef, getKeyStoreService());
-    }
-
-    public static PublicKey getPublicKey(String keyAlias, String trustStoreRef, KeyStoreService kss)
-            throws KeyStoreException, CertificateException, InvalidTokenException {
-        if (kss == null) {
-            return null;
-        }
-        if (trustStoreRef == null) {
-            trustStoreRef = getDefaultKeyStoreName("com.ibm.ssl.trustStoreName");
-            if (trustStoreRef == null) {
-                return null;
-            }
-        }
-        if (keyAlias != null) {
-            X509Certificate cert = kss.getX509CertificateFromKeyStore(trustStoreRef, keyAlias);
-            if (cert == null) {
-                return null;
-            }
-            return cert.getPublicKey();
-        } else {
-            Collection<String> aliases = kss.getTrustedCertEntriesInKeyStore(trustStoreRef);
-            // check for NO aliases in the trust store
-            if (aliases == null || aliases.size() == 0) {
-                X509Certificate cert = kss.getX509CertificateFromKeyStore(trustStoreRef);
-                if (cert != null) {
-                    return cert.getPublicKey();
-                }
-                String errorMsg = Tr.formatMessage(tc, "JWT_SIGNER_CERT_NOT_AVAILABLE");
-                throw new InvalidTokenException(errorMsg);
-
-            }
-            // check for more than 1 alias in the trust store (with more than 1,
-            // we need to have trustAlias specified (this is part of the no
-            // trustAlais path))
-            if (aliases.size() > 1) {
-                String errorMsg = Tr.formatMessage(tc, "JWT_SIGNER_CERT_AMBIGUOUS");
-                throw new InvalidTokenException(errorMsg);
-
-            }
-            // We now have 1 alias, we'll get the cert
-            String alias = aliases.iterator().next();
-            X509Certificate cert = kss.getX509CertificateFromKeyStore(trustStoreRef, alias);
-            // if NO cert, fail, otherwise get and return the public key
-            if (cert != null) {
-                return cert.getPublicKey();
-            } else {
-                String errorMsg = Tr.formatMessage(tc, "JWT_SIGNER_CERT_NOT_AVAILABLE");
-                throw new InvalidTokenException(errorMsg);
-
-            }
-        }
-
-    }
-
-    public static String getDate(long current) {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-        Date resultdate = new Date(current);
-        return sdf.format(resultdate);
-    }
-
-    @Sensitive
-    public static String processProtectedString(Map<String, Object> props, String cfgKey) {
-        return JwtConfigUtil.processProtectedString(props, cfgKey);
-    }
+	private static final TraceComponent tc = Tr.register(JwtUtils.class);
+
+	public static final String CFG_KEY_ID = "id";
+	public static final String CFG_KEY_ISSUER = "issuer";
+	public static final String CFG_KEY_JWK_ENABLED = "jwkEnabled";
+	public static final String CFG_KEY_VALID = "expiry";
+	public static final String CFG_KEY_JTI = "jti"; // builder
+	public static final String CFG_KEY_JTI_CHECK_ENABLED = "jtiCheckEnabled"; // consumer
+	public static final String CFG_KEY_SCOPE = "scope";
+	public static final String CFG_KEY_AUDIENCES = "audiences";
+	public static final String CFG_KEY_SIGNATURE_ALGORITHM = "signatureAlgorithm";
+	public static final String CFG_KEY_CLAIMS = "claims";
+	public static final String CFG_KEY_KEYSTORE_REF = "keyStoreRef";
+	public static final String CFG_KEY_KEY_ALIAS_NAME = "keyAlias";
+	public static final String CFG_KEY_TRUSTSTORE_REF = "trustStoreRef";
+	public static final String CFG_KEY_TRUSTED_ALIAS = "trustedAlias";
+	public static final String CFG_KEY_SHARED_KEY = "sharedKey";
+	public static final String CFG_KEY_JWK_ROTATION_TIME = "jwkRotationTime";
+	public static final String CFG_KEY_JWK_SIGNING_KEY_SIZE = "jwkSigningKeySize";
+	public static final String CFG_KEY_JWK_ENDPOINT_URL = "jwkEndpointUrl";
+	public static final String CFG_KEY_CLOCK_SKEW = "clockSkew";
+	public static final String CFG_KEY_VALIDATION_REQUIRED = "validationRequired";
+	public static final String CFG_KEY_SSL_REF = "sslRef";
+	public static final String CFG_KEY_EXPIRES_IN_SECONDS = "expiresInSeconds";
+	public static final String CFG_KEY_USE_SYSPROPS_FOR_HTTPCLIENT_CONNECTONS = "useSystemPropertiesForHttpClientConnections";
+
+	public static final String JCEPROVIDER_IBM = "IBMJCE";
+	public static final String SECRANDOM_SHA1PRNG = "SHA1PRNG";
+	public static final String SECRANDOM_IBM = "IBMSecureRandom";
+
+	public static final String ISSUER = "iss";
+	public static final String SUBJECT = "sub";
+	public static final String AUDIENCE = "aud";
+	public static final String SCOPE = "scope";
+	public static final String EXPIRATION = "exp";
+	public static final String NOT_BEFORE = "nbf";
+	public static final String ISSUED_AT = "iat";
+	public static final String ID = "jti";
+	public static final String KEY = "signKey";
+	public static final String ALG = "signAlg";
+	public static final String KS = "KeyStore";
+	public static final String KS_ALIAS = "KeyStore_ALIAS";
+	public static final String TS = "TrustStore";
+	public static final String TS_ALIAS = "TrustStore_ALIAS";
+
+	public static final String DELIMITER = ".";
+
+	private static final String KEY_VMM_SERVICE = "vmmService";
+	public static final String KEY_KEYSTORE_SERVICE = "keyStoreService";
+	private static AtomicServiceReference<VMMService> vmmServiceRef = new AtomicServiceReference<VMMService>(
+			KEY_VMM_SERVICE);
+	private static AtomicServiceReference<KeyStoreService> keyStoreServiceRef;
+	private static ConcurrentServiceReferenceMap<String, KeyStoreService> keyStoreServiceMapRef = new ConcurrentServiceReferenceMap<String, KeyStoreService>(
+			KEY_KEYSTORE_SERVICE);
+	private static AtomicServiceReference<SSLSupport> sslSupportRef;
+
+	// private static AtomicServiceReference<VirtualHost> virtualHostRef;
+
+	// some selective message management for expired token flows where we don't want
+	// a lot of stuff in the log
+	private static ThreadLocal<Boolean> isJwtSsoValidationPath = new ThreadLocal<Boolean>();
+	private static ThreadLocal<Boolean> isJwtSsoValidationPathExpiredToken = new ThreadLocal<Boolean>();
+
+	public static void setJwtSsoValidationPath() {
+		isJwtSsoValidationPath.set(true);
+	}
+
+	public static boolean setJwtSsoValidationPathExiredToken() {
+		if (isJwtSsoValidationPath.get() != null && isJwtSsoValidationPath.get() == true) {
+			isJwtSsoValidationPathExpiredToken.set(true);
+			return true;
+		}
+		return false;
+	}
+
+	public static boolean isJwtSsoValidationExpiredTokenCodePath() {
+		return isJwtSsoValidationPathExpiredToken.get() != null ? isJwtSsoValidationPathExpiredToken.get() : null;
+	}
+
+	public static String convertToBase64(String source) {
+		return Base64.encodeBase64URLSafeString(StringUtils.getBytesUtf8(source));
+	}
+
+	public static String decodeFromBase64String(String encoded) {
+		return new String(Base64.decodeBase64(encoded));
+	}
+
+	public static boolean isBase64Encoded(String str) {
+		if (!isNullEmpty(str)) {
+			return Base64.isArrayByteBase64(StringUtils.getBytesUtf8(str));
+		}
+		return false;
+	}
+
+	public static String fromBase64ToJsonString(String source) {
+		return StringUtils.newStringUtf8(Base64.decodeBase64(source));
+	}
+
+	public static String toJson(String source) {
+		try {
+			return StringUtils.newStringUtf8(source.getBytes("UTF8"));
+		} catch (UnsupportedEncodingException e) {
+			// TODO Auto-generated catch block
+			// e.printStackTrace();
+		}
+		return null;
+	}
+
+	public static boolean isNullEmpty(String value) {
+		return value == null || value.isEmpty();
+	}
+
+	public static boolean isJson(String tokenString) {
+		boolean result = false;
+		if (!isNullEmpty(tokenString)) {
+			if ((tokenString.startsWith("{") && tokenString.endsWith("}"))
+					|| (tokenString.startsWith("[") && tokenString.endsWith("]"))) {
+				// com.google.gson.JsonParser parser = new
+				// com.google.gson.JsonParser();
+				// parser.parse(tokenString);
+				result = true;
+			}
+		}
+		return result;
+	}
+
+	// either from header or payload
+	public static Object claimFromJsonObject(String jsonFormattedString, String claimName) throws JoseException {
+		Object claim = null;
+
+		// JSONObject jobj = JSONObject.parse(jsonFormattedString);
+		Map<String, Object> jobj = org.jose4j.json.JsonUtil.parseJson(jsonFormattedString);
+		if (jobj != null) {
+			claim = jobj.get(claimName);
+		}
+
+		return claim;
+	}
+
+	// assuming payload not the whole token string
+	public static Map claimsFromJsonObject(String jsonFormattedString) throws JoseException {
+		Map claimsMap = new ConcurrentHashMap<String, Object>();
+
+		// JSONObject jobj = JSONObject.parse(jsonFormattedString);
+		Map<String, Object> jobj = org.jose4j.json.JsonUtil.parseJson(jsonFormattedString);
+		Set<Entry<String, Object>> entries = jobj.entrySet();
+		Iterator<Entry<String, Object>> it = entries.iterator();
+
+		while (it.hasNext()) {
+			Entry<String, Object> entry = it.next();
+
+			String key = entry.getKey();
+			Object value = entry.getValue();
+			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+				Tr.debug(tc, "Key : " + key + ", Value: " + value);
+			}
+			if (!isNullEmpty(key) && value != null) {
+				claimsMap.put(key, value);
+			}
+
+			// JsonElement jsonElem = entry.getValue();
+		}
+
+		// claims.putAll(jobj.entrySet());
+
+		return claimsMap;
+	}
+
+	public static Map<String, Object> claimsFromJson(String jsonFormattedString) throws Exception {
+		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+			Tr.debug(tc, "JSON String =" + jsonFormattedString);
+		}
+		JSONObject object = JSONObject.parse(jsonFormattedString);
+
+		HashMap<String, Object> map = new HashMap<String, Object>();
+		Set<Entry<String, Object>> set = object.entrySet();
+		Iterator<Entry<String, Object>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Entry<String, Object> entry = iterator.next();
+			String key = entry.getKey();
+			Object value = entry.getValue();
+
+			if (isJsonArray(value)) {
+				handleJsonArray(value, key, map);
+			} else if (isJsonObject(value)) {
+				map.put(key, claimsFromJson(value.toString()));
+			} else {
+				map.put(key, value.toString());
+			}
+		}
+		return map;
+	}
+
+	@FFDCIgnore(Exception.class)
+	public static void handleJsonArray(Object value, String key, HashMap<String, Object> map) {
+		if (!isJsonArray(value)) {
+			map.put(key, value.toString());
+			return;
+		}
+		JSONArray jArray = null;
+		try {
+			jArray = JSONArray.parse(value.toString());
+		} catch (Exception e) {
+			// Shouldn't happen since we verified the value should be a JSON
+			// array if we get here
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Caught exception handling provided object [" + value.toString() + "]: " + e.getMessage());
+			}
+			map.put(key, value.toString());
+			return;
+		}
+		if (jArray != null && !jArray.isEmpty()) {
+			map.put(key, jArray);
+			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+				Tr.debug(tc, "array list of objects, Key : " + key + ", Value: " + jArray.toString());
+			}
+		}
+	}
+
+	@FFDCIgnore(Exception.class)
+	static boolean isJsonObject(Object value) {
+		if (value == null) {
+			return false;
+		}
+		try {
+			JSONObject.parse(value.toString());
+		} catch (Exception e) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Value [" + value + "] is not a valid JSON object: " + e.getMessage());
+			}
+			return false;
+		}
+		return true;
+	}
+
+	@FFDCIgnore(Exception.class)
+	static boolean isJsonArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+		try {
+			JSONArray.parse(value.toString());
+		} catch (Exception e) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Value [" + value + "] is not a valid JSON array: " + e.getMessage());
+			}
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Trims each of the strings in the array provided and returns a new list with
+	 * each string added to it. If the trimmed string is empty, that string will not
+	 * be added to the final array. If no entries are present in the final array,
+	 * null is returned.
+	 *
+	 * @param strings
+	 * @return
+	 */
+	public static List<String> trimIt(String[] strings) {
+		if (strings == null || strings.length == 0) {
+			return null;
+		}
+
+		List<String> results = new ArrayList<String>();
+
+		for (int i = 0; i < strings.length; i++) {
+			String result = trimIt(strings[i]);
+			if (result != null) {
+				results.add(result);
+			}
+		}
+
+		if (results.size() > 0) {
+			return results;
+		} else {
+			return null;
+		}
+	}
+
+	public static String trimIt(String str) {
+		if (str == null) {
+			return null;
+		}
+		str = str.trim();
+		if (str.isEmpty()) {
+			return null;
+		}
+		return str;
+	}
+
+	public static JwtConfig getTheAtomicService(String builderConfigId,
+			ConcurrentServiceReferenceMap<String, JwtConfig> jwtServiceMapRef) {
+		Iterator<JwtConfig> jwtServices = jwtServiceMapRef.getServices();
+		while (jwtServices.hasNext()) {
+			JwtConfig jwtService = jwtServices.next();
+			if (builderConfigId.equals(jwtService.getId())) {
+				return jwtService;
+			}
+		}
+		return null;
+
+	}
+
+	public static JwtConfig getTheService(String builderConfigId,
+			ConcurrentServiceReferenceMap<String, JwtConfig> jwtServiceMapRef) {
+		Iterator<JwtConfig> jwtServices = jwtServiceMapRef.getServices();
+		while (jwtServices.hasNext()) {
+			JwtConfig jwtService = jwtServices.next();
+			if (builderConfigId.equals(jwtService.getId())) {
+				return jwtService;
+			}
+		}
+		return null;
+
+	}
+
+	public static String[] splitTokenString(String tokenString) {
+		boolean isPlainTextJWT = false;
+		if (tokenString.endsWith(".")) {
+			isPlainTextJWT = true;
+		}
+		String[] pieces = tokenString.split(Pattern.quote(DELIMITER));
+		if (!isPlainTextJWT && pieces.length != 3) {
+			// Tr.warning("Expected JWT to have 3 segments separated by '" +
+			// DELIMITER + "', but it has " + pieces.length + " segments");
+			return null;
+		}
+		return pieces;
+	}
+
+	public static String getPayload(String jwt) {
+		String[] jwtInfo = splitTokenString(jwt);
+		if (jwtInfo != null) {
+			return jwtInfo[1];
+		}
+		return null;
+	}
+
+	public static String getRandom(int length) {
+		StringBuffer result = new StringBuffer(length);
+		final char[] chars = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',
+				'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+				'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u',
+				'v', 'w', 'x', 'y', 'z' };
+		Random r = getRandom();
+
+		for (int i = 0; i < length; i++) {
+			int n = r.nextInt(62);
+			result.append(chars[n]);
+		}
+
+		return result.toString();
+	}
+
+	static Random getRandom() {
+		Random result = null;
+		try {
+			if (Security.getProvider(JCEPROVIDER_IBM) != null) {
+				result = SecureRandom.getInstance(SECRANDOM_IBM);
+			} else {
+				result = SecureRandom.getInstance(SECRANDOM_SHA1PRNG);
+			}
+		} catch (Exception e) {
+			result = new Random();
+		}
+		return result;
+	}
+
+	public static long calculate(long valid) {
+		// TODO Auto-generated method stub
+		long lifetimeSeconds = valid * 60 * 60;
+		long timeInSeconds = System.currentTimeMillis() / 1000;
+
+		return timeInSeconds + lifetimeSeconds;
+	}
+
+	public static String toJson(Map<String, Object> claimsMap) {
+		// TODO Auto-generated method stub
+		return org.jose4j.json.JsonUtil.toJson(claimsMap);
+	}
+
+	public static void setVMMService(AtomicServiceReference<VMMService> vmmServiceRef) {
+		JwtUtils.vmmServiceRef = vmmServiceRef;
+	}
+
+	public static VMMService getVMMService() {
+		return vmmServiceRef.getService();
+	}
+
+	public static Object fetch(String claim, String subject) throws Exception {
+		RegistryClaims claims = new RegistryClaims(subject);
+		return claims.fetchClaim(claim);
+	}
+
+	public static void setSSLSupportService(AtomicServiceReference<SSLSupport> sslSupportRef) {
+		// TODO Auto-generated method stub
+		JwtUtils.sslSupportRef = sslSupportRef;
+	}
+
+	public static SSLSupport getSSLSupportService() {
+		// TODO Auto-generated method stub
+		return (sslSupportRef.getService());
+	}
+
+	public static void setKeyStoreService(AtomicServiceReference<KeyStoreService> kssRef) {
+		// TODO Auto-generated method stub
+		JwtUtils.keyStoreServiceRef = kssRef;
+	}
+
+	public static void setKeyStoreService2(ConcurrentServiceReferenceMap<String, KeyStoreService> kssMapRef) {
+		// TODO Auto-generated method stub
+		JwtUtils.keyStoreServiceMapRef = kssMapRef;
+	}
+
+	public static KeyStoreService getKeyStoreService() {
+		if (keyStoreServiceRef != null) {
+			return keyStoreServiceRef.getService();
+		}
+		return null;
+	}
+
+	public static String getDefaultKeyStoreName(String propKey) {
+		String keyStoreName = null;
+		// config does not specify keystore, so try to get one from servers
+		// default ssl config.
+		SSLSupport sslSupport = getSSLSupportService();
+		JSSEHelper helper = null;
+		if (sslSupport != null) {
+			helper = sslSupport.getJSSEHelper();
+		}
+		Properties props = null;
+		final JSSEHelper jsseHelper = helper;
+		final Map<String, Object> connectionInfo = new HashMap<String, Object>();
+		connectionInfo.put(Constants.CONNECTION_INFO_DIRECTION, Constants.DIRECTION_INBOUND);
+		if (jsseHelper != null) {
+			try {
+				// props = jsseHelper.getProperties("", null, null, true);
+				props = (Properties) AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
+					@Override
+					public Object run() throws Exception {
+						return jsseHelper.getProperties("", connectionInfo, null, true);
+					}
+				});
+
+			} catch (PrivilegedActionException pae) {
+				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+					Tr.debug(tc, "Exception getting properties from jssehelper!!!");
+				}
+				// throw (SSLException) pae.getCause();
+			}
+
+			if (props != null) {
+				keyStoreName = props.getProperty(propKey);
+				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+					Tr.debug(tc, "KeyStore name from default ssl config = " + keyStoreName);
+				}
+			}
+		}
+		return keyStoreName;
+	}
+
+	@Sensitive
+	public static PrivateKey getPrivateKey(String keyAlias, String keyStoreRef)
+			throws KeyStoreException, CertificateException {
+		return getPrivateKey(keyAlias, keyStoreRef, getKeyStoreService());
+	}
+
+	@Sensitive
+	public static PrivateKey getPrivateKey(String keyAlias, String keyStoreRef, KeyStoreService kss)
+			throws KeyStoreException, CertificateException {
+		if (kss != null) {
+			if (keyStoreRef == null) {
+				keyStoreRef = getDefaultKeyStoreName("com.ibm.ssl.keyStoreName");
+			}
+			if (keyStoreRef != null) {
+				if (keyAlias != null) {
+					return kss.getPrivateKeyFromKeyStore(keyStoreRef, keyAlias, null);
+				} else {
+					return kss.getPrivateKeyFromKeyStore(keyStoreRef);
+				}
+			}
+		}
+		return null;
+	}
+
+	public static PublicKey getPublicKey(String keyAlias, String trustStoreRef)
+			throws KeyStoreException, CertificateException, InvalidTokenException {
+		return getPublicKey(keyAlias, trustStoreRef, getKeyStoreService());
+	}
+
+	public static PublicKey getPublicKey(String keyAlias, String trustStoreRef, KeyStoreService kss)
+			throws KeyStoreException, CertificateException, InvalidTokenException {
+		if (kss == null) {
+			return null;
+		}
+		if (trustStoreRef == null) {
+			trustStoreRef = getDefaultKeyStoreName("com.ibm.ssl.trustStoreName");
+			if (trustStoreRef == null) {
+				return null;
+			}
+		}
+		if (keyAlias != null) {
+			X509Certificate cert = kss.getX509CertificateFromKeyStore(trustStoreRef, keyAlias);
+			if (cert == null) {
+				return null;
+			}
+			return cert.getPublicKey();
+		} else {
+			Collection<String> aliases = kss.getTrustedCertEntriesInKeyStore(trustStoreRef);
+			// check for NO aliases in the trust store
+			if (aliases == null || aliases.size() == 0) {
+				X509Certificate cert = kss.getX509CertificateFromKeyStore(trustStoreRef);
+				if (cert != null) {
+					return cert.getPublicKey();
+				}
+				String errorMsg = Tr.formatMessage(tc, "JWT_SIGNER_CERT_NOT_AVAILABLE");
+				throw new InvalidTokenException(errorMsg);
+
+			}
+			// check for more than 1 alias in the trust store (with more than 1,
+			// we need to have trustAlias specified (this is part of the no
+			// trustAlais path))
+			if (aliases.size() > 1) {
+				String errorMsg = Tr.formatMessage(tc, "JWT_SIGNER_CERT_AMBIGUOUS");
+				throw new InvalidTokenException(errorMsg);
+
+			}
+			// We now have 1 alias, we'll get the cert
+			String alias = aliases.iterator().next();
+			X509Certificate cert = kss.getX509CertificateFromKeyStore(trustStoreRef, alias);
+			// if NO cert, fail, otherwise get and return the public key
+			if (cert != null) {
+				return cert.getPublicKey();
+			} else {
+				String errorMsg = Tr.formatMessage(tc, "JWT_SIGNER_CERT_NOT_AVAILABLE");
+				throw new InvalidTokenException(errorMsg);
+
+			}
+		}
+
+	}
+
+	public static String getDate(long current) {
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+		Date resultdate = new Date(current);
+		return sdf.format(resultdate);
+	}
+
+	@Sensitive
+	public static String processProtectedString(Map<String, Object> props, String cfgKey) {
+		return JwtConfigUtil.processProtectedString(props, cfgKey);
+	}
 
 }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtUtils.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtUtils.java
@@ -23,6 +23,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -37,10 +38,10 @@ import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.StringUtils;
 import org.jose4j.lang.JoseException;
 
+import org.apache.commons.codec.binary.Base64;
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.Tr;
@@ -136,7 +137,10 @@ public class JwtUtils {
 	}
 
 	public static boolean isJwtSsoValidationExpiredTokenCodePath() {
-		return isJwtSsoValidationPathExpiredToken.get() != null ? isJwtSsoValidationPathExpiredToken.get() : null;
+		boolean result = isJwtSsoValidationPathExpiredToken.get() != null ? isJwtSsoValidationPathExpiredToken.get()
+				: false;
+
+		return result;
 	}
 
 	public static String convertToBase64(String source) {

--- a/dev/com.ibm.ws.security.jwtsso/src/com/ibm/ws/security/jwtsso/utils/JwtSsoTokenUtils.java
+++ b/dev/com.ibm.ws.security.jwtsso/src/com/ibm/ws/security/jwtsso/utils/JwtSsoTokenUtils.java
@@ -178,7 +178,7 @@ public class JwtSsoTokenUtils {
 	}
 
 	public Subject handleJwtSsoTokenValidationWithSubject(Subject subject, String tokenstr) throws Exception {
-
+		JwtUtils.setJwtSsoValidationPath(); // set a flag to suppress certain error messages.
 		JwtToken jwttoken = recreateJwt(tokenstr);
 		if (jwttoken != null) {
 			TokenBuilder tb = new TokenBuilder();

--- a/dev/com.ibm.ws.security.jwtsso/src/com/ibm/ws/security/jwtsso/utils/JwtSsoTokenUtils.java
+++ b/dev/com.ibm.ws.security.jwtsso/src/com/ibm/ws/security/jwtsso/utils/JwtSsoTokenUtils.java
@@ -23,6 +23,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.security.auth.WSSubject;
 import com.ibm.websphere.security.jwt.JwtToken;
 import com.ibm.ws.security.common.jwk.utils.JsonUtils;
+import com.ibm.ws.security.jwt.utils.JwtUtils;
 import com.ibm.ws.security.jwt.utils.TokenBuilder;
 import com.ibm.ws.security.mp.jwt.MicroProfileJwtConfig;
 import com.ibm.ws.security.mp.jwt.error.MpJwtProcessingException;
@@ -95,8 +96,7 @@ public class JwtSsoTokenUtils {
 	 *
 	 * Build a JsonWebToken Principal from the current Thread's RunAsSubject
 	 *
-	 * @return - a DefaultJsonWebTokenImpl, or null if user wasn't
-	 *         authenticated.
+	 * @return - a DefaultJsonWebTokenImpl, or null if user wasn't authenticated.
 	 */
 	public JsonWebToken buildTokenFromSecuritySubject() throws Exception {
 
@@ -150,6 +150,7 @@ public class JwtSsoTokenUtils {
 	}
 
 	public Subject handleJwtSsoTokenValidation(String tokenstr) throws Exception {
+		JwtUtils.setJwtSsoValidationPath(); // set a flag to suppress certain error messages.
 		Subject tempSubject = null;
 		tempSubject = handleValidationUsingMPjwtConsumer(tokenstr);
 		// JwtToken jwttoken = recreateJwt(tokenstr);
@@ -218,16 +219,16 @@ public class JwtSsoTokenUtils {
 		String mpJwtConfigId = null;
 		boolean jwtsso = false;
 		int jwtssoConfigs = 0;
-		
+
 		while (it.hasNext()) {
 			MicroProfileJwtConfig mpJwtConfig = it.next();
 			if (!(mpJwtConfig.toString().contains("com.ibm.ws.security.jwtsso.internal.JwtSsoComponent"))) {
-				 if (!taiRequestHelper.isMpJwtDefaultConfig(mpJwtConfig)) {
-					    mpjwt = true;
-						mpJwtConfigId = mpJwtConfig.getUniqueId();
-						mpjwtids = mpjwtids.concat(mpJwtConfigId).concat(" ");
-						mpJwtConfigs++;
-				 }	
+				if (!taiRequestHelper.isMpJwtDefaultConfig(mpJwtConfig)) {
+					mpjwt = true;
+					mpJwtConfigId = mpJwtConfig.getUniqueId();
+					mpjwtids = mpjwtids.concat(mpJwtConfigId).concat(" ");
+					mpJwtConfigs++;
+				}
 			}
 		}
 		if (mpJwtConfigs > 1) {

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/ConfigAttributeTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/ConfigAttributeTests.java
@@ -37,6 +37,7 @@ import com.ibm.ws.security.jwtsso.fat.utils.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
 import com.ibm.ws.security.jwtsso.fat.utils.MessageConstants;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -316,7 +317,7 @@ public class ConfigAttributeTests extends CommonSecurityFat {
      * see evidence in the logs that the customized issuer was presented.
      * That's all we care about.
      */
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException",
+    @AllowedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException",
                     "com.ibm.websphere.security.jwt.InvalidTokenException",
                     "com.ibm.ws.security.authentication.AuthenticationException" })
     @Mode(TestMode.LITE)
@@ -384,7 +385,8 @@ public class ConfigAttributeTests extends CommonSecurityFat {
      * Test the detection of the mpJwt server config element. Specify an extra element and try to authenticate.
      * We should get an error message about the extra element.
      */
-    @ExpectedFFDC({ "com.ibm.ws.security.mp.jwt.error.MpJwtProcessingException", "com.ibm.ws.security.authentication.AuthenticationException" })
+    @ExpectedFFDC({ "com.ibm.ws.security.mp.jwt.error.MpJwtProcessingException"})
+    @AllowedFFDC({ "com.ibm.ws.security.authentication.AuthenticationException" })
     @Mode(TestMode.LITE)
     @Test
     public void test_invalidConsumerRef() throws Exception {

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/CookieExpirationTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/CookieExpirationTests.java
@@ -28,6 +28,7 @@ import com.ibm.ws.security.jwtsso.fat.utils.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
 import com.ibm.ws.security.jwtsso.fat.utils.MessageConstants;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -103,7 +104,7 @@ public class CookieExpirationTests extends CommonSecurityFat {
      * Expects:
      * - Should be prompted with the login page because the JWT SSO cookie is no longer valid
      */
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException",
+    @AllowedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException",
                     "com.ibm.ws.security.authentication.AuthenticationException" })
     @Test
     public void test_shortJwtCookieLifetime_reuseCookieOutsideClockSkew() throws Exception {
@@ -121,10 +122,13 @@ public class CookieExpirationTests extends CommonSecurityFat {
 
         Expectations expectations = new Expectations();
         expectations.addExpectations(CommonExpectations.successfullyReachedLoginPage(currentAction));
+        // as of 6248 we now run quietly when a cookie routinely expires. 
+        /*
         expectations.addExpectation(new ServerMessageExpectation(currentAction, server, MessageConstants.CWWKS6025E_JWT_TOKEN_EXPIRED));
         expectations.addExpectation(new ServerMessageExpectation(currentAction, server, MessageConstants.CWWKS6031E_JWT_ERROR_PROCESSING_JWT));
         expectations.addExpectation(new ServerMessageExpectation(currentAction, server, MessageConstants.CWWKS5524E_ERROR_CREATING_JWT));
         expectations.addExpectation(new ServerMessageExpectation(currentAction, server, MessageConstants.CWWKS5523E_ERROR_CREATING_JWT_USING_TOKEN_IN_REQ));
+        */
 
         Page response = actions.invokeUrlWithCookie(_testName, protectedUrl, jwtCookie);
         validationUtils.validateResult(response, currentAction, expectations);

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
@@ -51,6 +51,7 @@ import com.ibm.ws.security.jwtsso.fat.utils.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
 import com.ibm.ws.security.jwtsso.fat.utils.MessageConstants;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -205,7 +206,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
      * - Upon re-access, should receive the login page because the JWT cookie is not valid
      * - FFDCs should be emitted because the JWT signature is not valid
      */
-    @ExpectedFFDC({ "org.jose4j.jwt.consumer.InvalidJwtException", "com.ibm.websphere.security.jwt.InvalidTokenException",
+    @AllowedFFDC({ "org.jose4j.jwt.consumer.InvalidJwtException", "com.ibm.websphere.security.jwt.InvalidTokenException",
                     "com.ibm.ws.security.authentication.AuthenticationException" })
     @Test
     public void test_reaccessResource_jwtCookieWithEmptySignature() throws Exception {
@@ -243,7 +244,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
      * - Upon re-access, should receive the login page because the JWT cookie is not valid
      * - FFDCs should be emitted because the JWT is not formatted correctly
      */
-    @ExpectedFFDC({ "org.jose4j.jwt.consumer.InvalidJwtException", "com.ibm.websphere.security.jwt.InvalidTokenException",
+    @AllowedFFDC({ "org.jose4j.jwt.consumer.InvalidJwtException", "com.ibm.websphere.security.jwt.InvalidTokenException",
                     "com.ibm.ws.security.authentication.AuthenticationException" })
     @Test
     public void test_reaccessResource_signatureRemovedFromJwtCookie() throws Exception {
@@ -461,7 +462,8 @@ public class ReplayCookieTests extends CommonSecurityFat {
      * Expects:
      * - Should receive the login page because the token does not contain all of the required claims
      */
-    @ExpectedFFDC({ "com.ibm.ws.security.mp.jwt.error.MpJwtProcessingException", "com.ibm.ws.security.authentication.AuthenticationException" })
+    @ExpectedFFDC({ "com.ibm.ws.security.mp.jwt.error.MpJwtProcessingException"})
+    @AllowedFFDC({"com.ibm.ws.security.authentication.AuthenticationException" })
     @Test
     public void test_buildJwt_missingClaims_accessProtectedResource() throws Exception {
 
@@ -490,7 +492,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
      * Expects:
      * - Should receive the login page because the issuer in the token is not trusted
      */
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException",
+    @AllowedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException",
                     "com.ibm.ws.security.authentication.AuthenticationException" })
     @Test
     public void test_buildJwt_accessProtectedResource_defaultMpJwtConsumer() throws Exception {
@@ -547,7 +549,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
      * Expects:
      * - Should receive the login page because the token signature cannot be validated
      */
-    @ExpectedFFDC({ "org.jose4j.jwt.consumer.InvalidJwtSignatureException", "com.ibm.websphere.security.jwt.InvalidTokenException",
+    @AllowedFFDC({ "org.jose4j.jwt.consumer.InvalidJwtSignatureException", "com.ibm.websphere.security.jwt.InvalidTokenException",
                     "com.ibm.ws.security.authentication.AuthenticationException" })
     @Test
     public void test_buildJwt_signedWithNonDefaultKey_accessProtectedResource() throws Exception {

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIJwtUtils.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIJwtUtils.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jose4j.lang.JoseException;
-
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
@@ -34,6 +34,7 @@ public class TAIJwtUtils {
     public TAIJwtUtils() {
     }
 
+    @FFDCIgnore(Exception.class)
     public JwtToken createJwt(@Sensitive String idToken, String jwtConfigId) throws MpJwtProcessingException {
         String methodName = "createJwt";
         if (tc.isDebugEnabled()) {
@@ -48,9 +49,9 @@ public class TAIJwtUtils {
         } catch (Exception e) {
             String msg = Tr.formatMessage(tc, "ERROR_CREATING_JWT", new Object[] { jwtConfigId, e.getLocalizedMessage() }); //CWWKS5524E
             if (JwtUtils.isJwtSsoValidationExpiredTokenCodePath()) {
-               Tr.debug(tc, msg) ;               
+                Tr.debug(tc, msg);
             } else {
-               Tr.error(tc,msg);
+                Tr.error(tc, msg);
             }
             throw new MpJwtProcessingException(msg, e);
         }

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIJwtUtils.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIJwtUtils.java
@@ -22,6 +22,7 @@ import com.ibm.websphere.security.jwt.Claims;
 import com.ibm.websphere.security.jwt.JwtConsumer;
 import com.ibm.websphere.security.jwt.JwtToken;
 import com.ibm.ws.security.mp.jwt.TraceConstants;
+import com.ibm.ws.security.jwt.utils.JwtUtils;
 import com.ibm.ws.security.mp.jwt.error.MpJwtProcessingException;
 import com.ibm.ws.security.mp.jwt.impl.DefaultJsonWebTokenImpl;
 
@@ -45,8 +46,12 @@ public class TAIJwtUtils {
             }
             return token;
         } catch (Exception e) {
-            String msg = Tr.formatMessage(tc, "ERROR_CREATING_JWT", new Object[] { jwtConfigId, e.getLocalizedMessage() });
-            Tr.error(tc, msg);
+            String msg = Tr.formatMessage(tc, "ERROR_CREATING_JWT", new Object[] { jwtConfigId, e.getLocalizedMessage() }); //CWWKS5524E
+            if (JwtUtils.isJwtSsoValidationExpiredTokenCodePath()) {
+               Tr.debug(tc, msg) ;               
+            } else {
+               Tr.error(tc,msg);
+            }
             throw new MpJwtProcessingException(msg, e);
         }
     }

--- a/dev/com.ibm.ws.security.mp.jwt_fat/fat/src/com/ibm/ws/security/mp/jwt/fat/MPJwtConfigUsingBuilderTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt_fat/fat/src/com/ibm/ws/security/mp/jwt/fat/MPJwtConfigUsingBuilderTests.java
@@ -241,7 +241,7 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * @throws Exception
      */
     @Mode(TestMode.LITE)
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @AllowedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test
     public void MPJwtConfigUsingBuilderTests_Issuer_Invalid() throws Exception {
 
@@ -603,7 +603,8 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      */
     @Mode(TestMode.LITE)
     @Test
-    @ExpectedFFDC({ "org.jose4j.jwt.consumer.InvalidJwtSignatureException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @ExpectedFFDC({ "org.jose4j.jwt.consumer.InvalidJwtSignatureException"})
+    @AllowedFFDC({"com.ibm.websphere.security.jwt.InvalidTokenException" })
     public void MPJwtConfigUsingBuilderTests_hs256_mismatchSharedKey() throws Exception {
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_audience_hs256.xml");

--- a/dev/com.ibm.ws.security.mp.jwt_fat/fat/src/com/ibm/ws/security/mp/jwt/fat/MPJwtConfigUsingBuilderTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt_fat/fat/src/com/ibm/ws/security/mp/jwt/fat/MPJwtConfigUsingBuilderTests.java
@@ -653,8 +653,8 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * 
      * @throws Exception
      */
-    @AllowedFFDC({"com.ibm.websphere.security.jwt.InvalidTokenException"})
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.KeyException", "java.security.cert.CertificateException", "org.jose4j.jwt.consumer.InvalidJwtSignatureException" })
+    @AllowedFFDC({"com.ibm.websphere.security.jwt.InvalidTokenException" , "org.jose4j.jwt.consumer.InvalidJwtSignatureException"})
+    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.KeyException", "java.security.cert.CertificateException" })
     @Test
     public void MPJwtConfigUsingBuilderTests_SSLRef_invalid_usingX509() throws Exception {
 

--- a/dev/com.ibm.ws.security.mp.jwt_fat/fat/src/com/ibm/ws/security/mp/jwt/fat/MPJwtConfigUsingBuilderTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt_fat/fat/src/com/ibm/ws/security/mp/jwt/fat/MPJwtConfigUsingBuilderTests.java
@@ -334,7 +334,7 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * 
      * @throws Exception
      */
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @AllowedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test
     public void MPJwtConfigUsingBuilderTests_Audience_NotSpecifiedInRS() throws Exception {
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_orig.xml");
@@ -356,7 +356,7 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * 
      * @throws Exception
      */
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @AllowedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test
     public void MPJwtConfigUsingBuilderTests_Audience_NotSpecifiedInJwt() throws Exception {
         super.restoreTestServers();
@@ -380,7 +380,7 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * @throws Exception
      */
     @Test
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @AllowedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
     public void MPJwtConfigUsingBuilderTests_Audience_Mismatch() throws Exception {
 
         super.restoreTestServers();
@@ -457,7 +457,8 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * 
      * @throws Exception
      */
-    @ExpectedFFDC({ "org.jose4j.jwt.consumer.InvalidJwtSignatureException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @ExpectedFFDC({ "org.jose4j.jwt.consumer.InvalidJwtSignatureException"})
+    @AllowedFFDC({"com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test
     public void MPJwtConfigUsingBuilderTests_buildUsingJWK_mpJWTusingX509() throws Exception {
 
@@ -481,7 +482,7 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * 
      * @throws Exception
      */
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidTokenException", "com.ibm.websphere.security.jwt.InvalidClaimException" })
+    @AllowedFFDC({ "com.ibm.websphere.security.jwt.InvalidTokenException", "com.ibm.websphere.security.jwt.InvalidClaimException" })
     @Test
     public void MPJwtConfigUsingBuilderTests_buildUsingX509_mpJWTusingJWK() throws Exception {
 
@@ -551,7 +552,8 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * 
      * @throws Exception
      */
-    @ExpectedFFDC({ "java.security.cert.CertificateException", "com.ibm.websphere.security.jwt.KeyException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @ExpectedFFDC({ "java.security.cert.CertificateException", "com.ibm.websphere.security.jwt.KeyException"})
+    @AllowedFFDC({"com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test
     public void MPJwtConfigUsingBuilderTests_KeyName_invalidKeyName() throws Exception {
 
@@ -651,8 +653,8 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * 
      * @throws Exception
      */
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidTokenException" })
-    @AllowedFFDC({ "com.ibm.websphere.security.jwt.KeyException", "java.security.cert.CertificateException", "org.jose4j.jwt.consumer.InvalidJwtSignatureException" })
+    @AllowedFFDC({"com.ibm.websphere.security.jwt.InvalidTokenException"})
+    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.KeyException", "java.security.cert.CertificateException", "org.jose4j.jwt.consumer.InvalidJwtSignatureException" })
     @Test
     public void MPJwtConfigUsingBuilderTests_SSLRef_invalid_usingX509() throws Exception {
 
@@ -711,7 +713,7 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * 
      * @throws Exception
      */
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @AllowedFFDC({ "com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test
     public void MPJwtConfigUsingBuilderTests_TokenReuse_False() throws Exception {
 
@@ -961,7 +963,7 @@ public class MPJwtConfigUsingBuilderTests extends CommonMpJwtFat {
      * 
      * @throws Exception
      */
-    @ExpectedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @AllowedFFDC({ "com.ibm.websphere.security.jwt.InvalidClaimException", "com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test
     public void MPJwtConfigUsingBuilderTests_clockSkew_useTokenOutsideClockSkew() throws Exception {
 

--- a/dev/com.ibm.ws.security.mp.jwt_fat_tck/fat/src/org/eclipse/microprofile/jwt/tck/container/jaxrs/InvalidTokenTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt_fat_tck/fat/src/org/eclipse/microprofile/jwt/tck/container/jaxrs/InvalidTokenTest.java
@@ -42,6 +42,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -107,8 +108,8 @@ public class InvalidTokenTest extends FATServletClient {
         server1.stopServer("CWWKS5523E", "CWWKS5524E");
     }
 
-    @ExpectedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidClaimException",
-                            "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @AllowedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidClaimException",
+                           "com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test //@Test(groups = TEST_GROUP_JAXRS,         description = "Validate a request with expired token fails with HTTP_UNAUTHORIZED")
     public void callEchoExpiredToken() throws Exception {
         HashSet<TokenUtils.InvalidClaims> invalidFields = new HashSet<>();
@@ -126,8 +127,8 @@ public class InvalidTokenTest extends FATServletClient {
         System.out.printf("Reply: %s\n", reply);
     }
 
-    @ExpectedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidClaimException",
-                            "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @AllowedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidClaimException",
+                           "com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test //@Test(groups = TEST_GROUP_JAXRS,         description = "Validate a request with an non-matching issuer fails with HTTP_UNAUTHORIZED")
     public void callEchoBadIssuer() throws Exception {
         HashSet<TokenUtils.InvalidClaims> invalidFields = new HashSet<>();
@@ -145,8 +146,8 @@ public class InvalidTokenTest extends FATServletClient {
         System.out.printf("Reply: %s\n", reply);
     }
 
-    @ExpectedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidTokenException",
-                            "org.jose4j.jwt.consumer.InvalidJwtSignatureException" })
+    @ExpectedFFDC(value = { "org.jose4j.jwt.consumer.InvalidJwtSignatureException" })
+    @AllowedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test //@Test(groups = TEST_GROUP_JAXRS,         description = "Validate a request with an incorrect signer fails with HTTP_UNAUTHORIZED")
     public void callEchoBadSigner() throws Exception {
         HashSet<TokenUtils.InvalidClaims> invalidFields = new HashSet<>();
@@ -164,7 +165,7 @@ public class InvalidTokenTest extends FATServletClient {
         System.out.printf("Reply: %s\n", reply);
     }
 
-    @ExpectedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @AllowedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test //@Test(groups = TEST_GROUP_JAXRS,         description = "Validate a request with an incorrect signature algorithm fails with HTTP_UNAUTHORIZED")
     public void callEchoBadSignerAlg() throws Exception {
         HashSet<TokenUtils.InvalidClaims> invalidFields = new HashSet<>();

--- a/dev/com.ibm.ws.security.mp.jwt_fat_tck/fat/src/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesAllowedTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt_fat_tck/fat/src/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesAllowedTest.java
@@ -44,6 +44,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -110,7 +111,7 @@ public class RolesAllowedTest extends FATServletClient {
                         .addClass(TCKApplication.class)
                         .addAsWebInfResource("beans.xml", "beans.xml")
                         .addAsWebInfResource("web.xml", "web.xml")
-                        .addAsManifestResource("permissions.xml"); 
+                        .addAsManifestResource("permissions.xml");
         System.out.printf("WebArchive: %s\n", webArchive.toString(true));
         ShrinkHelper.exportToServer(server1, "apps", webArchive);
 
@@ -143,8 +144,8 @@ public class RolesAllowedTest extends FATServletClient {
         Assert2.assertEquals(response.getStatus(), HttpURLConnection.HTTP_UNAUTHORIZED);
     }
 
-    @ExpectedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidTokenException",
-                            "org.jose4j.jwt.consumer.InvalidJwtException" })
+    @ExpectedFFDC(value = { "org.jose4j.jwt.consumer.InvalidJwtException" })
+    @AllowedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidTokenException" })
     @Test //@Test(groups = TCKConstants.TEST_GROUP_JAXRS, description = "Attempting access with BASIC auth header should fail with HTTP_UNAUTHORIZED")
     public void callEchoBASIC() throws Exception {
         Reporter.log("callEchoBASIC, expect HTTP_UNAUTHORIZED");

--- a/dev/com.ibm.ws.security.mp.jwt_fat_tck/fat/src/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesAllowedTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt_fat_tck/fat/src/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesAllowedTest.java
@@ -45,7 +45,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -144,8 +143,7 @@ public class RolesAllowedTest extends FATServletClient {
         Assert2.assertEquals(response.getStatus(), HttpURLConnection.HTTP_UNAUTHORIZED);
     }
 
-    @ExpectedFFDC(value = { "org.jose4j.jwt.consumer.InvalidJwtException" })
-    @AllowedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidTokenException" })
+    @AllowedFFDC(value = { "com.ibm.websphere.security.jwt.InvalidTokenException", "org.jose4j.jwt.consumer.InvalidJwtException" })
     @Test //@Test(groups = TCKConstants.TEST_GROUP_JAXRS, description = "Attempting access with BASIC auth header should fail with HTTP_UNAUTHORIZED")
     public void callEchoBASIC() throws Exception {
         Reporter.log("callEchoBASIC, expect HTTP_UNAUTHORIZED");

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/SSOAuthenticator.java
@@ -235,6 +235,7 @@ public class SSOAuthenticator implements WebAuthenticator {
         return null;
     }
 
+    @FFDCIgnore({ AuthenticationException.class })
     private AuthenticationResult authenticateWithJwt(HttpServletRequest req, HttpServletResponse res, String jwtToken) {
         AuthenticationResult authResult = null;
 
@@ -245,6 +246,9 @@ public class SSOAuthenticator implements WebAuthenticator {
             authResult = new AuthenticationResult(AuthResult.SUCCESS, new_subject, "jwtToken", null, AuditEvent.OUTCOME_SUCCESS);
             ssoCookieHelper.addJwtSsoCookiesToResponse(new_subject, req, res);
         } catch (AuthenticationException e) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "authenticateWithJwt exception: ", new Object[] { e });
+            }
             authResult = new AuthenticationResult(AuthResult.FAILURE, e.getMessage());
         }
         return authResult;


### PR DESCRIPTION
Quiet down error messages during routine jwtsso cookie expiration
addresses #6248

The gist of it is a couple of threadlocals are added in JwtUtils, and methods to be called when we  proceed down the "expired token" path.  When we're on that path, those get checked and if set, the offending messages become debug messages.