### PR TITLE
Handle JDK12 when invoking default interface methods.

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/org/apache/cxf/jaxrs/client/ClientProxyImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2/src/org/apache/cxf/jaxrs/client/ClientProxyImpl.java
@@ -213,13 +213,9 @@ public class ClientProxyImpl extends AbstractClient implements
                         return params != null && params.length > 0 ? mh.invokeWithArguments(params) : mh.invoke();
                         // Liberty change end
                     } catch (Throwable t) {
-                        if (t instanceof IllegalAccessException) {
-                            try {
-                                return invokeDefaultMethodUsingPrivateLookup(declaringClass, o, m, params);
-                            } catch (final NoSuchMethodException ex) {
-                                throw new WrappedException(t);
-                            }
-                        } else {
+                        try {
+                            return invokeDefaultMethodUsingPrivateLookup(declaringClass, o, m, params);
+                        } catch (final NoSuchMethodException ex) {
                             throw new WrappedException(t);
                         }
                     }


### PR DESCRIPTION
This removes the check that the Throwable must be an IllegalAccesssException. This is because the IBM JDK 12 removes the accessMode field that we used to in JDK 8 - that ends up throwing a NoSuchFieldException.

The mpRestClient-1.2 feature has not yet shipped (not has OL with JDK12 support), so this PR is not a release bug.