### PR TITLE
restore of already-completed transaction should be a no-op

### DIFF
--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextProviderImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextProviderImpl.java
@@ -68,7 +68,7 @@ public class TransactionContextProviderImpl implements JCAContextProvider, Threa
             return new TransactionContextImpl(false);
         else if ("PROPAGATE".equals(value)) {
             if (EmbeddableTransactionManagerFactory.getUOWCurrent().getUOWType() == UOWCurrent.UOW_GLOBAL)
-                return new SerialTransactionContextImpl();
+                return new SerialTransactionContextImpl(); // TODO raise IllegalStateException here to reject all propagation of transactions
             else
                 return new TransactionContextImpl(true);
         } else


### PR DESCRIPTION
Update our experimental transaction propagation code path such that an attempt to restore an already-completed transaction onto a thread (during the context restore phase) is a no-op rather than failing with InvalidTransactionException.  This happens when the completion stage commits or rolls back the transaction during its execution.  In this case, the proper transaction context to restore is empty because the transaction that had previously been active has ended.