### PR TITLE
Synchronize all variations of JDBC 4.2 Statement wrappers

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.2/src/com/ibm/ws/rsadapter/jdbc/v42/WSJdbc42PreparedStatement.java
+++ b/dev/com.ibm.ws.jdbc.4.2/src/com/ibm/ws/rsadapter/jdbc/v42/WSJdbc42PreparedStatement.java
@@ -49,6 +49,8 @@ public class WSJdbc42PreparedStatement extends WSJdbc41PreparedStatement impleme
 
     @Override
     public long getCompatibleUpdateCount() throws SQLException {
+        // KEEP CODE IN SYNC: This method is duplicated in WSJdbc42Statement, WSJdbc42PreparedStatement,
+        // and WSJdbc42CallableStatement because multiple inheritance isn't allowed.
         if (mcf.jdbcDriverSpecVersion >= 42 && mcf.supportsGetLargeUpdateCount) {
             try {
                 return stmtImpl.getLargeUpdateCount();


### PR DESCRIPTION
Fixes an issue raised on StackOverflow here: https://stackoverflow.com/questions/55126974/liberty-java-lang-unsupportedoperationexception-getlargeupdatecount-not-impleme