### PR TITLE
Increase arquillian undeploy timeout

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
@@ -68,7 +68,7 @@ public class MvnUtils {
 
     private static final String DEFAULT_FAILSAFE_UNDEPLOYMENT = "true";
     private static final String DEFAULT_APP_DEPLOY_TIMEOUT = "180";
-    private static final String DEFAULT_APP_UNDEPLOY_TIMEOUT = "20";
+    private static final String DEFAULT_APP_UNDEPLOY_TIMEOUT = "60";
     private static final int DEFAULT_MBEAN_TIMEOUT = 60000;
     public static File resultsDir;
     public static File componentRootDir;


### PR DESCRIPTION
MP Open API TCK fails while undeploying application with the timeout
Default timeout is 20 seconds.

Looking at last failed builds, server stopped tck application in 26 seconds
