### PR TITLE
Move initialization of shared class cache helper to AppClassLoader.

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
@@ -51,6 +51,8 @@ import com.ibm.ws.classloading.internal.providers.Providers;
 import com.ibm.ws.classloading.internal.util.ClassRedefiner;
 import com.ibm.ws.classloading.internal.util.FeatureSuggestion;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.kernel.boot.classloader.ClassLoaderHook;
+import com.ibm.ws.kernel.boot.classloader.ClassLoaderHookFactory;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.wsspi.adaptable.module.Container;
 import com.ibm.wsspi.classloading.ApiType;
@@ -102,6 +104,7 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
     private final ClassGenerator generator;
     private final ConcurrentHashMap<String, ProtectionDomain> protectionDomains = new ConcurrentHashMap<String, ProtectionDomain>();
     protected final ClassLoader parent;
+    private final ClassLoaderHook hook;
 
     AppClassLoader(ClassLoader parent, ClassLoaderConfiguration config, List<Container> containers, DeclaredApiAccess access, ClassRedefiner redefiner, ClassGenerator generator, GlobalClassloadingConfiguration globalConfig) {
         super(containers, parent, redefiner, globalConfig);
@@ -113,6 +116,7 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
         this.privateLibraries = Providers.getPrivateLibraries(config);
         this.delegateLoaders = Providers.getDelegateLoaders(config, apiAccess);
         this.generator = generator;
+        hook = ClassLoaderHookFactory.getClassLoaderHook(this);
     }
 
     /** Provides the delegate loaders so the {@link ShadowClassLoader} can mimic the structure. */
@@ -453,7 +457,7 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
     final ByteResourceInformation findClassBytes(String className) throws ClassNotFoundException {
         String resourceName = Util.convertClassNameToResourceName(className);
         try {
-            ByteResourceInformation result = findClassBytes(className, resourceName);
+            ByteResourceInformation result = findClassBytes(className, resourceName, hook);
             if (result == null) {
                 String message = String.format("Could not find class '%s' as resource '%s'", className, resourceName);
                 throw new ClassNotFoundException(message);

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -61,7 +61,6 @@ import com.ibm.ws.classloading.internal.util.ClassRedefiner;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.boot.classloader.ClassLoaderHook;
-import com.ibm.ws.kernel.boot.classloader.ClassLoaderHookFactory;
 import com.ibm.ws.kernel.feature.ServerStarted;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.util.CacheHashMap;
@@ -111,8 +110,6 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
     private final List<UniversalContainer> nativeLibraryContainers = new ArrayList<UniversalContainer>();
 
     private final ClassRedefiner redefiner;
-
-    protected final ClassLoaderHook hook;
 
     final String jarProtocol;
 
@@ -1403,8 +1400,6 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         //Temporary, reintroduced until WSJAR is implemented.
         JarCacheDisabler.disableJarCaching();
 
-        hook = ClassLoaderHookFactory.getClassLoaderHook(this);
-
         smartClassPath = new UnreadSmartClassPath();
 
         if (classpath != null) {
@@ -1487,7 +1482,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         return null;
     }
 
-    protected ByteResourceInformation findClassBytes(String className, String resourceName) throws IOException {
+    protected ByteResourceInformation findClassBytes(String className, String resourceName, ClassLoaderHook hook) throws IOException {
         Object token = ThreadIdentityManager.runAsServer();
         try {
             return smartClassPath.getByteResourceInformation(className, resourceName, hook);

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
@@ -32,6 +32,7 @@ import org.osgi.framework.InvalidSyntaxException;
 
 import com.ibm.ws.classloading.configuration.GlobalClassloadingConfiguration;
 import com.ibm.ws.classloading.internal.TestUtil.ClassSource;
+import com.ibm.ws.kernel.boot.classloader.ClassLoaderHook;
 import com.ibm.wsspi.adaptable.module.Container;
 import com.ibm.wsspi.classloading.ClassLoaderConfiguration;
 import com.ibm.wsspi.classloading.ClassLoaderIdentity;
@@ -67,7 +68,8 @@ public class LibertyClassLoaderTest {
 
         loader = new AppClassLoader(loader.getParent(), loader.config, Arrays.asList(c), (DeclaredApiAccess) (loader.getParent()), null, null, new GlobalClassloadingConfiguration()) {
             @Override
-            protected com.ibm.ws.classloading.internal.AppClassLoader.ByteResourceInformation findClassBytes(String className, String resourceName) throws IOException {
+            protected com.ibm.ws.classloading.internal.AppClassLoader.ByteResourceInformation findClassBytes(String className, String resourceName,
+                                                                                                             ClassLoaderHook hook) throws IOException {
                 throw new IOException();
             }
         };


### PR DESCRIPTION
This change moves initializing of the shared class cache helper to
AppClassLoader from ContainerClassLoader.  As such the ClassLoader is
more initialized that is passed to the SharedClassCache constructor.
