### PR TITLE
withContextCapture must reject Async actions without an executor

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/resources/com/ibm/ws/concurrent/mp/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/resources/com/ibm/ws/concurrent/mp/resources/CWWKCMessages.nlsprops
@@ -28,21 +28,15 @@ CWWKC1150.duplicate.context=CWWKC1150E: The same thread context type, {0}, is pr
 CWWKC1150.duplicate.context.explanation=The MicroProfile Concurrency specification permits no more than one ThreadContextProvider for each context type.
 CWWKC1150.duplicate.context.useraction=Update the available application, libraries, or both so that no more than one ThreadContextProvider of the specified type exists.
 
-CWWKC1151.context.lists.overlap=CWWKC1151E: The following thread context types are configured to be both cleared and propagated: {0}.
+# do not translate: cleared, propagated
+CWWKC1151.context.lists.overlap=CWWKC1151E: The ManagedExecutor configuration includes the following thread context types are configured to be both cleared and propagated: {0}.
 CWWKC1151.context.lists.overlap.explanation=A thread context type can be configured in no more than one category when building or injecting a ManagedExecutor.
 CWWKC1151.context.lists.overlap.useraction=Review and correct the categorization of thread context types in your ManagedExecutor builder or ManagedExecutorConfig annotation.
 
+# do not translate: cleared, propagated, unchanged
 CWWKC1152.context.lists.overlap=CWWKC1152E: The following thread context types are configured in more than one category of (cleared, propagated, unchanged): {0}.
 CWWKC1152.context.lists.overlap.explanation=A thread context type can be configured in no more than one category when building or injecting a ThreadContext instance.
 CWWKC1152.context.lists.overlap.useraction=Review and correct the categorization of thread context types in your ThreadContext builder or ThreadContextConfig annotation.
-
-CWWKC1153.invalid.name=CWWKC1153E: The {0} name is not valid for a ManagedExecutor or ThreadContext. Names must be limited to the following characters: {1}.
-CWWKC1153.invalid.name.explanation=Names for instances of ManagedExecutor and ThreadContext must consist of characters within the specified range.
-CWWKC1153.invalid.name.useraction=Update the application to specify a name that only uses characters within the specified range.
-
-CWWKC1154.duplicate.name=CWWKC1154E: The {0} name is used by another ManagedExecutor or ThreadContext.
-CWWKC1154.duplicate.name.explanation=Names for instances of ManagedExecutor and ThreadContext must be unique.
-CWWKC1154.duplicate.name.useraction=Update the application to specify a unique name for all created instances of ManagedExecutor and ThreadContext.
 
 CWWKC1155.unknown.context=CWWKC1155E: Thread context types {0} are configured to be cleared or propagated, but no thread context providers for these types are available to the application. Available thread context types are: {1}.
 CWWKC1155.unknown.context.explanation=For each configured thread context type that is not provided by the server, a thread context provider must be available on the application's thread context class loader. Thread context types provided by the server include: Application, CDI, Security, Transaction.

--- a/dev/com.ibm.ws.concurrent.mp.1.0/resources/com/ibm/ws/concurrent/mp/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/resources/com/ibm/ws/concurrent/mp/resources/CWWKCMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018,2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -29,7 +29,7 @@ CWWKC1150.duplicate.context.explanation=The MicroProfile Concurrency specificati
 CWWKC1150.duplicate.context.useraction=Update the available application, libraries, or both so that no more than one ThreadContextProvider of the specified type exists.
 
 # do not translate: cleared, propagated
-CWWKC1151.context.lists.overlap=CWWKC1151E: The ManagedExecutor configuration includes the following thread context types are configured to be both cleared and propagated: {0}.
+CWWKC1151.context.lists.overlap=CWWKC1151E: The ManagedExecutor configuration includes the following thread context types that are configured to be both cleared and propagated: {0}
 CWWKC1151.context.lists.overlap.explanation=A thread context type can be configured in no more than one category when building or injecting a ManagedExecutor.
 CWWKC1151.context.lists.overlap.useraction=Review and correct the categorization of thread context types in your ManagedExecutor builder or ManagedExecutorConfig annotation.
 
@@ -46,6 +46,6 @@ CWWKC1156.not.supported=CWWKC1156E: The requested operation is not available as 
 CWWKC1156.not.supported.explanation=The managed executor implementation of CompletableFuture does not provide static method equivalents to the static methods of CompletableFuture. 
 CWWKC1156.not.supported.useraction=Update the application to use the method that is recommended in the message in place of the requested operation.
 
