### PR TITLE
6999-CWPKI0023E-commit1

### DIFF
--- a/dev/com.ibm.ws.ssl/resources/com/ibm/ws/ssl/resources/ssl.nlsprops
+++ b/dev/com.ibm.ws.ssl/resources/com/ibm/ws/ssl/resources/ssl.nlsprops
@@ -117,11 +117,11 @@ ssl.client.handshake.error.CWPKI0022E=CWPKI0022E: SSL HANDSHAKE FAILURE:  A sign
 ssl.client.handshake.error.CWPKI0022E.explanation=An error occurred during the SSL handshake.  It might require a signer export/import from the target host to the client TrustStore.
 ssl.client.handshake.error.CWPKI0022E.useraction=Review the extended error message from the TrustManager to determine what needs to change between the target SSL configuration and the client SSL configuration.
 # -------------------------------------------------------------------------------------------------
-ssl.client.alias.not.found.CWPKI0023E=CWPKI0023E: The {0} certificate alias specified by the property com.ibm.ssl.keyStoreClientAlias is either not found in KeyStore {1} or it is invalid.
+ssl.client.alias.not.found.CWPKI0023E=CWPKI0023E: The {0} certificate alias specified by the attribute clientKeyAlias is either not found in KeyStore {1} or it is invalid.
 ssl.client.alias.not.found.CWPKI0023E.explanation=The certificate alias specified for this SSL configuration is not in the specified KeyStore or it was found to be invalid. An expired certificate is one example of an invalid certificate.
 ssl.client.alias.not.found.CWPKI0023E.useraction=Either add a certificate into the KeyStore with the specified certificate alias, or replace or renew the invalid certificate with the specified certificate alias found in the client KeyStore.
 # -------------------------------------------------------------------------------------------------
-ssl.server.alias.not.found.CWPKI0024E=CWPKI0024E: The {0} certificate alias specified by the property com.ibm.ssl.keyStoreServerAlias is either not found in KeyStore {1} or it is invalid.
+ssl.server.alias.not.found.CWPKI0024E=CWPKI0024E: The {0} certificate alias specified by the attribute serverKeyAlias is either not found in KeyStore {1} or it is invalid.
 ssl.server.alias.not.found.CWPKI0024E.explanation=The certificate alias specified for this SSL configuration is not in the specified KeyStore or it was found to be invalid. An expired certificate is one example of an invalid certificate.
 ssl.server.alias.not.found.CWPKI0024E.useraction=Either add a certificate into the KeyStore with the specified certificate alias, or replace or renew the invalid certificate with the specified certificate alias found in the server KeyStore.
 # -------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.ssl/resources/com/ibm/ws/ssl/resources/ssl.nlsprops
+++ b/dev/com.ibm.ws.ssl/resources/com/ibm/ws/ssl/resources/ssl.nlsprops
@@ -117,13 +117,13 @@ ssl.client.handshake.error.CWPKI0022E=CWPKI0022E: SSL HANDSHAKE FAILURE:  A sign
 ssl.client.handshake.error.CWPKI0022E.explanation=An error occurred during the SSL handshake.  It might require a signer export/import from the target host to the client TrustStore.
 ssl.client.handshake.error.CWPKI0022E.useraction=Review the extended error message from the TrustManager to determine what needs to change between the target SSL configuration and the client SSL configuration.
 # -------------------------------------------------------------------------------------------------
-ssl.client.alias.not.found.CWPKI0023E=CWPKI0023E: The certificate alias {0} specified by the property com.ibm.ssl.keyStoreClientAlias is either not found in KeyStore {1} or it is invalid.
+ssl.client.alias.not.found.CWPKI0023E=CWPKI0023E: The {0} certificate alias specified by the property com.ibm.ssl.keyStoreClientAlias is either not found in KeyStore {1} or it is invalid.
 ssl.client.alias.not.found.CWPKI0023E.explanation=The certificate alias specified for this SSL configuration is not in the specified KeyStore or it was found to be invalid. An expired certificate is one example of an invalid certificate.
 ssl.client.alias.not.found.CWPKI0023E.useraction=Either add a certificate into the KeyStore with the specified certificate alias, or replace or renew the invalid certificate with the specified certificate alias found in the client KeyStore.
 # -------------------------------------------------------------------------------------------------
