### PR TITLE
Ensure existing MP Rest Client 1.0/1.1 tests also work with 1.2

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
@@ -28,7 +28,7 @@ src: \
 
 fat.project: true
 
-tested.features=mpRestClient-1.2,jdbc-4.2
+tested.features=mpRestClient-1.2,jdbc-4.2,appSecurity-3.0
 
 javac.source: 1.8
 javac.target: 1.8

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
@@ -34,17 +34,19 @@ import mpRestClient11.async.AsyncTestServlet;
 @RunWith(FATRunner.class)
 public class AsyncMethodTest extends FATServletClient {
 
+    final static String SERVER_NAME = "mpRestClient11.async";
+
     @ClassRule
-    public static RepeatTests r = 
-        RepeatTests.withoutModification()
-                   .andWith(new FeatureReplacementAction().withID("mpRestClient-1.2")
-                                                          .addFeature("mpRestClient-1.2")
-                                                          .removeFeature("mpRestClient-1.1")
-                                                          .forServers("mpRestClient11.async"));
+    public static RepeatTests r = RepeatTests.withoutModification()
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .removeFeature("mpRestClient-1.1")
+                 .forServers(SERVER_NAME));
 
     private static final String appName = "asyncApp";
 
-    @Server("mpRestClient11.async")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = AsyncTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiInEE8Test.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiInEE8Test.java
@@ -29,20 +29,24 @@ import mpRestClient10.basicCdi.BasicClientTestServlet;
 @RunWith(FATRunner.class)
 public class BasicCdiInEE8Test extends FATServletClient {
 
+    final static String SERVER_NAME = "mpRestClient10.tolerateEE8";
+
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-         .andWith(new FeatureReplacementAction("mpRestClient-1.0", "mpRestClient-1.1")
-             .removeFeature("mpRestClient-1.2")
-             .addFeature("mpConfig-1.1")
-             .withID("mpRestClient-1.1")
-             .forServers("mpRestClient10.tolerateEE8"))
-         .andWith(FeatureReplacementAction.EE8_FEATURES()
-             .removeFeature("mpRestClient-1.1")
-             .removeFeature("mpRestClient-1.0")
-             .removeFeature("mpConfig-1.1")
-             .addFeature("mpRestClient-1.2")
-             .withID("mpRestClient-1.2")
-             .forServers("mpRestClient10.tolerateEE8"));
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.1")
+                 .addFeature("mpRestClient-1.1")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.2")
+                 .forServers(SERVER_NAME))
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .addFeature("mpConfig-1.3")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.1")
+                 .removeFeature("mpConfig-1.1")
+                 .forServers(SERVER_NAME));
 
 
     private static final String appName = "basicCdiClientApp";
@@ -55,7 +59,7 @@ public class BasicCdiInEE8Test extends FATServletClient {
      * code. The client should be able to work on its own - by splitting out
      * the "server" server into it's own server, we can verify this.
      */
-    @Server("mpRestClient10.tolerateEE8")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = BasicClientTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiTest.java
@@ -29,20 +29,24 @@ import mpRestClient10.basicCdi.BasicClientTestServlet;
 @RunWith(FATRunner.class)
 public class BasicCdiTest extends FATServletClient {
 
+    final static String SERVER_NAME = "mpRestClient10.basic.cdi";
+
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-        .andWith(new FeatureReplacementAction("mpRestClient-1.0", "mpRestClient-1.1")
-             .removeFeature("mpRestClient-1.2")
-             .addFeature("mpConfig-1.1")
-             .withID("mpRestClient-1.1")
-             .forServers("mpRestClient10.basic.cdi"))
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.1")
+                 .addFeature("mpRestClient-1.1")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.2")
+                 .forServers(SERVER_NAME))
         .andWith(FeatureReplacementAction.EE8_FEATURES()
-             .removeFeature("mpRestClient-1.1")
-             .removeFeature("mpRestClient-1.0")
-             .removeFeature("mpConfig-1.1")
-             .addFeature("mpRestClient-1.2")
-             .withID("mpRestClient-1.2")
-             .forServers("mpRestClient10.basic.cdi"));
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .addFeature("mpConfig-1.3")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.1")
+                 .removeFeature("mpConfig-1.1")
+                 .forServers(SERVER_NAME));
 
     private static final String appName = "basicCdiClientApp";
 
