### PR TITLE
Improve tracing of Fault Tolerance

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/.classpath
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" output="bin_test" path="test/src"/>
+	<classpathentry kind="src" output="bin_test" path="test/src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutionContextImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutionContextImpl.java
@@ -33,8 +33,13 @@ public class AsyncExecutionContextImpl<W> extends SyncExecutionContextImpl {
     private Consumer<Boolean> cancelCallback;
     private ThreadContextDescriptor threadContextDescriptor;
 
-    public AsyncExecutionContextImpl(Method method, Object[] parameters) {
-        super(method, parameters);
+    /**
+     * @param id         an id for the execution (used in trace messages)
+     * @param method     the method being executed
+     * @param parameters the parameters passed to the method
+     */
+    public AsyncExecutionContextImpl(String id, Method method, Object[] parameters) {
+        super(id, method, parameters);
     }
 
     public W getResultWrapper() {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutor.java
@@ -134,12 +134,12 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
 
     @Override
     public W execute(Callable<W> callable, ExecutionContext context) {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Fault tolerance asynchronous execution started for {0}", context.getMethod());
-        }
-
         @SuppressWarnings("unchecked")
         AsyncExecutionContextImpl<W> executionContext = (AsyncExecutionContextImpl<W>) context;
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+            Tr.event(tc, "Execution {0} Fault tolerance asynchronous execution started for {1}", executionContext.getId(), context.getMethod());
+        }
 
         executionContext.setCallable(callable);
 
@@ -179,7 +179,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
      */
     private void prepareExecutionAttempt(AsyncExecutionContextImpl<W> executionContext) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Method {0} enqueuing new execution attempt", executionContext.getMethod());
+            Tr.event(tc, "Execution {0} enqueuing new execution attempt", executionContext.getId());
         }
 
         AsyncAttemptContextImpl<W> attemptContext = new AsyncAttemptContextImpl<>(executionContext);
@@ -189,7 +189,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
 
         if (!circuitBreaker.requestPermissionToExecute()) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "Method {0} Circuit Breaker open, not executing", executionContext.getMethod());
+                Tr.event(tc, "Execution {0} Circuit Breaker open, not executing", executionContext.getId());
             }
 
             MethodResult<W> result = MethodResult.failure(new CircuitBreakerOpenException());
@@ -203,7 +203,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
 
         if (!ref.wasAccepted()) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "Method {0} bulkhead rejected execution", executionContext.getMethod());
+                Tr.event(tc, "Execution {0} bulkhead rejected execution", executionContext.getId());
             }
 
             processEndOfAttempt(attemptContext, MethodResult.failure(new BulkheadException()));
@@ -229,7 +229,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
         AsyncExecutionContextImpl<W> executionContext = attemptContext.getExecutionContext();
         try {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "Method {0} running execution attempt", executionContext.getMethod());
+                Tr.event(tc, "Execution {0} running execution attempt", executionContext.getId());
             }
 
             ThreadContextDescriptor contextDescriptor = executionContext.getThreadContextDescriptor();
@@ -246,14 +246,14 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
             }
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "Method {0} attempt execution reuslt: {1}", executionContext.getMethod(), methodResult);
+                Tr.event(tc, "Execution {0} attempt result: {1}", executionContext.getId(), methodResult);
             }
 
             processMethodResult(attemptContext, methodResult, reservation);
 
             if (attemptContext.getTimeoutState().isTimedOut()) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Method {0} timed out, clearing interrupted flag", executionContext.getMethod());
+                    Tr.debug(tc, "Execution {0} timed out, clearing interrupted flag", executionContext.getId());
                 }
 
                 Thread.interrupted(); // Clear interrupted thread
@@ -294,7 +294,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
      */
     private void timeout(AsyncAttemptContextImpl<W> attemptContext, ExecutionReference ref) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Method {0} timed out, attempting to cancel execution attempt", attemptContext.getExecutionContext().getMethod());
+            Tr.event(tc, "Execution {0} timed out, attempting to cancel execution attempt", attemptContext.getExecutionContext().getId());
         }
 
         ref.abort(true);
@@ -329,7 +329,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
             }
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "Method {0} processing end of attempt execution. Result: {1}", executionContext.getMethod(), result);
+                Tr.event(tc, "Execution {0} processing end of attempt execution. Result: {1}", executionContext.getId(), result);
             }
 
             circuitBreaker.recordResult(result);
@@ -339,7 +339,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
                 RetryResult retryResult = executionContext.getRetryState().recordResult(result);
                 if (retryResult.shouldRetry()) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                        Tr.event(tc, "Method {0} retrying with delay: {1} {2}", executionContext.getMethod(), retryResult.getDelay(), retryResult.getDelayUnit());
+                        Tr.event(tc, "Execution {0} retrying with delay: {1} {2}", executionContext.getId(), retryResult.getDelay(), retryResult.getDelayUnit());
                     }
                     if (retryResult.getDelay() > 0) {
                         executorService.schedule(handleExceptions(() -> prepareExecutionAttempt(executionContext), null, executionContext),
@@ -352,7 +352,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
                     return;
                 } else {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                        Tr.event(tc, "Method {0} not retrying", executionContext.getMethod());
+                        Tr.event(tc, "Execution {0} not retrying", executionContext.getId());
                     }
                 }
 
@@ -389,7 +389,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
      */
     private void prepareFallback(MethodResult<W> result, AsyncExecutionContextImpl<W> executionContext) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, "Method {0} fallback is required", executionContext.getMethod());
+            Tr.event(tc, "Execution {0} fallback is required", executionContext.getId());
         }
 
         executorService.submit(() -> runFallback(result, executionContext));
@@ -401,7 +401,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
         try {
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "Method {0} calling fallback", executionContext.getMethod());
+                Tr.event(tc, "Execution {0} calling fallback", executionContext.getId());
             }
 
             metricRecorder.incrementFallbackCalls();
@@ -421,7 +421,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
             }
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "Method {0} fallback result: {1}", executionContext.getMethod(), fallbackResult);
+                Tr.event(tc, "Execution {0} fallback result: {1}", executionContext.getId(), fallbackResult);
             }
 
             processEndOfExecution(executionContext, fallbackResult);
@@ -438,7 +438,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
 
     @Override
     public FTExecutionContext newExecutionContext(String id, Method method, Object... parameters) {
-        return new AsyncExecutionContextImpl<W>(method, parameters);
+        return new AsyncExecutionContextImpl<W>(id, method, parameters);
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncExecutor.java
@@ -352,7 +352,7 @@ public abstract class AsyncExecutor<W> implements Executor<W> {
                     return;
                 } else {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                        Tr.event(tc, "Execution {0} not retrying", executionContext.getId());
+                        Tr.event(tc, "Execution {0} not retrying: {1}", executionContext.getId(), retryResult);
                     }
                 }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/SyncExecutionContextImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/SyncExecutionContextImpl.java
@@ -12,6 +12,7 @@ package com.ibm.ws.microprofile.faulttolerance20.impl;
 
 import java.lang.reflect.Method;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.microprofile.faulttolerance.spi.FTExecutionContext;
 
 /**
@@ -21,9 +22,16 @@ public class SyncExecutionContextImpl implements FTExecutionContext {
 
     private final Method method;
     private final Object[] parameters;
+    private final String id;
     private Throwable failure;
 
-    public SyncExecutionContextImpl(Method method, Object[] parameters) {
+    /**
+     * @param id         an id for the execution (used in trace messages)
+     * @param method     the method being executed
+     * @param parameters the parameters passed to the method
+     */
+    public SyncExecutionContextImpl(String id, Method method, Object[] parameters) {
+        this.id = id;
         this.method = method;
         this.parameters = parameters;
     }
@@ -47,7 +55,22 @@ public class SyncExecutionContextImpl implements FTExecutionContext {
         return failure;
     }
 
+    /**
+     * Returns the execution ID
+     * <p>
+     * This is not guaranteed to be unique and should only be used for tracing.
+     * <p>
+     * It will be blank if no tracing is enabled
+     *
+     * @return the execution id, only used for tracing
+     */
+    @Trivial // When we're calling this method, we're tracing out the result anyway
+    public String getId() {
+        return id;
+    }
+
     @Override
