### PR TITLE
Revert "Publish runtime, javaee8, and webprofile8 images from release builds"

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -282,9 +282,6 @@ task zipOpenLiberty(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
-    doLast{
-        props.setProperty('zipopenliberty.runtime.archivename', archivePath.toString())
-    }
 }
 publish.dependsOn zipOpenLiberty
 
@@ -295,9 +292,6 @@ task zipOpenLibertyKernel(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
-    doLast{
-        props.setProperty('zipopenliberty.kernel.archivename', archivePath.toString())
-    }
 }
 publish.dependsOn zipOpenLibertyKernel
 
@@ -308,9 +302,6 @@ task zipOpenLibertyWebProfile8(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
-    doLast{
-        props.setProperty('zipopenliberty.webprofile8.archivename', archivePath.toString())
-    }
 }
 publish.dependsOn zipOpenLibertyWebProfile8
 
@@ -321,9 +312,6 @@ task zipOpenLibertyJavaee8(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
-    doLast{
-        props.setProperty('zipopenliberty.javaee8.archivename', archivePath.toString())
-    }
 }
 publish.dependsOn zipOpenLibertyJavaee8
 
@@ -333,9 +321,6 @@ task zipOpenLibertyMicroProfile2(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
-    doLast {
-        props.setProperty('zipopenliberty.microprofile2.archivename', archivePath.toString())
-    }
 }
 publish.dependsOn zipOpenLibertyMicroProfile2
 
@@ -678,12 +663,6 @@ task publishPublicArtifactsOnDhe {
             artifactList.add(props.getProperty("gradle.test.report.zip"))
         } else {
             artifactList.add(props.getProperty("junit.report.zip"))
-            // add runtime, javaee8, and webprofile8 images to publish list for release builds only
-            if (isRelease) {
-                artifactList.add(props.getProperty("zipopenliberty.runtime.archivename"))
-                artifactList.add(props.getProperty("zipopenliberty.javaee8.archivename"))
-                artifactList.add(props.getProperty("zipopenliberty.webprofile8.archivename"))
-            }
         }
 
         mkdir("${buildDir}/${version}")


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#6492

Something is failing in the DHE publish in the latest release build with this change.  I'm going to revert and investigate.