### PR TITLE
disable jaxrs-2.0 test who's test method was removed from the test se…

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTest.java
@@ -96,7 +96,7 @@ public class JAXRSClientSSLTest extends AbstractTest {
         this.runTestOnServer(target, "testClientBasicSSL_InvalidSSLRef", p, "the SSL configuration reference \"invalidSSLConfig\" is invalid.");
     }
 
-    @Test
+//    @Test
     public void testClientBasicSSL_CustomizedSSLContext() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "alex");


### PR DESCRIPTION
…rvlet resulting in a java.lang.NoSuchMethodException

caused by #6629