### PR TITLE
Add null check to each merged permission

### DIFF
--- a/dev/com.ibm.ws.app.manager.module/src/com/ibm/ws/app/manager/module/internal/DeployedAppInfoBase.java
+++ b/dev/com.ibm.ws.app.manager.module/src/com/ibm/ws/app/manager/module/internal/DeployedAppInfoBase.java
@@ -511,9 +511,13 @@ public abstract class DeployedAppInfoBase extends SimpleDeployedAppInfoBase impl
             }
 
             ArrayList<Permission> mergedPermissions = permissionManager.getEffectivePermissions(applicationInformation.getLocation());
-            int count = mergedPermissions.size();
-            for (int i = 0; i < count; i++)
-                perms.add(mergedPermissions.get(i));
+            if(!mergedPermissions.isEmpty()){
+                for(Permission permission: mergedPermissions){
+                    if(permission!=null){
+                        perms.add(permission);
+                    }
+                }
+            }
         }
 
         CodeSource codesource;


### PR DESCRIPTION
#6067
First ensure the list of merged permissions isn't
empty before iterating over it. Then, due to the fact
that null can be added to a List, null check each
Permission.