### PR TITLE
Pull in changes for CXF-7992 to resolve memory leak in MP RC 1.2

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/proxy/MPAsyncInvocationInterceptorImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/proxy/MPAsyncInvocationInterceptorImpl.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.proxy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.jaxrs.model.ProviderInfo;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.microprofile.client.MicroProfileClientProviderFactory;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.eclipse.microprofile.rest.client.ext.AsyncInvocationInterceptor;
+import org.eclipse.microprofile.rest.client.ext.AsyncInvocationInterceptorFactory;
+
+public class MPAsyncInvocationInterceptorImpl extends AbstractPhaseInterceptor<Message> {
+    private static final Logger LOG = LogUtils.getL7dLogger(MPAsyncInvocationInterceptorImpl.class);
+
+    private final List<AsyncInvocationInterceptor> interceptors = new ArrayList<>();
+
+    MPAsyncInvocationInterceptorImpl(Message message) {
+        super(Phase.POST_MARSHAL);
+
+        MicroProfileClientProviderFactory factory = MicroProfileClientProviderFactory.getInstance(message);
+        List<ProviderInfo<Object>> aiiProviderList = 
+            factory.getAsyncInvocationInterceptorFactories();
+
+        for (ProviderInfo<Object> providerInfo: aiiProviderList) {
+            AsyncInvocationInterceptor aiInterceptor = 
+                ((AsyncInvocationInterceptorFactory) providerInfo.getProvider()).newInterceptor();
+            interceptors.add(0, aiInterceptor); // sort in reverse order
+        }
+    }
+
+    List<AsyncInvocationInterceptor> getInterceptors() {
+        return interceptors;
+    }
+
+    /** {@inheritDoc}*/
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        for (int i = interceptors.size() - 1; i >= 0; i--) {
+            try {
+                interceptors.get(i).prepareContext();
+            } catch (Throwable t) {
+                LOG.log(Level.WARNING, "ASYNC_INTERCEPTOR_EXCEPTION_PREPARE_CONTEXT", 
+                        new Object[]{interceptors.get(i).getClass().getName(), t});
+            }
+        }
+        message.getExchange().put(MPAsyncInvocationInterceptorImpl.class, this); //Liberty change
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/proxy/MPAsyncInvocationInterceptorPostAsyncImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/proxy/MPAsyncInvocationInterceptorPostAsyncImpl.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.proxy;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.eclipse.microprofile.rest.client.ext.AsyncInvocationInterceptor;
+
+
+public class MPAsyncInvocationInterceptorPostAsyncImpl extends AbstractPhaseInterceptor<Message> {
+    private static final Logger LOG = LogUtils.getL7dLogger(MPAsyncInvocationInterceptorPostAsyncImpl.class);
+//Liberty change start
+    public MPAsyncInvocationInterceptorPostAsyncImpl() {
+        super(Phase.PRE_PROTOCOL);
+    }
+
+    /** {@inheritDoc}*/
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        MPAsyncInvocationInterceptorImpl aiii = message.getExchange().get(MPAsyncInvocationInterceptorImpl.class);
+        if (aiii != null) {
+            List<AsyncInvocationInterceptor> interceptors = aiii.getInterceptors();
+            for (AsyncInvocationInterceptor interceptor : interceptors) {
+                try {
+                    interceptor.applyContext();
+                } catch (Throwable t) {
+                    LOG.log(Level.WARNING, "ASYNC_INTERCEPTOR_EXCEPTION_APPLY_CONTEXT", 
+                            new Object[]{interceptor.getClass().getName(), t});
+                }
+            }
+        }
+    }
+//Liberty change end
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/proxy/MPAsyncInvocationInterceptorRemoveContextImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/proxy/MPAsyncInvocationInterceptorRemoveContextImpl.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.proxy;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.eclipse.microprofile.rest.client.ext.AsyncInvocationInterceptor;
+
+public class MPAsyncInvocationInterceptorRemoveContextImpl extends AbstractPhaseInterceptor<Message> {
+    private static final Logger LOG = LogUtils.getL7dLogger(MPAsyncInvocationInterceptorRemoveContextImpl.class);
+//Liberty change start
+    public MPAsyncInvocationInterceptorRemoveContextImpl() {
+        super(Phase.POST_INVOKE);
+    }
+
+    /** {@inheritDoc}*/
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        MPAsyncInvocationInterceptorImpl aiii = message.getExchange().get(MPAsyncInvocationInterceptorImpl.class);
+        if (aiii != null) {
+            List<AsyncInvocationInterceptor> interceptors = aiii.getInterceptors();
+            for (AsyncInvocationInterceptor interceptor : interceptors) {
+                try {
+                    interceptor.removeContext();
+                } catch (Throwable t) {
+                    LOG.log(Level.WARNING, "ASYNC_INTERCEPTOR_EXCEPTION_REMOVE_CONTEXT", 
+                            new Object[]{interceptor.getClass().getName(), t});
+                }
+            }
+        }
+    }
+//Liberty change end
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
@@ -110,9 +110,8 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
                                        Configuration configuration, CDIInterceptorWrapper interceptorWrapper, 
                                        Object... varValues) {
         super(new LocalClientState(baseURI), loader, cri, isRoot, inheritHeaders, varValues);
-        cfg.getRequestContext().put(EXECUTOR_SERVICE_PROPERTY, executorService);
-        cfg.getRequestContext().putAll(configuration.getProperties());
         this.interceptorWrapper = interceptorWrapper;
+        init(executorService, configuration); //Liberty change
     }
 
     public MicroProfileClientProxyImpl(ClientState initialState, ClassLoader loader, ClassResourceInfo cri,
@@ -120,11 +119,21 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
                                        Configuration configuration, CDIInterceptorWrapper interceptorWrapper,
                                        Object... varValues) {
         super(initialState, loader, cri, isRoot, inheritHeaders, varValues);
-        cfg.getRequestContext().put(EXECUTOR_SERVICE_PROPERTY, executorService);
-        cfg.getRequestContext().putAll(configuration.getProperties());
         this.interceptorWrapper = interceptorWrapper;
+        init(executorService, configuration); //Liberty change
     }
     //CHECKSTYLE:ON
