### PR TITLE
Disable dumps in JPA Spec10 Bucket

### DIFF
--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22BeanValidation.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22BeanValidation.java
@@ -55,7 +55,7 @@ public class JPA22BeanValidation extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.dumpServer("beanval");
+//        server1.dumpServer("beanval");
         server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22Injection.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22Injection.java
@@ -59,7 +59,7 @@ public class JPA22Injection extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.dumpServer("injection");
+//        server1.dumpServer("injection");
         server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22QueryTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22QueryTest.java
@@ -59,7 +59,7 @@ public class JPA22QueryTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.dumpServer("query");
+//        server1.dumpServer("query");
         server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22TimeAPITest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPA22TimeAPITest.java
@@ -59,7 +59,7 @@ public class JPA22TimeAPITest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.dumpServer("timeapi");
+//        server1.dumpServer("timeapi");
         server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPACDIIntegrationTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/jpa22/JPACDIIntegrationTest.java
@@ -59,7 +59,7 @@ public class JPACDIIntegrationTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.dumpServer("cdi");
+//        server1.dumpServer("cdi");
         server1.stopServer("CWWJP9991W"); // From Eclipselink drop-and-create tables option
     }
 }

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Callback_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Callback_EJB.java
@@ -187,7 +187,7 @@ public class Callback_EJB extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("callback_ejb");
+//            server1.dumpServer("callback_ejb");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Callback_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Callback_Web.java
@@ -146,7 +146,7 @@ public class Callback_Web extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("callback_web");
+//            server1.dumpServer("callback_web");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Inheritance_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Inheritance_EJB.java
@@ -150,7 +150,7 @@ public class Inheritance_EJB extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("relationships_manyXmany_ejb");
+//            server1.dumpServer("relationships_manyXmany_ejb");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Inheritance_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Inheritance_Web.java
@@ -141,7 +141,7 @@ public class Inheritance_Web extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("inheritance_web");
+//            server1.dumpServer("inheritance_web");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXMany_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXMany_EJB.java
@@ -167,7 +167,7 @@ public class Relationships_ManyXMany_EJB extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("relationships_manyXmany_ejb");
+//            server1.dumpServer("relationships_manyXmany_ejb");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXMany_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXMany_Web.java
@@ -148,7 +148,7 @@ public class Relationships_ManyXMany_Web extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("relationships_manyXmany_web");
+//            server1.dumpServer("relationships_manyXmany_web");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXOne_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXOne_EJB.java
@@ -162,7 +162,7 @@ public class Relationships_ManyXOne_EJB extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("relationships_manyXone_ejb");
+//            server1.dumpServer("relationships_manyXone_ejb");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXOne_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXOne_Web.java
@@ -145,7 +145,7 @@ public class Relationships_ManyXOne_Web extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("relationships_manyXone_web");
+//            server1.dumpServer("relationships_manyXone_web");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXMany_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXMany_EJB.java
@@ -160,7 +160,7 @@ public class Relationships_OneXMany_EJB extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("relationships_oneXmany_ejb");
+//            server1.dumpServer("relationships_oneXmany_ejb");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXMany_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXMany_Web.java
@@ -143,7 +143,7 @@ public class Relationships_OneXMany_Web extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("relationships_oneXmany_web");
+//            server1.dumpServer("relationships_oneXmany_web");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXOne_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXOne_EJB.java
@@ -174,7 +174,7 @@ public class Relationships_OneXOne_EJB extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("relationships_oneXone_ejb");
+//            server1.dumpServer("relationships_oneXone_ejb");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXOne_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXOne_Web.java
@@ -148,7 +148,7 @@ public class Relationships_OneXOne_Web extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("relationships_oneXone_web");
+//            server1.dumpServer("relationships_oneXone_web");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec20_fat/fat/src/com/ibm/ws/jpa/JPA20QueryLockMode_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec20_fat/fat/src/com/ibm/ws/jpa/JPA20QueryLockMode_EJB.java
@@ -138,7 +138,7 @@ public class JPA20QueryLockMode_EJB extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("querylockmode_ejb");
+//            server1.dumpServer("querylockmode_ejb");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );

--- a/dev/com.ibm.ws.jpa_spec20_fat/fat/src/com/ibm/ws/jpa/JPA20QueryLockMode_WEB.java
+++ b/dev/com.ibm.ws.jpa_spec20_fat/fat/src/com/ibm/ws/jpa/JPA20QueryLockMode_WEB.java
@@ -138,7 +138,7 @@ public class JPA20QueryLockMode_WEB extends JPAFATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            server1.dumpServer("QueryLockModeWeb");
+//            server1.dumpServer("QueryLockModeWeb");
             server1.stopServer("CWWJP9991W", // From Eclipselink drop-and-create tables option
                                "WTRN0074E: Exception caught from before_completion synchronization operation" // RuntimeException test, expected
             );


### PR DESCRIPTION
Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>

Disabling the dumps that are always requested by the jpa spec10 fat, jpa spec20 fat, and jpa_22 fat buckets.