### PR TITLE
[Issue 5903] Enhance JsonBProvider to use ContextResolver<Jsonb>

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-applications/subResourceApp/src"/>
+	<classpathentry kind="src" path="test-applications/cdiApp/src"/>
+	<classpathentry kind="src" path="test-applications/classSubResApp/src"/>
+	<classpathentry kind="src" path="test-applications/formApp/src"/>
+	<classpathentry kind="src" path="test-applications/jsonbapp/src"/>
+	<classpathentry kind="src" path="test-applications/jsonbContextResolverApp/src"/>
+	<classpathentry kind="src" path="test-applications/mutableHeadersApp/src"/>
 	<classpathentry kind="src" path="test-applications/patchapp/src"/>
 	<classpathentry kind="src" path="test-applications/providerPriorityApp/src"/>
-	<classpathentry kind="src" path="test-applications/classSubResApp/src"/>
-	<classpathentry kind="src" path="test-applications/cdiApp/src"/>
-	<classpathentry kind="src" path="test-applications/jsonbapp/src"/>
-	<classpathentry kind="src" path="test-applications/formApp/src"/>
-	<classpathentry kind="src" path="test-applications/mutableHeadersApp/src"/>
+	<classpathentry kind="src" path="test-applications/subResourceApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
@@ -13,13 +13,14 @@ bVersion=1.0
 
 src: \
   fat/src,\
+  test-applications/cdiApp/src,\
+  test-applications/classSubResApp/src,\
+  test-applications/formApp/src,\
+  test-applications/jsonbapp/src,\
+  test-applications/jsonbContextResolverApp/src,\
+  test-applications/mutableHeadersApp/src,\
   test-applications/patchapp/src,\
   test-applications/providerPriorityApp/src,\
-  test-applications/classSubResApp/src,\
-  test-applications/cdiApp/src,\
-  test-applications/jsonbapp/src,\
-  test-applications/formApp/src,\
-  test-applications/mutableHeadersApp/src,\
   test-applications/subResourceApp
 
 fat.project: true

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FATSuite.java
@@ -16,14 +16,16 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                PatchTest.class,
-                ProviderPriorityTest.class,
-                ClassSubResTest.class,
+                
                 CDITest.class,
-                PackageJsonBTestNoFeature.class,
-                PackageJsonBTestWithFeature.class,
+                ClassSubResTest.class,
+                JsonbContextResolverTest.class,
                 FormBehaviorTest.class,
                 MutableHeadersTest.class,
+                PackageJsonBTestNoFeature.class,
+                PackageJsonBTestWithFeature.class,
+                PatchTest.class,
+                ProviderPriorityTest.class,
                 SubResourceTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/JsonbContextResolverTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/JsonbContextResolverTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs21.fat.extended;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import jaxrs21.fat.jsonbcontextresolver.JsonbContextResolverTestServlet;
