### PR TITLE
Increase JobWaiter polling timeout to 30

### DIFF
--- a/dev/com.ibm.ws.jbatch.cdi_fat/util/src/fat/util/JobWaiter.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/util/src/fat/util/JobWaiter.java
@@ -83,7 +83,7 @@ public class JobWaiter {
         this.timeout = timeout;
     }
 
-    private static long DFLT_TIMEOUT = 10000;
+    private static long DFLT_TIMEOUT = 30000;
 
     /**
      * Wait for {@code JobWaiter#timeout} seconds for BOTH of:


### PR DESCRIPTION
Just a FAT change to decrease false failures due to missing a timing window.