### PR TITLE
IllegalArgumentException when Runnable supplied to ContextualExecutor.execute already has context

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualExecutor.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,9 @@ class ContextualExecutor implements Executor {
 
     @Override
     public void execute(Runnable action) {
+        if (action instanceof ContextualRunnable)
+            throw new IllegalArgumentException(ContextualRunnable.class.getSimpleName());
+
         ThreadContextDescriptor tcd = threadContextDescriptor.clone();
         ArrayList<ThreadContext> contextApplied = tcd.taskStarting();
         try {


### PR DESCRIPTION
Comply with recent spec update to require IllegalArgumentException when an already-contextualized Runnable is supplied to ContextualExecutor.execute.