### PR TITLE
Decouple cxf projects from the jaxrs.2.0.client project

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,33 +20,31 @@ WS-TraceGroup: JAXRS
 # jaxrs-2.0 is part of EE7 and therefore requires java 1.7
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))" 
 
-
 Export-Package: \
-  com.ibm.ws.jaxrs20.client;thread-context=true, \
-  com.ibm.ws.jaxrs20.client.configuration, \
-  com.ibm.ws.jaxrs20.client.component, \
-  com.ibm.ws.jaxrs20.client.security
+    com.ibm.ws.jaxrs20.client;thread-context=true, \
+    com.ibm.ws.jaxrs20.client.configuration, \
+    com.ibm.ws.jaxrs20.client.component, \
+    com.ibm.ws.jaxrs20.client.security
 
 Import-Package: \
-   org.apache.cxf.*;version=3.1.16, \
-   com.ibm.websphere.security.saml2;resolution:=optional, \
-   com.ibm.ws.jaxrs20.appsecurity.security;resolution:=optional, \
-   *
-   
+    org.apache.cxf.*;version=3.1.16, \
+    com.ibm.websphere.security.saml2;resolution:=optional, \
+    com.ibm.ws.jaxrs20.appsecurity.security;resolution:=optional, \
+    *
+
 Private-Package:\
-  com.ibm.ws.jaxrs20.client.*
+    com.ibm.ws.jaxrs20.client.*
 
 Service-Component: \
-  com.ibm.ws.jaxrs20.client.support.BundleRuntimeProviderFactoryServiceGateway; \
-     configuration-policy:=optional; \
-     providerFactoryService/setProviderFactoryService=com.ibm.ws.jaxrs20.api.JaxRsProviderFactoryService;\
-     immediate:=true; \
-     activate:=activate; \
-     deactivate:=deactivate; \
-     properties:="service.vendor=IBM"
+    com.ibm.ws.jaxrs20.client.support.BundleRuntimeProviderFactoryServiceGateway; \
+    configuration-policy:=optional; \
+    providerFactoryService/setProviderFactoryService=com.ibm.ws.jaxrs20.api.JaxRsProviderFactoryService;\
+    immediate:=true; \
+    activate:=activate; \
+    deactivate:=deactivate; \
+    properties:="service.vendor=IBM"
  
