### PR TITLE
Resolve outbound SSL connection problem

### DIFF
--- a/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLConnectionLink.java
+++ b/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLConnectionLink.java
@@ -856,7 +856,6 @@ public class SSLConnectionLink extends OutboundProtocolLink implements Connectio
             }
             exception = new IOException("Unexpected results of handshake after connect, " + hsStatus);
         }
-        AlpnSupportUtils.getAlpnResult(getSSLEngine(), this);
 
         // PK16095 - take certain actions when the handshake completes
         getChannel().onHandshakeFinish(getSSLEngine());

--- a/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLUtils.java
+++ b/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLUtils.java
@@ -1239,12 +1239,13 @@ public class SSLUtils {
                     Tr.debug(tc, "Client auth supported is " + engine.getWantClientAuth());
                 }
             }
+            // enable ALPN support if this is for an inbound connection
+            AlpnSupportUtils.registerAlpnSupport(connLink, engine);
+
         } else {
             // Update engine with client side specific config parameters.
             engine.setUseClientMode(true);
         }
-
-        AlpnSupportUtils.registerAlpnSupport(connLink, engine);
 
         try {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {


### PR DESCRIPTION
We currently attempt to negotiate an ALPN protocol for outbound SSL connections - which isn't actually supported.  ALPN negotiation should be skipped for outbound connections.

Fixes #7071