### PR TITLE
create mock resource adapter for validator tests

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -15,11 +15,14 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src
+	fat/src,\
+	test-resourceadapter/src
 
 fat.project: true
 
 -buildpath: \
+	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+	com.ibm.websphere.javaee.connector.1.7;version=latest,\
     com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
@@ -20,6 +20,7 @@ import componenttest.topology.utils.HttpUtils;
 @RunWith(Suite.class)
 @SuiteClasses({
                 ValidateDataSourceTest.class,
+                ValidateJCATest.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.rest.handler.validator.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.json.JsonObject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpsRequest;
+
+@RunWith(FATRunner.class)
+public class ValidateJCATest extends FATServletClient {
+    @Server("com.ibm.ws.rest.handler.validator.jca.fat")
+    public static LibertyServer server;
+
+    private static String VERSION_REGEX = "[0-9]+\\.[0-9]+.*";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "TestValidationAdapter.rar")
+                        .addAsLibraries(ShrinkWrap.create(JavaArchive.class)
+                                        .addPackage("org.test.validator.adapter"));
+        ShrinkHelper.exportToServer(server, "dropins", rar);
+
+        server.startServer();
+
+        // Wait for the API to become available
+        List<String> messages = new ArrayList<>();
+        messages.add("CWWKS0008I"); // CWWKS0008I: The security service is ready.
+        messages.add("CWWKS4105I"); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        messages.add("CWPKI0803A"); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
+        messages.add("CWWKO0219I: .* defaultHttpEndpoint-ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        messages.add("CWWKT0016I"); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
+        messages.add("J2CA7001I: .* TestValidationAdapter"); // J2CA7001I: Resource adapter TestValidationAdapter installed in # seconds.
+
+        server.waitForStringsInLogUsingMark(messages);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    /**
+     * Attempt to validate a connectionFactory that does not exist in server configuration.
+     */
+    @Test
+    public void testConnectionFactoryNotFound() throws Exception {
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/connectionFactory/NotAConfiguredConnectionFactory").run(JsonObject.class);
+        String err = "unexpected response: " + json;
+        assertEquals(err, "NotAConfiguredConnectionFactory", json.getString("uid"));
+        assertNull(err, json.get("id"));
+        assertNull(err, json.get("jndiName"));
+        assertFalse(err, json.getBoolean("successful"));
+        assertNull(err, json.get("info"));
+        assertNotNull(err, json = json.getJsonObject("failure"));
+        assertTrue(err, json.getString("message").contains("Did not find any configured instances of connectionFactory matching the request"));
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:rest.validator=all
+com.ibm.ws.logging.max.file.size=0
+ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
@@ -1,0 +1,29 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <include location="../fatTestPorts.xml" />
+
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>configValidator-1.0</feature> <!-- TODO replace when functionality is enabled via auto-feature -->
+    <feature>jca-1.7</feature>
+    <feature>mpOpenApi-1.0</feature>
+  </featureManager>
+
+  <variable name="onError" value="FAIL"/>
+
+  <keyStore id="defaultKeyStore" password="Liberty"/>
+  <quickStartSecurity userName="adminuser" userPassword="adminpwd"/>
+
+  <connectionFactory id="cf1" jndiName="eis/cf1">
+    <properties.TestValidationAdapter hostName="myhost.openliberty.io" portNumber="9876" userName="user1" password="1user"/>
+  </connectionFactory>
+</server>

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionFactoryImpl.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.cci.Connection;
+import javax.resource.cci.ConnectionFactory;
+import javax.resource.cci.ConnectionSpec;
+import javax.resource.cci.RecordFactory;
+import javax.resource.cci.ResourceAdapterMetaData;
+import javax.resource.spi.ConnectionManager;
+
+import org.test.validator.adapter.ConnectionSpecImpl.ConnectionRequestInfoImpl;
+
+public class ConnectionFactoryImpl implements ConnectionFactory {
+    private static final long serialVersionUID = 847022212144243370L;
+
+    private final ConnectionManager cm;
+    final ManagedConnectionFactoryImpl mcf;
+    private Reference ref;
+
+    ConnectionFactoryImpl(ConnectionManager cm, ManagedConnectionFactoryImpl mcf) {
+        this.cm = cm;
+        this.mcf = mcf;
+    }
+
+    @Override
+    public Connection getConnection() throws ResourceException {
+        return getConnection(new ConnectionSpecImpl());
+    }
+
+    @Override
+    public Connection getConnection(ConnectionSpec conSpec) throws ResourceException {
+        ConnectionRequestInfoImpl cri = ((ConnectionSpecImpl) conSpec).createConnectionRequestInfo();
+        return (Connection) cm.allocateConnection(mcf, cri);
+    }
+
+    @Override
+    public ResourceAdapterMetaData getMetaData() throws ResourceException {
+        return new ResourceAdapterMetaDataImpl();
+    }
+
+    @Override
+    public RecordFactory getRecordFactory() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public Reference getReference() throws NamingException {
+        return ref;
+    }
+
+    @Override
+    public void setReference(Reference ref) {
+        this.ref = ref;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionImpl.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.cci.Connection;
+import javax.resource.cci.ConnectionMetaData;
+import javax.resource.cci.Interaction;
+import javax.resource.cci.LocalTransaction;
+import javax.resource.cci.ResultSetInfo;
+
+import org.test.validator.adapter.ConnectionSpecImpl.ConnectionRequestInfoImpl;
+
+public class ConnectionImpl implements Connection, ConnectionMetaData {
+    private final ConnectionRequestInfoImpl cri;
+
+    ConnectionImpl(ManagedConnectionImpl mc, ConnectionRequestInfoImpl cri) {
+        this.cri = cri;
+    }
+
+    @Override
+    public void close() throws ResourceException {}
+
+    @Override
+    public Interaction createInteraction() throws ResourceException {
+        return new InteractionImpl(this);
+    }
+
+    @Override
+    public LocalTransaction getLocalTransaction() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public ConnectionMetaData getMetaData() throws ResourceException {
+        return this;
+    }
+
+    @Override
+    public String getEISProductName() throws ResourceException {
+        return "TestValidationEIS";
+    }
+
+    @Override
+    public String getEISProductVersion() throws ResourceException {
+        return "33.56.65";
+    }
+
+    @Override
+    public ResultSetInfo getResultSetInfo() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public String getUserName() throws ResourceException {
+        return (String) cri.get("UserName");
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionSpecImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionSpecImpl.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import java.util.TreeMap;
+
+import javax.resource.cci.ConnectionSpec;
+import javax.resource.spi.ConnectionRequestInfo;
+
+/**
+ * Example ConnectionSpec implementation with UserName and Password.
+ */
+public class ConnectionSpecImpl implements ConnectionSpec {
+    private String user = "DefaultUserName", password = "DefaultPassword";
+
+    ConnectionRequestInfoImpl createConnectionRequestInfo() {
+        ConnectionRequestInfoImpl cri = new ConnectionRequestInfoImpl();
+        cri.put("UserName", user);
+        cri.put("Password", password);
+        return cri;
+    }
+
+    public String getUserName() {
+        return user;
+    }
+
+    public void setPassword(String pwd) {
+        this.password = pwd;
+    }
+
+    public void setUserName(String user) {
+        this.user = user;
+    }
+
+    static class ConnectionRequestInfoImpl extends TreeMap<String, Object> implements ConnectionRequestInfo {
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/InteractionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/InteractionImpl.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.cci.Connection;
+import javax.resource.cci.Interaction;
+import javax.resource.cci.InteractionSpec;
+import javax.resource.cci.Record;
+import javax.resource.cci.ResourceWarning;
+
+public class InteractionImpl implements Interaction {
+    private final ConnectionImpl con;
+
+    InteractionImpl(ConnectionImpl con) {
+        this.con = con;
+    }
+
+    @Override
+    public void clearWarnings() throws ResourceException {}
+
+    @Override
+    public void close() throws ResourceException {}
+
+    @Override
+    public Record execute(InteractionSpec ispec, Record input) throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public boolean execute(InteractionSpec ispec, Record input, Record output) throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public Connection getConnection() {
+        return con;
+    }
+
+    @Override
+    public ResourceWarning getWarnings() throws ResourceException {
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionFactoryImpl.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import java.io.PrintWriter;
+import java.util.Set;
+
+import javax.resource.ResourceException;
+import javax.resource.cci.Connection;
+import javax.resource.cci.ConnectionFactory;
+import javax.resource.spi.CommException;
+import javax.resource.spi.ConfigProperty;
+import javax.resource.spi.ConnectionDefinition;
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.InvalidPropertyException;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionFactory;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterAssociation;
+import javax.resource.spi.ResourceAllocationException;
+import javax.security.auth.Subject;
+
+/**
+ * Test managed connection factory that doesn't connect to anything.
+ */
+@ConnectionDefinition(connectionFactory = ConnectionFactory.class,
+                      connectionFactoryImpl = ConnectionFactoryImpl.class,
+                      connection = Connection.class,
+                      connectionImpl = ConnectionImpl.class)
+public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, ResourceAdapterAssociation {
+    private static final long serialVersionUID = 1L;
+
+    ResourceAdapterImpl adapter;
+
+    @ConfigProperty
+    private String hostName = "localhost";
+
+    @ConfigProperty
+    private Integer portNumber = 4321;
+
+    @Override
+    public Object createConnectionFactory() throws ResourceException {
+        return createConnectionFactory(null);
+    }
+
+    @Override
+    public Object createConnectionFactory(ConnectionManager cm) throws ResourceException {
+        return new ConnectionFactoryImpl(cm, this);
+    }
+
+    @Override
+    public ManagedConnection createManagedConnection(Subject subject, ConnectionRequestInfo cri) throws ResourceException {
+        // Various sorts of exception paths for the validator to test
+
+        if (portNumber < 0) {
+            InvalidPropertyException x = new InvalidPropertyException("portNumber");
+            x.initCause(new IllegalArgumentException("Negative port numbers are not allowed."));
+            throw x;
+        }
+
+        if (portNumber < 1024)
+            throw new IllegalArgumentException(Integer.toString(portNumber));
+
+        if (portNumber % 10 == 0)
+            throw new ResourceAllocationException("Port " + portNumber + " is currently in use.");
+
+        if (!hostName.equals("localhost") && !hostName.endsWith(".openliberty.io"))
+            throw new CommException("Unable to connect to " + hostName);
+
+        return new ManagedConnectionImpl();
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws ResourceException {
+        return null;
+    }
+
+    public Integer getPortNumber() {
+        return portNumber;
+    }
+
+    @Override
+    public ResourceAdapter getResourceAdapter() {
+        return adapter;
+    }
+
+    @Override
+    public ManagedConnection matchManagedConnections(@SuppressWarnings("rawtypes") Set connections, Subject subject, ConnectionRequestInfo cri) throws ResourceException {
+        for (Object mc : connections)
+            if (mc instanceof ManagedConnectionImpl)
+                return (ManagedConnection) mc;
+        return null;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter logWriter) throws ResourceException {}
+
+    public void setPortNumber(Integer portNumber) {
+        this.portNumber = portNumber;
+    }
+
+    @Override
+    public void setResourceAdapter(ResourceAdapter adapter) throws ResourceException {
+        this.adapter = (ResourceAdapterImpl) adapter;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionImpl.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import java.io.PrintWriter;
+
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionEventListener;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.LocalTransaction;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionMetaData;
+import javax.security.auth.Subject;
+import javax.transaction.xa.XAResource;
+
+import org.test.validator.adapter.ConnectionSpecImpl.ConnectionRequestInfoImpl;
+
+public class ManagedConnectionImpl implements ManagedConnection {
+    @Override
+    public void addConnectionEventListener(ConnectionEventListener listener) {}
+
+    @Override
+    public void associateConnection(Object handle) throws ResourceException {}
+
+    @Override
+    public void cleanup() throws ResourceException {}
+
+    @Override
+    public void destroy() throws ResourceException {}
+
+    @Override
+    public Object getConnection(Subject subject, ConnectionRequestInfo cri) throws ResourceException {
+        return new ConnectionImpl(this, (ConnectionRequestInfoImpl) cri);
+    }
+
+    @Override
+    public LocalTransaction getLocalTransaction() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws ResourceException {
+        return null;
+    }
+
+    @Override
+    public ManagedConnectionMetaData getMetaData() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public XAResource getXAResource() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public void removeConnectionEventListener(ConnectionEventListener listener) {}
+
+    @Override
+    public void setLogWriter(PrintWriter logWriter) throws ResourceException {}
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ResourceAdapterImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ResourceAdapterImpl.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.BootstrapContext;
+import javax.resource.spi.Connector;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterInternalException;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.transaction.xa.XAResource;
+
+/**
+ * Test resource adapter that creates fake validatable connections.
+ */
+@Connector
+public class ResourceAdapterImpl implements ResourceAdapter {
+    @Override
+    public void endpointActivation(MessageEndpointFactory endpointFactory, ActivationSpec activationSpec) throws ResourceException {}
+
+    @Override
+    public void endpointDeactivation(MessageEndpointFactory endpointFactory, ActivationSpec activationSpec) {}
+
+    @Override
+    public XAResource[] getXAResources(ActivationSpec[] activationSpecs) throws ResourceException {
+        return null;
+    }
+
+    @Override
+    public void start(BootstrapContext bootstrapContext) throws ResourceAdapterInternalException {}
+
+    @Override
+    public void stop() {}
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ResourceAdapterMetaDataImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ResourceAdapterMetaDataImpl.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import javax.resource.cci.ResourceAdapterMetaData;
+
+public class ResourceAdapterMetaDataImpl implements ResourceAdapterMetaData {
+    @Override
+    public String getAdapterName() {
+        return "TestValidationAdapter";
+    }
+
+    @Override
+    public String getAdapterShortDescription() {
+        return "This tiny resource adapter doesn't do much at all.";
+    }
+
+    @Override
+    public String getAdapterVendorName() {
+        return "OpenLiberty";
+    }
+
+    @Override
+    public String getAdapterVersion() {
+        return "28.45.53";
+    }
+
+    @Override
+    public String[] getInteractionSpecsSupported() {
+        return new String[0];
+    }
+
+    @Override
+    public String getSpecVersion() {
+        return "1.7";
+    }
+
+    @Override
+    public boolean supportsExecuteWithInputAndOutputRecord() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsExecuteWithInputRecordOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsLocalTransactionDemarcation() {
+        return false;
+    }
+}


### PR DESCRIPTION
Create a fake resource adapter that doesn't connect to anything, but can be used to test the validator REST API on JCA connection factories that use the javax.resource.cci package.