### PR TITLE
change the metadata structure.

### DIFF
--- a/dev/com.ibm.ws.kernel.instrument.serialfilter.serverconfig/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter.serverconfig/bnd.bnd
@@ -16,6 +16,7 @@ Bundle-SymbolicName: com.ibm.ws.kernel.instrument.serialfilter.serverconfig
 Bundle-Description: Java Serialization Filter Server Configuration, version=${bVersion}
 
 Private-Package: \
+ com.ibm.ws.config.xml.internal.nester, \
  com.ibm.ws.kernel.instrument.serialfilter.serverconfig.internal.resources
 
 Export-Package: \
@@ -41,6 +42,7 @@ Include-Resource: \
     com.ibm.ws.kernel.instrument.serialfilter,\
     com.ibm.ws.kernel.service;version=latest,\
     com.ibm.ws.org.apache.felix.scr;version=latest, \
+    com.ibm.ws.config;version=latest, \
     com.ibm.ws.org.osgi.annotation.versioning;version=latest
 
 -testpath: \

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter.serverconfig/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter.serverconfig/resources/OSGI-INF/l10n/metatype.properties
@@ -18,8 +18,14 @@
 filter.config=Serial Filter
 filter.config.desc=Filter what classes can be deserialized by java.io.ObjectInputStream class. By default, all classes are permitted to be deserialized. 
 
-mode=Mode
-mode.desc=The filter operation to be used for specified Class or combination of Class and Method.
+filter.mode=Filter Mode
+filter.mode.desc=The filter operation to be used for specified Class or combination of Class and Method.
+
+filter.policy=Policy
+filter.policy.desc=The deserialization policy to be enforced. This value is effective when mode is set as Enforce.
+
+operation=Operation
+operation.desc=The filter operation for the specified class or class and method.
 permission=Permission
 permission.desc=The access permission to be enforced. This value is effective when mode is set as Enforce.
 class=Class

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter.serverconfig/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter.serverconfig/resources/OSGI-INF/metatype/metatype.xml
@@ -15,21 +15,41 @@
                    localization="OSGI-INF/l10n/metatype">
 
 <OCD id="com.ibm.ws.kernel.instrument.serialfilter.serverconfig" name="%filter.config" description="%filter.config.desc" ibm:alias="serialFilter" ibm:beta="true">
+    <AD id="filterMode" ibm:type="pid" ibm:flat="true" ibm:reference="com.ibm.ws.kernel.instrument.serialfilter.serverconfig.mode"
+            required="false" type="String" cardinality="2147483647" />
+    <AD id="policy" ibm:type="pid" ibm:flat="true" ibm:reference="com.ibm.ws.kernel.instrument.serialfilter.serverconfig.policy"
+            required="false" type="String" cardinality="2147483647" />
+</OCD>
+<Designate factoryPid="com.ibm.ws.kernel.instrument.serialfilter.serverconfig">
+    <Object ocdref="com.ibm.ws.kernel.instrument.serialfilter.serverconfig" />
+</Designate>
+
+<OCD id="com.ibm.ws.kernel.instrument.serialfilter.serverconfig.mode" name="%filter.mode" description="%filter.mode.desc">
     <AD id="class" name="%class" description="%class.desc" required="true" type="String"/>
     <AD id="method" name="%method" description="%method.desc" required="false" type="String"/>
-    <AD id="mode" name="%mode" description="%mode.desc" required="true" type="String" default="Enforce">
+    <AD id="operation" name="%operation" description="%operation.desc" required="true" type="String" default="Enforce">
             <Option label="%inactive" value="Inactive"/>
             <Option label="%discover" value="Discover"/>
             <Option label="%enforce" value="Enforce"/>
             <Option label="%reject" value="Reject"/>
     </AD>
-    <AD id="permission" name="%permission" description="%permission.desc" required="false" type="String">
+</OCD>
+
+<Designate factoryPid="com.ibm.ws.kernel.instrument.serialfilter.serverconfig.mode">
+    <Object ocdref="com.ibm.ws.kernel.instrument.serialfilter.serverconfig.mode" />
+</Designate>
+
+<OCD id="com.ibm.ws.kernel.instrument.serialfilter.serverconfig.policy" name="%filter.policy" description="%filter.policy.desc">
+    <AD id="class" name="%class" description="%class.desc" required="true" type="String"/>
+    <AD id="permission" name="%permission" description="%permission.desc" required="true" type="String" default="Allow">
             <Option label="%allow" value="Allow"/>
             <Option label="%deny" value="Deny"/>
