### PR TITLE
Increase timeout for shutdown

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -25,7 +25,7 @@
             <property name="appDeployTimeout">60</property>
             <property name="verifyAppDeployTimeout">60</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
-            <property name="appUndeployTimeout">${tck_appUndeployTimeout}</property>
+            <property name="appUndeployTimeout">60</property>
             <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes</property> <!-- this goes here because this tck project asks arquillian to start the server -->
         </configuration>
     </container>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -25,7 +25,7 @@
             <property name="appDeployTimeout">60</property>
             <property name="verifyAppDeployTimeout">60</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
-            <property name="appUndeployTimeout">${tck_appUndeployTimeout}</property>
+            <property name="appUndeployTimeout">60</property>
             <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes</property> <!-- this goes here because this tck project asks arquillian to start the server -->
         </configuration>
     </container>


### PR DESCRIPTION
On slow test machines, the arquillian shutdown timeout is firing before the server can shutdown, resulting in errors.  This fix increases the shutdown timeout to account for these slower test machines.