### PR TITLE
FT 2.0: rename AsyncExecutor stages

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncCompletionStageExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncCompletionStageExecutor.java
@@ -43,13 +43,13 @@ public class AsyncCompletionStageExecutor<R> extends AsyncExecutor<CompletionSta
     }
 
     @Override
-    protected CompletionStage<R> createReturnWrapper(AsyncExecutionContextImpl<CompletionStage<R>> executionContext) {
+    protected CompletionStage<R> createEmptyResultWrapper(AsyncExecutionContextImpl<CompletionStage<R>> executionContext) {
         return new CompletableFuture<R>();
     }
 
     @Override
-    protected void commitResult(AsyncExecutionContextImpl<CompletionStage<R>> executionContext, MethodResult<CompletionStage<R>> result) {
-        CompletableFuture<R> returnWrapper = (CompletableFuture<R>) executionContext.getReturnWrapper();
+    protected void setResult(AsyncExecutionContextImpl<CompletionStage<R>> executionContext, MethodResult<CompletionStage<R>> result) {
+        CompletableFuture<R> resultWrapper = (CompletableFuture<R>) executionContext.getResultWrapper();
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, "Method {0} final fault tolerance result: {1}", executionContext.getMethod(), result);
@@ -61,11 +61,11 @@ public class AsyncCompletionStageExecutor<R> extends AsyncExecutor<CompletionSta
 
         try {
             if (result.isFailure()) {
-                returnWrapper.completeExceptionally(result.getFailure());
+                resultWrapper.completeExceptionally(result.getFailure());
             } else {
-                result.getResult().thenAccept(returnWrapper::complete);
+                result.getResult().thenAccept(resultWrapper::complete);
                 result.getResult().exceptionally((ex) -> {
-                    returnWrapper.completeExceptionally(ex);
+                    resultWrapper.completeExceptionally(ex);
                     return null;
                 });
             }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutionContextImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutionContextImpl.java
@@ -21,11 +21,11 @@ import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 /**
  * Stores context for one asynchronous method execution
  *
- * @param <W> the return type of the code being executed, which is also the type of the return wrapper (e.g. {@code Future<String>})
+ * @param <W> the return type of the code being executed, which is also the type of the result wrapper (e.g. {@code Future<String>})
  */
 public class AsyncExecutionContextImpl<W> extends SyncExecutionContextImpl {
 
-    private W returnWrapper;
+    private W resultWrapper;
     private Callable<W> callable;
     private RetryState retryState;
     private final AtomicBoolean isCancelled = new AtomicBoolean(false);
@@ -37,12 +37,12 @@ public class AsyncExecutionContextImpl<W> extends SyncExecutionContextImpl {
         super(method, parameters);
     }
 
-    public W getReturnWrapper() {
-        return returnWrapper;
+    public W getResultWrapper() {
+        return resultWrapper;
     }
 
-    public void setReturnWrapper(W returnWrapper) {
-        this.returnWrapper = returnWrapper;
+    public void setResultWrapper(W returnWrapper) {
+        this.resultWrapper = returnWrapper;
     }
 
     public Callable<W> getCallable() {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutor.java
@@ -68,7 +68,7 @@ import com.ibm.wsspi.threadcontext.WSContextService;
  * <ul>
  * <li>start at {@code execute()} (called by the fault tolerance interceptor)</li>
  * <li>create a return wrapper and store it in the execution context (see createReturnWrapper)</li>
- * <li>enqueue the first execution attempt to run on another thread (by submitting a task to the AsyncBulkheadState, see enqueueAttempt)</li>
+ * <li>prepare the first execution attempt to run on another thread (by submitting a task to the AsyncBulkheadState, see prepareExecutionAttempt)</li>
  * <li>return the return wrapper to the interceptor</li>
  * </ul>
  * <p>
@@ -76,22 +76,22 @@ import com.ibm.wsspi.threadcontext.WSContextService;
  * <ul>
  * <li>entry point is {@code runExecutionAttempt}</li>
  * <li>the user's method is run and the result is stored in a MethodResult</li>
- * <li>fault tolerance policies are applied based on the MethodResult (see processMethodResult and finalizeAttempt)</li>
- * <li>if it's determined that a retry should be run, a new execution attempt is enqueued to run on another thread (see enqueueAttempt)</li>
- * <li>otherwise, the MethodResult is set into the return wrapper and the execution is complete (see commitResult)</li>
+ * <li>fault tolerance policies are applied based on the MethodResult (see processMethodResult and processEndOfAttempt)</li>
+ * <li>if it's determined that a retry should be run, a new execution attempt is enqueued to run on another thread (see prepareExecutionAttempt)</li>
+ * <li>otherwise, the MethodResult is set into the result wrapper and the execution is complete (see setResult)</li>
  * </ul>
  * <p>
  * There are also some complications that can disrupt the normal flow:
  * <ul>
  * <li>If a timeout occurs, the {@code timeout()} method is called where we try to abort the attempt (interrupting it if it's running) and do the fault tolerance handling (by
- * calling finalizeAttempt)</li>
- * <li>If the user cancels the execution, we try to abort the current attempt and do the fault tolerance handling (calling finalizeAttempt). We'll never retry if the user has tried
- * to cancel.</li>
- * <li>If an unexpected exception is caught, we call {@code handleException()} which will log an FFDC, return the exception as the result to the user and call finalizeAttempt to
- * record a failure and ensure any reserved resources are released.</li>
+ * calling processEndOfAttempt)</li>
+ * <li>If the user cancels the execution, we try to abort the current attempt and do the fault tolerance handling (calling processEndOfAttempt). We'll never retry if the user has
+ * tried to cancel.</li>
+ * <li>If an unexpected exception is caught, we call {@code handleException()} which will log an FFDC, return the exception as the result to the user and call processEndOfAttempt
+ * to record a failure and ensure any reserved resources are released.</li>
  * </ul>
  *
- * @param <W> the return type of the code being executed, which is also the type of the return wrapper (e.g. {@code Future<String>})
+ * @param <W> the return type of the code being executed, which is also the type of the result wrapper (e.g. {@code Future<String>})
  */
 public abstract class AsyncExecutor<W> implements Executor<W> {
 
@@ -143,8 +143,8 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
 
         executionContext.setCallable(callable);
 
-        W returnWrapper = createReturnWrapper(executionContext);
-        executionContext.setReturnWrapper(returnWrapper);
+        W resultWrapper = createEmptyResultWrapper(executionContext);
+        executionContext.setResultWrapper(resultWrapper);
 
         executionContext.setThreadContextDescriptor(contextService.captureThreadContext(null, THREAD_CONTEXT_PROVIDERS));
 
@@ -152,9 +152,9 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
         executionContext.setRetryState(retryState);
         retryState.start();
 
-        enqueueAttempt(executionContext);
+        prepareExecutionAttempt(executionContext);
 
-        return returnWrapper;
+        return resultWrapper;
     }
 
     /**
@@ -162,7 +162,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
      *
      * @return the wrapper instance
      */
-    abstract protected W createReturnWrapper(AsyncExecutionContextImpl<W> executionContext);
+    abstract protected W createEmptyResultWrapper(AsyncExecutionContextImpl<W> executionContext);
 
     /**
      * Stores the result of the execution inside the wrapper instance
@@ -170,12 +170,14 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
      * @param executionContext the execution context
      * @param result           the method result
      */
-    abstract protected void commitResult(AsyncExecutionContextImpl<W> executionContext, MethodResult<W> result);
+    abstract protected void setResult(AsyncExecutionContextImpl<W> executionContext, MethodResult<W> result);
 
     /**
-     * Enqueue an execution attempt on the bulkhead
+     * Submit an execution attempt to be run
+     * <p>
+     * Submission is done through the bulkhead object which may either queue the execution or immediately submit it to the global execution service
      */
-    private void enqueueAttempt(AsyncExecutionContextImpl<W> executionContext) {
+    private void prepareExecutionAttempt(AsyncExecutionContextImpl<W> executionContext) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, "Method {0} enqueuing new execution attempt", executionContext.getMethod());
         }
@@ -191,7 +193,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
             }
 
             MethodResult<W> result = MethodResult.failure(new CircuitBreakerOpenException());
-            finalizeAttempt(attemptContext, result);
+            processEndOfAttempt(attemptContext, result);
             return;
         }
 
@@ -204,7 +206,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
                 Tr.event(tc, "Method {0} bulkhead rejected execution", executionContext.getMethod());
             }
 
-            finalizeAttempt(attemptContext, MethodResult.failure(new BulkheadException()));
+            processEndOfAttempt(attemptContext, MethodResult.failure(new BulkheadException()));
             return;
         }
 
@@ -213,12 +215,14 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
         // Update what we should do if the user cancels the execution
         executionContext.setCancelCallback((mayInterrupt) -> {
             ref.abort(mayInterrupt);
-            finalizeAttempt(attemptContext, MethodResult.failure(new CancellationException()));
+            processEndOfAttempt(attemptContext, MethodResult.failure(new CancellationException()));
         });
     }
 
     /**
-     * Run one attempt at the execution {@link #execute(Callable, ExecutionContext)}
+     * Run one attempt of the execution {@link #execute(Callable, ExecutionContext)}
+     * <p>
+     * This stage includes running the user's code
      */
     @FFDCIgnore(Throwable.class)
     private void runExecutionAttempt(AsyncAttemptContextImpl<W> attemptContext, BulkheadReservation reservation) {
@@ -279,9 +283,9 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
 
         TimeoutState timeoutState = attemptContext.getTimeoutState();
         timeoutState.stop();
-        // Make sure that if we timed out, the timeout callback calls finalizeAttempt rather than us
+        // Make sure that if we timed out, the timeout callback calls processEndOfAttempt rather than us
         if (!timeoutState.isTimedOut()) {
-            finalizeAttempt(attemptContext, methodResult);
+            processEndOfAttempt(attemptContext, methodResult);
         }
     }
 
