### PR TITLE
Deploy arquillian support feature and use it for FT 2.0 TCK

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/server.xml
@@ -16,6 +16,7 @@
         <feature>mpConfig-1.3</feature>
         <feature>mpMetrics-1.1</feature> 
         <feature>localConnector-1.0</feature>
+        <feature>arquillian-support-1.0</feature>
    </featureManager>
 
    <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.3</version> 
+            <version>1.0.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -13,9 +13,6 @@
     <test name="microprofile-faulttolerance 2.0 TCK">
         <packages>
             <package name="org.eclipse.microprofile.fault.tolerance.tck.*">
-                <!-- Exclude due to https://github.com/OpenLiberty/liberty-arquillian/issues/36 -->
-                <exclude name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod"/>
-                <exclude name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters"/>
             </package>
         </packages>
     </test>

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -40,3 +40,32 @@ jar {
     dependsOn assembleBootstrap
     dependsOn assembleBinaryDependencies
 }
+
+configurations {
+    arquillianFeature
+}
+
+dependencies {
+    arquillianFeature 'io.openliberty.arquillian:arquillian-liberty-support:1.0.4:feature@zip'
+}
+
+task extractArquillianSupportFeature(type:Sync) {
+    configurations.arquillianFeature.each {
+        from(zipTree(it))
+    }
+    into('build/arquillian-feature-extract')
+    
+    doLast {
+        // Update the feature manifest to mark it as a test feature
+        file('build/arquillian-feature-extract/extension/lib/features/arquillian-liberty-support.mf')
+            .append('IBM-Test-Feature: true\n')
+    }
+}
+
+task publishArquillianSupportFeature(type:Copy) {
+    dependsOn extractArquillianSupportFeature
+    from('build/arquillian-feature-extract/extension')
+    into(buildImage.file('wlp'))
+}
+
+assemble.dependsOn publishArquillianSupportFeature


### PR DESCRIPTION
This change deploys the arquillian support feature as a test feature (rather than a user feature) and uses it to enable the disabled tests in the Fault Tolerance 2.0 TCK