### PR TITLE
update usage of MP Config to align with convention from MP Fault Tolerance

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedCompletableFuture.java
@@ -420,8 +420,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
             ContextualRunnable r = (ContextualRunnable) action;
             contextDescriptor = r.getContextDescriptor();
             action = r.getAction();
+        } else if (executor instanceof WSManagedExecutorService) {
+            WSContextService contextSvc = ((WSManagedExecutorService) executor).getContextService();
+            contextDescriptor = contextSvc.captureThreadContext(XPROPS_SUSPEND_TRAN);
         } else {
-            contextDescriptor = captureThreadContext(executor);
+            contextDescriptor = null;
         }
 
         if (JAVA8) {
@@ -469,8 +472,11 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
             ContextualSupplier<U> s = (ContextualSupplier<U>) action;
             contextDescriptor = s.getContextDescriptor();
             action = s.getAction();
+        } else if (executor instanceof WSManagedExecutorService) {
+            WSContextService contextSvc = ((WSManagedExecutorService) executor).getContextService();
+            contextDescriptor = contextSvc.captureThreadContext(XPROPS_SUSPEND_TRAN);
         } else {
-            contextDescriptor = captureThreadContext(executor);
+            contextDescriptor = null;
         }
 
         if (JAVA8) {
@@ -639,23 +645,26 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     }
 
     /**
-     * Captures thread context, if possible, based on thread context propagation configured for the specified executor.
+     * Captures thread context, if possible, first based on the default asynchronous execution facility,
+     * otherwise based on the specified executor. If neither of these executors are a managed executor,
+     * then thread context is not captured.
      *
-     * @param executor
-     * @return captured thread context. NULL if the executor does not support capturing context.
+     * @param executor executor argument that is supplied when creating a dependent stage.
+     * @return captured thread context. NULL neither the default asynchronous execution facility nor the
+     *         specified executor support capturing context.
      */
