### PR TITLE
When ucp is specified with ConnectionPoolDataSource, do not search ba…

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -519,6 +519,12 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 String vendorPropertiesPID = props instanceof PropertyService ? ((PropertyService) props).getFactoryPID() : PropertyService.FACTORY_PID;
                 className = JDBCDrivers.getConnectionPoolDataSourceClassName(vendorPropertiesPID);
                 if (className == null) {
+                    //if properties.oracle.ucp is configured do not search based on classname or infer because the customer has indicated
+                    //they want to use UCP, but this will likely pick up the Oracle driver instead of the UCP driver (since UCP has no ConnectionPoolDataSource)
+                    if(vendorPropertiesPID != null && vendorPropertiesPID.equals("com.ibm.ws.jdbc.dataSource.properties.oracle.ucp")) {
+                        //TODO consider if we want to throw a more specific exception here
+                        throw classNotFound(ConnectionPoolDataSource.class.getName(), null, dataSourceID, null);
+                    }
                     className = JDBCDrivers.getConnectionPoolDataSourceClassName(getClasspath(sharedLib, true));
                     if (className == null) {
                         Set<String> packagesSearched = new LinkedHashSet<String>();


### PR DESCRIPTION
…sed on classname or infer from driver name.  Otherwise we will return an impl of ConnectionPoolDataSource from the Oracle JDBC driver, when the user configured UCP.
