### PR TITLE
EJB ParseTime: Re-add JAXB implementation for JDK<9

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/AutomaticTimerBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/AutomaticTimerBean.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.metadata.ejb;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -190,11 +191,28 @@ public class AutomaticTimerBean {
      * runtime before calling the parse method.
      */
     private static final class DateHelper {
+        private static boolean initialized = false;
 
-        /* there is no longer any need to use JAXB to deserialize this */
         public static long parse(String dateTime) {
             try {
-                return parseJavaTime(dateTime);
+                // Reflection is needed here so that ejbcontainer can avoid a dependency on JAX-B, which
+                // is being removed from the JDK in Java 9.  If we are JDK <9 we will continue to use JAX-B,
+                // and if we are JDK >=9 we will use the java.time APIs that were introduced in JDK 8.
+                // NOTE: We still need JAXB for JDK < 8 as java.time does not exist.
+                boolean isJAXBAvailable = System.getProperty("java.version").startsWith("1.");
+                if (isJAXBAvailable) {
+                    if (!initialized) {
+                        // JAXBContext.newInstance(DateHelper.class);
+                        Class.forName("javax.xml.bind.JAXBContext").getMethod("newInstance", Class[].class)//
+                                        .invoke(null, new Object[] { new Class[] { DateHelper.class } });
+                        initialized = true;
+                    }
+                    // return DatatypeConverter.parseDateTime(dateTime).getTimeInMillis();
+                    Calendar calendar = (Calendar) Class.forName("javax.xml.bind.DatatypeConverter").getMethod("parseDateTime", String.class).invoke(null, dateTime);
+                    return calendar.getTimeInMillis();
+                } else {
+                    return parseJavaTime(dateTime);
+                }
             } catch (Exception e) {
                 throw new IllegalArgumentException(e);
             }


### PR DESCRIPTION
Undoing the change introduced here: https://github.com/OpenLiberty/open-liberty/commit/9ab9b93e9bc6058cd02b657a7f5ae1ab3288ea63#diff-7dc460d94709f1814108a5e0c9d037e5
because we still need JAXB support for JDK < 8 as `java.time` was added in JDK 8.