### PR TITLE
Revert "Incorrect encored cache name."

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -153,11 +153,8 @@ public class CacheHashMap extends BackedHashMap {
             // the / and : characters (JCache spec does not allow these in cache names)
             // and also the % character (which is necessary because of percent encoding)
             String a = PERCENT.matcher(_iStore.getId()).replaceAll("%25"); // must be done first to avoid replacing % that is added when replacing the others
-            // a = SLASH.matcher(a).replaceAll("%2F");
-            // a = COLON.matcher(a).replaceAll("%3A");
-            // #6762 The Hazelcast management center can not correctly display statistics for a cache with %2F
-            a = SLASH.matcher(a).replaceAll(".");
-            a = COLON.matcher(a).replaceAll(".");
+            a = SLASH.matcher(a).replaceAll("%2F");
+            a = COLON.matcher(a).replaceAll("%3A");
 
             // Session Meta Information Cache
 


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#6773 appears to have caused defect  261318
junit.framework.AssertionFailedError: 2019-03-06-12:06:38:685 Servlet call was not successful: ERROR: Caught exception attempting to call test method testSessionInfoCache on servlet session.cache.web.SessionCacheTestServlet
java.lang.NullPointerException
at session.cache.web.SessionCacheTestServlet.testSessionInfoCache(SessionCacheTestServlet.java:579)
at componenttest.app.FATServlet.doGet(FATServlet.java:67)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)

the personal build was incomplete so doesn't exhibit this issue - it should not have been used as evidence to deliver.