### PR TITLE
tests for transaction propagation with one-phase only sharable cached handle

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
@@ -1085,6 +1085,7 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                     else
                         tx.rollback();
                 } catch (Exception x) {
+                    x.printStackTrace();
                     if (failure == null)
                         throw new CompletionException(x);
                 }
@@ -1150,6 +1151,7 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                     } else
                         tx.rollback();
                 } catch (Exception x) {
+                    x.printStackTrace();
                     if (failure == null)
                         throw new CompletionException(x);
                 }


### PR DESCRIPTION
Add test cases covering the scenario where a single sharable connection handle is cached across usage of the same transaction propagated to different threads, where the connection is only capable of one-phase commit.