### PR TITLE
Improve message when UCP is configured with a type of ConnectionPoolD…

### DIFF
--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2001, 2016 IBM Corporation and others.
+# Copyright (c) 2001, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -286,6 +286,10 @@ DSRA4014.URL.for.Driver.missing.useraction=Add a valid URL to the data source.
 DSRA4015.no.ucp.connection.pool.datasource=DSRA4015E: The {0} data source was configured with the ConnectionPoolDataSource type, which is not supported by Oracle UCP. Instead, use the XADataSource or DataSource type.
 DSRA4015.no.ucp.connection.pool.datasource.explanation=The data source was configured with the ConnectionPoolDataSource type, which is not implemented by the Oracle UCP driver.
 DSRA4015.no.ucp.connection.pool.datasource.useraction=Update the data source to use either the XADataSource or DataSource type.
+
+DSRA4016.no.ucp.driver.datasource=DSRA4016E: The {0} data source was configured with the Driver type, which is not supported by Oracle UCP. Instead, use the XADataSource or DataSource type.
+DSRA4016.no.ucp.driver.datasource.explanation=The data source was configured with the Driver type, which is not implemented by the Oracle UCP driver.
+DSRA4016.no.ucp.driver.datasource.useraction=Update the data source to use either the XADataSource or DataSource type.
 
 # ----------------------------------------------------------------------------
 # 

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -283,6 +283,10 @@ DSRA4014.URL.for.Driver.missing=DSRA4014E: The type java.sql.Driver was specifie
 DSRA4014.URL.for.Driver.missing.explanation=A connection URL must be specified for a data source that is a java.sql.Driver type.
 DSRA4014.URL.for.Driver.missing.useraction=Add a valid URL to the data source.
 
+DSRA4015.no.ucp.connection.pool.datasource=DSRA4015E: The {0} data source was configured with the ConnectionPoolDataSource type, which is not supported by Oracle UCP. Instead, use the XADataSource or DataSource type.
+DSRA4015.no.ucp.connection.pool.datasource.explanation=The data source was configured with the ConnectionPoolDataSource type, which is not implemented by the Oracle UCP driver.
+DSRA4015.no.ucp.connection.pool.datasource.useraction=Update the data source to use either the XADataSource or DataSource type.
+
 # ----------------------------------------------------------------------------
 # 
 # Using 7000-7599 for DataStore Helper exception messages and warnings

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -677,8 +677,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 //if properties.oracle.ucp is configured do not search for driver impls because the customer has indicated
                 //they want to use UCP, but this will likely pick up the Oracle driver instead of the UCP driver (since UCP has no Driver interface)
                 if("com.ibm.ws.jdbc.dataSource.properties.oracle.ucp".equals(vendorPropertiesPID)) {
-                    //TODO update exception in NLS pr
-                    throw classNotFound(Driver.class.getName(), null, dataSourceID, null);
+                    throw new SQLNonTransientException(AdapterUtil.getNLSMessage("DSRA4016.no.ucp.driver.datasource", dataSourceID));
                 }
             }
             Driver driver = loadDriver(className, url, classloader, props, dataSourceID);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -522,8 +522,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                     //if properties.oracle.ucp is configured do not search based on classname or infer because the customer has indicated
                     //they want to use UCP, but this will likely pick up the Oracle driver instead of the UCP driver (since UCP has no ConnectionPoolDataSource)
                     if("com.ibm.ws.jdbc.dataSource.properties.oracle.ucp".equals(vendorPropertiesPID)) {
-                        //TODO consider if we want to throw a more specific exception here
-                        throw classNotFound(ConnectionPoolDataSource.class.getName(), null, dataSourceID, null);
+                        throw new SQLNonTransientException(AdapterUtil.getNLSMessage("DSRA4015.no.ucp.connection.pool.datasource", dataSourceID));
                     }
                     className = JDBCDrivers.getConnectionPoolDataSourceClassName(getClasspath(sharedLib, true));
                     if (className == null) {


### PR DESCRIPTION
…ataSource

Improve the message for when Oracle UCP is configured with a type of ConnectionPoolDataSource, which is not implemented in UCP.