### PR TITLE
OIDC login hint: Final update to client interface

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/ConvergedClientConfig.java
@@ -150,7 +150,6 @@ public interface ConvergedClientConfig {
 
     public HashMap<String, String> getJwkRequestParams();
 
-    // TODO - rename to getForwardLoginParameter
-    public List<String> getForwardAuthzParameter();
+    public List<String> getForwardLoginParameter();
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
@@ -408,7 +408,7 @@ public class OIDCClientAuthenticatorUtil {
     }
 
     String addForwardLoginParamsToQuery(ConvergedClientConfig clientConfig, HttpServletRequest req, String query) {
-        List<String> forwardAuthzParams = clientConfig.getForwardAuthzParameter();
+        List<String> forwardAuthzParams = clientConfig.getForwardLoginParameter();
         if (forwardAuthzParams == null || forwardAuthzParams.isEmpty()) {
             return query;
         }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/test/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtilTest.java
@@ -1154,7 +1154,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final List<String> configuredValue = null;
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                 }
             });
@@ -1172,7 +1172,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final List<String> configuredValue = new ArrayList<String>();
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                 }
             });
@@ -1191,7 +1191,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final List<String> configuredValue = Arrays.asList(paramName);
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                     one(req).getParameter(paramName);
                     will(returnValue(null));
@@ -1213,7 +1213,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final String paramValue = "";
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                     one(req).getParameter(paramName);
                     will(returnValue(paramValue));
@@ -1237,7 +1237,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final String paramValue = " \t\n \r";
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                     one(req).getParameter(paramName);
                     will(returnValue(paramValue));
@@ -1262,7 +1262,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final String paramValue = "some_simple_param_value";
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                     one(req).getParameter(paramName);
                     will(returnValue(paramValue));
@@ -1285,7 +1285,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final List<String> configuredValue = Arrays.asList(paramName);
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                     one(req).getParameter(paramName);
                     will(returnValue(null));
@@ -1307,7 +1307,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final String paramValue = "    ";
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                     one(req).getParameter(paramName);
                     will(returnValue(paramValue));
@@ -1332,7 +1332,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final String paramValue = "some parameter value";
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                     one(req).getParameter(paramName);
                     will(returnValue(paramValue));
@@ -1356,7 +1356,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final List<String> configuredValue = Arrays.asList(paramName);
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                     one(req).getParameter(paramName);
                     will(returnValue(null));
@@ -1378,7 +1378,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final String paramValue = paramName;
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValue));
                     one(req).getParameter(paramName);
                     will(returnValue(paramValue));
@@ -1402,7 +1402,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final List<String> configuredValues = Arrays.asList("", "my param", "Special! \n\t (Param) ", " 1234567890 ");
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValues));
                 }
             });
@@ -1433,7 +1433,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final String foundParamValue = "My\nParam\rValue";
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValues));
                     one(req).getParameter(emptyParam);
                     will(returnValue(null));
@@ -1469,7 +1469,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final String foundParamValue2 = "a_simple_param_value";
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValues));
                     one(req).getParameter(emptyParam);
                     will(returnValue(null));
@@ -1506,7 +1506,7 @@ public class OIDCClientAuthenticatorUtilTest {
             final List<String> configuredValues = Arrays.asList(paramName1, paramName2, paramName3, paramName4);
             mock.checking(new Expectations() {
                 {
-                    one(convClientConfig).getForwardAuthzParameter();
+                    one(convClientConfig).getForwardLoginParameter();
                     will(returnValue(configuredValues));
                     one(req).getParameter(paramName1);
                     will(returnValue(paramValue1));

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -806,7 +806,7 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements JwtCon
 
     /** {@inheritDoc} */
     @Override
-    public List<String> getForwardAuthzParameter() {
+    public List<String> getForwardLoginParameter() {
         return forwardLoginParameter;
     }
 


### PR DESCRIPTION
Renames the `getForwardAuthzParameter()` method to `getForwardLoginParameter()` to reflect the updated metatype property name.