### PR TITLE
New test the CRLFs are preserved when using text/plain POST bodies

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormBehaviorTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormBehaviorTestServlet.java
@@ -51,8 +51,21 @@ public class FormBehaviorTestServlet extends FATServlet {
         Form f = new Form("value", "ORIGINAL");
         Response r = client.target(uri)
                            .request(MediaType.APPLICATION_FORM_URLENCODED)
+                           .header("REPLACE-STREAM", "true")
                            .post(Entity.form(f));
         assertEquals("MODIFIED", r.getHeaderString("FromFormParam"));
         assertEquals("MODIFIED", r.getHeaderString("FromForm"));
+    }
+
+    @Test
+    public void testCRLFsArePreserved(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        
+        String uri = "http://localhost:" + req.getServerPort() + "/formApp/form/crlf";
+        String text = "Line 1" + System.lineSeparator() + "Line 2" + System.lineSeparator() + "Line 3";
+        Response r = client.target(uri)
+                           .request(MediaType.TEXT_PLAIN + "; charset=utf-8")
+                           .header("REPLACE-STREAM", "false")
+                           .post(Entity.text(text));
+        assertEquals(200, r.getStatus());
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormReaderInterceptor.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormReaderInterceptor.java
@@ -27,15 +27,17 @@ public class FormReaderInterceptor implements ReaderInterceptor {
 
     @Override
     public Object aroundReadFrom(ReaderInterceptorContext ctx) throws IOException, WebApplicationException {
-        BufferedReader br = new BufferedReader(new InputStreamReader(ctx.getInputStream()));
-        String line;
-        while ((line = br.readLine()) != null) {
-            LOG.info("readLine: " + line);
-        }
+        if ("true".equalsIgnoreCase(ctx.getHeaders().getFirst("REPLACE-STREAM"))) {
+            BufferedReader br = new BufferedReader(new InputStreamReader(ctx.getInputStream()));
+            String line;
+            while ((line = br.readLine()) != null) {
+                LOG.info("readLine: " + line);
+            }
 
-        ByteArrayInputStream bais = new ByteArrayInputStream("value=MODIFIED".getBytes());
-        LOG.info("set value=MODIFIED");
-        ctx.setInputStream(bais);
+            ByteArrayInputStream bais = new ByteArrayInputStream("value=MODIFIED".getBytes());
+            LOG.info("set value=MODIFIED");
+            ctx.setInputStream(bais);
+        }
         return ctx.proceed();
     }
 

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/formApp/src/jaxrs21/fat/form/FormResource.java
@@ -14,11 +14,14 @@ package jaxrs21.fat.form;
 import java.util.logging.Logger;
 
 import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @ApplicationPath("/")
@@ -36,5 +39,17 @@ public class FormResource extends Application {
                         .header("FromForm", fromForm)
                         .build();
       }
+
+    @POST
+    @Path("/crlf")
+    @Consumes(MediaType.TEXT_PLAIN + "; charset=utf-8")
+    @Produces(MediaType.TEXT_PLAIN + "; charset=utf-8")
+    public Response testCRLFsArePreserved(String body) {
+        LOG.info("body: " + body);
+        if (body.indexOf('\n') < 0) {
+            return Response.status(575).build();
+        }
+        return Response.ok().build();
+    }
 }
 


### PR DESCRIPTION
Creating new test to verify that whitespace (specifically `\n` characters) are preserved in the resource method when sending `text/plain; charset=utf8` content in a POST body.