### PR TITLE
Shared class cache updates for kernel and application classloader

### DIFF
--- a/dev/com.ibm.ws.artifact.file/src/com/ibm/ws/artifact/file/internal/FileContainer.java
+++ b/dev/com.ibm.ws.artifact.file/src/com/ibm/ws/artifact/file/internal/FileContainer.java
@@ -48,7 +48,7 @@ public class FileContainer implements com.ibm.wsspi.artifact.ArtifactContainer {
 
     /**
      * Used to build a FileContainer for a File, not present within an enclosing container.
-     * 
+     *
      * @param cacheDir location to host this containers cached data.
      * @param f the File to use.
      * @param c somewhere to obtain the current container factory from.
@@ -66,7 +66,7 @@ public class FileContainer implements com.ibm.wsspi.artifact.ArtifactContainer {
 
     /**
      * Builds a FileContainer that is enclosed by another Container instance.
-     * 
+     *
      * @param cacheDir location for this container to use for cache data.
      * @param parent the enclosing ArtifactContainer.
      * @param e the ArtifactEntry in the enclosing ArtifactContainer representing this ArtifactContainer.
@@ -86,7 +86,7 @@ public class FileContainer implements com.ibm.wsspi.artifact.ArtifactContainer {
     /**
      * Builds a FileContainer enclosed by another Container, where the Container created
      * may be a non-root Container.
-     * 
+     *
      * @param parent the enclosing Container.
      * @param e the entry in the enclosing Container representing this Container.
      * @param f the File object on disk representing this Container.
@@ -131,7 +131,7 @@ public class FileContainer implements com.ibm.wsspi.artifact.ArtifactContainer {
             if (childs != null) {
                 children = Collections.unmodifiableList(Arrays.asList(childs)).iterator();
             } else {
-                //the directory this iterator refers to has been deleted.. 
+                //the directory this iterator refers to has been deleted..
                 //so we cannot iterate it.. we'll use an empty collection to maintain
                 //consistency.
                 children = Collections.unmodifiableList(new ArrayList<File>()).iterator();
@@ -199,16 +199,9 @@ public class FileContainer implements com.ibm.wsspi.artifact.ArtifactContainer {
 
     @Override
     public ArtifactEntry getEntry(String pathAndName) {
-        return getEntry(pathAndName, false);
-    }
-
-    private ArtifactEntry getEntry(String pathAndName, boolean normalized) {
         //safeguard..
         //check the path is not trying to leave the archive
-        if (!normalized) {
-            pathAndName = PathUtils.normalizeUnixStylePath(pathAndName);
-            normalized = true;
-        }
+        pathAndName = PathUtils.normalizeUnixStylePath(pathAndName);
 
         if (pathAndName.equals("/") || pathAndName.equals("")) {
             return null;
@@ -254,8 +247,8 @@ public class FileContainer implements com.ibm.wsspi.artifact.ArtifactContainer {
                 return null;
         }
 
-        //if it starts with a / it's an absolute path, so we walk back up our 
-        //parent chain until we find the one claiming to be our local root, 
+        //if it starts with a / it's an absolute path, so we walk back up our
+        //parent chain until we find the one claiming to be our local root,
         //then invoke getEntry there with the path =)
         if (pathAndName.startsWith("/")) {
             ArtifactContainer c = this;
@@ -268,8 +261,8 @@ public class FileContainer implements com.ibm.wsspi.artifact.ArtifactContainer {
         //else.. it's a relative request to a non-root node..
         //  or.. it's a relative nested request to the root node..
 
-        //the request is valid, but we have to create the chain of Containers that 
-        //link from this node, to the Entry being returned. 
+        //the request is valid, but we have to create the chain of Containers that
+        //link from this node, to the Entry being returned.
 
         File top = dir;
         File container = target;

--- a/dev/com.ibm.ws.artifact.overlay/src/com/ibm/ws/artifact/overlay/internal/DirectoryBasedOverlayContainerImpl.java
+++ b/dev/com.ibm.ws.artifact.overlay/src/com/ibm/ws/artifact/overlay/internal/DirectoryBasedOverlayContainerImpl.java
@@ -71,7 +71,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
 
     /**
      * Build an overlay for the given ArtifactContainer
-     * 
+     *
      * @param base the ArtifactContainer to overlay.
      */
     public DirectoryBasedOverlayContainerImpl(ArtifactContainer base, ContainerFactoryHolder cfHolder) {
@@ -82,7 +82,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
                                               DirectoryBasedOverlayContainerImpl parentOverlay) {
         //Although overlays 'could' work at any ArtifactContainer depth, it
         //makes the implementation a lot simpler if they are restricted
-        //to the root level only. 
+        //to the root level only.
         //Requirements are met by a root-only overlay.. so restricting it here.
         if (!base.isRoot()) {
             throw new IllegalArgumentException();
@@ -113,7 +113,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
 
         /**
          * Build iterator for path, using overlay ArtifactContainer for data.
-         * 
+         *
          * @param overlay The OverlayContainer to use to supply entries.
          * @param path The path within OverlayContainer being iterated.
          */
@@ -170,7 +170,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
 
         /**
          * Internal method to calculate the next ArtifactEntry to return, or null if there isn't one.
-         * 
+         *
          * @return the next ArtifactEntry to use in this iteration, or null if finished.
          */
         private ArtifactEntry internalNext() {
@@ -191,7 +191,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
                         processedPaths.add(possiblePath);
                     }
                 } else if (overlaidEntries.hasNext()) {
-                    //overlaidEntries iterate over. 
+                    //overlaidEntries iterate over.
                     ArtifactEntry possibleEntry = overlaidEntries.next();
                     String possiblePath = possibleEntry.getPath();
 
@@ -222,7 +222,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
         @Override
         public ArtifactEntry next() {
             ArtifactEntry toBeReturned = this.internalNext;
-            //iterator semantics demands NoSuchElementException rather than null when the 
+            //iterator semantics demands NoSuchElementException rather than null when the
             //iterator has run out of options.
             if (toBeReturned != null) {
                 this.internalNext = internalNext();
@@ -261,7 +261,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
 
         @Override
         public Iterator<ArtifactEntry> iterator() {
-            //We use the overlay fs to provide entries to iterate, 
+            //We use the overlay fs to provide entries to iterate,
             //which works because the delegate is from the same
             //root as the ArtifactContainer being overlaid.
             return new EnhancedEntryIterator(owner, path, fileContainer);
@@ -274,7 +274,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
             String parent = PathUtils.getParent(path);
             ArtifactContainer c = null;
             if (parent != null) {
-                if ("/".equals(parent)) { //this delegating container can't be '/', but its parent can be.. 
+                if ("/".equals(parent)) { //this delegating container can't be '/', but its parent can be..
                     c = owner;
                 } else {
                     ArtifactEntry e = owner.getEntry(parent); //will always come back as a delegating e
@@ -410,7 +410,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
 
         /**
          * Build an OverlayEntry for a given ArtifactEntry, within a given OverlayFS, as a given path/name
-         * 
+         *
          * @param co The overlay ArtifactContainer this ArtifactEntry is part of.
          * @param e The ArtifactEntry being wrappered for return.
          * @param name The name to return for this ArtifactEntry
@@ -441,7 +441,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
                     c = e.convertToContainer();
                 }
             }
-            //C will be null, or a delegating ArtifactContainer.. 
+            //C will be null, or a delegating ArtifactContainer..
             //(must not return non-delegating ArtifactContainers, or they 'fall through' the overlay)
             return c;
         }
@@ -516,16 +516,17 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
         /** {@inheritDoc} */
         @Override
         public URL getResource() {
-            URL resource = delegate.getResource();
+            URL resource = null;
 
             //if this delegate has an override.. use its resource instead
             ArtifactEntry e = fileContainer.getEntry(getPath());
             if (e != null) {
-                URL cresource = e.getResource();
-                if (cresource != null)
-                    resource = cresource;
+                resource = e.getResource();
             }
 
+            if (resource == null) {
+                resource = delegate.getResource();
+            }
             return resource;
         }
 
@@ -598,7 +599,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
 
         //we have to do this, as if a jar is added to the overlay, and opened as a new root
         //and thus a new overlay, it needs a location to store overrides, and because the jar
-        //is present, we can't use a dir with the name of the jar.. 
+        //is present, we can't use a dir with the name of the jar..
 
         //this path manipulation for .cache is used to be compatible with the approach used
         //in the artifact api.
@@ -627,7 +628,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
             this.nestedOverlays.put(pathToEntryInOverlay, d);
             result = d;
         } else {
-            //we couldn't build our directories.. 
+            //we couldn't build our directories..
             //need to exit here, to prevent users believing this
             //nested overlay was just 'missing';
             throw new IllegalStateException();
@@ -836,7 +837,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
         if (isPassThroughMode) {
             ArtifactEntry baseEntry = base.getEntry(pathAndName);
             if (baseEntry != null) {
-                //note use of baseEntry.getPath to set the overlay entry path, pathAndName is unsanitized, 
+                //note use of baseEntry.getPath to set the overlay entry path, pathAndName is unsanitized,
                 //getPath will always be clean.
                 return new OverlayDelegatingEntry(this, baseEntry, baseEntry.getName(), baseEntry.getPath(), fileOverlayContainer);
             } else {
@@ -874,7 +875,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
             //make sure we always wrapper the return, so we get to handle the
             //navigation calls.
             if (target != null) {
-                //swapped from using pathAndName, to using getPath, to build path-sanitised overlay entries 
+                //swapped from using pathAndName, to using getPath, to build path-sanitised overlay entries
                 return new OverlayDelegatingEntry(this, target, target.getName(), target.getPath(), fileOverlayContainer);
             } else {
                 return null;
@@ -961,7 +962,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
                 collectPaths(entryAsContainer, paths);
             }
 
-            //kick the notifier to tell it the path has been 'added'. 
+            //kick the notifier to tell it the path has been 'added'.
             this.overlayNotifier.notifyEntryChange(new DefaultArtifactNotification(this, paths),
                                                    new DefaultArtifactNotification(this, Collections.<String> emptySet()),
                                                    new DefaultArtifactNotification(this, Collections.<String> emptySet()));
@@ -983,7 +984,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
      * it to the directory at the requested path, or converting it to a ArtifactContainer and processing
      * the entries recursively.<br>
      * Entries that convert to ArtifactContainers that claim to be isRoot true, are not processed recursively.
-     * 
+     *
      * @param e The ArtifactEntry to add
      * @param path The path to add the ArtifactEntry at
      * @param addAsRoot If the ArtifactEntry converts to a ArtifactContainer, should the isRoot be overridden? null = no, non-null=override value
@@ -992,7 +993,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
      */
     private synchronized boolean cloneEntryToOverlay(ArtifactEntry e, String path, Boolean addAsRoot) throws IOException {
 
-        //validate the ArtifactEntry.. 
+        //validate the ArtifactEntry..
         InputStream i = null;
         ArtifactContainer c = null;
         try {
@@ -1004,7 +1005,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
             if (i == null && c != null) {
                 boolean root = addAsRoot != null ? addAsRoot.booleanValue() : c.isRoot();
                 if (root)
-                    return false; //reject ArtifactContainers with no data that wish to be a new root. 
+                    return false; //reject ArtifactContainers with no data that wish to be a new root.
             }
 
             if (i != null) {
@@ -1092,7 +1093,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
 
     /**
      * Recursively remove a file/directory.
-     * 
+     *
      * @param f
      * @return true if the delete succeeded, false otherwise
      */
@@ -1145,7 +1146,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
 
     /**
      * Little recursive routine to collect all the files present within a ArtifactContainer.<p>
-     * 
+     *
      * @param c The ArtifactContainer to process
      * @param s The set to add paths to.
      */
@@ -1202,7 +1203,7 @@ public class DirectoryBasedOverlayContainerImpl implements OverlayContainer {
         }
 
         //initialise the overlay notifier.
-        //if we have a parentOverlay, the parent must have been configured with the overlay dir.. 
+        //if we have a parentOverlay, the parent must have been configured with the overlay dir..
         DirectoryBasedOverlayNotifier parentN = this.parentOverlay == null ? null : this.parentOverlay.overlayNotifier;
         this.overlayNotifier = new DirectoryBasedOverlayNotifier(this, fileOverlayContainer, parentN, this.entryInEnclosingContainer);
 

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
@@ -406,9 +406,104 @@ public class ZipFileContainerUtils {
         return true;
     }
 
-    //
+    abstract static class ZipEntryData {
 
-    public static class ZipEntryData {
+        @Trivial
+        ZipEntryData(String r_path, long time) {
+            this.r_path = r_path;
+            this.time = time;
+        }
+
+        final String r_path;
+        private final long time;
+        private int offset = -1;
+
+        final void setOffset(int offset) {
+            this.offset = offset;
+        }
+
+        final int getOffset() {
+            return offset;
+        }
+
+        @Trivial
+        final String r_getPath() {
+            return r_path;
+        }
+
+        @Trivial
+        final long getTime() {
+            return time;
+        }
+
+        abstract String getPath();
+
+        abstract boolean isDirectory();
+
+        abstract int getSize();
+    }
+
+    @Trivial
+    private static class FileZipEntryData extends ZipEntryData {
+        FileZipEntryData(ZipEntry zipEntry) {
+            super(stripPath(zipEntry.getName()), zipEntry.getTime());
+            this.path = zipEntry.getName();
+            this.size = (int) zipEntry.getSize();
+        }
+
+        final String path;
+
+        @Override
+        String getPath() {
+            return path;
+        }            
+
+        @Override
+        boolean isDirectory() {
+            return false; 
+        }
+        
+        final int size;
+
+        @Override
+        int getSize() {
+            return size;
+        }
+    }
+
+    @Trivial
+    private static class DirZipEntryData extends ZipEntryData {
+        DirZipEntryData(ZipEntry zipEntry) {
+            super(stripPath(zipEntry.getName()), zipEntry.getTime());
+        }
+
+        @Override
+        String getPath() {
+            return r_path;
+        }            
+
+        @Override
+        boolean isDirectory() {
+            return true; 
+        }
+
+        @Override
+        int getSize() {
+            return 0;
+        }
+    }
+
+    @Trivial
+    private static final ZipEntryData createZipEntryData(ZipEntry entry) {
+        String path = entry.getName();
+        if (path.charAt( path.length() - 1 ) == '/' ) {
+            return new DirZipEntryData(entry);
+        }
+        return new FileZipEntryData(entry);
+    }
+
+    private static class SearchZipEntryData extends ZipEntryData {
+
         /**
          * Create zip entry data with only the relative path
          * set.  This is for use in array searching operations.
@@ -416,73 +511,29 @@ public class ZipFileContainerUtils {
          * @param r_path The relative path for the new data.
          */
         @Trivial
-        public ZipEntryData(String r_path) {
-            this.path = null;
-            this.r_path = r_path;
-            this.size = -1L;
-            this.time = -1L;
-            
-            this.offset = -1;
-        }
-        
-        @Trivial        
-        public ZipEntryData(ZipEntry zipEntry) {
-            this.path = zipEntry.getName();
-            this.r_path = stripPath(this.path);
-            this.size = zipEntry.getSize();
-            this.time = zipEntry.getTime();
-            
-            this.offset = -1;
-        }
-
-        //
-
-        private int offset;
-
-        public void setOffset(int offset) {
-            this.offset = offset;
-        }
-
-        public int getOffset() {
-            return offset;
-        }
-
-        //
-
-        private final String path;
-        private final String r_path;
-
-        @Trivial
-        public String getPath() {
-            return path;
-        }            
-
-        @Trivial
-        public boolean isDirectory() {
-            return ( path.charAt( path.length() - 1 ) == '/' ); 
-        }
-
-        @Trivial
-        public String r_getPath() {
-            return r_path;
-        }
-
-        //
-        
-        private final long size;
-        private final long time;
-
-        @Trivial
-        public long getSize() {
-            return size;
+        SearchZipEntryData(String r_path) {
+            super(r_path, -1L);
         }
         
         @Trivial
-        public long getTime() {
-            return time;
+        @Override
+        String getPath() {
+            return null;
+        }
+
+        @Trivial
+        @Override
+        boolean isDirectory() {
+            return false;
+        }
+
+        @Trivial
+        @Override
+        int getSize() {
+            return -1;
         }
     }
-    
+
     public static class ZipEntryDataComparator implements Comparator<ZipEntryData> {
         @Trivial
         public int compare(ZipEntryData data1, ZipEntryData data2) {
@@ -510,7 +561,7 @@ public class ZipFileContainerUtils {
 
         final Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
         while ( zipEntries.hasMoreElements() ) {
-            entriesList.add( new ZipEntryData( zipEntries.nextElement() ) );
+            entriesList.add( createZipEntryData( zipEntries.nextElement() ) );
         }
         
         ZipEntryData[] entryData = entriesList.toArray( new ZipEntryData[ entriesList.size() ] );
@@ -556,7 +607,7 @@ public class ZipFileContainerUtils {
      */
     @Trivial
     public static int locatePath(ZipEntryData[] entryData, final String r_path) {
-        ZipEntryData targetData = new ZipEntryData(r_path);
+        ZipEntryData targetData = new SearchZipEntryData(r_path);
 
         // Given:
         //

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/PooledWsByteBufferImpl.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/PooledWsByteBufferImpl.java
@@ -44,7 +44,7 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
     protected int actionState = COPY_ALL_INIT;
     protected final Object actionAccess = new Object();
 
-    private final Object identifier;
+    private final int identifier;
     /** number of references to this pool entry */
     transient public int intReferenceCount = 1;
 
@@ -64,15 +64,13 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
      * Constructor.
      */
     public PooledWsByteBufferImpl() {
-        super();
-        this.wsBBRoot = this;
-        this.identifier = null;
+        this(-1);
         // if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
         // Tr.event(tc, "Created " + this);
         // }
     }
 
-    public PooledWsByteBufferImpl(Object id) {
+    public PooledWsByteBufferImpl(int id) {
         super();
         this.wsBBRoot = this;
         this.identifier = id;
@@ -86,7 +84,7 @@ public class PooledWsByteBufferImpl extends WsByteBufferImpl {
      *
      * @return Object
      */
-    public Object getID() {
+    public int getID() {
         return this.identifier;
     }
 

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/WsByteBufferImpl.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/WsByteBufferImpl.java
@@ -73,8 +73,8 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
     protected int quickBufferAction = NOT_ACTIVATED;
 
     // min/max are inclusive, so threshold will be this number + 1
-    private int GET_THRESHOLD = 1023; // minimum amount to copy from Direct to NonDirect
-    private int PUT_THRESHOLD = 2047; // maximum number of bytes between non-contiguous puts that will be bridged.
+    private static final int GET_THRESHOLD = 1023; // minimum amount to copy from Direct to NonDirect
+    private static final int PUT_THRESHOLD = 2047; // maximum number of bytes between non-contiguous puts that will be bridged.
 
     private int status = WsByteBuffer.STATUS_BUFFER;
 
@@ -90,7 +90,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
     /**
      * Query the root buffer of this one, may or may not exist
      * depending on if this instance is a duplicate or a slice.
-     * 
+     *
      * @return PooledWsByteBufferImpl
      */
     public PooledWsByteBufferImpl getWsBBRoot() {
@@ -99,7 +99,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
 
     /**
      * Store the parent pooled buffer that spawned this one.
-     * 
+     *
      * @param wsbb
      */
     public void setWsBBRoot(PooledWsByteBufferImpl wsbb) {
@@ -110,7 +110,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
      * Query the RefCount buffer owner of this one, which may or may
      * not exist depending on if this instance was a duplicate or a
      * slice.
-     * 
+     *
      * @return RefCountWsByteBufferImpl
      */
     public RefCountWsByteBufferImpl getWsBBRefRoot() {
@@ -119,13 +119,14 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
 
     /**
      * Store the parent refcount buffer that spawned this one.
-     * 
+     *
      * @param wsbb
      */
     public void setWsBBRefRoot(RefCountWsByteBufferImpl wsbb) {
         this.wsBBRefRoot = wsbb;
     }
 
+    @Override
     public byte[] array() {
         if (!this.trusted)
             checkValidity();
@@ -138,6 +139,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.array();
     }
 
+    @Override
     public int arrayOffset() {
         if (!this.trusted)
             checkValidity();
@@ -147,6 +149,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.arrayOffset();
     }
 
+    @Override
     public WsByteBuffer compact() {
         if (!this.trusted) {
             checkValidity();
@@ -197,6 +200,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return super.hashCode();
     }
 
+    @Override
     public char getChar() {
         if (!this.trusted)
             checkValidity();
@@ -206,6 +210,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getChar();
     }
 
+    @Override
     public char getChar(int index) {
         if (!this.trusted)
             checkValidity();
@@ -215,6 +220,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getChar(index);
     }
 
+    @Override
     public WsByteBuffer putChar(char value) {
         if (!this.trusted) {
             checkValidity();
@@ -227,6 +233,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer putChar(int index, char value) {
         if (!this.trusted) {
             checkValidity();
@@ -239,6 +246,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer putChar(char[] values) {
         if (!this.trusted) {
             checkValidity();
@@ -250,6 +258,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return putChar(values, 0, values.length);
     }
 
+    @Override
     public WsByteBuffer putChar(char[] values, int off, int len) {
         if (!this.trusted) {
             checkValidity();
@@ -268,6 +277,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public double getDouble() {
         if (!this.trusted)
             checkValidity();
@@ -277,6 +287,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getDouble();
     }
 
+    @Override
     public double getDouble(int index) {
         if (!this.trusted)
             checkValidity();
@@ -286,6 +297,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getDouble(index);
     }
 
+    @Override
     public WsByteBuffer putDouble(double value) {
         if (!this.trusted) {
             checkValidity();
@@ -298,6 +310,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer putDouble(int index, double value) {
         if (!this.trusted) {
             checkValidity();
@@ -310,6 +323,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public float getFloat() {
         if (!this.trusted)
             checkValidity();
@@ -319,6 +333,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getFloat();
     }
 
+    @Override
     public float getFloat(int index) {
         if (!this.trusted)
             checkValidity();
@@ -328,6 +343,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getFloat(index);
     }
 
+    @Override
     public WsByteBuffer putFloat(float value) {
         if (!this.trusted) {
             checkValidity();
@@ -340,6 +356,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer putFloat(int index, float value) {
         if (!this.trusted) {
             checkValidity();
@@ -352,6 +369,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public int getInt() {
         if (!this.trusted)
             checkValidity();
@@ -361,6 +379,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getInt();
     }
 
+    @Override
     public int getInt(int index) {
         if (!this.trusted)
             checkValidity();
@@ -370,6 +389,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getInt(index);
     }
 
+    @Override
     public WsByteBuffer putInt(int value) {
         if (!this.trusted) {
             checkValidity();
@@ -382,6 +402,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer putInt(int index, int value) {
         if (!this.trusted) {
             checkValidity();
@@ -394,6 +415,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public long getLong() {
         if (!this.trusted)
             checkValidity();
@@ -403,6 +425,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getLong();
     }
 
+    @Override
     public long getLong(int index) {
         if (!this.trusted)
             checkValidity();
@@ -412,6 +435,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getLong(index);
     }
 
+    @Override
     public WsByteBuffer putLong(long value) {
         if (!this.trusted) {
             checkValidity();
@@ -424,6 +448,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer putLong(int index, long value) {
         if (!this.trusted) {
             checkValidity();
@@ -436,6 +461,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public short getShort() {
         if (!this.trusted)
             checkValidity();
@@ -445,6 +471,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getShort();
     }
 
+    @Override
     public short getShort(int index) {
         if (!this.trusted)
             checkValidity();
@@ -454,6 +481,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.getShort(index);
     }
 
+    @Override
     public WsByteBuffer putShort(short value) {
         if (!this.trusted) {
             checkValidity();
@@ -466,6 +494,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer putShort(int index, short value) {
         if (!this.trusted) {
             checkValidity();
@@ -478,6 +507,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer putString(String value) {
         if (!this.trusted) {
             checkValidity();
@@ -490,16 +520,19 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public boolean hasArray() {
         // checkValidity();
         return this.oByteBuffer.hasArray();
     }
 
+    @Override
     public ByteOrder order() {
         // checkValidity();
         return this.oByteBuffer.order();
     }
 
+    @Override
     public WsByteBuffer order(ByteOrder bo) {
         if (!this.trusted)
             checkValidity();
@@ -507,6 +540,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer clear() {
         if (!this.trusted)
             checkValidity();
@@ -514,11 +548,13 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public int capacity() {
         // checkValidity();
         return (this.oByteBuffer.capacity());
     }
 
+    @Override
     public WsByteBuffer flip() {
         if (!this.trusted)
             checkValidity();
@@ -554,6 +590,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         }
     }
 
+    @Override
     public boolean setBufferAction(int newAction) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.entry(tc, "setBufferAction(newAction): " + newAction);
@@ -656,7 +693,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         }
 
         if (((newPutMin >= wsBBRoot.putMin)
-               && (newPutMax <= wsBBRoot.putMax))
+             && (newPutMax <= wsBBRoot.putMax))
             || (wsBBRoot.putMax == -1)) {
 
             // if new put is completely inside putMin/putMax, or putMin/putMax
@@ -1075,6 +1112,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         }
     }
 
+    @Override
     public byte get() {
         if (!this.trusted)
             checkValidity();
@@ -1101,11 +1139,13 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return b;
     }
 
+    @Override
     public int position() {
         // checkValidity();
         return (this.oByteBuffer.position());
     }
 
+    @Override
     public WsByteBuffer position(int p) {
         if (!this.trusted)
             checkValidity();
@@ -1113,6 +1153,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer limit(int l) {
         if (!this.trusted)
             checkValidity();
@@ -1120,16 +1161,19 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public int limit() {
         // checkValidity();
         return (this.oByteBuffer.limit());
     }
 
+    @Override
     public int remaining() {
         // checkValidity();
         return this.oByteBuffer.remaining();
     }
 
+    @Override
     public WsByteBuffer mark() {
         if (!this.trusted)
             checkValidity();
@@ -1137,6 +1181,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer reset() {
         if (!this.trusted)
             checkValidity();
@@ -1144,6 +1189,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer rewind() {
         if (!this.trusted)
             checkValidity();
@@ -1151,16 +1197,19 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public boolean isReadOnly() {
         // checkValidity();
         return this.oByteBuffer.isReadOnly();
     }
 
+    @Override
     public boolean hasRemaining() {
         // checkValidity();
         return this.oByteBuffer.hasRemaining();
     }
 
+    @Override
     public WsByteBuffer get(byte[] dst) {
         if (!this.trusted)
             checkValidity();
@@ -1194,6 +1243,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer get(byte[] dst, int offset, int length) {
         if (!this.trusted)
             checkValidity();
@@ -1231,6 +1281,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public byte get(int index) {
         if (!this.trusted)
             checkValidity();
@@ -1240,11 +1291,13 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.get(index);
     }
 
+    @Override
     public boolean isDirect() {
         // checkValidity();
         return this.oByteBuffer.isDirect();
     }
 
+    @Override
     public WsByteBuffer put(byte b) {
         if (!this.trusted) {
             checkValidity();
@@ -1272,6 +1325,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer put(byte[] src) {
         if (!this.trusted) {
             checkValidity();
@@ -1305,6 +1359,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer put(byte[] src, int offset, int length) {
         if (!this.trusted) {
             checkValidity();
@@ -1339,6 +1394,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer put(int index, byte b) {
         if (!this.trusted) {
             checkValidity();
@@ -1351,6 +1407,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer put(ByteBuffer src) {
         if (!this.trusted) {
             checkValidity();
@@ -1363,6 +1420,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer put(WsByteBuffer src) {
         if (!this.trusted) {
             checkValidity();
@@ -1375,6 +1433,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public WsByteBuffer put(WsByteBuffer[] src) {
         if (!this.trusted) {
             checkValidity();
@@ -1389,12 +1448,14 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this;
     }
 
+    @Override
     public ByteBuffer getWrappedByteBuffer() {
         if (!this.trusted)
             checkValidity();
         return getWrappedByteBufferCommon(false);
     }
 
+    @Override
     public ByteBuffer getWrappedByteBufferNonSafe() {
         return getWrappedByteBufferCommon(true);
     }
@@ -1408,6 +1469,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer;
     }
 
+    @Override
     public WsByteBuffer duplicate() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "duplicate");
@@ -1463,6 +1525,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         }
     }
 
+    @Override
     public WsByteBuffer slice() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "slice");
@@ -1538,6 +1601,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         }
     }
 
+    @Override
     public void release() {
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -1632,10 +1696,12 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.isDirectPool;
     }
 
+    @Override
     public void setReadOnly(boolean value) {
         this.readOnly = value;
     }
 
+    @Override
     public boolean getReadOnly() {
         return this.readOnly;
     }
@@ -1655,7 +1721,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
 
     /**
      * Set the PoolManager reference.
-     * 
+     *
      * @param oManagerRef
      */
     public void setPoolManagerRef(WsByteBufferPoolManagerImpl oManagerRef) {
@@ -1669,7 +1735,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
 
     /**
      * Set the NIO ByteBuffer wrapped by this WsByteBuffer to the input.
-     * 
+     *
      * @param buffer
      */
     public void setByteBuffer(ByteBuffer buffer) {
@@ -1681,7 +1747,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
     /**
      * Set the NIO ByteBuffer wrapped by this WsByteBuffer to the input
      * and avoid the buffer validity checks.
-     * 
+     *
      * @param buffer
      */
     public void setByteBufferNonSafe(ByteBuffer buffer) {
@@ -1700,7 +1766,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
     /**
      * Set the direct bytebuffer that backs an indirect heap buffer to
      * the input buffer.
-     * 
+     *
      * @param buffer
      */
     public void setDirectShadowBuffer(ByteBuffer buffer) {
@@ -1720,11 +1786,11 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
 
     private void checkReadOnly() {
         if (readOnly) {
-            String id = "none";
-            if ((wsBBRoot != null) && (wsBBRoot.pool != null)) {
-                id = (wsBBRoot.getID().toString());
-            }
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                String id = "none";
+                if ((wsBBRoot != null) && (wsBBRoot.pool != null)) {
+                    id = Integer.toString(wsBBRoot.getID());
+                }
                 Tr.debug(tc, "Attempt to update a read only WsByteBuffer."
                              + "\nWsByteBuffer: ID: " + id
                              + "\nBuffer: " + this.oByteBuffer);
@@ -1739,23 +1805,21 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         if (booleanReleaseCalled.get()) {
             String id = "none";
             if ((wsBBRoot != null) && (wsBBRoot.pool != null)) {
-                id = (wsBBRoot.getID().toString());
+                id = Integer.toString(wsBBRoot.getID());
             }
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc,
                          "Attempt to access WsByteBuffer that was already released."
-                                         + "\nWsByteBuffer: ID: "
-                                         + id
-                                         + " Sub ID: "
-                                         + this.oByteBuffer);
+                             + "\nWsByteBuffer: ID: "
+                             + id
+                             + " Sub ID: "
+                             + this.oByteBuffer);
             }
-            RuntimeException iae =
-                            new RuntimeException(
-                                            "Invalid call to WsByteBuffer method.  Buffer has already been released."
-                                                            + "\nWsByteBuffer: ID: "
-                                                            + id
-                                                            + "\nBuffer: "
-                                                            + this.oByteBuffer);
+            RuntimeException iae = new RuntimeException("Invalid call to WsByteBuffer method.  Buffer has already been released."
+                                                        + "\nWsByteBuffer: ID: "
+                                                        + id
+                                                        + "\nBuffer: "
+                                                        + this.oByteBuffer);
             FFDCFilter.processException(iae, getClass().getName() + ".checkValidity", "1", this);
             throw iae;
         }
@@ -1861,7 +1925,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
 
     /**
      * Copy the targeted number of bytes from the backing direct buffers.
-     * 
+     *
      * @param bytesRead
      */
     public void copyFromDirectBuffer(int bytesRead) {
@@ -1997,14 +2061,17 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         this.oByteBuffer.position(oWsBBDirect.position());
     }
 
+    @Override
     public int getType() {
         return WsByteBuffer.TYPE_WsByteBuffer;
     }
 
+    @Override
     public int getStatus() {
         return this.status;
     }
 
+    @Override
     public void setStatus(int value) {
         this.status = value;
     }
@@ -2020,6 +2087,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
         return this.oByteBuffer.toString();
     }
 
+    @Override
     public void removeFromLeakDetection() {
         // turn off leak detection for this WsByteBuffer
         if (ownerID != null) {
@@ -2036,6 +2104,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
     /*
      * @see java.io.Externalizable#writeExternal(java.io.ObjectOutput)
      */
+    @Override
     public void writeExternal(ObjectOutput s) throws IOException {
         if (!removedFromLeakDetection) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
@@ -2089,6 +2158,7 @@ public class WsByteBufferImpl implements WsByteBuffer, Externalizable {
     /*
      * @see java.io.Externalizable#readExternal(java.io.ObjectInput)
      */
+    @Override
     public void readExternal(ObjectInput s) throws IOException, ClassNotFoundException {
         String type = (String) s.readObject();
         String endian = (String) s.readObject();

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/WsByteBufferPool.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/WsByteBufferPool.java
@@ -78,7 +78,7 @@ public class WsByteBufferPool {
             intUniqueId = intUniqueCounter.getAndIncrement();
         }
 
-        return new PooledWsByteBufferImpl(Integer.valueOf(intUniqueId));
+        return new PooledWsByteBufferImpl(intUniqueId);
     }
 
     public void destroy(PooledWsByteBufferImpl obj) {

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -231,9 +231,9 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
                 } catch (MalformedURLException e) {
                     sharedClassCacheURL = null;
                 }
-            } else if (!"file".equals(protocol)) {
+            } else {//if (!"file".equals(protocol)) {
                 sharedClassCacheURL = null;
-            } else {
+            } /*else {
                 String externalForm = resourceURL.toExternalForm();
                 if (externalForm.endsWith(resourceName)) {
                     try {
@@ -244,7 +244,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
                 } else {
                     sharedClassCacheURL = null;
                 }
-            }
+            }*/
         }
         return sharedClassCacheURL;
     }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -168,7 +168,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
              *
              * @return
              */
-            public URL getResourceURL();
+            public URL getResourceURL(String jarProtocol);
 
             /**
              * Obtain the ByteResourceInformation for this resource.
@@ -176,7 +176,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
              * @return
              * @throws IOException if the ByteResourceInformation is unable to be returned.
              */
-            public ByteResourceInformation getByteResourceInformation() throws IOException;
+            public ByteResourceInformation getByteResourceInformation(String className, ClassLoaderHook hook) throws IOException;
 
             /**
              * Get the physical path for this native library resource, extracting
@@ -203,13 +203,66 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         void updatePackageMap(Map<Integer, List<UniversalContainer>> map);
     }
 
-    private static byte[] getClassBytesFromHook(UniversalContainer.UniversalResource resource, String resourceName, ClassLoaderHook hook) {
+    /**
+     * Computes the shared class cache URL from the resource URL.
+     * 
+     * If the URL is a jar protocol URL, then use it as is.
+     * If it is a wsjar protocol URL, then change it to a jar protocol URL.
+     * If it is a file protocol URL, confirm that the URL ends with the
+     * class file name, and return the directory before the package
+     * qualified class file name.
+     * 
+     * @param resourceURL The URL of the location of the class file.
+     * @param resourceName The resource path of the class file. i.e. package/sub/MyClass.class
+     * @return the URL to pass to the shared class cache, or null if protocol is wrong,
+     *         or path doesn't include resourceName.
+     */
+    static URL getSharedClassCacheURL(URL resourceURL, String resourceName) {
+        URL sharedClassCacheURL;
+        if (resourceURL == null) {
+            sharedClassCacheURL = null;
+        } else {
+            String protocol = resourceURL.getProtocol();
+            if ("jar".equals(protocol)) {
+                sharedClassCacheURL = resourceURL;
+            } else if ("wsjar".equals(protocol)) {
+                try {
+                    sharedClassCacheURL = new URL(resourceURL.toExternalForm().substring(2));
+                } catch (MalformedURLException e) {
+                    sharedClassCacheURL = null;
+                }
+            } else if (!"file".equals(protocol)) {
+                sharedClassCacheURL = null;
+            } else {
+                String externalForm = resourceURL.toExternalForm();
+                if (externalForm.endsWith(resourceName)) {
+                    try {
+                        sharedClassCacheURL = new URL(externalForm.substring(0, externalForm.length() - resourceName.length()));
+                    } catch (MalformedURLException e) {
+                        sharedClassCacheURL = null;
+                    }
+                } else {
+                    sharedClassCacheURL = null;
+                }
+            }
+        }
+        return sharedClassCacheURL;
+    }
+
+    private static byte[] getClassBytesFromHook(UniversalContainer.UniversalResource resource, String className, String resourceName, ClassLoaderHook hook) {
         byte[] bytes = null;
-        if (hook != null && resourceName.endsWith(".class")) {
-            URL resourcePath = resource.getResourceURL();
-            if (resourcePath != null) {
-                String className = resourceName.replace('/','.').substring(0, resourceName.length() - 6);
-                bytes = hook.loadClass(resourcePath, className);
+        if (hook != null) {
+            final URL resourceURL = resource.getResourceURL("jar");
+            URL sharedClassCacheURL = getSharedClassCacheURL(resourceURL, resourceName);
+            if (sharedClassCacheURL != null) {
+                bytes = hook.loadClass(sharedClassCacheURL, className);
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    if (bytes != null) {
+                        Tr.debug(tc, "Found class in shared class cache", new Object[] {className, sharedClassCacheURL});
+                    } else {
+                        Tr.debug(tc, "Did not find class in shared class cache", new Object[] {className, sharedClassCacheURL});
+                    }
+                }
             }
         }
         return bytes;
@@ -222,17 +275,15 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         final Container container;
         final Entry entry;
         final String resourceName;
-        final ClassLoaderHook hook;
 
-        public EntryUniversalResource(Container container, Entry entry, String resourceName, ClassLoaderHook hook) {
+        public EntryUniversalResource(Container container, Entry entry, String resourceName) {
             this.container = container;
             this.entry = entry;
             this.resourceName = resourceName;
-            this.hook = hook;
         }
 
         @Override
-        public URL getResourceURL() {
+        public URL getResourceURL(String jarProtocol) {
             URL url = this.entry.getResource();
             if (url == null) {
                 return null;
@@ -260,18 +311,19 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         }
 
         @Override
-        public ByteResourceInformation getByteResourceInformation() throws IOException {
-            byte[] bytes = ContainerClassLoader.getClassBytesFromHook(this, resourceName, hook);
+        public ByteResourceInformation getByteResourceInformation(String className, ClassLoaderHook hook) throws IOException {
+            byte[] bytes = ContainerClassLoader.getClassBytesFromHook(this, className, resourceName, hook);
 
-            try {
-                if (bytes == null) {
+            boolean foundInClassCache = bytes != null;
+            if (!foundInClassCache) {
+                try {
                     InputStream is = this.entry.adapt(InputStream.class);
                     bytes = ContainerClassLoader.getBytes(is, (int) entry.getSize());
+                } catch (UnableToAdaptException e) {
+                    throw new IOException(e);
                 }
-                return new EntryByteResourceInformation(bytes, this.entry, this.container, resourceName);
-            } catch (UnableToAdaptException e) {
-                throw new IOException(e);
             }
+            return new EntryByteResourceInformation(bytes, this.entry, this.container, resourceName, foundInClassCache);
         }
 
         @Override
@@ -290,15 +342,13 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
 
     private static class ContainerUniversalResource implements UniversalContainer.UniversalResource {
         private final Container container;
-        private String jarProtocol;
 
-        public ContainerUniversalResource(Container c, String jarProtocol) {
+        public ContainerUniversalResource(Container c) {
             container = c;
-            this.jarProtocol = jarProtocol;
         }
 
         @Override
-        public URL getResourceURL() {
+        public URL getResourceURL(String jarProtocol) {
             Collection<URL> urls = container.getURLs();
             if (urls.isEmpty())
                 return null;
@@ -317,7 +367,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         }
 
         @Override
-        public ByteResourceInformation getByteResourceInformation() throws IOException {
+        public ByteResourceInformation getByteResourceInformation(String className, ClassLoaderHook hook) throws IOException {
             return null;
         }
 
@@ -333,15 +383,11 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
     private static class ContainerUniversalContainer implements UniversalContainer {
         private final Container container;
         private final boolean isRoot;
-        private final ClassLoaderHook hook;
-        private final String jarProtocol;
         private String debugString;
 
-        public ContainerUniversalContainer(Container container, ClassLoaderHook hook, String jarProtocol) {
+        public ContainerUniversalContainer(Container container) {
             this.container = container;
             this.isRoot = container.isRoot();
-            this.hook = hook;
-            this.jarProtocol = jarProtocol;
         }
 
         @Override
@@ -362,13 +408,13 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
 
             // handle "" and "/" for roots since they refer to the container itself
             if (path.length() == 0 || path.equals("/")) {
-                return new ContainerUniversalResource(this.container, jarProtocol);
+                return new ContainerUniversalResource(this.container);
             }
 
             //try a lookup for the path in the container.
             Entry e = this.container.getEntry(path);
             if (e != null) {
-                return new EntryUniversalResource(this.container, e, path, hook);
+                return new EntryUniversalResource(this.container, e, path);
             } else {
                 return null;
             }
@@ -431,17 +477,15 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         final ArtifactContainer container;
         final ArtifactEntry entry;
         final String resourceName;
-        final ClassLoaderHook hook;
 
-        public ArtifactEntryUniversalResource(ArtifactContainer container, ArtifactEntry entry, String resourceName, ClassLoaderHook hook) {
+        public ArtifactEntryUniversalResource(ArtifactContainer container, ArtifactEntry entry, String resourceName) {
             this.container = container;
             this.entry = entry;
             this.resourceName = resourceName;
-            this.hook = hook;
         }
 
         @Override
-        public URL getResourceURL() {
+        public URL getResourceURL(String jarProtocol) {
             URL url = this.entry.getResource();
             if (url == null) {
                 return null;
@@ -468,14 +512,15 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         }
 
         @Override
-        public ByteResourceInformation getByteResourceInformation() throws IOException {
-            byte[] bytes = ContainerClassLoader.getClassBytesFromHook(this, resourceName, hook);
+        public ByteResourceInformation getByteResourceInformation(String className, ClassLoaderHook hook) throws IOException {
+            byte[] bytes = ContainerClassLoader.getClassBytesFromHook(this, className, resourceName, hook);
 
-            if (bytes == null) {
+            boolean foundInClassCache = bytes != null;
+            if (!foundInClassCache) {
                 InputStream is = this.entry.getInputStream();
                 bytes = ContainerClassLoader.getBytes(is, (int) entry.getSize());
             }
-            return new ArtifactEntryByteResourceInformation(bytes, this.entry, this.container, resourceName);
+            return new ArtifactEntryByteResourceInformation(bytes, this.entry, this.container, resourceName, foundInClassCache);
         }
 
         @Override
@@ -497,12 +542,10 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
     private static class ArtifactContainerUniversalContainer implements UniversalContainer {
         final ArtifactContainer container;
         final boolean isRoot;
-        final ClassLoaderHook hook;
 
-        public ArtifactContainerUniversalContainer(ArtifactContainer container, ClassLoaderHook hook) {
+        public ArtifactContainerUniversalContainer(ArtifactContainer container) {
             this.container = container;
             this.isRoot = container.isRoot();
-            this.hook = hook;
         }
 
         @Override
@@ -535,7 +578,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
                 //try a lookup for the path in the container.
                 ArtifactEntry e = this.container.getEntry(path);
                 if (e != null) {
-                    return new ArtifactEntryUniversalResource(this.container, e, path, hook);
+                    return new ArtifactEntryUniversalResource(this.container, e, path);
                 } else {
                     return null;
                 }
@@ -586,7 +629,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         }
 
         @Override
-        public URL getResourceURL() {
+        public URL getResourceURL(String jarProtocol) {
             Collection<URL> urls = container.getURLs();
             if (urls.isEmpty())
                 return null;
@@ -596,7 +639,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         }
 
         @Override
-        public ByteResourceInformation getByteResourceInformation() throws IOException {
+        public ByteResourceInformation getByteResourceInformation(String className, ClassLoaderHook hook) throws IOException {
             return null;
         }
 
@@ -621,11 +664,11 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
          */
         void addArtifactContainer(ArtifactContainer container);
 
-        ByteResourceInformation getByteResourceInformation(String path) throws IOException;
+        ByteResourceInformation getByteResourceInformation(String className, String path, ClassLoaderHook hook) throws IOException;
 
-        URL getResourceURL(String path);
+        URL getResourceURL(String path, String jarProtocol);
 
-        Collection<URL> getResourceURLs(String path);
+        Collection<URL> getResourceURLs(String path, String jarProtocol);
 
         boolean containsContainer(Container container);
     }
@@ -692,7 +735,6 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
     private static class SmartClassPathImpl implements SmartClassPath {
         final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
         final AtomicInteger outstandingContainers = new AtomicInteger(0);
-        final ClassLoaderHook hook;
 
         final static boolean usePackageMap = !Boolean.getBoolean("com.ibm.ws.classloading.container.disableMap");
         final static Integer maxLastNotFound = Integer.getInteger("com.ibm.ws.classloading.container.lastNotFound", 250);
@@ -739,12 +781,6 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         final Map<Integer, List<UniversalContainer>> packageMap = usePackageMap ? new HashMap<Integer, List<UniversalContainer>>() : null;
 
         final Set<Container> containers = Collections.newSetFromMap(new WeakHashMap<Container, Boolean>());
-
-        final String jarProtocol;
-        SmartClassPathImpl(ClassLoaderHook hook, String jarProtocol) {
-            this.hook = hook;
-            this.jarProtocol = jarProtocol;
-        }
 
         /**
          * Internal method to add a new UniversalContainer to the list.
@@ -804,12 +840,12 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         @Override
         public void addContainer(Container container) {
             containers.add(container);
-            addUniversalContainers(new ContainerUniversalContainer(container, hook, jarProtocol));
+            addUniversalContainers(new ContainerUniversalContainer(container));
         }
 
         @Override
         public void addArtifactContainer(ArtifactContainer container) {
-            addUniversalContainers(new ArtifactContainerUniversalContainer(container, hook));
+            addUniversalContainers(new ArtifactContainerUniversalContainer(container));
         }
 
         private List<UniversalContainer> getUniversalContainersForPath(String path, List<UniversalContainer> classpath) {
@@ -870,7 +906,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         }
 
         @Override
-        public ByteResourceInformation getByteResourceInformation(String path) throws IOException {
+        public ByteResourceInformation getByteResourceInformation(String className, String path, ClassLoaderHook hook) throws IOException {
             int idx = 0;
             List<UniversalContainer> locationsToCheck = classPath;
             if (usePackageMap) {
@@ -886,7 +922,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
                     UniversalContainer.UniversalResource ur = uc.getResource(path);
                     if (ur != null) {
                         //got one..
-                        ByteResourceInformation is = ur.getByteResourceInformation();
+                        ByteResourceInformation is = ur.getByteResourceInformation(className, hook);
                         if (is != null) {
                             return is;
                         }
@@ -905,7 +941,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         }
 
         @Override
-        public URL getResourceURL(String path) {
+        public URL getResourceURL(String path, String jarProtocol) {
             //test positive cache 1st.
             URL cached = lastFoundURL.get(path);
             if (cached != null) {
@@ -933,7 +969,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
                     //no hit found, try getResource
                     UniversalContainer.UniversalResource ur = uc.getResource(path);
                     if (ur != null) {
-                        URL url = ur.getResourceURL();
+                        URL url = ur.getResourceURL(jarProtocol);
                         //some resources may not have urls.. ensure we dont return null.
                         if (url != null) {
                             //add url to cache..
@@ -963,7 +999,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         }
 
         @Override
-        public Collection<URL> getResourceURLs(String path) {
+        public Collection<URL> getResourceURLs(String path, String jarProtocol) {
             List<URL> urls = new ArrayList<URL>();
             if (lastReallyNotFoundURL.containsKey(path)) {
                 return urls;
@@ -981,7 +1017,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
                     //cache did not know this path, attempt getResource
                     UniversalContainer.UniversalResource ur = uc.getResource(path);
                     if (ur != null) {
-                        URL url = ur.getResourceURL();
+                        URL url = ur.getResourceURL(jarProtocol);
                         if (url != null) {
                             urls.add(url);
                         }
@@ -1043,7 +1079,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         SmartClassPathImpl delegate;
 
         UnreadSmartClassPath() {
-            delegate = new SmartClassPathImpl(hook, jarProtocol);
+            delegate = new SmartClassPathImpl();
         }
 
         @Override
@@ -1057,21 +1093,21 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         }
 
         @Override
-        public synchronized ByteResourceInformation getByteResourceInformation(String path) throws IOException {
+        public synchronized ByteResourceInformation getByteResourceInformation(String className, String path, ClassLoaderHook hook) throws IOException {
             unwrap();
-            return delegate.getByteResourceInformation(path);
+            return delegate.getByteResourceInformation(className, path, hook);
         }
 
         @Override
-        public synchronized URL getResourceURL(String path) {
+        public synchronized URL getResourceURL(String path, String jarProtocol) {
             unwrap();
-            return delegate.getResourceURL(path);
+            return delegate.getResourceURL(path, jarProtocol);
         }
 
         @Override
-        public synchronized Collection<URL> getResourceURLs(String path) {
+        public synchronized Collection<URL> getResourceURLs(String path, String jarProtocol) {
             unwrap();
-            return delegate.getResourceURLs(path);
+            return delegate.getResourceURLs(path, jarProtocol);
         }
 
         private void unwrap() {
@@ -1143,6 +1179,14 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
          * @return The resource path
          */
         public String getResourcePath();
+
+        /**
+         * Returns whether the class was found in the shared class cache or not.  If it is found in the cache,
+         * there is no need to call the cache to store the class again.
+         * 
+         * @return whether the Class was found in the shared class cache or not.
+         */
+        public boolean foundInClassCache();
     }
 
     /**
@@ -1154,6 +1198,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         private final Entry resourceEntry;
         private final Container resourceContainer;
         private final String resourcePath;
+        private final boolean fromClassCache;
 
         private Manifest manifest;
         private boolean manifestLoaded;
@@ -1162,11 +1207,12 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
          * @param bytes
          * @param resourceUrl
          */
-        EntryByteResourceInformation(byte[] bytes, Entry resourceUrl, Container root, String resourcePath) {
+        EntryByteResourceInformation(byte[] bytes, Entry resourceUrl, Container root, String resourcePath, boolean fromClassCache) {
             this.bytes = bytes;
             this.resourceEntry = resourceUrl;
             this.resourceContainer = root;
             this.resourcePath = resourcePath;
+            this.fromClassCache = fromClassCache;
         }
 
         /**
@@ -1239,6 +1285,11 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         public String getResourcePath() {
             return this.resourcePath;
         }
+
+        @Override
+        public boolean foundInClassCache() {
+            return fromClassCache;
+        }
     }
 
     /**
@@ -1250,6 +1301,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         private final ArtifactEntry resourceEntry;
         private final ArtifactContainer resourceContainer;
         private final String resourcePath;
+        private final boolean fromClassCache;
 
         private Manifest manifest;
         private boolean manifestLoaded;
@@ -1258,11 +1310,12 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
          * @param bytes
          * @param resourceUrl
          */
-        ArtifactEntryByteResourceInformation(byte[] bytes, ArtifactEntry resourceUrl, ArtifactContainer root, String resourcePath) {
+        ArtifactEntryByteResourceInformation(byte[] bytes, ArtifactEntry resourceUrl, ArtifactContainer root, String resourcePath, boolean fromClassCache) {
             this.bytes = bytes;
             this.resourceEntry = resourceUrl;
             this.resourceContainer = root;
             this.resourcePath = resourcePath;
+            this.fromClassCache = fromClassCache;
         }
 
         /**
@@ -1330,6 +1383,11 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         public String getResourcePath() {
             return this.resourcePath;
         }
+
+        @Override
+        public boolean foundInClassCache() {
+            return fromClassCache;
+        }
     }
 
     /**
@@ -1365,7 +1423,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         if (url != null) {
             return url;
         }
-        url = smartClassPath.getResourceURL(name);
+        url = smartClassPath.getResourceURL(name, jarProtocol);
 
         //no need to retry smartClassPath with trailing / it already dealt with that.
         if (url == null && !name.endsWith("/")) {
@@ -1381,7 +1439,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
     public CompositeEnumeration<URL> findResources(String name) throws IOException {
         //start by collecting any from super, which checks parent, if any.
         CompositeEnumeration<URL> enumerations = new CompositeEnumeration<URL>(super.findResources(name));
-        Collection<URL> urls = smartClassPath.getResourceURLs(name);
+        Collection<URL> urls = smartClassPath.getResourceURLs(name, jarProtocol);
 
         //no need to retry the smartClassPath with trailing /, it already handled that.
         if (!name.endsWith("/")) {
@@ -1429,10 +1487,10 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         return null;
     }
 
-    protected ByteResourceInformation findBytes(String resourceName) throws IOException {
+    protected ByteResourceInformation findClassBytes(String className, String resourceName) throws IOException {
         Object token = ThreadIdentityManager.runAsServer();
         try {
-            return smartClassPath.getByteResourceInformation(resourceName);
+            return smartClassPath.getByteResourceInformation(className, resourceName, hook);
         } finally {
             ThreadIdentityManager.reset(token);
         }
@@ -1540,7 +1598,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
     }
 
     protected void addNativeLibraryContainer(Container container) {
-        nativeLibraryContainers.add(new ContainerUniversalContainer(container, hook, jarProtocol));
+        nativeLibraryContainers.add(new ContainerUniversalContainer(container));
     }
 
     /**

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
@@ -67,7 +67,7 @@ public class LibertyClassLoaderTest {
 
         loader = new AppClassLoader(loader.getParent(), loader.config, Arrays.asList(c), (DeclaredApiAccess) (loader.getParent()), null, null, new GlobalClassloadingConfiguration()) {
             @Override
-            protected com.ibm.ws.classloading.internal.AppClassLoader.ByteResourceInformation findBytes(String resourceName) throws IOException {
+            protected com.ibm.ws.classloading.internal.AppClassLoader.ByteResourceInformation findClassBytes(String className, String resourceName) throws IOException {
                 throw new IOException();
             }
         };

--- a/dev/com.ibm.ws.kernel.boot.common/src/com/ibm/ws/kernel/boot/classloader/SharedClassCacheHook.java
+++ b/dev/com.ibm.ws.kernel.boot.common/src/com/ibm/ws/kernel/boot/classloader/SharedClassCacheHook.java
@@ -73,10 +73,6 @@ final class SharedClassCacheHook implements ClassLoaderHook {
     @Override
     public byte[] loadClass(URL path, String name) {
         if (findSharedClassMethod != null) {
-            // file protocol doesn't appear to work right now.
-            if (path != null && "file".equals(path.getProtocol())) {
-                return null;
-            }
             try {
                 return (byte[]) findSharedClassMethod.invoke(sharedClassURLHelper, path, name);
             } catch (Exception e) {
@@ -89,10 +85,6 @@ final class SharedClassCacheHook implements ClassLoaderHook {
     @Override
     public void storeClass(URL path, Class<?> clazz) {
         if (storeSharedClassMethod != null) {
-            // file protocol doesn't appear to work right now.
-            if (path != null && "file".equals(path.getProtocol())) {
-                return;
-            }
             try {
                 storeSharedClassMethod.invoke(sharedClassURLHelper, path, clazz);
             } catch (Exception e) {

--- a/dev/com.ibm.ws.kernel.boot.common/src/com/ibm/ws/kernel/boot/classloader/SharedClassCacheHook.java
+++ b/dev/com.ibm.ws.kernel.boot.common/src/com/ibm/ws/kernel/boot/classloader/SharedClassCacheHook.java
@@ -23,11 +23,14 @@ final class SharedClassCacheHook implements ClassLoaderHook {
 
     private static final Method storeSharedClassMethod;
 
+    private static final Method minimizeChecksMethod;
+
     static {
         Object sharedClassHelperFactory = null;
         Method getURLHelper = null;
         Method findSharedClass = null;
         Method storeSharedClass = null;
+        Method minimizeChecks = null;
         try {
             Class<?> sharedClass = Class.forName("com.ibm.oti.shared.Shared");
             Method m = sharedClass.getDeclaredMethod("getSharedClassHelperFactory");
@@ -36,6 +39,7 @@ final class SharedClassCacheHook implements ClassLoaderHook {
             Class<?> sharedClassURLHelperClass = getURLHelper.getReturnType();
             findSharedClass = sharedClassURLHelperClass.getDeclaredMethod("findSharedClass", URL.class, String.class);
             storeSharedClass = sharedClassURLHelperClass.getDeclaredMethod("storeSharedClass", URL.class, Class.class);
+            minimizeChecks = sharedClassURLHelperClass.getDeclaredMethod("setMinimizeUpdateChecks", null);
         } catch (Exception e) {
             // If things fail, assume we aren't using shared classes.
         }
@@ -43,6 +47,7 @@ final class SharedClassCacheHook implements ClassLoaderHook {
         getURLHelperMethod = getURLHelper;
         findSharedClassMethod = findSharedClass;
         storeSharedClassMethod = storeSharedClass;
+        minimizeChecksMethod = minimizeChecks;
     }
 
     private final Object sharedClassURLHelper;
@@ -52,6 +57,7 @@ final class SharedClassCacheHook implements ClassLoaderHook {
         if (getURLHelperMethod != null && sharedClassHelperFactoryClass != null) {
             try {
                 helper = getURLHelperMethod.invoke(sharedClassHelperFactoryClass, loader);
+                minimizeChecksMethod.invoke(helper);
             } catch (Exception e) {
                 // We should never get here.
                 // If we do, we simply won't share for this ClassLoader

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/DirectoryResourceEntry.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/DirectoryResourceEntry.java
@@ -51,11 +51,6 @@ public class DirectoryResourceEntry implements ResourceEntry {
     }
 
     @Override
-    public URL toExternalURL() {
-        return JarFileClassLoader.toURL(file);
-    }
-
-    @Override
     public URL toURL() {
         return JarFileClassLoader.toURL(file);
     }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarFileClassLoader.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarFileClassLoader.java
@@ -126,16 +126,15 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
             throw new ClassNotFoundException(className);
         }
 
-        URL entryURL = null;
+        ResourceHandler resourceHandler = entry.getResourceHandler();
+        URL jarURL = resourceHandler.toURL();
+
         byte[] classBytes = null;
         boolean foundInClassCache = false;
         if (hook != null) {
-            entryURL = entry.toExternalURL();
-            classBytes = hook.loadClass(entryURL, className);
+            classBytes = hook.loadClass(jarURL, className);
             foundInClassCache = (classBytes != null);
         }
-
-        ResourceHandler resourceHandler = entry.getResourceHandler();
 
         Manifest manifest = null;
         try {
@@ -150,8 +149,6 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
             }
             throw new ClassNotFoundException(className, e);
         }
-
-        URL jarURL = resourceHandler.toURL();
 
         int packageEnd = className.lastIndexOf('.');
         if (packageEnd >= 0) {
@@ -169,7 +166,7 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
         Class<?> clazz = defineClass(className, classBytes, 0, classBytes.length, source);
 
         if (hook != null && !foundInClassCache) {
-            hook.storeClass(entryURL, clazz);
+            hook.storeClass(jarURL, clazz);
         }
 
         return clazz;

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarResourceEntry.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarResourceEntry.java
@@ -20,8 +20,6 @@ import java.security.cert.Certificate;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
-import com.ibm.ws.kernel.boot.classloader.URLEncodingUtils;
-
 /**
  */
 public class JarResourceEntry implements ResourceEntry {
@@ -52,21 +50,6 @@ public class JarResourceEntry implements ResourceEntry {
             return JarFileClassLoader.getBytes(in, jarEntry.getSize());
         } finally {
             JarFileClassLoader.close(in);
-        }
-    }
-
-    @Override
-    public URL toExternalURL() {
-        URL fileURL = handler.toURL();
-        if (!"file".equals(fileURL.getProtocol())) {
-            return toURL();
-        }
-
-        try {
-            return new URL("jar:" + fileURL + "!/" + URLEncodingUtils.encode(jarEntry.getName()));
-        } catch (MalformedURLException e) {
-            // this is very unexpected
-            throw new Error(e);
         }
     }
 

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/ResourceEntry.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/ResourceEntry.java
@@ -24,8 +24,5 @@ public interface ResourceEntry {
 
     byte[] getBytes() throws IOException;
 
-    URL toExternalURL();
-
     URL toURL();
-
 }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/data/GenericData.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/data/GenericData.java
@@ -20,7 +20,7 @@ public class GenericData {
 
     private String jsonMessage = null;
 
-    private Integer lastIndex = -1;
+    private int lastIndex = -1;
 
     public GenericData() {
         pairs = new KeyValuePair[DEFAULT_SIZE];


### PR DESCRIPTION
Updates improve how shared class cache url is calculated for all the different application artifact options.  Loose application updates are removed due to problems with FAT test failure for loose applications.  Loose application integration will be re-added when the problem is figured out.

These changes help resolve the problem in issue #6042. Previously a PR was put in to work around the problem, but this PR fixes it for real.

Additionally there are other minor changes related to things I found while doing these code changes for AppClassLoader and looking at heap dump to find other way to reduce heap usage.

This PR is a redo of PR #6510 