@@ -54,7 +58,7 @@ public class BasicCdiTest extends FATServletClient {
      * code. The client should be able to work on its own - by splitting out
      * the "server" server into it's own server, we can verify this.
      */
-    @Server("mpRestClient10.basic.cdi")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = BasicClientTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicEJBTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicEJBTest.java
@@ -29,9 +29,24 @@ import mpRestClient10.basicEJB.BasicClientTestServlet;
 @RunWith(FATRunner.class)
 public class BasicEJBTest extends FATServletClient {
 
+    final static String SERVER_NAME = "mpRestClient10.basic.ejb";
+
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-        .andWith(new FeatureReplacementAction("mpRestClient-1.0", "mpRestClient-1.1").forServers("mpRestClient10.basic.cdi"));
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.1")
+                 .addFeature("mpRestClient-1.1")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.2")
+                 .forServers(SERVER_NAME))
+        .andWith(FeatureReplacementAction.EE8_FEATURES()
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .addFeature("mpConfig-1.3")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.1")
+                 .removeFeature("mpConfig-1.1")
+                 .forServers(SERVER_NAME));
 
     private static final String appName = "basicEJBClientApp";
 
@@ -43,7 +58,7 @@ public class BasicEJBTest extends FATServletClient {
      * code. The client should be able to work on its own - by splitting out
      * the "server" server into it's own server, we can verify this.
      */
-    @Server("mpRestClient10.basic.ejb")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = BasicClientTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
@@ -29,16 +29,22 @@ import mpRestClient10.basic.BasicClientTestServlet;
 @RunWith(FATRunner.class)
 public class BasicTest extends FATServletClient {
 
+    final static String SERVER_NAME = "mpRestClient10.basic";
+
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-             .andWith(new FeatureReplacementAction("mpRestClient-1.0", "mpRestClient-1.1")
-                 .removeFeature("mpRestClient-1.2")
+        .andWith(new FeatureReplacementAction()
                  .withID("mpRestClient-1.1")
-                 .forServers("mpRestClient10.basic"))
-             .andWith(new FeatureReplacementAction("mpRestClient-1.0", "mpRestClient-1.2")
-                 .removeFeature("mpRestClient-1.1")
+                 .addFeature("mpRestClient-1.1")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.2")
+                 .forServers(SERVER_NAME))
+        .andWith(new FeatureReplacementAction()
                  .withID("mpRestClient-1.2")
-                 .forServers("mpRestClient10.basic"));
+                 .addFeature("mpRestClient-1.2")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.1")
+                 .forServers(SERVER_NAME));
 
     private static final String appName = "basicClientApp";
 
@@ -50,7 +56,7 @@ public class BasicTest extends FATServletClient {
      * work on its own - by splitting out the "server" server into it's
      * own server, we can verify this.
      */
-    @Server("mpRestClient10.basic")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = BasicClientTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CdiPropsAndProvidersTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CdiPropsAndProvidersTest.java
@@ -12,6 +12,7 @@ package com.ibm.ws.microprofile.rest.client.fat;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -19,6 +20,8 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import mpRestClient11.cdiPropsAndProviders.CdiPropsAndProvidersTestServlet;
@@ -27,9 +30,17 @@ import mpRestClient11.cdiPropsAndProviders.CdiPropsAndProvidersTestServlet;
 public class CdiPropsAndProvidersTest extends FATServletClient {
 
     private static final String appName = "cdiPropsAndProvidersApp";
+    final static String SERVER_NAME = "mpRestClient11.cdiPropsAndProviders";
 
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .removeFeature("mpRestClient-1.1")
+                 .forServers(SERVER_NAME));
 
-    @Server("mpRestClient11.cdiPropsAndProviders")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = CdiPropsAndProvidersTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
@@ -33,11 +33,22 @@ import mpRestClient10.collections.CollectionsTestServlet;
 @RunWith(FATRunner.class)
 public class CollectionsTest extends FATServletClient {
 
+    final static String SERVER_NAME = "mpRestClient10.collections";
+
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-             .andWith(new FeatureReplacementAction("mpRestClient-1.0", "mpRestClient-1.1")
+        .andWith(new FeatureReplacementAction()
                  .withID("mpRestClient-1.1")
-                 .forServers("mpRestClient10.collections"));
+                 .addFeature("mpRestClient-1.1")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.2")
+                 .forServers(SERVER_NAME))
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.1")
+                 .forServers(SERVER_NAME));
 
     private static final String appName = "collectionsApp";
     public static final String JOHNZON_IMPL = "publish/shared/resources/johnzon/";
@@ -51,7 +62,7 @@ public class CollectionsTest extends FATServletClient {
      * work on its own - by splitting out the "server" server into it's
      * own server, we can verify this.
      */
-    @Server("mpRestClient10.collections")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = CollectionsTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
@@ -30,9 +30,22 @@ import mpRestClient10.handleresponses.ClientTestServlet;
 @RunWith(FATRunner.class)
 public class HandleResponsesTest extends FATServletClient {
 
+    final static String SERVER_NAME = "mpRestClient10.handleresponses";
+
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-        .andWith(new FeatureReplacementAction("mpRestClient-1.0", "mpRestClient-1.1").forServers("mpRestClient10.handleresponses"));
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.1")
+                 .addFeature("mpRestClient-1.1")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.2")
+                 .forServers(SERVER_NAME))
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.1")
+                 .forServers(SERVER_NAME));
 
     private static final String appName = "handleresponsesApp";
 
@@ -44,7 +57,7 @@ public class HandleResponsesTest extends FATServletClient {
      * work on its own - by splitting out the "server" server into it's
      * own server, we can verify this.
      */
-    @Server("mpRestClient10.handleresponses")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = ClientTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagationTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagationTest.java
@@ -29,13 +29,26 @@ import mpRestClient10.headerPropagation.HeaderPropagationTestServlet;
 @RunWith(FATRunner.class)
 public class HeaderPropagationTest extends FATServletClient {
 
+    final static String SERVER_NAME = "mpRestClient10.headerPropagation";
+
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-        .andWith(new FeatureReplacementAction("mpRestClient-1.0", "mpRestClient-1.1").forServers("mpRestClient10.headerPropagation"));
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.1")
+                 .addFeature("mpRestClient-1.1")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.2")
+                 .forServers(SERVER_NAME))
+        .andWith(FeatureReplacementAction.EE8_FEATURES()
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.1")
+                 .forServers(SERVER_NAME));
 
     private static final String appName = "headerPropagationApp";
 
-    @Server("mpRestClient10.headerPropagation")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = HeaderPropagationTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/MultiClientCdiTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/MultiClientCdiTest.java
@@ -30,13 +30,28 @@ import mpRestClient10.multiClientCdi.MultiClientCdiTestServlet;
 @RunWith(FATRunner.class)
 public class MultiClientCdiTest extends FATServletClient {
 
+    final static String SERVER_NAME = "mpRestClient10.multi.client.cdi";
+
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-        .andWith(new FeatureReplacementAction("mpRestClient-1.0", "mpRestClient-1.1").forServers("mpRestClient10.multi.client.cdi"));
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.1")
+                 .addFeature("mpRestClient-1.1")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.2")
+                 .forServers(SERVER_NAME))
+        .andWith(FeatureReplacementAction.EE8_FEATURES()
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .addFeature("mpConfig-1.3")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.1")
+                 .removeFeature("mpConfig-1.1")
+                 .forServers(SERVER_NAME));
 
     private static final String appName = "multiClientCdiApp";
 
-    @Server("mpRestClient10.multi.client.cdi")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = MultiClientCdiTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
@@ -12,6 +12,7 @@ package com.ibm.ws.microprofile.rest.client.fat;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -19,6 +20,8 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import mpRestClient11.produceConsume.ProduceConsumeTestServlet;
@@ -31,8 +34,17 @@ import mpRestClient11.produceConsume.ProduceConsumeTestServlet;
 public class ProduceConsumeTest extends FATServletClient {
 
     private static final String appName = "produceConsumeApp";
+    final static String SERVER_NAME = "mpRestClient11.produceConsume";
 
-    @Server("mpRestClient11.produceConsume")
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .removeFeature("mpRestClient-1.1")
+                 .forServers(SERVER_NAME));
+
+    @Server(SERVER_NAME)
     @TestServlet(servlet = ProduceConsumeTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/PropsTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/PropsTest.java
@@ -29,13 +29,26 @@ import mpRestClient10.props.PropsTestServlet;
 @RunWith(FATRunner.class)
 public class PropsTest extends FATServletClient {
 
+    final static String SERVER_NAME = "mpRestClient10.props";
+
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-        .andWith(new FeatureReplacementAction("mpRestClient-1.0", "mpRestClient-1.1").forServers("mpRestClient10.props"));
+        .andWith(new FeatureReplacementAction()
+                 .withID("mpRestClient-1.1")
+                 .addFeature("mpRestClient-1.1")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.2")
+                 .forServers(SERVER_NAME))
+        .andWith(FeatureReplacementAction.EE8_FEATURES()
+                 .withID("mpRestClient-1.2")
+                 .addFeature("mpRestClient-1.2")
+                 .removeFeature("mpRestClient-1.0")
+                 .removeFeature("mpRestClient-1.1")
+                 .forServers(SERVER_NAME));
 
     private static final String appName = "propsApp";
 
-    @Server("mpRestClient10.props")
+    @Server(SERVER_NAME)
     @TestServlet(servlet = PropsTestServlet.class, contextRoot = appName)
     public static LibertyServer server;
 


### PR DESCRIPTION
Update existing MP Rest Client 1.0 & 1.1 FAT tests to repeat with MP Rest Client 1.2 (and updated MP/JavaEE features). New feature - not a release bug.

Part of epic #5941 