### PR TITLE
precontextualized actions supplied to managed executor and completion stage

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualRunnable.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,9 +20,9 @@ import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
  * If a CompletableFuture is supplied, triggers its completion upon completion of the Runnable.
  */
 class ContextualRunnable implements Runnable {
-    private final Runnable action;
+    final Runnable action;
     private ManagedCompletableFuture<Void> completableFuture;
-    private final ThreadContextDescriptor threadContextDescriptor;
+    final ThreadContextDescriptor threadContextDescriptor;
 
     ContextualRunnable(ThreadContextDescriptor threadContextDescriptor, Runnable action) {
         this.action = action;

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualSupplier.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,8 +22,8 @@ import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
  * @param <T> type of the result that is supplied by the supplier
  */
 class ContextualSupplier<T> implements Supplier<T> {
-    private final Supplier<T> action;
-    private final ThreadContextDescriptor threadContextDescriptor;
+    final Supplier<T> action;
+    final ThreadContextDescriptor threadContextDescriptor;
 
     ContextualSupplier(ThreadContextDescriptor threadContextDescriptor, Supplier<T> action) {
         this.action = action;

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletableFuture.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -415,7 +415,14 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+        ThreadContextDescriptor contextDescriptor;
+        if (action instanceof ContextualSupplier) {
+            ContextualRunnable r = (ContextualRunnable) action;
+            contextDescriptor = r.threadContextDescriptor;
+            action = r.action;
+        } else {
+            contextDescriptor = captureThreadContext(executor);
+        }
 
         if (JAVA8) {
             action = new ContextualRunnable(contextDescriptor, action);
@@ -457,7 +464,14 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+        ThreadContextDescriptor contextDescriptor;
+        if (action instanceof ContextualSupplier) {
+            ContextualSupplier<U> s = (ContextualSupplier<U>) action;
+            contextDescriptor = s.threadContextDescriptor;
+            action = s.action;
+        } else {
+            contextDescriptor = captureThreadContext(executor);
+        }
 
         if (JAVA8) {
             action = new ContextualSupplier<U>(contextDescriptor, action);
@@ -482,9 +496,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualConsumer<>(contextDescriptor, action);
+        if (!(action instanceof ContextualConsumer)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualConsumer<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -516,9 +532,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualConsumer<>(contextDescriptor, action);
+        if (!(action instanceof ContextualConsumer)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualConsumer<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -544,9 +562,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -578,9 +598,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -676,11 +698,20 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
             if (action instanceof ManagedTask)
                 throw new IllegalArgumentException(ManagedTask.class.getName());
 
-            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            ThreadContextDescriptor contextDescriptor;
+            if (action instanceof ContextualSupplier) {
+                ContextualSupplier<? extends T> s = (ContextualSupplier<? extends T>) action;
+                contextDescriptor = s.threadContextDescriptor;
+                action = s.action;
+            } else {
+                contextDescriptor = captureThreadContext(executor);
+            }
 
             if (!super.isDone()) {
                 @SuppressWarnings({ "rawtypes", "unchecked" })
                 Runnable task = new ContextualSupplierAction(contextDescriptor, action, this, false);
+                if (executor instanceof WSManagedExecutorService)
+                    executor = ((WSManagedExecutorService) executor).getNormalPolicyExecutor();
                 executor.execute(task);
                 // The existence of completeAsync means that any number of tasks could be submitted to complete a
                 // single ManagedCompletableFuture instance.  We are deciding that it is not worth it to track the
@@ -753,9 +784,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<T> dependentStage = completableFuture.exceptionally(action);
@@ -815,9 +848,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualBiFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualBiFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualBiFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<R> dependentStage = completableFuture.handle(action);
@@ -847,9 +882,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualBiFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualBiFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualBiFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<R> dependentStage = completableFuture.handleAsync(action, futureExecutor == null ? executor : futureExecutor);
@@ -1012,9 +1049,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualRunnable(contextDescriptor, action);
+        if (!(action instanceof ContextualRunnable)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualRunnable(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -1046,9 +1085,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualRunnable(contextDescriptor, action);
+        if (!(action instanceof ContextualRunnable)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualRunnable(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -1074,9 +1115,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualRunnable(contextDescriptor, action);
+        if (!(action instanceof ContextualRunnable)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualRunnable(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -1108,9 +1151,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualRunnable(contextDescriptor, action);
+        if (!(action instanceof ContextualRunnable)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualRunnable(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -1180,9 +1225,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualConsumer<>(contextDescriptor, action);
+        if (!(action instanceof ContextualConsumer)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualConsumer<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<Void> dependentStage = completableFuture.thenAccept(action);
@@ -1212,9 +1259,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualConsumer<>(contextDescriptor, action);
+        if (!(action instanceof ContextualConsumer)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualConsumer<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<Void> dependentStage = completableFuture.thenAcceptAsync(action, futureExecutor == null ? executor : futureExecutor);
@@ -1238,9 +1287,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualBiConsumer<>(contextDescriptor, action);
+        if (!(action instanceof ContextualBiConsumer)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualBiConsumer<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -1272,9 +1323,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualBiConsumer<>(contextDescriptor, action);
+        if (!(action instanceof ContextualBiConsumer)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualBiConsumer<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -1300,9 +1353,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<R> dependentStage = completableFuture.thenApply(action);
@@ -1332,9 +1387,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<R> dependentStage = completableFuture.thenApplyAsync(action, futureExecutor == null ? executor : futureExecutor);
@@ -1358,9 +1415,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualBiFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualBiFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualBiFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -1392,9 +1451,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualBiFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualBiFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualBiFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             if (other instanceof ManagedCompletableFuture)
@@ -1420,9 +1481,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<U> dependentStage = completableFuture.thenCompose(action);
@@ -1452,9 +1515,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualFunction<>(contextDescriptor, action);
+        if (!(action instanceof ContextualFunction)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualFunction<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<U> dependentStage = completableFuture.thenComposeAsync(action, futureExecutor == null ? executor : futureExecutor);
@@ -1478,9 +1543,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualRunnable(contextDescriptor, action);
+        if (!(action instanceof ContextualRunnable)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualRunnable(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<Void> dependentStage = completableFuture.thenRun(action);
@@ -1510,9 +1577,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualRunnable(contextDescriptor, action);
+        if (!(action instanceof ContextualRunnable)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualRunnable(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<Void> dependentStage = completableFuture.thenRunAsync(action, futureExecutor == null ? executor : futureExecutor);
@@ -1583,9 +1652,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         if (action instanceof ManagedTask)
             throw new IllegalArgumentException(ManagedTask.class.getName());
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
-        if (contextDescriptor != null)
-            action = new ContextualBiConsumer<>(contextDescriptor, action);
+        if (!(action instanceof ContextualBiConsumer)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(defaultExecutor);
+            if (contextDescriptor != null)
+                action = new ContextualBiConsumer<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<T> dependentStage = completableFuture.whenComplete(action);
@@ -1615,9 +1686,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
         FutureRefExecutor futureExecutor = supportsAsync(executor);
 
-        ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
-        if (contextDescriptor != null)
-            action = new ContextualBiConsumer<>(contextDescriptor, action);
+        if (!(action instanceof ContextualBiConsumer)) {
+            ThreadContextDescriptor contextDescriptor = captureThreadContext(executor);
+            if (contextDescriptor != null)
+                action = new ContextualBiConsumer<>(contextDescriptor, action);
+        }
 
         if (JAVA8) {
             CompletableFuture<T> dependentStage = completableFuture.whenCompleteAsync(action, futureExecutor == null ? executor : futureExecutor);


### PR DESCRIPTION
When a pre-contextualized action (for example, threadContext.contextualRunnable(action)) is supplied as the action for a ManagedExecutor or managed completion stage, the already-captured context from the action should be used rather than newly captured context according to the managed executor configuration.  However, the ManagedExecutor is still the default asynchronous execution facility and provides context propagation for other dependent actions which are not pre-contextualized.

Here is an example where 'supplier' and 'function2' run with context captured by 'myManagedExecutor', but 'function1' runs with context captured by 'myThreadContext',
```
myManagedExecutor
    .supplyAsync(supplier)
    .thenApplyAsync(myThreadContext.contextualFunction(function1))
    .thenApplyAsync(function2);
```