### PR TITLE
experiment with transaction context propagation while in beta

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/TransactionContextProvider.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/context/TransactionContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,11 +33,9 @@ public class TransactionContextProvider extends ContainerContextProvider {
     private static final TraceComponent tc = Tr.register(TransactionContextProvider.class);
 
     /**
-     * Map with execution property that instructs the transaction context to first detect the presence of a
-     * global transaction on the requesting thread. If present, a NULL is returning indicate that context
-     * cannot be captured. If a global transaction is not present, then captures a cleared context.
+     * Map with execution property that instructs the transaction context to propagate transactions for serial use.
      */
-    private static final Map<String, String> SUSPEND_IF_NO_GLOBAL_TX = Collections.singletonMap(ManagedTask.TRANSACTION, "SUSPEND_IF_NO_GLOBAL_TX");
+    private static final Map<String, String> PROPAGATE_TX_FOR_SERIAL_USE = Collections.singletonMap(ManagedTask.TRANSACTION, "PROPAGATE");
 
     public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> transactionContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("TransactionContextProvider");
 
@@ -48,9 +46,7 @@ public class TransactionContextProvider extends ContainerContextProvider {
         if (transactionProvider == null)
             snapshot = new DeferredClearedContext(transactionContextProviderRef);
         else if (op == ContextOp.PROPAGATED) {
-            snapshot = transactionProvider.captureThreadContext(SUSPEND_IF_NO_GLOBAL_TX, EMPTY_MAP);
-            if (snapshot == null)
-                throw new UnsupportedOperationException(Tr.formatMessage(tc, "CWWKC1157.cannot.propagate.tx"));
+            snapshot = transactionProvider.captureThreadContext(PROPAGATE_TX_FOR_SERIAL_USE, EMPTY_MAP);
         } else
             snapshot = transactionProvider.createDefaultThreadContext(EMPTY_MAP);
 

--- a/dev/com.ibm.ws.concurrent.mp_fat/.classpath
+++ b/dev/com.ibm.ws.concurrent.mp_fat/.classpath
@@ -4,6 +4,7 @@
 	<classpathentry kind="src" path="test-applications/MPConcurrentApp/src"/>
 	<classpathentry kind="src" path="test-applications/MPConcurrentCDIApp/src"/>
 	<classpathentry kind="src" path="test-applications/MPConcurrentConfigApp/src"/>
+	<classpathentry kind="src" path="test-applications/MPConcurrentTxApp/src"/>
 	<classpathentry kind="src" path="test-applications/customcontext/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
@@ -19,11 +19,13 @@ src: \
 	test-applications/MPConcurrentApp/src,\
 	test-applications/MPConcurrentCDIApp/src,\
 	test-applications/MPConcurrentConfigApp/src,\
+	test-applications/MPConcurrentTxApp/src,\
 	test-applications/customcontext/src
 
 fat.project: true
 
 -buildpath: \
+	com.ibm.tx.core;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp_fat/build.gradle
+++ b/dev/com.ibm.ws.concurrent.mp_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+addRequiredLibraries.dependsOn addDerby
+
 dependencies {
   requiredLibs project(':com.ibm.ws.concurrent.mp.1.0')
+  requiredLibs project(':com.ibm.tx.core')
 }
 

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
@@ -18,6 +18,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
                 MPConcurrentTest.class,
                 MPConcurrentCDITest.class,
-                MPConcurrentConfigTest.class
+                MPConcurrentConfigTest.class,
+                MPConcurrentTxTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentTxTest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentTxTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentTxTest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentTxTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.fat;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import concurrent.mp.fat.tx.web.MPConcurrentTxTestServlet;
+
+@RunWith(FATRunner.class)
+public class MPConcurrentTxTest extends FATServletClient {
+
+    private static final String APP_NAME = "MPConcurrentTxApp";
+
+    @Server("MPConcurrentTxTestServer")
+    @TestServlet(servlet = MPConcurrentTxTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, "concurrent.mp.fat.tx.web");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:concurrent=all:TransactionContext=all

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
@@ -1,0 +1,42 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+	<featureManager>
+	    <feature>componenttest-1.0</feature>
+	    <feature>jdbc-4.2</feature>
+	    <feature>jndi-1.0</feature>
+	    <feature>mpConcurrency-1.0</feature>
+		<feature>servlet-4.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <application location="MPConcurrentTxApp.war"/>
+
+    <dataSource id="DefaultDataSource">
+	    <jdbcDriver libraryRef="DerbyLib"/>
+	    <properties.derby.embedded createDatabase="create" databaseName="memory:txdb"/>
+	</dataSource>
+	
+	<library id="DerbyLib">
+	    <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+	</library>
+
+    <!-- permissions for Derby -->
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+
+    <!-- Needed for application to use a ForkJoinPool, access the thread context class loader, and shut down an unmanaged ExecutorService that the test application creates -->
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentTxApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentTxApp.war" className="java.lang.RuntimePermission" name="modifyThread"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentTxApp.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentTxApp.war" className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.*" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
@@ -10,12 +10,12 @@
  -->
 <server>
 
-	<featureManager>
-	    <feature>componenttest-1.0</feature>
-	    <feature>jdbc-4.2</feature>
-	    <feature>jndi-1.0</feature>
-	    <feature>mpConcurrency-1.0</feature>
-		<feature>servlet-4.0</feature>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>jdbc-4.2</feature>
+        <feature>jndi-1.0</feature>
+        <feature>mpConcurrency-1.0</feature>
+        <feature>servlet-4.0</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>
@@ -23,13 +23,13 @@
     <application location="MPConcurrentTxApp.war"/>
 
     <dataSource id="DefaultDataSource">
-	    <jdbcDriver libraryRef="DerbyLib"/>
-	    <properties.derby.embedded createDatabase="create" databaseName="memory:txdb"/>
-	</dataSource>
-	
-	<library id="DerbyLib">
-	    <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
-	</library>
+        <jdbcDriver libraryRef="DerbyLib"/>
+        <properties.derby.embedded createDatabase="create" databaseName="memory:txdb"/>
+    </dataSource>
+
+    <library id="DerbyLib">
+        <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+    </library>
 
     <!-- permissions for Derby -->
     <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/MPConcurrentCDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/MPConcurrentCDITestServlet.java
@@ -671,7 +671,8 @@ public class MPConcurrentCDITestServlet extends FATServlet {
             assertEquals(Status.STATUS_ACTIVE, tx.getStatus());
 
             Future<?> f = executor.submit(() -> System.out.println("Should not be able to submit this task."));
-            fail("Submitted task from within a transaction when transaction context propagation is enabled: " + f);
+            // TODO fail("Submitted task from within a transaction when transaction context propagation is enabled: " + f);
+            f.get(TIMEOUT_MIN, TimeUnit.MINUTES);
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1157E"))
                 throw x;

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.tx.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Resource;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.sql.DataSource;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.eclipse.microprofile.concurrent.ManagedExecutor;
+import org.eclipse.microprofile.concurrent.ThreadContext;
+import org.junit.Test;
+
+import com.ibm.tx.jta.TransactionManagerFactory;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/MPConcurrentTestServlet")
+public class MPConcurrentTxTestServlet extends FATServlet {
+    /**
+     * 2 minutes. Maximum number of nanoseconds to wait for a task to complete.
+     */
+    private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
+
+    @Resource
+    private DataSource defaultDataSource;
+
+    // Executor that can be used when tests don't want to tie up threads from the Liberty global thread pool to perform concurrent test logic
+    private ExecutorService testThreads;
+
+    private TransactionManager tm = TransactionManagerFactory.getTransactionManager();
+
+    @Resource
+    private UserTransaction tx;
+
+    private ThreadContext txContext = ThreadContext.builder()
+                    .propagated(ThreadContext.TRANSACTION)
+                    .unchanged()
+                    .cleared(ThreadContext.ALL_REMAINING)
+                    .build();
+
+    private ManagedExecutor txExecutor = ManagedExecutor.builder()
+                    .propagated(ThreadContext.TRANSACTION)
+                    .cleared(ThreadContext.ALL_REMAINING)
+                    .build();
+
+    @Override
+    public void destroy() {
+        testThreads.shutdownNow();
+    }
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        testThreads = Executors.newFixedThreadPool(5);
+
+        // create tables for tests to use and pre-populate each with a single entry
+        try {
+            try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+                st.execute("CREATE TABLE MNCOUNTIES (NAME VARCHAR(50) NOT NULL PRIMARY KEY, POPULATION INT NOT NULL)");
+                st.execute("CREATE TABLE IACOUNTIES (NAME VARCHAR(50) NOT NULL PRIMARY KEY, POPULATION INT NOT NULL)");
+                st.execute("INSERT INTO MNCOUNTIES VALUES ('Olmsted', 154930)");
+                st.execute("INSERT INTO IACOUNTIES VALUES ('Polk', 481830)");
+            }
+        } catch (SQLException x) {
+            throw new ServletException(x);
+        }
+    }
+
+    @Test
+    public void testTransactionPropagatedToSameThread() throws Exception {
+        CompletableFuture<Integer> stage0 = txExecutor.newIncompleteFuture();
+        CompletableFuture<Integer> stage1, stage2, stage3;
+        tx.begin();
+        try {
+            stage1 = stage0.thenApply(numUpdates -> {
+                try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+                    return numUpdates + st.executeUpdate("INSERT INTO MNCOUNTIES VALUES ('Winona', 50992)");
+                } catch (Exception x) {
+                    throw new CompletionException(x);
+                }
+            });
+            stage2 = stage1.thenApply(numUpdates -> {
+                try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+                    return numUpdates + st.executeUpdate("INSERT INTO MNCOUNTIES VALUES ('Rice', 65251)");
+                } catch (Exception x) {
+                    throw new CompletionException(x);
+                }
+            });
+            stage3 = stage2.thenApply(numUpdates -> {
+                try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+                    numUpdates += st.executeUpdate("INSERT INTO MNCOUNTIES VALUES ('Fillmore', 20825)");
+                    tx.commit();
+                    return numUpdates;
+                } catch (Exception x) {
+                    throw new CompletionException(x);
+                }
+            }).exceptionally(x -> {
+                try {
+                    tx.rollback();
+                } catch (Exception x2) {
+                    throw new CompletionException(x);
+                }
+                throw new CompletionException(x);
+            });
+        } finally {
+            tm.suspend();
+        }
+
+        assertTrue(stage0.complete(0));
+
+        assertEquals(Integer.valueOf(3), stage3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+            ResultSet result = st.executeQuery("SELECT SUM(POPULATION) FROM MNCOUNTIES WHERE NAME='Winona' OR NAME='Rice' OR NAME='Fillmore'");
+            assertTrue(result.next());
+            assertEquals(137068, result.getInt(1));
+        }
+    }
+
+    @Test
+    public void testTransactionUsedSeriallyAndCommitOnDifferentThread() throws Exception {
+        CompletableFuture<Integer> stage;
+        tx.begin();
+        try {
+            stage = txExecutor.supplyAsync(() -> {
+                try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+                    return st.executeUpdate("INSERT INTO MNCOUNTIES VALUES ('Freeborn', 30619)");
+                } catch (SQLException x) {
+                    throw new CompletionException(x);
+                }
+            }).thenApplyAsync(numUpdates -> {
+                try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+                    numUpdates += st.executeUpdate("INSERT INTO MNCOUNTIES VALUES ('Mower', 39386)");
+                    tx.commit();
+                    return numUpdates;
+                } catch (Exception x) {
+                    throw new CompletionException(x);
+                }
+            }).exceptionally(x -> {
+                try {
+                    tx.rollback();
+                } catch (Exception x2) {
+                    throw new CompletionException(x);
+                }
+                throw new CompletionException(x);
+            });
+        } finally {
+            tm.suspend();
+        }
+
+        assertEquals(Integer.valueOf(2), stage.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+            ResultSet result = st.executeQuery("SELECT SUM(POPULATION) FROM MNCOUNTIES WHERE NAME='Freeborn' OR NAME='Mower'");
+            assertTrue(result.next());
+            assertEquals(70005, result.getInt(1));
+        }
+    }
+
+    @Test
+    public void testTwoThreadsConcurrentlyOperateInTransaction() throws Exception {
+        tx.begin();
+        try (Connection con = defaultDataSource.getConnection()) {
+            PreparedStatement ps = con.prepareStatement("INSERT INTO MNCOUNTIES VALUES (?,?)");
+            ps.setString(1, "Goodhue");
+            ps.setInt(2, 46138);
+            ps.executeUpdate();
+
+            CompletableFuture<Integer> stage = txExecutor.supplyAsync(() -> {
+                try (Connection con2 = defaultDataSource.getConnection()) {
+                    assertEquals(Status.STATUS_ACTIVE, tx.getStatus());
+                    return con2.createStatement().executeUpdate("INSERT INTO IACOUNTIES VALUES ('Linn', 220008)");
+                } catch (SQLException | SystemException x) {
+                    throw new CompletionException(x);
+                }
+            });
+
+            ps.setString(1, "Wabasha");
+            ps.setInt(2, 21490);
+            ps.executeUpdate();
+
+            assertEquals(Integer.valueOf(1), stage.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        } finally {
+            tx.commit();
+        }
+
+        try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+            ResultSet result = st.executeQuery("SELECT SUM(POPULATION) FROM MNCOUNTIES WHERE NAME='Goodhue' OR NAME='Wabasha'");
+            assertTrue(result.next());
+            assertEquals(67628, result.getInt(1));
+            result.close();
+            result = st.executeQuery("SELECT POPULATION FROM IACOUNTIES WHERE NAME='Linn'");
+            assertTrue(result.next());
+            assertEquals(220008, result.getInt(1));
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
@@ -219,7 +219,7 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                 try {
                     tx.rollback();
                 } catch (Exception x2) {
-                    throw new CompletionException(x);
+                    x2.printStackTrace();
                 }
                 throw new CompletionException(x);
             });
