### PR TITLE
Added a try-catch for Premature EOF

### DIFF
--- a/dev/com.ibm.ws.security.registry_test.servlet/src/com/ibm/ws/security/registry/test/UserRegistryServletConnection.java
+++ b/dev/com.ibm.ws.security.registry_test.servlet/src/com/ibm/ws/security/registry/test/UserRegistryServletConnection.java
@@ -80,18 +80,21 @@ public class UserRegistryServletConnection implements UserRegistry {
 
             boolean foundResultLine = false;
             boolean populatedResultLine = false;
-            while ((line = br.readLine()) != null) {
-                logger.info("Read line: " + line);
-                if (foundResultLine && !populatedResultLine) {
-                    resultLine = line;
-                    populatedResultLine = true;
+            try {
+                while ((line = br.readLine()) != null) {
+                    logger.info("Read line: " + line);
+                    if (foundResultLine && !populatedResultLine) {
+                        resultLine = line;
+                        populatedResultLine = true;
+                    }
+                    if (line.startsWith("Result from method: " + methodName)) {
+                        foundResultLine = true;
+                    }
+                    if (line.startsWith("getCurrentUserRegistry exception message:")) {
+                        foundResultLine = true;
+                    }
                 }
-                if (line.startsWith("Result from method: " + methodName)) {
-                    foundResultLine = true;
-                }
-                if (line.startsWith("getCurrentUserRegistry exception message:")) {
-                    foundResultLine = true;
-                }
+            } catch (java.io.IOException ex) {
             }
             if (!foundResultLine || resultLine == null) {
                 throw new IllegalStateException("Error: expected return line from servlet response not found");


### PR DESCRIPTION
fixes #6481 

User was reaching the end of servlet method call without finding a proper EOF. Since the method call was still reading other lines in the files, we are assuming that the file was not properly terminated. The try-catch will catch the error and allow us to keep the lines currently read from the files
