### PR TITLE
NullPointerException when backed by unmanaged executor

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletableFuture.java
@@ -474,7 +474,8 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
         }
 
         if (JAVA8) {
-            action = new ContextualSupplier<U>(contextDescriptor, action);
+            if (contextDescriptor != null)
+                action = new ContextualSupplier<U>(contextDescriptor, action);
             CompletableFuture<U> completableFuture = CompletableFuture.supplyAsync(action, futureExecutor == null ? executor : futureExecutor);
             return new ManagedCompletableFuture<U>(completableFuture, executor, futureExecutor);
         } else {


### PR DESCRIPTION
The following NullPointerException occurs (Java SE 8 path only) when ManagedCompletableFuture is backed by an unmanaged executor that was obtained via supplyAsync,

java.lang.NullPointerException
at com.ibm.ws.concurrent.mp.ContextualSupplier.get(ContextualSupplier.java:37)
at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
at ...

Also, we don't have any test case for this code path, so I'm adding one.  This code path would only be used internally by Liberty when a completion stage is wanted with the Liberty thread pool as its default asynchronous execution facility.