### PR TITLE
Add JPA 2.0 support to JPA Spec 1.0 Bucket

### DIFF
--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -30,5 +30,6 @@ public class FATSuite {
                                                 "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(new RepeatWithJPA20())
                     .andWith(FeatureReplacementAction.EE8_FEATURES());
 }

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/RepeatWithJPA20.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/RepeatWithJPA20.java
@@ -27,10 +27,12 @@ import componenttest.topology.impl.LibertyServerFactory;
  *
  */
 public class RepeatWithJPA20 extends FeatureReplacementAction {
+    public static final String ID = "JPA20_FEATURES";
+
     public RepeatWithJPA20() {
         super(EE8FeatureReplacementAction.EE8_FEATURE_SET, featuresToAdd());
         forceAddFeatures(false);
-        this.withID("JPA_20");
+        this.withID(ID);
     }
 
     private static Set<String> featuresToAdd() {
@@ -47,5 +49,10 @@ public class RepeatWithJPA20 extends FeatureReplacementAction {
         File jpa20Feature = new File(server.getInstallRoot() + "/lib/features/com.ibm.websphere.appserver.jpa-2.0.mf");
         Log.info(getClass(), "isEnabled", "Does the jpa-2.0 feature exist? " + jpa20Feature.exists());
         return jpa20Feature.exists();
+    }
+
+    @Override
+    public String toString() {
+        return "Set JPA feature to 2.0 version";
     }
 }

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/RepeatWithJPA20.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/RepeatWithJPA20.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.rules.repeater.EE7FeatureReplacementAction;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+/**
+ *
+ */
+public class RepeatWithJPA20 extends FeatureReplacementAction {
+    public RepeatWithJPA20() {
+        super(EE8FeatureReplacementAction.EE8_FEATURE_SET, featuresToAdd());
+        forceAddFeatures(false);
+        this.withID("JPA_20");
+    }
+
+    private static Set<String> featuresToAdd() {
+        Set<String> addFeatures = new HashSet<>(EE7FeatureReplacementAction.EE7_FEATURE_SET);
+        addFeatures.remove("jpa-2.1");
+        addFeatures.add("jpa-2.0");
+        return addFeatures;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        LibertyServer server = LibertyServerFactory.getLibertyServer("JPA10Server");
+
+        File jpa20Feature = new File(server.getInstallRoot() + "/lib/features/com.ibm.websphere.appserver.jpa-2.0.mf");
+        Log.info(getClass(), "isEnabled", "Does the jpa-2.0 feature exist? " + jpa20Feature.exists());
+        return jpa20Feature.exists();
+    }
+}

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
@@ -20,7 +20,7 @@ public class EE7FeatureReplacementAction extends FeatureReplacementAction {
 
     static final String[] EE7_FEATURES_ARRAY = { "javaee-7.0", "webProfile-7.0", "javaeeClient-7.0", "servlet-3.1", "jdbc-4.1", "javaMail-1.5", "cdi-1.2", "jpa-2.1",
                                                  "beanValidation-1.1", "jaxrs-2.0", "jaxrsClient-2.0", "jsf-2.2", "appSecurity-2.0", "jsonp-1.0" };
-    static final Set<String> EE7_FEATURE_SET = new HashSet<>(Arrays.asList(EE7_FEATURES_ARRAY));
+    public static final Set<String> EE7_FEATURE_SET = new HashSet<>(Arrays.asList(EE7_FEATURES_ARRAY));
 
     public EE7FeatureReplacementAction() {
         super(EE8FeatureReplacementAction.EE8_FEATURE_SET, EE7_FEATURE_SET);

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
@@ -11,6 +11,7 @@
 package componenttest.rules.repeater;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -20,7 +21,7 @@ public class EE7FeatureReplacementAction extends FeatureReplacementAction {
 
     static final String[] EE7_FEATURES_ARRAY = { "javaee-7.0", "webProfile-7.0", "javaeeClient-7.0", "servlet-3.1", "jdbc-4.1", "javaMail-1.5", "cdi-1.2", "jpa-2.1",
                                                  "beanValidation-1.1", "jaxrs-2.0", "jaxrsClient-2.0", "jsf-2.2", "appSecurity-2.0", "jsonp-1.0" };
-    public static final Set<String> EE7_FEATURE_SET = new HashSet<>(Arrays.asList(EE7_FEATURES_ARRAY));
+    public static final Set<String> EE7_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE7_FEATURES_ARRAY)));
 
     public EE7FeatureReplacementAction() {
         super(EE8FeatureReplacementAction.EE8_FEATURE_SET, EE7_FEATURE_SET);

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
@@ -11,6 +11,7 @@
 package componenttest.rules.repeater;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -20,7 +21,7 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
 
     static final String[] EE8_FEATURES_ARRAY = { "javaee-8.0", "webProfile-8.0", "javaeeClient-8.0", "servlet-4.0", "jdbc-4.2", "javaMail-1.6", "cdi-2.0", "jpa-2.2",
                                                  "beanValidation-2.0", "jaxrs-2.1", "jaxrsClient-2.1", "jsf-2.3", "appSecurity-3.0", "jsonp-1.1", "jsonb-1.0", };
-    public static final Set<String> EE8_FEATURE_SET = new HashSet<>(Arrays.asList(EE8_FEATURES_ARRAY));
+    public static final Set<String> EE8_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE8_FEATURES_ARRAY)));
 
     public EE8FeatureReplacementAction() {
         super(EE7FeatureReplacementAction.EE7_FEATURE_SET, EE8_FEATURE_SET);

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
@@ -20,7 +20,7 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
 
     static final String[] EE8_FEATURES_ARRAY = { "javaee-8.0", "webProfile-8.0", "javaeeClient-8.0", "servlet-4.0", "jdbc-4.2", "javaMail-1.6", "cdi-2.0", "jpa-2.2",
                                                  "beanValidation-2.0", "jaxrs-2.1", "jaxrsClient-2.1", "jsf-2.3", "appSecurity-3.0", "jsonp-1.1", "jsonb-1.0", };
-    static final Set<String> EE8_FEATURE_SET = new HashSet<>(Arrays.asList(EE8_FEATURES_ARRAY));
+    public static final Set<String> EE8_FEATURE_SET = new HashSet<>(Arrays.asList(EE8_FEATURES_ARRAY));
 
     public EE8FeatureReplacementAction() {
         super(EE7FeatureReplacementAction.EE7_FEATURE_SET, EE8_FEATURE_SET);


### PR DESCRIPTION
Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>

Added a EE6 repeater to the JPA Spec 1.0 bucket.