-ssl.server.alias.not.found.CWPKI0024E=CWPKI0024E: The certificate alias {0} specified by the property com.ibm.ssl.keyStoreServerAlias is either not found in KeyStore {1} or it is invalid.
+ssl.server.alias.not.found.CWPKI0024E=CWPKI0024E: The {0} certificate alias specified by the property com.ibm.ssl.keyStoreServerAlias is either not found in KeyStore {1} or it is invalid.
 ssl.server.alias.not.found.CWPKI0024E.explanation=The certificate alias specified for this SSL configuration is not in the specified KeyStore or it was found to be invalid. An expired certificate is one example of an invalid certificate.
-ssl.server.alias.not.found.CWPKI0024E.useraction=Either add a certificate into the KeyStore with the specified certificate alias, or replace, or renew the invalid certificate with the specified certificate alias found in the server KeyStore.
+ssl.server.alias.not.found.CWPKI0024E.useraction=Either add a certificate into the KeyStore with the specified certificate alias, or replace or renew the invalid certificate with the specified certificate alias found in the server KeyStore.
 # -------------------------------------------------------------------------------------------------
 ssl.load.https.stream.handler.CWPKI0025E=CWPKI0025E: The system could not load the https Handler class {0}. Extended error message: {1}
 ssl.load.https.stream.handler.CWPKI0025E.explanation=There was a classloading error trying to load the HTTPS URLStreamHandler class. 

--- a/dev/com.ibm.ws.ssl/resources/com/ibm/ws/ssl/resources/ssl.nlsprops
+++ b/dev/com.ibm.ws.ssl/resources/com/ibm/ws/ssl/resources/ssl.nlsprops
@@ -117,13 +117,13 @@ ssl.client.handshake.error.CWPKI0022E=CWPKI0022E: SSL HANDSHAKE FAILURE:  A sign
 ssl.client.handshake.error.CWPKI0022E.explanation=An error occurred during the SSL handshake.  It might require a signer export/import from the target host to the client TrustStore.
 ssl.client.handshake.error.CWPKI0022E.useraction=Review the extended error message from the TrustManager to determine what needs to change between the target SSL configuration and the client SSL configuration.
 # -------------------------------------------------------------------------------------------------
-ssl.client.alias.not.found.CWPKI0023E=CWPKI0023E: The certificate alias {0} specified by the property com.ibm.ssl.keyStoreClientAlias is not found in KeyStore {1}.
-ssl.client.alias.not.found.CWPKI0023E.explanation=The certificate alias specified for this SSL configuration is not in the specified KeyStore. 
-ssl.client.alias.not.found.CWPKI0023E.useraction=Either add a certificate into the KeyStore with the specified certificate alias or change the specified certificate alias to match an alias found in the client KeyStore.
+ssl.client.alias.not.found.CWPKI0023E=CWPKI0023E: The certificate alias {0} specified by the property com.ibm.ssl.keyStoreClientAlias is either not found in KeyStore {1} or it is invalid.
+ssl.client.alias.not.found.CWPKI0023E.explanation=The certificate alias specified for this SSL configuration is not in the specified KeyStore or it was found to be invalid. An expired certificate is one example of an invalid certificate.
+ssl.client.alias.not.found.CWPKI0023E.useraction=Either add a certificate into the KeyStore with the specified certificate alias, or replace or renew the invalid certificate with the specified certificate alias found in the client KeyStore.
 # -------------------------------------------------------------------------------------------------