@@ -296,30 +300,31 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
         ref.abort(true);
 
         MethodResult<W> result = MethodResult.failure(new TimeoutException());
-        finalizeAttempt(attemptContext, result);
+        processEndOfAttempt(attemptContext, result);
     }
 
     /**
      * Process the result of an attempt
      * <p>
-     * This method is usually called from {@link #runExecutionAttempt(AsyncAttemptContextImpl)} at the end of the attempt or from
+     * This method is usually called from {@link #processMethodResult(AsyncAttemptContextImpl, MethodResult, BulkheadReservation)} at the end of the attempt or from
      * {@link #timeout(AsyncAttemptContextImpl, ExecutionReference)} in response to a timeout. In the case of an unexpected exception, it can also be called from
      * {@link #handleExceptions(Runnable, AsyncAttemptContextImpl, AsyncExecutionContextImpl)}.
      * <p>
-     * To ensure that the finalize logic is only run once, this method will do nothing if called a second time for the same attempt context.
+     * To ensure that the end-of-attempt logic is only run once, this method will do nothing if called a second time for the same attempt context.
      * <p>
-     * In regular execution, this method will enqueue another attempt if a retry is needed or run any fallback logic and commit the result if no retry is needed.
+     * In regular execution, if a retry is needed this method will prepare another attempt, if a fallback is needed it will prepare execution of the fallback and otherwise it will
+     * call {@link #processEndOfExecution(AsyncExecutionContextImpl, MethodResult)}.
      * <p>
-     * In the case of an internal exception, this method will commit the result directly, skipping any fallback or retry logic.
+     * In the case of an internal exception, this method will set the result directly, skipping any fallback or retry logic.
      */
