### PR TITLE
Migrate JPA Inheritance FAT to Open Liberty

### DIFF
--- a/dev/com.ibm.ws.jpa_22_fat/.classpath
+++ b/dev/com.ibm.ws.jpa_22_fat/.classpath
@@ -4,6 +4,7 @@
 	<classpathentry kind="src" path="test-applications/appclient/src"/>
 	<classpathentry kind="src" path="test-applications/jpabootstrap/src"/>
 	<classpathentry kind="src" path="test-applications/jpa10/callback/src"/>
+	<classpathentry kind="src" path="test-applications/jpa10/inheritance/src"/>
 	<classpathentry kind="src" path="test-applications/jpa10/relationships/manyXmany/src"/>
 	<classpathentry kind="src" path="test-applications/jpa10/relationships/manyXone/src"/>
 	<classpathentry kind="src" path="test-applications/jpa10/relationships/oneXmany/src"/>

--- a/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
@@ -20,6 +20,7 @@ src: \
 	test-applications/appclient/src,\
 	test-applications/jpabootstrap/src,\
 	test-applications/jpa10/callback/src,\
+	test-applications/jpa10/inheritance/src,\
 	test-applications/jpa10/relationships/manyXmany/src,\
 	test-applications/jpa10/relationships/manyXone/src,\
 	test-applications/jpa10/relationships/oneXmany/src,\

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/Inheritance_EJB.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/Inheritance_EJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/Inheritance_EJB.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/Inheritance_EJB.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.jpa10;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.Application;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.jpa.FATSuite;
+import com.ibm.ws.jpa.JPAFATServletClient;
+import com.ibm.ws.jpa.fvt.inheritance.tests.ejb.TestInheritance_EJB_SFEX_Servlet;
+import com.ibm.ws.jpa.fvt.inheritance.tests.ejb.TestInheritance_EJB_SF_Servlet;
+import com.ibm.ws.jpa.fvt.inheritance.tests.ejb.TestInheritance_EJB_SL_Servlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.PrivHelper;
+
+@RunWith(FATRunner.class)
+public class Inheritance_EJB extends JPAFATServletClient {
+    private final static String RESOURCE_ROOT = "test-applications/jpa10/inheritance/";
+
+    private final static Set<String> dropSet = new HashSet<String>();
+    private final static Set<String> createSet = new HashSet<String>();
+
+    private static long timestart = 0;
+
+    static {
+        dropSet.add("JPA10_INHERITANCE_DROP_${dbvendor}.ddl");
+        createSet.add("JPA10_INHERITANCE_CREATE_${dbvendor}.ddl");
+    }
+
+    @Server("JPA10Server")
+    @TestServlets({
+                    @TestServlet(servlet = TestInheritance_EJB_SL_Servlet.class, path = "Inheritance10EJB" + "/" + "TestInheritance_EJB_SL_Servlet"),
+                    @TestServlet(servlet = TestInheritance_EJB_SF_Servlet.class, path = "Inheritance10EJB" + "/" + "TestInheritance_EJB_SF_Servlet"),
+                    @TestServlet(servlet = TestInheritance_EJB_SFEX_Servlet.class, path = "Inheritance10EJB" + "/" + "TestInheritance_EJB_SFEX_Servlet"),
+
+    })
+    public static LibertyServer server1;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        PrivHelper.generateCustomPolicy(server1, FATSuite.JAXB_PERMS);
+        bannerStart(CallbackTest.class);
+        timestart = System.currentTimeMillis();
+
+        server1.startServer();
+
+        setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");
+
+        final Set<String> ddlSet = new HashSet<String>();
+
+        ddlSet.clear();
+        for (String ddlName : dropSet) {
+            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
+        }
+        executeDDL(server1, ddlSet, true);
+
+        ddlSet.clear();
+        for (String ddlName : createSet) {
+            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
+        }
+        executeDDL(server1, ddlSet, false);
+
+        setupTestApplication();
+    }
+
+    private static void setupTestApplication() throws Exception {
+        WebArchive webApp = ShrinkWrap.create(WebArchive.class, "inheritanceejb.war");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.tests.ejb");
+        ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + "ejb/inheritanceejb.war");
+
+        JavaArchive ejbApp = ShrinkWrap.create(JavaArchive.class, "inheritance.jar");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.ejblocal");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.ano");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.msc");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.msc.ano");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml");
+        ejbApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.testlogic");
+        ShrinkHelper.addDirectory(ejbApp, RESOURCE_ROOT + "ejb/inheritance.jar");
+
+        final JavaArchive testApiJar = buildTestAPIJar();
+
+        final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, "Inheritance10_EJB.ear");
+        app.addAsModule(ejbApp);
+        app.addAsModule(webApp);
+        app.addAsLibrary(testApiJar);
+        ShrinkHelper.addDirectory(app, RESOURCE_ROOT + "ejb", new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
+
+            @Override
+            public boolean include(ArchivePath arg0) {
+                if (arg0.get().startsWith("/META-INF/")) {
+                    return true;
+                }
+                return false;
+            }
+
+        });
+
+        ShrinkHelper.exportToServer(server1, "apps", app);
+        server1.addInstalledAppForValidation("Inheritance10_EJB");
+
+        Application appRecord = new Application();
+        appRecord.setLocation("Inheritance10_EJB.ear");
+        appRecord.setName("Inheritance10_EJB");
+
+        ServerConfiguration sc = server1.getServerConfiguration();
+        sc.getApplications().add(appRecord);
+        server1.updateServerConfiguration(sc);
+        server1.saveServerConfiguration();
+
+        HashSet<String> appNamesSet = new HashSet<String>();
+        appNamesSet.add("Inheritance10_EJB");
+        server1.waitForConfigUpdateInLogUsingMark(appNamesSet, "");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        try {
+            server1.dumpServer("relationships_manyXmany_ejb");
+            server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
+                               "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
+            );
+        } finally {
+            bannerEnd(Relationships_ManyXMany_Web.class, timestart);
+        }
+
+        ServerConfiguration sc = server1.getServerConfiguration();
+        sc.getApplications().clear();
+        server1.updateServerConfiguration(sc);
+        server1.saveServerConfiguration();
+
+        server1.deleteFileFromLibertyServerRoot("apps/Inheritance10_EJB.ear");
+        server1.deleteFileFromLibertyServerRoot("apps/DatabaseManagement.war");
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/Inheritance_Web.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/Inheritance_Web.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.jpa10;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.Application;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.jpa.FATSuite;
+import com.ibm.ws.jpa.JPAFATServletClient;
+import com.ibm.ws.jpa.fvt.inheritance.tests.web.TestInheritanceServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.PrivHelper;
+
+@RunWith(FATRunner.class)
+public class Inheritance_Web extends JPAFATServletClient {
+    private final static String RESOURCE_ROOT = "test-applications/jpa10/inheritance/";
+
+    private final static Set<String> dropSet = new HashSet<String>();
+    private final static Set<String> createSet = new HashSet<String>();
+
+    private static long timestart = 0;
+
+    static {
+        dropSet.add("JPA10_INHERITANCE_DROP_${dbvendor}.ddl");
+        createSet.add("JPA10_INHERITANCE_CREATE_${dbvendor}.ddl");
+    }
+
+    @Server("JPA10Server")
+    @TestServlets({
+                    @TestServlet(servlet = TestInheritanceServlet.class, path = "Inheritance10Web" + "/" + "TestInheritanceServlet"),
+
+    })
+    public static LibertyServer server1;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        PrivHelper.generateCustomPolicy(server1, FATSuite.JAXB_PERMS);
+        bannerStart(CallbackTest.class);
+        timestart = System.currentTimeMillis();
+
+        server1.startServer();
+
+        setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");
+
+        final Set<String> ddlSet = new HashSet<String>();
+
+        ddlSet.clear();
+        for (String ddlName : dropSet) {
+            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
+        }
+        executeDDL(server1, ddlSet, true);
+
+        ddlSet.clear();
+        for (String ddlName : createSet) {
+            ddlSet.add(ddlName.replace("${dbvendor}", getDbVendor().name()));
+        }
+        executeDDL(server1, ddlSet, false);
+
+        setupTestApplication();
+    }
+
+    private static void setupTestApplication() throws Exception {
+        WebArchive webApp = ShrinkWrap.create(WebArchive.class, "inheritance.war");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.ano");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.msc");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.msc.ano");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.testlogic");
+        webApp.addPackages(true, "com.ibm.ws.jpa.fvt.inheritance.tests.web");
+        ShrinkHelper.addDirectory(webApp, RESOURCE_ROOT + "web/inheritance.war");
+
+        final JavaArchive testApiJar = buildTestAPIJar();
+
+        final EnterpriseArchive app = ShrinkWrap.create(EnterpriseArchive.class, "Inheritance_Web.ear");
+        app.addAsModule(webApp);
+        app.addAsLibrary(testApiJar);
+        ShrinkHelper.addDirectory(app, RESOURCE_ROOT + "web", new org.jboss.shrinkwrap.api.Filter<ArchivePath>() {
+
+            @Override
+            public boolean include(ArchivePath arg0) {
+                if (arg0.get().startsWith("/META-INF/")) {
+                    return true;
+                }
+                return false;
+            }
+
+        });
+
+        ShrinkHelper.exportToServer(server1, "apps", app);
+        server1.addInstalledAppForValidation("Inheritance_Web");
+
+        Application appRecord = new Application();
+        appRecord.setLocation("Inheritance_Web.ear");
+        appRecord.setName("Inheritance_Web");
+
+        ServerConfiguration sc = server1.getServerConfiguration();
+        sc.getApplications().add(appRecord);
+        server1.updateServerConfiguration(sc);
+        server1.saveServerConfiguration();
+
+        HashSet<String> appNamesSet = new HashSet<String>();
+        appNamesSet.add("Inheritance_Web");
+        server1.waitForConfigUpdateInLogUsingMark(appNamesSet, "");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        try {
+            server1.dumpServer("inheritance_web");
+            server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
+                               "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
+            );
+        } finally {
+            bannerEnd(Relationships_OneXMany_Web.class, timestart);
+        }
+
+        ServerConfiguration sc = server1.getServerConfiguration();
+        sc.getApplications().clear();
+        server1.updateServerConfiguration(sc);
+        server1.saveServerConfiguration();
+
+        server1.deleteFileFromLibertyServerRoot("apps/Inheritance_Web.ear");
+        server1.deleteFileFromLibertyServerRoot("apps/DatabaseManagement.war");
+    }
+
+}

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/JPA10FATSuite.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa10/JPA10FATSuite.java
@@ -22,6 +22,8 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
                 CallbackTest.class,
+                Inheritance_EJB.class,
+                Inheritance_Web.class,
                 Relationships_ManyXMany_Web.class,
                 Relationships_ManyXMany_EJB.class,
                 Relationships_ManyXOne_Web.class,

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA10Server/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPA10Server/server.xml
@@ -35,10 +35,11 @@
     
     
     <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
-    
+<!--  
     <logging  traceSpecification="JPA=all=enabled:EJBContainer=all=enabled"
 traceFileName="trace.log"
 maxFileSize="2000"
 maxFiles="10"
 traceFormat="BASIC" />
