### PR TITLE
Restart JPA Applications when JPA Element's default datasource attrib…

### DIFF
--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAApplInfo.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAApplInfo.java
@@ -287,6 +287,22 @@ public abstract class JPAApplInfo {
         }
     }
 
+    public boolean hasPersistenceUnitsDefined() {
+        final Map<String, JPAScopeInfo> puScopesClone = new HashMap<String, JPAScopeInfo>();
+        synchronized (puScopes) {
+            puScopesClone.putAll(puScopes);
+        }
+
+        for (Map.Entry<String, JPAScopeInfo> entry : puScopesClone.entrySet()) {
+            final JPAScopeInfo scopeInfo = entry.getValue();
+            if (scopeInfo.getAllPuCount() > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     @Override
     public String toString() {
         synchronized (puScopes) {

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAPUnitInfo.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAPUnitInfo.java
@@ -372,10 +372,6 @@ public abstract class JPAPUnitInfo implements PersistenceUnitInfo {
      */
     @Override
     public final DataSource getJtaDataSource() {
-        if (this.ivTxType == PersistenceUnitTransactionType.RESOURCE_LOCAL) {
-            return null;
-        }
-
         if (ivJtaDataSource == null || ivJtaDataSource instanceof GenericDataSource) { // d455055
             ivJtaDataSource = getJPADataSource(ivJtaDataSourceJNDIName);
         }

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAPUnitInfo.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAPUnitInfo.java
@@ -501,7 +501,7 @@ public abstract class JPAPUnitInfo implements PersistenceUnitInfo {
      * environment.
      *
      * @param jarFileValues List of jar file paths from <jar-file> in persistence.xml
-     * @param looseConfig   class holding loose config mappings
+     * @param looseConfig class holding loose config mappings
      */
     //PK62950
     final void setJarFileUrls(List<String> jarFilePaths, JPAPXml pxml) {
@@ -787,8 +787,8 @@ public abstract class JPAPUnitInfo implements PersistenceUnitInfo {
      * created. <p>
      *
      * @param j2eeName
-     *                     JavaEE unique identifier for the component, identifying the
-     *                     java:comp/env context used.
+     *            JavaEE unique identifier for the component, identifying the
+     *            java:comp/env context used.
      *
      * @return EntityManager factory associated with this persistence unit.
      **/
@@ -869,10 +869,10 @@ public abstract class JPAPUnitInfo implements PersistenceUnitInfo {
      * component context (java:comp/env); in which case it will be a
      * component specific instance of JPACompPUnitInfo. <p>
      *
-     * @param puInfo             persistence unit information to pass on the call to
-     *                               createEntityManagerFactory.
+     * @param puInfo persistence unit information to pass on the call to
+     *            createEntityManagerFactory.
      * @param ignoreProviderCNFE whether or not a CNFE should be logged as an FFDC
-     *                               (provider CNFE's are tolerated for WABs per defect 152577)
+     *            (provider CNFE's are tolerated for WABs per defect 152577)
      * @throws RuntimeException if an error occurs while creating the EMF
      **/
     // d510184
@@ -975,12 +975,12 @@ public abstract class JPAPUnitInfo implements PersistenceUnitInfo {
      * accross PersistenceContext references. <p>
      *
      * @param j2eeName
-     *                       JavaEE unique identifier for the component, identifying the
-     *                       java:comp/env context used.
+     *            JavaEE unique identifier for the component, identifying the
+     *            java:comp/env context used.
      * @param refName
-     *                       Name of the PersistenceContext reference.
+     *            Name of the PersistenceContext reference.
      * @param properties
-     *                       additional properties to create the EntityManager
+     *            additional properties to create the EntityManager
      *
      * @return EntityManager pool for the specified component and reference.
      **/

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAPUnitInfo.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAPUnitInfo.java
@@ -372,6 +372,10 @@ public abstract class JPAPUnitInfo implements PersistenceUnitInfo {
      */
     @Override
     public final DataSource getJtaDataSource() {
+        if (this.ivTxType == PersistenceUnitTransactionType.RESOURCE_LOCAL) {
+            return null;
+        }
+
         if (ivJtaDataSource == null || ivJtaDataSource instanceof GenericDataSource) { // d455055
             ivJtaDataSource = getJPADataSource(ivJtaDataSourceJNDIName);
         }
@@ -497,7 +501,7 @@ public abstract class JPAPUnitInfo implements PersistenceUnitInfo {
      * environment.
      *
      * @param jarFileValues List of jar file paths from <jar-file> in persistence.xml
-     * @param looseConfig class holding loose config mappings
+     * @param looseConfig   class holding loose config mappings
      */
     //PK62950
     final void setJarFileUrls(List<String> jarFilePaths, JPAPXml pxml) {
@@ -783,8 +787,8 @@ public abstract class JPAPUnitInfo implements PersistenceUnitInfo {
      * created. <p>
      *
      * @param j2eeName
-     *            JavaEE unique identifier for the component, identifying the
-     *            java:comp/env context used.
+     *                     JavaEE unique identifier for the component, identifying the
+     *                     java:comp/env context used.
      *
      * @return EntityManager factory associated with this persistence unit.
      **/
@@ -865,10 +869,10 @@ public abstract class JPAPUnitInfo implements PersistenceUnitInfo {
      * component context (java:comp/env); in which case it will be a
      * component specific instance of JPACompPUnitInfo. <p>
      *
-     * @param puInfo persistence unit information to pass on the call to
-     *            createEntityManagerFactory.
+     * @param puInfo             persistence unit information to pass on the call to
+     *                               createEntityManagerFactory.
      * @param ignoreProviderCNFE whether or not a CNFE should be logged as an FFDC
-     *            (provider CNFE's are tolerated for WABs per defect 152577)
+     *                               (provider CNFE's are tolerated for WABs per defect 152577)
      * @throws RuntimeException if an error occurs while creating the EMF
      **/
     // d510184
@@ -971,12 +975,12 @@ public abstract class JPAPUnitInfo implements PersistenceUnitInfo {
      * accross PersistenceContext references. <p>
      *
      * @param j2eeName
-     *            JavaEE unique identifier for the component, identifying the
-     *            java:comp/env context used.
+     *                       JavaEE unique identifier for the component, identifying the
+     *                       java:comp/env context used.
      * @param refName
-     *            Name of the PersistenceContext reference.
+     *                       Name of the PersistenceContext reference.
      * @param properties
-     *            additional properties to create the EntityManager
+     *                       additional properties to create the EntityManager
      *
      * @return EntityManager pool for the specified component and reference.
      **/

--- a/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/JPAComponentImpl.java
+++ b/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/JPAComponentImpl.java
@@ -27,6 +27,7 @@ import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -159,22 +160,19 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
 
         boolean recycleJPAApplications = false;
 
-        if ((originalProvider != null && !originalProvider.equals(curProvider)) ||
-            (curProvider != null && !curProvider.equals(originalProvider))) {
+        if (!Objects.equals(originalProvider, curProvider)) {
             // If the <jpa defaultPersistenceProvider=""/> element has changed, restart all JPA apps
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(tc, "Detected change in defaultPersistenceProvider of the <jpa> element.  Restarting all JPA applications.",
                          originalProvider + " -> " + curProvider);
             recycleJPAApplications = true;
-        } else if ((originalDefaultJtaDataSourceJndiName != null && !originalDefaultJtaDataSourceJndiName.equals(curDefaultJtaDataSourceJndiName)) ||
-                   (curDefaultJtaDataSourceJndiName != null && !curDefaultJtaDataSourceJndiName.equals(originalDefaultJtaDataSourceJndiName))) {
+        } else if (!Objects.equals(originalDefaultJtaDataSourceJndiName, curDefaultJtaDataSourceJndiName)) {
             // If the <jpa defaultJtaDataSourceJndiName=""/> element has changed, restart all JPA apps
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(tc, "Detected change in defaultJtaDataSourceJndiName of the <jpa> element.  Restarting all JPA applications.",
                          originalProvider + " -> " + curProvider);
             recycleJPAApplications = true;
-        } else if ((originalDefaultNonJtaDataSourceJndiName != null && !originalDefaultNonJtaDataSourceJndiName.equals(curDefaultNonJtaDataSourceJndiName)) ||
-                   (curDefaultNonJtaDataSourceJndiName != null && !curDefaultNonJtaDataSourceJndiName.equals(originalDefaultNonJtaDataSourceJndiName))) {
+        } else if (!Objects.equals(originalDefaultNonJtaDataSourceJndiName, curDefaultNonJtaDataSourceJndiName)) {
             // If the <jpa defaultNonJtaDataSourceJndiName=""/> element has changed, restart all JPA apps
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(tc, "Detected change in defaultNonJtaDataSourceJndiName of the <jpa> element.  Restarting all JPA applications.",

--- a/dev/com.ibm.ws.jpa_22_fat/.classpath
+++ b/dev/com.ibm.ws.jpa_22_fat/.classpath
@@ -10,6 +10,7 @@
 	<classpathentry kind="src" path="test-applications/jpa22/jpa22injection/src"/>
 	<classpathentry kind="src" path="test-applications/helpers/DatabaseManagement/src"/>
 	<classpathentry kind="src" path="test-framework/src"/>
+	<classpathentry kind="src" path="test-applications/jpadefaultdatasource/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_22_fat/bnd.bnd
@@ -24,6 +24,7 @@ src: \
 	test-applications/jpa22/jpa22injection/src,\
 	test-applications/jpa22/jpa22query/src,\
 	test-applications/jpa22/jpa22timeapi/src,\
+	test-applications/jpadefaultdatasource/src,\
 	test-framework/src
 
 fat.project: true

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -19,6 +19,7 @@ import com.ibm.ws.jpa.jpa22.JPA22FATSuite;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+                JPADefaultDataSourceTest.class,
                 JPABootstrapTest.class,
                 JPA22FATSuite.class,
                 JPAAppClientTest.class

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPADefaultDataSourceTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPADefaultDataSourceTest.java
@@ -36,6 +36,10 @@ import componenttest.topology.utils.PrivHelper;
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class JPADefaultDataSourceTest {
+    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+
     @Server("JPADefaultDataSourceServer_JTANJTA")
     public static LibertyServer server_JTA_NJTA;
 
@@ -47,9 +51,9 @@ public class JPADefaultDataSourceTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server_JTA_NJTA, PrivHelper.JAXB_PERMISSION);
-        PrivHelper.generateCustomPolicy(server_JTA, PrivHelper.JAXB_PERMISSION);
-        PrivHelper.generateCustomPolicy(server_NJTA, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server_JTA_NJTA, JAXB_PERMS);
+        PrivHelper.generateCustomPolicy(server_JTA, JAXB_PERMS);
+        PrivHelper.generateCustomPolicy(server_NJTA, JAXB_PERMS);
 
         final WebArchive jdbcwebapp = ShrinkWrap.create(WebArchive.class, "jdbcwebapp.war");
         jdbcwebapp.addPackage("jpadds.web.jdbc");
@@ -86,7 +90,7 @@ public class JPADefaultDataSourceTest {
 
         try {
             server_JTA.startServer();
-            server_JTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jdbcwebapp started");
+            server_JTA.waitForStringInLogUsingMark("CWWKZ0001I: .*jdbcwebapp");
 
             // Set up database tables and rows
             final String response = HttpUtils.getHttpResponseAsString(server_JTA, "jdbcwebapp/JDBCServlet");
@@ -99,7 +103,7 @@ public class JPADefaultDataSourceTest {
             jpaApp.addClass(jpadds.web.jpa.JPAServlet.class);
             ShrinkHelper.addDirectory(jpaApp, "test-applications/jpadefaultdatasource/resources/JTA");
             ShrinkHelper.exportDropinAppToServer(server_JTA, jpaApp);
-            server_JTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jpawebapp started");
+            server_JTA.waitForStringInLogUsingMark("CWWKZ0001I: .*jpawebapp");
 
             // Check that the default datasource points to database #1
             String jpa_response1 = HttpUtils.getHttpResponseAsString(server_JTA, "jpawebapp/JPAServlet?targetId=1&testName=" + testName);
@@ -117,8 +121,8 @@ public class JPADefaultDataSourceTest {
             server_JTA.saveServerConfiguration();
 
             // The config chang should cause jpawebapp to restart.
-            server_JTA.waitForStringInLogUsingMark("CWWKG0017I: The server configuration was successfully updated");
-            server_JTA.waitForStringInLogUsingMark("CWWKZ0003I: The application jpawebapp updated");
+            server_JTA.waitForStringInLogUsingMark("CWWKG0017I:");
+            server_JTA.waitForStringInLogUsingMark("CWWKZ0003I: .*jpawebapp");
 
             //  Check that the default datasource points to database #2
             String jpa_response2 = HttpUtils.getHttpResponseAsString(server_JTA, "jpawebapp/JPAServlet?targetId=2&testName=" + testName);
@@ -128,7 +132,7 @@ public class JPADefaultDataSourceTest {
         } finally {
             if (server_JTA.isStarted()) {
                 server_JTA.stopServer(null);
-                server_JTA.waitForStringInLogUsingMark("CWWKE0036I: The server JPADefaultDataSourceServer stopped");
+                server_JTA.waitForStringInLogUsingMark("CWWKE0036I: .*JPADefaultDataSourceServer");
             }
         }
 
@@ -140,7 +144,7 @@ public class JPADefaultDataSourceTest {
 
         try {
             server_NJTA.startServer();
-            server_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jdbcwebapp started");
+            server_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: .*jdbcwebapp");
 
             // Set up database tables and rows
             final String response = HttpUtils.getHttpResponseAsString(server_NJTA, "jdbcwebapp/JDBCServlet");
@@ -153,7 +157,7 @@ public class JPADefaultDataSourceTest {
             jpaApp.addClass(jpadds.web.jpa.JPARLServlet.class);
             ShrinkHelper.addDirectory(jpaApp, "test-applications/jpadefaultdatasource/resources/NJTA");
             ShrinkHelper.exportDropinAppToServer(server_NJTA, jpaApp);
-            server_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jpawebapp started");
+            server_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: .*jpawebapp");
 
             // Check that the default datasource points to database #1
             String jparl_response1 = HttpUtils.getHttpResponseAsString(server_NJTA, "jpawebapp/JPARLServlet?targetId=1&testName=" + testName);
@@ -171,8 +175,8 @@ public class JPADefaultDataSourceTest {
             server_NJTA.saveServerConfiguration();
 
             // The config chang should cause jpawebapp to restart.
-            server_NJTA.waitForStringInLogUsingMark("CWWKG0017I: The server configuration was successfully updated");
-            server_NJTA.waitForStringInLogUsingMark("CWWKZ0003I: The application jpawebapp updated");
+            server_NJTA.waitForStringInLogUsingMark("CWWKG0017I:");
+            server_NJTA.waitForStringInLogUsingMark("CWWKZ0003I: .*jpawebapp");
 
             //  Check that the default datasource points to database #2
             String jparl_response2 = HttpUtils.getHttpResponseAsString(server_NJTA, "jpawebapp/JPARLServlet?targetId=2&testName=" + testName);
@@ -182,7 +186,7 @@ public class JPADefaultDataSourceTest {
         } finally {
             if (server_NJTA.isStarted()) {
                 server_NJTA.stopServer(null);
-                server_NJTA.waitForStringInLogUsingMark("CWWKE0036I: The server JPADefaultDataSourceServer stopped");
+                server_NJTA.waitForStringInLogUsingMark("CWWKE0036I: .*JPADefaultDataSourceServer");
             }
         }
     }
@@ -193,7 +197,7 @@ public class JPADefaultDataSourceTest {
 
         try {
             server_JTA_NJTA.startServer();
-            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jdbcwebapp started");
+            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: .*jdbcwebapp");
 
             // Set up database tables and rows
             final String response = HttpUtils.getHttpResponseAsString(server_JTA_NJTA, "jdbcwebapp/JDBCServlet");
@@ -206,7 +210,7 @@ public class JPADefaultDataSourceTest {
             jpaApp.addPackage("jpadds.web.jpa");
             ShrinkHelper.addDirectory(jpaApp, "test-applications/jpadefaultdatasource/resources/JTANJTA");
             ShrinkHelper.exportDropinAppToServer(server_JTA_NJTA, jpaApp);
-            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jpawebapp started");
+            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: .*jpawebapp");
 
             // Check that the default datasource points to database #1
             String jpa_response1 = HttpUtils.getHttpResponseAsString(server_JTA_NJTA, "jpawebapp/JPAServlet?targetId=1&testName=" + testName);
@@ -230,8 +234,8 @@ public class JPADefaultDataSourceTest {
             server_JTA_NJTA.saveServerConfiguration();
 
             // The config chang should cause jpawebapp to restart.
-            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKG0017I: The server configuration was successfully updated");
-            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKZ0003I: The application jpawebapp updated");
+            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKG0017I:");
+            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKZ0003I: .*jpawebapp");
 
             //  Check that the default datasource points to database #2
             String jpa_response2 = HttpUtils.getHttpResponseAsString(server_JTA_NJTA, "jpawebapp/JPAServlet?targetId=2&testName=" + testName);
@@ -246,7 +250,7 @@ public class JPADefaultDataSourceTest {
         } finally {
             if (server_JTA_NJTA.isStarted()) {
                 server_JTA_NJTA.stopServer(null);
-                server_JTA_NJTA.waitForStringInLogUsingMark("CWWKE0036I: The server JPADefaultDataSourceServer stopped");
+                server_JTA_NJTA.waitForStringInLogUsingMark("CWWKE0036I: .*JPADefaultDataSourceServer");
             }
         }
     }

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPADefaultDataSourceTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPADefaultDataSourceTest.java
@@ -27,11 +27,14 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 import componenttest.topology.utils.PrivHelper;
 
 @RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
 public class JPADefaultDataSourceTest {
     @Server("JPADefaultDataSourceServer_JTANJTA")
     public static LibertyServer server_JTA_NJTA;

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPADefaultDataSourceTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPADefaultDataSourceTest.java
@@ -1,0 +1,250 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.ConfigElementList;
+import com.ibm.websphere.simplicity.config.JPA;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+import componenttest.topology.utils.PrivHelper;
+
+@RunWith(FATRunner.class)
+public class JPADefaultDataSourceTest {
+    @Server("JPADefaultDataSourceServer_JTANJTA")
+    public static LibertyServer server_JTA_NJTA;
+
+    @Server("JPADefaultDataSourceServer_JTA")
+    public static LibertyServer server_JTA;
+
+    @Server("JPADefaultDataSourceServer_NJTA")
+    public static LibertyServer server_NJTA;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        PrivHelper.generateCustomPolicy(server_JTA_NJTA, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server_JTA, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server_NJTA, PrivHelper.JAXB_PERMISSION);
+
+        final WebArchive jdbcwebapp = ShrinkWrap.create(WebArchive.class, "jdbcwebapp.war");
+        jdbcwebapp.addPackage("jpadds.web.jdbc");
+        ShrinkHelper.exportDropinAppToServer(server_JTA_NJTA, jdbcwebapp);
+        ShrinkHelper.exportDropinAppToServer(server_JTA, jdbcwebapp);
+        ShrinkHelper.exportDropinAppToServer(server_NJTA, jdbcwebapp);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+
+    }
+
+    @Before
+    public void setupTest() throws Exception {
+
+    }
+
+    private JPA getJPAConfigElement(ServerConfiguration sc) {
+        ConfigElementList<JPA> jpaElements = sc.getJPAs();
+        JPA jpaElement = null;
+        if (jpaElements.isEmpty()) {
+            jpaElement = new JPA();
+            jpaElements.add(jpaElement);
+        } else {
+            jpaElement = jpaElements.get(0);
+        }
+        return jpaElement;
+    }
+
+    @Test
+    public void testApplicationRestartOnDefaultJTADatasourceChange() throws Exception {
+        String testName = "testApplicationRestartOnDefaultJTADatasourceChange";
+
+        try {
+            server_JTA.startServer();
+            server_JTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jdbcwebapp started");
+
+            // Set up database tables and rows
+            final String response = HttpUtils.getHttpResponseAsString(server_JTA, "jdbcwebapp/JDBCServlet");
+            System.out.println(response);
+            Assert.assertNotNull(response);
+            Assert.assertTrue(response.contains("CREATE TABLES GOOD."));
+
+            final WebArchive jpaApp = ShrinkWrap.create(WebArchive.class, "jpawebapp.war");
+            jpaApp.addPackage("jpadds.entity");
+            jpaApp.addClass(jpadds.web.jpa.JPAServlet.class);
+            ShrinkHelper.addDirectory(jpaApp, "test-applications/jpadefaultdatasource/resources/JTA");
+            ShrinkHelper.exportDropinAppToServer(server_JTA, jpaApp);
+            server_JTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jpawebapp started");
+
+            // Check that the default datasource points to database #1
+            String jpa_response1 = HttpUtils.getHttpResponseAsString(server_JTA, "jpawebapp/JPAServlet?targetId=1&testName=" + testName);
+            System.out.println(jpa_response1);
+            Assert.assertNotNull(jpa_response1);
+            Assert.assertTrue(jpa_response1.contains("TEST GOOD."));
+
+            // Switch default datasource to point to database #2
+
+            ServerConfiguration sc = server_JTA.getServerConfiguration();
+            JPA jpaElement = getJPAConfigElement(sc);
+            jpaElement.setDefaultJtaDataSourceJndiName("jdbc/JTA_DS2");
+
+            server_JTA.updateServerConfiguration(sc);
+            server_JTA.saveServerConfiguration();
+
+            // The config chang should cause jpawebapp to restart.
+            server_JTA.waitForStringInLogUsingMark("CWWKG0017I: The server configuration was successfully updated");
+            server_JTA.waitForStringInLogUsingMark("CWWKZ0003I: The application jpawebapp updated");
+
+            //  Check that the default datasource points to database #2
+            String jpa_response2 = HttpUtils.getHttpResponseAsString(server_JTA, "jpawebapp/JPAServlet?targetId=2&testName=" + testName);
+            System.out.println(jpa_response2);
+            Assert.assertNotNull(jpa_response2);
+            Assert.assertTrue(jpa_response2.contains("TEST GOOD."));
+        } finally {
+            if (server_JTA.isStarted()) {
+                server_JTA.stopServer(null);
+                server_JTA.waitForStringInLogUsingMark("CWWKE0036I: The server JPADefaultDataSourceServer stopped");
+            }
+        }
+
+    }
+
+    @Test
+    public void testApplicationRestartOnDefaultNJTADatasourceChange() throws Exception {
+        String testName = "testApplicationRestartOnDefaultNJTADatasourceChange";
+
+        try {
+            server_NJTA.startServer();
+            server_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jdbcwebapp started");
+
+            // Set up database tables and rows
+            final String response = HttpUtils.getHttpResponseAsString(server_NJTA, "jdbcwebapp/JDBCServlet");
+            System.out.println(response);
+            Assert.assertNotNull(response);
+            Assert.assertTrue(response.contains("CREATE TABLES GOOD."));
+
+            final WebArchive jpaApp = ShrinkWrap.create(WebArchive.class, "jpawebapp.war");
+            jpaApp.addPackage("jpadds.entity");
+            jpaApp.addClass(jpadds.web.jpa.JPARLServlet.class);
+            ShrinkHelper.addDirectory(jpaApp, "test-applications/jpadefaultdatasource/resources/NJTA");
+            ShrinkHelper.exportDropinAppToServer(server_NJTA, jpaApp);
+            server_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jpawebapp started");
+
+            // Check that the default datasource points to database #1
+            String jparl_response1 = HttpUtils.getHttpResponseAsString(server_NJTA, "jpawebapp/JPARLServlet?targetId=1&testName=" + testName);
+            System.out.println(jparl_response1);
+            Assert.assertNotNull(jparl_response1);
+            Assert.assertTrue(jparl_response1.contains("TEST GOOD."));
+
+            // Switch default datasource to point to database #2
+
+            ServerConfiguration sc = server_NJTA.getServerConfiguration();
+            JPA jpaElement = getJPAConfigElement(sc);
+            jpaElement.setDefaultNonJtaDataSourceJndiName("jdbc/NJTA_DS2");
+
+            server_NJTA.updateServerConfiguration(sc);
+            server_NJTA.saveServerConfiguration();
+
+            // The config chang should cause jpawebapp to restart.
+            server_NJTA.waitForStringInLogUsingMark("CWWKG0017I: The server configuration was successfully updated");
+            server_NJTA.waitForStringInLogUsingMark("CWWKZ0003I: The application jpawebapp updated");
+
+            //  Check that the default datasource points to database #2
+            String jparl_response2 = HttpUtils.getHttpResponseAsString(server_NJTA, "jpawebapp/JPARLServlet?targetId=2&testName=" + testName);
+            System.out.println(jparl_response2);
+            Assert.assertNotNull(jparl_response2);
+            Assert.assertTrue(jparl_response2.contains("TEST GOOD."));
+        } finally {
+            if (server_NJTA.isStarted()) {
+                server_NJTA.stopServer(null);
+                server_NJTA.waitForStringInLogUsingMark("CWWKE0036I: The server JPADefaultDataSourceServer stopped");
+            }
+        }
+    }
+
+    @Test
+    public void testApplicationRestartOnDefaultJTAAndNJTADatasourceChange() throws Exception {
+        String testName = "testApplicationRestartOnDefaultJTAAndNJTADatasourceChange";
+
+        try {
+            server_JTA_NJTA.startServer();
+            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jdbcwebapp started");
+
+            // Set up database tables and rows
+            final String response = HttpUtils.getHttpResponseAsString(server_JTA_NJTA, "jdbcwebapp/JDBCServlet");
+            System.out.println(response);
+            Assert.assertNotNull(response);
+            Assert.assertTrue(response.contains("CREATE TABLES GOOD."));
+
+            final WebArchive jpaApp = ShrinkWrap.create(WebArchive.class, "jpawebapp.war");
+            jpaApp.addPackage("jpadds.entity");
+            jpaApp.addPackage("jpadds.web.jpa");
+            ShrinkHelper.addDirectory(jpaApp, "test-applications/jpadefaultdatasource/resources/JTANJTA");
+            ShrinkHelper.exportDropinAppToServer(server_JTA_NJTA, jpaApp);
+            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKZ0001I: Application jpawebapp started");
+
+            // Check that the default datasource points to database #1
+            String jpa_response1 = HttpUtils.getHttpResponseAsString(server_JTA_NJTA, "jpawebapp/JPAServlet?targetId=1&testName=" + testName);
+            System.out.println(jpa_response1);
+            Assert.assertNotNull(jpa_response1);
+            Assert.assertTrue(jpa_response1.contains("TEST GOOD."));
+
+            String jparl_response1 = HttpUtils.getHttpResponseAsString(server_JTA_NJTA, "jpawebapp/JPARLServlet?targetId=1&testName=" + testName);
+            System.out.println(jparl_response1);
+            Assert.assertNotNull(jparl_response1);
+            Assert.assertTrue(jparl_response1.contains("TEST GOOD."));
+
+            // Switch default datasource to point to database #2
+
+            ServerConfiguration sc = server_JTA_NJTA.getServerConfiguration();
+            JPA jpaElement = getJPAConfigElement(sc);
+            jpaElement.setDefaultJtaDataSourceJndiName("jdbc/JTA_DS2");
+            jpaElement.setDefaultNonJtaDataSourceJndiName("jdbc/NJTA_DS2");
+
+            server_JTA_NJTA.updateServerConfiguration(sc);
+            server_JTA_NJTA.saveServerConfiguration();
+
+            // The config chang should cause jpawebapp to restart.
+            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKG0017I: The server configuration was successfully updated");
+            server_JTA_NJTA.waitForStringInLogUsingMark("CWWKZ0003I: The application jpawebapp updated");
+
+            //  Check that the default datasource points to database #2
+            String jpa_response2 = HttpUtils.getHttpResponseAsString(server_JTA_NJTA, "jpawebapp/JPAServlet?targetId=2&testName=" + testName);
+            System.out.println(jpa_response2);
+            Assert.assertNotNull(jpa_response2);
+            Assert.assertTrue(jpa_response2.contains("TEST GOOD."));
+
+            String jparl_response2 = HttpUtils.getHttpResponseAsString(server_JTA_NJTA, "jpawebapp/JPARLServlet?targetId=2&testName=" + testName);
+            System.out.println(jparl_response2);
+            Assert.assertNotNull(jparl_response2);
+            Assert.assertTrue(jparl_response2.contains("TEST GOOD."));
+        } finally {
+            if (server_JTA_NJTA.isStarted()) {
+                server_JTA_NJTA.stopServer(null);
+                server_JTA_NJTA.waitForStringInLogUsingMark("CWWKE0036I: The server JPADefaultDataSourceServer stopped");
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPADefaultDataSourceTest.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPADefaultDataSourceTest.java
@@ -249,7 +249,7 @@ public class JPADefaultDataSourceTest {
             Assert.assertTrue(jparl_response2.contains("TEST GOOD."));
         } finally {
             if (server_JTA_NJTA.isStarted()) {
-                server_JTA_NJTA.stopServer(null);
+                server_JTA_NJTA.stopServer("CWWJP9991W:");
                 server_JTA_NJTA.waitForStringInLogUsingMark("CWWKE0036I: .*JPADefaultDataSourceServer");
             }
         }

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTA/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTA/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTA/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTA/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,3 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jpa.management=all:com.ibm.ws.jpa.container.osgi.internal=all

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTA/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTA/server.xml
@@ -20,22 +20,22 @@
     
     <jpa defaultJtaDataSourceJndiName="jdbc/JTA_DS1" />
     
-    <dataSource id="jdbc/JTA_DS1" jndiName="jdbc/JTA_DS1" fat.modify="false">
+    <dataSource id="jdbc/JTA_DS1" jndiName="jdbc/JTA_DS1" >
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
-    <dataSource id="jdbc/NJTA_DS1" jndiName="jdbc/NJTA_DS1" fat.modify="false" transactional="false">
+    <dataSource id="jdbc/NJTA_DS1" jndiName="jdbc/NJTA_DS1" transactional="false" >
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
-    <dataSource id="jdbc/JTA_DS2" jndiName="jdbc/JTA_DS2" fat.modify="false">
+    <dataSource id="jdbc/JTA_DS2" jndiName="jdbc/JTA_DS2" >
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
-    <dataSource id="jdbc/NJTA_DS2" jndiName="jdbc/NJTA_DS2" fat.modify="false" transactional="false">
+    <dataSource id="jdbc/NJTA_DS2" jndiName="jdbc/NJTA_DS2" transactional="false" >
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTA/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTA/server.xml
@@ -1,0 +1,48 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="JPA Default DataSource Server">
+
+	<featureManager>
+		<feature>servlet-4.0</feature>
+		<feature>jpa-2.2</feature>
+	    <feature>componenttest-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <jpa defaultJtaDataSourceJndiName="jdbc/JTA_DS1" />
+    
+    <dataSource id="jdbc/JTA_DS1" jndiName="jdbc/JTA_DS1" fat.modify="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/NJTA_DS1" jndiName="jdbc/NJTA_DS1" fat.modify="false" transactional="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/JTA_DS2" jndiName="jdbc/JTA_DS2" fat.modify="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/NJTA_DS2" jndiName="jdbc/NJTA_DS2" fat.modify="false" transactional="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <library id="DerbyLib" fat.modify="true">
+    	<fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+    </library>
+    
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTANJTA/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTANJTA/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTANJTA/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTANJTA/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,3 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jpa.management=all:com.ibm.ws.jpa.container.osgi.internal=all

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTANJTA/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTANJTA/server.xml
@@ -1,0 +1,48 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="JPA Default DataSource Server">
+
+	<featureManager>
+		<feature>servlet-4.0</feature>
+		<feature>jpa-2.2</feature>
+	    <feature>componenttest-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <jpa defaultJtaDataSourceJndiName="jdbc/JTA_DS1" defaultNonJtaDataSourceJndiName="jdbc/NJTA_DS1" />
+    
+    <dataSource id="jdbc/JTA_DS1" jndiName="jdbc/JTA_DS1" fat.modify="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/NJTA_DS1" jndiName="jdbc/NJTA_DS1" fat.modify="false" transactional="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/JTA_DS2" jndiName="jdbc/JTA_DS2" fat.modify="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/NJTA_DS2" jndiName="jdbc/NJTA_DS2" fat.modify="false" transactional="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <library id="DerbyLib" fat.modify="true">
+    	<fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+    </library>
+    
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTANJTA/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_JTANJTA/server.xml
@@ -20,22 +20,22 @@
     
     <jpa defaultJtaDataSourceJndiName="jdbc/JTA_DS1" defaultNonJtaDataSourceJndiName="jdbc/NJTA_DS1" />
     
-    <dataSource id="jdbc/JTA_DS1" jndiName="jdbc/JTA_DS1" fat.modify="false">
+    <dataSource id="jdbc/JTA_DS1" jndiName="jdbc/JTA_DS1" >
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
-    <dataSource id="jdbc/NJTA_DS1" jndiName="jdbc/NJTA_DS1" fat.modify="false" transactional="false">
+    <dataSource id="jdbc/NJTA_DS1" jndiName="jdbc/NJTA_DS1" transactional="false">
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
-    <dataSource id="jdbc/JTA_DS2" jndiName="jdbc/JTA_DS2" fat.modify="false">
+    <dataSource id="jdbc/JTA_DS2" jndiName="jdbc/JTA_DS2" >
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
-    <dataSource id="jdbc/NJTA_DS2" jndiName="jdbc/NJTA_DS2" fat.modify="false" transactional="false">
+    <dataSource id="jdbc/NJTA_DS2" jndiName="jdbc/NJTA_DS2" transactional="false">
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_NJTA/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_NJTA/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_NJTA/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_NJTA/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,3 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jpa.management=all:com.ibm.ws.jpa.container.osgi.internal=all

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_NJTA/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_NJTA/server.xml
@@ -1,0 +1,48 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="JPA Default DataSource Server">
+
+	<featureManager>
+		<feature>servlet-4.0</feature>
+		<feature>jpa-2.2</feature>
+	    <feature>componenttest-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <jpa defaultNonJtaDataSourceJndiName="jdbc/NJTA_DS1" />
+    
+    <dataSource id="jdbc/JTA_DS1" jndiName="jdbc/JTA_DS1" fat.modify="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/NJTA_DS1" jndiName="jdbc/NJTA_DS1" fat.modify="false" transactional="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/JTA_DS2" jndiName="jdbc/JTA_DS2" fat.modify="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/NJTA_DS2" jndiName="jdbc/NJTA_DS2" fat.modify="false" transactional="false">
+    	    <jdbcDriver libraryRef="DerbyLib"/>
+    	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <library id="DerbyLib" fat.modify="true">
+    	<fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+    </library>
+    
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_NJTA/server.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/publish/servers/JPADefaultDataSourceServer_NJTA/server.xml
@@ -20,22 +20,22 @@
     
     <jpa defaultNonJtaDataSourceJndiName="jdbc/NJTA_DS1" />
     
-    <dataSource id="jdbc/JTA_DS1" jndiName="jdbc/JTA_DS1" fat.modify="false">
+    <dataSource id="jdbc/JTA_DS1" jndiName="jdbc/JTA_DS1" >
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
-    <dataSource id="jdbc/NJTA_DS1" jndiName="jdbc/NJTA_DS1" fat.modify="false" transactional="false">
+    <dataSource id="jdbc/NJTA_DS1" jndiName="jdbc/NJTA_DS1" transactional="false">
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
-    <dataSource id="jdbc/JTA_DS2" jndiName="jdbc/JTA_DS2" fat.modify="false">
+    <dataSource id="jdbc/JTA_DS2" jndiName="jdbc/JTA_DS2" >
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>
     
-    <dataSource id="jdbc/NJTA_DS2" jndiName="jdbc/NJTA_DS2" fat.modify="false" transactional="false">
+    <dataSource id="jdbc/NJTA_DS2" jndiName="jdbc/NJTA_DS2" transactional="false">
     	    <jdbcDriver libraryRef="DerbyLib"/>
     	    <properties.derby.embedded databaseName="memory:ds2" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
     </dataSource>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/resources/JTA/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/resources/JTA/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,10 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd"
+  version="2.2">
+    <persistence-unit name="jpa-jta">
+        <properties>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/resources/JTANJTA/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/resources/JTANJTA/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,16 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd"
+  version="2.2">
+    <persistence-unit name="jpa-jta">
+        <properties>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+        </properties>
+    </persistence-unit>
+    
+    <persistence-unit name="jpa-rl" transaction-type="RESOURCE_LOCAL">
+        <properties>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/resources/NJTA/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/resources/NJTA/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,10 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd"
+  version="2.2">
+    <persistence-unit name="jpa-rl" transaction-type="RESOURCE_LOCAL">
+        <properties>
+            <property name="eclipselink.cache.shared.default" value="false"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/src/jpadds/entity/DefDSEntity.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/src/jpadds/entity/DefDSEntity.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jpadds.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "DEFDSENTITY")
+public class DefDSEntity {
+    @Id
+    @Column(name = "ID")
+    private int id;
+
+    @Column(name = "STRDATA")
+    private String strData;
+
+    public DefDSEntity() {
+
+    }
+
+    /**
+     * @return the id
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the strData
+     */
+    public String getStrData() {
+        return strData;
+    }
+
+    /**
+     * @param strData the strData to set
+     */
+    public void setStrData(String strData) {
+        this.strData = strData;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "DefDSEntity [id=" + id + ", strData=" + strData + "]";
+    }
+
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/src/jpadds/web/jdbc/JDBCServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/src/jpadds/web/jdbc/JDBCServlet.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpadds.web.jdbc;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import javax.annotation.Resource;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import javax.transaction.UserTransaction;
+
+@WebServlet(urlPatterns = { "/JDBCServlet" })
+public class JDBCServlet extends HttpServlet {
+    @Resource
+    private UserTransaction tx;
+
+    @Resource(lookup = "jdbc/JTA_DS1")
+    private DataSource ds1Jta;
+
+    @Resource(lookup = "jdbc/NJTA_DS1")
+    private DataSource ds1Rl;
+
+    @Resource(lookup = "jdbc/JTA_DS2")
+    private DataSource ds2Jta;
+
+    @Resource(lookup = "jdbc/NJTA_DS2")
+    private DataSource ds2Rl;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        execRequest(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        execRequest(req, resp);
+    }
+
+    private void execRequest(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        System.out.println("Enter JDBCServlet execRequest");
+        Connection conn = null;
+        try {
+            conn = ds1Rl.getConnection();
+            System.out.println("Creating tables for database #1...");
+            createTables(conn, 1);
+            conn.close();
+
+            conn = ds2Rl.getConnection();
+            System.out.println("Creating tables for database #2...");
+            createTables(conn, 2);
+            // Closed by finally block
+
+            System.out.println("CREATE TABLES GOOD.");
+            resp.getOutputStream().println("CREATE TABLES GOOD.");
+        } catch (SQLException e) {
+            throw new ServletException(e);
+        } finally {
+            if (conn != null) {
+                try {
+                    conn.close();
+                } catch (Throwable t) {
+                }
+            }
+
+            System.out.println("Exit JDBCServlet execRequest");
+        }
+    }
+
+    private void createTables(Connection conn, int id) throws ServletException {
+        System.out.println("Executing createTables id = " + id);
+        PreparedStatement ps = null;
+        try {
+            String sql = "CREATE TABLE DEFDSENTITY (ID INTEGER NOT NULL, STRDATA VARCHAR(255), PRIMARY KEY (ID))";
+            System.out.println("Executing SQL: " + sql);
+            ps = conn.prepareStatement(sql);
+            boolean result1 = ps.execute();
+            if (!result1) {
+                int updateCount = ps.getUpdateCount();
+                if (updateCount != 0) {
+                    throw new RuntimeException("Failed to create new table: " + updateCount);
+                }
+
+            } else {
+                throw new RuntimeException("A problem occurred creating table.");
+            }
+            ps.close();
+
+            String sql2 = "INSERT INTO DEFDSENTITY (ID, STRDATA) VALUES (?, ?)";
+            System.out.println("Executing SQL: " + sql2);
+            ps = conn.prepareStatement(sql2);
+            ps.setInt(1, id);
+            ps.setString(2, Integer.toString(id));
+            boolean result2 = ps.execute();
+            if (!result2) {
+                int updateCount = ps.getUpdateCount();
+                if (updateCount != 1) {
+                    throw new RuntimeException("Failed to insert into table: " + updateCount);
+                }
+            } else {
+                throw new RuntimeException("A problem occurred inserting a row into the table.");
+            }
+            ps.close();
+
+            if (!conn.getAutoCommit())
+                conn.commit();
+        } catch (SQLException e) {
+            throw new ServletException(e);
+        } finally {
+            if (ps != null) {
+                try {
+                    ps.close();
+                } catch (Throwable t) {
+                }
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/src/jpadds/web/jpa/JPARLServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/src/jpadds/web/jpa/JPARLServlet.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpadds.web.jpa;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.Resource;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
+import javax.persistence.TypedQuery;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.transaction.UserTransaction;
+
+import jpadds.entity.DefDSEntity;
+
+@WebServlet(urlPatterns = { "/JPARLServlet" })
+public class JPARLServlet extends HttpServlet {
+    @Resource
+    private UserTransaction tx;
+
+    @PersistenceUnit(unitName = "jpa-rl")
+    private EntityManagerFactory emf;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        execRequest(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        execRequest(req, resp);
+    }
+
+    private void execRequest(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final String testParm = req.getParameter("targetId");
+        final String testName = req.getParameter("testName");
+        System.out.println("Enter JPARLServlet.execRequest, testName=" + testName + ", targetId = " + testParm);
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            int id = Integer.valueOf(testParm);
+            String jpql = "SELECT e FROM DefDSEntity e";
+
+            TypedQuery<DefDSEntity> query = em.createQuery(jpql, DefDSEntity.class);
+            List<DefDSEntity> rs = query.getResultList();
+            if (rs == null) {
+                throw new ServletException("rs is null.");
+            }
+            if (rs.size() != 1) {
+                throw new ServletException("rs.size() == " + rs.size());
+            }
+            DefDSEntity entity = rs.get(0);
+            if (entity.getId() != id) {
+                throw new ServletException("rs.getId() == " + entity.getId() + " not " + id);
+            }
+        } catch (ServletException se) {
+            throw se;
+        } catch (Exception e) {
+            throw new ServletException(e);
+        } finally {
+            em.close();
+        }
+
+        System.out.println("TEST GOOD.");
+        resp.getOutputStream().println("TEST GOOD.");
+    }
+}

--- a/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/src/jpadds/web/jpa/JPAServlet.java
+++ b/dev/com.ibm.ws.jpa_22_fat/test-applications/jpadefaultdatasource/src/jpadds/web/jpa/JPAServlet.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jpadds.web.jpa;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.Resource;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.transaction.UserTransaction;
+
+import jpadds.entity.DefDSEntity;
+
+@WebServlet(urlPatterns = { "/JPAServlet" })
+public class JPAServlet extends HttpServlet {
+    @Resource
+    private UserTransaction tx;
+
+    @PersistenceContext(unitName = "jpa-jta")
+    private EntityManager em;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        execRequest(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        execRequest(req, resp);
+    }
+
+    private void execRequest(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final String testParm = req.getParameter("targetId");
+        final String testName = req.getParameter("testName");
+        System.out.println("Enter JPAServlet.execRequest, testName=" + testName + ", targetId = " + testParm);
+
+        try {
+            tx.begin();
+            em.joinTransaction();
+
+            int id = Integer.valueOf(testParm);
+            String jpql = "SELECT e FROM DefDSEntity e";
+
+            TypedQuery<DefDSEntity> query = em.createQuery(jpql, DefDSEntity.class);
+            List<DefDSEntity> rs = query.getResultList();
+            if (rs == null) {
+                throw new ServletException("rs is null.");
+            }
+            if (rs.size() != 1) {
+                throw new ServletException("rs.size() == " + rs.size());
+            }
+            DefDSEntity entity = rs.get(0);
+            if (entity.getId() != id) {
+                throw new ServletException("rs.getId() == " + entity.getId() + " not " + id);
+            }
+        } catch (ServletException se) {
+            throw se;
+        } catch (Exception e) {
+            throw new ServletException(e);
+        } finally {
+            try {
+                tx.rollback();
+            } catch (Throwable t) {
+            }
+        }
+
+        System.out.println("TEST GOOD.");
+        resp.getOutputStream().println("TEST GOOD.");
+    }
+}


### PR DESCRIPTION
Changes introduced by this pull request:

1. When updating the <jpa> server config element's "defaultJtaDataSourceJndiName" "defaultNonJtaDataSourceJndiName" attributes, applications that use JPA will be automatically restarted. _(primary update)_
2. The restart JPA application code has been updated to only restart applications that define at least 1 persistence unit.  Applications that do not have a persistence.xml in legal JPA spec locations will not be restarted.

Update includes FAT to test the new behavior.