### PR TITLE
moved URAPIs_SUNLDAP_SSLTest to FULL

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAP_SSLTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAP_SSLTest.java
@@ -41,7 +41,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.LDAPUtils;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.LITE)
+@Mode(TestMode.FULL)
 public class URAPIs_SUNLDAP_SSLTest {
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.adapter.ldap.fat.sun.ssl");
     private static final Class<?> c = URAPIs_SUNLDAP_SSLTest.class;


### PR DESCRIPTION
Moved tests from Lite mode to Full in order to allow the JAVA 11 builds