### PR TITLE
Thread pool diagnostics for internal defect 259800

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/bootstrap.properties
@@ -3,7 +3,8 @@ com.ibm.ws.jaxrs2*=all:\
 com.ibm.websphere.jaxrs2*=all:\
 org.apache.cxf.*=all:\
 com.ibm.ws.microprofile.rest.*=all:\
-com.ibm.websphere.microprofile.rest.*=all
+com.ibm.websphere.microprofile.rest.*=all:\
+com.ibm.ws.threading.internal.ThreadPoolController=all
 
 com.ibm.ws.logging.max.file.size=0
 


### PR DESCRIPTION
Adding thread pool diagnostics for MP Rest Client test that fails on Mac and z/OS test machines - adding new trace spec and server dumps.