### PR TITLE
Increase servlet.4.0_fat app startup timeout

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/WCApplicationHelper.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/WCApplicationHelper.java
@@ -19,6 +19,8 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+import org.junit.Assert;
+
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.topology.impl.LibertyServer;
@@ -29,6 +31,8 @@ import componenttest.topology.impl.LibertyServer;
 public class WCApplicationHelper {
 
     private static final Logger LOG = Logger.getLogger(WCApplicationHelper.class.getName());
+
+    public static final int APP_STARTUP_TIMEOUT = 120 * 1000; // 120 seconds
 
     /*
      * Helper method to create a war and add it to the dropins directory
@@ -135,6 +139,20 @@ public class WCApplicationHelper {
         } else {
             ShrinkHelper.exportToServer(server, dir, war);
         }
+    }
 
+    /**
+     * Wait for APP_STARTUP_TIMEOUT (120s) for an application's start message (CWWKZ0001I)
+     * @param String appName
+     * @param String testName
+     * @param LibertyServer server
+     */
+    public static void waitForAppStart(String appName, String className, LibertyServer server) {
+        LOG.info("Setup : wait for the app startup complete (CWWKZ0001I) message for " + appName);
+
+        String appStarted = server.waitForStringInLog("CWWKZ0001I.* " + appName, APP_STARTUP_TIMEOUT);
+        if (appStarted == null) {
+            Assert.fail(className + ": application " + appName + " failed to start within " + APP_STARTUP_TIMEOUT +"ms");
+        }
     }
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCAddJspFileTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCAddJspFileTest.java
@@ -66,12 +66,8 @@ public class WCAddJspFileTest extends LoggingTest {
                                                   "TestAddJspFile.war", true, null, false, "testaddjspfile.war.listeners");
 
         SHARED_SERVER.startIfNotStarted();
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestAddJspFile", 10000);
-
-        LOG.info("Setup : wait for message to indicate app has started");
+        WCApplicationHelper.waitForAppStart("TestAddJspFile", WCAddJspFileTest.class.getName(), SHARED_SERVER.getLibertyServer());
+        LOG.info("Setup : complete, ready for Tests");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCContextRootPrecedence.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCContextRootPrecedence.java
@@ -93,18 +93,13 @@ public class WCContextRootPrecedence extends LoggingTest {
         WCApplicationHelper.addWarToServerDropins(SHARED_SERVER.getLibertyServer(),
                                                   "TestDefaultContextPathWithoutStartSlashInvalidCase.war", true, null);
 
-        LOG.info("Setup : wait for messages to indicate apps have started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestContextRootAppNamePrecedence", 10000);
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestContextRootDirOrFileNamePrecedence", 10000);
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestContextRootEARAppPrecedence", 10000);
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestContextRootServerXmlPrecedence", 10000);
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestContextRootWebExtPrecedence", 10000);
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestDefaultContextPathPrecedence", 10000);
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestDefaultContextPathWithEndSlashInvalidCase", 10000);
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestDefaultContextPathWithoutStartSlashInvalidCase", 10000);
-
-        LOG.info("Setup : ready to run tests.");
+        WCApplicationHelper.waitForAppStart("TestContextRootDirOrFileNamePrecedence", WCContextRootPrecedence.class.getName(), SHARED_SERVER.getLibertyServer());
+        WCApplicationHelper.waitForAppStart("AppNameContextRoot", WCContextRootPrecedence.class.getName(), SHARED_SERVER.getLibertyServer());
+        WCApplicationHelper.waitForAppStart("TestServerXmlContextRoot", WCContextRootPrecedence.class.getName(), SHARED_SERVER.getLibertyServer());
+        WCApplicationHelper.waitForAppStart("TestWebExtContextRoot", WCContextRootPrecedence.class.getName(), SHARED_SERVER.getLibertyServer());
+        WCApplicationHelper.waitForAppStart("TestDefaultContextPathPrecedence", WCContextRootPrecedence.class.getName(), SHARED_SERVER.getLibertyServer());
+        WCApplicationHelper.waitForAppStart("TestContextRootEARAppPrecedence", WCContextRootPrecedence.class.getName(), SHARED_SERVER.getLibertyServer());
+        LOG.info("Setup : complete, ready for Tests");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCContextRootPrecedence.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCContextRootPrecedence.java
@@ -23,6 +23,7 @@ import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.wc.WCApplicationHelper;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -118,6 +119,7 @@ public class WCContextRootPrecedence extends LoggingTest {
      * @throws Exception
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.wsspi.adaptable.module.UnableToAdaptException" })
     public void testContextRootServerXmlPrecedence() throws Exception {
         this.verifyResponse("/ServerContextRoot/", "Simple HTML page - TestContextRootServerXmlPrecedence");
     }
@@ -130,6 +132,7 @@ public class WCContextRootPrecedence extends LoggingTest {
      * @throws Exception
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.wsspi.adaptable.module.UnableToAdaptException" })
     public void testContextRootEARAppPrecedence() throws Exception {
         this.verifyResponse("/ApplicationContextRoot/", "Simple HTML page - TestContextRootEARAppPrecedence");
     }
@@ -142,6 +145,7 @@ public class WCContextRootPrecedence extends LoggingTest {
      * @throws Exception
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.wsspi.adaptable.module.UnableToAdaptException" })
     public void testContextRootWebExtPrecedence() throws Exception {
         this.verifyResponse("/WebExtContextRoot/", "Simple HTML page - TestContextRootWebExtPrecedence");
     }
@@ -154,6 +158,7 @@ public class WCContextRootPrecedence extends LoggingTest {
      * @throws Exception
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.wsspi.adaptable.module.UnableToAdaptException" })
     public void testContextRootAppNamePrecedence() throws Exception {
         this.verifyResponse("/AppNameContextRoot/", "Simple HTML page - TestContextRootAppNamePrecedence");
     }
@@ -165,6 +170,7 @@ public class WCContextRootPrecedence extends LoggingTest {
      * @throws Exception
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.wsspi.adaptable.module.UnableToAdaptException" })
     public void testDefaultContextPathElementPrecedence() throws Exception {
         this.verifyResponse("/WebDefaultContextPath/", "Simple HTML page - TestDefaultContextPathPrecedence");
     }
@@ -177,6 +183,7 @@ public class WCContextRootPrecedence extends LoggingTest {
      * @throws Exception
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.wsspi.adaptable.module.UnableToAdaptException" })
     public void testContextRootDirOrFileNamePrecedence() throws Exception {
         this.verifyResponse("/TestContextRootDirOrFileNamePrecedence/",
                             "Simple HTML page - TestContextRootDirOrFileNamePrecedence");
@@ -190,6 +197,7 @@ public class WCContextRootPrecedence extends LoggingTest {
      * @throws Exception
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.wsspi.adaptable.module.UnableToAdaptException" })
     @Mode(TestMode.FULL)
     public void testDefaultContextPathWithoutStartSlashInvalidCase() throws Exception {
         SHARED_SERVER.getLibertyServer().findStringsInLogs(
@@ -204,6 +212,7 @@ public class WCContextRootPrecedence extends LoggingTest {
      * @throws Exception
      */
     @Test
+    @AllowedFFDC({ "java.lang.IllegalStateException", "com.ibm.wsspi.adaptable.module.UnableToAdaptException" })
     @Mode(TestMode.FULL)
     public void testDefaultContextPathWithEndSlashInvalidCase() throws Exception {
         SHARED_SERVER.getLibertyServer().findStringsInLogs(

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCEncodingTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCEncodingTest.java
@@ -78,16 +78,10 @@ public class WCEncodingTest extends LoggingTest {
         ArrayList<String> expectedErrors = new ArrayList<String>();
         expectedErrors.add("CWWWC0401E:.*");
         SHARED_SERVER.getLibertyServer().addIgnoredErrors(expectedErrors);
-
         SHARED_SERVER.startIfNotStarted();
-
-        LOG.info("Setup : wait for message to indicate apps have started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestEncoding", 10000);
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestServlet40", 10000);
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
+        WCApplicationHelper.waitForAppStart("TestEncoding", WCEncodingTest.class.getName(), SHARED_SERVER.getLibertyServer());
+        WCApplicationHelper.waitForAppStart("TestServlet40", WCEncodingTest.class.getName(), SHARED_SERVER.getLibertyServer());
+        LOG.info("Setup : complete, ready for Tests");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCGetMappingTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCGetMappingTest.java
@@ -58,15 +58,9 @@ public class WCGetMappingTest extends LoggingTest {
         WCApplicationHelper.addWarToServerDropins(SHARED_SERVER.getLibertyServer(), "TestGetMapping.war", false,
                                                   "testgetmapping.war.servlets");
 
-        if (!SHARED_SERVER.getLibertyServer().isStarted())
-            SHARED_SERVER.getLibertyServer().startServer();
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestGetMapping", 10000);
-
-        LOG.info("Setup : ready to start tests");
-
+        SHARED_SERVER.startIfNotStarted();
+        WCApplicationHelper.waitForAppStart("TestGetMapping", WCGetMappingTest.class.getName(), SHARED_SERVER.getLibertyServer());
+        LOG.info("Setup : complete, ready for Tests");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCPushBuilderSecurityTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCPushBuilderSecurityTest.java
@@ -46,13 +46,8 @@ public class WCPushBuilderSecurityTest extends LoggingTest {
         WCApplicationHelper.addWarToServerApps(SHARED_SERVER.getLibertyServer(), "TestPushBuilderSecurity.war", true, "testpushbuildersecurity.war.servlets");
 
         SHARED_SERVER.startIfNotStarted();
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestPushBuilderSecurity", 10000);
-
+        WCApplicationHelper.waitForAppStart("TestPushBuilderSecurity", WCPushBuilderSecurityTest.class.getName(), SHARED_SERVER.getLibertyServer());
         LOG.info("Setup : complete, ready for Tests");
-
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCPushBuilderTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCPushBuilderTest.java
@@ -47,13 +47,8 @@ public class WCPushBuilderTest extends LoggingTest {
                                                   "testservlet40.war.listeners", "testservlet40.jar.servlets");
 
         SHARED_SERVER.startIfNotStarted();
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestServlet40", 10000);
-
+        WCApplicationHelper.waitForAppStart("TestServlet40", WCPushBuilderTest.class.getName(), SHARED_SERVER.getLibertyServer());
         LOG.info("Setup : complete, ready for Tests");
-
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServerTest.java
@@ -63,13 +63,8 @@ public class WCServerTest extends LoggingTest {
                                                   "testservlet40.war.listeners", "testservlet40.jar.servlets");
 
         SHARED_SERVER.startIfNotStarted();
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestServlet40", 10000);
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
+        WCApplicationHelper.waitForAppStart("TestServlet40", WCServerTest.class.getName(), SHARED_SERVER.getLibertyServer());
+        LOG.info("Setup : complete, ready for Tests");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServletClarificationTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServletClarificationTest.java
@@ -73,13 +73,8 @@ public class WCServletClarificationTest extends LoggingTest {
                                                   "testservlet40.war.listeners", "testservlet40.jar.servlets");
 
         SHARED_SERVER.startIfNotStarted();
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestServlet40", 10000);
-
+        WCApplicationHelper.waitForAppStart("TestServlet40", WCServletClarificationTest.class.getName(), SHARED_SERVER.getLibertyServer());
         LOG.info("Setup : complete, ready for Tests");
-
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServletPathForDefaultMappingDefault.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServletPathForDefaultMappingDefault.java
@@ -46,13 +46,9 @@ public class WCServletPathForDefaultMappingDefault extends LoggingTest {
                                                   "servletpathdefaultmapping.war.servlets");
 
         SHARED_SERVER.startIfNotStarted();
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* ServletPathDefaultMapping", 10000);
-
+        WCApplicationHelper.waitForAppStart("ServletPathDefaultMapping", WCServletPathForDefaultMappingDefault.class.getName(), 
+            SHARED_SERVER.getLibertyServer());
         LOG.info("Setup : complete, ready for Tests");
-
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServletPathForDefaultMappingFalse.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServletPathForDefaultMappingFalse.java
@@ -45,13 +45,8 @@ public class WCServletPathForDefaultMappingFalse extends LoggingTest {
                                                   "servletpathdefaultmapping.war.servlets");
 
         SHARED_SERVER.startIfNotStarted();
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* ServletPathDefaultMapping", 10000);
-
+        WCApplicationHelper.waitForAppStart("ServletPathDefaultMapping", WCServletPathForDefaultMappingFalse.class.getName(), SHARED_SERVER.getLibertyServer());
         LOG.info("Setup : complete, ready for Tests");
-
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCTrailersTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCTrailersTest.java
@@ -72,15 +72,9 @@ public class WCTrailersTest extends LoggingTest {
         ArrayList<String> expectedErrors = new ArrayList<String>();
         expectedErrors.add("CWWWC0401E:.*");
         SHARED_SERVER.getLibertyServer().addIgnoredErrors(expectedErrors);
-
         SHARED_SERVER.startIfNotStarted();
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* TestServlet40", 10000);
-
-        LOG.info("Setup : wait for message to indicate app has started");
-
+        WCApplicationHelper.waitForAppStart("TestServlet40", WCTrailersTest.class.getName(), SHARED_SERVER.getLibertyServer());
+        LOG.info("Setup : complete, ready for Tests");
     }
 
     @AfterClass


### PR DESCRIPTION
Infernal timeouts!  We need to increase the time to wait for application startup (CWWKZ0001I) messages in the servlet.4.0_fat bucket; the current timeout of 10 seconds isn't long enough to escape the demons in our infrastructure.