### PR TITLE
By default, Executor is configured to have 16 threads in the pool.

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/publish/shared/resources/hazelcast/hazelcast-localhost-only-multicastDisabled.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/shared/resources/hazelcast/hazelcast-localhost-only-multicastDisabled.xml
@@ -15,4 +15,7 @@
             </tcp-ip>
         </join>
     </network>
+    <executor-service name="default">
+        <pool-size>5</pool-size>
+    </executor-service>    
 </hazelcast>

--- a/dev/com.ibm.ws.session.cache_fat/publish/shared/resources/hazelcast/hazelcast-localhost-only.xml
+++ b/dev/com.ibm.ws.session.cache_fat/publish/shared/resources/hazelcast/hazelcast-localhost-only.xml
@@ -6,4 +6,7 @@
         <name>${hazelcast.group.name}</name>
         <password>dev-pass</password>
     </group>
+    <executor-service name="default">
+        <pool-size>5</pool-size>
+    </executor-service>    
 </hazelcast>


### PR DESCRIPTION
Change to 5 threads in the pool-size for z/OS test cases.
