### PR TITLE
6761 - fix javax.ws.rs.ext.ParamConverter not working for collection …

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/.classpath
@@ -17,6 +17,7 @@
 	<classpathentry kind="src" path="test-applications/jackson/src"/>
 	<classpathentry kind="src" path="test-applications/jacksonJsonIgnore/src"/>
 	<classpathentry kind="src" path="test-applications/json/src"/>
+	<classpathentry kind="src" path="test-applications/paramconverter/src"/>
 	<classpathentry kind="src" path="test-applications/params/src"/>
 	<classpathentry kind="src" path="test-applications/providerAndResource/src"/>
 	<classpathentry kind="src" path="test-applications/providerCache/src"/>

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
@@ -29,6 +29,7 @@ src: \
   test-applications/jackson/src,\
   test-applications/jacksonJsonIgnore/src,\
   test-applications/json/src,\
+  test-applications/paramconverter/src,\
   test-applications/params/src,\
   test-applications/providerAndResource/src,\
   test-applications/providerCache/src,\
@@ -58,6 +59,7 @@ tested.features: \
   com.ibm.websphere.javaee.cdi.1.2,\
   com.ibm.websphere.javaee.ejb.3.2,\
   com.ibm.websphere.javaee.jaxrs.2.0,\
+  com.ibm.websphere.javaee.jsonb.1.0,\
   com.ibm.websphere.javaee.servlet.3.1,\
   com.ibm.websphere.javaee.validation.1.1,\
   com.ibm.ws.jaxrs.2.0.common;version=latest,\

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
@@ -37,6 +37,7 @@ import com.ibm.ws.jaxrs20.fat.jackson1x.JacksonPOJOwithUserJacksonLib1xTest;
 import com.ibm.ws.jaxrs20.fat.jackson2x.JacksonPOJOwithUserJacksonLib2xTest;
 import com.ibm.ws.jaxrs20.fat.jacksonJsonIgnore.JacksonJsonIgnoreTest;
 import com.ibm.ws.jaxrs20.fat.json.UTF8Test;
+import com.ibm.ws.jaxrs20.fat.paramconverter.ParamConverterTest;
 import com.ibm.ws.jaxrs20.fat.params.ParamsTest;
 import com.ibm.ws.jaxrs20.fat.providercache.ProviderCacheTest;
 import com.ibm.ws.jaxrs20.fat.readerwriterprovider.ReaderWriterProvidersTest;
@@ -83,6 +84,7 @@ import componenttest.rules.repeater.RepeatTests;
                 JAXRSValidationDisabledTest.class,
                 JAXRSWebContainerTest.class,
                 JerseyTest.class,