-    public void close() {}
+    public void close() {
+    }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/SyncExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/SyncExecutor.java
@@ -149,7 +149,7 @@ public class SyncExecutor<R> implements Executor<R> {
             RetryResult retryResult = retryContext.recordResult(result);
             if (!retryResult.shouldRetry()) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                    Tr.event(tc, "Execution {0} not retrying", executionContext.getId());
+                    Tr.event(tc, "Execution {0} not retrying: {1}", executionContext.getId(), retryResult);
                 }
 
                 done = true;

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/RetryState.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/RetryState.java
@@ -86,6 +86,12 @@ public interface RetryState {
          * @return the TimeUnit used to express the result of {@link #getDelay()}
          */
         public TimeUnit getDelayUnit();
+
+        /**
+         * @return a string describing the result, for debugging and tracing purposes
+         */
+        @Override
+        public String toString();
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/RetryStateNullImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/RetryStateNullImpl.java
@@ -34,10 +34,16 @@ public class RetryStateNullImpl implements RetryState {
         public long getDelay() {
             return 0;
         }
+
+        @Override
+        public String toString() {
+            return "@Retry annotation not used";
+        }
     };
 
     @Override
-    public void start() {}
+    public void start() {
+    }
 
     @Override
     public RetryResult recordResult(MethodResult<?> result) {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/src/com/ibm/ws/microprofile/faulttolerance/cdi/FaultToleranceInterceptor.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.PreDestroy;
 import javax.annotation.Priority;
@@ -35,6 +36,7 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.microprofile.faulttolerance.cdi.config.AnnotationConfigFactory;
 import com.ibm.ws.microprofile.faulttolerance.cdi.config.AsynchronousConfig;
@@ -216,8 +218,7 @@ public class FaultToleranceInterceptor {
 
             Method method = invocationContext.getMethod();
             Object[] params = invocationContext.getParameters();
-            String id = method.getName(); //TODO does this id need to be better? it's only for debug
-            ExecutionContext executionContext = executor.newExecutionContext(id, method, params);
+            ExecutionContext executionContext = executor.newExecutionContext(generateId(method), method, params);
 
             Callable<Object> callable = () -> {
                 return invocationContext.proceed();
@@ -240,6 +241,12 @@ public class FaultToleranceInterceptor {
             result = invocationContext.proceed();
         }
         return result;
+    }
+
+    @Trivial
+    private String generateId(Method method) {
+        int rand = ThreadLocalRandom.current().nextInt();
+        return method.getName() + "-" + Integer.toHexString(rand);
     }
 
     @Dependent

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FTFallback/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FTFallback/server.xml
@@ -32,4 +32,6 @@
 		the test run take longer, so instead I'm setting a minimum number of threads. -->
 	<executor coreThreads="20"/>
 	
+	<logging traceSpecification="FAULTTOLERANCE=event"/>
+	
 </server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FaultToleranceMultiModule/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FaultToleranceMultiModule/server.xml
@@ -22,4 +22,6 @@
 		<feature>mpFaultTolerance-2.0</feature>
 	</featureManager>
 	
+	<logging traceSpecification="FAULTTOLERANCE=event"/>
+	
 </server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/Executor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/src/com/ibm/ws/microprofile/faulttolerance/spi/Executor.java
@@ -36,7 +36,7 @@ public interface Executor<R> {
     /**
      * Create a new execution context
      *
-     * @param id         an identifier for the execution, currently only used for tracing
+     * @param id         an identifier for the execution, only used for tracing
      * @param method     the method which is being executed by the callable, as returned by {@link ExecutionContext#getMethod()}
      * @param parameters the parameters passed to the method, as returned by {@link ExecutionContext#getParameters()}
      * @return the new execution context

--- a/dev/com.ibm.ws.microprofile.faulttolerance/.classpath
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/.classpath
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-        <classpathentry kind="src" path="resources"/>
-        <classpathentry kind="src" output="bin_test" path="test/src"/>
+	<classpathentry kind="src" path="resources"/>
+	<classpathentry kind="src" output="bin_test" path="test/src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/sync/SynchronousExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/sync/SynchronousExecutorImpl.java
@@ -11,7 +11,6 @@
 package com.ibm.ws.microprofile.faulttolerance.impl.sync;
 
 import java.lang.reflect.Method;
-import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -92,12 +91,12 @@ public class SynchronousExecutorImpl<R> implements Executor<R> {
     }
 
     //internal constructor for the nested synchronous part of an asynchronous execution
-    protected SynchronousExecutorImpl() {}
+    protected SynchronousExecutorImpl() {
+    }
 
     @Override
-    public FTExecutionContext newExecutionContext(String id_prefix, Method method, Object... params) {
+    public FTExecutionContext newExecutionContext(String id, Method method, Object... params) {
 
-        String id = id_prefix + "_" + UUID.randomUUID();
         TimeoutImpl timeout = null;
         if (this.timeoutPolicy != null && !this.timeoutPolicy.getTimeout().isZero()) {
             timeout = new TimeoutImpl(id, this.timeoutPolicy, this.scheduledExecutorService);
@@ -127,7 +126,7 @@ public class SynchronousExecutorImpl<R> implements Executor<R> {
      * Subclasses can override this if they require different end of execution behaviour
      *
      * @param executionContext the execution context
-     * @param t the exception thrown, or {@code null} if no exception was thrown
+     * @param t                the exception thrown, or {@code null} if no exception was thrown
      */
     protected void executionComplete(ExecutionContextImpl executionContext, Throwable t) {
         executionContext.onFullExecutionComplete(t);
@@ -140,7 +139,7 @@ public class SynchronousExecutorImpl<R> implements Executor<R> {
      * <p>
      * Subclasses can override this if they require different behaviour
      *
-     * @param failsafe the failsafe executor to configure
+     * @param failsafe             the failsafe executor to configure
      * @param executionContextImpl the execution context
      */
     protected void configureFailsafe(SyncFailsafe<R> failsafe, ExecutionContextImpl executionContextImpl) {


### PR DESCRIPTION
Generates a random ID for each execution, resulting in shorter messages
which are easier to track when there are multiple executions running
concurrently.

For FT 1.x, change from using a UUID to using a shorter pseudorandom
string

Also trace out the reason why when a retry does not occur.

Fixes #6664 
Fixes #6526 