-CWWKC1157.cannot.propagate.tx=CWWKC1157E: Propagation of transactions to contextual actions and tasks is not supported.
-CWWKC1157.cannot.propagate.tx.explanation=A ManagedExecutor or ThreadContext that is configured to propagate transaction context is limited to propagating empty transaction context. Therefore, it is not supported to create contextual actions and tasks within a transaction. 
-CWWKC1157.cannot.propagate.tx.useraction=Create the contextual action or task outside of a transaction. Alternatively, configure the ManagedExecutor or ThreadContext to not propagate transaction context.
+CWWKC1157.cannot.propagate.tx=CWWKC1157E: Propagating transactions to contextual actions and tasks is not supported.
+CWWKC1157.cannot.propagate.tx.explanation=A ManagedExecutor or ThreadContext that is configured to propagate transaction contexts can propagate empty transaction contexts only. Therefore, you cannot create contextual actions and tasks within a transaction.
+CWWKC1157.cannot.propagate.tx.useraction=Create the contextual action or task outside of a transaction. Alternatively, configure the ManagedExecutor or ThreadContext to not propagate transaction contexts.

--- a/dev/com.ibm.ws.concurrent.mp.1.0/resources/com/ibm/ws/concurrent/mp/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/resources/com/ibm/ws/concurrent/mp/resources/CWWKCMessages.nlsprops
@@ -22,7 +22,7 @@
 #   which do NOT contain replacement variables are NOT processed by the MessageFormat class 
 #   (single quote must be coded as one single quote '). 
 
-# All messages must use the range CWWCK1150 to CWWCK1199 except those specifically identified as moved
+# All messages must use the range CWWCK1150 to CWWCK1189 except those specifically identified as moved
 
 CWWKC1150.duplicate.context=CWWKC1150E: The same thread context type, {0}, is provided by multiple thread context providers which are available to the application. Thread context providers are: {1}, {2}.
 CWWKC1150.duplicate.context.explanation=The MicroProfile Concurrency specification permits no more than one ThreadContextProvider for each context type.
@@ -51,3 +51,7 @@ CWWKC1155.unknown.context.useraction=Update the application, libraries or both t
 CWWKC1156.not.supported=CWWKC1156E: The requested operation is not available as a static method on the managed executor implementation of CompletableFuture. Use the following operation instead: {0}.
 CWWKC1156.not.supported.explanation=The managed executor implementation of CompletableFuture does not provide static method equivalents to the static methods of CompletableFuture. 
 CWWKC1156.not.supported.useraction=Update the application to use the method that is recommended in the message in place of the requested operation.
+
+CWWKC1157.cannot.propagate.tx=CWWKC1157E: Propagation of transactions to contextual actions and tasks is not supported.
+CWWKC1157.cannot.propagate.tx.explanation=A ManagedExecutor or ThreadContext that is configured to propagate transaction context is limited to propagating empty transaction context. Therefore, it is not supported to create contextual actions and tasks within a transaction. 
+CWWKC1157.cannot.propagate.tx.useraction=Create the contextual action or task outside of a transaction. Alternatively, configure the ManagedExecutor or ThreadContext to not propagate transaction context.

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextServiceImpl.java
@@ -175,7 +175,7 @@ public class ContextServiceImpl extends AbstractContextService implements Thread
     public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> stage) {
         CompletableFuture<T> newCompletableFuture;
 
-        SameThreadExecutor executor = new SameThreadExecutor(this);
+        UnusableExecutor executor = new UnusableExecutor(this);
         if (ManagedCompletableFuture.JAVA8)
             newCompletableFuture = new ManagedCompletableFuture<T>(new CompletableFuture<T>(), executor, null);
         else
@@ -197,7 +197,7 @@ public class ContextServiceImpl extends AbstractContextService implements Thread
     public <T> CompletionStage<T> withContextCapture(CompletionStage<T> stage) {
         ManagedCompletionStage<T> newStage;
 
-        SameThreadExecutor executor = new SameThreadExecutor(this);
+        UnusableExecutor executor = new UnusableExecutor(this);
         if (ManagedCompletableFuture.JAVA8)
             newStage = new ManagedCompletionStage<T>(new CompletableFuture<T>(), executor, null);
         else

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletableFuture.java
@@ -413,7 +413,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
 
@@ -455,7 +455,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
 
@@ -514,7 +514,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -576,7 +576,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -630,7 +630,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         }
 
         if (contextSvc == null)
-            return null;
+            return null; // TODO should we capture context based on the default executor when unmanaged executor is supplied???
 
         @SuppressWarnings("unchecked")
         ThreadContextDescriptor contextDescriptor = contextSvc.captureThreadContext(XPROPS_SUSPEND_TRAN);
@@ -845,7 +845,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -1044,7 +1044,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -1106,7 +1106,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -1154,6 +1154,24 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     }
 
     /**
+     * Convenience method to validate that an executor supports running asynchronously
+     * and to wrap the executor, if an ExecutorService, with FutureRefExecutor.
+     * This method is named supportsAsync to make failure stacks more meaningful to users.
+     *
+     * @param executor executor instance supplied to *Async methods.
+     * @return FutureRefExecutor if an ExecutorService is supplied. Null if a valid executor is supplied.
+     * @throws UnsupportedOperation if the executor is incapable of running tasks.
+     */
+    @Trivial
+    private final static FutureRefExecutor supportsAsync(Executor executor) {
+        if (executor instanceof ExecutorService)
+            return new FutureRefExecutor((ExecutorService) executor); // valid
+        if (executor instanceof UnusableExecutor)
+            throw new UnsupportedOperationException(); // not valid for executing tasks
+        return null; // valid
+    }
+
+    /**
      * @see java.util.concurrent.CompletionStage#thenAccept(java.util.function.Consumer)
      */
     @Override
