### PR TITLE
avoid warning for feature version that does not exist in OpenLiberty

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/configValidator-1.0/com.ibm.websphere.appserver.configValidator-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/configValidator-1.0/com.ibm.websphere.appserver.configValidator-1.0.feature
@@ -5,7 +5,8 @@ singleton=true
 IBM-ShortName: configValidator-1.0
 Subsystem-Name: Config and Validator REST API 1.0
 -features=\
- com.ibm.websphere.appserver.restHandler-1.0
+ com.ibm.websphere.appserver.restHandler-1.0,\
+ com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="3.0, 4.0"
 -bundles=\
  com.ibm.ws.rest.handler.config,\
  com.ibm.ws.rest.handler.validator,\


### PR DESCRIPTION
Update feature file so that it doesn't default to servlet-3.0 because there is no such version in OpenLiberty.  This is causing a warning to appear in server logs when the validator feature is enabled.