### PR TITLE
beans for container-produced ThreadContext and ManagedExecutor must not have an EL name

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ManagedExecutorBean.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ManagedExecutorBean.java
@@ -38,7 +38,6 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
     private static final Set<Type> TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(TYPE_ARR)));
 
     private final String injectionPointName;
-    private final String instanceName;
     private final Set<Annotation> qualifiers;
     private final ManagedExecutor executor;
 
@@ -46,7 +45,6 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
         Objects.requireNonNull(injectionPointName);
         Objects.requireNonNull(instanceName);
         this.injectionPointName = injectionPointName;
-        this.instanceName = instanceName;
         this.executor = executor;
         Set<Annotation> qualifiers = new HashSet<>(2);
         qualifiers.add(Any.Literal.INSTANCE);
@@ -67,7 +65,7 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
     @Override
     @Trivial
     public String getName() {
-        return instanceName; // TODO should change this to null because @Named qualifier is not present ?
+        return null; // because @Named qualifier is not present. See section 2.6.3, "Beans with no name", of CDI 2.0 spec.
     }
 
     @Override
@@ -127,7 +125,7 @@ public class ManagedExecutorBean implements Bean<ManagedExecutor>, PassivationCa
     @Override
     @Trivial
     public String toString() {
-        return this.getClass().getSimpleName() + '-' + getName();
+        return this.getClass().getSimpleName() + '-' + getId();
     }
 
 }

--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ThreadContextBean.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ThreadContextBean.java
@@ -57,7 +57,7 @@ public class ThreadContextBean implements Bean<ThreadContext>, PassivationCapabl
     @Override
     @Trivial
     public String getName() {
-        return null; // because @Named qualifier is not present
+        return null; // because @Named qualifier is not present. See section 2.6.3, "Beans with no name", of CDI 2.0 spec.
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentCDITestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentCDITestServer/server.xml
@@ -29,6 +29,8 @@
         <file name="${server.config.dir}/lib/customContextProviders.jar"/>
     </library>
 
+    <!-- Needed for application to construct annotation literal -->
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentCDIApp.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
     <!-- Needed for application to use a ForkJoinPool, access the thread context class loader, and shut down an unmanaged ExecutorService that the test application creates -->
     <javaPermission codebase="${server.config.dir}/apps/MPConcurrentCDIApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
     <javaPermission codebase="${server.config.dir}/apps/MPConcurrentCDIApp.war" className="java.lang.RuntimePermission" name="modifyThread"/>


### PR DESCRIPTION
Per section 2.6.3 "Beans with no name" of the CDI 2.0 spec doc, there is no EL name for beans without the `@Named` annotation.  This pull updates our implementation to be consistent with this requirement.