### PR TITLE
raise DefinitionException when misconfigured

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/MPConfigAccessorImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/MPConfigAccessorImpl.java
@@ -41,7 +41,21 @@ public class MPConfigAccessorImpl implements MPConfigAccessor {
         Class<?> cl = defaultValue == null ? String[].class : defaultValue.getClass();
         @SuppressWarnings("unchecked")
         Optional<T> configuredValue = (Optional<T>) ((Config) config).getOptionalValue(name, cl);
-        return configuredValue.orElse(defaultValue);
+        T value = configuredValue.orElse(defaultValue);
+
+        // MicroProfile Config is unclear about whether empty value for String[] results in
+        // an empty String array or a size 1 String array where the element is the empty string.
+        // Allow for both possibilities,
+        if (value instanceof String[]) {
+            String[] arr = ((String[]) value);
+            if (arr.length == 1 && arr[0].length() == 0) {
+                @SuppressWarnings("unchecked")
+                T emptyArray = (T) new String[0];
+                value = emptyArray;
+            }
+        }
+
+        return value;
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ManagedExecutorBean.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ManagedExecutorBean.java
@@ -29,8 +29,6 @@ import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.inject.spi.PassivationCapable;
 
 import org.eclipse.microprofile.concurrent.ManagedExecutor;
-import org.eclipse.microprofile.concurrent.ManagedExecutor.Builder;
-import org.eclipse.microprofile.concurrent.ManagedExecutorConfig;
 import org.eclipse.microprofile.concurrent.NamedInstance;
 
 import com.ibm.websphere.ras.annotation.Trivial;
@@ -40,34 +38,28 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
     private static final Type[] TYPE_ARR = { ManagedExecutor.class, ExecutorService.class, Executor.class };
     private static final Set<Type> TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(TYPE_ARR)));
 
-    // This instance is used as a marker for when no configured is specified for a String[]. The reference is compared; its content does not matter.
-    private static final String[] UNSPECIFIED_ARRAY = new String[] {};
-
     private final String injectionPointName;
     private final String instanceName;
     private final Set<Annotation> qualifiers;
-    private final ManagedExecutorConfig config;
-    private final ConcurrencyCDIExtension cdiExtension;
+    private final ManagedExecutor executor;
 
     // TODO remove this constructor given the decision not to supply unqualified instance for programmatic lookup
-    public ManagedExecutorBean(ConcurrencyCDIExtension cdiExtension) {
+    public ManagedExecutorBean() {
         this.injectionPointName = getClass().getCanonicalName();
         this.instanceName = getClass().getCanonicalName();
-        this.config = null;
-        this.cdiExtension = cdiExtension;
+        this.executor = null;
         Set<Annotation> qualifiers = new HashSet<>(2);
         qualifiers.add(Any.Literal.INSTANCE);
         qualifiers.add(Default.Literal.INSTANCE);
         this.qualifiers = Collections.unmodifiableSet(qualifiers);
     }
 
-    public ManagedExecutorBean(String injectionPointName, String instanceName, ManagedExecutorConfig config, ConcurrencyCDIExtension cdiExtension) {
+    public ManagedExecutorBean(String injectionPointName, String instanceName, ManagedExecutor executor) {
         Objects.requireNonNull(injectionPointName);
         Objects.requireNonNull(instanceName);
         this.injectionPointName = injectionPointName;
         this.instanceName = instanceName;
-        this.config = config;
-        this.cdiExtension = cdiExtension;
+        this.executor = executor;
         Set<Annotation> qualifiers = new HashSet<>(2);
         qualifiers.add(Any.Literal.INSTANCE);
         qualifiers.add(NamedInstance.Literal.of(instanceName));
@@ -76,46 +68,7 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
 
     @Override
     public ManagedExecutor create(CreationalContext<ManagedExecutor> cc) {
-        Builder b = ManagedExecutor.builder();
-        MPConfigAccessor configAccessor = cdiExtension.mpConfigAccessor;
-        if (configAccessor == null) {
-            if (config != null) {
-                b.maxAsync(config.maxAsync());
-                b.maxQueued(config.maxQueued());
-                b.propagated(config.propagated());
-                b.cleared(config.cleared());
-            }
-        } else {
-            Object mpConfig = cdiExtension.mpConfig;
-
-            int start = injectionPointName.length() + 1;
-            int len = start + 10;
-            StringBuilder propName = new StringBuilder(len).append(injectionPointName).append('.');
-
-            // In order to efficiently reuse StringBuilder, properties are added in the order of the length of their names,
-
-            propName.append("cleared");
-            String[] c = configAccessor.get(mpConfig, propName.toString(), config == null ? UNSPECIFIED_ARRAY : config.cleared());
-            if (c != UNSPECIFIED_ARRAY)
-                b.cleared(c);
-
-            propName.replace(start, len, "maxAsync");
-            Integer a = configAccessor.get(mpConfig, propName.toString(), config == null ? null : config.maxAsync());
-            if (a != null)
-                b.maxAsync(a);
-
-            propName.replace(start, len, "maxQueued");
-            Integer q = configAccessor.get(mpConfig, propName.toString(), config == null ? null : config.maxQueued());
-            if (q != null)
-                b.maxQueued(q);
-
-            propName.replace(start, len, "propagated");
-            String[] p = configAccessor.get(mpConfig, propName.toString(), config == null ? UNSPECIFIED_ARRAY : config.propagated());
-            if (p != UNSPECIFIED_ARRAY)
-                b.propagated(p);
-        }
-
-        return b.build();
+        return executor;
     }
 
     @Override


### PR DESCRIPTION
Per the MP Concurrency spec, DefinitionException must be raised when injection points for ManagedExecutor and ThreadContext are supplied with invalid configuration.