### PR TITLE
Issue 6822: Fail Automatic EJB Timers if no tables exist

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,10 +31,17 @@ task addEJBTools {
     copy {
       from configurations.ejbTools
       into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.timer.persistent.fat.NoDatasourceServer/lib/global"
+      rename 'com.ibm.ws.ejbcontainer.fat_tools-(.*).jar', 'com.ibm.ws.ejbcontainer.fat_tools.jar'
+    }
+    copy {
+      from configurations.ejbTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.timer.persistent.fat.NoTablesServer/lib/global"
+      rename 'com.ibm.ws.ejbcontainer.fat_tools-(.*).jar', 'com.ibm.ws.ejbcontainer.fat_tools.jar'
     }
   }
 }
 
 addRequiredLibraries {
   dependsOn addEJBTools
+  dependsOn addDerby
 }

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/FATSuite.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,11 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.ejbcontainer.timer.persistent.fat.tests.NoDatasourceTest;
+import com.ibm.ws.ejbcontainer.timer.persistent.fat.tests.NoTablesTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                NoDatasourceTest.class
+                NoDatasourceTest.class,
+                NoTablesTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/NoTablesTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/NoTablesTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.ejbcontainer.timer.persistent.fat.tests;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Test ejbPersistentTimer feature when a datasource tables have not been created.
+ */
+@RunWith(FATRunner.class)
+public class NoTablesTest extends FATServletClient {
+
+    private static final String CNTR0218E = "CNTR0218E.* " + "NoDBPersistAutoTimerEJB.jar";
+    private static final String CNTR4002E = "CNTR4002E.* " + "NoDBPersistAutoTimerEJB.jar.* " + "NoDBPersistAutoTimerApp";
+    private static final String CWWKZ0106E = "CWWKZ0106E.* " + "NoDBPersistAutoTimerApp";
+    private static final String CWWKZ0002E = "CWWKZ0002E.* " + "NoDBPersistAutoTimerApp";
+
+    @Server("com.ibm.ws.ejbcontainer.timer.persistent.fat.NoTablesServer")
+    public static LibertyServer server;
+
+    @After
+    public void cleanUp() throws Exception {
+        // clean up just in case the test fails and doesn't complete server stop.
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    protected void runTest(String servlet, String testName) throws Exception {
+        FATServletClient.runTest(server, servlet, testName);
+    }
+
+    /**
+     * Test that an application with persistent automatic EJB timers will not start with
+     * appropriate errors in the logs when the ejbPersistentTimer feature is enabled, but
+     * no tables have been created in the datasource.
+     */
+    @Test
+    @ExpectedFFDC({ "javax.persistence.PersistenceException", "com.ibm.ws.exception.RuntimeWarning", "com.ibm.ws.container.service.state.StateChangeException" })
+    public void testNoTablesPersistentAutoTimer() throws Exception {
+        // Start the server with no applications
+        server.startServer();
+        server.setMarkToEndOfLog();
+
+        // Use ShrinkHelper to build the ear and export to server dropins
+        JavaArchive NoDBPersistAutoTimerEJB = ShrinkHelper.buildJavaArchive("NoDBPersistAutoTimerEJB.jar", "com.ibm.ws.ejbcontainer.timer.nodb.pauto.ejb.");
+        EnterpriseArchive NoDBPersistAutoTimerApp = ShrinkWrap.create(EnterpriseArchive.class, "NoDBPersistAutoTimerApp.ear");
+        NoDBPersistAutoTimerApp.addAsModule(NoDBPersistAutoTimerEJB);
+        ShrinkHelper.exportToServer(server, "dropins", NoDBPersistAutoTimerApp);
+
+        // Verify the application failed to start with correct messages
+        assertNotNull(CNTR0218E, server.waitForStringInLogUsingMark(CNTR0218E)); // persistent timers not supported
+        assertNotNull(CNTR4002E, server.waitForStringInLogUsingMark(CNTR4002E)); // EJB module failed to start
+        assertNotNull(CWWKZ0106E, server.waitForStringInLogUsingMark(CWWKZ0106E)); // App failed to start
+        assertNotNull(CWWKZ0002E, server.waitForStringInLogUsingMark(CWWKZ0002E)); // Exception occurred starting app
+
+        // Verify an info message did NOT occur that persistent timers not configured
+        assertNull("CNTR4021I", server.verifyStringNotInLogUsingMark("CNTR4021I", 0));
+
+        // Stop the server and remove the application from dropins
+        server.stopServer(CNTR0218E, CNTR4002E, CWWKZ0106E, CWWKZ0002E);
+        assertTrue("NoDBPersistAutoTimerApp.ear not removed", server.removeDropinsApplications("NoDBPersistAutoTimerApp.ear"));
+    }
+
+}

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.persistent.fat.NoTablesServer/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.persistent.fat.NoTablesServer/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:EJBContainer=all

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.persistent.fat.NoTablesServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.persistent.fat.NoTablesServer/server.xml
@@ -1,0 +1,30 @@
+<server>
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>ejbLite-3.2</feature>
+        <feature>ejbPersistentTimer-3.2</feature>
+        <feature>componenttest-1.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <library id="DerbyLib" filesetRef="DerbyFileset"/>
+    <fileset id="DerbyFileset" dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+
+    <!-- Override default store to turn off createTables -->
+	<databaseStore id="defaultDatabaseStore" createTables="false" keyGenerationStrategy="SEQUENCE"/>
+
+	<!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
+	+    is required beyond a single server start, configure the databaseName with a file location such as:
+	+    databaseName="${shared.config.dir}/data/derbydb" --> 
+    <dataSource id="DefaultDataSource" jdbcDriverRef="DerbyEmbedded">
+        <properties.derby.embedded createDatabase="create" databaseName="memory:EJBTimerDB"/>
+    </dataSource>
+
+    <jdbcDriver id="DerbyEmbedded" libraryRef="DerbyLib"/>
+    
+    <!-- Increased due to filesystem access on our poor build/test infrastructure taking more than the default 2 minutes -->
+  	<transaction totalTranLifetimeTimeout="30m"/>
+	
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+</server>


### PR DESCRIPTION
Fixed the createProperty method on the DatabaseTaskStore to properly
return false only when the row exists in the database.

EJB Container will:
- true : know row was inserted, so create automatic timers
- false : know row already exists, so do nothing
- exception : fail application start since required timers cannot be created

Also, added a new test that verifies the exception case when
no tables exist in the database.

fixes #6822 