### PR TITLE
update com.ibm.ws.microprofile.metrics_fat_tck to use 1.0.2 metrics API

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
@@ -16,7 +16,7 @@
 	<name>MicroProfile Metrics TCK Runner 1.0 TCK Module</name>
 
 	<properties>
-		<microprofile.metrics.version>1.0.2-RC2</microprofile.metrics.version>
+		<microprofile.metrics.version>1.0.2</microprofile.metrics.version>
 		<arquillian.version>1.1.13.Final</arquillian.version>
 
 		<!-- the below is used in arquillian.xml -->


### PR DESCRIPTION
fixes #6471