### PR TITLE
Enable waitForRecovery test with transaction bundle set to CONTAINER_LATE

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.1.feature
@@ -23,7 +23,7 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.anno-1.0
 -bundles=com.ibm.ws.tx.jta.extensions, \
- com.ibm.ws.transaction, \
+ com.ibm.ws.transaction; start-phase:=CONTAINER_LATE, \
  com.ibm.tx.jta, \
  com.ibm.tx.util, \
  com.ibm.tx.ltc, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.2.feature
@@ -25,7 +25,7 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
  com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3; apiJar=false, \
  com.ibm.websphere.appserver.anno-1.0
 -bundles=com.ibm.ws.tx.jta.extensions, \
- com.ibm.ws.transaction, \
+ com.ibm.ws.transaction; start-phase:=CONTAINER_LATE, \
  com.ibm.tx.jta, \
  com.ibm.ws.transaction.cdi, \
  com.ibm.tx.util, \

--- a/dev/com.ibm.ws.transaction.core_fat/publish/servers/com.ibm.ws.transaction_waitForRecovery/server.xml
+++ b/dev/com.ibm.ws.transaction.core_fat/publish/servers/com.ibm.ws.transaction_waitForRecovery/server.xml
@@ -31,7 +31,7 @@
     
     <transaction
         recoverOnStartup="true"
-        waitForRecovery="false"
+        waitForRecovery="true"
         heuristicRetryInterval="10"
     />
 


### PR DESCRIPTION
The WaitForRecoveryTest confirms that the waitForRecovery configuration option is honoured. Prior to issue #5119 's resolution waitForRecovery processing could hang. 

The combination of #5119 - which means that the OSGi DS services do not conflict - and the setting of CONTAINER_LATE for the com.ibm.ws.transaction bundle - which means that the Liberty bundles can start without conflict - allow waitForRecovery to work.
