### PR TITLE
Test fix: ensure builder timeout is reset after test that changes it.

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
@@ -62,6 +62,6 @@ public class BasicTest extends FATServletClient {
     @AfterClass
     public static void afterClass() throws Exception {
         server.stopServer();
-        remoteAppServer.stopServer();
+        remoteAppServer.stopServer("CWWKO0801E");
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicClientApp/src/mpRestClient10/basic/BasicClientTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicClientApp/src/mpRestClient10/basic/BasicClientTestServlet.java
@@ -118,23 +118,27 @@ public class BasicClientTestServlet extends FATServlet {
 
     @Test
     public void testReadTimeout(HttpServletRequest req, HttpServletResponse resp) throws Exception {
-        builder.property("com.ibm.ws.jaxrs.client.receive.timeout", "5");
-        long startTime = System.nanoTime();
-        WaitServiceClient client = builder.build(WaitServiceClient.class);
-        Response r = null;
         try {
-            r = client.waitFor(20);
-            fail("Did not throw expected ProcessingException");
-        } catch (ProcessingException expected) {
-            LOG.info("Caught expected ProcessingException");
-        } catch (Throwable t) {
-            LOG.log(Level.SEVERE, "Caught unexpected exception", t);
-            fail("Caught unexpected exception: " + t);
+            builder.property("com.ibm.ws.jaxrs.client.receive.timeout", "5");
+            long startTime = System.nanoTime();
+            WaitServiceClient client = builder.build(WaitServiceClient.class);
+            Response r = null;
+            try {
+                r = client.waitFor(20);
+                fail("Did not throw expected ProcessingException");
+            } catch (ProcessingException expected) {
+                LOG.info("Caught expected ProcessingException");
+            } catch (Throwable t) {
+                LOG.log(Level.SEVERE, "Caught unexpected exception", t);
+                fail("Caught unexpected exception: " + t);
+            }
+            long elapsedTime = System.nanoTime() - startTime;
+            long elapsedTimeSecs = TimeUnit.SECONDS.convert(elapsedTime, TimeUnit.NANOSECONDS);
+            LOG.info("waited >=" + elapsedTimeSecs + " seconds");
+            assertTrue("Did not time out when expected (5 secs) - instead waited at least 20 seconds.",
+                       elapsedTimeSecs < 20);
+        } finally {
+            builder.property("com.ibm.ws.jaxrs.client.receive.timeout", "120000");
         }
-        long elapsedTime = System.nanoTime() - startTime;
-        long elapsedTimeSecs = TimeUnit.SECONDS.convert(elapsedTime, TimeUnit.NANOSECONDS);
-        LOG.info("waited >=" + elapsedTimeSecs + " seconds");
-        assertTrue("Did not time out when expected (5 secs) - instead waited at least 20 seconds.",
-                   elapsedTimeSecs < 20);
     }
 }


### PR DESCRIPTION
Fix a test to reset the read timeout after a test lowers it.  This comes into play when the test cases are executed "out of order" and a non-timeout-related test attempts to run after the read timeout has been set to a low value.  The tests should not assume any ordering.  This fix ensures that the timeout gets reset properly.