@@ -1192,7 +1210,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -1252,7 +1270,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -1312,7 +1330,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -1372,7 +1390,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -1432,7 +1450,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -1490,7 +1508,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)
@@ -1595,7 +1613,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        FutureRefExecutor futureExecutor = executor instanceof ExecutorService ? new FutureRefExecutor((ExecutorService) executor) : null;
+        FutureRefExecutor futureExecutor = supportsAsync(executor);
 
         ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
         if (contextDescriptor != null)

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextImpl.java
@@ -129,7 +129,7 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
     public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> stage) {
         CompletableFuture<T> newCompletableFuture;
 
-        SameThreadExecutor executor = new SameThreadExecutor(this);
+        UnusableExecutor executor = new UnusableExecutor(this);
         if (ManagedCompletableFuture.JAVA8)
             newCompletableFuture = new ManagedCompletableFuture<T>(new CompletableFuture<T>(), executor, null);
         else
@@ -151,7 +151,7 @@ class ThreadContextImpl implements ThreadContext, WSContextService {
     public <T> CompletionStage<T> withContextCapture(CompletionStage<T> stage) {
         ManagedCompletionStage<T> newStage;
 
-        SameThreadExecutor executor = new SameThreadExecutor(this);
+        UnusableExecutor executor = new UnusableExecutor(this);
         if (ManagedCompletableFuture.JAVA8)
             newStage = new ManagedCompletionStage<T>(new CompletableFuture<T>(), executor, null);
         else

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/UnusableExecutor.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/UnusableExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,37 +18,35 @@ import com.ibm.ws.threading.PolicyExecutor;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 /**
- * Executor that runs tasks on the same thread that invokes execute.
+ * Executor that provides thread context capture/propagation only and is incapable of running tasks.
  * WSManagedExecutorService is implemented to store a context service instance
  * as a convenience to the managed completable future implementation.
+ * The execute method is rejected as unsupported.
  */
-class SameThreadExecutor implements Executor, WSManagedExecutorService {
+@Trivial
+class UnusableExecutor implements Executor, WSManagedExecutorService {
     private final WSContextService contextService;
 
-    @Trivial
-    SameThreadExecutor(WSContextService contextService) {
+    UnusableExecutor(WSContextService contextService) {
         this.contextService = contextService;
     }
 
     @Override
     public void execute(Runnable command) {
-        command.run();
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    @Trivial
     public WSContextService getContextService() {
         return contextService;
     }
 
     @Override
-    @Trivial
     public PolicyExecutor getNormalPolicyExecutor() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    @Trivial
     public int hashCode() {
         return contextService.hashCode(); // for easy correlation in trace with the context service that created it
     }

--- a/dev/com.ibm.ws.concurrent.mp.cdi/resources/com/ibm/ws/concurrent/mp/cdi/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/resources/com/ibm/ws/concurrent/mp/cdi/resources/CWWKCMessages.nlsprops
@@ -1,0 +1,29 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
+#ISMESSAGEFILE TRUE
+#NLS_ENCODING=UNICODE
+#
+#COMPONENTPREFIX CWWKC
+#COMPONENTNAMEFOR CWWKC CDI integration for MicroProfile Concurrency
+#
+# NLS_MESSAGEFORMAT_VAR
+#
+#   Strings in this file which contain replacement variables are processed by the MessageFormat 
+#   class (single quote must be coded as 2 consecutive single quotes ''). Strings in this file 
+#   which do NOT contain replacement variables are NOT processed by the MessageFormat class 
+#   (single quote must be coded as one single quote '). 
+
+# All messages must use the range CWWCK1190 to CWWCK1199 except those specifically identified as moved
+
+CWWKC1190.duplicate.namedinstance=CWWKC1190E: Multiple injections points produce a {0} that is qualified by @NamedInstance("{1}"). The conflicting injection points are: {2}.
+CWWKC1190.duplicate.namedinstance.explanation=For any given NamedInstance value N, the combination of @NamedInstance("N") with @ManagedExecutorConfig or @ThreadContextConfig is permitted on at most one injection point.
+CWWKC1190.duplicate.namedinstance.useraction=Remove the @ManagedExecutorConfig or @ThreadContextConfig annotation from one of the injection points so that it shares the instance produced by the other injection point. Alternatively, choose a different NamedInstance value for one of the injection points such that separate instances are produced for each.

--- a/dev/com.ibm.ws.concurrent.mp.cdi/resources/com/ibm/ws/concurrent/mp/cdi/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/resources/com/ibm/ws/concurrent/mp/cdi/resources/CWWKCMessages.nlsprops
@@ -24,6 +24,6 @@
 
 # All messages must use the range CWWCK1190 to CWWCK1199 except those specifically identified as moved
 
-CWWKC1190.duplicate.namedinstance=CWWKC1190E: Multiple injections points produce a {0} that is qualified by @NamedInstance("{1}"). The conflicting injection points are: {2}.
-CWWKC1190.duplicate.namedinstance.explanation=For any given NamedInstance value N, the combination of @NamedInstance("N") with @ManagedExecutorConfig or @ThreadContextConfig is permitted on at most one injection point.
-CWWKC1190.duplicate.namedinstance.useraction=Remove the @ManagedExecutorConfig or @ThreadContextConfig annotation from one of the injection points so that it shares the instance produced by the other injection point. Alternatively, choose a different NamedInstance value for one of the injection points such that separate instances are produced for each.
+CWWKC1190.duplicate.namedinstance=CWWKC1190E: Multiple injections points produce a {0} that is qualified by @NamedInstance("{1}"). The conflicting injection points are: {2}
+CWWKC1190.duplicate.namedinstance.explanation=For any given NamedInstance value N, the combination of @NamedInstance("N") with @ManagedExecutorConfig or @ThreadContextConfig is allowed for one injection point only.
+CWWKC1190.duplicate.namedinstance.useraction=Remove the @ManagedExecutorConfig or @ThreadContextConfig annotation from one of the injection points so that it shares the instance produced by the other injection point. Alternatively, choose a different NamedInstance value for one of the injection points so that separate instances are produced for each.

--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/package-info.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 @Version("1.0.0")
-@TraceOptions(traceGroup = "concurrent")
+@TraceOptions(traceGroup = "concurrent", messageBundle = "com.ibm.ws.concurrent.mp.cdi.resources.CWWKCMessages")
 package com.ibm.ws.concurrent.mp.cdi;
 
 import org.osgi.annotation.versioning.Version;

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -4635,8 +4635,8 @@ public class MPConcurrentTestServlet extends FATServlet {
     /**
      * Use ThreadContext.testWithContextCapture to create a contextualized CompletableFuture
      * based on one that isn't context aware. Verify that its dependent actions run with the
-     * configured context of the ThreadContext instance and that Async operations run on the
-     * servlet thread rather than a different thread from the Liberty global thread pool,
+     * configured context of the ThreadContext instance and that Async operations requested
+     * without an executor parameter raise UnsupportedOperationException,
      * as required by the spec for CompletionStage that is backed by a ThreadContext rather
      * than a managed executor.
      */
@@ -4663,10 +4663,10 @@ public class MPConcurrentTestServlet extends FATServlet {
                 }
                 String threadName = Thread.currentThread().getName();
                 assertEquals("", CurrentLocation.getCity());
-                assertEquals("Minnesota", CurrentLocation.getState()); // runs on servlet thread
-                assertEquals(servletThreadName, threadName);
+                assertEquals("", CurrentLocation.getState());
+                assertNotSame(servletThreadName, threadName);
                 return i + 1;
-            });
+            }, defaultManagedExecutor);
 
             assertEquals(Integer.valueOf(116), cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 
@@ -4676,13 +4676,18 @@ public class MPConcurrentTestServlet extends FATServlet {
                 } catch (NamingException x) {
                     throw new RuntimeException(x);
                 }
-                String threadName = Thread.currentThread().getName();
                 assertEquals("", CurrentLocation.getCity()); // context of servlet thread is cleared
                 assertEquals("Minnesota", CurrentLocation.getState()); // context of servlet thread not cleared
-                assertEquals(servletThreadName, threadName); // runs on servlet thread
                 CurrentLocation.setLocation("La Crosse", "Wisconsin");
                 return i + 1;
             });
+
+            try {
+                CompletableFuture<Integer> cf5 = cf4.whenCompleteAsync((i, x) -> System.out.println("This task should not have run."));
+                fail("whenCompleteAsync should be rejected when completion stage is not backed by an executor. " + cf5);
+            } catch (UnsupportedOperationException x) {
+                // expected
+            }
 
             assertEquals(Integer.valueOf(117), cf4.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 
@@ -4709,8 +4714,8 @@ public class MPConcurrentTestServlet extends FATServlet {
      * Use testWithContextCapture on a ContextService configured in server.xml
      * to create a contextualized CompletableFuture based on one that isn't context aware.
      * Verify that its dependent actions run with the configured context of the ContextService
-     * instance and that Async operations run on the servlet thread rather than a different
-     * thread from the Liberty global thread pool, as required by the spec for
+     * instance and that Async operations requested without an executor parameter raise
+     * UnsupportedOperationException, as required by the spec for
      * CompletionStage that is backed by a ThreadContext rather than a managed executor.
      */
     @Test
@@ -4732,9 +4737,9 @@ public class MPConcurrentTestServlet extends FATServlet {
                 String threadName = Thread.currentThread().getName();
                 assertEquals("", CurrentLocation.getCity());
                 assertEquals("", CurrentLocation.getState());
-                assertEquals(servletThreadName, threadName);
+                assertNotSame(servletThreadName, threadName);
                 return i + 1;
-            });
+            }, defaultManagedExecutor);
 
             assertEquals(Integer.valueOf(123), cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 
@@ -4744,15 +4749,20 @@ public class MPConcurrentTestServlet extends FATServlet {
                 } catch (NamingException x) {
                     throw new RuntimeException(x);
                 }
-                String threadName = Thread.currentThread().getName();
                 assertEquals("", CurrentLocation.getCity()); // context of servlet thread is cleared
                 assertEquals("", CurrentLocation.getState()); // context of servlet thread is cleared
-                assertEquals(servletThreadName, threadName);
                 CurrentLocation.setLocation("Onalaska", "Wisconsin");
                 return i + 1;
             });
 
             assertEquals(Integer.valueOf(124), cf4.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+            try {
+                CompletableFuture<Integer> cf5 = cf4.thenCombineAsync(cf3, (i, j) -> j - i);
+                fail("thenCombineAsync should be rejected when completion stage is not backed by an executor. " + cf5);
+            } catch (UnsupportedOperationException x) {
+                // expected
+            }
 
             // context restored on current thread
             assertEquals("Mankato", CurrentLocation.getCity());
@@ -4762,9 +4772,11 @@ public class MPConcurrentTestServlet extends FATServlet {
                 Executor executor = defaultExecutor.apply(cf4);
                 assertFalse(executor instanceof ExecutorService); // no way for the user to shut it down
 
-                AtomicReference<String> threadNameRef = new AtomicReference<String>();
-                executor.execute(() -> threadNameRef.set(Thread.currentThread().getName()));
-                assertEquals(servletThreadName, threadNameRef.get());
+                try {
+                    executor.execute(() -> System.out.println("Should not be able to submit this task."));
+                } catch (UnsupportedOperationException x) {
+                    // pass - completable futures from withContextCapture are not backed by a usable executor
+                }
             }
         } finally {
             CurrentLocation.clear();
@@ -4774,8 +4786,8 @@ public class MPConcurrentTestServlet extends FATServlet {
     /**
      * Use ThreadContext.testWithContextCapture to create a contextualized CompletionStage
      * based on one that isn't context aware. Verify that its dependent actions run with the
-     * configured context of the ThreadContext instance and that Async operations run on the
-     * current thread rather than a different thread from the Liberty global thread pool,
+     * configured context of the ThreadContext instance and that Async operations
+     * requested without an executor parameter raise UnsupportedOperationException,
      * as required by the spec for CompletionStage that is backed by a ThreadContext rather
      * than a managed executor.
      */
@@ -4815,10 +4827,10 @@ public class MPConcurrentTestServlet extends FATServlet {
                 }
                 String threadName = Thread.currentThread().getName();
                 assertEquals("", CurrentLocation.getCity());
-                assertEquals("", CurrentLocation.getState()); // thread from prior stage used instead of thread from Liberty global thread pool
-                assertTrue(threadName, !threadName.startsWith("Default Executor-thread-"));
+                assertEquals("", CurrentLocation.getState());
+                assertNotSame(threadName, servletThreadName);
                 return i + 1;
-            });
+            }, defaultManagedExecutor);
 
             // verify that cs3 is a CompletionStage or limited to CompletionStage methods
             if (cs3 instanceof CompletableFuture)