-    </AD></OCD>
+    </AD>
 
-<Designate factoryPid="com.ibm.ws.kernel.instrument.serialfilter.serverconfig">
-    <Object ocdref="com.ibm.ws.kernel.instrument.serialfilter.serverconfig" />
+</OCD>
+
+<Designate factoryPid="com.ibm.ws.kernel.instrument.serialfilter.serverconfig.policy">
+    <Object ocdref="com.ibm.ws.kernel.instrument.serialfilter.serverconfig.policy" />
 </Designate>
 
 </metatype:MetaData>

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter.serverconfig/resources/com/ibm/ws/kernel/instrument/serialfilter/serverconfig/internal/resources/SerialFilterConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter.serverconfig/resources/com/ibm/ws/kernel/instrument/serialfilter/serverconfig/internal/resources/SerialFilterConfigMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -22,3 +22,12 @@
 SF_INFO_ENABLED=CWWKS8000I: WebSphere Application Server Serial Filter is enabled.
 SF_INFO_ENABLED.explanation=This message is for informational purposes only.
 SF_INFO_ENABLED.useraction=No action is required.
+SF_ERROR_NOT_ENABLED=CWWKS8070E: serialFilter element is ignored because WebSphere Application Server Serial Filter is not enabled.
+SF_ERROR_NOT_ENABLED.explanation=serialFilter element is ignored because required function is not enabled.
+SF_ERROR_NOT_ENABLED.useraction=Make sure that WebSphere Application Server Serial Filter is enabled.
+SF_WARNING_DUPLICATE_MODE=CWWKS8071W: The operation value ''{0}'' of class ''{1}'' method ''{2}'' is ignored because the value was already defined.
+SF_WARNING_DUPLICATE_MODE.explanation=The operation value of the specified class or class and method is already defined, and the duplicate definition is ignored.
+SF_WARNING_DUPLICATE_MODE.useraction=Check for multiple definitions in the filterMode attribute of serialFilter element in the server configuration. Delete duplicates.
+SF_WARNING_DUPLICATE_POLICY=CWWKS8072W: The permission value ''{0}'' of class ''{1}'' is ignored because the value was already defined.
+SF_WARNING_DUPLICATE_POLICY.explanation=The permission value of the specified class is already defined, and the duplicate definition is ignored.
+SF_WARNING_DUPLICATE_POLICY.useraction=Check for multiple definitions in the permisson attribute of serialFilter element in the server configuration. Delete duplicates.

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/fat/src/com/ibm/ws/kernel/instrument/serialfilter/fat/SerialFilterDisabledTest.java
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/fat/src/com/ibm/ws/kernel/instrument/serialfilter/fat/SerialFilterDisabledTest.java
@@ -68,7 +68,7 @@ public class SerialFilterDisabledTest extends FATServletClient {
     public static void cleanUp() throws Exception {
         restorePropFile(backupFile);
         if (server != null && server.isStarted()) {
-            server.stopServer();
+            server.stopServer("CWWKS8070E:");
         }
     }
 

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/fat/src/com/ibm/ws/kernel/instrument/serialfilter/fat/SerialFilterEnabledTest.java
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/fat/src/com/ibm/ws/kernel/instrument/serialfilter/fat/SerialFilterEnabledTest.java
@@ -87,10 +87,6 @@ public class SerialFilterEnabledTest extends FATServletClient {
 
         // update server.xml
         server.reconfigureServer("serverAllAllowed.xml");
-
-        server.resetLogMarks();
-        assertNotNull("The messages.log file should contain CWWKS8000I message.", server.waitForStringInLogUsingMark("CWWKS8000I"));
-
         server.setMarkToEndOfLog();
         String result = runTestWithResponse(server, SERVLET_NAME, "AllAllowed").toString();
         Log.info(this.getClass(), "AllAllowed", "AllAllowed returned: " + result);

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/fat/src/com/ibm/ws/kernel/instrument/serialfilter/fat/SerialFilterEnabledTest.java
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/fat/src/com/ibm/ws/kernel/instrument/serialfilter/fat/SerialFilterEnabledTest.java
@@ -76,7 +76,7 @@ public class SerialFilterEnabledTest extends FATServletClient {
     public static void cleanUp() throws Exception {
         restorePropFile(backupFile);
         if (server != null && server.isStarted()) {
-            server.stopServer("CWWKS8014E.*", "CWWKS8015E.*", "CWWKS8028E.*");
+            server.stopServer("CWWKS8014E.*", "CWWKS8015E.*", "CWWKS8028E.*", "CWWKS8071W.*", "CWWKS8072W.*");
         }
     }
 
@@ -169,6 +169,39 @@ public class SerialFilterEnabledTest extends FATServletClient {
         Log.info(this.getClass(), "testCallerMethodDenied", "AllAllowed returned: " + result);
         assertTrue("The result should be SUCCESS", result.contains("SUCCESS"));
         assertNull("The messages.log file should not contain CWWKS8028E message.", server.waitForStringInLogUsingMark("CWWKS8028E:", 1000));
+    }
+
+    @Mode(TestMode.LITE)
+    @Test
+    @AllowedFFDC(value = { "com.ibm.ws.kernel.productinfo.ProductInfoParseException" })
+    public void testDuplicateMode() throws Exception {
+        // update server.xml
+        server.setMarkToEndOfLog();
+        server.reconfigureServer("serverDuplicateMode.xml");
+        assertNotNull("The messages.log file should contain CWWKS8071W.",
+                      server.waitForStringInLogUsingMark("CWWKS8071W:.*Enforce.*duplicateClass.*", 5000));
+    }
+
+    @Mode(TestMode.LITE)
+    @Test
+    @AllowedFFDC(value = { "com.ibm.ws.kernel.productinfo.ProductInfoParseException" })
+    public void testDuplicateModeWithMethod() throws Exception {
+        // update server.xml
+        server.setMarkToEndOfLog();
+        server.reconfigureServer("serverDuplicateMode2.xml");
+        assertNotNull("The messages.log file should contain CWWKS8071W.",
+                      server.waitForStringInLogUsingMark("CWWKS8071W:.*Enforce.*duplicateClass.*duplicateMethod.*", 5000));
+    }
+
+    @Mode(TestMode.LITE)
+    @Test
+    @AllowedFFDC(value = { "com.ibm.ws.kernel.productinfo.ProductInfoParseException" })
+    public void testDuplicatePolicy() throws Exception {
+        // update server.xml
+        server.setMarkToEndOfLog();
+        server.reconfigureServer("serverDuplicatePolicy.xml");
+        assertNotNull("The messages.log file should contain CWWKS8072W.",
+                      server.waitForStringInLogUsingMark("CWWKS8072W:.*Deny.*duplicateClass.*", 5000));
     }
 
     private static String backupPropFile() throws Exception {

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverAllAllowed.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverAllAllowed.xml
@@ -6,5 +6,10 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
     
-    <serialFilter class="*" permission="Allow" mode="Enforce"/>
+    <serialFilter>
+    <!--  default values will be used -->
+        <policy class="*"/>
+        <filterMode class="*"/>
+    </serialFilter>
+    
 </server>

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverAllRejected.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverAllRejected.xml
@@ -6,5 +6,8 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
     
-    <serialFilter class="*" mode="Reject"/>
+    <serialFilter>
+        <filterMode class="*" operation="Reject"/>
+    </serialFilter>
+
 </server>

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverCallerMethodDenied.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverCallerMethodDenied.xml
@@ -6,6 +6,10 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
     
-    <serialFilter class="*" permission="Allow" mode="Enforce"/>
-    <serialFilter class="com.ibm.ws.serialfilter.fat.web.SerialFilterTestServlet" method="ProhibitedCaller" mode="Reject"/>
+    <serialFilter>
+        <filterMode class="*" operation="Enforce"/>
+        <filterMode class="com.ibm.ws.serialfilter.fat.web.SerialFilterTestServlet" method="ProhibitedCaller" operation="Reject"/>
+        <policy class="*" permission="Allow"/>
+    </serialFilter>
+
 </server>

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverDuplicateMode.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverDuplicateMode.xml
@@ -6,12 +6,11 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
     
-    <serialFilter class="com.ibm.ws.serialfilter.fat.object.*" permission="Allow"/>
     <serialFilter>
-        <!-- default value "Enforce" will be used -->
-        <filterMode class="*"/>
         <policy class="*" permission="Deny"/>
-        <policy class="com.ibm.ws.serialfilter.fat.object.*" permission="Allow"/>
+        <filterMode class="*" operation="Enforce"/>
+        <!-- duplicate filterMode -->        
+        <filterMode class="duplicateClass" operation="Enforce"/>
+        <filterMode class="duplicateClass" operation="Enforce"/>
     </serialFilter>
-    
 </server>

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverDuplicateMode2.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverDuplicateMode2.xml
@@ -6,12 +6,11 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
     
-    <serialFilter class="com.ibm.ws.serialfilter.fat.object.*" permission="Allow"/>
     <serialFilter>
-        <!-- default value "Enforce" will be used -->
-        <filterMode class="*"/>
         <policy class="*" permission="Deny"/>
-        <policy class="com.ibm.ws.serialfilter.fat.object.*" permission="Allow"/>
+        <filterMode class="*" operation="Enforce"/>
+        <!-- duplicate filterMode -->        
+        <filterMode class="duplicateClass" method = "duplicateMethod" operation="Enforce"/>
+        <filterMode class="duplicateClass" method = "duplicateMethod" operation="Enforce"/>
     </serialFilter>
-    
 </server>

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverDuplicatePolicy.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverDuplicatePolicy.xml
@@ -6,12 +6,11 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
     
-    <serialFilter class="com.ibm.ws.serialfilter.fat.object.*" permission="Allow"/>
     <serialFilter>
-        <!-- default value "Enforce" will be used -->
-        <filterMode class="*"/>
         <policy class="*" permission="Deny"/>
-        <policy class="com.ibm.ws.serialfilter.fat.object.*" permission="Allow"/>
+        <filterMode class="*" operation="Enforce"/>
+        <!-- duplicate policy -->        
+        <policy class="com.ibm.duplicateClass.*" permission="Deny"/>
+        <policy class="com.ibm.duplicateClass.*" permission="Deny"/>
     </serialFilter>
-    
 </server>

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverTest1Allowed.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverTest1Allowed.xml
@@ -6,7 +6,11 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
     
-    <serialFilter class="*" permission="Deny" mode="Enforce"/>
-    <serialFilter class="com.ibm.ws.serialfilter.fat.object.allowed.Test1" mode="Enforce" permission="Allow"/>
-    
+    <serialFilter>
+        <policy class="*" permission="Deny"/>
+        <filterMode class="*" operation="Enforce"/>
+        <!-- default value "Allow" will be used -->        
+        <policy class="com.ibm.ws.serialfilter.fat.object.allowed.Test1"/>
+        <filterMode class="com.ibm.ws.serialfilter.fat.object.allowed.Test1" operation="Enforce"/>
+    </serialFilter>
 </server>

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverTest1And2Allowed.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/files/serverTest1And2Allowed.xml
@@ -6,7 +6,10 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
     
-    <serialFilter class="*" mode="Enforce" permission="Deny"/>
-    <serialFilter class="com.ibm.ws.serialfilter.fat.object.allowed.*" permission="Allow"/>
+    <serialFilter>
+        <filterMode class="*" operation="Enforce"/>
+        <policy class="*" permission="Deny"/>
+        <policy class="com.ibm.ws.serialfilter.fat.object.allowed.*" permission="Allow"/>
+    </serialFilter>
     
 </server>

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/servers/com.ibm.ws.kernel.instrument.serialfilter.fat.SerialFilterDisabled/server.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/servers/com.ibm.ws.kernel.instrument.serialfilter.fat.SerialFilterDisabled/server.xml
@@ -6,6 +6,9 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
 
-    <serialFilter class="*" permission="Deny" mode="Enforce"/>
-    <serialFilter class="com.ibm.ws.serialfilter.fat.object.Test1" permission="Allow" mode="Enforce"/>
+    <serialFilter>
+        <policy class="*" permission="Deny"/>
+        <filterMode class="*" operation="Enforce"/>
+    </serialFilter>
+    
 </server>

--- a/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/servers/com.ibm.ws.kernel.instrument.serialfilter.fat.SerialFilterEnabled/server.xml
+++ b/dev/com.ibm.ws.kernel.instrument.serialfilter_fat/publish/servers/com.ibm.ws.kernel.instrument.serialfilter.fat.SerialFilterEnabled/server.xml
@@ -6,6 +6,4 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
 
-    <serialFilter class="*" permission="Deny" mode="Enforce"/>
-    <serialFilter class="com.ibm.ws.serialfilter.fat.object.Test1" permission="Allow" mode="Enforce"/>
 </server>


### PR DESCRIPTION
The format of the metadata of serialFilter needs to be changed. Instead of using multiple element to specify multiple filter mode and permission, use serialFilter as an enclosure and introduce filterMode and policy element to specify filter mode and permission respectively. 