### PR TITLE
Changed FAT servlet to make it a better base for stress tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/test-applications/ReactiveStreamsTest/src/com/ibm/ws/microprofile/reactive/streams/test/basic/IntegerSubscriber.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/test-applications/ReactiveStreamsTest/src/com/ibm/ws/microprofile/reactive/streams/test/basic/IntegerSubscriber.java
@@ -14,9 +14,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 
+import javax.enterprise.context.Dependent;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+@Dependent
 public class IntegerSubscriber implements Subscriber<Integer> {
 
     private Subscription sub;

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/test-applications/ReactiveStreamsTest/src/com/ibm/ws/microprofile/reactive/streams/test/basic/IntegerSubscriber.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/test-applications/ReactiveStreamsTest/src/com/ibm/ws/microprofile/reactive/streams/test/basic/IntegerSubscriber.java
@@ -14,17 +14,15 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 
-import javax.enterprise.context.Dependent;
-
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-@Dependent
 public class IntegerSubscriber implements Subscriber<Integer> {
 
     private Subscription sub;
-    private final ArrayList<Integer> results = new ArrayList<Integer>();
+    private ArrayList<Integer> results = null;
     private boolean complete = false;
+    private boolean alreadyUsed = false;
 
     @Override
     public void onComplete() {
@@ -47,7 +45,13 @@ public class IntegerSubscriber implements Subscriber<Integer> {
 
     @Override
     public void onSubscribe(Subscription arg0) {
+
+        if (alreadyUsed) {
+            throw new RuntimeException("Please don't reuse this instance");
+        }
+        alreadyUsed = true;
         sub = arg0;
+        results = new ArrayList<Integer>();
         System.out.println("onSubscribe" + sub);
     }
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/test-applications/ReactiveStreamsTest/src/com/ibm/ws/microprofile/reactive/streams/test/basic/ReactiveStreamsTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat/test-applications/ReactiveStreamsTest/src/com/ibm/ws/microprofile/reactive/streams/test/basic/ReactiveStreamsTestServlet.java
@@ -46,8 +46,7 @@ public class ReactiveStreamsTestServlet extends FATServlet {
     @Inject
     ReactiveStreamsEngine engine1;
 
-    @Inject
-    IntegerSubscriber integerSubscriber;
+    IntegerSubscriber integerSubscriber = null;
 
     String value = "v";
     String expectedValue = "v";
@@ -75,6 +74,7 @@ public class ReactiveStreamsTestServlet extends FATServlet {
         PublisherBuilder<Integer> data = ReactiveStreams.of(1, 2, 3, 4, 5);
         ProcessorBuilder<Integer, Integer> filter = ReactiveStreams.<Integer> builder().dropWhile(t -> t < 3);
 
+        integerSubscriber = new IntegerSubscriber();
         data.via(filter).to(integerSubscriber).run();
         integerSubscriber.startConsuming();
 


### PR DESCRIPTION
The servlet had a single Subscriber object that was injected as a dependant bean, it had a single results object that had and .add(result).

SVT (not unreasonably) copied this code and called servlet 3 million...times -> 3 million integer arrayList :-)

Prevents long running mem test of server impl.