### PR TITLE
FT 2.0: Handle exceptions when applying thread context

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncCompletionStageExecutor.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncCompletionStageExecutor.java
@@ -13,6 +13,7 @@ package com.ibm.ws.microprofile.faulttolerance20.impl;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException;
@@ -39,9 +40,12 @@ public class AsyncCompletionStageExecutor<R> extends AsyncExecutor<CompletionSta
 
     private static final TraceComponent tc = Tr.register(AsyncCompletionStageExecutor.class);
 
+    private final ScheduledExecutorService executorService;
+
     public AsyncCompletionStageExecutor(RetryPolicy retry, CircuitBreakerPolicy cbPolicy, TimeoutPolicy timeoutPolicy, FallbackPolicy fallbackPolicy, BulkheadPolicy bulkheadPolicy,
                                         ScheduledExecutorService executorService, WSContextService contextService, MetricRecorder metricRecorder) {
         super(retry, cbPolicy, timeoutPolicy, fallbackPolicy, bulkheadPolicy, executorService, contextService, metricRecorder);
+        this.executorService = executorService;
     }
 
     @Override
@@ -51,6 +55,18 @@ public class AsyncCompletionStageExecutor<R> extends AsyncExecutor<CompletionSta
 
     @Override
     protected void setResult(AsyncExecutionContextImpl<CompletionStage<R>> executionContext, MethodResult<CompletionStage<R>> result) {
+
+        if (System.getSecurityManager() != null && Thread.currentThread() instanceof ForkJoinWorkerThread) {
+            // Workaround in case the user completes the result on a ForkJoin thread
+            // Note: user should _never_ be using ForkJoin threads but we'll try to handle this gracefully
+            // If a security manager is present, we won't be able to apply thread context so submit a new task to set the result
+            executorService.submit(() -> doSetResult(executionContext, result));
+        } else {
+            doSetResult(executionContext, result);
+        }
+    }
+
+    private void doSetResult(AsyncExecutionContextImpl<CompletionStage<R>> executionContext, MethodResult<CompletionStage<R>> result) {
         CompletableFuture<R> resultWrapper = (CompletableFuture<R>) executionContext.getResultWrapper();
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {


### PR DESCRIPTION
Fixes #6776 

* Catch and handle exceptions which occur when applying thread context before completing the result of an asynchronous method which returns a completion stage.
* Add a workaround for the fairly common (but not permitted) case where a completion stage is completed on a fork join thread and thread context cannot be applied if a security manager is present.