### PR TITLE
Update WebContainer.getCacheManager() to avoid NullPointerException

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/WebContainer.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/WebContainer.java
@@ -1397,7 +1397,12 @@ public class WebContainer extends com.ibm.ws.webcontainer.WebContainer implement
     }
     
     public static CacheManager getCacheManager() {
-        return instance.get().getCacheManagerService();      
+        WebContainer thisService = instance.get();
+        CacheManager cacheManager = null;
+        if (thisService != null) {
+            cacheManager = thisService.getCacheManagerService();
+        }
+        return cacheManager;
     }
     
     private CacheManager getCacheManagerService() {


### PR DESCRIPTION
The getCacheManager() method was the only method in the WebContainer
class that was not coded to avoid a NullPointerException when
instance.get() returns null.  This method is now updated to avoid
getting a NullPointerExeption by using the same pattern as other methods
that call instance.get().

I saw the NullPointerException that this PR is supposed to fix in a test failure from one of the builds, but I cannot find it or any built break defect for that had this failure in it.  I found a defect from a while ago that had the stack for this problem.  Here is an example:

> Stack Dump = java.lang.NullPointerException
> at com.ibm.ws.webcontainer.osgi.WebContainer.getCacheManager(WebContainer.java:1349)
> at com.ibm.ws.webcontainer.osgi.servlet.ServletWrapper.modifyTarget(ServletWrapper.java:72)
> at com.ibm.ws.webcontainer.servlet.ServletWrapper.init(ServletWrapper.java:333)
> at com.ibm.ws.webcontainer.servlet.ServletWrapper.loadOnStartupCheck(ServletWrapper.java:1428)
> at com.ibm.ws.webcontainer.webapp.WebApp.doLoadOnStartupActions(WebApp.java:1204)
> at com.ibm.ws.webcontainer.webapp.WebApp.commonInitializationFinally(WebApp.java:1172)
> at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:1074)
> at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:6583)
> at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApp(DynamicVirtualHost.java:468)
> at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApplication(DynamicVirtualHost.java:463)
> at com.ibm.ws.webcontainer.osgi.WebContainer.startWebApplication(WebContainer.java:1081)
> at com.ibm.ws.webcontainer.osgi.WebContainer.access$000(WebContainer.java:104)
> at com.ibm.ws.webcontainer.osgi.WebContainer$2.run(WebContainer.java:900)