### PR TITLE
Avoid test ordering problems in config fat

### DIFF
--- a/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ChildAliasTest.java
+++ b/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ChildAliasTest.java
@@ -92,21 +92,38 @@ public class ChildAliasTest {
 
     @Test
     public void testChildAlias1() throws Exception {
+        // precondition: regular server.xml
+        testServer.setMarkToEndOfLog();
+        testServer.setServerConfigurationFile("childalias/server.xml");
+        testServer.waitForConfigUpdateInLogUsingMark(null);
+        
         test(testServer);
     }
 
     @Test
     public void testChildAlias2() throws Exception {
+        // precondition: regular server.xml
+        testServer.setMarkToEndOfLog();
+        testServer.setServerConfigurationFile("childalias/server.xml");
+        testServer.waitForConfigUpdateInLogUsingMark(null);
         test(testServer);
     }
 
     @Test
     public void testChildAliasSingleton1() throws Exception {
+        // precondition: regular server.xml
+        testServer.setMarkToEndOfLog();
+        testServer.setServerConfigurationFile("childalias/server.xml");
+        testServer.waitForConfigUpdateInLogUsingMark(null);
         test(testServer);
     }
 
     @Test
     public void testChildAliasSingleton2() throws Exception {
+        // precondition: regular server.xml
+        testServer.setMarkToEndOfLog();
+        testServer.setServerConfigurationFile("childalias/server.xml");
+        testServer.waitForConfigUpdateInLogUsingMark(null);
         test(testServer);
     }
 
@@ -123,6 +140,8 @@ public class ChildAliasTest {
         testServer.setServerConfigurationFile("childalias/serverB.xml");
         testServer.waitForConfigUpdateInLogUsingMark(null);
         test(testServer);
+        
+       
     }
 
     @Test
@@ -157,6 +176,11 @@ public class ChildAliasTest {
 
     @Test
     public void testRemoveChild() throws Exception {
+        // precondition: serverC.xml
+        testServer.setMarkToEndOfLog();
+        testServer.setServerConfigurationFile("childalias/serverC.xml");
+        testServer.waitForConfigUpdateInLogUsingMark(null);
+        
         testServer.setMarkToEndOfLog();
         testServer.setServerConfigurationFile("childalias/serverC2.xml");
         testServer.waitForConfigUpdateInLogUsingMark(null);
@@ -165,6 +189,11 @@ public class ChildAliasTest {
 
     @Test
     public void testAddNewChild() throws Exception {
+        // precondition: serverC2.xml
+        testServer.setMarkToEndOfLog();
+        testServer.setServerConfigurationFile("childalias/serverC2.xml");
+        testServer.waitForConfigUpdateInLogUsingMark(null);
+        
         testServer.setMarkToEndOfLog();
         testServer.setServerConfigurationFile("childalias/serverC3.xml");
         testServer.waitForConfigUpdateInLogUsingMark(null);
@@ -173,6 +202,11 @@ public class ChildAliasTest {
 
     @Test
     public void testUpdateChild() throws Exception {
+        // precondition: serverC3
+        testServer.setMarkToEndOfLog();
+        testServer.setServerConfigurationFile("childalias/serverC3.xml");
+        testServer.waitForConfigUpdateInLogUsingMark(null);
+        
         testServer.setMarkToEndOfLog();
         testServer.setServerConfigurationFile("childalias/serverC4.xml");
         testServer.waitForConfigUpdateInLogUsingMark(null);
@@ -181,6 +215,11 @@ public class ChildAliasTest {
 
     @Test
     public void testRemoveSingletonChild() throws Exception {
+        // precondition: serverC4.xml
+        testServer.setMarkToEndOfLog();
+        testServer.setServerConfigurationFile("childalias/serverC4.xml");
+        testServer.waitForConfigUpdateInLogUsingMark(null);
+        
         testServer.setMarkToEndOfLog();
         testServer.setServerConfigurationFile("childalias/serverC5.xml");
         testServer.waitForConfigUpdateInLogUsingMark(null);
@@ -189,6 +228,11 @@ public class ChildAliasTest {
 
     @Test
     public void testAddNewSingletonChild() throws Exception {
+        // precondition: serverC5.xml
+        testServer.setMarkToEndOfLog();
+        testServer.setServerConfigurationFile("childalias/serverC5.xml");
+        testServer.waitForConfigUpdateInLogUsingMark(null);
+        
         testServer.setMarkToEndOfLog();
         testServer.setServerConfigurationFile("childalias/serverC6.xml");
         testServer.waitForConfigUpdateInLogUsingMark(null);
@@ -197,6 +241,11 @@ public class ChildAliasTest {
 
     @Test
     public void testUpdateSingletonChild() throws Exception {
+        // precondition: serverC6.xml
+        testServer.setMarkToEndOfLog();
+        testServer.setServerConfigurationFile("childalias/serverC6.xml");
+        testServer.waitForConfigUpdateInLogUsingMark(null);
+        
         testServer.setMarkToEndOfLog();
         testServer.setServerConfigurationFile("childalias/serverC7.xml");
         testServer.waitForConfigUpdateInLogUsingMark(null);

--- a/dev/com.ibm.ws.config_fat/test-applications/childalias/src/test/server/config/childalias/ChildAliasTestServlet.java
+++ b/dev/com.ibm.ws.config_fat/test-applications/childalias/src/test/server/config/childalias/ChildAliasTestServlet.java
@@ -101,7 +101,7 @@ public class ChildAliasTestServlet extends HttpServlet {
 
     /**
      * Just for manual debugging
-     * 
+     *
      * @param writer
      * @throws Exception
      */
@@ -241,11 +241,11 @@ public class ChildAliasTestServlet extends HttpServlet {
 
     /**
      * Simulate bundle ordering issues by loading a new feature that forces a new bundle to load.
-     * 
+     *
      * Bundle B has a parent with an unloaded child and a child with an unloaded parent. At this point,
      * nothing much will be resolved, but we can verify that there is no contamination with other child
      * elements with the same childAlias.
-     * 
+     *
      * @throws Exception
      */
     public void testBundleOrdering1() throws Exception {
@@ -271,7 +271,7 @@ public class ChildAliasTestServlet extends HttpServlet {
         String[] child6Pids = (String[]) parentProperties.get("testCAChild");
         assertNotNull(PARENT_6_PID + " should have a child element testCAChild", child6Pids);
         assertEquals("There should be 1 child pid", 1, child6Pids.length);
-        Configuration child6Config = ca.getConfiguration(child6Pids[0]);
+        Configuration child6Config = ca.getConfiguration(child6Pids[0], null);
         assertNotNull("The child for " + PARENT_6_PID + " should be available in the configuration", child6Config);
         Dictionary<String, Object> child6Props = child6Config.getProperties();
         assertEquals("The child should not be metatype processed", "Not Default", child6Props.get("testAttribute6"));
@@ -283,10 +283,10 @@ public class ChildAliasTestServlet extends HttpServlet {
 
     /**
      * Simulate bundle ordering issues by loading a new feature that forces a new bundle to load.
-     * 
+     *
      * Bundle C has a parent with a child in Bundle B and a child with a parent in Bundle B. All
      * elements should be resolved correctly at this point.
-     * 
+     *
      * @throws Exception
      */
     public void testBundleOrdering2() throws Exception {
@@ -310,7 +310,7 @@ public class ChildAliasTestServlet extends HttpServlet {
         String[] child6Pids = (String[]) parentProperties.get("testCAChild");
         assertNotNull(PARENT_6_PID + " should have a child element testCAChild", child6Pids);
         assertEquals("There should be only one child pid", 1, child6Pids.length);
-        Configuration child6Config = ca.getConfiguration(child6Pids[0]);
+        Configuration child6Config = ca.getConfiguration(child6Pids[0], null);
         assertNotNull("The child for " + PARENT_6_PID + " should be available in the configuration", child6Config);
         Dictionary<String, Object> child6Props = child6Config.getProperties();
         assertEquals("The child should have correct properties", "Not Default", child6Props.get("testAttribute6"));
@@ -323,7 +323,7 @@ public class ChildAliasTestServlet extends HttpServlet {
     /**
      * Same scenario as testBundleOrdering2, but asserting that there are no contamination issues between the
      * top level element and the child alias elements.
-     * 
+     *
      * @throws Exception
      */
     public void testBundleOrderingAliasConflict() throws Exception {
@@ -369,7 +369,7 @@ public class ChildAliasTestServlet extends HttpServlet {
         String[] child6Pids = (String[]) parentProperties.get("testCAChild");
         assertNotNull(PARENT_6_PID + " should have a child element testCAChild", child6Pids);
         assertEquals("There should be only one child pid", 1, child6Pids.length);
-        Configuration child6Config = ca.getConfiguration(child6Pids[0]);
+        Configuration child6Config = ca.getConfiguration(child6Pids[0], null);
         assertNotNull("The child for " + PARENT_6_PID + " should be available in the configuration", child6Config);
         Dictionary<String, Object> child6Props = child6Config.getProperties();
         assertEquals("The child should have correct properties", "New Child", child6Props.get("testAttribute6"));
@@ -417,7 +417,7 @@ public class ChildAliasTestServlet extends HttpServlet {
         String[] child3Pids = (String[]) parentProperties.get("testCAChild");
         assertNotNull(PARENT_3_PID + " should have a child element testCAChild", child3Pids);
         assertEquals("There should be only one child pid", 1, child3Pids.length);
-        Configuration child3Config = ca.getConfiguration(child3Pids[0]);
+        Configuration child3Config = ca.getConfiguration(child3Pids[0], null);
         assertNotNull("The child for " + PARENT_3_PID + " should be available in the configuration", child3Config);
         Dictionary<String, Object> child3Props = child3Config.getProperties();
         assertEquals("The child should have correct properties", "New Singleton Child", child3Props.get("testAttribute3"));


### PR DESCRIPTION
The child alias tests can fail if run in a different order. 