-    protected void finalizeAttempt(AsyncAttemptContextImpl<W> attemptContext, MethodResult<W> result) {
+    protected void processEndOfAttempt(AsyncAttemptContextImpl<W> attemptContext, MethodResult<W> result) {
         AsyncExecutionContextImpl<W> executionContext = attemptContext.getExecutionContext();
 
         try {
 
             if (!attemptContext.end()) {
-                // This attempt has already been finalized (probably because an error occurred)
-                // Whatever the reason, we don't want to run the finalization logic again
+                // This attempt has already been completed (probably because an error occurred)
+                // Whatever the reason, we don't want to run the end-of-attempt logic again
                 return;
             }
 
@@ -337,11 +342,11 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
                         Tr.event(tc, "Method {0} retrying with delay: {1} {2}", executionContext.getMethod(), retryResult.getDelay(), retryResult.getDelayUnit());
                     }
                     if (retryResult.getDelay() > 0) {
-                        executorService.schedule(handleExceptions(() -> enqueueAttempt(executionContext), null, executionContext),
+                        executorService.schedule(handleExceptions(() -> prepareExecutionAttempt(executionContext), null, executionContext),
                                                  retryResult.getDelay(),
                                                  retryResult.getDelayUnit());
                     } else {
-                        enqueueAttempt(executionContext);
+                        prepareExecutionAttempt(executionContext);
                     }
                     // We've enqueued the retry to run, exit here
                     return;
@@ -352,35 +357,37 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
                 }
 
                 if (result.isFailure() && fallbackPolicy != null) {
-                    scheduleFallback(result, executionContext);
+                    prepareFallback(result, executionContext);
                     return;
                 }
             }
 
-            finalizeExecution(executionContext, result);
+            processEndOfExecution(executionContext, result);
 
         } catch (Throwable t) {
             // This method is used as a general error handler, so we need some special logic in case something goes wrong while handling the error
             MethodResult<W> errorResult = MethodResult.internalFailure(new FaultToleranceException(Tr.formatMessage(tc, "internal.error.CWMFT4998E", t), t));
-            commitResult(attemptContext.getExecutionContext(), errorResult);
+            setResult(attemptContext.getExecutionContext(), errorResult);
             throw t;
         }
     }
 
