### PR TITLE
Correctly handle case where we need to wait for multiple updates

### DIFF
--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
@@ -204,7 +204,7 @@ public class FATTest extends AbstractAppManagerTest {
                 // It's possible that we're restarting twice because the file monitor picked up the changes in the middle
                 // of the unzip. If that happens, wait for another updated message and try again.
                 assertNotNull("The application testWarApplication did not appear to have been updated a second time.",
-                              server.waitForStringInLog("CWWKZ0003I.* testWarApplication|CWWKZ0062I.* testWarApplication"));
+                              server.waitForMultipleStringsInLogUsingMark(2, "CWWKZ0003I.* testWarApplication|CWWKZ0062I.* testWarApplication"));
                 con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_OK, CONN_TIMEOUT);
                 br = HttpUtils.getConnectionStream(con);
                 line = br.readLine();


### PR DESCRIPTION
An app manager test can fail if the file update monitor picks up a change while we are still unzipping files. We have code to handle this case that attempts to wait for a second update to the application before running the test, but it doesn't work as intended. The log offset is not updated by the initial search for the "application updated" message, so the test finds the first "updated" message again rather than waiting for a new one. 