### PR TITLE
Update FaultTolerance interfaces

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/ExecutorBuilderImpl20.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/ExecutorBuilderImpl20.java
@@ -19,7 +19,7 @@ import com.ibm.ws.microprofile.faulttolerance.spi.Executor;
 import com.ibm.ws.threading.PolicyExecutorProvider;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
-public class ExecutorBuilderImpl20<T, R> extends ExecutorBuilderImpl<T, R> {
+public class ExecutorBuilderImpl20<R> extends ExecutorBuilderImpl<R> {
 
     public ExecutorBuilderImpl20(WSContextService contextService, PolicyExecutorProvider policyExecutorProvider, ScheduledExecutorService scheduledExecutorService) {
         super(contextService, policyExecutorProvider, scheduledExecutorService);

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/ProviderResolverImpl20.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/ProviderResolverImpl20.java
@@ -21,7 +21,7 @@ import com.ibm.ws.microprofile.faulttolerance.spi.FaultToleranceProviderResolver
 public class ProviderResolverImpl20 extends ProviderResolverImpl {
 
     @Override
-    public <T, R> ExecutorBuilder<T, R> newExecutionBuilder() {
+    public <R> ExecutorBuilder<R> newExecutionBuilder() {
         return new ExecutorBuilderImpl20<>(contextService, policyExecutorProvider, getScheduledExecutorService());
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/AsyncTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/AsyncTest.java
@@ -48,7 +48,7 @@ public class AsyncTest extends AbstractFTTest {
 
     @Test
     public void testAsync() throws InterruptedException, ExecutionException, TimeoutException {
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         Executor<Future<String>> executor = builder.buildAsync(Future.class);
 
         List<Future<String>> futures = new ArrayList<>();
@@ -78,7 +78,7 @@ public class AsyncTest extends AbstractFTTest {
 
     @Test
     public void testAsyncCancel() throws InterruptedException, ExecutionException, TimeoutException {
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         Executor<Future<String>> executor = builder.buildAsync(Future.class);
         ExecutionContext context = executor.newExecutionContext("testAsyncCancellation", null);
 
@@ -135,7 +135,7 @@ public class AsyncTest extends AbstractFTTest {
 
     @Test
     public void testAsyncCS() throws InterruptedException, ExecutionException, TimeoutException {
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         Executor<CompletionStage<String>> executor = builder.buildAsync(CompletionStage.class);
         ExecutionContext context = executor.newExecutionContext("testAsyncCS", null);
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/BulkheadTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/BulkheadTest.java
@@ -53,7 +53,7 @@ public class BulkheadTest extends AbstractFTTest {
         BulkheadPolicy bulkhead = FaultToleranceProvider.newBulkheadPolicy();
         bulkhead.setMaxThreads(2);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
         Executor<String> executor = builder.build();
 
@@ -112,7 +112,7 @@ public class BulkheadTest extends AbstractFTTest {
         retryPolicy.setRetryOn(BulkheadException.class);
         retryPolicy.setDelay(Duration.ofMillis(100));
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
         builder.setRetryPolicy(retryPolicy);
         Executor<String> executor = builder.build();
@@ -169,7 +169,7 @@ public class BulkheadTest extends AbstractFTTest {
         retryPolicy.setJitter(Duration.ofMillis(499));
         retryPolicy.setMaxDuration(Duration.ofMillis(20000)); //maximum duration of 20seconds
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
         builder.setRetryPolicy(retryPolicy);
         Executor<String> executor = builder.build();
@@ -213,7 +213,7 @@ public class BulkheadTest extends AbstractFTTest {
         bulkhead.setMaxThreads(20);
         bulkhead.setQueueSize(20);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
 
         Executor<Future<String>> executor = builder.buildAsync(Future.class);
@@ -264,7 +264,7 @@ public class BulkheadTest extends AbstractFTTest {
         bulkhead.setMaxThreads(2);
         bulkhead.setQueueSize(2);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
 
         Executor<Future<String>> executor = builder.buildAsync(Future.class);
@@ -319,7 +319,7 @@ public class BulkheadTest extends AbstractFTTest {
         FallbackPolicy fallback = FaultToleranceProvider.newFallbackPolicy();
         fallback.setFallbackFunction(getFallbackFunction(Duration.ofMillis(5000), fallbackLatch));
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
         builder.setFallbackPolicy(fallback);
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/CircuitBreakerTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/CircuitBreakerTest.java
@@ -39,7 +39,7 @@ public class CircuitBreakerTest extends AbstractFTTest {
         circuitBreaker.setFailureRatio(1.0);
         circuitBreaker.setRequestVolumeThreshold(2);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setCircuitBreakerPolicy(circuitBreaker);
 
         Executor<String> executor = builder.build();

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/FallbackTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/FallbackTest.java
@@ -36,7 +36,7 @@ public class FallbackTest extends AbstractFTTest {
         TestFallback fallbackCallable = new TestFallback();
         fallback.setFallbackFunction(fallbackCallable);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setFallbackPolicy(fallback);
         Executor<String> executor = builder.build();
 
@@ -59,7 +59,7 @@ public class FallbackTest extends AbstractFTTest {
         TestFallbackFactory fallbackFactory = new TestFallbackFactory();
         fallback.setFallbackHandler(TestFallback.class, fallbackFactory);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setFallbackPolicy(fallback);
 
         Executor<String> executor = builder.build();

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/RetryTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/RetryTest.java
@@ -42,7 +42,7 @@ public class RetryTest extends AbstractFTTest {
         RetryPolicy retry = FaultToleranceProvider.newRetryPolicy();
         retry.setMaxRetries(3);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setRetryPolicy(retry);
 
         Executor<String> executor = builder.build();
@@ -66,7 +66,7 @@ public class RetryTest extends AbstractFTTest {
         //100ms between retries
         retry.setDelay(Duration.ofMillis(100));
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setRetryPolicy(retry);
 
         TimeoutPolicy timeout = FaultToleranceProvider.newTimeoutPolicy();
@@ -95,7 +95,7 @@ public class RetryTest extends AbstractFTTest {
         RetryPolicy retry = FaultToleranceProvider.newRetryPolicy();
         retry.setMaxRetries(3);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setRetryPolicy(retry);
 
         Executor<Future<String>> executor = builder.buildAsync(Future.class);

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/TimeoutTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance/test/TimeoutTest.java
@@ -36,7 +36,7 @@ public class TimeoutTest extends AbstractFTTest {
         TimeoutPolicy timeout = FaultToleranceProvider.newTimeoutPolicy();
         timeout.setTimeout(Duration.ofMillis(500));
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setTimeoutPolicy(timeout);
 
         Executor<String> executor = builder.build();

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/AggregatedFTPolicy.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/AggregatedFTPolicy.java
@@ -12,8 +12,6 @@ package com.ibm.ws.microprofile.faulttolerance.cdi;
 
 import java.lang.reflect.Method;
 
-import org.eclipse.microprofile.faulttolerance.ExecutionContext;
-
 import com.ibm.ws.microprofile.faulttolerance.spi.BulkheadPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.CircuitBreakerPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.Executor;
@@ -137,7 +135,7 @@ public class AggregatedFTPolicy {
     public Executor<Object> getExecutor() {
         synchronized (this) {
             if (this.executor == null) {
-                ExecutorBuilder<ExecutionContext, ?> builder = newBuilder();
+                ExecutorBuilder<?> builder = newBuilder();
 
                 if (isAsynchronous()) {
                     this.executor = builder.buildAsync(asyncResultWrapper);
@@ -149,13 +147,13 @@ public class AggregatedFTPolicy {
         }
     }
 
-    private ExecutorBuilder<ExecutionContext, ?> newBuilder() {
-        ExecutorBuilder<ExecutionContext, ?> builder = FaultToleranceProvider.newExecutionBuilder();
+    private ExecutorBuilder<?> newBuilder() {
+        ExecutorBuilder<?> builder = FaultToleranceProvider.newExecutionBuilder();
         builder = updateBuilder(builder);
         return builder;
     }
 
-    private <R> ExecutorBuilder<ExecutionContext, R> updateBuilder(ExecutorBuilder<ExecutionContext, R> builder) {
+    private <R> ExecutorBuilder<R> updateBuilder(ExecutorBuilder<R> builder) {
         TimeoutPolicy timeoutPolicy = getTimeoutPolicy();
         CircuitBreakerPolicy circuitBreakerPolicy = getCircuitBreakerPolicy();
         RetryPolicy retryPolicy = getRetryPolicy();
@@ -179,12 +177,12 @@ public class AggregatedFTPolicy {
         }
 
         builder.setMetricRecorder(FaultToleranceCDIComponent.getMetricProvider().getMetricRecorder(method,
-                                                                                        retryPolicy,
-                                                                                        circuitBreakerPolicy,
-                                                                                        timeoutPolicy,
-                                                                                        bulkheadPolicy,
-                                                                                        fallbackPolicy,
-                                                                                        isAsynchronous() ? AsyncType.ASYNC : AsyncType.SYNC));
+                                                                                                   retryPolicy,
+                                                                                                   circuitBreakerPolicy,
+                                                                                                   timeoutPolicy,
+                                                                                                   bulkheadPolicy,
+                                                                                                   fallbackPolicy,
+                                                                                                   isAsynchronous() ? AsyncType.ASYNC : AsyncType.SYNC));
 
         return builder;
     }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/Executor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/Executor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,13 +17,30 @@ import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 
 /**
  * Executes a callable, applying fault tolerance logic around it
+ * <p>
+ * Instances of this class should be obtained from an {@link ExecutorBuilder}
  *
  * @param <R> the return type of the callable
  */
 public interface Executor<R> {
 
+    /**
+     * Execute a callable, applying fault tolerance logic around it
+     *
+     * @param callable the callable to execute
+     * @param context  the execution context, which must have be obtained from a prior call to {@link #newExecutionContext(String, Method, Object...)}
+     * @return the result of executing the callable, after all fault tolerance policies have been applied
+     */
     public R execute(Callable<R> callable, ExecutionContext context);
 
+    /**
+     * Create a new execution context
+     *
+     * @param id         an identifier for the execution, currently only used for tracing
+     * @param method     the method which is being executed by the callable, as returned by {@link ExecutionContext#getMethod()}
+     * @param parameters the parameters passed to the method, as returned by {@link ExecutionContext#getParameters()}
+     * @return the new execution context
+     */
     public FTExecutionContext newExecutionContext(String id, Method method, Object... parameters);
 
     /**

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/ExecutorBuilder.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/ExecutorBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2018 IBM Corporation and others.
+ * Copyright (c) 2017,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,21 +10,86 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance.spi;
 
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+
+/**
+ * Configures and produces {@link Executor}s
+ * <p>
+ * Instances of this class should be obtained from {@link FaultToleranceProvider#newExecutionBuilder()}
+ *
+ * @param <R> the type of the result returned by {@code Executor}s created by this builder
+ */
 public interface ExecutorBuilder<R> {
 
+    /**
+     * Set the retry policy for executors created by this builder
+     *
+     * @param retry the retry policy
+     * @return this builder
+     */
     public ExecutorBuilder<R> setRetryPolicy(RetryPolicy retry);
 
+    /**
+     * Set the circuit breaker policy for executors created by this builder
+     *
+     * @param circuitBreaker the circuit breaker policy
+     * @return this builder
+     */
     public ExecutorBuilder<R> setCircuitBreakerPolicy(CircuitBreakerPolicy circuitBreaker);
 
+    /**
+     * Set the bulkhead policy for executors created by this builder
+     *
+     * @param bulkhead the bulkhead policy
+     * @return this builder
+     */
     public ExecutorBuilder<R> setBulkheadPolicy(BulkheadPolicy bulkhead);
 
+    /**
+     * Set the fallback policy for executors created by this builder
+     *
+     * @param fallback the fallback policy
+     * @return this builder
+     */
     public ExecutorBuilder<R> setFallbackPolicy(FallbackPolicy fallback);
 
+    /**
+     * Set the timeout policy for executors created by this builder
+     *
+     * @param timeout the timeout policy
+     * @return this builder
+     */
     public ExecutorBuilder<R> setTimeoutPolicy(TimeoutPolicy timeout);
 
+    /**
+     * Set the metric recorder for executors created by this builder
+     *
+     * @param metricRecorder the metric recorder
+     * @return this builder
+     */
     public ExecutorBuilder<R> setMetricRecorder(MetricRecorder metricRecorder);
 
+    /**
+     * Create a new synchronous executor
+     *
+     * @return the new executor
+     */
     public Executor<R> build();
 
+    /**
+     * Create a new asynchronous executor
+     * <p>
+     * An asynchronous executor returns its result inside a wrapper class. This is to allow an empty wrapper instance to be returned initially, which is later populated with the
+     * result once the asynchronous method has completed.
+     * <p>
+     * The type returned by this method will be an Executor which returns an instance of {@code asyncResultWrapperType} which contains an instance of {@code R}
+     * <p>
+     * For example, if {@code asyncResultWrapperType == CompletionStage.class} and {@code R == String}, the actual type returned by this method will be
+     * {@code Executor<CompletionStage<String>>}. Unfortunately, this isn't encapsulated in the signature itself because it's hard to express properly with Java generics.
+     *
+     * @param asyncResultWrapperType the wrapper type for executor, either {@link Future} or {@link CompletionStage}
+     * @return the new executor
+     */
     public <W> Executor<W> buildAsync(Class<?> asyncResultWrapperType);
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/ExecutorBuilder.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/ExecutorBuilder.java
@@ -10,19 +10,19 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance.spi;
 
-public interface ExecutorBuilder<T, R> {
+public interface ExecutorBuilder<R> {
 
-    public ExecutorBuilder<T, R> setRetryPolicy(RetryPolicy retry);
+    public ExecutorBuilder<R> setRetryPolicy(RetryPolicy retry);
 
-    public ExecutorBuilder<T, R> setCircuitBreakerPolicy(CircuitBreakerPolicy circuitBreaker);
+    public ExecutorBuilder<R> setCircuitBreakerPolicy(CircuitBreakerPolicy circuitBreaker);
 
-    public ExecutorBuilder<T, R> setBulkheadPolicy(BulkheadPolicy bulkhead);
+    public ExecutorBuilder<R> setBulkheadPolicy(BulkheadPolicy bulkhead);
 
-    public ExecutorBuilder<T, R> setFallbackPolicy(FallbackPolicy fallback);
+    public ExecutorBuilder<R> setFallbackPolicy(FallbackPolicy fallback);
 
-    public ExecutorBuilder<T, R> setTimeoutPolicy(TimeoutPolicy timeout);
+    public ExecutorBuilder<R> setTimeoutPolicy(TimeoutPolicy timeout);
 
-    public ExecutorBuilder<T, R> setMetricRecorder(MetricRecorder metricRecorder);
+    public ExecutorBuilder<R> setMetricRecorder(MetricRecorder metricRecorder);
 
     public Executor<R> build();
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/FaultToleranceProvider.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/FaultToleranceProvider.java
@@ -41,7 +41,7 @@ public final class FaultToleranceProvider {
         return INSTANCE.newTimeoutPolicy();
     }
 
-    public static <T, R> ExecutorBuilder<T, R> newExecutionBuilder() {
+    public static <R> ExecutorBuilder<R> newExecutionBuilder() {
         return INSTANCE.newExecutionBuilder();
     }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/FaultToleranceProviderResolver.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/FaultToleranceProviderResolver.java
@@ -26,7 +26,8 @@ import java.util.ServiceLoader;
  *
  */
 public abstract class FaultToleranceProviderResolver {
-    protected FaultToleranceProviderResolver() {}
+    protected FaultToleranceProviderResolver() {
+    }
 
     private static volatile FaultToleranceProviderResolver instance = null;
 
@@ -40,7 +41,7 @@ public abstract class FaultToleranceProviderResolver {
 
     public abstract TimeoutPolicy newTimeoutPolicy();
 
-    public abstract <T, R> ExecutorBuilder<T, R> newExecutionBuilder();
+    public abstract <R> ExecutorBuilder<R> newExecutionBuilder();
 
     /**
      * Creates a FaultToleranceProviderResolver object
@@ -114,7 +115,7 @@ public abstract class FaultToleranceProviderResolver {
      * pattern is not supported.
      *
      * @param resolver
-     *            set the instance.
+     *                     set the instance.
      */
     public static void setInstance(FaultToleranceProviderResolver resolver) {
         instance = resolver;

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/ExecutorBuilderImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/ExecutorBuilderImpl.java
@@ -27,7 +27,7 @@ import com.ibm.ws.microprofile.faulttolerance.utils.DummyMetricRecorder;
 import com.ibm.ws.threading.PolicyExecutorProvider;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
-public class ExecutorBuilderImpl<T, R> implements ExecutorBuilder<T, R> {
+public class ExecutorBuilderImpl<R> implements ExecutorBuilder<R> {
 
     protected CircuitBreakerPolicy circuitBreakerPolicy = null;
     protected RetryPolicy retryPolicy = null;
@@ -47,42 +47,42 @@ public class ExecutorBuilderImpl<T, R> implements ExecutorBuilder<T, R> {
 
     /** {@inheritDoc} */
     @Override
-    public ExecutorBuilder<T, R> setRetryPolicy(RetryPolicy retry) {
+    public ExecutorBuilder<R> setRetryPolicy(RetryPolicy retry) {
         this.retryPolicy = retry;
         return this;
     }
 
     /** {@inheritDoc} */
     @Override
-    public ExecutorBuilder<T, R> setCircuitBreakerPolicy(CircuitBreakerPolicy circuitBreaker) {
+    public ExecutorBuilder<R> setCircuitBreakerPolicy(CircuitBreakerPolicy circuitBreaker) {
         this.circuitBreakerPolicy = circuitBreaker;
         return this;
     }
 
     /** {@inheritDoc} */
     @Override
-    public ExecutorBuilder<T, R> setBulkheadPolicy(BulkheadPolicy bulkhead) {
+    public ExecutorBuilder<R> setBulkheadPolicy(BulkheadPolicy bulkhead) {
         this.bulkheadPolicy = bulkhead;
         return this;
     }
 
     /** {@inheritDoc} */
     @Override
-    public ExecutorBuilder<T, R> setFallbackPolicy(FallbackPolicy fallback) {
+    public ExecutorBuilder<R> setFallbackPolicy(FallbackPolicy fallback) {
         this.fallbackPolicy = fallback;
         return this;
     }
 
     /** {@inheritDoc} */
     @Override
-    public ExecutorBuilder<T, R> setTimeoutPolicy(TimeoutPolicy timeout) {
+    public ExecutorBuilder<R> setTimeoutPolicy(TimeoutPolicy timeout) {
         this.timeoutPolicy = timeout;
         return this;
     }
 
     /** {@inheritDoc} */
     @Override
-    public ExecutorBuilder<T, R> setMetricRecorder(MetricRecorder metricRecorder) {
+    public ExecutorBuilder<R> setMetricRecorder(MetricRecorder metricRecorder) {
         this.metricRecorder = metricRecorder;
         return this;
     }

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/ProviderResolverImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/ProviderResolverImpl.java
@@ -104,8 +104,8 @@ public class ProviderResolverImpl extends FaultToleranceProviderResolver {
     }
 
     @Override
-    public <T, R> ExecutorBuilder<T, R> newExecutionBuilder() {
-        ExecutorBuilderImpl<T, R> ex = new ExecutorBuilderImpl<T, R>(contextService, policyExecutorProvider, getScheduledExecutorService());
+    public <R> ExecutorBuilder<R> newExecutionBuilder() {
+        ExecutorBuilderImpl<R> ex = new ExecutorBuilderImpl<R>(contextService, policyExecutorProvider, getScheduledExecutorService());
         return ex;
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/AsyncTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/AsyncTest.java
@@ -48,7 +48,7 @@ public class AsyncTest extends AbstractFTTest {
 
     @Test
     public void testAsync() throws InterruptedException, ExecutionException, TimeoutException {
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         Executor<Future<String>> executor = builder.buildAsync(Future.class);
 
         Future<String>[] futures = new Future[TASKS];
@@ -78,7 +78,7 @@ public class AsyncTest extends AbstractFTTest {
 
     @Test
     public void testAsyncCancel() throws InterruptedException, ExecutionException, TimeoutException {
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         Executor<Future<String>> executor = builder.buildAsync(Future.class);
 
         String id = "testAsyncCancel";
@@ -100,7 +100,7 @@ public class AsyncTest extends AbstractFTTest {
         TimeoutPolicyImpl timeout = new TimeoutPolicyImpl();
         timeout.setTimeout(Duration.ofMillis(500));
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setTimeoutPolicy(timeout);
         Executor<Future<String>> executor = builder.buildAsync(Future.class);
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/BulkheadTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/BulkheadTest.java
@@ -47,7 +47,7 @@ public class BulkheadTest extends AbstractFTTest {
         BulkheadPolicy bulkhead = FaultToleranceProvider.newBulkheadPolicy();
         bulkhead.setMaxThreads(2);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
         Executor<String> executor = builder.build();
 
@@ -106,7 +106,7 @@ public class BulkheadTest extends AbstractFTTest {
         retryPolicy.setRetryOn(BulkheadException.class);
         retryPolicy.setDelay(Duration.ofMillis(100));
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
         builder.setRetryPolicy(retryPolicy);
         Executor<String> executor = builder.build();
@@ -163,7 +163,7 @@ public class BulkheadTest extends AbstractFTTest {
         retryPolicy.setJitter(Duration.ofMillis(499));
         retryPolicy.setMaxDuration(Duration.ofMillis(20000)); //maximum duration of 20seconds
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
         builder.setRetryPolicy(retryPolicy);
         Executor<String> executor = builder.build();
@@ -207,7 +207,7 @@ public class BulkheadTest extends AbstractFTTest {
         bulkhead.setMaxThreads(20);
         bulkhead.setQueueSize(20);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
 
         Executor<Future<String>> executor = builder.buildAsync(Future.class);
@@ -243,7 +243,7 @@ public class BulkheadTest extends AbstractFTTest {
         bulkhead.setMaxThreads(2);
         bulkhead.setQueueSize(2);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setBulkheadPolicy(bulkhead);
 
         Executor<Future<String>> executor = builder.buildAsync(Future.class);

--- a/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/CircuitBreakerTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/CircuitBreakerTest.java
@@ -39,7 +39,7 @@ public class CircuitBreakerTest extends AbstractFTTest {
         circuitBreaker.setFailureRatio(1.0);
         circuitBreaker.setRequestVolumeThreshold(2);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setCircuitBreakerPolicy(circuitBreaker);
 
         Executor<String> executor = builder.build();

--- a/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/FallbackTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/FallbackTest.java
@@ -36,7 +36,7 @@ public class FallbackTest extends AbstractFTTest {
         TestFallback fallbackCallable = new TestFallback();
         fallback.setFallbackFunction(fallbackCallable);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setFallbackPolicy(fallback);
         Executor<String> executor = builder.build();
 
@@ -59,7 +59,7 @@ public class FallbackTest extends AbstractFTTest {
         TestFallbackFactory fallbackFactory = new TestFallbackFactory();
         fallback.setFallbackHandler(TestFallback.class, fallbackFactory);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setFallbackPolicy(fallback);
 
         Executor<String> executor = builder.build();

--- a/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/RetryTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/RetryTest.java
@@ -42,7 +42,7 @@ public class RetryTest extends AbstractFTTest {
         RetryPolicy retry = FaultToleranceProvider.newRetryPolicy();
         retry.setMaxRetries(3);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setRetryPolicy(retry);
 
         Executor<String> executor = builder.build();
@@ -66,7 +66,7 @@ public class RetryTest extends AbstractFTTest {
         //100ms between retries
         retry.setDelay(Duration.ofMillis(100));
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setRetryPolicy(retry);
 
         TimeoutPolicy timeout = FaultToleranceProvider.newTimeoutPolicy();
@@ -95,7 +95,7 @@ public class RetryTest extends AbstractFTTest {
         RetryPolicy retry = FaultToleranceProvider.newRetryPolicy();
         retry.setMaxRetries(3);
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setRetryPolicy(retry);
 
         Executor<Future<String>> executor = builder.buildAsync(Future.class);

--- a/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/TimeoutTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/TimeoutTest.java
@@ -36,7 +36,7 @@ public class TimeoutTest extends AbstractFTTest {
         TimeoutPolicy timeout = FaultToleranceProvider.newTimeoutPolicy();
         timeout.setTimeout(Duration.ofMillis(500));
 
-        ExecutorBuilder<String, String> builder = FaultToleranceProvider.newExecutionBuilder();
+        ExecutorBuilder<String> builder = FaultToleranceProvider.newExecutionBuilder();
         builder.setTimeoutPolicy(timeout);
 
         Executor<String> executor = builder.build();


### PR DESCRIPTION
* Remove unused type parameter from `ExecutorBuilder`
* Add javadoc to `ExecutorBuilder` and `Executor`

Recommend reviewing commits separately

Fixes #3515