### PR TITLE
Fix permissions.xml in BasicAuth app

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security_test.servlets/test-applications/basicauth/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.webcontainer.security_test.servlets/test-applications/basicauth/resources/META-INF/permissions.xml
@@ -34,7 +34,7 @@
    
    <permission>
        <class-name>javax.security.auth.PrivateCredentialPermission</class-name>
-       <name>*</name>
+       <name>* * "*"</name>
        <actions>read</actions>
    </permission>
 


### PR DESCRIPTION
Fixes #6537

Hitting a failure in OutboundSSLLDAPTest using the basicauth.war. The format of the PrivateCredentialPermission is incorrect.

```
testLDAPUsingDefaultOutboundSSLConfiguration
java.lang.Exception: 2019-02-14-07:22:55:078 Errors/warnings were found in server com.ibm.ws.security.wim.adapter.ldap.fat.outbound.ssl logs:
<br>[2/14/19 7:18:43:419 UTC] 00000032 com.ibm.ws.classloading.java2sec.PermissionManager           W CWWKS1800W: The java permission configuration in permissions.xml is incorrect. An attempt to create permission javax.security.auth.PrivateCredentialPermission resulted in an exception due to java.lang.IllegalArgumentException[permission name [*] syntax invalid: Credential Class not followed by a Principal Class and Name].
at componenttest.topology.impl.LibertyServer.checkLogsForErrorsAndWarnings(LibertyServer.java:2488)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:2364)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:2204)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:2179)
at com.ibm.ws.security.wim.adapter.ldap.fat.OutboundSSLLDAPTest.tearDown(OutboundSSLLDAPTest.java:92)
```

Correcting the permissions.xml.