### PR TITLE
Fix ConcurrentModificationException in channelfw unit tests

### DIFF
--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/bytebuffer/test/ByteBufferTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/bytebuffer/test/ByteBufferTest.java
@@ -29,10 +29,9 @@ import java.nio.channels.FileChannel;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -45,40 +44,9 @@ import com.ibm.wsspi.channelfw.ChannelFrameworkFactory;
  * Test the WsByteBuffer interface.
  */
 public class ByteBufferTest {
-    private static SharedOutputManager outputMgr;
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     /**
      * Test the various pooled buffers.

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/bytebuffer/test/ByteBufferUtilsTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/bytebuffer/test/ByteBufferUtilsTest.java
@@ -15,10 +15,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -30,42 +29,11 @@ import com.ibm.wsspi.channelfw.ChannelFrameworkFactory;
  * Test the bytebuffer utils class.
  */
 public class ByteBufferUtilsTest {
-    private static SharedOutputManager outputMgr;
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
     private static final String data = "test string";
     private static final String data2 = "secondary test data";
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
 
     private WsByteBuffer setupBuffer(int size, String content) {
         WsByteBuffer buffer = ChannelFrameworkFactory.getBufferManager().allocate(size);

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/CFEndPointTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/CFEndPointTest.java
@@ -30,11 +30,10 @@ import javax.management.DynamicMBean;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
@@ -64,7 +63,9 @@ import test.common.SharedOutputManager;
  * Unit tests for the CFEndPoint logic.
  */
 public class CFEndPointTest {
-    private static SharedOutputManager outputMgr;
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     private final Mockery mock = new JUnit4Mockery();
     private final EndPointMgr mgrMock = mock.mock(EndPointMgr.class);
@@ -76,39 +77,6 @@ public class CFEndPointTest {
     public void setUp() {
         endpointPort = Integer.parseInt(System.getProperty("CFEndPointTest.endpointPort", "1010"));
         EndPointMgrImpl.setRef(mgrMock);
-    }
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     *
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     *
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     *
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
     }
 
     /**

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChainDataTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChainDataTest.java
@@ -18,10 +18,9 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -57,40 +56,9 @@ import com.ibm.wsspi.channelfw.exception.InvalidChannelNameException;
  * Chain runtime configuration tests.
  */
 public class ChainDataTest {
-    private static SharedOutputManager outputMgr;
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     // Helper method to create valid tcp props to start a chain with TCP in it.
     protected Map<Object, Object> getTcpProps(String portProp, String defaultPort) {

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChainEventListenerTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChainEventListenerTest.java
@@ -19,10 +19,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -45,44 +45,19 @@ import com.ibm.wsspi.channelfw.exception.RetryableChannelException;
  * Testcase for the chain lifecycle listener code.
  */
 public class ChainEventListenerTest {
-    private static SharedOutputManager outputMgr;
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     static Field chainEventListeners;
 
     /**
-     * Capture stdout/stderr output to the manager.
-     * 
      * @throws Exception
      */
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-
         chainEventListeners = ChainDataImpl.class.getDeclaredField("chainEventListeners");
         chainEventListeners.setAccessible(true);
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
     }
 
     // Helper method to create valid tcp props to start a chain with TCP in it.

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChainLifeCycleTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChainLifeCycleTest.java
@@ -19,10 +19,9 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -62,40 +61,9 @@ import com.ibm.wsspi.channelfw.exception.InvalidRuntimeStateException;
  * Test the lifecycle of chains.
  */
 public class ChainLifeCycleTest {
-    private static SharedOutputManager outputMgr;
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     // Helper method to create valid tcp props to start a chain with TCP in it.
     private Map<Object, Object> getTcpProps(String portProp, String defPort) {

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChannelDataTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChannelDataTest.java
@@ -19,10 +19,9 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -44,40 +43,9 @@ import com.ibm.wsspi.channelfw.exception.InvalidWeightException;
  * Runtime channel configuration test code.
  */
 public class ChannelDataTest {
-    private static SharedOutputManager outputMgr;
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     // Helper method to create valid tcp props to start a chain with TCP in it.
     protected Map<Object, Object> getTcpProps(String portProp, String defPort) {

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChannelFactoryDataTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChannelFactoryDataTest.java
@@ -19,10 +19,9 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -38,40 +37,9 @@ import com.ibm.wsspi.channelfw.exception.InvalidChannelFactoryException;
  * Test code for the channel factory runtime configuration.
  */
 public class ChannelFactoryDataTest {
-    private static SharedOutputManager outputMgr;
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     /**
      * Test the full updates.

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChannelFactoryLifeCycleTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChannelFactoryLifeCycleTest.java
@@ -15,10 +15,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -34,40 +33,9 @@ import com.ibm.wsspi.channelfw.exception.ChannelException;
  * Test the channel factory life cycle methods
  */
 public class ChannelFactoryLifeCycleTest {
-    private static SharedOutputManager outputMgr;
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     /**
      * Test non-persistent creation.

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChannelLifeCycleTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/ChannelLifeCycleTest.java
@@ -20,10 +20,9 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -43,40 +42,9 @@ import com.ibm.wsspi.channelfw.exception.InvalidRuntimeStateException;
  * in ChannelFrameworkImpl.
  */
 public class ChannelLifeCycleTest {
-    private static SharedOutputManager outputMgr;
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     // Helper method to create valid tcp props to start a chain with TCP in it.
     protected Map<Object, Object> getTcpProps(String portProp, String defPort) {

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/DiscriminationTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/DiscriminationTest.java
@@ -20,10 +20,9 @@ import static org.junit.Assert.fail;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -47,7 +46,9 @@ import com.ibm.wsspi.channelfw.exception.DiscriminationProcessException;
  */
 @SuppressWarnings("unused")
 public class DiscriminationTest {
-    private static SharedOutputManager outputMgr;
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     protected boolean channelCheck = false;
     protected int noCheckCount = 0;
@@ -64,39 +65,6 @@ public class DiscriminationTest {
     private static final int idC = 3;
     private static final int idD = 4;
     private static final int idE = 5;
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
 
     /**
      * Test simple discrimination.

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/GroupDataTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/GroupDataTest.java
@@ -17,10 +17,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -44,40 +43,9 @@ import com.ibm.wsspi.channelfw.exception.InvalidChainNameException;
  */
 @SuppressWarnings("unused")
 public class GroupDataTest {
-    private static SharedOutputManager outputMgr;
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     /**
      * Test addChainGroup method.

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/GroupLifeCycleTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/GroupLifeCycleTest.java
@@ -18,10 +18,9 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -48,40 +47,9 @@ import com.ibm.wsspi.channelfw.exception.ChannelException;
  * in ChannelFrameworkImpl.
  */
 public class GroupLifeCycleTest {
-    private static SharedOutputManager outputMgr;
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
 
     private Map<Object, Object> getTcpProps(String portProp, String defPort) {
         String port = System.getProperty(portProp, defPort);

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/VirtualConnectionTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/ws/channelfw/testsuite/junit/VirtualConnectionTest.java
@@ -15,10 +15,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -36,41 +35,10 @@ import com.ibm.wsspi.channelfw.VirtualConnectionFactory;
  * Virtual connection unit tests.
  */
 public class VirtualConnectionTest {
-    private static SharedOutputManager outputMgr;
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
     private static final ChannelFramework framework = ChannelFrameworkFactory.getChannelFramework();
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
 
     /**
      * Test the inbound VC objects.

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/wsspi/connmgmt/ConnectionHandleTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/wsspi/connmgmt/ConnectionHandleTest.java
@@ -20,10 +20,9 @@ import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import test.common.SharedOutputManager;
 
@@ -38,41 +37,10 @@ import com.ibm.wsspi.connmgmt.ConnectionHandle.ConnectionHandleFactory;
 /**
  */
 public class ConnectionHandleTest {
-    private static SharedOutputManager outputMgr;
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
     private static final ChannelFramework framework = ChannelFrameworkFactory.getChannelFramework();
-
-    /**
-     * Capture stdout/stderr output to the manager.
-     * 
-     * @throws Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        outputMgr = SharedOutputManager.getInstance();
-        outputMgr.captureStreams();
-    }
-
-    /**
-     * Final teardown work when class is exiting.
-     * 
-     * @throws Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-        // Make stdout and stderr "normal"
-        outputMgr.restoreStreams();
-    }
-
-    /**
-     * Individual teardown after each test.
-     * 
-     * @throws Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        // Clear the output generated after each method invocation
-        outputMgr.resetStreams();
-    }
 
     /**
      * Verify exception paths


### PR DESCRIPTION
Updating the channelfw unit tests to use the TestRule invocation of SharedOutputManager, instead of calling the methods individually.  This is to avoid the intermittent ConcurrentModificationException we have seen break our builds on the `captureStreams()` method call when executing these tests.

The other option for a fix that we have used in this type of case would be to add `dumpStreams()` and `restoreStreams()` before the `captureStreams()` call, but this seemed like a cleaner fix.

#build