### PR TITLE
Revert "Fix arquillian dependency"

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -63,7 +63,6 @@ commons-logging:commons-logging:1.1.1
 commons-logging:commons-logging:1.1.3
 httpunit:httpunit:1.5.4
 httpunit:httpunit:1.7
-io.openliberty.arquillian:arquillian-liberty-support:1.0.4
 io.reactivex.rxjava2:rxjava:2.2.4
 io.smallrye.reactive:smallrye-reactive-streams-operators:1.0.0
 javax:javaee-api:7.0

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/server.xml
@@ -16,7 +16,6 @@
         <feature>mpConfig-1.3</feature>
         <feature>mpMetrics-1.1</feature> 
         <feature>localConnector-1.0</feature>
-        <feature>usr:arquillian-support-1.0</feature>
    </featureManager>
 
    <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.3</version> 
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -13,6 +13,9 @@
     <test name="microprofile-faulttolerance 2.0 TCK">
         <packages>
             <package name="org.eclipse.microprofile.fault.tolerance.tck.*">
+                <!-- Exclude due to https://github.com/OpenLiberty/liberty-arquillian/issues/36 -->
+                <exclude name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod"/>
+                <exclude name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters"/>
             </package>
         </packages>
     </test>

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -40,20 +40,3 @@ jar {
     dependsOn assembleBootstrap
     dependsOn assembleBinaryDependencies
 }
-
-configurations {
-    arquillianFeature
-}
-
-dependencies {
-    arquillianFeature 'io.openliberty.arquillian:arquillian-liberty-support:1.0.4:feature@zip'
-}
-
-task publishArquillianUserFeature(type:Copy) {
-    configurations.arquillianFeature.each {
-        from(zipTree(it))
-    }
-    into(buildImage.file('wlp/usr'))
-}
-
-assemble.dependsOn publishArquillianUserFeature


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#6928

PR #6928 drops a usr feature into usr/extensions/lib and expects it to stay there. However, there are some other FAT buckets which delete that whole dir as part of their cleanup.