+
+@RunWith(FATRunner.class)
+public class JsonbContextResolverTest extends FATServletClient {
+
+    private static final String appName = "jsonbContextResolverApp";
+
+    @Server("jaxrs21.fat.jsonbContextResolver")
+    @TestServlet(servlet = JsonbContextResolverTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive app = ShrinkHelper.buildDefaultApp(appName, "jaxrs21.fat.jsonbcontextresolver");
+        ShrinkHelper.exportDropinAppToServer(server, app);
+        server.addInstalledAppForValidation(appName);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.jsonbContextResolver/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.jsonbContextResolver/bootstrap.properties
@@ -1,0 +1,5 @@
+com.ibm.ws.logging.trace.specification=*=info:LogService=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.jsonbContextResolver/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.jsonbContextResolver/server.xml
@@ -1,0 +1,10 @@
+<server>
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+    <feature>jsonb-1.0</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbContextResolverApp/src/jaxrs21/fat/jsonbcontextresolver/JsonbContextResolver.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbContextResolverApp/src/jaxrs21/fat/jsonbcontextresolver/JsonbContextResolver.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.jsonbcontextresolver;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+import javax.json.bind.JsonbConfig;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class JsonbContextResolver implements ContextResolver<Jsonb> {
+    @Override
+    public Jsonb getContext(Class<?> type) {
+        JsonbConfig config = new JsonbConfig().
+                withPropertyVisibilityStrategy(new PrivateVisibilityStrategy());
+        return JsonbBuilder.newBuilder().
+                withConfig(config).
+                build();
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbContextResolverApp/src/jaxrs21/fat/jsonbcontextresolver/JsonbContextResolverTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbContextResolverApp/src/jaxrs21/fat/jsonbcontextresolver/JsonbContextResolverTestServlet.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.jsonbcontextresolver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringReader;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.stream.JsonParsingException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/JsonbContextResolverTestServlet")
+public class JsonbContextResolverTestServlet extends FATServlet {
+
+    private Client client;
+
+    @Override
+    public void init() throws ServletException {
+        client = ClientBuilder.newBuilder().build();
+    }
+
+    @Override
+    public void destroy() {
+        client.close();
+    }
+
+    @Test
+    public void testGETPerson(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        String pattern = "{\"name\":\"Bob Smith\",\"age\":34}";
+        Response response = target(req, "person").request().get();
+        assertEquals(200, response.getStatus());
+        compareJSON(pattern, response.readEntity(String.class));
+    }
+
+
+    private void compareJSON(String expected, String actual) throws Exception {
+        try {
+            JsonReader jsonReader = Json.createReader(new StringReader(expected));
+            JsonObject exp = jsonReader.readObject();
+            jsonReader = Json.createReader(new StringReader(actual));
+            JsonObject act = jsonReader.readObject();
+            assertTrue("expected=" + expected + ", actual=" + actual, exp.equals(act));
+        } catch (JsonParsingException e) {
+            // Json failed to parse as an object, try array
+            JsonReader jsonReader = Json.createReader(new StringReader(expected));
+            JsonArray exp = jsonReader.readArray();
+            jsonReader = Json.createReader(new StringReader(actual));
+            JsonArray act = jsonReader.readArray();
+            assertTrue("expected=" + expected + ", actual=" + actual, exp.equals(act));
+        }
+    }
+
+    private WebTarget target(HttpServletRequest request, String path) {
+        String base = "http://" + request.getServerName() + ':' + request.getServerPort()
+            + "/jsonbContextResolverApp/rest/person/";
+        return client.target(base + path);
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbContextResolverApp/src/jaxrs21/fat/jsonbcontextresolver/Person.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbContextResolverApp/src/jaxrs21/fat/jsonbcontextresolver/Person.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.jsonbcontextresolver;
+
+public class Person {
+
+    private String name;
+    private int age;
+
+    public Person(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbContextResolverApp/src/jaxrs21/fat/jsonbcontextresolver/PrivateVisibilityStrategy.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbContextResolverApp/src/jaxrs21/fat/jsonbcontextresolver/PrivateVisibilityStrategy.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.jsonbcontextresolver;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import javax.json.bind.config.PropertyVisibilityStrategy;
+
+public class PrivateVisibilityStrategy implements PropertyVisibilityStrategy {
+
+    /* (non-Javadoc)
+     * @see javax.json.bind.config.PropertyVisibilityStrategy#isVisible(java.lang.reflect.Field)
+     */
+    @Override
+    public boolean isVisible(Field arg0) {
+        return true;
+    }
+
+    /* (non-Javadoc)
+     * @see javax.json.bind.config.PropertyVisibilityStrategy#isVisible(java.lang.reflect.Method)
+     */
+    @Override
+    public boolean isVisible(Method arg0) {
+        return false;
+    }
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbContextResolverApp/src/jaxrs21/fat/jsonbcontextresolver/Resource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbContextResolverApp/src/jaxrs21/fat/jsonbcontextresolver/Resource.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.jsonbcontextresolver;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/rest")
+@Path("/person")
+@Produces("application/json")
+public class Resource extends Application {
+
+    @GET
+    @Path("person")
+    public Person getPerson() {
+        Person p = new Person("Bob Smith", 34);
+        return p;
+    }
+
+}


### PR DESCRIPTION
Includes FAT test where user provides Jsonb object that can serialize
private fields.

Reference issue #5903 - this is a feature that goes beyond the JAX-RS spec, but provides a similar functionality that is mandated in the spec for JAXB (XML), but in this case for JSON-B.  