### PR TITLE
New implementation of AsyncBulkheadState

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/bnd.bnd
@@ -39,7 +39,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 Include-Resource: \
   @${repo;com.ibm.ws.microprofile.faulttolerance}!/!(OSGI-INF)/*
 
-src: src,resources
+src: src
 testsrc: test/src
 
 -buildpath: \
@@ -71,6 +71,4 @@ testsrc: test/src
         org.slf4j:slf4j-api;version=1.7.7, \
         org.slf4j:slf4j-jdk14;version=1.7.7, \
         com.ibm.websphere.javaee.jsonp.1.0;version=latest, \
-        org.apache.commons:commons-lang3;version=3.7, \
-        ./resources/;version=file
-
+        org.apache.commons:commons-lang3;version=3.7

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutor.java
@@ -25,6 +25,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.microprofile.faulttolerance.spi.BulkheadPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.CircuitBreakerPolicy;
@@ -35,6 +36,7 @@ import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance.spi.RetryPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.TimeoutPolicy;
 import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState;
+import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState.BulkheadReservation;
 import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState.ExceptionHandler;
 import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState.ExecutionReference;
 import com.ibm.ws.microprofile.faulttolerance20.state.CircuitBreakerState;
@@ -42,7 +44,6 @@ import com.ibm.ws.microprofile.faulttolerance20.state.FaultToleranceStateFactory
 import com.ibm.ws.microprofile.faulttolerance20.state.RetryState;
 import com.ibm.ws.microprofile.faulttolerance20.state.RetryState.RetryResult;
 import com.ibm.ws.microprofile.faulttolerance20.state.TimeoutState;
-import com.ibm.ws.threading.PolicyExecutorProvider;
 
 /**
  * Abstract executor for asynchronous calls.
@@ -54,6 +55,35 @@ import com.ibm.ws.threading.PolicyExecutorProvider;
  * <p>
  * If an internal exception occurs, this may be thrown directly from the {@link #execute(Callable, ExecutionContext)} method, or logged and propagated back to the user via the
  * result wrapper.
+ * <p>
+ * Flow through this class:
+ * <p>
+ * On the calling thread:
+ * <ul>
+ * <li>start at {@code execute()} (called by the fault tolerance interceptor)</li>
+ * <li>create a return wrapper and store it in the execution context (see createReturnWrapper)</li>
+ * <li>enqueue the first execution attempt to run on another thread (by submitting a task to the AsyncBulkheadState, see enqueueAttempt)</li>
+ * <li>return the return wrapper to the interceptor</li>
+ * </ul>
+ * <p>
+ * Each execution attempt runs on another thread:
+ * <ul>
+ * <li>entry point is {@code runExecutionAttempt}</li>
+ * <li>the user's method is run and the result is stored in a MethodResult</li>
+ * <li>fault tolerance policies are applied based on the MethodResult (see processMethodResult and finalizeAttempt)</li>
+ * <li>if it's determined that a retry should be run, a new execution attempt is enqueued to run on another thread (see enqueueAttempt)</li>
+ * <li>otherwise, the MethodResult is set into the return wrapper and the execution is complete (see commitResult)</li>
+ * </ul>
+ * <p>
+ * There are also some complications that can disrupt the normal flow:
+ * <ul>
+ * <li>If a timeout occurs, the {@code timeout()} method is called where we try to abort the attempt (interrupting it if it's running) and do the fault tolerance handling (by
+ * calling finalizeAttempt)</li>
+ * <li>If the user cancels the execution, we try to abort the current attempt and do the fault tolerance handling (calling finalizeAttempt). We'll never retry if the user has tried
+ * to cancel.</li>
+ * <li>If an unexpected exception is caught, we call {@code handleException()} which will log an FFDC, return the exception as the result to the user and call finalizeAttempt to
+ * record a failure and ensure any reserved resources are released.</li>
+ * </ul>
  *
  * @param <W> the return type of the code being executed, which is also the type of the return wrapper (e.g. {@code Future<String>})
  */
@@ -62,13 +92,13 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
     private static final TraceComponent tc = Tr.register(AsyncExecutor.class);
 
     public AsyncExecutor(RetryPolicy retry, CircuitBreakerPolicy cbPolicy, TimeoutPolicy timeoutPolicy, FallbackPolicy fallbackPolicy, BulkheadPolicy bulkheadPolicy,
-                         ScheduledExecutorService executorService, PolicyExecutorProvider policyExecutorProvider, MetricRecorder metricRecorder) {
+                         ScheduledExecutorService executorService, MetricRecorder metricRecorder) {
         retryPolicy = retry;
         circuitBreaker = FaultToleranceStateFactory.INSTANCE.createCircuitBreakerState(cbPolicy, metricRecorder);
         this.timeoutPolicy = timeoutPolicy;
         this.executorService = executorService;
         this.fallbackPolicy = fallbackPolicy;
-        bulkhead = FaultToleranceStateFactory.INSTANCE.createAsyncBulkheadState(policyExecutorProvider, executorService, bulkheadPolicy, metricRecorder);
+        bulkhead = FaultToleranceStateFactory.INSTANCE.createAsyncBulkheadState(executorService, bulkheadPolicy, metricRecorder);
         this.metricRecorder = metricRecorder;
     }
 
@@ -143,8 +173,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
 
         timeout.start();
 
