### PR TITLE
Improve performance of JsonBProvider

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -189,7 +189,7 @@ public abstract class ProviderFactory {
                              //new StringProvider<Object>(), // Liberty Change for CXF
                              //new JAXBElementSubProvider(),
                              createJsonpProvider(), // Liberty Change for CXF Begin
-                             createJsonBindingProvider(),
+                             createJsonBindingProvider(null),
                              new IBMMultipartProvider(), // Liberty Change for CXF End
                              new MultipartProvider());
         Object prop = factory.getBus().getProperty("skip.default.json.provider.registration");
@@ -283,7 +283,7 @@ public abstract class ProviderFactory {
         return c;
     }
 
-    public static Object createJsonBindingProvider() {
+    public static Object createJsonBindingProvider(Iterable<ProviderInfo<ContextResolver<?>>> contextResolvers) {
 
         JacksonJaxbJsonProvider jacksonjaxbprovider = new JacksonJaxbJsonProviderWrapper();
         jacksonjaxbprovider.addUntouchable(DataSource.class);//Let DataSourceProvider handle DataSource.class
@@ -1155,6 +1155,12 @@ public abstract class ProviderFactory {
         return Collections.unmodifiableList(contextResolvers.get());
         //Liberty code change end
     }
+
+    //Liberty change start
+    public Iterable<ProviderInfo<ContextResolver<?>>> getContextResolversActual() {
+        return contextResolvers;
+    }
+    //Liberty change end
 
     public void registerUserProvider(Object provider) {
         setUserProviders(Collections.singletonList(provider));

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs21/providers/json/JsonBProvider.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs21/providers/json/JsonBProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,14 +28,14 @@ import javax.json.bind.spi.JsonbProvider;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
-import javax.ws.rs.ext.Providers;
+
+import org.apache.cxf.jaxrs.model.ProviderInfo;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -46,13 +46,12 @@ import com.ibm.websphere.ras.TraceComponent;
 public class JsonBProvider implements MessageBodyWriter<Object>, MessageBodyReader<Object> {
 
     private final static TraceComponent tc = Tr.register(JsonBProvider.class);
-
     private final Jsonb jsonb;
+    private final Iterable<ProviderInfo<ContextResolver<?>>> contextResolvers;
 
-    @Context
-    private Providers providers;
+    public JsonBProvider(JsonbProvider jsonbProvider, Iterable<ProviderInfo<ContextResolver<?>>> contextResolvers) {
+        this.contextResolvers = contextResolvers;
 
-    public JsonBProvider(JsonbProvider jsonbProvider) {
         if(jsonbProvider != null) {
             this.jsonb = jsonbProvider.create().build();
         } else {
@@ -161,7 +160,7 @@ public class JsonBProvider implements MessageBodyWriter<Object>, MessageBodyRead
         }
         return untouchable;
     }
-    
+
     private boolean isJsonType(MediaType mediaType) {
         return mediaType.getSubtype().toLowerCase().startsWith("json")
                         || mediaType.getSubtype().toLowerCase().contains("+json");
@@ -178,12 +177,15 @@ public class JsonBProvider implements MessageBodyWriter<Object>, MessageBodyRead
     }
 
     private Jsonb getJsonb() {
-        if (providers != null) {
-            ContextResolver<Jsonb> cr = providers.getContextResolver(Jsonb.class, MediaType.WILDCARD_TYPE);
-            if (cr != null) {
-                return cr.getContext(null);
+        for (ProviderInfo<ContextResolver<?>> crPi : contextResolvers) {
+            ContextResolver<?> cr = crPi.getProvider();
+            Object o = cr.getContext(null);
+            if (o instanceof Jsonb) {
+                return (Jsonb) o;
             }
-        } else if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "Context-injected Providers is null");
         }
         return this.jsonb;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -203,7 +203,7 @@ public abstract class ProviderFactory {
                      //tryCreateInstance("org.apache.cxf.jaxrs.provider.JAXBElementTypedProvider"),
                      new JAXBElementTypedProvider(), // Liberty change - tryCreateInstance changes behavior
                      createJsonpProvider(), // Liberty Change for CXF Begin
-                     createJsonBindingProvider(),
+                     createJsonBindingProvider(factory.contextResolvers),
                      new IBMMultipartProvider(), // Liberty Change for CXF End
                      //tryCreateInstance("org.apache.cxf.jaxrs.provider.MultipartProvider"));
                      new MultipartProvider());// Liberty change - tryCreateInstance changes behavior
@@ -293,7 +293,7 @@ public abstract class ProviderFactory {
         return c;
     }
 
-    public static Object createJsonBindingProvider() {
+    public static Object createJsonBindingProvider(Iterable<ProviderInfo<ContextResolver<?>>> contextResolvers) {
         JsonbProvider jsonbProvider = AccessController.doPrivileged(new PrivilegedAction<JsonbProvider>(){
 
             @Override
@@ -311,7 +311,7 @@ public abstract class ProviderFactory {
                 return null;
             }});
 
-        return new JsonBProvider(jsonbProvider);
+        return new JsonBProvider(jsonbProvider, contextResolvers);
     }
 
     // Liberty Change for CXF End
@@ -1167,6 +1167,12 @@ private final Map<MessageBodyReader<?>, List<MediaType>> readerMediaTypesMap = n
         return Collections.unmodifiableList(contextResolvers.get());
         //Liberty code change end
     }
+
+    //Liberty change start
+    public Iterable<ProviderInfo<ContextResolver<?>>> getContextResolversActual() {
+        return contextResolvers;
+    }
+    //Liberty change end
 
 
     public void registerUserProvider(Object provider) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
@@ -70,7 +70,6 @@ public class MicroProfileClientFactoryBean extends JAXRSClientFactoryBean {
         //Liberty change start
         //registeredProviders.add(new ProviderInfo<>(new JsrJsonpProvider(), getBus(), false));
         registeredProviders.add(new ProviderInfo<>(ProviderFactory.createJsonpProvider(), getBus(), false));
-        registeredProviders.add(new ProviderInfo<>(ProviderFactory.createJsonBindingProvider(), getBus(), false));
         //Liberty change end
         super.setProviders(registeredProviders);
     }
@@ -96,6 +95,7 @@ public class MicroProfileClientFactoryBean extends JAXRSClientFactoryBean {
         super.initClient(client, ep, addHeaders);
         MicroProfileClientProviderFactory factory = MicroProfileClientProviderFactory.createInstance(getBus(),
                 comparator);
+        registeredProviders.add(new ProviderInfo<>(ProviderFactory.createJsonBindingProvider(factory.getContextResolversActual()), getBus(), false));
         factory.setUserProviders(registeredProviders);
         ep.put(MicroProfileClientProviderFactory.CLIENT_FACTORY_NAME, factory);
     }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
@@ -71,7 +71,7 @@ public class MicroProfileClientFactoryBean extends JAXRSClientFactoryBean {
         //Liberty change start
         //registeredProviders.add(new ProviderInfo<>(new JsrJsonpProvider(), getBus(), false));
         registeredProviders.add(new ProviderInfo<>(ProviderFactory.createJsonpProvider(), getBus(), false));
-        registeredProviders.add(new ProviderInfo<>(ProviderFactory.createJsonBindingProvider(), getBus(), false));
+        
         //Liberty change end
         super.setProviders(registeredProviders);
     }
@@ -97,6 +97,7 @@ public class MicroProfileClientFactoryBean extends JAXRSClientFactoryBean {
         super.initClient(client, ep, addHeaders);
         MicroProfileClientProviderFactory factory = MicroProfileClientProviderFactory.createInstance(getBus(),
                 comparator);
+        registeredProviders.add(new ProviderInfo<>(ProviderFactory.createJsonBindingProvider(factory.getContextResolversActual()), getBus(), false));
         factory.setUserProviders(registeredProviders);
         ep.put(MicroProfileClientProviderFactory.CLIENT_FACTORY_NAME, factory);
     }


### PR DESCRIPTION
This change avoids Context injection of Providers - instead it captures the ContextResolvers at construction time iterating through to determine if the customer has provided their own Jsonb implementation.

This resolves issue #6982.
