### PR TITLE
Publish runtime, javaee8, and webProfile8 images to DHE

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -282,6 +282,11 @@ task zipOpenLiberty(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
+    doLast{
+        props.setProperty('zipopenliberty.runtime.archivename', archivePath.toString())
+        File propsFile = rootProject.file('generated.properties')
+        props.store(propsFile.newWriter(), null)
+    }
 }
 publish.dependsOn zipOpenLiberty
 
@@ -292,6 +297,11 @@ task zipOpenLibertyKernel(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
+    doLast{
+        props.setProperty('zipopenliberty.kernel.archivename', archivePath.toString())
+        File propsFile = rootProject.file('generated.properties')
+        props.store(propsFile.newWriter(), null)
+    }
 }
 publish.dependsOn zipOpenLibertyKernel
 
@@ -302,6 +312,11 @@ task zipOpenLibertyWebProfile8(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
+    doLast{
+        props.setProperty('zipopenliberty.webprofile8.archivename', archivePath.toString())
+        File propsFile = rootProject.file('generated.properties')
+        props.store(propsFile.newWriter(), null)
+    }
 }
 publish.dependsOn zipOpenLibertyWebProfile8
 
@@ -312,6 +327,11 @@ task zipOpenLibertyJavaee8(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
+    doLast{
+        props.setProperty('zipopenliberty.javaee8.archivename', archivePath.toString())
+        File propsFile = rootProject.file('generated.properties')
+        props.store(propsFile.newWriter(), null)
+    }
 }
 publish.dependsOn zipOpenLibertyJavaee8
 
@@ -321,6 +341,11 @@ task zipOpenLibertyMicroProfile2(type: Zip) {
     from packageDir
     destinationDir distsDir
     version releaseVersion
+    doLast {
+        props.setProperty('zipopenliberty.microprofile2.archivename', archivePath.toString())
+        File propsFile = rootProject.file('generated.properties')
+        props.store(propsFile.newWriter(), null)
+    }
 }
 publish.dependsOn zipOpenLibertyMicroProfile2
 
@@ -663,6 +688,12 @@ task publishPublicArtifactsOnDhe {
             artifactList.add(props.getProperty("gradle.test.report.zip"))
         } else {
             artifactList.add(props.getProperty("junit.report.zip"))
+            // add runtime, javaee8, and webprofile8 images to publish list for release builds only
+            if (isRelease) {
+                artifactList.add(props.getProperty("zipopenliberty.runtime.archivename"))
+                artifactList.add(props.getProperty("zipopenliberty.javaee8.archivename"))
+                artifactList.add(props.getProperty("zipopenliberty.webprofile8.archivename"))
+            }
         }
 
         mkdir("${buildDir}/${version}")

--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -44,6 +44,21 @@ pluginManagement {
       if (genProps['zipopenliberty.archivename'] != null) {
         props.setProperty('zipopenliberty.archivename', genProps['zipopenliberty.archivename'])
       }
+      if (genProps['zipopenliberty.runtime.archivename'] != null) {
+        props.setProperty('zipopenliberty.runtime.archivename', genProps['zipopenliberty.runtime.archivename'])
+      }
+      if (genProps['zipopenliberty.kernel.archivename'] != null) {
+        props.setProperty('zipopenliberty.kernel.archivename', genProps['zipopenliberty.kernel.archivename'])
+      }
+      if (genProps['zipopenliberty.webprofile8.archivename'] != null) {
+        props.setProperty('zipopenliberty.webprofile8.archivename', genProps['zipopenliberty.webprofile8.archivename'])
+      }
+      if (genProps['zipopenliberty.javaee8.archivename'] != null) {
+        props.setProperty('zipopenliberty.javaee8.archivename', genProps['zipopenliberty.javaee8.archivename'])
+      }
+      if (genProps['zipopenliberty.microprofile2.archivename'] != null) {
+        props.setProperty('zipopenliberty.microprofile2.archivename', genProps['zipopenliberty.microprofile2.archivename'])
+      }
     }
 
     // Properties for automated-build relevant tasks. These assignments below are defaults for when building locally


### PR DESCRIPTION
Redo of the fix in #6492, which did not work and had to be reverted.  This change will publish the runtime, javaee8, and webProfile8 images to DHE from release builds only.  It is needed for the daily Open Liberty Docker images to run properly.