### PR TITLE
NLS messages and reject transaction context propagation

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/resources/com/ibm/ws/concurrent/mp/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/resources/com/ibm/ws/concurrent/mp/resources/CWWKCMessages.nlsprops
@@ -22,7 +22,7 @@
 #   which do NOT contain replacement variables are NOT processed by the MessageFormat class 
 #   (single quote must be coded as one single quote '). 
 
-# All messages must use the range CWWCK1150 to CWWCK1199 except those specifically identified as moved
+# All messages must use the range CWWCK1150 to CWWCK1189 except those specifically identified as moved
 
 CWWKC1150.duplicate.context=CWWKC1150E: The same thread context type, {0}, is provided by multiple thread context providers which are available to the application. Thread context providers are: {1}, {2}.
 CWWKC1150.duplicate.context.explanation=The MicroProfile Concurrency specification permits no more than one ThreadContextProvider for each context type.
@@ -51,3 +51,7 @@ CWWKC1155.unknown.context.useraction=Update the application, libraries or both t
 CWWKC1156.not.supported=CWWKC1156E: The requested operation is not available as a static method on the managed executor implementation of CompletableFuture. Use the following operation instead: {0}.
 CWWKC1156.not.supported.explanation=The managed executor implementation of CompletableFuture does not provide static method equivalents to the static methods of CompletableFuture. 
 CWWKC1156.not.supported.useraction=Update the application to use the method that is recommended in the message in place of the requested operation.
+
+CWWKC1157.cannot.propagate.tx=CWWKC1157E: Propagation of transactions to contextual actions and tasks is not supported.
+CWWKC1157.cannot.propagate.tx.explanation=A ManagedExecutor or ThreadContext that is configured to propagate transaction context is limited to propagating empty transaction context. Therefore, it is not supported to create contextual actions and tasks within a transaction. 
+CWWKC1157.cannot.propagate.tx.useraction=Create the contextual action or task outside of a transaction. Alternatively, configure the ManagedExecutor or ThreadContext to not propagate transaction context.

--- a/dev/com.ibm.ws.concurrent.mp.cdi/resources/com/ibm/ws/concurrent/mp/cdi/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/resources/com/ibm/ws/concurrent/mp/cdi/resources/CWWKCMessages.nlsprops
@@ -1,0 +1,29 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
+#ISMESSAGEFILE TRUE
+#NLS_ENCODING=UNICODE
+#
+#COMPONENTPREFIX CWWKC
+#COMPONENTNAMEFOR CWWKC CDI integration for MicroProfile Concurrency
+#
+# NLS_MESSAGEFORMAT_VAR
+#
+#   Strings in this file which contain replacement variables are processed by the MessageFormat 
+#   class (single quote must be coded as 2 consecutive single quotes ''). Strings in this file 
+#   which do NOT contain replacement variables are NOT processed by the MessageFormat class 
+#   (single quote must be coded as one single quote '). 
+
+# All messages must use the range CWWCK1190 to CWWCK1199 except those specifically identified as moved
+
+CWWKC1190.duplicate.namedinstance=CWWKC1190E: Multiple injections points produce a {0} that is qualified by @NamedInstance("{1}"). The conflicting injection points are: {2}.
+CWWKC1190.duplicate.namedinstance.explanation=For any given NamedInstance value N, the combination of @NamedInstance("N") with @ManagedExecutorConfig or @ThreadContextConfig is permitted on at most one injection point.
+CWWKC1190.duplicate.namedinstance.useraction=Remove the @ManagedExecutorConfig or @ThreadContextConfig annotation from one of the injection points so that it shares the instance produced by the other injection point. Alternatively, choose a different NamedInstance value for one of the injection points such that separate instances are produced for each.

--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/package-info.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 @Version("1.0.0")
-@TraceOptions(traceGroup = "concurrent")
+@TraceOptions(traceGroup = "concurrent", messageBundle = "com.ibm.ws.concurrent.mp.cdi.resources.CWWKCMessages")
 package com.ibm.ws.concurrent.mp.cdi;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Add NLS messages for remaining error paths that are marked with TODO.
Also, add code to more precisely reject attempts to propagate global transactions, but not allow propagating from an empty transaction context.