### PR TITLE
fix for connection wait timeout translation

### DIFF
--- a/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/j2c/resources/J2CAMessages.nlsprops
+++ b/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/j2c/resources/J2CAMessages.nlsprops
@@ -112,7 +112,7 @@ NO_VALID_TRANSACTION_CONTEXT_J2CA0040.explanation=There was an internal error in
 NO_VALID_TRANSACTION_CONTEXT_J2CA0040.useraction=CMSG0002
 
 # --------------------------------
-POOL_MANAGER_EXCP_CCF2_0001_J2CA0045=J2CA0045E: Connection not available while invoking method {0} for resource {1}. Timed out waiting for {2} millisecond(s) with {3} remaining waiting requests and current total connections used {4}.
+POOL_MANAGER_EXCP_CCF2_0001_J2CA0045=J2CA0045E: Connection not available while invoking method {0} for resource {1}. Timed out waiting for {2} millisecond(s) with {3} remaining waiting requests and {4} current total connections used.
 POOL_MANAGER_EXCP_CCF2_0001_J2CA0045.explanation=A connection wait timeout has occurred. A ConnectionWaitTimeoutException was created.
 POOL_MANAGER_EXCP_CCF2_0001_J2CA0045.useraction=Reconfigure the connection pool. Increase the maximum number of connections or increase the connection wait time to avoid this error.
 

--- a/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/j2c/resources/J2CAMessages.nlsprops
+++ b/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/j2c/resources/J2CAMessages.nlsprops
@@ -112,7 +112,7 @@ NO_VALID_TRANSACTION_CONTEXT_J2CA0040.explanation=There was an internal error in
 NO_VALID_TRANSACTION_CONTEXT_J2CA0040.useraction=CMSG0002
 
 # --------------------------------
-POOL_MANAGER_EXCP_CCF2_0001_J2CA0045=J2CA0045E: Connection not available while invoking method {0} for resource {1}.
+POOL_MANAGER_EXCP_CCF2_0001_J2CA0045=J2CA0045E: Connection not available while invoking method {0} for resource {1}.  Timed out waiting for {2} with {3} remaining waiting requests and current total connections used {4}.
 POOL_MANAGER_EXCP_CCF2_0001_J2CA0045.explanation=A connection wait timeout has occurred. A ConnectionWaitTimeoutException was created.
 POOL_MANAGER_EXCP_CCF2_0001_J2CA0045.useraction=Reconfigure the connection pool. Increase the maximum number of connections or increase the connection wait time to avoid this error.
 

--- a/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/j2c/resources/J2CAMessages.nlsprops
+++ b/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/j2c/resources/J2CAMessages.nlsprops
@@ -112,7 +112,7 @@ NO_VALID_TRANSACTION_CONTEXT_J2CA0040.explanation=There was an internal error in
 NO_VALID_TRANSACTION_CONTEXT_J2CA0040.useraction=CMSG0002
 
 # --------------------------------
-POOL_MANAGER_EXCP_CCF2_0001_J2CA0045=J2CA0045E: Connection not available while invoking method {0} for resource {1}.  Timed out waiting for {2} with {3} remaining waiting requests and current total connections used {4}.
+POOL_MANAGER_EXCP_CCF2_0001_J2CA0045=J2CA0045E: Connection not available while invoking method {0} for resource {1}. Timed out waiting for {2} millisecond with {3} remaining waiting requests and current total connections used {4}.
 POOL_MANAGER_EXCP_CCF2_0001_J2CA0045.explanation=A connection wait timeout has occurred. A ConnectionWaitTimeoutException was created.
 POOL_MANAGER_EXCP_CCF2_0001_J2CA0045.useraction=Reconfigure the connection pool. Increase the maximum number of connections or increase the connection wait time to avoid this error.
 

--- a/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/j2c/resources/J2CAMessages.nlsprops
+++ b/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/j2c/resources/J2CAMessages.nlsprops
@@ -112,7 +112,7 @@ NO_VALID_TRANSACTION_CONTEXT_J2CA0040.explanation=There was an internal error in
 NO_VALID_TRANSACTION_CONTEXT_J2CA0040.useraction=CMSG0002
 
 # --------------------------------
-POOL_MANAGER_EXCP_CCF2_0001_J2CA0045=J2CA0045E: Connection not available while invoking method {0} for resource {1}. Timed out waiting for {2} millisecond with {3} remaining waiting requests and current total connections used {4}.
+POOL_MANAGER_EXCP_CCF2_0001_J2CA0045=J2CA0045E: Connection not available while invoking method {0} for resource {1}. Timed out waiting for {2} millisecond(s) with {3} remaining waiting requests and current total connections used {4}.
 POOL_MANAGER_EXCP_CCF2_0001_J2CA0045.explanation=A connection wait timeout has occurred. A ConnectionWaitTimeoutException was created.
 POOL_MANAGER_EXCP_CCF2_0001_J2CA0045.useraction=Reconfigure the connection pool. Increase the maximum number of connections or increase the connection wait time to avoid this error.
 

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
@@ -172,7 +172,7 @@ public final class FreePool implements JCAPMIHelper {
                              + " on datasource "
                              + gConfigProps.cfName);
             }
-            Object[] connWaitTimeoutparms = new Object[] { "createOrWaitForConnection", gConfigProps.cfName, 0, pm.waiterCount,
+            Object[] connWaitTimeoutparms = new Object[] { "queueRequest", gConfigProps.cfName, 0, pm.waiterCount,
                                                            pm.totalConnectionCount.get() };
             Tr.error(
                      tc,


### PR DESCRIPTION
The connection wait timeout exception text is not translated.

The follow error in the trace and connection wait timeout exception will be translated and contain the same information to better problem determination.

[2/5/18 7:32:35:183 CST] 0000004b id=00000000 com.ibm.ejs.j2c.FreePool                                     E J2CA0045E: Connection not available while invoking method createOrWaitForConnection for resource jdbc/test.  Timed out waiting for 20,005 with 3 remaining waiting requests and current total connections used 1.

Exception returned to application,
Caused by: com.ibm.websphere.ce.j2c.ConnectionWaitTimeoutException: J2CA0045E: Connection not available while invoking method createOrWaitForConnection for resource jdbc/test.  Timed out waiting for 20,005 with 3 remaining waiting requests and current total connections used 1.