@@ -261,7 +261,7 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                 try {
                     tx.rollback();
                 } catch (Exception x2) {
-                    throw new CompletionException(x);
+                    x2.printStackTrace();
                 }
                 throw new CompletionException(x);
             });

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/SerialTransactionContextImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/SerialTransactionContextImpl.java
@@ -87,7 +87,6 @@ public class SerialTransactionContextImpl implements ThreadContext {
 
         // Suspend the transaction that we propagated to the thread if it is still active
         try {
-            EmbeddableTransactionManagerFactory.getTransactionManager();
             if (tx.equals(tm.getTransaction()))
                 tm.suspend();
         } catch (Throwable x) {

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/SerialTransactionContextImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/SerialTransactionContextImpl.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.transaction.context.internal;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.RejectedExecutionException;
+
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+
+import com.ibm.tx.jta.embeddable.EmbeddableTransactionManagerFactory;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.LocalTransaction.LocalTransactionCoordinator;
+import com.ibm.ws.LocalTransaction.LocalTransactionCurrent;
+import com.ibm.ws.Transaction.UOWCurrent;
+import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
+import com.ibm.ws.uow.embeddable.UOWManager;
+import com.ibm.ws.uow.embeddable.UOWManagerFactory;
+import com.ibm.ws.uow.embeddable.UOWToken;
+import com.ibm.wsspi.threadcontext.ThreadContext;
+
+/**
+ * A special transaction context implementation for MicroProfile Concurrency that propagates a
+ * transaction to another thread on the condition that it is only active on one thread at a time.
+ */
+public class SerialTransactionContextImpl implements ThreadContext {
+    private static final long serialVersionUID = 1;
+
+    /**
+     * Unit of work that was on the thread of execution prior to invoking the contextual task.
+     */
+    private UOWToken suspendedUOW;
+
+    private final Transaction tx;
+
+    SerialTransactionContextImpl() {
+        try {
+            tx = EmbeddableTransactionManagerFactory.getTransactionManager().getTransaction();
+        } catch (SystemException x) {
+            throw new RejectedExecutionException(x);
+        }
+    }
+
+    @Override
+    public ThreadContext clone() {
+        try {
+            SerialTransactionContextImpl copy = (SerialTransactionContextImpl) super.clone();
+            return copy;
+        } catch (CloneNotSupportedException x) {
+            throw new RuntimeException(x);
+        }
+    }
+
+    @Override
+    public void taskStarting() throws RejectedExecutionException {
+        // Suspend whatever is currently on the thread.
+        try {
+            UOWManager uowManager = UOWManagerFactory.getUOWManager();
+            suspendedUOW = uowManager.suspend();
+        } catch (com.ibm.ws.uow.embeddable.SystemException e) {
+        }
+
+        try {
+            EmbeddableTransactionManagerFactory.getTransactionManager().resume(tx);
+        } catch (InvalidTransactionException x) {
+            throw new RejectedExecutionException(x);
+        } catch (SystemException x) {
+            throw new RejectedExecutionException(x);
+        }
+    }
+
+    @Override
+    public void taskStopping() {
+        EmbeddableWebSphereTransactionManager tm = EmbeddableTransactionManagerFactory.getTransactionManager();
+        Throwable exception = null;
+
+        // Suspend the transaction that we propagated to the thread if it is still active
+        try {
+            EmbeddableTransactionManagerFactory.getTransactionManager();
+            if (tx.equals(tm.getTransaction()))
+                tm.suspend();
+        } catch (Throwable x) {
+            exception = x;
+        }
+
+        // Cleanup any unresolved transactions.
+        UOWCurrent uowCurrent = EmbeddableTransactionManagerFactory.getUOWCurrent();
+        switch (uowCurrent.getUOWType()) {
+            case UOWCurrent.UOW_GLOBAL:
+                // Rollback global transactions.
+                try {
+                    tm.rollback();
+                    if (exception == null)
+                        exception = new Exception("Global transaction rolled back.");
+                } catch (Exception e) {
+                    if (exception == null)
+                        exception = e;
+                }
+                break;
+
+            case UOWCurrent.UOW_LOCAL:
+                // Commit local transaction.
+                try {
+                    LocalTransactionCurrent ltCurrent = EmbeddableTransactionManagerFactory.getLocalTransactionCurrent();
+                    ltCurrent.end(LocalTransactionCoordinator.EndModeCommit);
+                } catch (Exception e) {
+                    if (exception == null)
+                        exception = e;
+                }
+                break;
+
+            case UOWCurrent.UOW_NONE:
+                break;
+            default:
+                if (exception == null)
+                    exception = new Exception("Invalid transaction type: " + uowCurrent.getUOWType());
+                break;
+        }
+
+        // Resume the original transaction.
+        try {
+            if (suspendedUOW != null) {
+                UOWManager uowManager = UOWManagerFactory.getUOWManager();
+                uowManager.resume(suspendedUOW);
+                suspendedUOW = null;
+            }
+        } catch (Throwable e) {
+            exception = e;
+        }
+
+        // Throw any pending exception.
+        if (exception != null) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    @Override
+    @Trivial
+    public String toString() {
+        StringBuilder sb = new StringBuilder(100).append(getClass().getSimpleName()).append('@').append(Integer.toHexString(hashCode())).append(" tx=").append(tx);
+        return sb.toString();
+    }
+
+    private void writeObject(ObjectOutputStream outStream) throws IOException {
+        throw new NotSerializableException();
+    }
+}

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextProviderImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextProviderImpl.java
@@ -66,9 +66,9 @@ public class TransactionContextProviderImpl implements JCAContextProvider, Threa
             return new TransactionContextImpl(true);
         else if (ManagedTask.USE_TRANSACTION_OF_EXECUTION_THREAD.equals(value))
             return new TransactionContextImpl(false);
-        else if ("SUSPEND_IF_NO_GLOBAL_TX".equals(value)) {
+        else if ("PROPAGATE".equals(value)) {
             if (EmbeddableTransactionManagerFactory.getUOWCurrent().getUOWType() == UOWCurrent.UOW_GLOBAL)
-                return null;
+                return new SerialTransactionContextImpl();
             else
                 return new TransactionContextImpl(true);
         } else


### PR DESCRIPTION
This pull temporarily switches on transaction context propagation for MP Concurrency and creates a test bucket where we attempt to use real transactional resources that operate in propagated  transactions.