### PR TITLE
Wait for SSL activation before driving HTTPS requests to server

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -16,6 +16,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 
@@ -23,6 +26,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
@@ -34,6 +39,8 @@ import componenttest.topology.utils.HttpsRequest;
 @RunWith(FATRunner.class)
 public class ValidateDataSourceTest extends FATServletClient {
 
+    private static final Class<?> c = ValidateDataSourceTest.class;
+
     @Server("com.ibm.ws.rest.handler.validator.jdbc.fat")
     public static LibertyServer server;
 
@@ -44,17 +51,20 @@ public class ValidateDataSourceTest extends FATServletClient {
         server.startServer();
 
         // Wait for the API to become available
-        assertNotNull(server.waitForStringInLog("CWWKS0008I")); // CWWKS0008I: The security service is ready.
-        assertNotNull(server.waitForStringInLog("CWWKS4105I")); // CWWKS4105I: LTPA configuration is ready after # seconds.
-        assertNotNull(server.waitForStringInLog("CWPKI0803A")); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
-        assertNotNull(server.waitForStringInLog("CWWKO0219I")); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
-        assertNotNull(server.waitForStringInLog("CWWKT0016I")); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
+        List<String> messages = new ArrayList<>();
+        messages.add("CWWKS0008I"); // CWWKS0008I: The security service is ready.
+        messages.add("CWWKS4105I"); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        messages.add("CWPKI0803A"); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
+        messages.add("CWWKO0219I: .* defaultHttpEndpoint-ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        messages.add("CWWKT0016I"); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
+        server.waitForStringsInLogUsingMark(messages);
 
         // TODO remove once transactions code is fixed to use container auth for the recovery log dataSource
         // Lacking this fix, transaction manager will experience an auth failure and log FFDC for it.
         // The following line causes an XA-capable data source to be used for the first time outside of a test method execution,
         // so that the FFDC is not considered a test failure.
-        new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource").run(JsonObject.class);
+        JsonObject response = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource").run(JsonObject.class);
+        Log.info(c, "setUp", "DefaultDataSource response: " + response);
     }
 
     @AfterClass


### PR DESCRIPTION
In the @BeforeClass we wait for a series of messages to ensure the server is ready, and then invoke an HTTPS request to pre-warm the DB. Currently, we wait for "CWWKO0219I", which is the "TCP endpoint available" message, but the issue is that we get this same msg key when the HTTP and HTTPS endpoints are available.

In the failing scenario, HTTP becomes available quite a while before HTTPS is available:
```
[3/10/19, 7:34:18:898 UTC] 0000002d com.ibm.ws.tcpchannel.internal.TCPChannel                    I CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv6) port 8010.
...
[3/10/19, 7:34:22:894 UTC] 00000033 com.ibm.ws.tcpchannel.internal.TCPChannel                    I CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
```
On the test client side, I see that we finish waiting for the last message just before HTTPS becomes available:
```
[03/10/2019 07:34:22:816 UTC] 001 LogMonitor                     getMarkOffset                  I Mark offset for /home/jazz_build/_KsmLMELrEemzxv6qGNuYMg-EBC.PROD.WASRTC-6CX-000-00-00/jbe/build/dev/image/output/wlp/usr/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/logs/messages.log=0 for /home/jazz_build/_KsmLMELrEemzxv6qGNuYMg-EBC.PROD.WASRTC-6CX-000-00-00/jbe/build/dev/image/output/wlp/usr/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/logs/messages.log
```
To fix this, we simply need to wait for the HTTPS version of CWWKO0219I before we allow the test to proceed.