### PR TITLE
Increase the timeout of testMultiRequestBulkhead

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIBulkheadTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIBulkheadTest.java
@@ -57,7 +57,7 @@ public class CDIBulkheadTest extends FATServletClient {
 
     public static final long TEST_TWEAK_TIME_UNIT = 100;
     public static final long TIMEOUT = 5000;
-    public static final long FUTURE_THRESHOLD = 2000;
+    public static final long FUTURE_THRESHOLD = 6000;
 
     @BeforeClass
     public static void setup() throws Exception {


### PR DESCRIPTION
This test occasionally fails in the build due to the request taking too
long. The time taken is not critical to the correct running of the test
so we can improve reliability by increasing the timeout.