@@ -4840,13 +4852,18 @@ public class MPConcurrentTestServlet extends FATServlet {
                 } catch (NamingException x) {
                     throw new RuntimeException(x);
                 }
-                String threadName = Thread.currentThread().getName();
                 assertEquals("", CurrentLocation.getCity()); // context of servlet thread is cleared
                 assertEquals("Minnesota", CurrentLocation.getState()); // context of servlet thread not cleared
-                assertEquals(servletThreadName, threadName);
                 CurrentLocation.setLocation("Clear Lake", "Iowa");
                 return i + 1;
             });
+
+            try {
+                CompletionStage<Void> cs5 = cs4.thenAcceptBothAsync(cs3, (i, j) -> System.out.println(i * j));
+                fail("thenAcceptBothAsync should be rejected when completion stage is not backed by an executor. " + cs5);
+            } catch (UnsupportedOperationException x) {
+                // expected
+            }
 
             // verify that cs4 is a CompletionStage or limited to CompletionStage methods
             if (cs4 instanceof CompletableFuture)
@@ -4873,8 +4890,8 @@ public class MPConcurrentTestServlet extends FATServlet {
      * Use ThreadContext.testWithContextCapture on a ContextService configured in server.xml
      * to create a contextualized CompletionStage based on one that isn't context aware.
      * Verify that its dependent actions run with the configured context of the ContextService
-     * instance and that Async operations run on the current thread rather than a different
-     * thread from the Liberty global thread pool, as required by the spec for
+     * instance and that Async operations requested without an executor parameter
+     * raise UnsupportedOperationException, as required by the spec for
      * CompletionStage that is backed by a ThreadContext rather than a managed executor.
      */
     @Test
@@ -4909,9 +4926,9 @@ public class MPConcurrentTestServlet extends FATServlet {
                 String threadName = Thread.currentThread().getName();
                 assertEquals("", CurrentLocation.getCity());
                 assertEquals("", CurrentLocation.getState());
-                assertTrue(threadName, !threadName.startsWith("Default Executor-thread-"));
+                assertNotSame(servletThreadName, threadName);
                 return i + 1;
-            });
+            }, defaultManagedExecutor);
 
             // verify that cs3 is a CompletionStage or limited to CompletionStage methods
             if (cs3 instanceof CompletableFuture)
@@ -4933,13 +4950,18 @@ public class MPConcurrentTestServlet extends FATServlet {
                 } catch (NamingException x) {
                     throw new RuntimeException(x);
                 }
-                String threadName = Thread.currentThread().getName();
                 assertEquals("", CurrentLocation.getCity()); // context of servlet thread is cleared
                 assertEquals("", CurrentLocation.getState()); // context of servlet thread is cleared
-                assertEquals(servletThreadName, threadName);
                 CurrentLocation.setLocation("Superior", "Wisconsin");
                 return i + 1;
             });
+
+            try {
+                CompletionStage<Integer> cs5 = cs4.handleAsync((i, x) -> i);
+                fail("handleAsync should be rejected when completion stage is not backed by an executor. " + cs5);
+            } catch (UnsupportedOperationException x) {
+                // expected
+            }
 
             // verify that cs4 is a CompletionStage or limited to CompletionStage methods
             if (cs4 instanceof CompletableFuture)


### PR DESCRIPTION
Per recent updates to the MP Concurrency spec, the withContextCapture method must create stages that reject Async operations when no executor is supplied, rather than running them inline.