### PR TITLE
tests for transaction propagation with one-phase resource used serially with multiple handles involved

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
@@ -27,6 +27,11 @@
         <properties.derby.embedded createDatabase="create" databaseName="memory:txdb"/>
     </dataSource>
 
+    <dataSource id="OnePhaseDataSource" jndiName="jdbc/ds1phase" type="javax.sql.ConnectionPoolDataSource">
+        <jdbcDriver libraryRef="DerbyLib"/>
+        <properties.derby.embedded createDatabase="create" databaseName="memory:txdb"/>
+    </dataSource>
+
     <library id="DerbyLib">
         <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
     </library>


### PR DESCRIPTION
Add tests case where multiple sharable and unsharable (not expected to work due to enlisting multiple one-phase resources) connection handles are used serially to perform transactional work within a transaction that is propagated across threads.