### PR TITLE
temporary approximate enforcement of limitation against resuming transaction onto multiple threads at once

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
@@ -243,6 +243,10 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                 } catch (Exception x2) {
                     x2.printStackTrace();
                 }
+                if (x instanceof RuntimeException)
+                    throw (RuntimeException) x;
+                if (x instanceof Error)
+                    throw (Error) x;
                 throw new CompletionException(x);
             });
         } finally {
@@ -301,6 +305,10 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                 } catch (Exception x2) {
                     x2.printStackTrace();
                 }
+                if (x instanceof RuntimeException)
+                    throw (RuntimeException) x;
+                if (x instanceof Error)
+                    throw (Error) x;
                 throw new CompletionException(x);
             });
         } finally {
@@ -361,6 +369,10 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                 } catch (Exception x2) {
                     x2.printStackTrace();
                 }
+                if (x instanceof RuntimeException)
+                    throw (RuntimeException) x;
+                if (x instanceof Error)
+                    throw (Error) x;
                 throw new CompletionException(x);
             });
         } finally {
@@ -371,8 +383,6 @@ public class MPConcurrentTxTestServlet extends FATServlet {
             assertEquals(Integer.valueOf(2), stage2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
         } catch (ExecutionException x) {
             Throwable cause = x.getCause();
-            if (cause instanceof CompletionException)
-                cause = cause.getCause();
             if (cause instanceof IllegalStateException) // transaction used on 2 threads at once
                 return;
             else
@@ -425,6 +435,10 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                 } catch (Exception x2) {
                     x2.printStackTrace();
                 }
+                if (x instanceof RuntimeException)
+                    throw (RuntimeException) x;
+                if (x instanceof Error)
+                    throw (Error) x;
                 throw new CompletionException(x);
             });
         } finally {
@@ -435,8 +449,6 @@ public class MPConcurrentTxTestServlet extends FATServlet {
             fail("Should report exceptional completion. Instead: " + stage2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
         } catch (ExecutionException x) {
             Throwable cause = x.getCause();
-            if (cause instanceof CompletionException)
-                cause = cause.getCause();
             if (cause instanceof IllegalStateException) // transaction used on 2 threads at once
                 return;
             else if (cause instanceof SQLException)
@@ -600,6 +612,10 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                 } catch (Exception x2) {
                     x2.printStackTrace();
                 }
+                if (x instanceof RuntimeException)
+                    throw (RuntimeException) x;
+                if (x instanceof Error)
+                    throw (Error) x;
                 throw new CompletionException(x);
             });
         } finally {
@@ -610,8 +626,6 @@ public class MPConcurrentTxTestServlet extends FATServlet {
             assertEquals(Integer.valueOf(2), stage.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
         } catch (ExecutionException x) {
             Throwable cause = x.getCause();
-            if (cause instanceof CompletionException)
-                cause = cause.getCause(); // TODO why is cause sometimes showing with CompletionException? Is the exception supplied to exceptionally() varying?
             if (cause instanceof IllegalStateException) // transaction used on 2 threads at once
                 return;
             else
@@ -661,6 +675,10 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                 } catch (Exception x2) {
                     x2.printStackTrace();
                 }
+                if (x instanceof RuntimeException)
+                    throw (RuntimeException) x;
+                if (x instanceof Error)
+                    throw (Error) x;
                 throw new CompletionException(x);
             });
         } finally {
@@ -671,8 +689,6 @@ public class MPConcurrentTxTestServlet extends FATServlet {
             fail("Should raise CompletionException. Instead: " + stage.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
         } catch (ExecutionException x) {
             Throwable cause = x.getCause();
-            if (cause instanceof CompletionException)
-                cause = cause.getCause();
             if (cause instanceof IllegalStateException) // transaction used on 2 threads at once
                 return;
             else if (cause instanceof SQLException)

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/fat/src/com/ibm/ws/concurrent/mp/fat/tck/MPConcurrencyTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/fat/src/com/ibm/ws/concurrent/mp/fat/tck/MPConcurrencyTCKLauncher.java
@@ -37,7 +37,8 @@ public class MPConcurrencyTCKLauncher {
         server.stopServer();
     }
 
-    @AllowedFFDC({ "java.lang.NegativeArraySizeException", // intentionally raised by test case to simulate failure during completion stage action
+    @AllowedFFDC({ "java.lang.IllegalStateException", // transaction cannot be propagated to 2 threads at the same time
+                   "java.lang.NegativeArraySizeException", // intentionally raised by test case to simulate failure during completion stage action
                    "org.jboss.weld.contexts.ContextNotActiveException" // expected when testing TransactionScoped bean cannot be accessed outside of transaction
     })
     @Test

--- a/dev/com.ibm.ws.transaction.context/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.context/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ Service-Component: \
     provide:='com.ibm.wsspi.threadcontext.ThreadContextProvider,com.ibm.wsspi.threadcontext.jca.JCAContextProvider'; \
     configuration-policy:=ignore;\
     transactionInflowManager=com.ibm.tx.jta.TransactionInflowManager;\
+    transactionManager=com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager; \
     properties:='\
      alwaysCaptureThreadContext:Boolean=true,\
      type=javax.resource.spi.work.TransactionContext'

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/SerialTransactionContextImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/SerialTransactionContextImpl.java
@@ -13,7 +13,6 @@ package com.ibm.ws.transaction.context.internal;
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -33,8 +32,6 @@ import com.ibm.ws.uow.embeddable.UOWManager;
 import com.ibm.ws.uow.embeddable.UOWManagerFactory;
 import com.ibm.ws.uow.embeddable.UOWToken;
 import com.ibm.wsspi.threadcontext.ThreadContext;
-import com.ibm.wsspi.tx.UOWEventEmitter;
-import com.ibm.wsspi.tx.UOWEventListener;
 
 /**
  * A special transaction context implementation for MicroProfile Concurrency that propagates a
@@ -43,6 +40,9 @@ import com.ibm.wsspi.tx.UOWEventListener;
 public class SerialTransactionContextImpl implements ThreadContext {
     private static final long serialVersionUID = 1;
 
+    // TODO remove the following temporary code once the transaction manager provides a proper mechanism to prevent a transaction on multiple threads at once
+    private final SuspendCount suspendCounts;
+
     /**
      * Unit of work that was on the thread of execution prior to invoking the contextual task.
      */
@@ -50,46 +50,21 @@ public class SerialTransactionContextImpl implements ThreadContext {
 
     private final Transaction tx;
 
-    SerialTransactionContextImpl() {
+    // TODO remove the temporary suspend count code once the transaction manager provides a proper mechanism to prevent a transaction on multiple threads at once
+    SerialTransactionContextImpl(SuspendCount suspendCounts) {
         try {
+            this.suspendCounts = suspendCounts;
             tx = EmbeddableTransactionManagerFactory.getTransactionManager().getTransaction();
-            // TODO remove the following temporary code once the transaction manager provides a proper mechanism to prevent a transaction on multiple threads at once
             if (tx != null) {
-                SuspendCount s = suspendCounts.get(tx);
-                if (s == null) {
-                    ((UOWCurrent) EmbeddableTransactionManagerFactory.getTransactionManager()).setUOWEventListener(s = new SuspendCount(tx));
-                    if (suspendCounts.putIfAbsent(tx, s) != null)
-                        ((UOWCurrent) EmbeddableTransactionManagerFactory.getTransactionManager()).unsetUOWEventListener(s);
+                AtomicInteger count = suspendCounts.get(tx);
+                if (count == null) {
+                    AtomicInteger found = suspendCounts.putIfAbsent(tx, count = new AtomicInteger());
+                    if (found != null)
+                        count = found;
                 }
             }
         } catch (SystemException x) {
             throw new RejectedExecutionException(x);
-        }
-    }
-
-    // TODO remove the following temporary code once the transaction manager provides a proper mechanism to prevent a transaction on multiple threads at once
-    private static final ConcurrentHashMap<Transaction, SuspendCount> suspendCounts = new ConcurrentHashMap<Transaction, SuspendCount>();
-
-    // TODO remove the following temporary code once the transaction manager provides a proper mechanism to prevent a transaction on multiple threads at once
-    private static class SuspendCount extends AtomicInteger implements UOWEventListener {
-        private static final long serialVersionUID = 1L;
-        private final Transaction tx;
-
-        private SuspendCount(Transaction tx) {
-            this.tx = tx;
-        }
-
-        /**
-         * @see com.ibm.wsspi.tx.UOWEventListener#UOWEvent(com.ibm.wsspi.tx.UOWEventEmitter, int, java.lang.Object)
-         */
-        @Override
-        public void UOWEvent(UOWEventEmitter uow, int event, Object data) {
-            if (event == UOWEventListener.SUSPEND)
-                incrementAndGet();
-            else if (event == UOWEventListener.RESUME)
-                decrementAndGet();
-            else if (event == UOWEventListener.POST_END)
-                suspendCounts.remove(tx);
         }
     }
 

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/SuspendCount.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/SuspendCount.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.transaction.context.internal;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.transaction.Transaction;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.wsspi.tx.UOWEventEmitter;
+import com.ibm.wsspi.tx.UOWEventListener;
+
+/**
+ * TODO Remove the following temporary code once the transaction manager provides a proper mechanism to prevent a transaction on multiple threads at once.
+ * This data structure will accumulate transaction references if the application leaves transactions unresolved.
+ */
+@Trivial
+public class SuspendCount extends ConcurrentHashMap<Transaction, AtomicInteger> implements UOWEventListener {
+    private static final TraceComponent tc = Tr.register(SuspendCount.class);
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @see com.ibm.wsspi.tx.UOWEventListener#UOWEvent(com.ibm.wsspi.tx.UOWEventEmitter, int, java.lang.Object)
+     */
+    @Override
+    public void UOWEvent(UOWEventEmitter uow, int event, Object data) {
+        if (event == UOWEventListener.SUSPEND) {
+            AtomicInteger count = get(uow);
+            if (count != null) {
+                int c = count.incrementAndGet();
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "SUSPEND UOWEvent, count=" + c + " for " + uow);
+            }
+        } else if (event == UOWEventListener.RESUME) {
+            AtomicInteger count = get(uow);
+            if (count != null) {
+                int c = count.decrementAndGet();
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "RESUME UOWEvent, count=" + c + " for " + uow);
+            }
+        } else if (event == UOWEventListener.POST_END) {
+            AtomicInteger count = remove(uow);
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "END UOWEvent, count=" + count + " for " + uow);
+        }
+    }
+}

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextProviderImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextProviderImpl.java
@@ -16,14 +16,15 @@ import java.io.ObjectInputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.enterprise.concurrent.ManagedTask;
 
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 
-import com.ibm.tx.jta.embeddable.EmbeddableTransactionManagerFactory;
 import com.ibm.ws.Transaction.UOWCurrent;
+import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.threadcontext.ThreadContext;
 import com.ibm.wsspi.threadcontext.ThreadContextDeserializationInfo;
@@ -35,10 +36,15 @@ import com.ibm.wsspi.threadcontext.jca.JCAContextProvider;
  * Transaction context service provider.
  */
 public class TransactionContextProviderImpl implements JCAContextProvider, ThreadContextProvider {
+    // TODO remove the following temporary code once the transaction manager provides a proper mechanism to prevent a transaction on multiple threads at once
+    private final AtomicReference<SuspendCount> suspendCountRef = new AtomicReference<SuspendCount>();
+
     /**
      * Reference to the transaction inflow manager.
      */
     final AtomicServiceReference<Object> transactionInflowManagerRef = new AtomicServiceReference<Object>("transactionInflowManager");
+
+    private EmbeddableWebSphereTransactionManager transactionManager;
 
     /**
      * Called during service activation.
@@ -56,6 +62,11 @@ public class TransactionContextProviderImpl implements JCAContextProvider, Threa
      */
     protected void deactivate(ComponentContext context) {
         transactionInflowManagerRef.deactivate(context);
+
+        // TODO remove the following temporary code once the transaction manager provides a proper mechanism to prevent a transaction on multiple threads at once
+        SuspendCount suspendCount = suspendCountRef.get();
+        if (suspendCount != null)
+            ((UOWCurrent) transactionManager).unsetUOWEventListener(suspendCount);
     }
 
     /** {@inheritDoc} */
@@ -67,9 +78,20 @@ public class TransactionContextProviderImpl implements JCAContextProvider, Threa
         else if (ManagedTask.USE_TRANSACTION_OF_EXECUTION_THREAD.equals(value))
             return new TransactionContextImpl(false);
         else if ("PROPAGATE".equals(value)) {
-            if (EmbeddableTransactionManagerFactory.getUOWCurrent().getUOWType() == UOWCurrent.UOW_GLOBAL)
-                return new SerialTransactionContextImpl(); // TODO raise IllegalStateException here to reject all propagation of transactions
-            else
+            UOWCurrent uowCurrent = (UOWCurrent) transactionManager;
+            if (uowCurrent.getUOWType() == UOWCurrent.UOW_GLOBAL) {
+                // TODO raise IllegalStateException here to reject all propagation of transactions
+                // TODO remove the following temporary code once the transaction manager provides a proper mechanism to prevent a transaction on multiple threads at once
+                SuspendCount suspendCount = suspendCountRef.get();
+                if (suspendCount == null) {
+                    uowCurrent.setUOWEventListener(suspendCount = new SuspendCount());
+                    if (!suspendCountRef.compareAndSet(null, suspendCount)) {
+                        uowCurrent.unsetUOWEventListener(suspendCount);
+                        suspendCount = suspendCountRef.get();
+                    }
+                }
+                return new SerialTransactionContextImpl(suspendCount);
+            } else
                 return new TransactionContextImpl(true);
         } else
             throw new IllegalArgumentException(ManagedTask.TRANSACTION + '=' + value);
@@ -141,11 +163,25 @@ public class TransactionContextProviderImpl implements JCAContextProvider, Threa
     }
 
     /**
+     * Declarative Services method to set the transaction manager.
+     */
+    protected void setTransactionManager(EmbeddableWebSphereTransactionManager tm) {
+        transactionManager = tm;
+    }
+
+    /**
      * Declarative Services method for unsetting the TransactionInflowManager service
      *
      * @param ref reference to the service
      */
     protected void unsetTransactionInflowManager(ServiceReference<Object> ref) {
         transactionInflowManagerRef.unsetReference(ref);
+    }
+
+    /**
+     * Declarative Services method to unset the transaction manager.
+     */
+    protected void unsetTransactionManager(EmbeddableWebSphereTransactionManager tm) {
+        transactionManager = null;
     }
 }


### PR DESCRIPTION
The transaction manager doesn't yet have the ability to stop a transaction from being resumed onto multiple threads at once, so I'm adding some temporary code that aims to at least sometimes be able to enforce it on our own, which will allow us to start to get our tests updated according to this expectation.