### PR TITLE
Avoid warning when no providers are specified for MP Rest Client

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
@@ -195,16 +195,18 @@ public class RestClientBean implements Bean<Object>, PassivationCapable {
     @FFDCIgnore(ClassNotFoundException.class)
     private List<Class<?>> getConfiguredProviders() {
         String property = String.format(REST_PROVIDERS_FORMAT, clientInterface.getName());
-        String providersList = ConfigFacade.getOptionalValue(property, String.class).orElse("");
-        String[] providerClassNames = providersList.split(",");
+        String providersList = ConfigFacade.getOptionalValue(property, String.class).orElse(null);
         List<Class<?>> providers = new ArrayList<>();
-        for (int i=0; i<providerClassNames.length; i++) {
-            try {
-                providers.add(ClassLoaderUtils.loadClass(providerClassNames[i], RestClientBean.class));
-            } catch (ClassNotFoundException e) {
-                LOG.log(Level.WARNING,
-                        "Could not load provider, {0}, configured for Rest Client interface, {1} ",
-                        new Object[]{providerClassNames[i], clientInterface.getName()});
+        if (providersList != null) {
+            String[] providerClassNames = providersList.split(",");
+            for (int i=0; i<providerClassNames.length; i++) {
+                try {
+                    providers.add(ClassLoaderUtils.loadClass(providerClassNames[i], RestClientBean.class));
+                } catch (ClassNotFoundException e) {
+                    LOG.log(Level.WARNING,
+                            "Could not load provider, {0}, configured for Rest Client interface, {1} ",
+                            new Object[]{providerClassNames[i], clientInterface.getName()});
+                }
             }
         }
         return providers;


### PR DESCRIPTION
Resolves this warning message when no providers are specified via MP Config:
```
[2/5/19 16:30:24:615 CST] 00000026 .cxf.rt.rs.mp.client.3.2:1.0.24.cl190120190124-2339(id=195)] W Could not load provider, , configured for Rest Client interface, io.mycompany.MyClient 
```

This resolves issue [962](https://github.com/OpenLiberty/openliberty.io/issues/962).