### PR TITLE
Don't run jaxb-2.3 FATs on Java 7 builds

### DIFF
--- a/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/FATSuite.java
@@ -29,5 +29,6 @@ public class FATSuite {
     public static RepeatTests r = RepeatTests.withoutModification()
                     .andWith(new FeatureReplacementAction("jaxb-2.2", "jaxb-2.3")
                                     .forceAddFeatures(false)
-                                    .withID("JAXB-2.3"));
+                                    .withID("JAXB-2.3")
+                                    .withMinJavaLevel(8));
 }


### PR DESCRIPTION
I'll need to request a personal build from a Java 7 build.