### PR TITLE
Make ORB startup timeout value configurable

### DIFF
--- a/dev/com.ibm.ws.transport.iiop/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.transport.iiop/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,8 @@ orbWrapper.iiopEndpoint.desc=Optional IIOP Endpoint describing the ports open fo
 orbWrapper.name=Object Request Broker (ORB)
 orbWrapper.nameService=Naming context location for a client ORB
 orbWrapper.nameService.desc=Optional URL for the remote name service, for example corbaname::localhost:2809
+orbWrapper.orbSSLInitTimeout=Timeout that governs ORB SSL initialization
+orbWrapper.orbSSLInitTimeout.desc=ORB SSL initialization timeout specified in seconds
 
 #deprecated
 iiopClient.desc=Configuration for IIOP client

--- a/dev/com.ibm.ws.transport.iiop/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.transport.iiop/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011 IBM Corporation and others.
+    Copyright (c) 2011, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -37,7 +37,10 @@
 
         <AD name="%orbWrapper.nameService" description="%orbWrapper.nameService.desc"
             id="nameService" required="false" type="String" default="corbaname::localhost:2809" />
-            
+
+        <AD name="%orbWrapper.orbSSLInitTimeout" description="%orbWrapper.orbSSLInitTimeout.desc"
+            id="orbSSLInitTimeout" required="false" type="String" default="10" />    
+
         <AD id="iiopEndpoint" name="%orbWrapper.iiopEndpoint" description="%orbWrapper.iiopEndpoint.desc" cardinality="100"
             required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.transport.iiop.internal.IIOPEndpointImpl" default="defaultIiopEndpoint"/>
             


### PR DESCRIPTION
Occasionally, CWWKS9582E message which indicates that SSL is not initialized within 10 seconds is logged. Most of the time, it is due to the hardware performance. This PR intends to provide a way to modify the timeout value other than 10.