### PR TITLE
Correct Circuit Breaker metric reporting

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncAttemptContextImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/impl/AsyncAttemptContextImpl.java
@@ -23,6 +23,7 @@ public class AsyncAttemptContextImpl<W> {
 
     private final AsyncExecutionContextImpl<W> executionContext;
     private TimeoutState timeoutState;
+    private boolean circuitBreakerPermittedExecution = false;
     private final AtomicBoolean complete = new AtomicBoolean(false);
 
     public AsyncAttemptContextImpl(AsyncExecutionContextImpl<W> executionContext) {
@@ -39,6 +40,14 @@ public class AsyncAttemptContextImpl<W> {
 
     public void setTimeoutState(TimeoutState timeoutState) {
         this.timeoutState = timeoutState;
+    }
+
+    public boolean getCircuitBreakerPermittedExecution() {
+        return circuitBreakerPermittedExecution;
+    }
+
+    public void setCircuitBreakerPermittedExecution(boolean circuitBreakerPermittedExecution) {
+        this.circuitBreakerPermittedExecution = circuitBreakerPermittedExecution;
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/CircuitBreakerState.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/CircuitBreakerState.java
@@ -44,6 +44,8 @@ public interface CircuitBreakerState {
      * This may result in the circuit breaker changing its state.
      * <p>
      * If this method returns true, an execution must be attempted and the result recorded with a call to {@link #recordResult(MethodResult)}.
+     * <p>
+     * If this method returns false, {@link #recordResult(MethodResult)} must not be called.
      *
      * @return {@code true} if the circuit breaker permits an execution at this time, {@code false} otherwise.
      */
@@ -51,6 +53,8 @@ public interface CircuitBreakerState {
 
     /**
      * Record the result of an execution on the circuit breaker
+     * <p>
+     * Must be called once for every time that {@link #requestPermissionToExecute()} returns {@code true}.
      *
      * @param result the result the execution
      */

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImpl.java
@@ -50,7 +50,11 @@ public class CircuitBreakerStateImpl implements CircuitBreakerState {
         } else {
             circuitBreaker.recordFailure(result.getFailure());
             if (!(result.getFailure() instanceof CircuitBreakerOpenException)) {
-                metricRecorder.incrementCircuitBreakerCallsFailureCount();
+                if (circuitBreaker.isFailure(null, result.getFailure())) {
+                    metricRecorder.incrementCircuitBreakerCallsFailureCount();
+                } else {
+                    metricRecorder.incrementCircuitBreakerCallsSuccessCount();
+                }
             }
         }
     }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImpl.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance20.state.impl;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
-
 import com.ibm.ws.microprofile.faulttolerance.impl.CircuitBreakerImpl;
 import com.ibm.ws.microprofile.faulttolerance.spi.CircuitBreakerPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
@@ -49,12 +47,10 @@ public class CircuitBreakerStateImpl implements CircuitBreakerState {
             metricRecorder.incrementCircuitBreakerCallsSuccessCount();
         } else {
             circuitBreaker.recordFailure(result.getFailure());
-            if (!(result.getFailure() instanceof CircuitBreakerOpenException)) {
-                if (circuitBreaker.isFailure(null, result.getFailure())) {
-                    metricRecorder.incrementCircuitBreakerCallsFailureCount();
-                } else {
-                    metricRecorder.incrementCircuitBreakerCallsSuccessCount();
-                }
+            if (circuitBreaker.isFailure(null, result.getFailure())) {
+                metricRecorder.incrementCircuitBreakerCallsFailureCount();
+            } else {
+                metricRecorder.incrementCircuitBreakerCallsSuccessCount();
             }
         }
     }


### PR DESCRIPTION
Ensure that the metrics reported for passing/failing executions reflect the value of the `failOn` attribute of the circuit breaker.

Without this change, any exception is logged as a failure, even if the circuit breaker is configured to only treat certain exceptions as failures.

Fixes #7052 