-ssl.server.alias.not.found.CWPKI0024E=CWPKI0024E: The certificate alias {0} specified by the property com.ibm.ssl.keyStoreServerAlias is not found in KeyStore {1}.
-ssl.server.alias.not.found.CWPKI0024E.explanation=The certificate alias specified for this SSL configuration is not in the specified KeyStore. 
-ssl.server.alias.not.found.CWPKI0024E.useraction=Either add a certificate into the KeyStore with the specified certificate alias or change the specified certificate alias to match an alias found in the server KeyStore.
+ssl.server.alias.not.found.CWPKI0024E=CWPKI0024E: The certificate alias {0} specified by the property com.ibm.ssl.keyStoreServerAlias is either not found in KeyStore {1} or it is invalid.
+ssl.server.alias.not.found.CWPKI0024E.explanation=The certificate alias specified for this SSL configuration is not in the specified KeyStore or it was found to be invalid. An expired certificate is one example of an invalid certificate.
+ssl.server.alias.not.found.CWPKI0024E.useraction=Either add a certificate into the KeyStore with the specified certificate alias, or replace, or renew the invalid certificate with the specified certificate alias found in the server KeyStore.
 # -------------------------------------------------------------------------------------------------
 ssl.load.https.stream.handler.CWPKI0025E=CWPKI0025E: The system could not load the https Handler class {0}. Extended error message: {1}
 ssl.load.https.stream.handler.CWPKI0025E.explanation=There was a classloading error trying to load the HTTPS URLStreamHandler class. 

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
@@ -41,7 +41,7 @@ import com.ibm.wsspi.ssl.KeyManagerExtendedInfo;
  * This class is the KeyManager wrapper that delegates to the "real" KeyManager
  * configured for the system.
  * </p>
- * 
+ *
  * @author IBM Corporation
  * @version WAS 7.0
  * @since WAS 7.0
@@ -62,7 +62,7 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
 
     /**
      * Constructor.
-     * 
+     *
      * @param keystore
      * @param passPhrase
      * @param kmf
@@ -110,7 +110,7 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
 
     /**
      * Set the client alias value for the given slot number.
-     * 
+     *
      * @param alias
      * @param slotnum
      * @throws Exception
@@ -124,7 +124,7 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
             String location = keyFileName != null ? keyFileName : tokenLibraryFile;
 
             String message = TraceNLSHelper.getInstance().getFormattedMessage("ssl.client.alias.not.found.CWPKI0023E", new Object[] { alias, location },
-                                                                              "Client alias " + alias + " not found in keystore.");
+                                                                              "Client alias " + alias + " is invalid or not found in keystore.");
             Tr.error(tc, "ssl.client.alias.not.found.CWPKI0023E", new Object[] { alias, location });
             throw new IllegalArgumentException(message);
         }
@@ -139,7 +139,7 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
 
     /**
      * Set the server alias for the given slot number.
-     * 
+     *
      * @param alias
      * @param slotnum
      * @throws Exception
@@ -240,7 +240,7 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
 
     /**
      * Choose a client alias.
-     * 
+     *
      * @param keyType
      * @param issuers
      * @return String
@@ -274,7 +274,8 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
                     // JCERACFKS and JCECCARACFKS support mixed case, if we see that type,
                     // do not lowercase the alias
                     if (ks.getType() != null
-                        && (ks.getType().equals(Constants.KEYSTORE_TYPE_JCERACFKS) || ks.getType().equals(Constants.KEYSTORE_TYPE_JCECCARACFKS) || ks.getType().equals(Constants.KEYSTORE_TYPE_JCEHYBRIDRACFKS))) {
+                        && (ks.getType().equals(Constants.KEYSTORE_TYPE_JCERACFKS) || ks.getType().equals(Constants.KEYSTORE_TYPE_JCECCARACFKS)
+                            || ks.getType().equals(Constants.KEYSTORE_TYPE_JCEHYBRIDRACFKS))) {
                         return clientAlias;
                     }
                     return clientAlias.toLowerCase();
@@ -292,7 +293,8 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
             // JCERACFKS and JCECCARACFKS support mixed case, if we see that type, do
             // not lowercase the alias
             if (ks.getType() != null
-                && (!ks.getType().equals(Constants.KEYSTORE_TYPE_JCERACFKS) && !ks.getType().equals(Constants.KEYSTORE_TYPE_JCECCARACFKS) && !ks.getType().equals(Constants.KEYSTORE_TYPE_JCEHYBRIDRACFKS))) {
+                && (!ks.getType().equals(Constants.KEYSTORE_TYPE_JCERACFKS) && !ks.getType().equals(Constants.KEYSTORE_TYPE_JCECCARACFKS)
+                    && !ks.getType().equals(Constants.KEYSTORE_TYPE_JCEHYBRIDRACFKS))) {
                 if (alias != null) {
                     alias = alias.toLowerCase();
                 }
@@ -307,7 +309,7 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
     /**
      * Handshakes that use the SSLEngine and not an SSLSocket require this method
      * from the extended X509KeyManager.
-     * 
+     *
      * @see javax.net.ssl.X509ExtendedKeyManager#chooseEngineServerAlias(java.lang.String, java.security.Principal[], javax.net.ssl.SSLEngine)
      */
     @Override
