### PR TITLE
test coverage for TransactionScoped bean

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/TransactionScopedBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/TransactionScopedBean.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.cdi.web;
+
+import java.io.Serializable;
+
+import javax.transaction.TransactionScoped;
+
+@TransactionScoped
+public class TransactionScopedBean extends AbstractBean implements Serializable {
+    private static final long serialVersionUID = 1L;
+}


### PR DESCRIPTION
Add test coverage for maintaining the state of a TransactionScoped bean when CDI context is propagated vs cleared.  TransactionScoped follows the transaction that is on the thread, not the propagated CDI context or lack thereof.