-    private void finalizeExecution(AsyncExecutionContextImpl<W> executionContext, MethodResult<W> result) {
+    private void processEndOfExecution(AsyncExecutionContextImpl<W> executionContext, MethodResult<W> result) {
         metricRecorder.incrementInvocationCount();
         if (result.isFailure()) {
             metricRecorder.incrementInvocationFailedCount();
         }
 
-        commitResult(executionContext, result);
+        setResult(executionContext, result);
     }
 
     /**
+     * Prepare the execution of the fallback method or handler to run on another thread
+     *
      * @param result
      * @param executionContext
      */
-    private void scheduleFallback(MethodResult<W> result, AsyncExecutionContextImpl<W> executionContext) {
+    private void prepareFallback(MethodResult<W> result, AsyncExecutionContextImpl<W> executionContext) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, "Method {0} fallback is required", executionContext.getMethod());
         }
@@ -417,7 +424,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
                 Tr.event(tc, "Method {0} fallback result: {1}", executionContext.getMethod(), fallbackResult);
             }
 
-            finalizeExecution(executionContext, fallbackResult);
+            processEndOfExecution(executionContext, fallbackResult);
 
         } catch (Throwable t) {
             // Handle any unexpected exceptions
@@ -447,8 +454,8 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
      * The strategy used to handle exceptions is as follows:
      * <ul>
      * <li>Log and FFDC the exception
-     * <li>If an attemptContext was passed, call finalizeContext, reporting the exception as an internal error
-     * <li>If an attemptContext was not passed, call commitResult, reporting the exception as the result
+     * <li>If an attemptContext was passed, call processEndOfAttempt, reporting the exception as an internal error
+     * <li>If an attemptContext was not passed, call setResult, reporting the exception as the result
      * </ul>
      *
      * @param runnable         the runnable to wrap
@@ -476,9 +483,9 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
         Tr.error(tc, "internal.error.CWMFT4998E", t);
         MethodResult<W> result = MethodResult.internalFailure(new FaultToleranceException(Tr.formatMessage(tc, "internal.error.CWMFT4998E", t), t));
         if (attemptContext != null) {
-            finalizeAttempt(attemptContext, result);
+            processEndOfAttempt(attemptContext, result);
         } else {
-            commitResult(executionContext, result);
+            setResult(executionContext, result);
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncFutureExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncFutureExecutor.java
@@ -39,27 +39,27 @@ public class AsyncFutureExecutor<R> extends AsyncExecutor<Future<R>> {
     }
 
     @Override
-    protected void commitResult(AsyncExecutionContextImpl<Future<R>> executionContext, MethodResult<Future<R>> result) {
+    protected void setResult(AsyncExecutionContextImpl<Future<R>> executionContext, MethodResult<Future<R>> result) {
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, "Method {0} final fault tolerance result: {1}", executionContext.getMethod(), result);
         }
 
-        FutureShell<R> returnWrapper = (FutureShell<R>) executionContext.getReturnWrapper();
+        FutureShell<R> resultWrapper = (FutureShell<R>) executionContext.getResultWrapper();
         if (result.isFailure()) {
             CompletableFuture<R> failureResult = new CompletableFuture<R>();
             failureResult.completeExceptionally(result.getFailure());
-            returnWrapper.setDelegate(failureResult);
+            resultWrapper.setDelegate(failureResult);
         } else {
-            returnWrapper.setDelegate(result.getResult());
+            resultWrapper.setDelegate(result.getResult());
         }
     }
 
     @Override
-    protected Future<R> createReturnWrapper(AsyncExecutionContextImpl<Future<R>> executionContext) {
-        FutureShell<R> returnWrapper = new FutureShell<>();
-        returnWrapper.setCancellationCallback(executionContext::cancel);
-        return returnWrapper;
+    protected Future<R> createEmptyResultWrapper(AsyncExecutionContextImpl<Future<R>> executionContext) {
+        FutureShell<R> resultWrapper = new FutureShell<>();
+        resultWrapper.setCancellationCallback(executionContext::cancel);
+        return resultWrapper;
     }
 
 }


### PR DESCRIPTION
After discussion with the team, we agreed on some new consistent names for the execution stages which made more sense to everyone.