### PR TITLE
Custom login module support for validator API

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator.jdbc/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator.jdbc/bnd.bnd
@@ -29,6 +29,7 @@ Private-Package:\
   com.ibm.ws.rest.handler.validator.jdbc.DataSourceValidator
 
 -buildpath:\
+  com.ibm.json4j;version=latest,\
   com.ibm.websphere.appserver.spi.kernel.service,\
   com.ibm.websphere.appserver.spi.logging,\
   com.ibm.websphere.org.osgi.core,\

--- a/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
@@ -75,7 +75,8 @@ public class DataSourceValidator implements Validator {
                 if (loginConfig != null) {
                     // Add custom login module name and properties
                     config.setLoginConfigurationName(loginConfig);
-                    JSONObject requestBodyJson = (JSONObject) props.get(Validator.JSON_BODY_KEY);
+                    String requestBodyString = (String) props.get(Validator.JSON_BODY_KEY);
+                    JSONObject requestBodyJson = requestBodyString == null ? null : JSONObject.parse(requestBodyString);
                     if (requestBodyJson != null && requestBodyJson.containsKey("loginConfigProperties")) {
                         Object loginConfigProperties = requestBodyJson.get("loginConfigProperties");
                         if (loginConfigProperties instanceof JSONObject) {

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.internal;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -24,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
@@ -193,8 +197,7 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
                 params.put("password", resolvePotentialVariable(pass));
             String contentType = request.getContentType();
             if ("application/json".equalsIgnoreCase(contentType)) {
-                JSONObject jsonBody = JSONObject.parse(request.getInputStream());
-                params.put(Validator.JSON_BODY_KEY, jsonBody);
+                params.put(Validator.JSON_BODY_KEY, read(request.getInputStream()));
             }
 
             Validator validator = getService(context, validatorRefs.iterator().next());
@@ -317,6 +320,13 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
         }
 
         return json;
+    }
+
+    @Trivial
+    private static String read(InputStream input) throws IOException {
+        try (BufferedReader buffer = new BufferedReader(new InputStreamReader(input))) {
+            return buffer.lines().collect(Collectors.joining("\n"));
+        }
     }
 
     @Trivial

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
@@ -191,6 +191,11 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
             String pass = request.getHeader("X-Validator-Password");
             if (pass != null)
                 params.put("password", resolvePotentialVariable(pass));
+            String contentType = request.getContentType();
+            if ("application/json".equalsIgnoreCase(contentType)) {
+                JSONObject jsonBody = JSONObject.parse(request.getInputStream());
+                params.put(Validator.JSON_BODY_KEY, jsonBody);
+            }
 
             Validator validator = getService(context, validatorRefs.iterator().next());
             if (validator == null) {

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/wsspi/validator/Validator.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/wsspi/validator/Validator.java
@@ -24,16 +24,24 @@ import java.util.Map;
  * Validator implementations should be registered as OSGi service in the service registry.
  */
 public interface Validator {
-    // TODO add custom login module/properties
+
+    /**
+     * Key used to obtain the JSONObject representing a JSON request body.
+     * If present, it will be present in the <code>Map&ltString,Object></code> passed into
+     * the <code>validate</code> method.
+     */
+    public static final String JSON_BODY_KEY = "com.ibm.wsspi.validator.jsonBody";
+
     /**
      * Validates the specified instance.
      *
      * @param instance the instance to validate.
-     * @param props properties describing the validation request, as determined by the ValidatorAPIProvider.
-     *            Possible property keys include:
-     *            <code>user</code>, <code>password</code>, <code>auth</code>, <code>authAlias</code>.
-     *            Possible values for <code>auth</code> are: <code>application</code>, <code>container</code>.
-     * @param locale locale of the client invoking the API.
+     * @param props    properties describing the validation request, as determined by the ValidatorAPIProvider.
+     *                     Possible property keys include:
+     *                     <code>user</code>, <code>password</code>, <code>auth</code>, <code>authAlias</code>,
+     *                     <code>loginConfig</code>, <code>com.ibm.wsspi.validator.jsonBody</code>
+     *                     Possible values for <code>auth</code> are: <code>application</code>, <code>container</code>.
+     * @param locale   locale of the client invoking the API.
      * @return ordered name/value pairs with information about the result. If the test operation is unsuccessful,
      *         the "failure" key must be included, with the value either being a Throwable or a String indicating the error.
      */

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/wsspi/validator/Validator.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/wsspi/validator/Validator.java
@@ -25,12 +25,14 @@ import java.util.Map;
  */
 public interface Validator {
 
+    // TODO add constants for various reserved properties such as: user, password, and auth
+
     /**
-     * Key used to obtain the JSONObject representing a JSON request body.
-     * If present, it will be present in the <code>Map&ltString,Object></code> passed into
+     * Key used to obtain a String representation of the JSON request body.
+     * If present, it will added to the <code>Map&ltString,Object></code> passed into
      * the <code>validate</code> method.
      */
-    public static final String JSON_BODY_KEY = "com.ibm.wsspi.validator.jsonBody";
+    public static final String JSON_BODY_KEY = "json";
 
     /**
      * Validates the specified instance.

--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -20,10 +20,11 @@ src: \
 fat.project: true
 
 -buildpath: \
+    com.ibm.websphere.javaee.connector.1.7;version=latest,\
     com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-    org.apache.derby:derby;version=10.11.1.1
+    com.ibm.ws.security.jaas.common;version=latest

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
@@ -20,6 +20,7 @@ import componenttest.topology.utils.HttpUtils;
 @RunWith(Suite.class)
 @SuiteClasses({
                 ValidateDataSourceTest.class,
+                ValidateDSCustomLoginModuleTest.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -1,0 +1,234 @@
+/*******************************************************************************
+ * Copyright (c) 2017,2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.rest.handler.validator.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.json.JsonObject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.rest.handler.validator.loginmodule.TestLoginModule;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpsRequest;
+
+@RunWith(FATRunner.class)
+public class ValidateDSCustomLoginModuleTest extends FATServletClient {
+
+    private static final Class<?> c = ValidateDSCustomLoginModuleTest.class;
+
+    @Server("validator-customLoginModule-Server")
+    public static LibertyServer server;
+
+    private static String VERSION_REGEX = "[0-9]+\\.[0-9]+.*";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "customLoginModule.jar");
+        jar.addPackage("com.ibm.ws.rest.handler.validator.loginmodule");
+        ShrinkHelper.exportToServer(server, "/", jar);
+
+        server.startServer();
+
+        // Wait for the API to become available
+        List<String> messages = new ArrayList<>();
+        messages.add("CWWKS0008I"); // CWWKS0008I: The security service is ready.
+        messages.add("CWWKS4105I"); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        messages.add("CWPKI0803A"); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
+        messages.add("CWWKO0219I: .* defaultHttpEndpoint-ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        messages.add("CWWKT0016I"); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
+        server.waitForStringsInLogUsingMark(messages);
+
+        // TODO remove once transactions code is fixed to use container auth for the recovery log dataSource
+        // Lacking this fix, transaction manager will experience an auth failure and log FFDC for it.
+        // The following line causes an XA-capable data source to be used for the first time outside of a test method execution,
+        // so that the FFDC is not considered a test failure.
+        JsonObject response = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource")
+                        .method("POST")
+                        .run(JsonObject.class);
+        Log.info(c, "setUp", "DefaultDataSource response: " + response);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer("CWWKE0701E", // TODO remove once transaction manager fixes its circular reference bug
+                          "CWWKS1300E", // auth alias doesn't exist
+                          "WTRN0112E" // TODO remove once transactions code is fixed to use container auth for the recovery log dataSource
+        );
+    }
+
+    /**
+     * Test validation of a dataSource that relies on a custom login module to add credentials.
+     * This default endpoint invocation is equivalent to an application direct lookup, which does
+     * not get container managed authentication applied and therefore should not succeed.
+     */
+    @Test
+    @ExpectedFFDC({ "java.sql.SQLNonTransientConnectionException",
+                    "java.sql.SQLNonTransientException",
+                    "javax.resource.spi.SecurityException",
+                    "javax.resource.spi.ResourceAllocationException" })
+    public void testCustomLoginModuleDirectLookupInvalid() throws Exception {
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/customLoginDS")
+                        .method("POST")
+                        .run(JsonObject.class);
+        Log.info(c, testName.getMethodName(), "HTTP response: " + json);
+        String err = "unexpected response: " + json;
+        assertEquals(err, "customLoginDS", json.getString("uid"));
+        assertEquals(err, "customLoginDS", json.getString("id"));
+        assertFalse(err, json.getBoolean("successful"));
+        assertNull(err, json.get("info"));
+        assertNull(err, json.get("cause"));
+
+        // Now examine the failure object
+        json = json.getJsonObject("failure");
+        assertNotNull(err, json);
+        assertNull(err, json.get("uid"));
+        assertNull(err, json.get("id"));
+        assertNull(err, json.get("jndiName"));
+        assertNull(err, json.get("successful"));
+        assertNull(err, json.get("failure"));
+        assertNull(err, json.get("info"));
+        assertEquals(err, "08004", getString(json, "sqlState"));
+        assertEquals(err, 40000, json.getInt("errorCode"));
+        assertEquals(err, "java.sql.SQLNonTransientException", getString(json, "class"));
+        assertTrue(err, getString(json, "message").contains("Invalid authentication"));
+    }
+
+    /**
+     * Test validation of a dataSource that relies on a custom login module to add credentials
+     */
+    @Test
+    public void testCustomLoginContainerAuth() throws Exception {
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/customLoginDS?auth=container")
+                        .method("POST")
+                        .run(JsonObject.class);
+        Log.info(c, testName.getMethodName(), "HTTP response: " + json);
+        assertSuccessResponse(json, "customLoginDS", "customLoginDS", "jdbc/customLoginDS");
+    }
+
+    /**
+     * Test validation of a dataSource has no auth configured in server.xml, but specifies a customLoginConfig
+     * as a request parameter. This is to account for apps that may be doing this in their ibm-web-bnd.xml:
+     * <resource-ref name="jdbc/customLoginDSWebBnd" binding-name="jdbc/customLoginDSWebBnd">
+     * <custom-login-configuration name="customLoginEntry"/>
+     * </resource-ref>
+     */
+    @Test
+    public void testCustomLoginIBMWebBnd() throws Exception {
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/customLoginDSWebBnd?auth=container&loginConfig=customLoginEntry")
+                        .method("POST")
+                        .run(JsonObject.class);
+        Log.info(c, testName.getMethodName(), "HTTP response: " + json);
+        assertSuccessResponse(json, "customLoginDSWebBnd", "customLoginDSWebBnd", "jdbc/customLoginDSWebBnd");
+    }
+
+    /**
+     * Test validation of a dataSource has no auth configured in server.xml, but specifies a customLoginConfig
+     * as a request parameter. This is to account for apps that may be doing this in their ibm-web-bnd.xml:
+     * <resource-ref name="jdbc/customLoginDSWebBnd" binding-name="jdbc/customLoginDSWebBnd">
+     * <custom-login-configuration name="customLoginEntry">
+     * <property name="custom-login-prop" value="foo"/>
+     * </custom-login-configuration>
+     * </resource-ref>
+     */
+    @Test
+    public void testCustomLoginModuleProperties() throws Exception {
+        String URL = "/ibm/api/validator/dataSource/customLoginDSWebBnd?auth=container&loginConfig=customLoginEntry";
+        String propsJson = "{ \"loginConfigProperties\": { \"" + TestLoginModule.CUSTOM_PROPERTY_KEY + "\": \"foo\" } }";
+        JsonObject json = new HttpsRequest(server, URL)
+                        .method("POST")
+                        .jsonBody(propsJson)
+                        .run(JsonObject.class);
+        Log.info(c, testName.getMethodName(), "HTTP response: " + json);
+        assertSuccessResponse(json, "customLoginDSWebBnd", "customLoginDSWebBnd", "jdbc/customLoginDSWebBnd");
+
+        assertTrue("Did not find expected log statement indiciating custom login property was set",
+                   server.findStringsInLogs("TEST_CHECK " + TestLoginModule.CUSTOM_PROPERTY_KEY + "=foo").size() > 0);
+    }
+
+    /**
+     * Test specifyig a non-existant customLoginConfig
+     */
+    @Test
+    @ExpectedFFDC({ "javax.security.auth.login.LoginException",
+                    "javax.resource.ResourceException",
+                    "java.sql.SQLException" })
+    public void testCustomLoginIBMWebBndWrongName() throws Exception {
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/customLoginDSWebBnd?auth=container&loginConfig=bogus")
+                        .method("POST")
+                        .run(JsonObject.class);
+        Log.info(c, testName.getMethodName(), "HTTP response: " + json);
+        String err = "unexpected response: " + json;
+        assertEquals(err, "customLoginDSWebBnd", getString(json, "uid"));
+        assertEquals(err, "customLoginDSWebBnd", getString(json, "id"));
+        assertEquals(err, "jdbc/customLoginDSWebBnd", getString(json, "jndiName"));
+        assertFalse(err, json.getBoolean("successful"));
+        assertNull(err, json.get("info"));
+        assertNull(err, json.get("cause"));
+
+        // Now examine the failure object
+        json = json.getJsonObject("failure");
+        assertNotNull(err, json);
+        assertNull(err, json.get("uid"));
+        assertNull(err, json.get("id"));
+        assertNull(err, json.get("successful"));
+        assertNull(err, json.get("failure"));
+        assertNull(err, json.get("info"));
+        assertEquals(err, "java.sql.SQLException", getString(json, "class"));
+        assertTrue(err, getString(json, "message").contains("No LoginModules configured for bogus"));
+    }
+
+    private static void assertSuccessResponse(JsonObject json, String expectedUID, String expectedID, String expectedJndiName) {
+        String err = "Unexpected json response: " + json.toString();
+        assertEquals(err, expectedUID, getString(json, "uid"));
+        assertEquals(err, expectedID, getString(json, "id"));
+        assertEquals(err, expectedJndiName, getString(json, "jndiName"));
+        assertTrue(err, json.getBoolean("successful"));
+        assertNull(err, json.get("failure"));
+        JsonObject info = json.getJsonObject("info");
+        assertNotNull(err, info);
+        assertEquals(err, "Apache Derby", info.getString("databaseProductName"));
+        assertTrue(err, info.getString("databaseProductVersion").matches(VERSION_REGEX));
+        assertEquals(err, "Apache Derby Embedded JDBC Driver", info.getString("jdbcDriverName"));
+        assertTrue(err, info.getString("jdbcDriverVersion").matches(VERSION_REGEX));
+    }
+
+    private static String getString(JsonObject json, String key) {
+        try {
+            return json.getString(key);
+        } catch (NullPointerException e) {
+            // JSON-P will annoyingly throw a NPE if we request a String key that does not exist,
+            // which leaves us with pretty useless JUnit failure messages. Return null instead so
+            // the JUnit failures are more helpful
+            return null;
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/loginmodule/TestLoginModule.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/loginmodule/TestLoginModule.java
@@ -1,0 +1,105 @@
+package com.ibm.ws.rest.handler.validator.loginmodule;
+
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import javax.resource.spi.ManagedConnectionFactory;
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
+import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
+
+public class TestLoginModule implements LoginModule {
+
+    public static final String DB_USERNAME = "dbuser";
+    public static final String DB_PASSWORD = "dbpass";
+    public static final String CUSTOM_PROPERTY_KEY = "testCustomLoginModuleProperties-fooProp";
+
+    private static final String c = TestLoginModule.class.getSimpleName();
+
+    public CallbackHandler callbackHandler;
+    public Subject subject;
+    public Map<String, Object> sharedState;
+    public Map<String, ?> options;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        System.out.println(c + " >>> initialize");
+        this.callbackHandler = callbackHandler;
+        this.subject = subject;
+        this.sharedState = (Map<String, Object>) sharedState;
+        this.options = options;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean login() throws LoginException {
+        System.out.println(c + " >>> login");
+        try {
+            Callback[] callbacks = getHandledCallbacks();
+            setPasswordCredentialInSubject(callbacks);
+            Map<?, ?> properties = ((WSMappingPropertiesCallback) callbacks[1]).getProperties();
+            System.out.println("   properties=" + properties);
+            // Check for specific custom login module prop set by testCustomLoginModuleProperties
+            String customProp = (String) properties.get(CUSTOM_PROPERTY_KEY);
+            if (customProp != null)
+                System.out.println("  TEST_CHECK " + CUSTOM_PROPERTY_KEY + "=" + customProp);
+        } catch (Exception e) {
+            throw (LoginException) new LoginException(e.getMessage()).initCause(e);
+        }
+
+        return true;
+    }
+
+    private Callback[] getHandledCallbacks() throws IOException, UnsupportedCallbackException {
+        Callback callbacks[] = new Callback[2];
+        callbacks[0] = new WSManagedConnectionFactoryCallback("Target ManagedConnectionFactory: ");
+        callbacks[1] = new WSMappingPropertiesCallback("Mapping Properties (HashMap): ");
+        callbackHandler.handle(callbacks);
+        return callbacks;
+    }
+
+    private void setPasswordCredentialInSubject(Callback[] callbacks) {
+        ManagedConnectionFactory managedConnectionFactory = ((WSManagedConnectionFactoryCallback) callbacks[0]).getManagedConnectionFacotry();
+        final PasswordCredential passwordCredential = new PasswordCredential(DB_USERNAME, DB_PASSWORD.toCharArray());
+        passwordCredential.setManagedConnectionFactory(managedConnectionFactory);
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @Override
+            public Void run() {
+                subject.getPrivateCredentials().add(passwordCredential);
+                return null;
+            }
+        });
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean abort() throws LoginException {
+        System.out.println(c + " >>> abort");
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean commit() throws LoginException {
+        System.out.println(c + " >>> commit");
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean logout() throws LoginException {
+        System.out.println(c + " >>> logout");
+        return true;
+    }
+
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/bootstrap.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2017,2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:rest.validator=all:com.ibm.ws.jdbc.DataSourceService=all
+com.ibm.ws.logging.max.file.size=0
+ds.loglevel=debug
+derby.connection.requireAuthentication=true
+derby.user.dbuser=dbpass

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/server.xml
@@ -1,0 +1,49 @@
+<server>
+  <include location="../fatTestPorts.xml" />
+
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>configValidator-1.0</feature> <!-- TODO replace when functionality is enabled via auto-feature -->
+    <feature>jdbc-4.2</feature>
+    <feature>appSecurity-2.0</feature>
+    <feature>jca-1.7</feature>
+  </featureManager>
+
+  <variable name="onError" value="FAIL"/>
+
+  <keyStore id="defaultKeyStore" password="Liberty"/>
+  <quickStartSecurity userName="adminuser" userPassword="adminpwd"/>
+  
+  <library id="Derby">
+    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  </library>
+
+  <jaasLoginModule id="customLoginModule" className="com.ibm.ws.rest.handler.validator.loginmodule.TestLoginModule" controlFlag="REQUIRED">
+    <library>
+      <fileset dir="${server.config.dir}" includes="customLoginModule.jar"/>
+    </library>
+  </jaasLoginModule>
+  
+  <jaasLoginContextEntry id="customLoginEntry" name="customLoginEntry" loginModuleRef="customLoginModule" />
+  
+  <dataSource id="customLoginDS" jndiName="jdbc/customLoginDS" jaasLoginContextEntry="customLoginEntry">
+    <jdbcDriver libraryRef="Derby"/>
+    <!-- user/password settings propagated by custom login module -->
+    <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+  </dataSource>
+  
+  <!-- This datasource intentionally has no auth data associated in server.xml, to simulate a <custom-login-configuration>
+       being applied in an app's ibm-web-bnd.xml like so:
+       <resource-ref name="jdbc/customLoginDSWebBnd" binding-name="jdbc/customLoginDSWebBnd">
+         <custom-login-configuration name="customLoginEntry">
+       </resource-ref>
+  -->
+  <dataSource id="customLoginDSWebBnd" jndiName="jdbc/customLoginDSWebBnd">
+    <jdbcDriver libraryRef="Derby"/>
+    <!-- user/password settings propagated by custom login module -->
+    <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+  </dataSource>
+  
+  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${server.config.dir}/customLoginModule.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/HttpsRequest.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/HttpsRequest.java
@@ -144,10 +144,12 @@ public class HttpsRequest {
                     }
 
                     @Override
-                    public void checkClientTrusted(X509Certificate[] certs, String authType) {}
+                    public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                    }
 
                     @Override
-                    public void checkServerTrusted(X509Certificate[] certs, String authType) {}
+                    public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                    }
                 } };
                 try {
                     SSLContext sc = SSLContext.getInstance("TLS");
@@ -165,17 +167,17 @@ public class HttpsRequest {
             con.setDoOutput(true);
             con.setRequestMethod(reqMethod);
 
-            if (type.getPackage().equals("javax.json"))
-                con.setRequestProperty("Content-Type", "application/json");
-            else
-                con.setRequestProperty("Content-Type", "text/html");
-
             if (json != null) {
-                con.setRequestProperty("Accept", "application/json");
+                con.setRequestProperty("Content-Type", "application/json");
                 OutputStream out = con.getOutputStream();
                 out.write(json.getBytes("UTF-8"));
                 out.close();
+            } else {
+                con.setRequestProperty("Content-Type", "text/html");
             }
+
+            if (type.getPackage().toString().startsWith("javax.json"))
+                con.setRequestProperty("Accept", "application/json");
 
             if (basicAuth != null)
                 con.setRequestProperty("Authorization", basicAuth);


### PR DESCRIPTION
Adds two elements for the DataSource validator API:

- **loginConfig**: The `jaasLoginContextEntry` (aka custom login module name) to use for authentication
- **loginConfigProperties**: This is passed in as part of the JSON request body, and holds any amount of custom login module properties, for example:
```json
Content-Type: application/json
{
  "loginConfigProperties" : {
    "fooProp": "bar",
    "another": "prop"
  }
}
```