### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/dev/.build-scans.gradle
+++ b/dev/.build-scans.gradle
@@ -1,0 +1,33 @@
+def acceptFile = new File(gradle.gradleUserHomeDir, "build-scans/open-liberty/gradle-scans-license-agree.txt")
+def env = System.getenv()
+boolean isCI = env.CI || env.TRAVIS
+boolean hasAccepted = isCI || env.GRADLE_SCANS_ACCEPT=='yes' || acceptFile.exists() && acceptFile.text.trim() == 'yes'
+boolean hasRefused = env.GRADLE_SCANS_ACCEPT=='no' || acceptFile.exists() && acceptFile.text.trim() == 'no'
+
+buildScan {
+    if (hasAccepted) {
+        termsOfServiceAgree = 'yes'
+    } else if (!hasRefused) {
+        gradle.buildFinished {
+            println """
+This build uses Gradle Build Scans to gather statistics, share information about 
+failures, environmental issues, dependencies resolved during the build and more.
+Build scans will be published after each build, if you accept the terms of 
+service, and in particular the privacy policy.
+
+Please read 
+   
+    https://gradle.com/terms-of-service 
+    https://gradle.com/legal/privacy
+
+and then:
+
+  - set the `GRADLE_SCANS_ACCEPT` to `yes`/`no` if you agree with/refuse the TOS
+  - or create the ${acceptFile} file with `yes`/`no` in it if you agree with/refuse
+
+And we'll not bother you again. Note that build scans are only made public if 
+you share the URL at the end of the build.
+"""
+        }
+    }
+}

--- a/dev/build.gradle
+++ b/dev/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.gradle.build-scan'
 
 buildScan {
     termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
-    termsOfServiceAgree = 'yes'
+    apply from: './.build-scans.gradle'
 }
 
 /*

--- a/dev/build.gradle
+++ b/dev/build.gradle
@@ -8,6 +8,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+apply plugin: 'com.gradle.build-scan'
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+}
+
 /*
  * Master Gradle build script
  *

--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -242,6 +242,7 @@ buildscript {
   dependencies {
     classpath bnd_plugin
     classpath 'net.ossindex.audit:net.ossindex.audit.gradle.plugin:0.3.8-beta'
+    classpath 'com.gradle:build-scan-plugin:2.1'
   }
 
   /* Since the files in the repository change with each build, we need to recheck for changes */


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.

If this PR is accepted then scan generation must be enabled on the command line, like so

    ./gradlew build --scan