### PR TITLE
fix dynamic changing of connection timeout to 0

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
@@ -919,10 +919,7 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
     public void propertyChange(PropertyChangeEvent event) {}
 
     public int getConnctionWaitTime() {
-        // TODO Auto-generated method stub
-        // This may not be needed, keep for now, but most likely will be removed.
-
-        return 0;
+        return connectionTimeout;
     }
 
     /**


### PR DESCRIPTION
The connection wait time can dynamically be changed to any value except 0. By preventing the value to change to 0, threads waiting for connections can not be dynamically release immediately. 1 second can be use as a temporary work around to the problem.