- -dsannotations: com.ibm.ws.jaxrs20.client.component.*, \
- 	com.ibm.ws.jaxrs20.client.security.oauth.OAuthPropagationHelper
+-dsannotations: com.ibm.ws.jaxrs20.client.security.oauth.OAuthPropagationHelper
 
 instrument.classesExcludes: com/ibm/ws/jaxrs20/client/internal/resources/*.class
     

--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -28,6 +28,8 @@ WS-TraceGroup: JAXRS
    org.apache.cxf.*;version=3.1.16, \
 
 Export-Package: \
+	com.ibm.ws.cxf.client,\
+	com.ibm.ws.cxf.client.component,\
 	com.ibm.ws.jaxrs20,\
 	com.ibm.ws.jaxrs20.api;provide=true,\
 	com.ibm.ws.jaxrs20.bus,\
@@ -149,7 +151,8 @@ Include-Resource: \
   org/apache/cxf=${bin}/org/apache/cxf, \
   org/codehaus/jackson=${bin}/org/codehaus/jackson
 
--dsannotations: com.ibm.ws.jaxrs20.component.*, \
+-dsannotations: com.ibm.ws.cxf.client.component.*, \
+	com.ibm.ws.jaxrs20.component.*, \
  	com.ibm.ws.jaxrs20.clientconfig.JAXRSClientConfigImpl, \
  	com.ibm.ws.jaxrs20.providers.customexceptionmapper.CustomExceptionMapperRegister, \
  	com.ibm.ws.jaxrs20.providers.security.SecurityAnnoProviderRegister

--- a/dev/com.ibm.ws.jaxrs.2.x.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.x.concurrent/bnd.bnd
@@ -25,6 +25,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 Import-Package: \
   org.apache.cxf.*;version="[3.0.2,4)", \
   com.ibm.websphere.ras.*, \
+  com.ibm.ws.cxf.client, \
   com.ibm.ws.jaxrs20.client, \
   com.ibm.ws.ffdc, \
   com.ibm.ws.concurrent, \
@@ -33,13 +34,12 @@ Import-Package: \
   org.osgi.framework, \
   org.osgi.service.component
 
-  
 # If you need use MESSAGE, you must enable this Private-Package, or message will translate wrong
 Private-Package:\
    com.ibm.ws.jaxrs2x.concurrent.*
 
--dsannotations: com.ibm.ws.jaxrs2x.concurrent.component.*    
- 
+-dsannotations: com.ibm.ws.jaxrs2x.concurrent.component.*
+
 -buildpath: \
 	org.apache.cxf.cxf-core;strategy=exact;version=3.1.16,\
 	org.apache.cxf.cxf-rt-frontend-jaxrs;strategy=exact;version=3.1.16,\

--- a/dev/com.ibm.ws.jaxrs.2.x.concurrent/src/com/ibm/ws/jaxrs2x/concurrent/component/ManagedExecutorRunnableWrapper.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.concurrent/src/com/ibm/ws/jaxrs2x/concurrent/component/ManagedExecutorRunnableWrapper.java
@@ -16,7 +16,7 @@ import org.apache.cxf.message.Message;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.ws.concurrent.WSManagedExecutorService;
-import com.ibm.ws.jaxrs20.client.AsyncClientRunnableWrapper;
+import com.ibm.ws.cxf.client.AsyncClientRunnableWrapper;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.WSContextService;
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.bnd
@@ -13,14 +13,16 @@
 javac.source: 1.8
 javac.target: 1.8
 
+-dsannotations: com.ibm.ws.cxf.client.component.*
+
 -includeresource: \
    @${repo;org.apache.cxf:cxf-rt-transports-http;3.2.6}!/!META-INF/*,\
    org/apache/cxf=${bin}/org/apache/cxf
 
 -buildpath: org.apache.cxf:cxf-rt-transports-http;version=3.2.6,\
   com.ibm.websphere.javaee.servlet.4.0;version=latest,\
-  com.ibm.ws.jaxrs.2.0.client,\
   com.ibm.ws.logging.core,\
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  com.ibm.wsspi.org.osgi.core
+  com.ibm.wsspi.org.osgi.core,\
+  com.ibm.wsspi.org.osgi.service.component.annotations

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
@@ -8,6 +8,8 @@ Bundle-Activator: com.ibm.ws.jaxrs21.transports.http.NoOpActivator
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Export-Package: \
+  com.ibm.ws.cxf.client,\
+  com.ibm.ws.cxf.client.component,\
   com.ibm.ws.jaxrs21.transports.http,\
   org.apache.cxf.transport.http,\
   org.apache.cxf.transport.http.auth,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/com/ibm/ws/cxf/client/AsyncClientRunnableWrapper.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/com/ibm/ws/cxf/client/AsyncClientRunnableWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs20.client;
+package com.ibm.ws.cxf.client;
 
 import org.apache.cxf.message.Message;
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/com/ibm/ws/cxf/client/component/AsyncClientRunnableWrapperManager.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/com/ibm/ws/cxf/client/component/AsyncClientRunnableWrapperManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jaxrs20.client.component;
+package com.ibm.ws.cxf.client.component;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -20,9 +20,9 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
-import com.ibm.ws.jaxrs20.client.AsyncClientRunnableWrapper;
+import com.ibm.ws.cxf.client.AsyncClientRunnableWrapper;
 
-@Component(name = "com.ibm.ws.jaxrs20.client.component.AsyncClientRunnableWrapperManager",
+@Component(name = "com.ibm.ws.cxf.client.component.AsyncClientRunnableWrapperManager",
            immediate = true,
            property = { "service.vendor=IBM" })
 public class AsyncClientRunnableWrapperManager {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/com/ibm/ws/cxf/client/component/package-info.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/com/ibm/ws/cxf/client/component/package-info.java
@@ -1,0 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+@org.osgi.annotation.versioning.Version("1.0.0")
+package com.ibm.ws.cxf.client.component;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/com/ibm/ws/cxf/client/package-info.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/com/ibm/ws/cxf/client/package-info.java
@@ -1,0 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+@org.osgi.annotation.versioning.Version("1.0.0")
+package com.ibm.ws.cxf.client;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -94,7 +94,7 @@ import org.apache.cxf.ws.addressing.EndpointReferenceType;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.jaxrs20.client.component.AsyncClientRunnableWrapperManager;
+import com.ibm.ws.cxf.client.component.AsyncClientRunnableWrapperManager;
 
 /*
  * HTTP Conduit implementation.

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/bnd.bnd
@@ -20,8 +20,5 @@ javac.target: 1.8
 -buildpath: org.apache.cxf:cxf-rt-transports-http-hc;version=3.2.6,\
  com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2;version=latest,\
- com.ibm.ws.jaxrs.2.0.client;version=latest,\
  com.ibm.ws.org.apache.httpcomponents;version=latest,\
  com.ibm.ws.logging.core;version=latest
- 
- 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/src/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2/src/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduit.java
@@ -96,7 +96,7 @@ import org.apache.http.nio.reactor.IOSession;
 import org.apache.http.nio.util.HeapByteBufferAllocator;
 
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.jaxrs20.client.component.AsyncClientRunnableWrapperManager;
+import com.ibm.ws.cxf.client.component.AsyncClientRunnableWrapperManager;
 
 /**
  *


### PR DESCRIPTION
Decouple org.apache.cxf.cxf.rt.transports.http.3.2 and org.apache.cxf.cxf.rt.transports.http.hc.3.2 from com.ibm.ws.jaxrs.2.0.client