+ -->
 </server>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ddl/WEB-INF/classes/JPA10_INHERITANCE_CREATE_DERBY.ddl
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ddl/WEB-INF/classes/JPA10_INHERITANCE_CREATE_DERBY.ddl
@@ -1,0 +1,64 @@
+
+CREATE TABLE ${schemaname}.AnoConcreteLeaf1 (id INTEGER NOT NULL, name VARCHAR(255), intVal INTEGER, PRIMARY KEY (id));  
+CREATE TABLE ${schemaname}.AnoConcreteLeaf2 (id INTEGER NOT NULL, name VARCHAR(255), floatVal REAL, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoConcreteLeaf3 (id INTEGER NOT NULL, name VARCHAR(255), stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), PRIMARY KEY (id));          
+CREATE TABLE ${schemaname}.XMLConcreteLeaf1 (id INTEGER NOT NULL, name VARCHAR(255), intVal INTEGER, PRIMARY KEY (id));  
+CREATE TABLE ${schemaname}.XMLConcreteLeaf2 (id INTEGER NOT NULL, name VARCHAR(255), floatVal REAL, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLConcreteLeaf3 (id INTEGER NOT NULL, name VARCHAR(255), stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), PRIMARY KEY (id));          
+
+CREATE TABLE ${schemaname}.AnoJTCDRoot  (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL VARCHAR(255), PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoJTCDLeaf1 (id INTEGER NOT NULL, intVal INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoJTCDLeaf2 (id INTEGER NOT NULL, floatVal REAL, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoJTCDLeaf3 (id INTEGER NOT NULL, stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), PRIMARY KEY (id));
+            
+CREATE TABLE ${schemaname}.XMLJTCDRoot  (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL VARCHAR(255), PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLJTCDLeaf1 (id INTEGER NOT NULL, intVal INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLJTCDLeaf2 (id INTEGER NOT NULL, floatVal REAL, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLJTCDLeaf3 (id INTEGER NOT NULL, stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), PRIMARY KEY (id));
+                    
+CREATE INDEX I_JNCHRRT_DTYPE ON ${schemaname}.AnoJTCDRoot (DISC_COL);
+CREATE INDEX I_XMLJRRT_DTYPE ON ${schemaname}.XMLJTCDRoot (DISC_COL);    
+            
+CREATE TABLE ${schemaname}.AnoJTIDRoot  (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoJTIDLeaf1 (id INTEGER NOT NULL, intVal INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoJTIDLeaf2 (id INTEGER NOT NULL, floatVal REAL, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoJTIDLeaf3 (id INTEGER NOT NULL, stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), PRIMARY KEY (id));            
+CREATE TABLE ${schemaname}.XMLJTIDRoot  (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLJTIDLeaf1 (id INTEGER NOT NULL, intVal INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLJTIDLeaf2 (id INTEGER NOT NULL, floatVal REAL, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLJTIDLeaf3 (id INTEGER NOT NULL, stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), PRIMARY KEY (id));            
+         
+CREATE INDEX I_JNINRRT_DTYPE ON ${schemaname}.AnoJTIDRoot (DISC_COL);
+CREATE INDEX I_XMLINRT_DTYPE ON ${schemaname}.XMLJTIDRoot (DISC_COL);
+               
+CREATE TABLE ${schemaname}.AnoJTSDRoot  (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL VARCHAR(31), PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoJTSDLeaf1 (id INTEGER NOT NULL, intVal INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoJTSDLeaf2 (id INTEGER NOT NULL, floatVal REAL, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoJTSDLeaf3 (id INTEGER NOT NULL, stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), PRIMARY KEY (id));            
+CREATE TABLE ${schemaname}.XMLJTSDRoot  (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL VARCHAR(31), PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLJTSDLeaf1 (id INTEGER NOT NULL, intVal INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLJTSDLeaf2 (id INTEGER NOT NULL, floatVal REAL, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLJTSDLeaf3 (id INTEGER NOT NULL, stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), PRIMARY KEY (id));
+            
+CREATE INDEX I_JNSTRRT_DTYPE ON ${schemaname}.AnoJTSDRoot (DISC_COL);
+CREATE INDEX I_XMLSTRT_DTYPE ON ${schemaname}.XMLJTSDRoot (DISC_COL); 
+         
+CREATE TABLE ${schemaname}.AnoSTCDRoot (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL VARCHAR(255), stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), intVal INTEGER, floatVal REAL, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoSTIDRoot (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL INTEGER, floatVal REAL, stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), intVal INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoSTSDRoot (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL VARCHAR(31), floatVal REAL, stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), intVal INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLSTCDRoot (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL VARCHAR(255), stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), intVal INTEGER, floatVal REAL, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLSTIDRoot (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL INTEGER, floatVal REAL, stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), intVal INTEGER, PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLSTSDRoot (id INTEGER NOT NULL, name VARCHAR(255), DISC_COL VARCHAR(31), floatVal REAL, stringVal1 VARCHAR(255), stringVal2 VARCHAR(255), intVal INTEGER, PRIMARY KEY (id));
+         
+CREATE INDEX I_SNGLTTY_DTYPE1 ON ${schemaname}.AnoSTCDRoot (DISC_COL);
+CREATE INDEX I_SNGLTTY_DTYPE ON  ${schemaname}.AnoSTIDRoot (DISC_COL);
+CREATE INDEX I_SNGLTTY_DTYPE2 ON ${schemaname}.AnoSTSDRoot (DISC_COL);
+CREATE INDEX I_XMLSTTY_DTYPE1 ON ${schemaname}.XMLSTCDRoot (DISC_COL);
+CREATE INDEX I_XMLSTTY_DTYPE ON  ${schemaname}.XMLSTIDRoot (DISC_COL);
+CREATE INDEX I_XMLSTTY_DTYPE2 ON ${schemaname}.XMLSTSDRoot (DISC_COL);
+                 
+CREATE TABLE ${schemaname}.AnoAnoMSCEntity (id INTEGER NOT NULL, name VARCHAR(255), overridenNameAO VARCHAR(255), description VARCHAR(255), PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.AnoXMLMSCEntity (id INTEGER NOT NULL, name VARCHAR(255), overridenNameAO VARCHAR(255), description VARCHAR(255), PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLAnoMSCEntity (id INTEGER NOT NULL, name VARCHAR(255), originalNameAO VARCHAR(255), description VARCHAR(255), PRIMARY KEY (id));
+CREATE TABLE ${schemaname}.XMLXMLMSCEntity (id INTEGER NOT NULL, name VARCHAR(255), originalNameAO VARCHAR(255), description VARCHAR(255), PRIMARY KEY (id));   
+

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ddl/WEB-INF/classes/JPA10_INHERITANCE_DELETE_DERBY.ddl
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ddl/WEB-INF/classes/JPA10_INHERITANCE_DELETE_DERBY.ddl
@@ -1,0 +1,47 @@
+DELETE FROM ${schemaname}.AnoConcreteLeaf1;
+DELETE FROM ${schemaname}.AnoConcreteLeaf2;    
+DELETE FROM ${schemaname}.AnoConcreteLeaf3;      
+DELETE FROM ${schemaname}.XMLConcreteLeaf1;
+DELETE FROM ${schemaname}.XMLConcreteLeaf2;    
+DELETE FROM ${schemaname}.XMLConcreteLeaf3;      
+
+DELETE FROM ${schemaname}.AnoJTCDRoot;
+DELETE FROM ${schemaname}.AnoJTCDLeaf1;
+DELETE FROM ${schemaname}.AnoJTCDLeaf2;
+DELETE FROM ${schemaname}.AnoJTCDLeaf3; 
+            
+DELETE FROM ${schemaname}.XMLJTCDRoot;
+DELETE FROM ${schemaname}.XMLJTCDLeaf1;
+DELETE FROM ${schemaname}.XMLJTCDLeaf2;
+DELETE FROM ${schemaname}.XMLJTCDLeaf3;   
+
+DELETE FROM ${schemaname}.AnoJTIDRoot;
+DELETE FROM ${schemaname}.AnoJTIDLeaf1;
+DELETE FROM ${schemaname}.AnoJTIDLeaf2;
+DELETE FROM ${schemaname}.AnoJTIDLeaf3; 
+            
+DELETE FROM ${schemaname}.XMLJTIDRoot;
+DELETE FROM ${schemaname}.XMLJTIDLeaf1;
+DELETE FROM ${schemaname}.XMLJTIDLeaf2;
+DELETE FROM ${schemaname}.XMLJTIDLeaf3;     
+
+DELETE FROM ${schemaname}.AnoJTSDRoot;
+DELETE FROM ${schemaname}.AnoJTSDLeaf1;
+DELETE FROM ${schemaname}.AnoJTSDLeaf2;
+DELETE FROM ${schemaname}.AnoJTSDLeaf3;             
+DELETE FROM ${schemaname}.XMLJTSDRoot;
+DELETE FROM ${schemaname}.XMLJTSDLeaf1;
+DELETE FROM ${schemaname}.XMLJTSDLeaf2;
+DELETE FROM ${schemaname}.XMLJTSDLeaf3;     
+
+DELETE FROM ${schemaname}.AnoSTCDRoot;
+DELETE FROM ${schemaname}.AnoSTIDRoot;
+DELETE FROM ${schemaname}.AnoSTSDRoot;
+DELETE FROM ${schemaname}.XMLSTCDRoot;
+DELETE FROM ${schemaname}.XMLSTIDRoot;
+DELETE FROM ${schemaname}.XMLSTSDRoot;
+
+DELETE FROM  ${schemaname}.AnoAnoMSCEntity;
+DELETE FROM  ${schemaname}.AnoXMLMSCEntity;
+DELETE FROM  ${schemaname}.XMLAnoMSCEntity;
+DELETE FROM  ${schemaname}.XMLXMLMSCEntity;

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ddl/WEB-INF/classes/JPA10_INHERITANCE_DROP_DERBY.ddl
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ddl/WEB-INF/classes/JPA10_INHERITANCE_DROP_DERBY.ddl
@@ -1,0 +1,47 @@
+DROP TABLE ${schemaname}.AnoConcreteLeaf1;
+DROP TABLE ${schemaname}.AnoConcreteLeaf2;    
+DROP TABLE ${schemaname}.AnoConcreteLeaf3;      
+DROP TABLE ${schemaname}.XMLConcreteLeaf1;
+DROP TABLE ${schemaname}.XMLConcreteLeaf2;    
+DROP TABLE ${schemaname}.XMLConcreteLeaf3;      
+
+DROP TABLE ${schemaname}.AnoJTCDRoot;
+DROP TABLE ${schemaname}.AnoJTCDLeaf1;
+DROP TABLE ${schemaname}.AnoJTCDLeaf2;
+DROP TABLE ${schemaname}.AnoJTCDLeaf3; 
+            
+DROP TABLE ${schemaname}.XMLJTCDRoot;
+DROP TABLE ${schemaname}.XMLJTCDLeaf1;
+DROP TABLE ${schemaname}.XMLJTCDLeaf2;
+DROP TABLE ${schemaname}.XMLJTCDLeaf3;   
+
+DROP TABLE ${schemaname}.AnoJTIDRoot;
+DROP TABLE ${schemaname}.AnoJTIDLeaf1;
+DROP TABLE ${schemaname}.AnoJTIDLeaf2;
+DROP TABLE ${schemaname}.AnoJTIDLeaf3; 
+            
+DROP TABLE ${schemaname}.XMLJTIDRoot;
+DROP TABLE ${schemaname}.XMLJTIDLeaf1;
+DROP TABLE ${schemaname}.XMLJTIDLeaf2;
+DROP TABLE ${schemaname}.XMLJTIDLeaf3;     
+
+DROP TABLE ${schemaname}.AnoJTSDRoot;
+DROP TABLE ${schemaname}.AnoJTSDLeaf1;
+DROP TABLE ${schemaname}.AnoJTSDLeaf2;
+DROP TABLE ${schemaname}.AnoJTSDLeaf3;             
+DROP TABLE ${schemaname}.XMLJTSDRoot;
+DROP TABLE ${schemaname}.XMLJTSDLeaf1;
+DROP TABLE ${schemaname}.XMLJTSDLeaf2;
+DROP TABLE ${schemaname}.XMLJTSDLeaf3;     
+
+DROP TABLE ${schemaname}.AnoSTCDRoot;
+DROP TABLE ${schemaname}.AnoSTIDRoot;
+DROP TABLE ${schemaname}.AnoSTSDRoot;
+DROP TABLE ${schemaname}.XMLSTCDRoot;
+DROP TABLE ${schemaname}.XMLSTIDRoot;
+DROP TABLE ${schemaname}.XMLSTSDRoot;
+
+DROP TABLE   ${schemaname}.AnoAnoMSCEntity;
+DROP TABLE   ${schemaname}.AnoXMLMSCEntity;
+DROP TABLE   ${schemaname}.XMLAnoMSCEntity;
+DROP TABLE   ${schemaname}.XMLXMLMSCEntity;

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/META-INF/application.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/META-INF/application.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<application xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd"
+	id="Application_ID">
+
+	<display-name>Inheritance10_EJB</display-name>
+	<module id="EjbModule_1"> 
+		<ejb>inheritance.jar</ejb>
+	</module>
+	<module id="WebModule_1">
+        <web>
+            <web-uri>inheritanceejb.war</web-uri>
+            <context-root>Inheritance10EJB</context-root>
+        </web>
+    </module>
+</application>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/META-INF/permissions.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd" 
+             version="7">
+   <permission>
+      <class-name>java.lang.reflect.ReflectPermission</class-name>
+      <name>suppressAccessChecks</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>getClassLoader</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>accessDeclaredMembers</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>createClassLoader</name>
+   </permission>
+   <permission>
+      <class-name>java.io.FilePermission</class-name>
+      <name>-</name>
+      <actions>read</actions>
+   </permission>
+   <permission>
+      <class-name>java.net.URLPermission</class-name>
+      <name>http://localhost:*/DatabaseManagement/DMS</name>
+      <actions>GET</actions>
+   </permission>
+
+</permissions>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/ejb-jar.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
 <ejb-jar id="ejb-jar_id" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd"

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/ejb-jar.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar id="ejb-jar_id" xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd"
+	metadata-complete="false" version="3.0">
+
+	<enterprise-beans>
+		<!-- Stateful Session Bean, PC: AM-JTA, AM-RL, CM-TS -->
+		<session>
+			<ejb-name>InheritanceTestSFEJB</ejb-name>
+			<business-local>com.ibm.ws.jpa.fvt.inheritance.ejblocal.InheritanceSFEJBLocal</business-local>
+			<ejb-class>com.ibm.ws.testtooling.vehicle.ejb.BMTEJBTestVehicle</ejb-class>
+			<session-type>Stateful</session-type>
+			<remove-method>
+				<bean-method>
+					<method-name>release</method-name>
+				</bean-method>
+			</remove-method>
+			<transaction-type>Bean</transaction-type>
+			<resource-ref>
+				<res-ref-name>jdbc/JPA_DS</res-ref-name>
+				<res-type>javax.sql.DataSource</res-type>
+				<res-auth>Container</res-auth>
+				<res-sharing-scope>Shareable</res-sharing-scope>
+			</resource-ref>
+			<resource-ref>
+				<res-ref-name>jdbc/JPA_NJTADS</res-ref-name>
+				<res-type>javax.sql.DataSource</res-type>
+				<res-auth>Container</res-auth>
+				<res-sharing-scope>Shareable</res-sharing-scope>
+			</resource-ref>
+
+			<!-- Persistence Context Definitions -->
+			<persistence-context-ref>
+				<description>Transaction-Scoped Persistence Context</description>
+				<persistence-context-ref-name>jpa/JPAInheritance_CMTS</persistence-context-ref-name>
+				<persistence-unit-name>Inheritance_JTA</persistence-unit-name>
+				<persistence-context-type>Transaction</persistence-context-type>
+			</persistence-context-ref>
+
+			<persistence-unit-ref>
+				<description>Application-Managed JTA-Tran Persistence Context</description>
+				<persistence-unit-ref-name>jpa/JPAInheritance_AMJTA</persistence-unit-ref-name>
+				<persistence-unit-name>Inheritance_JTA</persistence-unit-name>
+			</persistence-unit-ref>
+
+			<persistence-unit-ref>
+				<description>Application-Managed RL-Tran Persistence Context</description>
+				<persistence-unit-ref-name>jpa/JPAInheritance_AMRL</persistence-unit-ref-name>
+				<persistence-unit-name>Inheritance_RL</persistence-unit-name>
+			</persistence-unit-ref>
+
+			<persistence-unit-ref>
+				<description>Cleanup Persistence Context</description>
+				<persistence-unit-ref-name>jpa/cleanup</persistence-unit-ref-name>
+				<persistence-unit-name>Cleanup</persistence-unit-name>
+			</persistence-unit-ref>
+		</session>
+		<!-- Stateful Session Bean, PC: CM-ES -->
+		<session>
+			<ejb-name>InheritanceTestSFEXEJB</ejb-name>
+			<business-local>com.ibm.ws.jpa.fvt.inheritance.ejblocal.InheritanceSFEXEJBLocal</business-local>
+			<ejb-class>com.ibm.ws.testtooling.vehicle.ejb.BMTEJBTestVehicle</ejb-class>
+			<session-type>Stateful</session-type>
+			<remove-method>
+				<bean-method>
+					<method-name>release</method-name>
+				</bean-method>
+			</remove-method>
+			<transaction-type>Bean</transaction-type>
+			<resource-ref>
+				<res-ref-name>jdbc/JPA_DS</res-ref-name>
+				<res-type>javax.sql.DataSource</res-type>
+				<res-auth>Container</res-auth>
+				<res-sharing-scope>Shareable</res-sharing-scope>
+			</resource-ref>
+			<resource-ref>
+				<res-ref-name>jdbc/JPA_NJTADS</res-ref-name>
+				<res-type>javax.sql.DataSource</res-type>
+				<res-auth>Container</res-auth>
+				<res-sharing-scope>Shareable</res-sharing-scope>
+			</resource-ref>
+
+			<!-- Persistence Context Definitions -->
+			<persistence-context-ref>
+				<persistence-context-ref-name>jpa/JPAInheritance_CMEX</persistence-context-ref-name>
+				<persistence-unit-name>Inheritance_JTA</persistence-unit-name>
+				<persistence-context-type>Extended</persistence-context-type>
+			</persistence-context-ref>
+
+			<persistence-unit-ref>
+				<description>Cleanup Persistence Context</description>
+				<persistence-unit-ref-name>jpa/cleanup</persistence-unit-ref-name>
+				<persistence-unit-name>Cleanup</persistence-unit-name>
+			</persistence-unit-ref>
+		</session>
+
+		<!-- Stateless Session Bean, PC: AM-JTA, AM-RL, CM-TS -->
+		<session>
+			<ejb-name>InheritanceTestSLEJB</ejb-name>
+			<business-local>com.ibm.ws.jpa.fvt.inheritance.ejblocal.InheritanceSLEJBLocal</business-local>
+			<ejb-class>com.ibm.ws.testtooling.vehicle.ejb.BMTEJBTestVehicle</ejb-class>
+			<session-type>Stateless</session-type>
+			<transaction-type>Bean</transaction-type>
+			<resource-ref>
+				<res-ref-name>jdbc/JPA_DS</res-ref-name>
+				<res-type>javax.sql.DataSource</res-type>
+				<res-auth>Container</res-auth>
+				<res-sharing-scope>Shareable</res-sharing-scope>
+			</resource-ref>
+			<resource-ref>
+				<res-ref-name>jdbc/JPA_NJTADS</res-ref-name>
+				<res-type>javax.sql.DataSource</res-type>
+				<res-auth>Container</res-auth>
+				<res-sharing-scope>Shareable</res-sharing-scope>
+			</resource-ref>
+
+			<!-- Persistence Context Definitions -->
+			<persistence-context-ref>
+				<description>Transaction-Scoped Persistence Context</description>
+				<persistence-context-ref-name>jpa/JPAInheritance_CMTS</persistence-context-ref-name>
+				<persistence-unit-name>Inheritance_JTA</persistence-unit-name>
+				<persistence-context-type>Transaction</persistence-context-type>
+			</persistence-context-ref>
+
+			<persistence-unit-ref>
+				<description>Application-Managed JTA-Tran Persistence Context</description>
+				<persistence-unit-ref-name>jpa/JPAInheritance_AMJTA</persistence-unit-ref-name>
+				<persistence-unit-name>Inheritance_JTA</persistence-unit-name>
+			</persistence-unit-ref>
+
+			<persistence-unit-ref>
+				<description>Application-Managed RL-Tran Persistence Context</description>
+				<persistence-unit-ref-name>jpa/JPAInheritance_AMRL</persistence-unit-ref-name>
+				<persistence-unit-name>Inheritance_RL</persistence-unit-name>
+			</persistence-unit-ref>
+
+			<persistence-unit-ref>
+				<description>Cleanup Persistence Context</description>
+				<persistence-unit-ref-name>jpa/cleanup</persistence-unit-ref-name>
+				<persistence-unit-name>Cleanup</persistence-unit-name>
+			</persistence-unit-ref>
+		</session>
+	</enterprise-beans>
+</ejb-jar>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/ibm-ejb-jar-bnd.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
 <ejb-jar-bnd
 xmlns="http://websphere.ibm.com/xml/ns/javaee"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/ibm-ejb-jar-bnd.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar-bnd
+xmlns="http://websphere.ibm.com/xml/ns/javaee"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ejb-jar-bnd_1_0.xsd"
+version="1.0">
+	<session name="InheritanceTestSFEJB">
+		<resource-ref name="jdbc/JPA_DS"     binding-name="jdbc/JPA_DS" />
+		<resource-ref name="jdbc/JPA_NJTADS" binding-name="jdbc/JPA_NJTADS" />
+	</session>
+	<session name="InheritanceTestSFEXEJB">
+		<resource-ref name="jdbc/JPA_DS"     binding-name="jdbc/JPA_DS" />
+		<resource-ref name="jdbc/JPA_NJTADS" binding-name="jdbc/JPA_NJTADS" />
+	</session>
+	<session name="InheritanceTestSLEJB">
+		<resource-ref name="jdbc/JPA_DS"     binding-name="jdbc/JPA_DS" />
+		<resource-ref name="jdbc/JPA_NJTADS" binding-name="jdbc/JPA_NJTADS" />
+	</session>
+</ejb-jar-bnd>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/orm.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/orm.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
 <entity-mappings
     xmlns="http://java.sun.com/xml/ns/persistence/orm"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/orm.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/orm.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-mappings
+    xmlns="http://java.sun.com/xml/ns/persistence/orm"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_1_0.xsd"
+    version="1.0">
+    
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>  
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml.XMLMSC">
+        <attributes>
+            <id name="id"/>
+            <basic name="name"/>
+            <basic name="nameAO"><column name="originalNameAO" /></basic>
+            <transient name="parsedName"/>
+        </attributes>
+    </mapped-superclass>
+    
+    <!-- Mapped Superclass -->
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.msc.ano.XMLAnoMSCEntity">
+        <attributes>
+            <basic name="description"></basic>
+        </attributes>
+    </entity>
+    
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml.XMLXMLMSCEntity">
+        <attributes>
+            <basic name="description"></basic>
+        </attributes>
+    </entity>
+    <!-- -->
+    
+    <!-- Table Per Class Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeRootEntity">
+        <inheritance strategy="TABLE_PER_CLASS" />
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeLeaf1Entity">
+        <table name="XMLConcreteLeaf1"></table>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeLeaf2Entity">
+        <table name="XMLConcreteLeaf2"></table>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeLeaf3Entity">
+        <table name="XMLConcreteLeaf3"></table>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Join-Table Char-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeRootEntity">
+        <table name="XMLJTCDRoot"/>
+        <inheritance strategy="JOINED" />
+        <discriminator-value>A</discriminator-value>
+        <discriminator-column discriminator-type="CHAR" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeLeaf1Entity">
+        <table name="XMLJTCDLeaf1"></table>
+        <discriminator-value>B</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeLeaf2Entity">
+        <table name="XMLJTCDLeaf2"></table>
+        <discriminator-value>C</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeLeaf3Entity">
+        <table name="XMLJTCDLeaf3"></table>
+        <discriminator-value>D</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Join-Table Integer-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeRootEntity">
+        <table name="XMLJTIDRoot"/>
+        <inheritance strategy="JOINED" />
+        <discriminator-column discriminator-type="INTEGER" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeLeaf1Entity">
+        <table name="XMLJTIDLeaf1"></table>
+        <discriminator-value>1</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeLeaf2Entity">
+        <table name="XMLJTIDLeaf2"></table>
+        <discriminator-value>2</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeLeaf3Entity">
+        <table name="XMLJTIDLeaf3"></table>
+        <discriminator-value>3</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Join-Table String-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeRootEntity">
+        <table name="XMLJTSDRoot"/>
+        <inheritance strategy="JOINED" />
+        <discriminator-column discriminator-type="STRING" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeLeaf1Entity">
+        <table name="XMLJTSDLeaf1"></table>
+        <discriminator-value>XMLJTSDTreeLeaf1Entity</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeLeaf2Entity">
+        <table name="XMLJTSDLeaf2"></table>
+        <discriminator-value>XMLJTSDTreeLeaf2Entity</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeLeaf3Entity">
+        <table name="XMLJTSDLeaf3"></table>
+        <discriminator-value>XMLJTSDTreeLeaf3Entity</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Single-Table Char-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeRootEntity">
+        <table name="XMLSTCDRoot"/>
+        <inheritance strategy="SINGLE_TABLE" />
+        <discriminator-value>A</discriminator-value>
+        <discriminator-column discriminator-type="CHAR" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeLeaf1Entity">
+        <discriminator-value>B</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeLeaf2Entity">
+        <discriminator-value>C</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeLeaf3Entity">
+        <discriminator-value>D</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Single-Table Integer-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeRootEntity">
+        <table name="XMLSTIDRoot"/>
+        <inheritance strategy="SINGLE_TABLE" />
+        <discriminator-column discriminator-type="INTEGER" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeLeaf1Entity">
+        <discriminator-value>1</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeLeaf2Entity">
+        <discriminator-value>2</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeLeaf3Entity">
+        <discriminator-value>3</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Single-Table String-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeRootEntity">
+        <table name="XMLSTSDRoot"/>
+        <inheritance strategy="SINGLE_TABLE" />
+        <discriminator-column discriminator-type="STRING" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeLeaf1Entity">
+        <discriminator-value>XMLSTCDTreeLeaf1Entity</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeLeaf2Entity">
+        <discriminator-value>XMLSTIDTreeLeaf2Entity</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeLeaf3Entity">
+        <discriminator-value>XMLSTSDTreeLeaf3Entity</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    
+    
+ </entity-mappings>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/persistence.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+    version="1.0">
+
+    <persistence-unit name="Cleanup" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>java:comp/env/jdbc/JPA_NJTADS</non-jta-data-source>
+         <properties>
+            <property name="openjpa.jdbc.DBDictionary" value="StoreCharsAsNumbers=false"/>
+            <!-- Hibernate Support Properties -->
+            <property name="hibernate.temp.use_jdbc_metadata_defaults" value="false"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.DerbyDialect"/>
+            <!-- <property name="hibernate.transaction.factory_class" value="org.hibernate.transaction.JDBCTransactionFactory"/> -->
+        </properties>
+    </persistence-unit>
+    
+    <persistence-unit name="Inheritance_JTA">
+        <jta-data-source>java:comp/env/jdbc/JPA_DS</jta-data-source>
+        <properties>
+            <property name="openjpa.jdbc.DBDictionary" value="StoreCharsAsNumbers=false"/>
+            <!-- Hibernate Support Properties -->
+            <property name="hibernate.temp.use_jdbc_metadata_defaults" value="false"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.DerbyDialect"/>
+            <!-- <property name="jta.UserTransaction" value="java:comp/UserTransaction"/> -->
+            <!-- <property name="hibernate.transaction.factory_class" value="org.hibernate.transaction.CMTTransactionFactory"/> -->      
+            <property name="hibernate.transaction.manager_lookup_class" value="org.hibernate.transaction.WebSphereExtendedJTATransactionLookup"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="Inheritance_RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>java:comp/env/jdbc/JPA_NJTADS</non-jta-data-source>
+        <properties>
+            <property name="openjpa.jdbc.DBDictionary" value="StoreCharsAsNumbers=false"/>
+            <!-- Hibernate Support Properties -->
+            <property name="hibernate.temp.use_jdbc_metadata_defaults" value="false"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.DerbyDialect"/>
+            <!-- <property name="hibernate.transaction.factory_class" value="org.hibernate.transaction.JDBCTransactionFactory"/> -->
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritance.jar/META-INF/persistence.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritanceejb.war/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritanceejb.war/WEB-INF/ibm-web-bnd.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd"
+    version="1.0">
+
+    <virtual-host name="default_host" />
+
+</web-bnd>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritanceejb.war/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritanceejb.war/WEB-INF/ibm-web-bnd.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
 <web-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd"

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritanceejb.war/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritanceejb.war/WEB-INF/web.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    version="2.5">
+
+    <!-- EJB References -->
+    <ejb-local-ref>
+        <ejb-ref-name>ejb/InheritanceSFEJB</ejb-ref-name>
+        <local>com.ibm.ws.jpa.fvt.inheritance.ejblocal.InheritanceSFEJBLocal</local>
+        <ejb-link>InheritanceTestSFEJB</ejb-link>
+    </ejb-local-ref>
+    <ejb-local-ref>
+        <ejb-ref-name>ejb/InheritanceSFExEJB</ejb-ref-name>
+        <local>com.ibm.ws.jpa.fvt.inheritance.ejblocal.InheritanceSFEXEJBLocal</local>
+        <ejb-link>InheritanceTestSFEXEJB</ejb-link>
+    </ejb-local-ref>
+    <ejb-local-ref>
+        <ejb-ref-name>ejb/InheritanceSLEJB</ejb-ref-name>
+        <local>com.ibm.ws.jpa.fvt.inheritance.ejblocal.InheritanceSLEJBLocal</local>
+        <ejb-link>InheritanceTestSLEJB</ejb-link>
+    </ejb-local-ref>
+</web-app>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritanceejb.war/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/ejb/inheritanceejb.war/WEB-INF/web.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/ejblocal/InheritanceSFEJBLocal.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/ejblocal/InheritanceSFEJBLocal.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.ejblocal;
+
+import com.ibm.ws.testtooling.vehicle.ejb.EJBTestVehicle;
+
+public interface InheritanceSFEJBLocal extends EJBTestVehicle {
+
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/ejblocal/InheritanceSFEXEJBLocal.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/ejblocal/InheritanceSFEXEJBLocal.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.ejblocal;
+
+import com.ibm.ws.testtooling.vehicle.ejb.EJBTestVehicle;
+
+public interface InheritanceSFEXEJBLocal extends EJBTestVehicle {
+
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/ejblocal/InheritanceSLEJBLocal.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/ejblocal/InheritanceSLEJBLocal.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.ejblocal;
+
+import com.ibm.ws.testtooling.vehicle.ejb.EJBTestVehicle;
+
+public interface InheritanceSLEJBLocal extends EJBTestVehicle {
+
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/ITreeLeaf1.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/ITreeLeaf1.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities;
+
+public interface ITreeLeaf1 extends ITreeRoot {
+    public int getIntVal();
+
+    public void setIntVal(int intVal);
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/ITreeLeaf2.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/ITreeLeaf2.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities;
+
+public interface ITreeLeaf2 extends ITreeRoot {
+    public float getFloatVal();
+
+    public void setFloatVal(float floatVal);
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/ITreeLeaf3.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/ITreeLeaf3.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities;
+
+public interface ITreeLeaf3 extends ITreeMSC {
+    public String getStringVal2();
+
+    public void setStringVal2(String stringVal2);
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/ITreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/ITreeMSC.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities;
+
+public interface ITreeMSC extends ITreeRoot {
+    public String getStringVal1();
+
+    public void setStringVal1(String stringVal1);
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/ITreeRoot.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/ITreeRoot.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities;
+
+public interface ITreeRoot {
+    public int getId();
+
+    public void setId(int id);
+
+    public String getName();
+
+    public void setName(String name);
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/ano/AnoConcreteTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/ano/AnoConcreteTreeLeaf1Entity.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.ano;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+@Entity
+@Table(name = "AnoConcreteLeaf1")
+public class AnoConcreteTreeLeaf1Entity extends AnoConcreteTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoConcreteTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/ano/AnoConcreteTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/ano/AnoConcreteTreeLeaf2Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.ano;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+@Entity
+@Table(name = "AnoConcreteLeaf2")
+public class AnoConcreteTreeLeaf2Entity extends AnoConcreteTreeRootEntity implements ITreeLeaf2 {
+    public AnoConcreteTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoConcreteTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/ano/AnoConcreteTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/ano/AnoConcreteTreeLeaf3Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.ano;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+@Entity
+@Table(name = "AnoConcreteLeaf3")
+public class AnoConcreteTreeLeaf3Entity extends AnoConcreteTreeMSC implements ITreeLeaf3 {
+    public AnoConcreteTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoConcreteTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/ano/AnoConcreteTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/ano/AnoConcreteTreeMSC.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.ano;
+
+import javax.persistence.MappedSuperclass;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+@MappedSuperclass
+public class AnoConcreteTreeMSC extends AnoConcreteTreeRootEntity implements ITreeMSC {
+    public AnoConcreteTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoConcreteTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/ano/AnoConcreteTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/ano/AnoConcreteTreeRootEntity.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.ano;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+@Entity
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+public abstract class AnoConcreteTreeRootEntity implements ITreeRoot {
+    @Id
+    private int id;
+
+    private String name;
+
+    public AnoConcreteTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoConcreteTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/xml/XMLConcreteTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/xml/XMLConcreteTreeLeaf1Entity.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+public class XMLConcreteTreeLeaf1Entity extends XMLConcreteTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLConcreteTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/xml/XMLConcreteTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/xml/XMLConcreteTreeLeaf2Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+public class XMLConcreteTreeLeaf2Entity extends XMLConcreteTreeRootEntity implements ITreeLeaf2 {
+    public XMLConcreteTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLConcreteTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/xml/XMLConcreteTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/xml/XMLConcreteTreeLeaf3Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+public class XMLConcreteTreeLeaf3Entity extends XMLConcreteTreeMSC implements ITreeLeaf3 {
+    public XMLConcreteTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLConcreteTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/xml/XMLConcreteTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/xml/XMLConcreteTreeMSC.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+public class XMLConcreteTreeMSC extends XMLConcreteTreeRootEntity implements ITreeMSC {
+    public XMLConcreteTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLConcreteTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/xml/XMLConcreteTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/concretetable/xml/XMLConcreteTreeRootEntity.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml;
+
+import javax.persistence.Id;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+public abstract class XMLConcreteTreeRootEntity implements ITreeRoot {
+    @Id
+    private int id;
+
+    private String name;
+
+    public XMLConcreteTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLConcreteTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTCDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTCDTreeLeaf1Entity.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+@Entity
+@Table(name = "AnoJTCDLeaf1")
+@DiscriminatorValue("B")
+public class AnoJTCDTreeLeaf1Entity extends AnoJTCDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public AnoJTCDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTCDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTCDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTCDTreeLeaf2Entity.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+@Entity
+@Table(name = "AnoJTCDLeaf2")
+@DiscriminatorValue("C")
+public class AnoJTCDTreeLeaf2Entity extends AnoJTCDTreeRootEntity implements ITreeLeaf2 {
+    public AnoJTCDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTCDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTCDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTCDTreeLeaf3Entity.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+@Entity
+@Table(name = "AnoJTCDLeaf3")
+@DiscriminatorValue("D")
+public class AnoJTCDTreeLeaf3Entity extends AnoJTCDTreeMSC implements ITreeLeaf3 {
+    public AnoJTCDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTCDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTCDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTCDTreeMSC.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.MappedSuperclass;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+@MappedSuperclass
+public class AnoJTCDTreeMSC extends AnoJTCDTreeRootEntity implements ITreeMSC {
+    public AnoJTCDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTCDTreeMSCEntity [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTCDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTCDTreeRootEntity.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+@Entity
+@Table(name = "AnoJTCDRoot")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "DISC_COL", discriminatorType = DiscriminatorType.CHAR)
+@DiscriminatorValue("A")
+public abstract class AnoJTCDTreeRootEntity implements ITreeRoot {
+    @Id
+    private int id;
+
+    private String name;
+
+    public AnoJTCDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTCDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTIDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTIDTreeLeaf1Entity.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+@Entity
+@Table(name = "AnoJTIDLeaf1")
+@DiscriminatorValue("1")
+public class AnoJTIDTreeLeaf1Entity extends AnoJTIDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public AnoJTIDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTIDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTIDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTIDTreeLeaf2Entity.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+@Entity
+@Table(name = "AnoJTIDLeaf2")
+@DiscriminatorValue("2")
+public class AnoJTIDTreeLeaf2Entity extends AnoJTIDTreeRootEntity implements ITreeLeaf2 {
+    public AnoJTIDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTIDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTIDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTIDTreeLeaf3Entity.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+@Entity
+@Table(name = "AnoJTIDLeaf3")
+@DiscriminatorValue("3")
+public class AnoJTIDTreeLeaf3Entity extends AnoJTIDTreeMSC implements ITreeLeaf3 {
+    public AnoJTIDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTIDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTIDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTIDTreeMSC.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.MappedSuperclass;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+@MappedSuperclass
+public class AnoJTIDTreeMSC extends AnoJTIDTreeRootEntity implements ITreeMSC {
+    public AnoJTIDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTIDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTIDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTIDTreeRootEntity.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+@Entity
+@Table(name = "AnoJTIDRoot")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "DISC_COL", discriminatorType = DiscriminatorType.INTEGER)
+public abstract class AnoJTIDTreeRootEntity implements ITreeRoot {
+    @Id
+    private int id;
+
+    private String name;
+
+    public AnoJTIDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTIDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTSDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTSDTreeLeaf1Entity.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+@Entity
+@Table(name = "AnoJTSDLeaf1")
+@DiscriminatorValue("AnoJTSDLeaf1")
+public class AnoJTSDTreeLeaf1Entity extends AnoJTSDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public AnoJTSDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTSDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTSDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTSDTreeLeaf2Entity.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+@Entity
+@Table(name = "AnoJTSDLeaf2")
+@DiscriminatorValue("AnoJTSDLeaf2")
+public class AnoJTSDTreeLeaf2Entity extends AnoJTSDTreeRootEntity implements ITreeLeaf2 {
+    public AnoJTSDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTSDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTSDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTSDTreeLeaf3Entity.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+@Entity
+@Table(name = "AnoJTSDLeaf3")
+@DiscriminatorValue("AnoJTSDLeaf3")
+public class AnoJTSDTreeLeaf3Entity extends AnoJTSDTreeMSC implements ITreeLeaf3 {
+    public AnoJTSDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTSDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTSDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTSDTreeMSC.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.MappedSuperclass;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+@MappedSuperclass
+public class AnoJTSDTreeMSC extends AnoJTSDTreeRootEntity implements ITreeMSC {
+    public AnoJTSDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTSDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTSDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/ano/AnoJTSDTreeRootEntity.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+@Entity
+@Table(name = "AnoJTSDRoot")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "DISC_COL", discriminatorType = DiscriminatorType.STRING)
+public abstract class AnoJTSDTreeRootEntity implements ITreeRoot {
+    @Id
+    private int id;
+
+    private String name;
+
+    public AnoJTSDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoJTSDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTCDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTCDTreeLeaf1Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+public class XMLJTCDTreeLeaf1Entity extends XMLJTCDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public XMLJTCDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTCDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTCDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTCDTreeLeaf2Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+public class XMLJTCDTreeLeaf2Entity extends XMLJTCDTreeRootEntity implements ITreeLeaf2 {
+    public XMLJTCDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTCDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTCDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTCDTreeLeaf3Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+public class XMLJTCDTreeLeaf3Entity extends XMLJTCDTreeMSC implements ITreeLeaf3 {
+    public XMLJTCDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTCDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTCDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTCDTreeMSC.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+public class XMLJTCDTreeMSC extends XMLJTCDTreeRootEntity implements ITreeMSC {
+    public XMLJTCDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTCDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTCDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTCDTreeRootEntity.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+public abstract class XMLJTCDTreeRootEntity implements ITreeRoot {
+    private int id;
+
+    private String name;
+
+    public XMLJTCDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTCDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTIDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTIDTreeLeaf1Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+public class XMLJTIDTreeLeaf1Entity extends XMLJTIDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public XMLJTIDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTIDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTIDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTIDTreeLeaf2Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+public class XMLJTIDTreeLeaf2Entity extends XMLJTIDTreeRootEntity implements ITreeLeaf2 {
+    public XMLJTIDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTIDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTIDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTIDTreeLeaf3Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+public class XMLJTIDTreeLeaf3Entity extends XMLJTIDTreeMSC implements ITreeLeaf3 {
+    public XMLJTIDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTIDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTIDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTIDTreeMSC.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+public class XMLJTIDTreeMSC extends XMLJTIDTreeRootEntity implements ITreeMSC {
+    public XMLJTIDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTIDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTIDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTIDTreeRootEntity.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+public abstract class XMLJTIDTreeRootEntity implements ITreeRoot {
+    private int id;
+
+    private String name;
+
+    public XMLJTIDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTIDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTSDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTSDTreeLeaf1Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+public class XMLJTSDTreeLeaf1Entity extends XMLJTSDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public XMLJTSDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTSDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTSDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTSDTreeLeaf2Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+public class XMLJTSDTreeLeaf2Entity extends XMLJTSDTreeRootEntity implements ITreeLeaf2 {
+    public XMLJTSDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTSDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTSDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTSDTreeLeaf3Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+public class XMLJTSDTreeLeaf3Entity extends XMLJTSDTreeMSC implements ITreeLeaf3 {
+    public XMLJTSDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTSDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTSDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTSDTreeMSC.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+public class XMLJTSDTreeMSC extends XMLJTSDTreeRootEntity implements ITreeMSC {
+    public XMLJTSDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTSDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTSDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/jointable/xml/XMLJTSDTreeRootEntity.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+public abstract class XMLJTSDTreeRootEntity implements ITreeRoot {
+    private int id;
+
+    private String name;
+
+    public XMLJTSDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLJTSDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/IMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/IMSC.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.msc;
+
+public interface IMSC {
+    public int getId();
+
+    public void setId(int id);
+
+    public String getName();
+
+    public void setName(String name);
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/IMSCEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/IMSCEntity.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.msc;
+
+public interface IMSCEntity extends IMSC {
+    public String getDescription();
+
+    public void setDescription(String description);
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/ano/AnoAnoMSCEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/ano/AnoAnoMSCEntity.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.msc.ano;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.msc.IMSCEntity;
+
+@Entity
+@AttributeOverride(name = "nameAO", column = @Column(name = "overridenNameAO"))
+public class AnoAnoMSCEntity extends AnoMSC implements IMSCEntity {
+    private String description;
+
+    public AnoAnoMSCEntity() {
+        super();
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoAnoMSCEntity [description=" + description + ", getId()=" + getId() + ", getName()=" + getName()
+               + ", getNameAO()=" + getNameAO() + ", getParsedName()=" + getParsedName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/ano/AnoMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/ano/AnoMSC.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.msc.ano;
+
+import javax.persistence.Column;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.msc.IMSC;
+
+@MappedSuperclass
+public abstract class AnoMSC implements IMSC {
+    @Id
+    private int id;
+
+    private String name;
+
+    @Column(name = "originalNameAO")
+    private String nameAO; // The entity class extending from this Mapped Superclass should use attributeOverride
+
+    private transient String parsedName;
+
+    public AnoMSC() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNameAO() {
+        return nameAO;
+    }
+
+    public void setNameAO(String nameAO) {
+        this.nameAO = nameAO;
+    }
+
+    public String getParsedName() {
+        return parsedName;
+    }
+
+    public void setParsedName(String parsedName) {
+        this.parsedName = parsedName;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoMSC [id=" + id + ", name=" + name + ", nameAO=" + nameAO + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/ano/XMLAnoMSCEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/ano/XMLAnoMSCEntity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.msc.ano;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.msc.IMSCEntity;
+
+public class XMLAnoMSCEntity extends AnoMSC implements IMSCEntity {
+    private String description;
+
+    public XMLAnoMSCEntity() {
+        super();
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLAnoMSCEntity [description=" + description + ", getId()=" + getId() + ", getName()=" + getName()
+               + ", getNameAO()=" + getNameAO() + ", getParsedName()=" + getParsedName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/xml/AnoXMLMSCEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/xml/AnoXMLMSCEntity.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.msc.IMSCEntity;
+
+@Entity
+@AttributeOverride(name = "nameAO", column = @Column(name = "overridenNameAO"))
+public class AnoXMLMSCEntity extends XMLMSC implements IMSCEntity {
+    private String description;
+
+    public AnoXMLMSCEntity() {
+        super();
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoXMLMSCEntity [description=" + description + ", getId()=" + getId() + ", getName()=" + getName()
+               + ", getNameAO()=" + getNameAO() + ", getParsedName()=" + getParsedName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/xml/XMLMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/xml/XMLMSC.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.msc.IMSC;
+
+public abstract class XMLMSC implements IMSC {
+    private int id;
+    private String name;
+    private String nameAO; // The entity class extending from this Mapped Superclass should use attributeOverride
+    private transient String parsedName;
+
+    public XMLMSC() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNameAO() {
+        return nameAO;
+    }
+
+    public void setNameAO(String nameAO) {
+        this.nameAO = nameAO;
+    }
+
+    public String getParsedName() {
+        return parsedName;
+    }
+
+    public void setParsedName(String parsedName) {
+        this.parsedName = parsedName;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLMSC [id=" + id + ", name=" + name + ", nameAO=" + nameAO + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/xml/XMLXMLMSCEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/msc/xml/XMLXMLMSCEntity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.msc.IMSCEntity;
+
+public class XMLXMLMSCEntity extends XMLMSC implements IMSCEntity {
+    private String description;
+
+    public XMLXMLMSCEntity() {
+        super();
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLXMLMSCEntity [description=" + description + ", getId()=" + getId() + ", getName()=" + getName()
+               + ", getNameAO()=" + getNameAO() + ", getParsedName()=" + getParsedName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTCDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTCDTreeLeaf1Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+@Entity
+@DiscriminatorValue("B")
+public class AnoSTCDTreeLeaf1Entity extends AnoSTCDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public AnoSTCDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTCDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTCDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTCDTreeLeaf2Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+@Entity
+@DiscriminatorValue("C")
+public class AnoSTCDTreeLeaf2Entity extends AnoSTCDTreeRootEntity implements ITreeLeaf2 {
+    public AnoSTCDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTCDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTCDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTCDTreeLeaf3Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+@Entity
+@DiscriminatorValue("D")
+public class AnoSTCDTreeLeaf3Entity extends AnoSTCDTreeMSC implements ITreeLeaf3 {
+    public AnoSTCDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTCDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTCDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTCDTreeMSC.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.MappedSuperclass;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+@MappedSuperclass
+public class AnoSTCDTreeMSC extends AnoSTCDTreeRootEntity implements ITreeMSC {
+    public AnoSTCDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTCDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTCDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTCDTreeRootEntity.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+@Entity
+@Table(name = "AnoSTCDRoot")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "DISC_COL", discriminatorType = DiscriminatorType.CHAR)
+@DiscriminatorValue("A")
+public abstract class AnoSTCDTreeRootEntity implements ITreeRoot {
+    @Id
+    private int id;
+
+    private String name;
+
+    public AnoSTCDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTCDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTIDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTIDTreeLeaf1Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+@Entity
+@DiscriminatorValue("1")
+public class AnoSTIDTreeLeaf1Entity extends AnoSTIDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public AnoSTIDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTIDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTIDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTIDTreeLeaf2Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+@Entity
+@DiscriminatorValue("2")
+public class AnoSTIDTreeLeaf2Entity extends AnoSTIDTreeRootEntity implements ITreeLeaf2 {
+    public AnoSTIDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTIDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTIDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTIDTreeLeaf3Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+@Entity
+@DiscriminatorValue("3")
+public class AnoSTIDTreeLeaf3Entity extends AnoSTIDTreeMSC implements ITreeLeaf3 {
+    public AnoSTIDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTIDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTIDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTIDTreeMSC.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.MappedSuperclass;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+@MappedSuperclass
+public class AnoSTIDTreeMSC extends AnoSTIDTreeRootEntity implements ITreeMSC {
+    public AnoSTIDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTIDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTIDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTIDTreeRootEntity.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+@Entity
+@Table(name = "AnoSTIDRoot")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "DISC_COL", discriminatorType = DiscriminatorType.INTEGER)
+public abstract class AnoSTIDTreeRootEntity implements ITreeRoot {
+    @Id
+    private int id;
+
+    private String name;
+
+    public AnoSTIDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTIDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTSDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTSDTreeLeaf1Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+@Entity
+@DiscriminatorValue("AnoSTSDLeaf1")
+public class AnoSTSDTreeLeaf1Entity extends AnoSTSDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public AnoSTSDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTSDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTSDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTSDTreeLeaf2Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+@Entity
+@DiscriminatorValue("AnoSTSDLeaf2")
+public class AnoSTSDTreeLeaf2Entity extends AnoSTSDTreeRootEntity implements ITreeLeaf2 {
+    public AnoSTSDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTSDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTSDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTSDTreeLeaf3Entity.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+@Entity
+@DiscriminatorValue("AnoSTSDLeaf3")
+public class AnoSTSDTreeLeaf3Entity extends AnoSTSDTreeMSC implements ITreeLeaf3 {
+    public AnoSTSDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTSDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTSDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTSDTreeMSC.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.MappedSuperclass;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+@MappedSuperclass
+public class AnoSTSDTreeMSC extends AnoSTSDTreeRootEntity implements ITreeMSC {
+    public AnoSTSDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTSDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTSDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/ano/AnoSTSDTreeRootEntity.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+@Entity
+@Table(name = "AnoSTSDRoot")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "DISC_COL", discriminatorType = DiscriminatorType.STRING)
+public abstract class AnoSTSDTreeRootEntity implements ITreeRoot {
+    @Id
+    private int id;
+
+    private String name;
+
+    public AnoSTSDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "AnoSTSDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTCDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTCDTreeLeaf1Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+public class XMLSTCDTreeLeaf1Entity extends XMLSTCDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public XMLSTCDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTCDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTCDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTCDTreeLeaf2Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+public class XMLSTCDTreeLeaf2Entity extends XMLSTCDTreeRootEntity implements ITreeLeaf2 {
+    public XMLSTCDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTCDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTCDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTCDTreeLeaf3Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+public class XMLSTCDTreeLeaf3Entity extends XMLSTCDTreeMSC implements ITreeLeaf3 {
+    public XMLSTCDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTCDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTCDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTCDTreeMSC.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+public class XMLSTCDTreeMSC extends XMLSTCDTreeRootEntity implements ITreeMSC {
+    public XMLSTCDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTCDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTCDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTCDTreeRootEntity.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+public abstract class XMLSTCDTreeRootEntity implements ITreeRoot {
+    private int id;
+
+    private String name;
+
+    public XMLSTCDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTCDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTIDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTIDTreeLeaf1Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+public class XMLSTIDTreeLeaf1Entity extends XMLSTIDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public XMLSTIDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTIDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTIDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTIDTreeLeaf2Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+public class XMLSTIDTreeLeaf2Entity extends XMLSTIDTreeRootEntity implements ITreeLeaf2 {
+    public XMLSTIDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTIDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTIDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTIDTreeLeaf3Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+public class XMLSTIDTreeLeaf3Entity extends XMLSTIDTreeMSC implements ITreeLeaf3 {
+    public XMLSTIDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTIDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTIDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTIDTreeMSC.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+public class XMLSTIDTreeMSC extends XMLSTIDTreeRootEntity implements ITreeMSC {
+    public XMLSTIDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTIDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTIDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTIDTreeRootEntity.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+public abstract class XMLSTIDTreeRootEntity implements ITreeRoot {
+    private int id;
+
+    private String name;
+
+    public XMLSTIDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTIDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTSDTreeLeaf1Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTSDTreeLeaf1Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+
+public class XMLSTSDTreeLeaf1Entity extends XMLSTSDTreeRootEntity implements ITreeLeaf1 {
+    private int intVal;
+
+    public XMLSTSDTreeLeaf1Entity() {
+        super();
+    }
+
+    @Override
+    public int getIntVal() {
+        return intVal;
+    }
+
+    @Override
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTSDTreeLeaf1Entity [intVal=" + intVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTSDTreeLeaf2Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTSDTreeLeaf2Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+
+public class XMLSTSDTreeLeaf2Entity extends XMLSTSDTreeRootEntity implements ITreeLeaf2 {
+    public XMLSTSDTreeLeaf2Entity() {
+        super();
+    }
+
+    private float floatVal;
+
+    @Override
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    @Override
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTSDTreeLeaf2Entity [floatVal=" + floatVal + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTSDTreeLeaf3Entity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTSDTreeLeaf3Entity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+
+public class XMLSTSDTreeLeaf3Entity extends XMLSTSDTreeMSC implements ITreeLeaf3 {
+    public XMLSTSDTreeLeaf3Entity() {
+        super();
+    }
+
+    private String stringVal2;
+
+    @Override
+    public String getStringVal2() {
+        return stringVal2;
+    }
+
+    @Override
+    public void setStringVal2(String stringVal2) {
+        this.stringVal2 = stringVal2;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTSDTreeLeaf3Entity [stringVal2=" + stringVal2 + ", getStringVal1()=" + getStringVal1()
+               + ", getId()=" + getId() + ", getName()=" + getName() + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTSDTreeMSC.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTSDTreeMSC.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeMSC;
+
+public class XMLSTSDTreeMSC extends XMLSTSDTreeRootEntity implements ITreeMSC {
+    public XMLSTSDTreeMSC() {
+        super();
+    }
+
+    private String stringVal1;
+
+    @Override
+    public String getStringVal1() {
+        return stringVal1;
+    }
+
+    @Override
+    public void setStringVal1(String stringVal1) {
+        this.stringVal1 = stringVal1;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTSDTreeMSC [stringVal1=" + stringVal1 + ", getId()=" + getId() + ", getName()=" + getName()
+               + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTSDTreeRootEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/entities/singletable/xml/XMLSTSDTreeRootEntity.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+
+public abstract class XMLSTSDTreeRootEntity implements ITreeRoot {
+    private int id;
+
+    private String name;
+
+    public XMLSTSDTreeRootEntity() {
+        super();
+    }
+
+    @Override
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "XMLSTSDTreeRootEntity [id=" + id + ", name=" + name + "]";
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/testlogic/InheritanceEntityEnum.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/testlogic/InheritanceEntityEnum.java
@@ -1,0 +1,533 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.testlogic;
+
+import com.ibm.ws.testtooling.testlogic.JPAEntityClassEnum;
+
+public enum InheritanceEntityEnum implements JPAEntityClassEnum {
+    AnoConcreteTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.ano.AnoConcreteTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoConcreteTreeLeaf1Entity";
+        }
+    },
+    AnoConcreteTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.ano.AnoConcreteTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoConcreteTreeLeaf2Entity";
+        }
+    },
+    AnoConcreteTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.ano.AnoConcreteTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoConcreteTreeLeaf3Entity";
+        }
+    },
+    XMLConcreteTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLConcreteTreeLeaf1Entity";
+        }
+    },
+    XMLConcreteTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLConcreteTreeLeaf2Entity";
+        }
+    },
+    XMLConcreteTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLConcreteTreeLeaf3Entity";
+        }
+    },
+    AnoJTCDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano.AnoJTCDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoJTCDTreeLeaf1Entity";
+        }
+    },
+    AnoJTCDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano.AnoJTCDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoJTCDTreeLeaf2Entity";
+        }
+    },
+    AnoJTCDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano.AnoJTCDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoJTCDTreeLeaf3Entity";
+        }
+    },
+    XMLJTCDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLJTCDTreeLeaf1Entity";
+        }
+    },
+    XMLJTCDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLJTCDTreeLeaf2Entity";
+        }
+    },
+    XMLJTCDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLJTCDTreeLeaf3Entity";
+        }
+    },
+    AnoJTIDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano.AnoJTIDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoJTIDTreeLeaf1Entity";
+        }
+    },
+    AnoJTIDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano.AnoJTIDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoJTIDTreeLeaf2Entity";
+        }
+    },
+    AnoJTIDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano.AnoJTIDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoJTIDTreeLeaf3Entity";
+        }
+    },
+    XMLJTIDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLJTIDTreeLeaf1Entity";
+        }
+    },
+    XMLJTIDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLJTIDTreeLeaf2Entity";
+        }
+    },
+    XMLJTIDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLJTIDTreeLeaf3Entity";
+        }
+    },
+    AnoJTSDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano.AnoJTSDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoJTSDTreeLeaf1Entity";
+        }
+    },
+    AnoJTSDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano.AnoJTSDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoJTSDTreeLeaf2Entity";
+        }
+    },
+    AnoJTSDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.ano.AnoJTSDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoJTSDTreeLeaf3Entity";
+        }
+    },
+    XMLJTSDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLJTSDTreeLeaf1Entity";
+        }
+    },
+    XMLJTSDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLJTSDTreeLeaf2Entity";
+        }
+    },
+    XMLJTSDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLJTSDTreeLeaf3Entity";
+        }
+    },
+    AnoSTCDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano.AnoSTCDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoSTCDTreeLeaf1Entity";
+        }
+    },
+    AnoSTCDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano.AnoSTCDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoSTCDTreeLeaf2Entity";
+        }
+    },
+    AnoSTCDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano.AnoSTCDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoSTCDTreeLeaf3Entity";
+        }
+    },
+    XMLSTCDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLSTCDTreeLeaf1Entity";
+        }
+    },
+    XMLSTCDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLSTCDTreeLeaf2Entity";
+        }
+    },
+    XMLSTCDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLSTCDTreeLeaf3Entity";
+        }
+    },
+    AnoSTIDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano.AnoSTIDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoSTIDTreeLeaf1Entity";
+        }
+    },
+    AnoSTIDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano.AnoSTIDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoSTIDTreeLeaf2Entity";
+        }
+    },
+    AnoSTIDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano.AnoSTIDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoSTIDTreeLeaf3Entity";
+        }
+    },
+    XMLSTIDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLSTIDTreeLeaf1Entity";
+        }
+    },
+    XMLSTIDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLSTIDTreeLeaf2Entity";
+        }
+    },
+    XMLSTIDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLSTIDTreeLeaf3Entity";
+        }
+    },
+    AnoSTSDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano.AnoSTSDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoSTSDTreeLeaf1Entity";
+        }
+    },
+    AnoSTSDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano.AnoSTSDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoSTSDTreeLeaf2Entity";
+        }
+    },
+    AnoSTSDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.ano.AnoSTSDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoSTSDTreeLeaf3Entity";
+        }
+    },
+    XMLSTSDTreeLeaf1Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeLeaf1Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLSTSDTreeLeaf1Entity";
+        }
+    },
+    XMLSTSDTreeLeaf2Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeLeaf2Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLSTSDTreeLeaf2Entity";
+        }
+    },
+    XMLSTSDTreeLeaf3Entity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeLeaf3Entity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLSTSDTreeLeaf3Entity";
+        }
+    },
+    AnoAnoMSCEntity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.msc.ano.AnoAnoMSCEntity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoAnoMSCEntity";
+        }
+    },
+    XMLAnoMSCEntity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.msc.ano.XMLAnoMSCEntity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLAnoMSCEntity";
+        }
+    },
+    AnoXMLMSCEntity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml.AnoXMLMSCEntity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "AnoXMLMSCEntity";
+        }
+    },
+    XMLXMLMSCEntity {
+        @Override
+        public String getEntityClassName() {
+            return "com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml.XMLXMLMSCEntity";
+        }
+
+        @Override
+        public String getEntityName() {
+            return "XMLXMLMSCEntity";
+        }
+    };
+
+    @Override
+    public abstract String getEntityClassName();
+
+    @Override
+    public abstract String getEntityName();
+
+    public static InheritanceEntityEnum resolveEntityByName(String entityName) {
+        return InheritanceEntityEnum.valueOf(entityName);
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/testlogic/InheritanceTestLogic.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/testlogic/InheritanceTestLogic.java
@@ -1,0 +1,508 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.testlogic;
+
+import org.junit.Assert;
+
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf1;
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf2;
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeLeaf3;
+import com.ibm.ws.jpa.fvt.inheritance.entities.ITreeRoot;
+import com.ibm.ws.jpa.fvt.inheritance.entities.msc.IMSC;
+import com.ibm.ws.jpa.fvt.inheritance.entities.msc.IMSCEntity;
+import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
+import com.ibm.ws.testtooling.testlogic.AbstractTestLogic;
+import com.ibm.ws.testtooling.vehicle.resources.JPAResource;
+import com.ibm.ws.testtooling.vehicle.resources.TestExecutionResources;
+
+public class InheritanceTestLogic extends AbstractTestLogic {
+    /**
+     * Test basic CRUD operations with the targeted entity type to verify basic inheritance.
+     *
+     * Points: 13
+     */
+    public void testInheritance001(TestExecutionContext testExecCtx, TestExecutionResources testExecResources,
+                                   Object managedComponentObject) {
+        // Verify parameters
+        if (testExecCtx == null || testExecResources == null) {
+            Assert.fail("InheritanceTestLogic.testInheritance001: Missing context and/or resources.  Cannot execute the test.");
+            return;
+        }
+
+        // Fetch JPA Resources
+        JPAResource jpaCleanupResource = testExecResources.getJpaResourceMap().get("cleanup");
+        if (jpaCleanupResource == null) {
+            Assert.fail("Missing JPAResource 'cleanup').  Cannot execute the test.");
+            return;
+        }
+        JPAResource jpaResource = testExecResources.getJpaResourceMap().get("test-jpa-resource");
+        if (jpaResource == null) {
+            Assert.fail("Missing JPAResource 'test-jpa-resource').  Cannot execute the test.");
+            return;
+        }
+
+        // Fetch target entity type from test parameters
+        String entityName = (String) testExecCtx.getProperties().get("EntityName");
+        InheritanceEntityEnum targetEntityType = InheritanceEntityEnum.resolveEntityByName(entityName);
+        if (targetEntityType == null) {
+            // Oops, unknown type
+            Assert.fail("Invalid entity type specified ('" + entityName + "').  Cannot execute the test.");
+            return;
+        }
+
+        // Execute Test Case
+        try {
+            System.out.println("InheritanceTestLogic.testInheritance001(): Begin");
+            cleanupDatabase(jpaCleanupResource);
+
+            System.out.println("1) Create and persist " + targetEntityType.getEntityName() + " (id=1).");
+
+            System.out.println("Beginning new transaction...");
+            jpaResource.getTj().beginTransaction();
+            if (jpaResource.getTj().isApplicationManaged()) {
+                System.out.println("Joining entitymanager to JTA transaction...");
+                jpaResource.getEm().joinTransaction();
+            }
+
+            // Clear persistence context
+            System.out.println("Clearing persistence context...");
+            jpaResource.getEm().clear();
+
+            // Construct a new entity instance
+            System.out.println("Creating new object instance of " + targetEntityType.getEntityName() + "...");
+            ITreeRoot new_entity = (ITreeRoot) constructNewEntityObject(targetEntityType);
+            new_entity.setId(1);
+            new_entity.setName(targetEntityType.getEntityName() + "-1");
+
+            if (new_entity instanceof ITreeLeaf1 || new_entity instanceof IMSCEntity) {
+                ((ITreeLeaf1) new_entity).setIntVal(42);
+            } else if (new_entity instanceof ITreeLeaf2) {
+                ((ITreeLeaf2) new_entity).setFloatVal(42.0f);
+            } else if (new_entity instanceof ITreeLeaf3) {
+                ((ITreeLeaf3) new_entity).setStringVal1("String-Val1");
+                ((ITreeLeaf3) new_entity).setStringVal2("String-Val2");
+            }
+
+            System.out.println("Persisting " + new_entity);
+            jpaResource.getEm().persist(new_entity);
+
+            System.out.println("Committing transaction...");
+            jpaResource.getTj().commitTransaction();
+
+            // 2) Verify the entity was saved to the database
+            System.out.println("2) Verify the entity was saved to the database");
+
+            System.out.println("Clearing persistence context...");
+            jpaResource.getEm().clear();
+
+            System.out.println("Beginning new transaction...");
+            jpaResource.getTj().beginTransaction();
+            if (jpaResource.getTj().isApplicationManaged()) {
+                System.out.println("Joining entitymanager to JTA transaction...");
+                jpaResource.getEm().joinTransaction();
+            }
+
+            ITreeRoot find_entity = (ITreeRoot) jpaResource.getEm().find(resolveEntityClass(targetEntityType), 1);
+            System.out.println("Object returned by find: " + find_entity);
+
+            // Verify that em.find() returned an object.
+            Assert.assertNotNull("Assert that the find operation did not return null", find_entity);
+            if (find_entity == null) {
+                // If the find returned null, then terminate the remainder of the test.
+                Assert.fail("Find returned null, cancelling the remainder of the test.");
+                return;
+            }
+
+            // Perform basic verifications (4 points)
+            Assert.assertTrue(
+                              "Assert find did not return the original object",
+                              new_entity != find_entity);
+            Assert.assertTrue(
+                              "Assert entity returned by find is managed by the persistence context.",
+                              jpaResource.getEm().contains(find_entity));
+            Assert.assertEquals(
+                                "Assert that the entity's id is 1",
+                                find_entity.getId(),
+                                1);
+            Assert.assertEquals(
+                                "Assert that the entity's name field is \"" + targetEntityType.getEntityName() + "-1" + "\"",
+                                find_entity.getName(),
+                                targetEntityType.getEntityName() + "-1");
+
+            // Perform Entity-type specific verifications (1 point)
+            if (find_entity instanceof ITreeLeaf1 || new_entity instanceof IMSCEntity) {
+                Assert.assertEquals("Assert intVal field == 42", 42, ((ITreeLeaf1) find_entity).getIntVal());
+            } else if (find_entity instanceof ITreeLeaf2) {
+                Assert.assertEquals("Asert floatVal field == 42.0f", 42.0f, ((ITreeLeaf2) find_entity).getFloatVal(), 0.1);
+            } else if (find_entity instanceof ITreeLeaf3) {
+                System.out.println(targetEntityType.getEntityName() + "(id=1).getStringVal1 = " +
+                                   ((ITreeLeaf3) find_entity).getStringVal1());
+                System.out.println(targetEntityType.getEntityName() + "(id=1).getStringVal2 = " +
+                                   ((ITreeLeaf3) find_entity).getStringVal2());
+
+                boolean passed = true;
+                passed = passed && "String-Val1".equals(((ITreeLeaf3) find_entity).getStringVal1());
+                passed = passed && "String-Val2".equals(((ITreeLeaf3) find_entity).getStringVal2());
+                Assert.assertTrue("Assert StringVal1 and StringVal2 are correct.", passed);
+            }
+
+            // 3) Update the entity
+            System.out.println("3) Updating the entity...");
+            find_entity.setName("Updated-" + targetEntityType.getEntityName() + "-1");
+
+            if (new_entity instanceof ITreeLeaf1 || new_entity instanceof IMSCEntity) {
+                ((ITreeLeaf1) find_entity).setIntVal(420);
+            } else if (new_entity instanceof ITreeLeaf2) {
+                ((ITreeLeaf2) find_entity).setFloatVal(420.0f);
+            } else if (new_entity instanceof ITreeLeaf3) {
+                ((ITreeLeaf3) find_entity).setStringVal1("Updated-String-Val1");
+                ((ITreeLeaf3) find_entity).setStringVal2("Updated-String-Val2");
+            }
+
+            System.out.println("Committing transaction...");
+            jpaResource.getTj().commitTransaction();
+
+            // 4) Verify Update
+            System.out.println("4) Verify the updates were saved to the database");
+
+            System.out.println("Clearing persistence context...");
+            jpaResource.getEm().clear();
+
+            System.out.println("Beginning new transaction...");
+            jpaResource.getTj().beginTransaction();
+            if (jpaResource.getTj().isApplicationManaged()) {
+                System.out.println("Joining entitymanager to JTA transaction...");
+                jpaResource.getEm().joinTransaction();
+            }
+
+            ITreeRoot find2_entity = (ITreeRoot) jpaResource.getEm().find(resolveEntityClass(targetEntityType), 1);
+            System.out.println("Object returned by find: " + find2_entity);
+
+            // Verify that em.find() returned an object.
+            Assert.assertNotNull("Assert that the find operation did not return null", find2_entity);
+            if (find2_entity == null) {
+                // If the find returned null, then terminate the remainder of the test.
+                Assert.fail("Find returned null, cancelling the remainder of the test.");
+                return;
+            }
+
+            // Perform basic verifications (4 points)
+            Assert.assertTrue(
+                              "Assert find did not return the original object",
+                              new_entity != find2_entity);
+            Assert.assertTrue(
+                              "Assert entity returned by find is managed by the persistence context.",
+                              jpaResource.getEm().contains(find2_entity));
+            Assert.assertEquals(
+                                "Assert that the entity's id is 1",
+                                find2_entity.getId(),
+                                1);
+            Assert.assertEquals(
+                                "Assert that the entity's name field is \"" + find_entity.getName() + "\"",
+                                find_entity.getName(),
+                                find2_entity.getName());
+
+            // Perform Entity-type specific verifications (1 point)
+            if (find_entity instanceof ITreeLeaf1 || new_entity instanceof IMSCEntity) {
+                Assert.assertEquals("Assert intVal field == " + ((ITreeLeaf1) find_entity).getIntVal(),
+                                    ((ITreeLeaf1) find_entity).getIntVal(),
+                                    ((ITreeLeaf1) find2_entity).getIntVal());
+            } else if (find_entity instanceof ITreeLeaf2) {
+                Assert.assertEquals("Asert floatVal field == " + ((ITreeLeaf2) find_entity).getFloatVal(),
+                                    ((ITreeLeaf2) find_entity).getFloatVal(),
+                                    ((ITreeLeaf2) find2_entity).getFloatVal(), 0.1);
+            } else if (find_entity instanceof ITreeLeaf3) {
+                System.out.println(targetEntityType.getEntityName() + "(id=1).getStringVal1 = " +
+                                   ((ITreeLeaf3) find2_entity).getStringVal1());
+                System.out.println(targetEntityType.getEntityName() + "(id=1).getStringVal2 = " +
+                                   ((ITreeLeaf3) find2_entity).getStringVal2());
+
+                boolean passed = true;
+                passed = passed && ((ITreeLeaf3) find_entity).getStringVal1().equals(((ITreeLeaf3) find2_entity).getStringVal1());
+                passed = passed && ((ITreeLeaf3) find_entity).getStringVal2().equals(((ITreeLeaf3) find2_entity).getStringVal2());
+                Assert.assertTrue("Assert StringVal1 and StringVal2 are correct.", passed);
+            }
+
+            // 6) Delete the entity from the database
+            System.out.println("5) Delete the entity from the database");
+
+            System.out.println("Removing " + targetEntityType.getEntityName() + "(id=1)...");
+            jpaResource.getEm().remove(find2_entity);
+
+            System.out.println("Committing transaction...");
+            jpaResource.getTj().commitTransaction();
+
+            // 7) Verify the entity remove was successful
+            System.out.println("7) Verify the entity remove was successful");
+
+            System.out.println("Clearing persistence context...");
+            jpaResource.getEm().clear();
+
+            // Perform the find operation
+            System.out.println("Finding " + targetEntityType.getEntityName() + "(id=1)...");
+            ITreeRoot removed_entity = (ITreeRoot) jpaResource.getEm().find(resolveEntityClass(targetEntityType), 1);
+            System.out.println("Object returned by find: " + removed_entity);
+
+            // Verify that the entity could not be found.
+            Assert.assertNull("Assert that the find operation did return null", removed_entity);
+
+            System.out.println("Ending test.");
+        } catch (java.lang.AssertionError ae) {
+            throw ae;
+        } catch (Throwable t) {
+            // Catch any Exceptions thrown by the test case for proper error logging.
+            Assert.fail("Caught an unexpected Exception during test execution." + t);
+        } finally {
+            System.out.println("InheritanceTestLogic.testInheritance001(): End");
+        }
+    }
+
+    /**
+     * Test basic CRUD operations with the targeted entity type to verify mapped superclass inheritance.
+     *
+     * Points: 13
+     */
+    public void testMSCInheritance001(TestExecutionContext testExecCtx, TestExecutionResources testExecResources,
+                                      Object managedComponentObject) {
+        // Verify parameters
+        if (testExecCtx == null || testExecResources == null) {
+            Assert.fail("InheritanceTestLogic.testMSCInheritance001: Missing context and/or resources.  Cannot execute the test.");
+            return;
+        }
+
+        // Fetch JPA Resources
+        JPAResource jpaCleanupResource = testExecResources.getJpaResourceMap().get("cleanup");
+        if (jpaCleanupResource == null) {
+            Assert.fail("Missing JPAResource 'cleanup').  Cannot execute the test.");
+            return;
+        }
+        JPAResource jpaResource = testExecResources.getJpaResourceMap().get("test-jpa-resource");
+        if (jpaResource == null) {
+            Assert.fail("Missing JPAResource 'test-jpa-resource').  Cannot execute the test.");
+            return;
+        }
+
+        // Fetch target entity type from test parameters
+        String entityName = (String) testExecCtx.getProperties().get("EntityName");
+        InheritanceEntityEnum targetEntityType = InheritanceEntityEnum.resolveEntityByName(entityName);
+        if (targetEntityType == null) {
+            // Oops, unknown type
+            Assert.fail("Invalid entity type specified ('" + entityName + "').  Cannot execute the test.");
+            return;
+        }
+
+        // Execute Test Case
+        try {
+            System.out.println("InheritanceTestLogic.testMSCInheritance001(): Begin");
+            cleanupDatabase(jpaCleanupResource);
+
+            System.out.println("1) Create and persist " + targetEntityType.getEntityName() + " (id=1).");
+
+            System.out.println("Beginning new transaction...");
+            jpaResource.getTj().beginTransaction();
+            if (jpaResource.getTj().isApplicationManaged()) {
+                System.out.println("Joining entitymanager to JTA transaction...");
+                jpaResource.getEm().joinTransaction();
+            }
+
+            // Clear persistence context
+            System.out.println("Clearing persistence context...");
+            jpaResource.getEm().clear();
+
+            // Construct a new entity instance
+            System.out.println("Creating new object instance of " + targetEntityType.getEntityName() + "...");
+            IMSCEntity new_entity = (IMSCEntity) constructNewEntityObject(targetEntityType);
+            new_entity.setId(1);
+            new_entity.setName("Dr. Doom");
+            new_entity.setDescription("Latveria");
+
+            System.out.println("Persisting " + new_entity);
+            jpaResource.getEm().persist(new_entity);
+
+            System.out.println("Committing transaction...");
+            jpaResource.getTj().commitTransaction();
+
+            // 2) Verify the entity was saved to the database
+            System.out.println("2) Verify the entity was saved to the database");
+
+            System.out.println("Clearing persistence context...");
+            jpaResource.getEm().clear();
+
+            System.out.println("Beginning new transaction...");
+            jpaResource.getTj().beginTransaction();
+            if (jpaResource.getTj().isApplicationManaged()) {
+                System.out.println("Joining entitymanager to JTA transaction...");
+                jpaResource.getEm().joinTransaction();
+            }
+
+            IMSCEntity find_entity = (IMSCEntity) jpaResource.getEm().find(resolveEntityClass(targetEntityType), 1);
+            System.out.println("Object returned by find: " + find_entity);
+
+            // Verify that em.find() returned an object.
+            Assert.assertNotNull("Assert that the find operation did not return null", find_entity);
+            if (find_entity == null) {
+                // If the find returned null, then terminate the remainder of the test.
+                Assert.fail("Find returned null, cancelling the remainder of the test.");
+                return;
+            }
+
+            // Perform basic verifications (4 points)
+            Assert.assertTrue(
+                              "Assert find did not return the original object",
+                              new_entity != find_entity);
+            Assert.assertTrue(
+                              "Assert entity returned by find is managed by the persistence context.",
+                              jpaResource.getEm().contains(find_entity));
+            Assert.assertEquals(
+                                "Assert that the entity's id is 1",
+                                find_entity.getId(),
+                                1);
+            Assert.assertEquals(
+                                "Assert that the entity's name field is \"Dr. Doom\"",
+                                find_entity.getName(),
+                                "Dr. Doom");
+
+            Assert.assertEquals(
+                                "Assert that the entity's description field is \"Latveria\"",
+                                find_entity.getDescription(),
+                                "Latveria");
+
+            // 3) Update the entity
+            System.out.println("3) Updating the entity...");
+            find_entity.setName("Reed Richards");
+            find_entity.setDescription("Baxtrr Building");
+
+            System.out.println("Committing transaction...");
+            jpaResource.getTj().commitTransaction();
+
+            // 4) Verify Update
+            System.out.println("4) Verify the updates were saved to the database");
+
+            System.out.println("Clearing persistence context...");
+            jpaResource.getEm().clear();
+
+            System.out.println("Beginning new transaction...");
+            jpaResource.getTj().beginTransaction();
+            if (jpaResource.getTj().isApplicationManaged()) {
+                System.out.println("Joining entitymanager to JTA transaction...");
+                jpaResource.getEm().joinTransaction();
+            }
+
+            IMSC find2_entity = (IMSC) jpaResource.getEm().find(resolveEntityClass(targetEntityType), 1);
+            System.out.println("Object returned by find: " + find2_entity);
+
+            // Verify that em.find() returned an object.
+            Assert.assertNotNull("Assert that the find operation did not return null", find2_entity);
+            if (find2_entity == null) {
+                // If the find returned null, then terminate the remainder of the test.
+                Assert.fail("Find returned null, cancelling the remainder of the test.");
+                return;
+            }
+
+            // Perform basic verifications (4 points)
+            Assert.assertTrue(
+                              "Assert find did not return the original object",
+                              new_entity != find2_entity);
+            Assert.assertTrue(
+                              "Assert entity returned by find is managed by the persistence context.",
+                              jpaResource.getEm().contains(find2_entity));
+            Assert.assertEquals(
+                                "Assert that the entity's id is 1",
+                                find2_entity.getId(),
+                                1);
+            Assert.assertEquals(
+                                "Assert that the entity's name field is \"Reed Richards\"",
+                                "Reed Richards",
+                                find2_entity.getName());
+
+            Assert.assertEquals(
+                                "Assert that the entity's description field is \"Latveria\"",
+                                find_entity.getDescription(),
+                                "Baxtrr Building");
+
+            // 6) Delete the entity from the database
+            System.out.println("5) Delete the entity from the database");
+
+            System.out.println("Removing " + targetEntityType.getEntityName() + "(id=1)...");
+            jpaResource.getEm().remove(find2_entity);
+
+            System.out.println("Committing transaction...");
+            jpaResource.getTj().commitTransaction();
+
+            // 7) Verify the entity remove was successful
+            System.out.println("7) Verify the entity remove was successful");
+
+            System.out.println("Clearing persistence context...");
+            jpaResource.getEm().clear();
+
+            // Perform the find operation
+            System.out.println("Finding " + targetEntityType.getEntityName() + "(id=1)...");
+            ITreeRoot removed_entity = (ITreeRoot) jpaResource.getEm().find(resolveEntityClass(targetEntityType), 1);
+            System.out.println("Object returned by find: " + removed_entity);
+
+            // Verify that the entity could not be found.
+            Assert.assertNull("Assert that the find operation did return null", removed_entity);
+
+            System.out.println("Ending test.");
+        } catch (java.lang.AssertionError ae) {
+            throw ae;
+        } catch (Throwable t) {
+            // Catch any Exceptions thrown by the test case for proper error logging.
+            Assert.fail("Caught an unexpected Exception during test execution." + t);
+        } finally {
+            System.out.println("InheritanceTestLogic.testMSCInheritance001(): End");
+        }
+    }
+
+    public void testTemplate(TestExecutionContext testExecCtx, TestExecutionResources testExecResources,
+                             Object managedComponentObject) {
+        // Verify parameters
+        if (testExecCtx == null || testExecResources == null) {
+            Assert.fail("InheritanceTestLogic.testTemplate: Missing context and/or resources.  Cannot execute the test.");
+            return;
+        }
+
+        // Fetch JPA Resources
+        JPAResource jpaCleanupResource = testExecResources.getJpaResourceMap().get("cleanup");
+        if (jpaCleanupResource == null) {
+            Assert.fail("Missing JPAResource 'cleanup').  Cannot execute the test.");
+            return;
+        }
+        JPAResource jpaResource = testExecResources.getJpaResourceMap().get("test-jpa-resource");
+        if (jpaResource == null) {
+            Assert.fail("Missing JPAResource 'test-jpa-resource').  Cannot execute the test.");
+            return;
+        }
+
+        // Execute Test Case
+        try {
+            System.out.println("InheritanceTestLogic.testTemplate(): Begin");
+            cleanupDatabase(jpaCleanupResource);
+
+            System.out.println("Ending test.");
+        } catch (java.lang.AssertionError ae) {
+            throw ae;
+        } catch (Throwable t) {
+            // Catch any Exceptions thrown by the test case for proper error logging.
+            Assert.fail("Caught an unexpected Exception during test execution." + t);
+        } finally {
+            System.out.println("InheritanceTestLogic.testTemplate(): End");
+        }
+    }
+
+    private void cleanupDatabase(JPAResource jpaResource) {
+        // Cleanup the database for executing the test
+        System.out.println("Cleaning up database before executing test...");
+        cleanupDatabase(jpaResource.getEm(), jpaResource.getTj(), InheritanceEntityEnum.values());
+        System.out.println("Database cleanup complete.\n");
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/tests/ejb/TestInheritance_EJB_SFEX_Servlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/tests/ejb/TestInheritance_EJB_SFEX_Servlet.java
@@ -1,0 +1,891 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.tests.ejb;
+
+import java.util.HashMap;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceContextType;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceInjectionType;
+import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
+import com.ibm.ws.testtooling.vehicle.web.EJBTestVehicleServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestInheritance_EJB_SFEX_Servlet")
+public class TestInheritance_EJB_SFEX_Servlet extends EJBTestVehicleServlet {
+    private final String testLogicClassName = "com.ibm.ws.jpa.fvt.inheritance.testlogic.InheritanceTestLogic";
+
+    private final HashMap<String, JPAPersistenceContext> jpaPctxMap = new HashMap<String, JPAPersistenceContext>();
+
+    private final static String ejbJNDIName = "ejb/InheritanceSFExEJB";
+
+    @PostConstruct
+    private void initFAT() {
+        jpaPctxMap.put("test-jpa-resource-cmex",
+                       new JPAPersistenceContext("test-jpa-resource-cmex", PersistenceContextType.CONTAINER_MANAGED_ES, PersistenceInjectionType.JNDI, "java:comp/env/jpa/JPAInheritance_CMEX"));
+        jpaPctxMap.put("cleanup",
+                       new JPAPersistenceContext("cleanup", PersistenceContextType.APPLICATION_MANAGED_RL, PersistenceInjectionType.JNDI, "java:comp/env/jpa/cleanup"));
+    }
+
+    /*
+     * Container Managed Transaction Scope
+     */
+
+    //  TABLE-PER-CLASS (Concrete Table) Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_CMEX_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Mapped Superclass Inheritance Tests
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_CMEX_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_CMEX_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_CMEX_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_CMEX_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_CMEX_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmex"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/tests/ejb/TestInheritance_EJB_SF_Servlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/tests/ejb/TestInheritance_EJB_SF_Servlet.java
@@ -1,0 +1,2592 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.tests.ejb;
+
+import java.util.HashMap;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceContextType;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceInjectionType;
+import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
+import com.ibm.ws.testtooling.vehicle.web.EJBTestVehicleServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestInheritance_EJB_SF_Servlet")
+public class TestInheritance_EJB_SF_Servlet extends EJBTestVehicleServlet {
+    private final String testLogicClassName = "com.ibm.ws.jpa.fvt.inheritance.testlogic.InheritanceTestLogic";
+
+    private final HashMap<String, JPAPersistenceContext> jpaPctxMap = new HashMap<String, JPAPersistenceContext>();
+
+    private final static String ejbJNDIName = "ejb/InheritanceSFEJB";
+
+    @PostConstruct
+    private void initFAT() {
+        jpaPctxMap.put("test-jpa-resource-amjta",
+                       new JPAPersistenceContext("test-jpa-resource-amjta", PersistenceContextType.APPLICATION_MANAGED_JTA, PersistenceInjectionType.JNDI, "java:comp/env/jpa/JPAInheritance_AMJTA"));
+        jpaPctxMap.put("test-jpa-resource-amrl",
+                       new JPAPersistenceContext("test-jpa-resource-amrl", PersistenceContextType.APPLICATION_MANAGED_RL, PersistenceInjectionType.JNDI, "java:comp/env/jpa/JPAInheritance_AMRL"));
+        jpaPctxMap.put("test-jpa-resource-cmts",
+                       new JPAPersistenceContext("test-jpa-resource-cmts", PersistenceContextType.CONTAINER_MANAGED_TS, PersistenceInjectionType.JNDI, "java:comp/env/jpa/JPAInheritance_CMTS"));
+        jpaPctxMap.put("cleanup",
+                       new JPAPersistenceContext("cleanup", PersistenceContextType.APPLICATION_MANAGED_RL, PersistenceInjectionType.JNDI, "java:comp/env/jpa/cleanup"));
+
+    }
+
+    /*
+     * Application Managed JTA
+     */
+
+    //  TABLE-PER-CLASS (Concrete Table) Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Mapped Superclass Inheritance Tests
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMJTA_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMJTA_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMJTA_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMJTA_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMJTA_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    /*
+     * Application Managed Resource Local
+     */
+
+    //  TABLE-PER-CLASS (Concrete Table) Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Mapped Superclass Inheritance Tests
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMRL_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMRL_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMRL_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMRL_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMRL_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    /*
+     * Container Managed Transaction Scope
+     */
+
+    //  TABLE-PER-CLASS (Concrete Table) Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SF";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Mapped Superclass Inheritance Tests
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_CMTS_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_CMTS_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_CMTS_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_CMTS_EJB_SF() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_CMTS_EJB_SF";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/tests/ejb/TestInheritance_EJB_SL_Servlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/tests/ejb/TestInheritance_EJB_SL_Servlet.java
@@ -1,0 +1,2592 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.tests.ejb;
+
+import java.util.HashMap;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceContextType;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceInjectionType;
+import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
+import com.ibm.ws.testtooling.vehicle.web.EJBTestVehicleServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestInheritance_EJB_SL_Servlet")
+public class TestInheritance_EJB_SL_Servlet extends EJBTestVehicleServlet {
+    private final String testLogicClassName = "com.ibm.ws.jpa.fvt.inheritance.testlogic.InheritanceTestLogic";
+
+    private final HashMap<String, JPAPersistenceContext> jpaPctxMap = new HashMap<String, JPAPersistenceContext>();
+
+    private final static String ejbJNDIName = "ejb/InheritanceSLEJB";
+
+    @PostConstruct
+    private void initFAT() {
+        jpaPctxMap.put("test-jpa-resource-amjta",
+                       new JPAPersistenceContext("test-jpa-resource-amjta", PersistenceContextType.APPLICATION_MANAGED_JTA, PersistenceInjectionType.JNDI, "java:comp/env/jpa/JPAInheritance_AMJTA"));
+        jpaPctxMap.put("test-jpa-resource-amrl",
+                       new JPAPersistenceContext("test-jpa-resource-amrl", PersistenceContextType.APPLICATION_MANAGED_RL, PersistenceInjectionType.JNDI, "java:comp/env/jpa/JPAInheritance_AMRL"));
+        jpaPctxMap.put("test-jpa-resource-cmts",
+                       new JPAPersistenceContext("test-jpa-resource-cmts", PersistenceContextType.CONTAINER_MANAGED_TS, PersistenceInjectionType.JNDI, "java:comp/env/jpa/JPAInheritance_CMTS"));
+        jpaPctxMap.put("cleanup",
+                       new JPAPersistenceContext("cleanup", PersistenceContextType.APPLICATION_MANAGED_RL, PersistenceInjectionType.JNDI, "java:comp/env/jpa/cleanup"));
+
+    }
+
+    /*
+     * Application Managed JTA
+     */
+
+    //  TABLE-PER-CLASS (Concrete Table) Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Mapped Superclass Inheritance Tests
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMJTA_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMJTA_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMJTA_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMJTA_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMJTA_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    /*
+     * Application Managed Resource Local
+     */
+
+    //  TABLE-PER-CLASS (Concrete Table) Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Mapped Superclass Inheritance Tests
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMRL_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMRL_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMRL_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMRL_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMRL_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    /*
+     * Container Managed Transaction Scope
+     */
+
+    //  TABLE-PER-CLASS (Concrete Table) Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Joined Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Single Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_EJB_SL";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    // Mapped Superclass Inheritance Tests
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_CMTS_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_CMTS_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_CMTS_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_CMTS_EJB_SL() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_CMTS_EJB_SL";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx, ejbJNDIName);
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/tests/web/TestInheritanceServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/src/com/ibm/ws/jpa/fvt/inheritance/tests/web/TestInheritanceServlet.java
@@ -1,0 +1,2611 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.fvt.inheritance.tests.web;
+
+import java.util.HashMap;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceUnit;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.jpa.fvt.inheritance.testlogic.InheritanceTestLogic;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceContextType;
+import com.ibm.ws.testtooling.testinfo.JPAPersistenceContext.PersistenceInjectionType;
+import com.ibm.ws.testtooling.testinfo.TestExecutionContext;
+import com.ibm.ws.testtooling.vehicle.web.JPATestServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/TestInheritanceServlet")
+public class TestInheritanceServlet extends JPATestServlet {
+    // Container Managed Transaction Scope
+    @PersistenceContext(unitName = "Inheritance_JTA")
+    private EntityManager cmtsEm;
+
+    // Application Managed JTA
+    @PersistenceUnit(unitName = "Inheritance_JTA")
+    private EntityManagerFactory amjtaEmf;
+
+    // Application Managed Resource-Local
+    @PersistenceUnit(unitName = "Inheritance_RL")
+    private EntityManagerFactory amrlEmf;
+
+    // Cleanup
+    @PersistenceUnit(unitName = "Cleanup")
+    private EntityManagerFactory cleanupEmf;
+
+    private final String testLogicClassName = InheritanceTestLogic.class.getName();
+
+    private final HashMap<String, JPAPersistenceContext> jpaPctxMap = new HashMap<String, JPAPersistenceContext>();
+
+    @PostConstruct
+    private void initFAT() {
+        jpaPctxMap.put("test-jpa-resource-amjta",
+                       new JPAPersistenceContext("test-jpa-resource-amjta", PersistenceContextType.APPLICATION_MANAGED_JTA, PersistenceInjectionType.FIELD, "amjtaEmf"));
+        jpaPctxMap.put("test-jpa-resource-amrl",
+                       new JPAPersistenceContext("test-jpa-resource-amrl", PersistenceContextType.APPLICATION_MANAGED_RL, PersistenceInjectionType.FIELD, "amrlEmf"));
+        jpaPctxMap.put("test-jpa-resource-cmts",
+                       new JPAPersistenceContext("test-jpa-resource-cmts", PersistenceContextType.CONTAINER_MANAGED_TS, PersistenceInjectionType.FIELD, "cmtsEm"));
+        jpaPctxMap.put("cleanup",
+                       new JPAPersistenceContext("cleanup", PersistenceContextType.APPLICATION_MANAGED_RL, PersistenceInjectionType.FIELD, "cleanupEmf"));
+
+    }
+
+    /*
+     * Application Managed JTA
+     */
+
+    //  TABLE-PER-CLASS (Concrete Table) Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Joined Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Joined Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Joined Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Single Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Single Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Single Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMJTA_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Mapped Superclass Inheritance Tests
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMJTA_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMJTA_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMJTA_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMJTA_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMJTA_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amjta"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    /*
+     * Application Managed Resource Local
+     */
+
+    //  TABLE-PER-CLASS (Concrete Table) Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Joined Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Joined Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Joined Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Single Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Single Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Single Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_AMRL_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Mapped Superclass Inheritance Tests
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_AMRL_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_AMRL_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_AMRL_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMRL_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_AMRL_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-amrl"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    /*
+     * Container Managed Transaction Scope
+     */
+
+    //  TABLE-PER-CLASS (Concrete Table) Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf1_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf2_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_Concrete_Leaf3_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLConcreteTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Joined Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Joined Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Joined Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_JoinedTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLJTSDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Single Table, Character Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf1_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf2_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_CharDisc_Leaf3_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTCDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Single Table, Integer Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf1_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf2_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf2Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_IntDisc_Leaf3_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTIDTreeLeaf3Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Single Table, String Discrminator Ano and XML Tests
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_Ano_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf1_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf2_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_SingleTable_StringDisc_Leaf3_CRUDTest_001_XML_CMTS_Web";
+        final String testMethod = "testInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLSTSDTreeLeaf1Entity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    // Mapped Superclass Inheritance Tests
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_AnoEntity_CRUDTest_001_CMTS_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_AnoMSC_XMLEntity_CRUDTest_001_CMTS_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLAnoMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_AnoEntity_CRUDTest_001_CMTS_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "AnoXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+
+    @Test
+    public void jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_CMTS_Web() throws Exception {
+        final String testName = "jpa10_Inheritance_MappedSuperclass_XMLMSC_XMLEntity_CRUDTest_001_CMTS_Web";
+        final String testMethod = "testMSCInheritance001";
+
+        final TestExecutionContext testExecCtx = new TestExecutionContext(testName, testLogicClassName, testMethod);
+
+        final HashMap<String, JPAPersistenceContext> jpaPCInfoMap = testExecCtx.getJpaPCInfoMap();
+        jpaPCInfoMap.put("test-jpa-resource", jpaPctxMap.get("test-jpa-resource-cmts"));
+        jpaPCInfoMap.put("cleanup", jpaPctxMap.get("cleanup"));
+
+        HashMap<String, java.io.Serializable> properties = testExecCtx.getProperties();
+        properties.put("EntityName", "XMLXMLMSCEntity");
+
+        executeDDL("JPA10_INHERITANCE_DELETE_${dbvendor}.ddl");
+        executeTestVehicle(testExecCtx);
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/META-INF/application.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/META-INF/application.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<application xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="5"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd"
+	id="Application_ID">
+
+	<display-name>Inheritance_Web</display-name>
+	<module id="WebModule_1">
+        <web>
+            <web-uri>inheritance.war</web-uri>
+            <context-root>Inheritance10Web</context-root>
+        </web>
+    </module>
+</application>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/META-INF/permissions.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd" 
+             version="7">
+   <permission>
+      <class-name>java.lang.reflect.ReflectPermission</class-name>
+      <name>suppressAccessChecks</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>getClassLoader</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>accessDeclaredMembers</name>
+   </permission>
+   <permission>
+      <class-name>java.lang.RuntimePermission</class-name>
+      <name>createClassLoader</name>
+   </permission>
+   <permission>
+      <class-name>java.io.FilePermission</class-name>
+      <name>-</name>
+      <actions>read</actions>
+   </permission>
+   <permission>
+      <class-name>java.net.URLPermission</class-name>
+      <name>http://localhost:*/DatabaseManagement/DMS</name>
+      <actions>GET</actions>
+   </permission>
+
+</permissions>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/classes/META-INF/orm.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/classes/META-INF/orm.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
 <entity-mappings
     xmlns="http://java.sun.com/xml/ns/persistence/orm"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/classes/META-INF/orm.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/classes/META-INF/orm.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-mappings
+    xmlns="http://java.sun.com/xml/ns/persistence/orm"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_1_0.xsd"
+    version="1.0">
+    
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>  
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeMSC">
+        <attributes>
+            <basic name="stringVal1"/>
+        </attributes>
+    </mapped-superclass>
+    <mapped-superclass 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml.XMLMSC">
+        <attributes>
+            <id name="id"/>
+            <basic name="name"/>
+            <basic name="nameAO"><column name="originalNameAO" /></basic>
+            <transient name="parsedName"/>
+        </attributes>
+    </mapped-superclass>
+    
+    <!-- Mapped Superclass -->
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.msc.ano.XMLAnoMSCEntity">
+        <attributes>
+            <basic name="description"></basic>
+        </attributes>
+    </entity>
+    
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.msc.xml.XMLXMLMSCEntity">
+        <attributes>
+            <basic name="description"></basic>
+        </attributes>
+    </entity>
+    <!-- -->
+    
+    <!-- Table Per Class Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeRootEntity">
+        <inheritance strategy="TABLE_PER_CLASS" />
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeLeaf1Entity">
+        <table name="XMLConcreteLeaf1"></table>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeLeaf2Entity">
+        <table name="XMLConcreteLeaf2"></table>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.concretetable.xml.XMLConcreteTreeLeaf3Entity">
+        <table name="XMLConcreteLeaf3"></table>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Join-Table Char-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeRootEntity">
+        <table name="XMLJTCDRoot"/>
+        <inheritance strategy="JOINED" />
+        <discriminator-value>A</discriminator-value>
+        <discriminator-column discriminator-type="CHAR" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeLeaf1Entity">
+        <table name="XMLJTCDLeaf1"></table>
+        <discriminator-value>B</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeLeaf2Entity">
+        <table name="XMLJTCDLeaf2"></table>
+        <discriminator-value>C</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTCDTreeLeaf3Entity">
+        <table name="XMLJTCDLeaf3"></table>
+        <discriminator-value>D</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Join-Table Integer-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeRootEntity">
+        <table name="XMLJTIDRoot"/>
+        <inheritance strategy="JOINED" />
+        <discriminator-column discriminator-type="INTEGER" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeLeaf1Entity">
+        <table name="XMLJTIDLeaf1"></table>
+        <discriminator-value>1</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeLeaf2Entity">
+        <table name="XMLJTIDLeaf2"></table>
+        <discriminator-value>2</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTIDTreeLeaf3Entity">
+        <table name="XMLJTIDLeaf3"></table>
+        <discriminator-value>3</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Join-Table String-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeRootEntity">
+        <table name="XMLJTSDRoot"/>
+        <inheritance strategy="JOINED" />
+        <discriminator-column discriminator-type="STRING" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeLeaf1Entity">
+        <table name="XMLJTSDLeaf1"></table>
+        <discriminator-value>XMLJTSDTreeLeaf1Entity</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeLeaf2Entity">
+        <table name="XMLJTSDLeaf2"></table>
+        <discriminator-value>XMLJTSDTreeLeaf2Entity</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.jointable.xml.XMLJTSDTreeLeaf3Entity">
+        <table name="XMLJTSDLeaf3"></table>
+        <discriminator-value>XMLJTSDTreeLeaf3Entity</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Single-Table Char-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeRootEntity">
+        <table name="XMLSTCDRoot"/>
+        <inheritance strategy="SINGLE_TABLE" />
+        <discriminator-value>A</discriminator-value>
+        <discriminator-column discriminator-type="CHAR" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeLeaf1Entity">
+        <discriminator-value>B</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeLeaf2Entity">
+        <discriminator-value>C</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTCDTreeLeaf3Entity">
+        <discriminator-value>D</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Single-Table Integer-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeRootEntity">
+        <table name="XMLSTIDRoot"/>
+        <inheritance strategy="SINGLE_TABLE" />
+        <discriminator-column discriminator-type="INTEGER" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeLeaf1Entity">
+        <discriminator-value>1</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeLeaf2Entity">
+        <discriminator-value>2</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTIDTreeLeaf3Entity">
+        <discriminator-value>3</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    <!-- Single-Table String-Discriminator Inheritance Mapping -->   
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeRootEntity">
+        <table name="XMLSTSDRoot"/>
+        <inheritance strategy="SINGLE_TABLE" />
+        <discriminator-column discriminator-type="STRING" name="DISC_COL"/>
+        <attributes>
+            <id name="id"></id>
+            <basic name="name"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeLeaf1Entity">
+        <discriminator-value>XMLSTCDTreeLeaf1Entity</discriminator-value>
+        <attributes>
+            <basic name="intVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeLeaf2Entity">
+        <discriminator-value>XMLSTIDTreeLeaf2Entity</discriminator-value>
+        <attributes>
+            <basic name="floatVal"></basic>
+        </attributes>
+    </entity>
+    <entity 
+        class="com.ibm.ws.jpa.fvt.inheritance.entities.singletable.xml.XMLSTSDTreeLeaf3Entity">
+        <discriminator-value>XMLSTSDTreeLeaf3Entity</discriminator-value>
+        <attributes>
+            <basic name="stringVal2"></basic>
+        </attributes>
+    </entity>
+    
+    
+    
+ </entity-mappings>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+    version="1.0">
+
+    <persistence-unit name="Cleanup" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>java:comp/env/jdbc/JPA_NJTADS</non-jta-data-source>
+        <properties>
+            <property name="openjpa.jdbc.DBDictionary" value="StoreCharsAsNumbers=false"/>
+            <property name="eclipselink.logging.parameters" value="true"/>
+        	<property name="eclipselink.cache.shared.default" value="false"/>
+        </properties>
+    </persistence-unit>
+    
+    <persistence-unit name="Inheritance_JTA">
+        <jta-data-source>java:comp/env/jdbc/JPA_DS</jta-data-source>
+        <properties>
+            <property name="openjpa.jdbc.DBDictionary" value="StoreCharsAsNumbers=false"/>
+            <property name="eclipselink.logging.parameters" value="true"/>
+        	<property name="eclipselink.cache.shared.default" value="false"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="Inheritance_RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>java:comp/env/jdbc/JPA_NJTADS</non-jta-data-source>
+        <properties>
+            <property name="openjpa.jdbc.DBDictionary" value="StoreCharsAsNumbers=false"/>
+            <property name="eclipselink.logging.parameters" value="true"/>
+        	<property name="eclipselink.cache.shared.default" value="false"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/classes/META-INF/persistence.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/ibm-web-bnd.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<web-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd"
+	version="1.0">
+
+	<virtual-host name="default_host" />
+	<resource-ref name="jdbc/JPA_DS"     binding-name="jdbc/JPA_DS" />
+	<resource-ref name="jdbc/JPA_NJTADS" binding-name="jdbc/JPA_NJTADS" />
+
+</web-bnd>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpa10/inheritance/web/inheritance.war/WEB-INF/web.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    version="2.5">
+
+    <!-- Resource Ref Definitions -->
+    <resource-ref>
+        <res-ref-name>jdbc/JPA_DS</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+    </resource-ref>
+    <resource-ref>
+        <res-ref-name>jdbc/JPA_NJTADS</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+    </resource-ref>
+</web-app>


### PR DESCRIPTION
Migrate JPA Inheritance JPA10 bucket to Open Liberty.

Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>