+                ParamConverterTest.class,
                 ParamsTest.class,
                 ProviderCacheTest.class,
                 ReaderWriterProvidersTest.class,

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/paramconverter/ParamConverterTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/paramconverter/ParamConverterTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.fat.paramconverter;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jaxrs.fat.paramconverter.ClientTestServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class ParamConverterTest extends FATServletClient {
+
+    private static final String app = "paramconverter";
+
+    @Server("com.ibm.ws.jaxrs.fat.paramconverter")
+    @TestServlet(servlet = ClientTestServlet.class, contextRoot = app)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, app, "com.ibm.ws.jaxrs.fat.paramconverter",
+                                      "com.ibm.ws.jaxrs.fat.paramconverter.annotations",
+                                      "com.ibm.ws.jaxrs.fat.paramconverter.objects");
+
+        // Make sure we don't fail because we try to start an
+        // already started server
+        try {
+            server.startServer(true);
+        } catch (Exception e) {
+            System.out.println(e.toString());
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null) {
+            server.stopServer();
+        }
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.paramconverter/.gitignore
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.paramconverter/.gitignore
@@ -1,0 +1,1 @@
+/dropins

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.paramconverter/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.paramconverter/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.max.file.size=0
+
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.paramconverter/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.paramconverter/server.xml
@@ -1,0 +1,11 @@
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>jaxrs-2.0</feature>
+    </featureManager>
+    
+ 
+  	<include location="../fatTestPorts.xml"/>
+  	<javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
+
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/ClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/ClientTestServlet.java
@@ -1,0 +1,246 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.ibm.ws.jaxrs.fat.paramconverter.objects.TestListObject;
+import com.ibm.ws.jaxrs.fat.paramconverter.objects.TestObject;
+
+import componenttest.app.FATServlet;
+
+@WebServlet(urlPatterns = "/ClientTestServlet")
+public class ClientTestServlet extends FATServlet {
+
+    private static final long serialVersionUID = 4563445389586844836L;
+
+    final static String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/paramconverter/";
+
+    private Client client;
+
+    @Override
+    public void init() throws ServletException {
+        client = ClientBuilder.newClient();
+    }
+
+    @After
+    private void teardown() {
+        client.close();
+    }
+
+    @Test
+    public void testStringArrayParamConverter() throws Exception {
+
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/stringarray")
+                        .queryParam("ids", "a,b,c")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        String[] actual = response.readEntity(String[].class);
+
+        Object expected = Array.newInstance(String.class, 3);
+        ((String[]) expected)[0] = "a";
+        ((String[]) expected)[1] = "b";
+        ((String[]) expected)[2] = "c";
+
+        for (int i = 0; i < 3; i++) {
+            assertEquals("expected: " + ((String[]) expected)[i] + " actual: " + actual[i], ((String[]) expected)[i], actual[i]);
+        }
+    }
+
+    @Test
+    public void testStringListParamConverter() throws Exception {
+
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/stringlist")
+                        .queryParam("ids", "a,b,c")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        List<String> actual = response.readEntity(new GenericType<List<String>>() {});
+
+        List<String> expected = new ArrayList<String>();
+        expected.add("a");
+        expected.add("b");
+        expected.add("c");
+
+        assertEquals("expected: " + expected + " actual: " + actual, expected, actual);
+    }
+
+    @Test
+    public void testStringSetParamConverter() throws Exception {
+
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/stringset")
+                        .queryParam("ids", "a,b,c")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        Set<String> actual = response.readEntity(new GenericType<Set<String>>() {});
+
+        Set<String> expected = new HashSet<String>();
+        expected.add("a");
+        expected.add("b");
+        expected.add("c");
+
+        assertEquals("expected: " + expected + " actual: " + actual, expected, actual);
+    }
+
+    @Test
+    public void testStringSortedSetParamConverter() throws Exception {
+
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/stringset")
+                        .queryParam("ids", "a,b,c")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        Set<String> actual = response.readEntity(new GenericType<SortedSet<String>>() {});
+
+        Set<String> expected = new TreeSet<String>();
+        expected.add("a");
+        expected.add("b");
+        expected.add("c");
+
+        assertEquals("expected: " + expected + " actual: " + actual, expected, actual);
+    }
+
+    @Test
+    public void testStringMapParamConverter() throws Exception {
+
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/stringmap")
+                        .queryParam("ids", "overwrittenbyconverter")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        Map<String, String> actual = response.readEntity(new GenericType<Map<String, String>>() {});
+
+        Map<String, String> expected = new HashMap<String, String>();
+        expected.put("a", "3");
+        expected.put("b", "1");
+        expected.put("c", "2");
+
+        assertEquals("expected: " + expected + " actual: " + actual, expected, actual);
+    }
+
+    @Test
+    public void testMultiParameters() throws Exception {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/multiparam")
+                        .queryParam("list", "a,b,c")
+                        .queryParam("set", "1,2,3")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        String expected = "[a, b, c],[1, 2, 3]";
+        String actual = response.readEntity(String.class);
+        assertEquals("expected: " + expected + " actual: " + actual, expected, actual);
+    }
+
+    // negative test when user mis specifies the @QueryParam(id), object should come back null, shouldn't blow up code
+    @Test
+    public void testBadQueryParamId() throws Exception {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/stringset")
+                        .queryParam("bad", "a,b,c")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        String expected = "";
+        String actual = response.readEntity(String.class);
+        assertEquals("expected: " + expected + " actual: " + actual, expected, actual);
+    }
+
+    @Test
+    public void testObject() throws Exception {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/testobject")
+                        .queryParam("object", "testobject")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        TestObject actual = response.readEntity(TestObject.class);
+        String expected = "testobject";
+        assertEquals("expected: " + expected + " actual: " + actual.content, expected, actual.content);
+    }
+
+    @Test
+    public void testListObject() throws Exception {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/testlistobject")
+                        .queryParam("object", "a,b,c")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+        TestListObject actual = response.readEntity(TestListObject.class);
+
+        TestListObject expected = new TestListObject();
+        expected.add("a");
+        expected.add("b");
+        expected.add("c");
+
+        assertEquals("expected: " + expected + " actual: " + actual, expected, actual);
+    }
+
+    @Test
+    public void testNoPublicConstructorObject() throws Exception {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/nopublicconstructorobject")
+                        .queryParam("object", "nopublicconstructor")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+
+        // return a string because jaxrs-2.1 blows up trying to read the json object with a private constructor
+        String actual = response.readEntity(String.class);
+        String expected = "nopublicconstructor";
+        assertEquals("expected: " + expected + " actual: " + actual, expected, actual);
+    }
+
+    @Test
+    public void testNoPublicConstructorListObject() throws Exception {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("application/resource/nopublicconstructorlistobject")
+                        .queryParam("object", "a,b,c")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+        assertEquals(200, response.getStatus());
+
+        // return a string because jaxrs-2.1 blows up trying to read the json object with a private constructor
+        String actual = response.readEntity(String.class);
+        String expected = "abc";
+        assertEquals("expected: " + expected + " actual: " + actual, expected, actual);
+    }
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/TestApplication.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/TestApplication.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("application")
+public class TestApplication extends Application {
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/TestParamConverterProvider.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/TestParamConverterProvider.java
@@ -1,0 +1,275 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import javax.ws.rs.ext.Provider;
+
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.NoPublicConstructorListObjectParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.NoPublicConstructorObjectParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.StringArrayParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.StringListParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.StringMapParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.StringSetParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.StringSortedSetParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.TestListObjectParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.TestObjectParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.objects.NoPublicConstructorListObject;
+import com.ibm.ws.jaxrs.fat.paramconverter.objects.NoPublicConstructorObject;
+import com.ibm.ws.jaxrs.fat.paramconverter.objects.TestListObject;
+import com.ibm.ws.jaxrs.fat.paramconverter.objects.TestObject;
+
+@Provider
+public class TestParamConverterProvider implements ParamConverterProvider {
+
+    private static class StringArrayParamConverter implements ParamConverter<String[]> {
+        static final StringArrayParamConverter INSTANCE = new StringArrayParamConverter();
+
+        @Override
+        public String[] fromString(final String value) {
+            System.out.println("StringArrayParamConverter.fromString() value=" + value);
+            return value.split(",");
+        }
+
+        @Override
+        public String toString(final String[] value) {
+            String string = "";
+            for (String s : value) {
+                if (string == "") {
+                    string = s;
+                } else {
+                    string += "," + s;
+                }
+            }
+            return string;
+        }
+    }
+
+    private static class StringListParamConverter implements ParamConverter<List<String>> {
+        static final StringListParamConverter INSTANCE = new StringListParamConverter();
+
+        @Override
+        public List<String> fromString(final String value) {
+            System.out.println("StringListParamConverter.fromString() value=" + value);
+            return Arrays.asList(value.split(","));
+        }
+
+        @Override
+        public String toString(final List<String> value) {
+            String string = "";
+            for (String s : value) {
+                if (string == "") {
+                    string = s;
+                } else {
+                    string += "," + s;
+                }
+            }
+            return string;
+        }
+    }
+
+    private static class StringSetParamConverter implements ParamConverter<Set<String>> {
+        static final StringSetParamConverter INSTANCE = new StringSetParamConverter();
+
+        @Override
+        public Set<String> fromString(final String value) {
+            System.out.println("StringSetParamConverter.fromString() value=" + value);
+            return new HashSet<String>(Arrays.asList(value.split(",")));
+        }
+
+        @Override
+        public String toString(final Set<String> value) {
+            String string = "";
+            for (String s : value) {
+                if (string == "") {
+                    string = s;
+                } else {
+                    string += "," + s;
+                }
+            }
+            return string;
+        }
+    }
+
+    private static class StringSortedSetParamConverter implements ParamConverter<SortedSet<String>> {
+        static final StringSortedSetParamConverter INSTANCE = new StringSortedSetParamConverter();
+
+        @Override
+        public SortedSet<String> fromString(final String value) {
+            System.out.println("StringSortedSetParamConverter.fromString() value=" + value);
+            return new TreeSet<String>(Arrays.asList(value.split(",")));
+        }
+
+        @Override
+        public String toString(final SortedSet<String> value) {
+            String string = "";
+            for (String s : value) {
+                if (string == "") {
+                    string = s;
+                } else {
+                    string += "," + s;
+                }
+            }
+            return string;
+        }
+    }
+
+    private static class StringMapParamConverter implements ParamConverter<Map<String, String>> {
+        static final StringMapParamConverter INSTANCE = new StringMapParamConverter();
+
+        @Override
+        public Map<String, String> fromString(final String value) {
+            System.out.println("StringMapParamConverter.fromString() value=" + value);
+            Map<String, String> map = new HashMap<String, String>();
+            map.put("a", "3");
+            map.put("b", "1");
+            map.put("c", "2");
+            return map;
+        }
+
+        @Override
+        public String toString(final Map<String, String> value) {
+            String string = "";
+            return string;
+        }
+    }
+
+    private static class TestObjectParamConverter implements ParamConverter<TestObject> {
+        static final TestObjectParamConverter INSTANCE = new TestObjectParamConverter();
+
+        @Override
+        public TestObject fromString(final String value) {
+            System.out.println("TestObjectParamConverter.fromString() value=" + value);
+            TestObject obj = new TestObject();
+            obj.content = value;
+            return obj;
+        }
+
+        @Override
+        public String toString(final TestObject value) {
+            return value.content;
+        }
+    }
+
+    private static class TestListObjectParamConverter implements ParamConverter<TestListObject> {
+        static final TestListObjectParamConverter INSTANCE = new TestListObjectParamConverter();
+
+        @Override
+        public TestListObject fromString(final String value) {
+            System.out.println("TestListObjectParamConverter.fromString() value=" + value);
+            TestListObject obj = new TestListObject();
+            String[] values = value.split(",");
+            for (String v : values) {
+                obj.add(v);
+            }
+            return obj;
+        }
+
+        @Override
+        public String toString(final TestListObject value) {
+            String string = "";
+            for (String s : value) {
+                if (string == "") {
+                    string = s;
+                } else {
+                    string += "," + s;
+                }
+            }
+            return string;
+        }
+    }
+
+    private static class NoPublicConstructorObjectParamConverter implements ParamConverter<NoPublicConstructorObject> {
+        static final NoPublicConstructorObjectParamConverter INSTANCE = new NoPublicConstructorObjectParamConverter();
+
+        @Override
+        public NoPublicConstructorObject fromString(final String value) {
+            System.out.println("NoPublicConstructorObjectParamConverter.fromString() value=" + value);
+            NoPublicConstructorObject obj = NoPublicConstructorObject.getInstance();
+            obj.content = value;
+            return obj;
+        }
+
+        @Override
+        public String toString(final NoPublicConstructorObject value) {
+            return value.content;
+        }
+    }
+
+    private static class NoPublicConstructorListObjectParamConverter implements ParamConverter<NoPublicConstructorListObject> {
+        static final NoPublicConstructorListObjectParamConverter INSTANCE = new NoPublicConstructorListObjectParamConverter();
+
+        @Override
+        public NoPublicConstructorListObject fromString(final String value) {
+            System.out.println("NoPublicConstructorListObjectParamConverter.fromString() value=" + value);
+            NoPublicConstructorListObject obj = NoPublicConstructorListObject.getInstance();
+            String[] values = value.split(",");
+            for (String v : values) {
+                obj.add(v);
+            }
+            return obj;
+        }
+
+        @Override
+        public String toString(final NoPublicConstructorListObject value) {
+            String string = "";
+            for (String s : value) {
+                if (string == "") {
+                    string = s;
+                } else {
+                    string += "," + s;
+                }
+            }
+            return string;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType, final Annotation[] annotations) {
+        System.out.println("TestParamConverterProvider.getConverter rawType=" + rawType);
+        System.out.println("TestParamConverterProvider.getConverter genericType=" + genericType);
+        for (final Annotation annotation : annotations) {
+            if (StringArrayParam.class.isInstance(annotation)) {
+                return (ParamConverter<T>) StringArrayParamConverter.INSTANCE;
+            } else if (StringListParam.class.isInstance(annotation)) {
+                return (ParamConverter<T>) StringListParamConverter.INSTANCE;
+            } else if (StringSetParam.class.isInstance(annotation)) {
+                return (ParamConverter<T>) StringSetParamConverter.INSTANCE;
+            } else if (StringSortedSetParam.class.isInstance(annotation)) {
+                return (ParamConverter<T>) StringSortedSetParamConverter.INSTANCE;
+            } else if (StringMapParam.class.isInstance(annotation)) {
+                return (ParamConverter<T>) StringMapParamConverter.INSTANCE;
+            } else if (TestObjectParam.class.isInstance(annotation)) {
+                return (ParamConverter<T>) TestObjectParamConverter.INSTANCE;
+            } else if (TestListObjectParam.class.isInstance(annotation)) {
+                return (ParamConverter<T>) TestListObjectParamConverter.INSTANCE;
+            } else if (NoPublicConstructorObjectParam.class.isInstance(annotation)) {
+                return (ParamConverter<T>) NoPublicConstructorObjectParamConverter.INSTANCE;
+            } else if (NoPublicConstructorListObjectParam.class.isInstance(annotation)) {
+                return (ParamConverter<T>) NoPublicConstructorListObjectParamConverter.INSTANCE;
+            }
+        }
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/TestResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/TestResource.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.NoPublicConstructorListObjectParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.NoPublicConstructorObjectParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.StringArrayParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.StringListParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.StringMapParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.StringSetParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.TestListObjectParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.annotations.TestObjectParam;
+import com.ibm.ws.jaxrs.fat.paramconverter.objects.NoPublicConstructorListObject;
+import com.ibm.ws.jaxrs.fat.paramconverter.objects.NoPublicConstructorObject;
+import com.ibm.ws.jaxrs.fat.paramconverter.objects.TestListObject;
+import com.ibm.ws.jaxrs.fat.paramconverter.objects.TestObject;
+
+@Path("resource")
+@Produces(MediaType.APPLICATION_JSON)
+public class TestResource {
+
+    @GET
+    @Path("stringarray")
+    public Response stringArrayParam(@QueryParam("ids") @StringArrayParam final String[] ids) {
+        System.out.println("stringArrayParam ids=" + ids);
+        return Response.ok(ids).build();
+    }
+
+    @GET
+    @Path("stringlist")
+    public Response stringListParam(@QueryParam("ids") @StringListParam final List<String> ids) {
+        System.out.println("stringListParam stringListParam ids=");
+        for (String id : ids) {
+            System.out.println("\"" + id + "\"");
+        }
+        return Response.ok(ids).build();
+    }
+
+    @GET
+    @Path("stringset")
+    public Response stringSetParam(@QueryParam("ids") @StringSetParam final Set<String> ids) {
+        System.out.println("stringSetParam ids=" + ids);
+        return Response.ok(ids).build();
+    }
+
+    @GET
+    @Path("stringsortedset")
+    public Response stringSortedSetParam(@QueryParam("ids") @StringSetParam final SortedSet<String> ids) {
+        System.out.println("stringSortedSetParam ids=" + ids);
+        return Response.ok(ids).build();
+    }
+
+    @GET
+    @Path("stringmap")
+    public Response stringMapParam(@QueryParam("ids") @StringMapParam final Map<String, String> ids) {
+        System.out.println("stringMapParam ids=" + ids);
+        return Response.ok(ids).build();
+    }
+
+    @GET
+    @Path("multiparam")
+    public Response multiParams(@QueryParam("list") @StringListParam final List<String> list,
+                                @QueryParam("set") @StringSetParam final Set<String> set) {
+        System.out.println("multiParams list=" + list);
+        System.out.println("multiParams set=" + set);
+        return Response.ok(list.toString() + "," + set.toString()).build();
+    }
+
+    @GET
+    @Path("testobject")
+    public Response testObject(@QueryParam("object") @TestObjectParam final TestObject object) {
+        System.out.println("testObject ids=" + object.content);
+        return Response.ok(object).build();
+    }
+
+    @GET
+    @Path("testlistobject")
+    public Response testListObject(@QueryParam("object") @TestListObjectParam final TestListObject object) {
+        System.out.println("testListObject ids=" + object);
+        return Response.ok(object).build();
+    }
+
+    @GET
+    @Path("nopublicconstructorobject")
+    public Response noPublicConstructorObject(@QueryParam("object") @NoPublicConstructorObjectParam final NoPublicConstructorObject object) {
+        System.out.println("noPublicConstructorObject ids=" + object.content);
+        return Response.ok(object.content).build();
+    }
+
+    @GET
+    @Path("nopublicconstructorlistobject")
+    public Response noPublicConstructorListObject(@QueryParam("object") @NoPublicConstructorListObjectParam final NoPublicConstructorListObject object) {
+        System.out.println("noPublicConstructorListObject ids=" + object);
+        String string = "";
+        for (String s : object) {
+            string += s;
+        }
+        return Response.ok(string).build();
+    }
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/TestStringList.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/TestStringList.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter;
+
+import java.util.ArrayList;
+
+// this tests a custom Collection with a non public constructor
+public class TestStringList extends ArrayList<String> {
+
+    private static final long serialVersionUID = 2345673566345656425L;
+
+    public static TestStringList newInstance() {
+        return new TestStringList();
+    }
+
+    private TestStringList() {
+        super();
+    }
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/NoPublicConstructorListObjectParam.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/NoPublicConstructorListObjectParam.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+public @interface NoPublicConstructorListObjectParam {
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/NoPublicConstructorObjectParam.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/NoPublicConstructorObjectParam.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+public @interface NoPublicConstructorObjectParam {
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/StringArrayParam.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/StringArrayParam.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+public @interface StringArrayParam {
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/StringListParam.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/StringListParam.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+public @interface StringListParam {
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/StringMapParam.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/StringMapParam.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+public @interface StringMapParam {
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/StringSetParam.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/StringSetParam.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+public @interface StringSetParam {
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/StringSortedSetParam.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/StringSortedSetParam.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+public @interface StringSortedSetParam {
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/TestListObjectParam.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/TestListObjectParam.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+public @interface TestListObjectParam {
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/TestObjectParam.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/annotations/TestObjectParam.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+public @interface TestObjectParam {
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/objects/NoPublicConstructorListObject.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/objects/NoPublicConstructorListObject.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.objects;
+
+import java.util.ArrayList;
+
+public class NoPublicConstructorListObject extends ArrayList<String> {
+
+    private static final long serialVersionUID = 646543532165146L;
+
+    public static NoPublicConstructorListObject getInstance() {
+        return new NoPublicConstructorListObject();
+    }
+
+    private NoPublicConstructorListObject() {
+        super();
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/objects/NoPublicConstructorObject.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/objects/NoPublicConstructorObject.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.objects;
+
+public class NoPublicConstructorObject {
+
+    public String content = "";
+
+    public static NoPublicConstructorObject getInstance() {
+        return new NoPublicConstructorObject();
+    }
+
+    private NoPublicConstructorObject() {}
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/objects/TestListObject.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/objects/TestListObject.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.objects;
+
+import java.util.ArrayList;
+
+public class TestListObject extends ArrayList<String>{
+
+    private static final long serialVersionUID = 234967884234L;
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/objects/TestObject.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/paramconverter/src/com/ibm/ws/jaxrs/fat/paramconverter/objects/TestObject.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.paramconverter.objects;
+
+public class TestObject {
+
+    public String content = "";
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/InjectionUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/InjectionUtils.java
@@ -1001,6 +1001,7 @@ public final class InjectionUtils {
     }
 
     //CHECKSTYLE:OFF
+    @FFDCIgnore(value = { IndexOutOfBoundsException.class }) // Liberty Change
     private static Object injectIntoCollectionOrArray(Class<?> rawType,
                                                       Type genericType,
                                                       Annotation[] paramAnns,
@@ -1008,6 +1009,27 @@ public final class InjectionUtils {
                                                       boolean isbean, boolean decoded,
                                                       ParameterType pathParam, Message message) {
         //CHECKSTYLE:ON
+        // Liberty change start
+        ParamConverter<?> pm = null;
+        if (message != null) {
+            ServerProviderFactory pf = ServerProviderFactory.getInstance(message);
+            pm = pf.createParameterHandler(rawType, genericType, paramAnns, message);
+            if (pm != null) {
+                if (tc.isDebugEnabled() && values.size() > 1) {
+                    Tr.debug(tc, "injectIntoCollectionOrArray unexpected: size of values > 1, values.size()=" + values.size());
+                }
+                for (Map.Entry<String, List<String>> entry : values.entrySet()) {
+                    // always only ever 1?
+                    // if a user specifies the wrong id we should return null instead of blowing up
+                    try {
+                        return pm.fromString(entry.getValue().get(0));
+                    } catch (IndexOutOfBoundsException e) {
+                        return null;
+                    }
+                }
+            }
+        }
+        // Liberty change end
         Class<?> type = getCollectionType(rawType);
 
         Class<?> realType = null;


### PR DESCRIPTION
…and array types

#6761

It seems that InjectionUtils.injectIntoCollectionOrArray() tries to build a list, but when a param converter is specified it blows up because it tries to cast the list returned from the param converter to the generic type of the list.

To fix this, I check for a param converter right away and skip all of the extra work if we find one. This passes all of our param tests locally and I wrote some new tests to test param converter functionality.