### PR TITLE
restrict the version of the org.apache.cxf project that we import in …

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2/bnd.overrides
@@ -7,4 +7,5 @@ Import-Package: \
   !javax.wsdl,\
   !org.apache.velocity.*,\
   !org.junit.*,\
+  org.apache.cxf;version="[3.0.0,4)",\
   *


### PR DESCRIPTION
…com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2 project to avoid importing the 2.6.2 version

Currently, if you start an OpenLiberty server with the javaee-8.0 feature enabled the following error will appear in your logs:

CWWKE0702E: Could not resolve module: com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2

This appears to be intermittent.