### PR TITLE
Don't search for Driver with UCP

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corporation and others.
+ * Copyright (c) 2011, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -521,7 +521,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 if (className == null) {
                     //if properties.oracle.ucp is configured do not search based on classname or infer because the customer has indicated
                     //they want to use UCP, but this will likely pick up the Oracle driver instead of the UCP driver (since UCP has no ConnectionPoolDataSource)
-                    if(vendorPropertiesPID != null && vendorPropertiesPID.equals("com.ibm.ws.jdbc.dataSource.properties.oracle.ucp")) {
+                    if("com.ibm.ws.jdbc.dataSource.properties.oracle.ucp".equals(vendorPropertiesPID)) {
                         //TODO consider if we want to throw a more specific exception here
                         throw classNotFound(ConnectionPoolDataSource.class.getName(), null, dataSourceID, null);
                     }
@@ -673,6 +673,15 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 }
 
             final String className = (String) properties.get(Driver.class.getName());
+            if (className == null) {
+                String vendorPropertiesPID = props instanceof PropertyService ? ((PropertyService) props).getFactoryPID() : PropertyService.FACTORY_PID;
+                //if properties.oracle.ucp is configured do not search for driver impls because the customer has indicated
+                //they want to use UCP, but this will likely pick up the Oracle driver instead of the UCP driver (since UCP has no Driver interface)
+                if("com.ibm.ws.jdbc.dataSource.properties.oracle.ucp".equals(vendorPropertiesPID)) {
+                    //TODO update exception in NLS pr
+                    throw classNotFound(Driver.class.getName(), null, dataSourceID, null);
+                }
+            }
             Driver driver = loadDriver(className, url, classloader, props, dataSourceID);
             if (driver == null)
                throw classNotFound(Driver.class.getName(), Collections.singleton("META-INF/services/java.sql.Driver"), dataSourceID, null);


### PR DESCRIPTION
Similar to what we are doing for UCP with `ConnectionPoolDataSource` we should throw an exception if someone tries to configure UCP with `type=java.sql.Driver` and the `properties.oracle.ucp` element.  Because UCP has no driver interface this will result in them using the Driver interface from the Oracle driver, when they are attempting to use UCP.