### PR TITLE
FT 2.0: Fix async fallback

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/BulkheadTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/BulkheadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,17 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance.test;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -23,14 +29,18 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 import org.junit.Test;
 
 import com.ibm.ws.microprofile.faulttolerance.spi.BulkheadPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.Executor;
 import com.ibm.ws.microprofile.faulttolerance.spi.ExecutorBuilder;
+import com.ibm.ws.microprofile.faulttolerance.spi.FallbackPolicy;
+import com.ibm.ws.microprofile.faulttolerance.spi.FaultToleranceFunction;
 import com.ibm.ws.microprofile.faulttolerance.spi.FaultToleranceProvider;
 import com.ibm.ws.microprofile.faulttolerance.spi.RetryPolicy;
+import com.ibm.ws.microprofile.faulttolerance.test.util.AsyncTestFunction;
 import com.ibm.ws.microprofile.faulttolerance.test.util.TestTask;
 
 /**
@@ -195,6 +205,165 @@ public class BulkheadTest extends AbstractFTTest {
         long diff = now - relativePoint;
         double seconds = ((double) diff / (double) 1000000000);
         return "" + seconds + "s";
+    }
+
+    @Test
+    public void testAsyncBulkhead() throws InterruptedException, ExecutionException, TimeoutException {
+        BulkheadPolicy bulkhead = FaultToleranceProvider.newBulkheadPolicy();
+        bulkhead.setMaxThreads(20);
+        bulkhead.setQueueSize(20);
+
+        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        builder.setBulkheadPolicy(bulkhead);
+
+        Executor<Future<String>> executor = builder.buildAsync(Future.class);
+
+        Future<String>[] futures = new Future[10];
+        CountDownLatch isRunningLatch = new CountDownLatch(10);
+        CountDownLatch mayCompleteLatch = new CountDownLatch(1);
+        CountDownLatch completedLatch = new CountDownLatch(10);
+        try {
+            for (int i = 0; i < 10; i++) {
+                String id = "testAsyncBulkhead" + i;
+                AsyncTestFunction callable = new AsyncTestFunction(Duration.ofMillis(10000), isRunningLatch, mayCompleteLatch, completedLatch, id);
+                ExecutionContext context = executor.newExecutionContext(id, (Method) null, id);
+                Future<String> future = executor.execute(callable, context);
+                assertFalse(future.isDone());
+                futures[i] = future;
+            }
+
+            // Wait for all tasks to start
+            isRunningLatch.await(5000, TimeUnit.MILLISECONDS);
+            assertEquals("not all tasks started", 0, isRunningLatch.getCount());
+
+            for (int i = 0; i < 10; i++) {
+                assertFalse(futures[i].isDone());
+            }
+
+            // Release tasks
+            mayCompleteLatch.countDown();
+
+            for (int i = 0; i < 10; i++) {
+                String data = futures[i].get(2300, TimeUnit.MILLISECONDS);
+                assertEquals("testAsyncBulkhead" + i, data);
+            }
+        } finally {
+            mayCompleteLatch.countDown();
+            for (int i = 0; i < 10; i++) {
+                Future<String> future = futures[i];
+                if (future != null && !future.isDone()) {
+                    future.cancel(true);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testAsyncBulkheadQueueFull() throws InterruptedException, ExecutionException, TimeoutException {
+        BulkheadPolicy bulkhead = FaultToleranceProvider.newBulkheadPolicy();
+        bulkhead.setMaxThreads(2);
+        bulkhead.setQueueSize(2);
+
+        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        builder.setBulkheadPolicy(bulkhead);
+
+        Executor<Future<String>> executor = builder.buildAsync(Future.class);
+
+        Future<String>[] futures = new Future[5];
+        CountDownLatch isRunningLatch = new CountDownLatch(2);
+        CountDownLatch mayCompleteLatch = new CountDownLatch(1);
+        CountDownLatch completedLatch = new CountDownLatch(4);
+        try {
+            for (int i = 0; i < 5; i++) {
+                String id = "testAsyncBulkheadQueueFull" + i;
+                ExecutionContext context = executor.newExecutionContext(id, (Method) null, id);
+                AsyncTestFunction callable = new AsyncTestFunction(Duration.ofMillis(10000), isRunningLatch, mayCompleteLatch, completedLatch, id);
+                futures[i] = executor.execute(callable, context);
+                System.out.println(System.currentTimeMillis() + " Test " + id + " - submitted");
+            }
+
+            isRunningLatch.await(5000, TimeUnit.MILLISECONDS);
+            assertEquals("not all tasks started", 0, isRunningLatch.getCount());
+
+            // No tasks are allowed to complete, first two should be running, second two should be queued, last one should be rejected
+            for (int i = 0; i < 4; i++) {
+                assertFalse("task " + i + " should not be complete", futures[i].isDone());
+            }
+
+            assertTrue("task 4 should be complete", futures[4].isDone());
+            try {
+                futures[4].get(5000, TimeUnit.MILLISECONDS);
+                fail("Exception not thrown");
+            } catch (ExecutionException e) {
+                assertThat("Should fail with bulkhead exception", e.getCause(), instanceOf(BulkheadException.class));
+            }
+
+            mayCompleteLatch.countDown();
+        } finally {
+            for (int i = 0; i < 5; i++) {
+                Future<String> future = futures[i];
+                if (future != null && !future.isDone()) {
+                    future.cancel(true);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testAsyncBulkheadFullFallback() throws InterruptedException, TimeoutException, ExecutionException {
+        BulkheadPolicy bulkhead = FaultToleranceProvider.newBulkheadPolicy();
+        bulkhead.setMaxThreads(2);
+        bulkhead.setQueueSize(2);
+
+        CountDownLatch fallbackLatch = new CountDownLatch(1);
+        FallbackPolicy fallback = FaultToleranceProvider.newFallbackPolicy();
+        fallback.setFallbackFunction(getFallbackFunction(Duration.ofMillis(5000), fallbackLatch));
+
+        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        builder.setBulkheadPolicy(bulkhead);
+        builder.setFallbackPolicy(fallback);
+
+        Executor<Future<String>> executor = builder.buildAsync(Future.class);
+
+        Future<String>[] futures = new Future[5];
+        CountDownLatch isRunningLatch = new CountDownLatch(2);
+        CountDownLatch mayCompleteLatch = new CountDownLatch(1);
+        CountDownLatch completedLatch = new CountDownLatch(4);
+        try {
+            for (int i = 0; i < 5; i++) {
+                String id = "testAsyncBulkheadQueueFull" + i;
+                ExecutionContext context = executor.newExecutionContext(id, (Method) null, id);
+                AsyncTestFunction callable = new AsyncTestFunction(Duration.ofMillis(10000), isRunningLatch, mayCompleteLatch, completedLatch, id);
+                futures[i] = executor.execute(callable, context);
+                System.out.println(System.currentTimeMillis() + " Test " + id + " - submitted");
+            }
+
+            isRunningLatch.await(5000, TimeUnit.MILLISECONDS);
+            assertEquals("not all tasks started", 0, isRunningLatch.getCount());
+
+            // Task 4 should have been rejected and be waiting in its fallback method
+            assertFalse("Fallback for rejected task should not be done", futures[4].isDone());
+
+            fallbackLatch.countDown();
+
+            assertEquals("Rejected task should now complete", "fallback result", futures[4].get(5000, MILLISECONDS));
+
+            mayCompleteLatch.countDown();
+        } finally {
+            for (int i = 0; i < 5; i++) {
+                Future<String> future = futures[i];
+                if (future != null && !future.isDone()) {
+                    future.cancel(true);
+                }
+            }
+        }
+    }
+
+    private FaultToleranceFunction<ExecutionContext, ?> getFallbackFunction(Duration duration, CountDownLatch waitLatch) {
+        return (c) -> {
+            waitLatch.await(duration.toMillis(), TimeUnit.MILLISECONDS);
+            return CompletableFuture.completedFuture("fallback result");
+        };
     }
 
     @Test

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/util/AsyncTestFunction.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/util/AsyncTestFunction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,11 @@ public class AsyncTestFunction implements Callable<Future<String>> {
 
     public AsyncTestFunction(Duration callLength, CountDownLatch wait, CountDownLatch notify, String context) {
         this.function = new TestFunction(callLength, wait, notify, context);
+    }
+
+    public AsyncTestFunction(Duration callLength, CountDownLatch latch, CountDownLatch wait, CountDownLatch notify, String context) {
+        this.function = new TestFunction(callLength, wait, notify, context);
+        this.latch = latch;
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/ejb/AsyncEJBServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/ejb/AsyncEJBServlet.java
@@ -68,4 +68,26 @@ public class AsyncEJBServlet extends FATServlet {
         }
     }
 
+    /**
+     * Test that the thread context is set during a fallback method
+     */
+    @Test
+    public void testAsyncEjbSecurityFallback(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        Future<String> value = threadContextBean.fallbackToSecuredEjb();
+        try {
+            value.get();
+            fail("Able to access EJB without logging in");
+        } catch (ExecutionException e) {
+            assertThat(e.getCause(), instanceOf(EJBAccessException.class));
+        }
+
+        try {
+            req.login("test", "test");
+            Future<String> value2 = threadContextBean.fallbackToSecuredEjb();
+            assertThat(value2.get(), is("OK"));
+        } finally {
+            req.logout();
+        }
+    }
+
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/ejb/AsyncEJBThreadContextBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/ejb/AsyncEJBThreadContextBean.java
@@ -18,6 +18,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Fallback;
 
 @ApplicationScoped
 @Asynchronous
@@ -33,6 +34,16 @@ public class AsyncEJBThreadContextBean {
 
     public Future<Principal> getEjbPrincipal() {
         Principal result = securedEjb.getPrincipal();
+        return CompletableFuture.completedFuture(result);
+    }
+
+    @Fallback(fallbackMethod = "securedEjbFallback")
+    public Future<String> fallbackToSecuredEjb() {
+        throw new RuntimeException("Test Exception");
+    }
+
+    public Future<String> securedEjbFallback() {
+        String result = securedEjb.securedCall();
         return CompletableFuture.completedFuture(result);
     }
 


### PR DESCRIPTION
Ensure that the AsyncExecutor always runs the fallback method
asynchronously, even if the bulkhead is full.

Run fallback with the correct thread context.

Fixes #5493