@@ -331,7 +333,7 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
     /**
      * Handshakes that use the SSLEngine and not an SSLSocket require this method
      * from the extended X509KeyManager.
-     * 
+     *
      * @see javax.net.ssl.X509ExtendedKeyManager#chooseEngineClientAlias(java.lang.String[], java.security.Principal[], javax.net.ssl.SSLEngine)
      */
     @Override
@@ -355,7 +357,7 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
 
     /**
      * Choose a server alias.
-     * 
+     *
      * @param keyType
      * @param issuers
      * @return String
@@ -394,7 +396,8 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
                         // JCERACFKS and JCECCARACFKS support mixed case, if we see that
                         // type, do not lowercase the alias
                         if (ks.getType() != null
-                            && (ks.getType().equals(Constants.KEYSTORE_TYPE_JCERACFKS) || ks.getType().equals(Constants.KEYSTORE_TYPE_JCECCARACFKS) || ks.getType().equals(Constants.KEYSTORE_TYPE_JCEHYBRIDRACFKS))) {
+                            && (ks.getType().equals(Constants.KEYSTORE_TYPE_JCERACFKS) || ks.getType().equals(Constants.KEYSTORE_TYPE_JCECCARACFKS)
+                                || ks.getType().equals(Constants.KEYSTORE_TYPE_JCEHYBRIDRACFKS))) {
                             return serverAlias;
                         }
                         return serverAlias.toLowerCase();
@@ -410,7 +413,8 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
             // JCERACFKS and JCECCARACFKS support mixed case, if we see that type, do
             // not lowercase the alias
             if (ks.getType() != null
-                && (!ks.getType().equals(Constants.KEYSTORE_TYPE_JCERACFKS) && !ks.getType().equals(Constants.KEYSTORE_TYPE_JCECCARACFKS) && !ks.getType().equals(Constants.KEYSTORE_TYPE_JCEHYBRIDRACFKS))) {
+                && (!ks.getType().equals(Constants.KEYSTORE_TYPE_JCERACFKS) && !ks.getType().equals(Constants.KEYSTORE_TYPE_JCECCARACFKS)
+                    && !ks.getType().equals(Constants.KEYSTORE_TYPE_JCEHYBRIDRACFKS))) {
                 if (alias != null) {
                     alias = alias.toLowerCase();
                 }
@@ -490,7 +494,7 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
 
     /**
      * Get the appropriate X509KeyManager for this instance.
-     * 
+     *
      * @return X509KeyManager
      */
     public X509KeyManager getX509KeyManager() {

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
@@ -153,7 +153,7 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
             String location = keyFileName != null ? keyFileName : tokenLibraryFile;
 
             String message = TraceNLSHelper.getInstance().getFormattedMessage("ssl.server.alias.not.found.CWPKI0024E", new Object[] { alias, location },
-                                                                              "Server alias " + alias + " not found in keystore.");
+                                                                              "Server alias " + alias + " is invalid or not found in keystore.");
             Tr.error(tc, "ssl.server.alias.not.found.CWPKI0024E", new Object[] { alias, location });
             throw new IllegalArgumentException(message);
         }


### PR DESCRIPTION
Messages CWPKI0023E and CWPKI0024E can be issued if the target certificate is invalid, expired. That should be clarified in the messages.

fixes #6999 