### PR TITLE
Fixing missing PS Exception Filter

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/PSProcessStatusImpl.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/PSProcessStatusImpl.java
@@ -73,7 +73,7 @@ public class PSProcessStatusImpl implements ProcessStatus {
             else
                 return State.NO;
         } catch (IOException e) {
-            if (e.getMessage().equals("No such file or directory")) // "ps" doesn't exist on this machine.
+            if (e.getMessage().contains("Cannot run program \"ps\"")) // "ps" doesn't exist on this machine.
                 // Return Undetermined since we can't poll the process
                 return State.UNDETERMINED;
             Debug.printStackTrace(e);


### PR DESCRIPTION
My initial Docker test was invalid, so an additional fix was required.  (Filter for the proper IOException was invalid)

This fix is now validated on the minimal Docker image.