### PR TITLE
Publish runtime, javaee8, and webprofile8 images from release builds

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -282,6 +282,9 @@ task zipOpenLiberty(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
+    doLast{
+        props.setProperty('zipopenliberty.runtime.archivename', archivePath.toString())
+    }
 }
 publish.dependsOn zipOpenLiberty
 
@@ -292,6 +295,9 @@ task zipOpenLibertyKernel(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
+    doLast{
+        props.setProperty('zipopenliberty.kernel.archivename', archivePath.toString())
+    }
 }
 publish.dependsOn zipOpenLibertyKernel
 
@@ -302,6 +308,9 @@ task zipOpenLibertyWebProfile8(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
+    doLast{
+        props.setProperty('zipopenliberty.webprofile8.archivename', archivePath.toString())
+    }
 }
 publish.dependsOn zipOpenLibertyWebProfile8
 
@@ -312,6 +321,9 @@ task zipOpenLibertyJavaee8(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
+    doLast{
+        props.setProperty('zipopenliberty.javaee8.archivename', archivePath.toString())
+    }
 }
 publish.dependsOn zipOpenLibertyJavaee8
 
@@ -321,6 +333,9 @@ task zipOpenLibertyMicroProfile2(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
+    doLast {
+        props.setProperty('zipopenliberty.microprofile2.archivename', archivePath.toString())
+    }
 }
 publish.dependsOn zipOpenLibertyMicroProfile2
 
@@ -663,6 +678,12 @@ task publishPublicArtifactsOnDhe {
             artifactList.add(props.getProperty("gradle.test.report.zip"))
         } else {
             artifactList.add(props.getProperty("junit.report.zip"))
+            // add runtime, javaee8, and webprofile8 images to publish list for release builds only
+            if (isRelease) {
+                artifactList.add(props.getProperty("zipopenliberty.runtime.archivename"))
+                artifactList.add(props.getProperty("zipopenliberty.javaee8.archivename"))
+                artifactList.add(props.getProperty("zipopenliberty.webprofile8.archivename"))
+            }
         }
 
         mkdir("${buildDir}/${version}")


### PR DESCRIPTION
To be able to run daily Docker image builds for Open Liberty (https://github.com/OpenLiberty/ci.docker.daily) based on the latest release build output on DHE (public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/), we need to publish the runtime, javaee8, and webProfile8 images from the release builds, since those images are used to generate the official Open Liberty Docker images.