### PR TITLE
specify defaults globally via MP Config

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/bnd.bnd
@@ -27,7 +27,13 @@ Export-Package:\
 
 Import-Package:\
   javax.inject;resolution:=optional,\
+  !org.eclipse.microprofile.config,\
+  !org.eclipse.microprofile.config.spi,\
   *
+
+DynamicImport-Package:\
+  org.eclipse.microprofile.config,\
+  org.eclipse.microprofile.config.spi
 
 Private-Package:\
   com.ibm.ws.concurrent.mp.*
@@ -39,14 +45,16 @@ instrument.classesExcludes: com/ibm/ws/concurrent/mp/resources/*.class
   com.ibm.ws.concurrent.mp.ContextServiceImpl,\
   com.ibm.ws.concurrent.mp.ManagedExecutorImpl,\
   com.ibm.ws.concurrent.mp.ManagedScheduledExecutorImpl,\
-  com.ibm.ws.concurrent.mp.MicroProfileClearedContextProvider
+  com.ibm.ws.concurrent.mp.MicroProfileClearedContextProvider,\
+  com.ibm.ws.concurrent.mp.MPConfigAccessorImpl
 
 -buildpath: \
   com.ibm.websphere.appserver.spi.logging,\
   com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
   com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0,\
-  com.ibm.websphere.org.osgi.core,\
-  com.ibm.websphere.org.osgi.service.component,\
+  com.ibm.websphere.org.eclipse.microprofile.config.1.4;version=latest,\
+  com.ibm.websphere.org.osgi.core;version=latest,\
+  com.ibm.websphere.org.osgi.service.component;version=latest,\
   com.ibm.ws.app.manager.lifecycle;version=latest,\
   com.ibm.ws.bnd.annotations;version=latest, \
   com.ibm.ws.concurrency.policy;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyProviderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ConcurrencyProviderImpl.java
@@ -36,6 +36,7 @@ import com.ibm.ws.concurrent.mp.context.CDIContextProviderHolder;
 import com.ibm.ws.concurrent.mp.context.SecurityContextProvider;
 import com.ibm.ws.concurrent.mp.context.TransactionContextProvider;
 import com.ibm.ws.concurrent.mp.context.WLMContextProvider;
+import com.ibm.ws.concurrent.mp.service.MPConfigAccessor;
 import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
 import com.ibm.ws.container.service.metadata.extended.MetaDataIdentifierService;
 import com.ibm.ws.container.service.state.ApplicationStateListener;
@@ -65,6 +66,11 @@ public class ConcurrencyProviderImpl implements ApplicationStateListener, Concur
     @Reference
     protected MetaDataIdentifierService metadataIdentifierService;
 
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.DYNAMIC,
+               policyOption = ReferencePolicyOption.GREEDY)
+    protected volatile MPConfigAccessor mpConfigAccessor;
+
     @Reference
     protected PolicyExecutorProvider policyExecutorProvider;
 
@@ -86,13 +92,11 @@ public class ConcurrencyProviderImpl implements ApplicationStateListener, Concur
 
     @Override
     @Trivial
-    public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {
-    }
+    public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {}
 
     @Override
     @Trivial
-    public void applicationStarting(ApplicationInfo appInfo) throws StateChangeException {
-    }
+    public void applicationStarting(ApplicationInfo appInfo) throws StateChangeException {}
 
     @Override
     public void applicationStopped(ApplicationInfo appInfo) {

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/service/MPConfigAccessor.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/service/MPConfigAccessor.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.concurrent.mp.cdi;
+package com.ibm.ws.concurrent.mp.service;
 
 /**
  * This interface abstracts away usage of MicroProfile Config so that values can be

--- a/dev/com.ibm.ws.concurrent.mp.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/bnd.bnd
@@ -26,13 +26,7 @@ Private-Package:\
   com.ibm.ws.concurrent.mp.cdi
 
 Import-Package: \
-  !org.eclipse.microprofile.config,\
-  !org.eclipse.microprofile.config.spi,\
   *
-
-DynamicImport-Package: \
-  org.eclipse.microprofile.config,\
-  org.eclipse.microprofile.config.spi
 
 Include-Resource: \
   META-INF=resources/META-INF
@@ -40,15 +34,13 @@ Include-Resource: \
 instrument.classesExcludes: com/ibm/ws/concurrent/mp/cdi/resources/*.class
 
 -dsannotations: \
-  com.ibm.ws.concurrent.mp.cdi.ConcurrencyCDIExtension,\
-  com.ibm.ws.concurrent.mp.cdi.MPConfigAccessorImpl
+  com.ibm.ws.concurrent.mp.cdi.ConcurrencyCDIExtension
 
 -buildpath: \
   com.ibm.websphere.appserver.spi.logging,\
   com.ibm.websphere.javaee.cdi.2.0;version=latest,\
   com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
   com.ibm.websphere.org.eclipse.microprofile.concurrency.1.0,\
-  com.ibm.websphere.org.eclipse.microprofile.config.1.4;version=latest,\
   com.ibm.websphere.org.osgi.core,\
   com.ibm.websphere.org.osgi.service.component,\
   com.ibm.ws.app.manager.lifecycle;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ConcurrencyCDIExtension.java
+++ b/dev/com.ibm.ws.concurrent.mp.cdi/src/com/ibm/ws/concurrent/mp/cdi/ConcurrencyCDIExtension.java
@@ -49,6 +49,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.cdi.extension.WebSphereCDIExtension;
+import com.ibm.ws.concurrent.mp.service.MPConfigAccessor;
 import com.ibm.ws.concurrent.mp.service.ConcurrencyCDIHelper;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
@@ -3,3 +3,10 @@ concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet/containerExecutorWith
 concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet/containerExecutorWithNameAndConfig/ManagedExecutorConfig/maxQueued=2
 concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet/executorWithMPConfigOverride/ManagedExecutorConfig/cleared=City
 concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet/executorWithMPConfigOverride/ManagedExecutorConfig/propagated=Application,State
+ManagedExecutor/maxAsync=2
+ManagedExecutor/maxQueued=3
+ManagedExecutor/cleared=Transaction
+ManagedExecutor/propagated=City,Application
+ThreadContext/cleared=
+ThreadContext/propagated=State
+ThreadContext/unchanged=Remaining


### PR DESCRIPTION
Implement recent spec update to allow MP Config to be used to specify global defaults for ManagedExecutor and ThreadContext configuration attributes.