### PR TITLE
Don't perform server dump all the time in plugin.utility_fat

### DIFF
--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/fat/src/com/ibm/ws/webserver/plugin/utility/fat/PluginUtilityGenerateTest.java
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/fat/src/com/ibm/ws/webserver/plugin/utility/fat/PluginUtilityGenerateTest.java
@@ -77,11 +77,9 @@ public class PluginUtilityGenerateTest {
     public static void tearDown() throws Exception {
         try {
             if (localAccessServer.isStarted()) {
-                localAccessServer.dumpServer("localAccessServer");
                 localAccessServer.stopServer();
             }
             if (remoteAccessServer.isStarted()) {
-                remoteAccessServer.dumpServer("remoteAccessServer");
                 remoteAccessServer.stopServer();
             }
         } catch (Exception e) {


### PR DESCRIPTION
On remote builds, taking a server dump takes about 5 minutes, along with producing ~25MB of compressed data. The test infrastructure will already automatically take a server dump if some catastrophic failure occurs, so it's not necessary for a FAT to be taking server dumps on every run.