### PR TITLE
Update JPA Spec10 and Spec20 for jpa-2.0 feature execution

### DIFF
--- a/dev/com.ibm.ws.jpa_spec10_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_spec10_fat/bnd.bnd
@@ -26,6 +26,7 @@ src: \
 	test-framework/src
 
 fat.project: true
+tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -30,6 +30,6 @@ public class FATSuite {
                                                 "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new RepeatWithJPA20())
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(FeatureReplacementAction.EE7_FEATURES())
+                    .andWith(new RepeatWithJPA20());
 }

--- a/dev/com.ibm.ws.jpa_spec10_fat/publish/servers/JPA10Server/server.xml
+++ b/dev/com.ibm.ws.jpa_spec10_fat/publish/servers/JPA10Server/server.xml
@@ -12,12 +12,13 @@
 
 	<featureManager>
 	    <feature>ejblite-3.2</feature>
+	    <!-- 
 	    <feature>servlet-3.1</feature>
 		<feature>jpa-2.1</feature>
-	    <!-- 
+		-->
 		<feature>servlet-4.0</feature>
 		<feature>jpa-2.2</feature>
-		 -->
+
 	    <feature>componenttest-1.0</feature>
     </featureManager>
     

--- a/dev/com.ibm.ws.jpa_spec20_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_spec20_fat/bnd.bnd
@@ -22,6 +22,7 @@ src: \
 	test-framework/src
 
 fat.project: true
+tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jpa_spec20_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa_spec20_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -28,7 +28,9 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
                                                 "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";" };
+
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(FeatureReplacementAction.EE7_FEATURES())
+                    .andWith(new RepeatWithJPA20());
 }

--- a/dev/com.ibm.ws.jpa_spec20_fat/fat/src/com/ibm/ws/jpa/RepeatWithJPA20.java
+++ b/dev/com.ibm.ws.jpa_spec20_fat/fat/src/com/ibm/ws/jpa/RepeatWithJPA20.java
@@ -43,7 +43,7 @@ public class RepeatWithJPA20 extends FeatureReplacementAction {
 
     @Override
     public boolean isEnabled() {
-        LibertyServer server = LibertyServerFactory.getLibertyServer("JPA10Server");
+        LibertyServer server = LibertyServerFactory.getLibertyServer("JPA20Server");
 
         File jpa20Feature = new File(server.getInstallRoot() + "/lib/features/com.ibm.websphere.appserver.jpa-2.0.mf");
         Log.info(getClass(), "isEnabled", "Does the jpa-2.0 feature exist? " + jpa20Feature.exists());

--- a/dev/com.ibm.ws.jpa_spec20_fat/publish/servers/JPA20Server/server.xml
+++ b/dev/com.ibm.ws.jpa_spec20_fat/publish/servers/JPA20Server/server.xml
@@ -12,12 +12,13 @@
 
 	<featureManager>
 	    <feature>ejblite-3.2</feature>
+	    <!-- 
 	    <feature>servlet-3.1</feature>
 		<feature>jpa-2.1</feature>
-	    <!-- 
+	     -->
 		<feature>servlet-4.0</feature>
 		<feature>jpa-2.2</feature>
-		 -->
+		
 	    <feature>componenttest-1.0</feature>
     </featureManager>
     

--- a/dev/com.ibm.ws.jpa_spec20_fat/test-applications/querylockmode/ejb/querylockmode.jar/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_spec20_fat/test-applications/querylockmode/ejb/querylockmode.jar/META-INF/persistence.xml
@@ -132,6 +132,8 @@
         <properties>
             <property name="eclipselink.logging.parameters" value="true"/>
         	<property name="eclipselink.cache.shared.default" value="false"/>
+        	<property name="openjpa.jdbc.DBDictionary" value="StoreCharsAsNumbers=false"/>
+        	<property name="openjpa.ConnectionFactoryProperties" value="PrintParameters=true" />
         </properties>
     </persistence-unit>
     <persistence-unit name="QueryLockMode_JEE_RL" transaction-type="RESOURCE_LOCAL">
@@ -249,6 +251,8 @@
         <properties>
             <property name="eclipselink.logging.parameters" value="true"/>
         	<property name="eclipselink.cache.shared.default" value="false"/>
+        	<property name="openjpa.jdbc.DBDictionary" value="StoreCharsAsNumbers=false"/>
+        	<property name="openjpa.ConnectionFactoryProperties" value="PrintParameters=true" />
         </properties>
     </persistence-unit>
 

--- a/dev/com.ibm.ws.jpa_spec20_fat/test-applications/querylockmode/src/com/ibm/ws/jpa/fvt/jpa20/querylockmode/testlogic/QueryLockModeTestLogic.java
+++ b/dev/com.ibm.ws.jpa_spec20_fat/test-applications/querylockmode/src/com/ibm/ws/jpa/fvt/jpa20/querylockmode/testlogic/QueryLockModeTestLogic.java
@@ -128,7 +128,11 @@ public class QueryLockModeTestLogic extends AbstractTestLogic {
             return;
         }
 
-        final boolean isOpenJPA = jpaResource.getEm().getDelegate().getClass().getName().toLowerCase().contains("openjpa");
+        final Class delegateClass = jpaResource.getEm().getDelegate().getClass();
+        final String delegateClassStr = delegateClass.getName().toLowerCase();
+        final boolean isOpenJPA = delegateClassStr.contains("org.apache.openjpa") || delegateClassStr.contains("com.ibm.websphere.persistence")
+                                  || delegateClassStr.contains("com.ibm.ws.persistence");
+        System.out.println("isOpenJPA = " + isOpenJPA);
 
         String lockModeTypeStr = (String) testExecCtx.getProperties().get("LockModeType");
         LockModeType lockModeType = LockModeType.valueOf(lockModeTypeStr);

--- a/dev/com.ibm.ws.jpa_spec20_fat/test-applications/querylockmode/web/QueryLockModeWeb.war/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_spec20_fat/test-applications/querylockmode/web/QueryLockModeWeb.war/WEB-INF/classes/META-INF/persistence.xml
@@ -132,6 +132,8 @@
         <properties>
             <property name="eclipselink.logging.parameters" value="true"/>
         	<property name="eclipselink.cache.shared.default" value="false"/>
+        	<property name="openjpa.jdbc.DBDictionary" value="StoreCharsAsNumbers=false"/>
+        	<property name="openjpa.ConnectionFactoryProperties" value="PrintParameters=true" />
         </properties>
     </persistence-unit>
     <persistence-unit name="QueryLockMode_JEE_RL" transaction-type="RESOURCE_LOCAL">
@@ -249,6 +251,8 @@
         <properties>
             <property name="eclipselink.logging.parameters" value="true"/>
         	<property name="eclipselink.cache.shared.default" value="false"/>
+        	<property name="openjpa.jdbc.DBDictionary" value="StoreCharsAsNumbers=false"/>
+        	<property name="openjpa.ConnectionFactoryProperties" value="PrintParameters=true" />
         </properties>
     </persistence-unit>
 


### PR DESCRIPTION
Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>

Corrections made to JPA Spec 1.0 and 2.0 buckets for executing against the jpa-2.0 feature in WS-CD environments.
