### PR TITLE
Remove stray JAX-B dependency from repository bundle

### DIFF
--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/RestClient.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/RestClient.java
@@ -79,9 +79,9 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * password
      *
      * @param userId
-     *            The user id to use in Massive
+     *                     The user id to use in Massive
      * @param password
-     *            The password to use in Massive
+     *                     The password to use in Massive
      */
     public RestClient(ClientLoginInfo loginInfo) {
         super();
@@ -109,8 +109,8 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * @return This will return void if all is ok but will throw an exception if
      *         there are any problems
      * @throws RequestFailureException If the response code is not OK or the headers returned are missing
-     *             the count field (which can happen if we hit a URL that returns 200 but is not a valid repository).
-     * @throws IOException If there is a problem with the URL
+     *                                     the count field (which can happen if we hit a URL that returns 200 but is not a valid repository).
+     * @throws IOException             If there is a problem with the URL
      */
     @Override
     public void checkRepositoryStatus() throws IOException, RequestFailureException {
@@ -158,7 +158,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * this method.
      *
      * @param asset
-     *            The asset to add, it will not be modified by this method
+     *                  The asset to add, it will not be modified by this method
      * @return The asset with information added by Massive
      * @throws IOException
      */
@@ -183,7 +183,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * after calling this method.
      *
      * @param asset
-     *            The asset to add, it will not be modified by this method
+     *                  The asset to add, it will not be modified by this method
      * @return The asset with information added by Massive
      * @throws IOException
      * @throws RequestFailureException
@@ -216,7 +216,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      *
      * @see #deleteAssetAndAttachments(String)
      * @param id
-     *            The ID to delete
+     *               The ID to delete
      * @return <code>true</code> if the delete is successful
      * @throws IOException
      * @throws RequestFailureException
@@ -236,7 +236,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * incorrectly).
      *
      * @param searchString The string to search for
-     * @param types The types to filter the results for
+     * @param types        The types to filter the results for
      * @return The assets that match the search string and type
      * @throws IOException
      * @throws RequestFailureException
@@ -456,9 +456,9 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * Returns the contents of an attachment
      *
      * @param assetId
-     *            The ID of the asset owning the attachment
+     *                         The ID of the asset owning the attachment
      * @param attachmentId
-     *            The ID of the attachment
+     *                         The ID of the attachment
      * @return The input stream for the attachment
      * @throws IOException
      * @throws RequestFailureException
@@ -479,7 +479,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
         if (attachment.getLinkType() == AttachmentLinkType.DIRECT) {
             if ((loginInfo.getAttachmentBasicAuthUserId() != null) && (loginInfo.getAttachmentBasicAuthPassword() != null)) {
                 String userpass = loginInfo.getAttachmentBasicAuthUserId() + ":" + loginInfo.getAttachmentBasicAuthPassword();
-                String basicAuth = "Basic " + javax.xml.bind.DatatypeConverter.printBase64Binary(userpass.getBytes(Charset.forName("UTF-8")));
+                String basicAuth = "Basic " + encode(userpass.getBytes(Charset.forName("UTF-8")));
                 connection.setRequestProperty("Authorization", basicAuth);
             }
         }
@@ -493,9 +493,9 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * Returns the meta data about an attachment
      *
      * @param assetId
-     *            The ID of the asset owning the attachment
+     *                         The ID of the asset owning the attachment
      * @param attachmentId
-     *            The ID of the attachment
+     *                         The ID of the attachment
      * @return The attachment meta data
      * @throws IOException
      * @throws RequestFailureException
@@ -518,9 +518,9 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * Delete an attachment from an asset
      *
      * @param assetId
-     *            The ID of the asset containing the attachment
+     *                         The ID of the asset containing the attachment
      * @param attachmentId
-     *            The ID of the attachment to delete
+     *                         The ID of the attachment to delete
      * @return <code>true</code> if the delete was successful
      * @throws IOException
      * @throws RequestFailureException
@@ -537,7 +537,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * This will delete an asset and all its attachments
      *
      * @param assetId
-     *            The id of the asset
+     *                    The id of the asset
      * @return <code>true</code> if the asset and all its attachments are
      *         deleted. Note this is not atomic so some attachments may be
      *         deleted and <code>false</code> returned.
@@ -561,7 +561,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * Gets a single asset
      *
      * @param assetId
-     *            The ID of the asset to obtain
+     *                    The ID of the asset to obtain
      * @return The Asset
      * @throws IOException
      * @throws RequestFailureException
@@ -598,9 +598,9 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * action.
      *
      * @param assetId
-     *            The ID of the asset to update
+     *                    The ID of the asset to update
      * @param action
-     *            The action to take to modify the state
+     *                    The action to take to modify the state
      * @return <code>true</code> if the update was successful (currently always
      *         returns <code>true</code> from Massive)
      * @throws IOException
@@ -625,8 +625,8 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * information to connect to massive using the versioned URL as the base URL
      *
      * @param path
-     *            The path within massive to connect to (note this does not need
-     *            the API key or base path of "/ma/v1")
+     *                 The path within massive to connect to (note this does not need
+     *                 the API key or base path of "/ma/v1")
      * @return The {@link HttpURLConnection}
      * @throws IOException
      */
@@ -641,7 +641,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * </p>
      *
      * @param url
-     *            The complete URL to use (does not include the apiKey)
+     *                The complete URL to use (does not include the apiKey)
      * @return the {@link HttpURLConnection} with the api key and security
      *         information added
      * @throws IOException
@@ -760,13 +760,13 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * delete and an add.
      *
      * @param assetId
-     *            The ID of the asset that the attachment is attached to
+     *                    The ID of the asset that the attachment is attached to
      * @param name
-     *            The name of the attachment to update
+     *                    The name of the attachment to update
      * @param file
-     *            The file to attach
+     *                    The file to attach
      * @param attach
-     *            Attachment metadata
+     *                    Attachment metadata
      * @return
      * @throws IOException
      * @throws RequestFailureException
@@ -835,7 +835,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * Creates a URL filter for the <code>attribute</code> where the <code>values</code> are the valid values.
      *
      * @param attributeName The attributes to use in the filter
-     * @param values The valid values. Must not be <code>null</code> or empty
+     * @param values        The valid values. Must not be <code>null</code> or empty
      * @return The filter strings
      */
     private String createListFilter(FilterableAttribute attribute, Collection<String> values) {


### PR DESCRIPTION
Since the repository bundle is a rather low-level dependency, and JAX-B was removed from the JDK in Java 9+. Since JAX-B is several MB in size, we want to minimize dependencies on it where possible.
Since the repository bundle only used JAX-B for Base64 conversion, we can use the java.util.Base64 utility class instead which was added in JDK 8 when running on newer JDKs.

#build 