### PR TITLE
Updates to make new project work in eclipse.

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -364,7 +364,7 @@ org.springframework:spring-beans:5.1.4.RELEASE
 org.springframework:spring-context:5.1.4.RELEASE
 org.springframework:spring-web:5.1.4.RELEASE
 org.springframework:spring-webflux:5.1.4.RELEASE
-org.springframework:spring-webmvc:5.1.4	.RELEASE
+org.springframework:spring-webmvc:5.1.4.RELEASE
 org.springframework.boot:spring-boot:2.1.2.RELEASE
 org.springframework.boot:spring-boot-autoconfigure:2.1.2.RELEASE
 io.projectreactor:reactor-core:3.1.8.RELEASE

--- a/dev/com.ibm.ws.springboot.support.version21.test.app/.classpath
+++ b/dev/com.ibm.ws.springboot.support.version21.test.app/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+    <classpathentry kind="src" path="src/main/java"/>
+    <classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+    <classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.ws.springboot.support.version21.test.app/.project
+++ b/dev/com.ibm.ws.springboot.support.version21.test.app/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+    <name>com.ibm.ws.springboot.support.version21.test.app</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.ws.springboot.support.version21.test.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support.version21.test.app/bnd.bnd
@@ -36,6 +36,8 @@ javac.target: 1.8
 	org.springframework:spring-core;strategy=exact;version=5.1.4.RELEASE, \
 	org.springframework:spring-context;strategy=exact;version=5.1.4.RELEASE, \
 	org.springframework:spring-beans;strategy=exact;version=5.1.4.RELEASE, \
+	org.springframework:spring-web;strategy=exact;version=5.1.4.RELEASE, \
+	org.springframework:spring-webmvc;strategy=exact;version=5.1.4.RELEASE, \
 	org.springframework.boot:spring-boot-autoconfigure;version=2.1.2.RELEASE, \
 	org.springframework.boot:spring-boot;version=2.1.2.RELEASE, \
 	org.springframework.security:spring-security-web;strategy=exact;version=5.1.3.RELEASE, \


### PR DESCRIPTION
Update oss_dependencies.maven to remove tab character that causes havoc.
Add .project and .classpath files for
springboot.support.version21.test.app project.
Update bnd.bnd file so that the springboot.support.version21.test.app
actually builds in eclipse.