-    private static ThreadContextDescriptor captureThreadContext(Executor executor) {
-        WSContextService contextSvc = null;
-        if (executor instanceof WSManagedExecutorService) {
-            WSManagedExecutorService managedExecutor = (WSManagedExecutorService) executor;
-            contextSvc = managedExecutor.getContextService();
-        }
+    private ThreadContextDescriptor captureThreadContext(Executor executor) {
+        WSManagedExecutorService managedExecutor = defaultExecutor instanceof WSManagedExecutorService //
+                        ? (WSManagedExecutorService) defaultExecutor //
+                        : executor != defaultExecutor && executor instanceof WSManagedExecutorService //
+                                        ? (WSManagedExecutorService) executor //
+                                        : null;
 
-        if (contextSvc == null)
-            return null; // TODO should we capture context based on the default executor when unmanaged executor is supplied???
+        if (managedExecutor == null)
+            return null;
 
         @SuppressWarnings("unchecked")
-        ThreadContextDescriptor contextDescriptor = contextSvc.captureThreadContext(XPROPS_SUSPEND_TRAN);
+        ThreadContextDescriptor contextDescriptor = managedExecutor.getContextService().captureThreadContext(XPROPS_SUSPEND_TRAN);
         return contextDescriptor;
     }
 

--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ConcurrencyCDIExtension.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ConcurrencyCDIExtension.java
@@ -101,9 +101,9 @@ public class ConcurrencyCDIExtension implements Extension, WebSphereCDIExtension
                 b.propagated(config.propagated());
             }
         } else {
-            int start = injectionPointName.length() + 1;
+            int start = injectionPointName.length() + 23;
             int len = start + 10;
-            StringBuilder propName = new StringBuilder(len).append(injectionPointName).append('.');
+            StringBuilder propName = new StringBuilder(len).append(injectionPointName).append("/ManagedExecutorConfig/");
 
             // In order to efficiently reuse StringBuilder, properties are added in the order of the length of their names,
 
@@ -163,9 +163,9 @@ public class ConcurrencyCDIExtension implements Extension, WebSphereCDIExtension
                 b.propagated(config.propagated());
             }
         } else {
-            int start = injectionPointName.length() + 1;
+            int start = injectionPointName.length() + 21;
             int len = start + 10;
-            StringBuilder propName = new StringBuilder(len).append(injectionPointName).append('.');
+            StringBuilder propName = new StringBuilder(len).append(injectionPointName).append("/ThreadContextConfig/");
 
             // In order to efficiently reuse StringBuilder, properties are added in the order of the length of their names,
 
@@ -236,9 +236,9 @@ public class ConcurrencyCDIExtension implements Extension, WebSphereCDIExtension
         // Instance name is either @NamedInstance.value() or generated from fully-qualified field name or method parameter index
         NamedInstance nameAnno = injectionPoint.getAnnotation(NamedInstance.class);
         Member member = event.getInjectionPoint().getMember();
-        StringBuilder n = new StringBuilder(member.getDeclaringClass().getTypeName()).append('.').append(member.getName());
+        StringBuilder n = new StringBuilder(member.getDeclaringClass().getTypeName()).append('/').append(member.getName());
         if (injectionPoint instanceof AnnotatedParameter)
-            n.append('.').append(((AnnotatedParameter<?>) injectionPoint).getPosition() + 1); // switch from 0-based to 1-based
+            n.append('/').append(((AnnotatedParameter<?>) injectionPoint).getPosition() + 1); // switch from 0-based to 1-based
         String injectionPointName = n.toString();
         String instanceName = nameAnno == null ? injectionPointName : nameAnno.value();
 

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentConfigTestServer/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentConfigTestServer/bootstrap.properties
@@ -11,5 +11,5 @@
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:concurrent=all
 AppProducedExecutor.maxQueued=2
-concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.annotatedExecutorWithMPConfigOverride.maxAsync=2
-concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.annotatedExecutorWithMPConfigOverride.maxQueued=3
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet/annotatedExecutorWithMPConfigOverride/ManagedExecutorConfig/maxAsync=2
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet/annotatedExecutorWithMPConfigOverride/ManagedExecutorConfig/maxQueued=3

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -480,14 +480,13 @@ public class MPConcurrentTestServlet extends FATServlet {
                 results.add(Thread.currentThread().getName());
                 try {
                     ManagedExecutorService result = InitialContext.doLookup("java:module/noContextExecutorRef");
-                    results.add(result);
                     System.out.println("< lookup: " + result);
+                    fail("Application context should have been cleared. Looked up " + result);
                 } catch (NamingException x) {
                     System.out.println("< lookup failed");
-                    x.printStackTrace(System.out);
                     throw new CompletionException(x);
                 }
-            }, defaultManagedExecutor);
+            }, defaultManagedExecutor); // expect dependent action to run on this executor, but not with its context propagation
 
             assertFalse(cf3.isDone());
             try {
@@ -500,10 +499,15 @@ public class MPConcurrentTestServlet extends FATServlet {
             blocker2.countDown();
 
             // Dependent stage must be able to complete now
-            assertNull(cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+            try {
+                cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+            } catch (ExecutionException x) {
+                if (!(x.getCause() instanceof NamingException))
+                    throw x;
+            }
             assertTrue(cf3.isDone());
             assertFalse(cf3.isCancelled());
-            assertFalse(cf3.isCompletedExceptionally());
+            assertTrue(cf3.isCompletedExceptionally());
 
             // Verify the parameter that is supplied to acceptEither's consumer
             assertEquals(Boolean.TRUE, results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
@@ -512,11 +516,6 @@ public class MPConcurrentTestServlet extends FATServlet {
             String threadName;
             assertNotNull(threadName = (String) results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
             assertTrue(threadName, threadName.startsWith(("Default Executor-thread-")));
-
-            // thread context is made available to acceptEither's consumer per the supplied managed executor, enabling java:module lookup to succeed
-            Object lookupResult;
-            assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-            assertEquals(noContextExecutor, lookupResult);
 
             // allow cf1 to complete
             blocker1.countDown();
@@ -867,12 +866,9 @@ public class MPConcurrentTestServlet extends FATServlet {
             assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
             assertFalse(threadName, threadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
             assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-            if (lookupResult instanceof NamingException)
-                ; // pass
-            else if (lookupResult instanceof Throwable)
+            if (lookupResult instanceof Throwable)
                 throw new Exception((Throwable) lookupResult);
-            else
-                fail("Unexpected result of lookup: " + lookupResult);
+            assertEquals(defaultManagedExecutor, lookupResult);
 
             // [cf5] applyToEither on unmanaged thread (or possibly servlet thread) - context should be applied from stage creation time
             assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
@@ -1260,7 +1256,7 @@ public class MPConcurrentTestServlet extends FATServlet {
         String result = cf2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
         assertTrue(result, result.startsWith("Default Executor-thread-")); // runs on Liberty thread pool
         assertTrue(result, !Thread.currentThread().getName().equals(result)); // does not run on servlet thread
-        assertTrue(result, result.endsWith(":NamingException")); // namespace context not available to thread
+        assertTrue(result, result.startsWith("Default Executor-thread-") && result.contains(":ManagedExecutor"));
 
         assertTrue(cf2.isDone());
         assertFalse(cf2.isCancelled());
@@ -1660,30 +1656,25 @@ public class MPConcurrentTestServlet extends FATServlet {
 
         CompletableFuture<?> cf2 = defaultManagedExecutor
                         .completedFuture((Throwable) null)
-                        .thenApplyAsync(lookup, testThreads) // expect lookup to fail without the context of the servlet thread
+                        .thenApplyAsync(x -> 1 / 0 < 2 ? sameThreadExecutor : null, testThreads) // force ArithmeticException to occur
                         .exceptionally(lookup);
 
         assertTrue(s = cf2.toString(), s.startsWith("ManagedCompletableFuture@"));
 
-        // thenApplyAsync on unmanaged executor
-        assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
-        assertFalse(threadName, threadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
-
         // exceptionally on unmanaged thread or servlet thread
         assertNotNull(previousFailure = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        if (previousFailure instanceof CompletionException && ((CompletionException) previousFailure).getCause() instanceof NamingException)
+        if (previousFailure instanceof CompletionException && ((CompletionException) previousFailure).getCause() instanceof ArithmeticException)
             ; // pass
         else if (previousFailure instanceof Throwable)
             throw new Exception((Throwable) previousFailure);
         else
             fail("Unexpected value supplied to function as previous failure: " + previousFailure);
 
-        String previousThreadName = threadName;
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
-        assertTrue(threadName, previousThreadName.equals(threadName) || currentThreadName.equals(threadName)); // must run on same unmanaged thread or on servlet thread
+        assertTrue(threadName, !threadName.startsWith("Default Executor-thread-") || currentThreadName.equals(threadName)); // must run on same unmanaged thread or on servlet thread
 
         assertEquals(defaultManagedExecutor, cf2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        assertEquals(3, count.get()); // two additional executions of the lookup function
+        assertEquals(2, count.get()); // one additional execution of the lookup function
     }
 
     /**
@@ -1795,6 +1786,10 @@ public class MPConcurrentTestServlet extends FATServlet {
             results.add(Thread.currentThread().getName());
             try {
                 results.add(InitialContext.doLookup("java:comp/env/executorRef"));
+                if (failure == null && !Thread.currentThread().getName().startsWith("Default Executor-thread-")) {
+                    System.out.println("< increment ArrayIndexOutOfBoundsException");
+                    throw new CompletionException(new ArrayIndexOutOfBoundsException("Intentional failure caused by test."));
+                }
                 System.out.println("< increment");
                 return count;
             } catch (NamingException x) {
@@ -1844,19 +1839,9 @@ public class MPConcurrentTestServlet extends FATServlet {
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
         assertFalse(threadName, threadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
         assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        if (lookupResult instanceof NamingException)
-            ; // pass
-        else if (lookupResult instanceof Throwable)
+        if (lookupResult instanceof Throwable)
             throw new Exception((Throwable) lookupResult);
-        else
-            fail("Unexpected result of lookup: " + lookupResult);
-        try {
-            Integer result = cf2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
-            fail("Action should fail, not return " + result);
-        } catch (ExecutionException x) {
-            if (!(x.getCause() instanceof NamingException))
-                throw x;
-        }
+        assertEquals(defaultManagedExecutor, lookupResult);
 
         // handle on unmanaged thread (context should be applied from stage creation time)
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
@@ -3298,19 +3283,16 @@ public class MPConcurrentTestServlet extends FATServlet {
             assertNotSame(currentThreadName, threadName2);
             assertTrue(threadName2, threadName2.startsWith("Default Executor-thread-"));
             assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-            if (lookupResult instanceof NamingException)
-                ; // pass
-            else if (lookupResult instanceof Throwable)
+            if (lookupResult instanceof Throwable)
                 throw new Exception((Throwable) lookupResult);
-            else
-                fail("Unexpected result of lookup: " + lookupResult);
+            assertEquals(defaultManagedExecutor, lookupResult);
 
             // runAfterEitherAsync
             assertNotNull(threadName3 = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
             assertNotSame(currentThreadName, threadName3);
             assertTrue(threadName3, threadName3.startsWith("Default Executor-thread-"));
             assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-            if (lookupResult instanceof Throwable) // thread context is available, even if it wasn't available to the previous stage
+            if (lookupResult instanceof Throwable)
                 throw new Exception((Throwable) lookupResult);
             assertEquals(defaultManagedExecutor, lookupResult);
 
@@ -3398,9 +3380,12 @@ public class MPConcurrentTestServlet extends FATServlet {
             assertNotSame(currentThreadName, threadName3);
             assertTrue(threadName3, threadName3.startsWith("Default Executor-thread-"));
             assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-            if (lookupResult instanceof Throwable) // thread context is available, even if it wasn't available to the previous stage
+            if (lookupResult instanceof NamingException)
+                ; // pass
+            else if (lookupResult instanceof Throwable)
                 throw new Exception((Throwable) lookupResult);
-            assertEquals(defaultManagedExecutor, lookupResult);
+            else
+                fail("Unexpected result of lookup: " + lookupResult);
 
             assertNull(cf3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
             assertTrue(cf3.isDone());
@@ -3848,12 +3833,9 @@ public class MPConcurrentTestServlet extends FATServlet {
         assertTrue(threadName, threadName.startsWith("Default Executor-thread-")); // must run on Liberty global thread pool
         assertNotSame(currentThreadName, threadName); // cannot be the servlet thread because operation is async
         assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        if (lookupResult instanceof NamingException)
-            ; // pass
-        else if (lookupResult instanceof Throwable)
+        if (lookupResult instanceof Throwable)
             throw new Exception((Throwable) lookupResult);
-        else
-            fail("Unexpected result of lookup: " + lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
 
         // thenApplyAsync on unmanaged executor (value stored by dependent stage)
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
@@ -3940,12 +3922,9 @@ public class MPConcurrentTestServlet extends FATServlet {
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
         assertFalse(threadName, threadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
         assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        if (lookupResult instanceof NamingException)
-            ; // pass
-        else if (lookupResult instanceof Throwable)
+        if (lookupResult instanceof Throwable)
             throw new Exception((Throwable) lookupResult);
-        else
-            fail("Unexpected result of lookup: " + lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
 
         // thenAcceptBoth on unmanaged thread or servlet thread (context should be applied from stage creation time)
         assertEquals(Integer.valueOf(5), results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
@@ -4023,12 +4002,9 @@ public class MPConcurrentTestServlet extends FATServlet {
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
         assertFalse(threadName, threadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
         assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        if (lookupResult instanceof NamingException)
-            ; // pass
-        else if (lookupResult instanceof Throwable)
+        if (lookupResult instanceof Throwable)
             throw new Exception((Throwable) lookupResult);
-        else
-            fail("Unexpected result of lookup: " + lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
 
         // thenApply on unmanaged thread (context should be applied from stage creation time)
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
@@ -4159,12 +4135,9 @@ public class MPConcurrentTestServlet extends FATServlet {
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
         assertFalse(threadName, threadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
         assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        if (lookupResult instanceof NamingException)
-            ; // pass
-        else if (lookupResult instanceof Throwable)
+        if (lookupResult instanceof Throwable)
             throw new Exception((Throwable) lookupResult);
-        else
-            fail("Unexpected result of lookup: " + lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
         assertEquals(Integer.valueOf(4), cf4.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 
         // thenCombine on unmanaged thread or servlet thread (context should be applied from stage creation time)
@@ -4263,12 +4236,9 @@ public class MPConcurrentTestServlet extends FATServlet {
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
         assertFalse(threadName, threadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
         assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        if (lookupResult instanceof NamingException)
-            ; // pass
-        else if (lookupResult instanceof Throwable)
+        if (lookupResult instanceof Throwable)
             throw new Exception((Throwable) lookupResult);
-        else
-            fail("Unexpected result of lookup: " + lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
 
         // thenCompose on unmanaged thread (context should be applied from stage creation time)
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
@@ -4384,12 +4354,9 @@ public class MPConcurrentTestServlet extends FATServlet {
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
         assertFalse(threadName, threadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
         assertNotNull(lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        if (lookupResult instanceof NamingException)
-            ; // pass
-        else if (lookupResult instanceof Throwable)
+        if (lookupResult instanceof Throwable)
             throw new Exception((Throwable) lookupResult);
-        else
-            fail("Unexpected result of lookup: " + lookupResult);
+        assertEquals(defaultManagedExecutor, lookupResult);
 
         // thenRun on unmanaged thread (context should be applied from stage creation time)
         assertNotNull(threadName = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS).toString());
@@ -4816,9 +4783,9 @@ public class MPConcurrentTestServlet extends FATServlet {
         assertTrue(s = cf2.toString(), s.startsWith("ManagedCompletableFuture@"));
         assertTrue(s = cf3.toString(), s.startsWith("ManagedCompletableFuture@"));
 
-        // Order in which the above run is unpredictable. Distinguish by looking at the execution thread and lookup result.
+        // Order in which the above run is unpredictable. Distinguish by looking at the execution thread.
 
-        Object[] cf1result = null, cf2result = null, cf3result = null;
+        Object[] cf1or2resultA = null, cf1or2resultB = null, cf3result = null;
 
         for (int i = 1; i <= 3; i++) {
             Object[] result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS);
@@ -4826,30 +4793,31 @@ public class MPConcurrentTestServlet extends FATServlet {
             System.out.println(Arrays.asList(result));
             String threadName = (String) result[THREAD];
             if (threadName.startsWith("Default Executor-thread-") && !threadName.equals(currentThreadName))
-                if (result[LOOKUP_RESULT] instanceof ManagedExecutorService)
-                    cf1result = result;
+                if (cf1or2resultA == null)
+                    cf1or2resultA = result;
                 else
-                    cf2result = result;
+                    cf1or2resultB = result;
             else
                 cf3result = result;
         }
 
-        assertNotNull(cf1result);
-        assertNotNull(cf2result);
+        assertNotNull(cf1or2resultA);
+        assertNotNull(cf1or2resultB);
         assertNotNull(cf3result);
 
-        // whenCompleteAsync on default asynchronous execution facility
-        assertNull(cf1result[PREV_RESULT]);
-        assertTrue(cf1result[PREV_FAILURE].toString(), // CompletableFuture wraps the exception with CompletionException, so expect the same here
-                   cf1result[PREV_FAILURE] instanceof CompletionException && ((CompletionException) cf1result[PREV_FAILURE]).getCause() instanceof ArithmeticException);
-        assertNotSame(currentThreadName, cf1result[THREAD]); // cannot be the servlet thread because operation is async
+        // whenCompleteAsync on default asynchronous execution facility or noContextExecutor
+        assertNull(cf1or2resultA[PREV_RESULT]);
+        assertTrue(cf1or2resultA[PREV_FAILURE].toString(), // CompletableFuture wraps the exception with CompletionException, so expect the same here
+                   cf1or2resultA[PREV_FAILURE] instanceof CompletionException && ((CompletionException) cf1or2resultA[PREV_FAILURE]).getCause() instanceof ArithmeticException);
+        assertNotSame(currentThreadName, cf1or2resultA[THREAD]); // cannot be the servlet thread because operation is async
+        assertEquals(defaultManagedExecutor, cf1or2resultA[LOOKUP_RESULT]);
 
-        // whenCompleteAsync on noContextExecutor
-        assertNull(cf2result[PREV_RESULT]);
-        assertTrue(cf2result[PREV_FAILURE].toString(), // CompletableFuture wraps the exception with CompletionException, so expect the same here
-                   cf2result[PREV_FAILURE] instanceof CompletionException && ((CompletionException) cf2result[PREV_FAILURE]).getCause() instanceof ArithmeticException);
-        assertNotSame(currentThreadName, cf2result[THREAD]); // cannot be the servlet thread because operation is async
-        assertTrue(cf2result[LOOKUP_RESULT].toString(), cf2result[LOOKUP_RESULT] instanceof NamingException);
+        // whenCompleteAsync on default asynchronous execution facility or noContextExecutor
+        assertNull(cf1or2resultB[PREV_RESULT]);
+        assertTrue(cf1or2resultB[PREV_FAILURE].toString(), // CompletableFuture wraps the exception with CompletionException, so expect the same here
+                   cf1or2resultB[PREV_FAILURE] instanceof CompletionException && ((CompletionException) cf1or2resultB[PREV_FAILURE]).getCause() instanceof ArithmeticException);
+        assertNotSame(currentThreadName, cf1or2resultB[THREAD]); // cannot be the servlet thread because operation is async
+        assertEquals(defaultManagedExecutor, cf1or2resultB[LOOKUP_RESULT]);
 
         // whenComplete on unmanaged thread or servlet thread
         assertNull(cf3result[PREV_RESULT]);
@@ -4933,9 +4901,9 @@ public class MPConcurrentTestServlet extends FATServlet {
         String cf0ThreadName = cf0.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
         assertFalse(cf0ThreadName, cf0ThreadName.startsWith("Default Executor-thread-")); // must run async on unmanaged thread
 
-        // Order in which the above run is unpredictable. Distinguish by looking at the execution thread and lookup result.
+        // Order in which the above run is unpredictable. Distinguish by looking at the execution thread.
 
-        Object[] cf1result = null, cf2result = null, cf3result = null;
+        Object[] cf1or2resultA = null, cf1or2resultB = null, cf3result = null;
 
         for (int i = 1; i <= 3; i++) {
             Object[] result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS);
@@ -4943,28 +4911,29 @@ public class MPConcurrentTestServlet extends FATServlet {
             System.out.println(Arrays.asList(result));
             String threadName = (String) result[THREAD];
             if (threadName.startsWith("Default Executor-thread-") && !threadName.equals(currentThreadName))
-                if (result[LOOKUP_RESULT] instanceof ManagedExecutorService)
-                    cf1result = result;
+                if (cf1or2resultA == null)
+                    cf1or2resultA = result;
                 else
-                    cf2result = result;
+                    cf1or2resultB = result;
             else
                 cf3result = result;
         }
 
-        assertNotNull(cf1result);
-        assertNotNull(cf2result);
+        assertNotNull(cf1or2resultA);
+        assertNotNull(cf1or2resultB);
         assertNotNull(cf3result);
 
-        // whenCompleteAsync on default asynchronous execution facility
-        assertEquals(cf0ThreadName, cf1result[PREV_RESULT]);
-        assertNull(cf1result[PREV_FAILURE]);
-        assertNotSame(currentThreadName, cf1result[THREAD]); // cannot be the servlet thread because operation is async
+        // whenCompleteAsync on default asynchronous execution facility or noContextExecutor
+        assertEquals(cf0ThreadName, cf1or2resultA[PREV_RESULT]);
+        assertNull(cf1or2resultA[PREV_FAILURE]);
+        assertNotSame(currentThreadName, cf1or2resultA[THREAD]); // cannot be the servlet thread because operation is async
+        assertEquals(defaultManagedExecutor, cf1or2resultA[LOOKUP_RESULT]);
 
-        // whenCompleteAsync on noContextExecutor
-        assertEquals(cf0ThreadName, cf2result[PREV_RESULT]);
-        assertNull(cf2result[PREV_FAILURE]);
-        assertNotSame(currentThreadName, cf2result[THREAD]); // cannot be the servlet thread because operation is async
-        assertTrue(cf2result[LOOKUP_RESULT].toString(), cf2result[LOOKUP_RESULT] instanceof NamingException);
+        // whenCompleteAsync on default asynchronous execution facility or noContextExecutor
+        assertEquals(cf0ThreadName, cf1or2resultB[PREV_RESULT]);
+        assertNull(cf1or2resultB[PREV_FAILURE]);
+        assertNotSame(currentThreadName, cf1or2resultB[THREAD]); // cannot be the servlet thread because operation is async
+        assertEquals(defaultManagedExecutor, cf1or2resultB[LOOKUP_RESULT]);
 
         // whenComplete on unmanaged thread or servlet thread
         assertEquals(cf0ThreadName, cf3result[PREV_RESULT]);

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/MPConcurrentCDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/MPConcurrentCDITestServlet.java
@@ -325,7 +325,7 @@ public class MPConcurrentCDITestServlet extends FATServlet {
                     String message = x.getCause().getMessage();
                     if (message == null
                         || !message.contains("CWWKE1201E")
-                        || !message.contains("_MPConcurrentCDIApp_concurrent.mp.fat.cdi.web.MPConcurrentCDITestServlet.max2(maxAsync=2,maxQueued=2,cleared=[Transaction])")
+                        || !message.contains("_MPConcurrentCDIApp_concurrent.mp.fat.cdi.web.MPConcurrentCDITestServlet/max2(maxAsync=2,maxQueued=2,cleared=[Transaction])")
                         || !message.contains("maxQueueSize")
                         || !message.contains(" 2")) // the maximum queue size
                         throw x;

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
-concurrent.mp.fat.config.web.ConcurrencyConfigBean.getExecutor.1.maxQueued=3
-concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.containerExecutorWithNameAndConfig.maxAsync=1
-concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.containerExecutorWithNameAndConfig.maxQueued=2
-concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.executorWithMPConfigOverride.cleared=City
-concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet.executorWithMPConfigOverride.propagated=Application,State
+concurrent.mp.fat.config.web.ConcurrencyConfigBean/getExecutor/1/ManagedExecutorConfig/maxQueued=3
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet/containerExecutorWithNameAndConfig/ManagedExecutorConfig/maxAsync=1
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet/containerExecutorWithNameAndConfig/ManagedExecutorConfig/maxQueued=2
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet/executorWithMPConfigOverride/ManagedExecutorConfig/cleared=City
+concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet/executorWithMPConfigOverride/ManagedExecutorConfig/propagated=Application,State


### PR DESCRIPTION
This pull switches us to the same pattern of using MP Config as MP Fault Tolerance for overriding annotation attributes of field injection points,

`org.example.MyBean.exec1.maxAsync=10`
-->
`org.example.MyBean/exec1/ManagedExecutorConfig/maxAsync=10`

Here is how we will cover method parameter injection points, although I did not see this explicitly addressed by Fault Tolerance convention,

`org.example.MyBean.setCompletableFuture.1.propagated=Security`
-->
`org.example.MyBean/setCompletableFuture/1/ManagedExecutorConfig/propagated=Security`
