### PR TITLE
Adding Threading/FaultTolerance trace for rest client/FT diag

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client.FT_fat/publish/servers/mpRestClientFT.timeout/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client.FT_fat/publish/servers/mpRestClientFT.timeout/bootstrap.properties
@@ -1,4 +1,6 @@
-#com.ibm.ws.logging.trace.specification=\
+com.ibm.ws.logging.trace.specification=\
+Threading=event:\
+FaultTolerance=all
 #LogService=all:\
 #com.ibm.ws.microprofile.*=all:\
 #com.ibm.ws.jaxrs*=all:\


### PR DESCRIPTION
Just adding diagnostics to a FAT test - not a release bug.