+
+    //Liberty change start
+    private void init(ExecutorService executorService, Configuration configuration) {
+        cfg.getRequestContext().put(EXECUTOR_SERVICE_PROPERTY, executorService);
+        cfg.getRequestContext().putAll(configuration.getProperties());
+
+        List<Interceptor<? extends Message>>inboundChain = cfg.getInInterceptors();
+        inboundChain.add(new MPAsyncInvocationInterceptorPostAsyncImpl());
+        inboundChain.add(new MPAsyncInvocationInterceptorRemoveContextImpl());
+    }
+    //Liberty change end
 
     @SuppressWarnings("unchecked")
     @Override
@@ -150,9 +159,6 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
                                    InvocationCallback<Object> asyncCallback) {
         MPAsyncInvocationInterceptorImpl aiiImpl = new MPAsyncInvocationInterceptorImpl(outMessage);
         outMessage.getInterceptorChain().add(aiiImpl);
-        List<Interceptor<? extends Message>>inboundChain = cfg.getInInterceptors();
-        inboundChain.add(new MPAsyncInvocationInterceptorPostAsyncImpl(aiiImpl.getInterceptors()));
-        inboundChain.add(new MPAsyncInvocationInterceptorRemoveContextImpl(aiiImpl.getInterceptors()));
 
         setTimeouts(cfg.getRequestContext());
         super.doInvokeAsync(ori, outMessage, asyncCallback);


### PR DESCRIPTION
Resolve memory leak when using Async methods in MP Rest Client 1.2 - this has not been released yet, so not a release bug.