### PR TITLE
Do not pass shared class settings to server client operations.

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -590,7 +590,7 @@ serverEnvDefaults()
   # Add -Xquickstart -Xnoaot for client JVMs only.  AOT is ineffective if JVMs
   # have conflicting options, and it's more important that the server JVMs be
   # able to use AOT.
-  IBM_JAVA_OPTIONS="-Xquickstart -Xnoaot ${SERVER_IBM_JAVA_OPTIONS}"
+  IBM_JAVA_OPTIONS="-Xquickstart -Xnoaot ${IBM_JAVA_OPTIONS}"
   export IBM_JAVA_OPTIONS
 
   # Set a default file encoding if needed

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -488,7 +488,7 @@ goto:eof
   @REM Add -Xquickstart -Xnoaot for client JVMs only.  AOT is ineffective if
   @REM JVMs have conflicting options, and it's more important that server JVMs
   @REM be able to use AOT.
-  set IBM_JAVA_OPTIONS=-Xquickstart -Xnoaot !SERVER_IBM_JAVA_OPTIONS!
+  set IBM_JAVA_OPTIONS=-Xquickstart -Xnoaot !IBM_JAVA_OPTIONS!
 goto:eof
 
 @REM


### PR DESCRIPTION
server stop and other non start commands should not use the shared class cache.  It isn't needed and can cause things to be put in the cache that we do not want.  The idea of this change already was in the code from a change that was made years ago.  This change makes it so that the shared class isn't enabled at all.  The comments seem to indicate that is the intention.