-        ExecutionReference ref = bulkhead.submit(handleExceptions(() -> runExecutionAttempt(attemptContext), attemptContext, executionContext),
-                                                 getExceptionHandler(attemptContext));
+        ExecutionReference ref = bulkhead.submit((reservation) -> runExecutionAttempt(attemptContext, reservation), getExceptionHandler(attemptContext));
 
         if (!ref.wasAccepted()) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
@@ -168,35 +197,57 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
      * Run one attempt at the execution {@link #execute(Callable, ExecutionContext)}
      */
     @FFDCIgnore(Throwable.class)
-    private void runExecutionAttempt(AsyncAttemptContextImpl<W> attemptContext) {
+    private void runExecutionAttempt(AsyncAttemptContextImpl<W> attemptContext, BulkheadReservation reservation) {
         AsyncExecutionContextImpl<W> executionContext = attemptContext.getExecutionContext();
-
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Method {0} running execution attempt", executionContext.getMethod());
-        }
-
-        MethodResult<W> methodResult;
         try {
-            W result = executionContext.getCallable().call();
-            methodResult = MethodResult.success(result);
-        } catch (Throwable e) {
-            methodResult = MethodResult.failure(e);
-        }
-
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Method {0} attempt execution reuslt: {1}", executionContext.getMethod(), methodResult);
-        }
-
-        finalizeAttempt(attemptContext, methodResult);
-
-        if (attemptContext.getTimeoutState().isTimedOut()) {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Method {0} timed out, clearing interrupted flag", executionContext.getMethod());
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                Tr.event(tc, "Method {0} running execution attempt", executionContext.getMethod());
             }
 
-            Thread.interrupted(); // Clear interrupted thread
-        }
+            MethodResult<W> methodResult;
+            try {
+                W result = executionContext.getCallable().call();
+                methodResult = MethodResult.success(result);
+            } catch (Throwable e) {
+                methodResult = MethodResult.failure(e);
+            }
 
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                Tr.event(tc, "Method {0} attempt execution reuslt: {1}", executionContext.getMethod(), methodResult);
+            }
+
+            processMethodResult(attemptContext, methodResult, reservation);
+
+            if (attemptContext.getTimeoutState().isTimedOut()) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Method {0} timed out, clearing interrupted flag", executionContext.getMethod());
+                }
+
+                Thread.interrupted(); // Clear interrupted thread
+            }
+        } catch (Throwable t) {
+            // Handle any Unexpected exceptions
+            // Manual FFDC since we've ignored it for the catch above
+            String sourceId = AsyncExecutor.class.getName() + "runExecutionAttempt";
+            FFDCFilter.processException(t, sourceId, "errorBarrier", this);
+
+            // Release bulkhead before handling exception so we don't leak permits
+            reservation.release();
+            handleException(t, attemptContext, executionContext);
+        }
+    }
+
+    /**
+     * Called to process the result of a call to the user's method
+     * <p>
+     * If a timeout or cancellation occurs prevents the user's method from being called, this method will not be called.
+     * <p>
+     * If a timeout or cancellation occurs while the user's method is running, this method will only be called when the user's method actually returns
+     */
+    protected void processMethodResult(AsyncAttemptContextImpl<W> attemptContext, MethodResult<W> methodResult, BulkheadReservation reservation) {
+        // Release bulkhead permit
+        reservation.release();
+        finalizeAttempt(attemptContext, methodResult);
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncFutureExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncFutureExecutor.java
@@ -22,7 +22,6 @@ import com.ibm.ws.microprofile.faulttolerance.spi.FallbackPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance.spi.RetryPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.TimeoutPolicy;
-import com.ibm.ws.threading.PolicyExecutorProvider;
 
 /**
  * Executor for Asynchronous calls which return a {@link Future}
@@ -34,8 +33,8 @@ public class AsyncFutureExecutor<R> extends AsyncExecutor<Future<R>> {
     private static final TraceComponent tc = Tr.register(AsyncFutureExecutor.class);
 
     public AsyncFutureExecutor(RetryPolicy retry, CircuitBreakerPolicy cbPolicy, TimeoutPolicy timeoutPolicy, FallbackPolicy fallbackPolicy, BulkheadPolicy bulkheadPolicy,
-                               ScheduledExecutorService executorService, PolicyExecutorProvider policyExecutorProvider, MetricRecorder metricRecorder) {
-        super(retry, cbPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, executorService, policyExecutorProvider, metricRecorder);
+                               ScheduledExecutorService executorService, MetricRecorder metricRecorder) {
+        super(retry, cbPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, executorService, metricRecorder);
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/ExecutorBuilderImpl20.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/ExecutorBuilderImpl20.java
@@ -34,9 +34,9 @@ public class ExecutorBuilderImpl20<T, R> extends ExecutorBuilderImpl<T, R> {
     @Override
     public <W> Executor<W> buildAsync(Class<?> asyncResultWrapperType) {
         if (asyncResultWrapperType == Future.class) {
-            return (Executor<W>) new AsyncFutureExecutor<Object>(retryPolicy, circuitBreakerPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, scheduledExecutorService, policyExecutorProvider, metricRecorder);
+            return (Executor<W>) new AsyncFutureExecutor<Object>(retryPolicy, circuitBreakerPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, scheduledExecutorService, metricRecorder);
         } else if (asyncResultWrapperType == CompletionStage.class) {
-            return (Executor<W>) new AsyncCompletionStageExecutor<Object>(retryPolicy, circuitBreakerPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, scheduledExecutorService, policyExecutorProvider, metricRecorder);
+            return (Executor<W>) new AsyncCompletionStageExecutor<Object>(retryPolicy, circuitBreakerPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, scheduledExecutorService, metricRecorder);
         } else {
             throw new IllegalArgumentException("Invalid return type for async execution: " + asyncResultWrapperType);
         }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/AsyncBulkheadState.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/AsyncBulkheadState.java
@@ -19,7 +19,14 @@ package com.ibm.ws.microprofile.faulttolerance20.state;
  *
  * <pre>
  * <code>
- * ExecutionReference reference = asyncBulkheadState.submit(() -> {codeToRun()});
+ * ExecutionReference reference = asyncBulkheadState.submit((reservation) -> {
+ *   try {
+ *     codeToRun();
+ *   } finally {
+ *     reservation.release();
+ *   }
+ * });
+ *
  * if (!reference.wasAccepted) {
  *   throw new BulkheadException();
  * }
@@ -35,16 +42,36 @@ public interface AsyncBulkheadState {
      * <p>
      * The exception handler will be called if an exception occurs handling the runnable after the submit method has returned.
      *
-     * @param runnable the runnable
+     * @param task             the task to run
      * @param exceptionHandler the exception handler
      * @return an ExecutionReference, allowing the caller to see whether the execution was accepted and to abort later if required
      */
-    public ExecutionReference submit(Runnable runnable, ExceptionHandler exceptionHandler);
+    public ExecutionReference submit(AsyncBulkheadTask task, ExceptionHandler exceptionHandler);
 
     /**
      * Shutdown the bulkhead. Any new tasks will be rejected.
      */
     public void shutdown();
+
+    /**
+     * A task that can be run by an async bulkhead
+     * <p>
+     * This is basically a Runnable except the run method takes a {@link BulkheadReservation} parameter
+     */
+    @FunctionalInterface
+    public interface AsyncBulkheadTask {
+
+        /**
+         * Run the task
+         * <p>
+         * All implementations of this method must ensure that {@code reservation.release()} is always called (whether execution of the task is successful or fails).
+         * Failure to do this will result in bulkhead permits being leaked.
+         *
+         * @param bulkheadReservation a callback to indicate that execution is complete and the bulkhead reservation should be released
+         */
+        public void run(BulkheadReservation reservation);
+
+    }
 
     /**
      * A reference to an execution submitted to the bulkhead
@@ -65,6 +92,18 @@ public interface AsyncBulkheadState {
          * @return {@code true} if the runnable was accepted, {@code false} otherwise
          */
         public boolean wasAccepted();
+    }
+
+    /**
+     * A reference to the reservation on the bulkhead
+     * <p>
+     * Allows the task to release it's reservation on the bulkhead when its work is done, allowing another task to run
+     */
+    public interface BulkheadReservation {
+        /**
+         * Report that the execution is complete, releasing the bulkhead permit
+         */
+        public void release();
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/FaultToleranceStateFactory.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/FaultToleranceStateFactory.java
@@ -27,7 +27,6 @@ import com.ibm.ws.microprofile.faulttolerance20.state.impl.SyncBulkheadStateImpl
 import com.ibm.ws.microprofile.faulttolerance20.state.impl.SyncBulkheadStateNullImpl;
 import com.ibm.ws.microprofile.faulttolerance20.state.impl.TimeoutStateImpl;
 import com.ibm.ws.microprofile.faulttolerance20.state.impl.TimeoutStateNullImpl;
-import com.ibm.ws.threading.PolicyExecutorProvider;
 
 /**
  * Factory for creating Fault Tolerance State objects, which implement one of the fault tolerance policies.
@@ -42,7 +41,8 @@ public class FaultToleranceStateFactory {
     public static final FaultToleranceStateFactory INSTANCE = new FaultToleranceStateFactory();
 
     // Singleton: no public constructor
-    private FaultToleranceStateFactory() {}
+    private FaultToleranceStateFactory() {
+    }
 
     /**
      * Create an object implementing Retry
@@ -111,12 +111,11 @@ public class FaultToleranceStateFactory {
      * @param policy           the BulkheadPolicy, may be {@code null}
      * @return a new AsyncBulkheadState
      */
-    public AsyncBulkheadState createAsyncBulkheadState(PolicyExecutorProvider executorProvider, ScheduledExecutorService executorService, BulkheadPolicy policy,
-                                                       MetricRecorder metricRecorder) {
+    public AsyncBulkheadState createAsyncBulkheadState(ScheduledExecutorService executorService, BulkheadPolicy policy, MetricRecorder metricRecorder) {
         if (policy == null) {
             return new AsyncBulkheadStateNullImpl(executorService);
         } else {
-            return new AsyncBulkheadStateImpl(executorProvider, policy, metricRecorder);
+            return new AsyncBulkheadStateImpl(executorService, policy, metricRecorder);
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/AsyncBulkheadStateImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/AsyncBulkheadStateImpl.java
@@ -10,92 +10,246 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance20.state.impl;
 
-import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
 
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.microprofile.faulttolerance.spi.BulkheadPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState;
-import com.ibm.ws.threading.PolicyExecutor;
-import com.ibm.ws.threading.PolicyExecutorProvider;
-import com.ibm.ws.threading.PolicyTaskCallback;
-import com.ibm.ws.threading.PolicyTaskFuture;
 
 /**
- * Implements the asynchronous bulkhead using a {@link PolicyExecutor}
+ * An implementation of {@link AsyncBulkheadState} which implements a {@link BulkheadPolicy} and reports metrics to a {@link MetricRecorder}
  */
 public class AsyncBulkheadStateImpl implements AsyncBulkheadState {
 
-    private final PolicyExecutor executorService;
+    private final ExecutorService executorService;
     private final MetricRecorder metrics;
 
-    public AsyncBulkheadStateImpl(PolicyExecutorProvider executorProvider, BulkheadPolicy policy, MetricRecorder metricRecorder) {
-        this.executorService = executorProvider.create("Fault Tolerance-" + UUID.randomUUID());
+    /**
+     * The queue to store tasks which have been submitted but there isn't space to run yet
+     */
+    private final BlockingQueue<ExecutionTask> queue;
+
+    /**
+     * The semaphore used to limit the number of concurrently running tasks
+     */
+    private final Semaphore runningSemaphore;
+
+    public AsyncBulkheadStateImpl(ExecutorService executorService, BulkheadPolicy policy, MetricRecorder metricRecorder) {
+        this.executorService = executorService;
         final int queueSize = policy.getQueueSize();
-        executorService.maxConcurrency(policy.getMaxThreads());
-        executorService.maxQueueSize(queueSize);
+        queue = new LinkedBlockingQueue<>(queueSize);
+        final int maxThreads = policy.getMaxThreads();
+        runningSemaphore = new Semaphore(maxThreads);
         this.metrics = metricRecorder;
-        metrics.setBulkheadConcurentExecutionCountSupplier(executorService::getRunningTaskCount);
-        metrics.setBulkheadQueuePopulationSupplier(() -> queueSize - executorService.queueCapacityRemaining());
-        // TODO: add recording of queue and execution times
+        metrics.setBulkheadConcurentExecutionCountSupplier(() -> maxThreads - runningSemaphore.availablePermits());
+        metrics.setBulkheadQueuePopulationSupplier(queue::size);
     }
 
+    /** {@inheritDoc} */
     @Override
-    @FFDCIgnore(RejectedExecutionException.class)
-    public ExecutionReference submit(Runnable runnable, ExceptionHandler exceptionHandler) {
-        ExecutionReferenceImpl execution = new ExecutionReferenceImpl();
-        try {
-            execution.future = executorService.submit(runnable, new TaskMonitor(exceptionHandler));
-            execution.accepted = true;
+    public ExecutionReference submit(AsyncBulkheadTask task, ExceptionHandler exceptionHandler) {
+        ExecutionTask execution = new ExecutionTask(task, exceptionHandler);
+        execution.enqueue();
+
+        if (execution.wasAccepted()) {
             metrics.incrementBulkeadAcceptedCount();
-        } catch (RejectedExecutionException e) {
-            execution.accepted = false;
+            execution.startTime = System.nanoTime();
+            tryRunNext();
+        } else {
             metrics.incrementBulkheadRejectedCount();
         }
+
         return execution;
     }
 
-    private class ExecutionReferenceImpl implements ExecutionReference {
-
-        private Future<?> future;
-        private boolean accepted = false;
-
-        @Override
-        public void abort(boolean mayInterrupt) {
-            if (future != null) {
-                future.cancel(mayInterrupt);
+    /**
+     * Attempt to run any queued executions
+     */
+    private void tryRunNext() {
+        while (runningSemaphore.tryAcquire()) {
+            ExecutionTask execution = queue.poll();
+            if (execution != null) {
+                // Note: we've removed the execution from the queue so we're committed to running it
+                // if we fail to do so for any reason, we need to call the exception handler to fail the execution
+                try {
+                    execution.submit();
+                } catch (Throwable e) {
+                    // Any exception here is unexpected
+                    runningSemaphore.release();
+                    execution.exceptionHandler.handle(e);
+                }
+            } else {
+                runningSemaphore.release();
+                break;
             }
-        }
-
-        @Override
-        public boolean wasAccepted() {
-            return accepted;
         }
     }
 
-    private class TaskMonitor extends PolicyTaskCallback {
+    /**
+     * This class incorporates everything we need to know about a AsyncBulkhedTask in order to run it, cancel it, complete it and report any unexpected exceptions.
+     * <p>
+     * It is returned from {@link AsyncBulkheadStateImpl#submit(AsyncBulkheadTask, ExceptionHandler)} as the {@link ExecutionReference} as well as being passed into
+     * {@link AsyncBulkheadTask#run(BulkheadReservation)} as the {@link BulkheadReservation}.
+     */
+    private class ExecutionTask implements ExecutionReference, Runnable, BulkheadReservation {
 
+        /**
+         * Whether the task has been queued, rejected, submitted, cancelled etc.
+         * <p>
+         * This is used to ensure that semaphore permits are released at the right time and that we take the correct action if the user calls {@link #abort(boolean)}
+         * <p>
+         * Most state changes use {@link AtomicReference#compareAndSet(Object, Object)} to avoid race conditions (e.g. starting execution after abort has been called)
+         */
+        private final AtomicReference<Status> status;
+
+        /**
+         * The task to run
+         */
+        private final AsyncBulkheadTask task;
+
+        /**
+         * The {@code Future} which was returned when this {@code ExecutionTask} was submitted for execution
+         * <p>
+         * This will be {@code null} until {@link #submit()} has been called
+         */
+        private Future<?> future;
+
+        /**
+         * The exception handler, provided by the caller, to use to report any unexpected exceptions
+         * <p>
+         * E.g. this task is rejected when it's submitted for execution
+         */
         private final ExceptionHandler exceptionHandler;
 
-        public TaskMonitor(ExceptionHandler exceptionHandler) {
-            super();
+        /**
+         * Depending on the current status, this is either the time we were queued, or the time we started running
+         */
+        private long startTime;
+
+        public ExecutionTask(AsyncBulkheadTask task, ExceptionHandler exceptionHandler) {
+            this.task = task;
             this.exceptionHandler = exceptionHandler;
+            this.status = new AtomicReference<>(Status.NEW);
         }
 
-        @Override
-        public void onEnd(Object task, PolicyTaskFuture<?> future, Object startObj, boolean aborted, int pending, Throwable failure) {
-            if (failure != null) {
-                exceptionHandler.handle(failure);
+        /**
+         * Add this task to the back of the bulkhead queue
+         */
+        public void enqueue() {
+            // Ensures enqueuing and setting status doesn't overlap with submission
+            synchronized (this) {
+                if (queue.offer(this)) {
+                    status.set(Status.QUEUED);
+                } else {
+                    status.set(Status.REJECTED);
+                }
             }
         }
 
+        /**
+         * Submit this task to the executorService
+         * <p>
+         * This should only be called after having removed this task from the queue
+         */
+        public void submit() {
+            // Ensures we don't overlap with enqueuing or cancellation
+            synchronized (this) {
+                if (status.compareAndSet(Status.QUEUED, Status.SUBMITTED)) {
+                    future = executorService.submit(this);
+                }
+            }
+        }
+
+        @Override
+        public void run() {
+            if (status.compareAndSet(Status.SUBMITTED, Status.RUNNING)) {
+                try {
+                    try {
+                        long now = System.nanoTime();
+                        metrics.reportQueueWaitTime(now - startTime);
+                        startTime = now;
+                        task.run(this);
+                    } finally {
+                        long now = System.nanoTime();
+                        metrics.recordBulkheadExecutionTime(now - startTime);
+                    }
+                } catch (Throwable t) {
+                    // Any exception here is unexpected
+                    exceptionHandler.handle(t);
+                }
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void abort(boolean mayInterrupt) {
+            // synchronized block prevents overlap with submission
+            synchronized (this) {
+                if (status.compareAndSet(Status.QUEUED, Status.CANCELLED)) {
+                    queue.remove(this);
+                } else if (status.compareAndSet(Status.SUBMITTED, Status.CANCELLED)) {
+                    // Task never started running
+                    future.cancel(mayInterrupt);
+                    runningSemaphore.release();
+                    tryRunNext();
+                } else if (status.get().equals(Status.RUNNING)) {
+                    // Task is running
+                    // Running code is responsible for releasing semaphore permit
+                    future.cancel(mayInterrupt);
+                }
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public boolean wasAccepted() {
+            return status.get() != Status.REJECTED;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void release() {
+            // Note: the user's task will call this method
+            if (status.compareAndSet(Status.RUNNING, Status.COMPLETE)) {
+                runningSemaphore.release();
+                tryRunNext();
+            }
+        }
+    }
+
+    /**
+     * The different states that an {@link ExecutionTask} can be in
+     */
+    private enum Status {
+        /** Task has just been created */
+        NEW,
+        /** Task has been added to the bulkhead queue */
+        QUEUED,
+        /** Task has been removed from the bulkhead queue and submitted to the executorService */
+        SUBMITTED,
+        /** Task has started running */
+        RUNNING,
+        /** {@link ExecutionTask#release()} has been called while the task was running */
+        COMPLETE,
+        /** Task was rejected because the bulkhead queue was full and will never run */
+        REJECTED,
+
+        /**
+         * Task was accepted but then cancelled and never ran.
+         * <p>
+         * Note: if a task is running when {@link ExecutionTask#abort(boolean)} is called, the running thread is interrupted, but the task remains in the RUNNING state
+         */
+        CANCELLED
     }
 
     @Override
     public void shutdown() {
-        executorService.shutdown();
+        // Do nothing
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/AsyncBulkheadStateNullImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/AsyncBulkheadStateNullImpl.java
@@ -15,25 +15,32 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState;
 
+/**
+ * An implementation of {@link AsyncBulkheadState} which does not implement any bulkhead logic
+ * <p>
+ * Although it does not implement any bulkhead logic, it will schedule any tasks passed to {@link #submit(AsyncBulkheadTask, ExceptionHandler)} to be run asynchronously.
+ */
+
 public class AsyncBulkheadStateNullImpl implements AsyncBulkheadState {
 
     private final ScheduledExecutorService executorService;
+    private static final BulkheadReservationNullImpl NULL_RESERVATION = new BulkheadReservationNullImpl();
 
     public AsyncBulkheadStateNullImpl(ScheduledExecutorService executorService) {
         this.executorService = executorService;
     }
 
     @Override
-    public ExecutionReference submit(Runnable runnable, ExceptionHandler exceptionHandler) {
-        Future<?> future = executorService.submit(runnable);
-        return new ExecutionReferenceImpl(future);
+    public ExecutionReference submit(AsyncBulkheadTask task, ExceptionHandler exceptionHandler) {
+        Future<?> future = executorService.submit(() -> task.run(NULL_RESERVATION));
+        return new ExecutionReferenceNullImpl(future);
     }
 
-    private class ExecutionReferenceImpl implements ExecutionReference {
+    private static class ExecutionReferenceNullImpl implements ExecutionReference {
 
         private final Future<?> future;
 
-        public ExecutionReferenceImpl(Future<?> future) {
+        public ExecutionReferenceNullImpl(Future<?> future) {
             this.future = future;
         }
 
@@ -46,6 +53,16 @@ public class AsyncBulkheadStateNullImpl implements AsyncBulkheadState {
         public boolean wasAccepted() {
             return true;
         }
+
+    }
+
+    private static class BulkheadReservationNullImpl implements BulkheadReservation {
+
+        @Override
+        public void release() {
+            // Do nothing
+        }
+
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/AsyncBulkheadStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/AsyncBulkheadStateImplTest.java
@@ -1,0 +1,357 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance20.state.impl;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.faulttolerance.impl.policy.BulkheadPolicyImpl;
+import com.ibm.ws.microprofile.faulttolerance.utils.DummyMetricRecorder;
+import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState.AsyncBulkheadTask;
+import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState.BulkheadReservation;
+import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState.ExceptionHandler;
+import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState.ExecutionReference;
+
+public class AsyncBulkheadStateImplTest {
+
+    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
+    private final AtomicInteger tasksStarted = new AtomicInteger(0);
+
+    private final ArrayList<Throwable> loggedExceptions = new ArrayList<>();
+    private final ExceptionHandler testExceptionHandler = loggedExceptions::add;
+    private final ArrayList<CompletableFuture<?>> waitingFutures = new ArrayList<>();
+
+    @After
+    public void cleanup() {
+        try {
+            assertThat("Logged exceptions", loggedExceptions, is(empty()));
+            executor.shutdownNow();
+            for (CompletableFuture<?> f : waitingFutures) {
+                f.complete(null);
+            }
+        } finally {
+            loggedExceptions.clear();
+            waitingFutures.clear();
+            waitUntil(5, SECONDS, executor::isTerminated);
+        }
+    }
+
+    private CompletableFuture<Void> newWaitingFuture() {
+        CompletableFuture<Void> future = new CompletableFuture<Void>();
+        waitingFutures.add(future);
+        return future;
+    }
+
+    @Test
+    public void testAsyncExecution() {
+        BulkheadPolicyImpl bulkheadPolicy = new BulkheadPolicyImpl();
+        bulkheadPolicy.setMaxThreads(2);
+        bulkheadPolicy.setQueueSize(1);
+
+        AsyncBulkheadStateImpl bulkheadState = new AsyncBulkheadStateImpl(executor, bulkheadPolicy, DummyMetricRecorder.get());
+
+        CompletableFuture<Void> waitingFuture = newWaitingFuture();
+
+        WaitingTask task = new WaitingTask(waitingFuture);
+        ExecutionReference ref = bulkheadState.submit(task, testExceptionHandler);
+        assertThat(ref.wasAccepted(), is(true));
+        assertThat(task.isDone(), is(false));
+
+        waitingFuture.complete(null);
+
+        waitUntil(2, SECONDS, task::isDone);
+    }
+
+    @Test
+    public void testTasksRejectedIfFull() {
+        BulkheadPolicyImpl bulkheadPolicy = new BulkheadPolicyImpl();
+        bulkheadPolicy.setMaxThreads(2);
+        bulkheadPolicy.setQueueSize(1);
+
+        AsyncBulkheadStateImpl bulkheadState = new AsyncBulkheadStateImpl(executor, bulkheadPolicy, DummyMetricRecorder.get());
+
+        CompletableFuture<Void> waitingFuture = newWaitingFuture();
+
+        ArrayList<WaitingTask> tasks = new ArrayList<>();
+        ArrayList<ExecutionReference> refs = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+            WaitingTask task = new WaitingTask(waitingFuture);
+            tasks.add(task);
+            ExecutionReference ref = bulkheadState.submit(task, testExceptionHandler);
+            refs.add(ref);
+        }
+
+        // First three should be accepted and be waiting for the waitingFuture
+        for (int i = 0; i < 3; i++) {
+            assertThat(refs.get(i).wasAccepted(), is(true));
+            assertThat(tasks.get(i).isDone(), is(false));
+        }
+
+        // Rest should have been rejected as the bulkhead is full
+        for (int i = 3; i < 10; i++) {
+            assertThat(refs.get(i).wasAccepted(), is(false));
+        }
+
+        waitingFuture.complete(null);
+
+        waitUntil(2, SECONDS, () -> tasks.stream().limit(3).allMatch(WaitingTask::isDone));
+    }
+
+    @Test
+    public void testTasksQueuedIfFull() {
+        BulkheadPolicyImpl bulkheadPolicy = new BulkheadPolicyImpl();
+        bulkheadPolicy.setMaxThreads(2);
+        bulkheadPolicy.setQueueSize(3);
+
+        AsyncBulkheadStateImpl bulkheadState = new AsyncBulkheadStateImpl(executor, bulkheadPolicy, DummyMetricRecorder.get());
+
+        ArrayList<WaitingTask> tasks = new ArrayList<>();
+        ArrayList<ExecutionReference> refs = new ArrayList<>();
+        ArrayList<CompletableFuture<Void>> waitingFutures = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+            CompletableFuture<Void> waitingFuture = newWaitingFuture();
+            WaitingTask task = new WaitingTask(waitingFuture);
+            waitingFutures.add(waitingFuture);
+            tasks.add(task);
+            ExecutionReference ref = bulkheadState.submit(task, testExceptionHandler);
+            refs.add(ref);
+        }
+
+        // First five should be accepted and be waiting for the waitingFuture
+        for (int i = 0; i < 5; i++) {
+            assertThat(refs.get(i).wasAccepted(), is(true));
+            assertThat(tasks.get(i).isDone(), is(false));
+        }
+
+        // Rest should have been rejected as the bulkhead is full
+        for (int i = 5; i < 10; i++) {
+            assertThat(refs.get(i).wasAccepted(), is(false));
+        }
+
+        // Only two of the tasks should start
+        waitUntil(2, SECONDS, () -> tasksStarted.get() == 2);
+
+        for (int i = 0; i < 3; i++) {
+            // Need a final copy of i to use inside lambdas
+            final int j = i;
+
+            // Complete waiting future for task i
+            waitingFutures.get(j).complete(null);
+
+            // Check that task i now finishes
+            waitUntil(2, SECONDS, () -> tasks.get(j).isDone());
+
+            // Check that a new task is started
+            waitUntil(2, SECONDS, () -> tasksStarted.get() == j + 3);
+        }
+
+        // Complete the rest of the tasks
+        for (int i = 3; i < 10; i++) {
+            waitingFutures.get(i).complete(null);
+        }
+
+    }
+
+    @Test
+    public void testAbortRunning() {
+        BulkheadPolicyImpl bulkheadPolicy = new BulkheadPolicyImpl();
+        bulkheadPolicy.setMaxThreads(2);
+        bulkheadPolicy.setQueueSize(3);
+
+        AsyncBulkheadStateImpl bulkheadState = new AsyncBulkheadStateImpl(executor, bulkheadPolicy, DummyMetricRecorder.get());
+
+        CompletableFuture<Void> waitingFuture = newWaitingFuture();
+        WaitingTask task = new WaitingTask(waitingFuture);
+        ExecutionReference ref = bulkheadState.submit(task, testExceptionHandler);
+
+        waitUntil(2, SECONDS, () -> tasksStarted.get() == 1);
+        ref.abort(true);
+
+        expectException(task.getResult(), InterruptedException.class);
+    }
+
+    @Test
+    public void testAbortQueued() {
+        BulkheadPolicyImpl bulkheadPolicy = new BulkheadPolicyImpl();
+        bulkheadPolicy.setMaxThreads(2);
+        bulkheadPolicy.setQueueSize(3);
+
+        AsyncBulkheadStateImpl bulkheadState = new AsyncBulkheadStateImpl(executor, bulkheadPolicy, DummyMetricRecorder.get());
+
+        ArrayList<ExecutionReference> refs = new ArrayList<>();
+
+        CompletableFuture<Void> waitingFuture = newWaitingFuture();
+        for (int i = 0; i < 5; i++) {
+            ExecutionReference ref = bulkheadState.submit(new WaitingTask(waitingFuture), testExceptionHandler);
+            assertThat("Execution accepted", ref.wasAccepted(), is(true));
+            refs.add(ref);
+        }
+
+        ExecutionReference ref = bulkheadState.submit(new WaitingTask(waitingFuture), testExceptionHandler);
+        assertThat("Execution accepted when queue full", ref.wasAccepted(), is(false));
+
+        // Abort one of the queued tasks
+        refs.get(3).abort(true);
+
+        // Should now be space to queue one more task
+        ref = bulkheadState.submit(new WaitingTask(waitingFuture), testExceptionHandler);
+        assertThat("Execution accepted after queued task aborted", ref.wasAccepted(), is(true));
+    }
+
+    @Test
+    public void testDelayedCompletion() throws InterruptedException, ExecutionException, TimeoutException {
+        BulkheadPolicyImpl bulkheadPolicy = new BulkheadPolicyImpl();
+        bulkheadPolicy.setMaxThreads(1);
+        bulkheadPolicy.setQueueSize(1);
+
+        CompletableFuture<BulkheadReservation> reservationFuture = new CompletableFuture<>();
+
+        AsyncBulkheadTask nonCompletingTask = (r) -> {
+            try {
+                reservationFuture.complete(r);
+            } catch (Exception e) {
+            }
+        };
+
+        AsyncBulkheadStateImpl bulkheadState = new AsyncBulkheadStateImpl(executor, bulkheadPolicy, DummyMetricRecorder.get());
+        bulkheadState.submit(nonCompletingTask, testExceptionHandler);
+
+        // First task should not clear the bulkhead until release is called on the reservation, even though the method itself will complete
+        BulkheadReservation reservation = reservationFuture.get(2, SECONDS);
+
+        // Short wait to allow the first task the opportunity to complete, even though we expect it not to
+        Thread.sleep(100);
+        CompletableFuture<Void> waitingFuture = newWaitingFuture();
+
+        // Next task should be queued
+        ExecutionReference ref = bulkheadState.submit(new WaitingTask(waitingFuture), testExceptionHandler);
+        assertThat("Task accepted", ref.wasAccepted(), is(true));
+
+        // Next task should be rejected because first task is still incomplete
+        ref = bulkheadState.submit(new WaitingTask(waitingFuture), testExceptionHandler);
+        assertThat("Task accepted", ref.wasAccepted(), is(false));
+
+        // Releasing the reservation should allow us to queue another task
+        reservation.release();
+        ref = bulkheadState.submit(new WaitingTask(waitingFuture), testExceptionHandler);
+        assertThat("Task accepted", ref.wasAccepted(), is(true));
+    }
+
+    /**
+     * Test for correct behaviour if a task is accepted by the bulkhead but is later rejected when submitted to the global executor
+     */
+    @Test
+    public void testRejectedByExecutor() {
+        BulkheadPolicyImpl bulkheadPolicy = new BulkheadPolicyImpl();
+        bulkheadPolicy.setMaxThreads(1);
+        bulkheadPolicy.setQueueSize(1);
+
+        AsyncBulkheadStateImpl bulkheadState = new AsyncBulkheadStateImpl(new MockRejectingExecutor(), bulkheadPolicy, DummyMetricRecorder.get());
+        CompletableFuture<?> waitingFuture = newWaitingFuture();
+
+        // Tests two things:
+        // 1) An exception is reported via the exception handler if the executorService rejects the task
+        // 2) When an exception occurs, the bulkhead permit is released
+        for (int i = 0; i < 10; i++) {
+            WaitingTask task = new WaitingTask(waitingFuture);
+            AtomicBoolean didFail = new AtomicBoolean(false);
+            ExecutionReference ref = bulkheadState.submit(task, (e) -> didFail.set(true));
+            assertTrue("Execution was not accepted for task " + i, ref.wasAccepted());
+            assertTrue("Failure was not reported for task " + i, didFail.get());
+        }
+
+    }
+
+    private class WaitingTask implements AsyncBulkheadTask {
+        private final Future<?> waitingFuture;
+        private final CompletableFuture<Void> resultFuture;
+        private final AtomicBoolean isDone = new AtomicBoolean(false);
+
+        public WaitingTask(Future<?> waitingFuture) {
+            this.waitingFuture = waitingFuture;
+            this.resultFuture = new CompletableFuture<Void>();
+        }
+
+        @Override
+        public void run(BulkheadReservation reservation) {
+            try {
+                tasksStarted.incrementAndGet();
+                waitingFuture.get();
+                isDone.set(true);
+                resultFuture.complete(null);
+            } catch (InterruptedException | ExecutionException ex) {
+                resultFuture.completeExceptionally(ex);
+            } finally {
+                reservation.release();
+            }
+        }
+
+        public boolean isDone() {
+            return isDone.get();
+        }
+
+        public Future<Void> getResult() {
+            return resultFuture;
+        }
+
+    }
+
+    private void waitUntil(long time, TimeUnit timeUnit, BooleanSupplier condition) {
+        long timeNanos = TimeUnit.NANOSECONDS.convert(time, timeUnit);
+        long startNanos = System.nanoTime();
+        while (!condition.getAsBoolean()) {
+            if (System.nanoTime() - startNanos > timeNanos) {
+                fail("Timed out while waiting for condition to become true");
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new AssertionError("Interrupted while waiting for condition to become true", e);
+            }
+        }
+    }
+
+    private void expectException(Future<?> future, Class<? extends Exception> clazz) {
+        try {
+            future.get(2, SECONDS);
+            fail("Future did not complete with an exception");
+        } catch (ExecutionException e) {
+            assertThat("Exception returned from future", e.getCause(), instanceOf(clazz));
+        } catch (InterruptedException e) {
+            fail("Interrupted while waiting for future to return an exception");
+        } catch (TimeoutException e) {
+            fail("Future did not return any result within two seconds");
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/MockRejectingExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/MockRejectingExecutor.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance20.state.impl;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * An ExecutorService which rejects any task passed to it
+ */
+public class MockRejectingExecutor implements ExecutorService {
+
+    /** {@inheritDoc} */
+    @Override
+    public void execute(Runnable command) {
+        throw new RejectedExecutionException("REJECTED");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void shutdown() {
+        throw new RejectedExecutionException("REJECTED");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<Runnable> shutdownNow() {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isTerminated() {
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        throw new RejectedExecutionException("REJECTED");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        throw new RejectedExecutionException("REJECTED");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Future<?> submit(Runnable task) {
+        throw new RejectedExecutionException("REJECTED");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        throw new RejectedExecutionException("REJECTED");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        throw new RejectedExecutionException("REJECTED");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        throw new RejectedExecutionException("REJECTED");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        throw new RejectedExecutionException("REJECTED");
+    }
+
+}


### PR DESCRIPTION
Featues:
 - doesn't use PolicyExecutor
 - bulkhead permit must be released manually

Manual release of the bulkhead permit is an important feature which
allows the permit to be held even after the async task has returned.
This is to allow the release of the bulkhead reservation to be attached
to the completion of a CompletionStage returned by another component
(e.g. JAX-RS client) which is required by the spec.

Fixes #6147 