### PR TITLE
Do a server dump when test gets a SocketTimeoutException while trying…

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_ADLDAPTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_ADLDAPTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.net.SocketTimeoutException;
 import java.util.List;
 
 import org.junit.AfterClass;
@@ -27,6 +28,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.LocalFile;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.registry.EntryNotFoundException;
 import com.ibm.ws.security.registry.RegistryException;
@@ -334,7 +336,7 @@ public class URAPIs_ADLDAPTest {
      * This verifies the various required bundles got installed and are working.
      */
     @Test
-    public void getUsersForMaxSearchResultException() {
+    public void getUsersForMaxSearchResultException() throws Exception {
         // This test will only be executed when using physical LDAP server
         Assume.assumeTrue(!LDAPUtils.USE_LOCAL_LDAP_SERVER);
         String user = "*";
@@ -345,6 +347,13 @@ public class URAPIs_ADLDAPTest {
         } catch (RegistryException e) {
             String msg = e.getMessage();
             assertTrue("Message did not contain expected message 'CWIML1018E': " + msg, msg.contains("CWIML1018E"));
+        } catch (Exception e) {
+            // I am looking for a SocketTimeoutException
+            Log.info(c, "Caught Exception ", e.toString());
+            if (e.toString().contains("SocketTimeoutException")) {
+                final LocalFile lf = server.dumpServer("wlp_adapter_fat_dump");
+                Log.info(c, "Got dump file: ", lf.toString());
+            }
         }
     }
 


### PR DESCRIPTION
… to read from LDAP server

OpenLiberty Pull Requester,

ATTENTION, READ THIS: Updated 4/11/2018 - Read and understand this completely,
then delete this entire template. If a reviewer or merger sees this template,
they should fail the review or merge.

If this code change is fixing a user-visible bug in previously released code, it MUST
have an associated issue mentioned in the PR text or description. That Issue also
MUST be labelled “release bug”

This directs automation to scrape this fix for inclusion in the next release's
list of bugs fixed.

If this code is NOT for fixing a released bug, for example new function, fixing
a bug in unreleased function, or other improvements that do not affect the
user-space, no label is needed. An issue could or could not be used based
on the developer’s discretion, but do still delete this text block.

For full details, please see this wiki page:

https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions

