### PR TITLE
Remove use of Hamcrest asserts where they are not needed

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1/test/src/com/ibm/ws/microprofile/config/dynamic/test/DynamicSourceCleanupTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1/test/src/com/ibm/ws/microprofile/config/dynamic/test/DynamicSourceCleanupTest.java
@@ -11,7 +11,7 @@
 package com.ibm.ws.microprofile.config.dynamic.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.lang.ref.WeakReference;
@@ -51,7 +51,7 @@ public class DynamicSourceCleanupTest extends AbstractConfigTest {
 
         // Ensure that the source is being refreshed
         Thread.sleep(refreshInterval + extraInterval);
-        assertNotSame("Config source was not refreshed", TestDynamicConfigSource.getPropertiesLastCalled, lastGetPropertiesTime);
+        assertFalse("Config source was not refreshed", TestDynamicConfigSource.getPropertiesLastCalled == lastGetPropertiesTime);
 
         // Remove references to the config and wait for it to be garbage collected
         WeakReference<Config> weakConfig = new WeakReference<>(config);

--- a/dev/com.ibm.ws.microprofile.config.1.1/test/src/com/ibm/ws/microprofile/config/dynamic/test/DynamicSourceCleanupTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1/test/src/com/ibm/ws/microprofile/config/dynamic/test/DynamicSourceCleanupTest.java
@@ -10,9 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config.dynamic.test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 
 import java.lang.ref.WeakReference;
@@ -52,7 +51,7 @@ public class DynamicSourceCleanupTest extends AbstractConfigTest {
 
         // Ensure that the source is being refreshed
         Thread.sleep(refreshInterval + extraInterval);
-        assertThat("Config source was not refreshed", TestDynamicConfigSource.getPropertiesLastCalled, not(equalTo(lastGetPropertiesTime)));
+        assertNotSame("Config source was not refreshed", TestDynamicConfigSource.getPropertiesLastCalled, lastGetPropertiesTime);
 
         // Remove references to the config and wait for it to be garbage collected
         WeakReference<Config> weakConfig = new WeakReference<>(config);
@@ -71,7 +70,7 @@ public class DynamicSourceCleanupTest extends AbstractConfigTest {
         lastGetPropertiesTime = TestDynamicConfigSource.getPropertiesLastCalled;
 
         Thread.sleep(refreshInterval + extraInterval);
-        assertThat("Config source was refreshed after config was GC'd", TestDynamicConfigSource.getPropertiesLastCalled, equalTo(lastGetPropertiesTime));
+        assertEquals("Config source was refreshed after config was GC'd", TestDynamicConfigSource.getPropertiesLastCalled, lastGetPropertiesTime);
 
     }
 

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/test-applications/dynamicSources.war/src/com/ibm/ws/microprofile/appConfig/dynamicSources/test/DynamicSourcesTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/test-applications/dynamicSources.war/src/com/ibm/ws/microprofile/appConfig/dynamicSources/test/DynamicSourcesTestServlet.java
@@ -10,9 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.appConfig.dynamicSources.test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.fail;
 
 import javax.servlet.annotation.WebServlet;
@@ -200,7 +199,7 @@ public class DynamicSourcesTestServlet extends FATServlet {
             Thread.sleep(ConfigConstants.MINIMUM_DYNAMIC_REFRESH_INTERVAL + 1000);
 
             // Check that config source is currently being refreshed
-            assertThat(s1.lastRefresh, not(equalTo(lastRefresh)));
+            assertNotSame("Config Source was not refreshed", s1.lastRefresh, lastRefresh);
 
         } finally {
             ConfigProviderResolver.instance().releaseConfig(config);
@@ -209,7 +208,7 @@ public class DynamicSourcesTestServlet extends FATServlet {
         // Check that now that config has been closed, the config source is no longer being refreshed
         long lastRefresh = s1.lastRefresh;
         Thread.sleep(1500);
-        assertThat(s1.lastRefresh, equalTo(lastRefresh));
+        assertEquals("Config Source was still being refreshed", s1.lastRefresh, lastRefresh);
 
         // Check that the config itself is actually closed
         try {

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/test-applications/dynamicSources.war/src/com/ibm/ws/microprofile/appConfig/dynamicSources/test/DynamicSourcesTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/test-applications/dynamicSources.war/src/com/ibm/ws/microprofile/appConfig/dynamicSources/test/DynamicSourcesTestServlet.java
@@ -11,7 +11,7 @@
 package com.ibm.ws.microprofile.appConfig.dynamicSources.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import javax.servlet.annotation.WebServlet;
@@ -199,7 +199,7 @@ public class DynamicSourcesTestServlet extends FATServlet {
             Thread.sleep(ConfigConstants.MINIMUM_DYNAMIC_REFRESH_INTERVAL + 1000);
 
             // Check that config source is currently being refreshed
-            assertNotSame("Config Source was not refreshed", s1.lastRefresh, lastRefresh);
+            assertFalse("Config Source was not refreshed", s1.lastRefresh == lastRefresh);
 
         } finally {
             ConfigProviderResolver.instance().releaseConfig(config);


### PR DESCRIPTION
A classpath issue in the build means that some hamcrest methods can not be found...

java.lang.NoSuchMethodError: org/hamcrest/Matcher.describeMismatch(Ljava/lang/Object;Lorg/hamcrest/Description;)V (loaded from file:/home/jazz_build/_RM78UDqTEem5aoSbj2kEbg-EBC.PROD.WASRTC-6CX-000-00-00/jbe/build/open-liberty/dev/build.sharedResources/lib/junit/old/junit.jar by sun.misc.Launcher$AppClassLoader@8ca573b6) called from class org.hamcrest.MatcherAssert (loaded from file:/home/jazz_build/.ibmartifactory/repository/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar by sun.misc.Launcher$AppClassLoader@8ca573b6).
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
at com.ibm.ws.microprofile.config.dynamic.test.DynamicSourceCleanupTest.testDynamicSourceCleanup(DynamicSourceCleanupTest.java:74)

Hamcrest is not really needed by these tests so easy enough to remove.