### PR TITLE
FT 2.0: add tests for circuitbreaker metrics

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
@@ -25,7 +25,9 @@ tested.features: mpFaultTolerance-1.1,\
                  mpConfig-1.2,\
                  mpConfig-1.3,\
                  cdi-1.2,\
-                 cdi-2.0
+                 cdi-2.0,\
+                 appsecurity-3.0,\
+                 el-3.0
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
@@ -40,4 +42,5 @@ tested.features: mpFaultTolerance-1.1,\
 	com.ibm.ws.security;version=latest,\
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
-	com.ibm.websphere.javaee.cdi.1.2;version=latest
+	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
+	com.ibm.ws.microprofile.faulttolerance.cdi_fat;version=latest

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/build.gradle
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/build.gradle
@@ -11,4 +11,6 @@
 
 dependencies {
   requiredLibs 'commons-logging:commons-logging:1.1.3', 'commons-codec:commons-codec:1.6'
+  requiredLibs project(':com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.1')
+  requiredLibs project(':com.ibm.ws.microprofile.faulttolerance.cdi_fat')
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/suite/FATSuite.java
@@ -22,12 +22,14 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.CDIFallbackTest;
 import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.MetricRemovalTest;
+import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.circuitbreaker.CircuitBreakerMetricTest;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 @RunWith(Suite.class)
 @SuiteClasses({
                 CDIFallbackTest.class,
-                MetricRemovalTest.class
+                MetricRemovalTest.class,
+                CircuitBreakerMetricTest.class,
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/CDIFallbackTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/CDIFallbackTest.java
@@ -16,8 +16,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.suite.RepeatMicroProfile13;
-import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.suite.RepeatMicroProfile20;
+import com.ibm.websphere.microprofile.faulttolerance_fat.suite.RepeatFaultTolerance;
 import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.browser.WebBrowser;
@@ -34,10 +33,8 @@ public class CDIFallbackTest extends LoggingTest {
     @ClassRule
     public static SharedServer SHARED_SERVER = new SharedServer("CDIFaultToleranceMetrics");
 
-    //run against both EE8 and EE7 features
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(new RepeatMicroProfile13(SHARED_SERVER.getServerName()))
-                    .andWith(new RepeatMicroProfile20(SHARED_SERVER.getServerName()));
+    public static RepeatTests rep = RepeatFaultTolerance.repeatAll(SHARED_SERVER.getServerName());
 
     @Test
     public void testFallback() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/MetricRemovalTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/MetricRemovalTest.java
@@ -24,24 +24,32 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal.MetricListServlet;
 import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal.RemovalBean;
 import com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal.RemovalServlet;
+import com.ibm.websphere.microprofile.faulttolerance_fat.suite.RepeatFaultTolerance;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
 public class MetricRemovalTest {
 
-    @Server("CDIFaultToleranceMetricsRemoval")
+    private static final String SERVER_NAME = "CDIFaultToleranceMetricsRemoval";
+
+    @Server(SERVER_NAME)
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatFaultTolerance.repeatDefault(SERVER_NAME);
 
     private final static String TEST_METRIC = "ft.com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal.RemovalBean.doWorkWithRetry.invocations.total";
 
@@ -56,9 +64,8 @@ public class MetricRemovalTest {
                         .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                         .addAsManifestResource(MetricRemovalTest.class.getResource("removal/permissions.xml"), "permissions.xml");
 
-        server.startServer();
-
         try {
+            server.startServer();
             deployApp(removalTest);
 
             try {
@@ -79,6 +86,7 @@ public class MetricRemovalTest {
             assertThat(getMetricsPage(), not(containsString(TEST_METRIC)));
         } finally {
             undeployApp(metricReporter);
+            server.stopServer();
         }
 
     }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricBean.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.circuitbreaker;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+@ApplicationScoped
+public class CircuitBreakerMetricBean {
+
+    @CircuitBreaker(requestVolumeThreshold = 4, failureRatio = 0.5, failOn = TestException.class)
+    public void doWorkWithExeception(RuntimeException e) {
+        if (e != null) {
+            throw e;
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricServlet.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.circuitbreaker;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/circuit-breaker-metric")
+public class CircuitBreakerMetricServlet extends FATServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private CircuitBreakerMetricBean testBean;
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Test
+    public void testCircuitBreakerMetrics() {
+        String methodName = CircuitBreakerMetricBean.class.getCanonicalName() + ".doWorkWithExeception";
+        Counter callsSucceeded = registry.counter("ft." + methodName + ".circuitbreaker.callsSucceeded.total");
+        Counter callsFailed = registry.counter("ft." + methodName + ".circuitbreaker.callsFailed.total");
+        Counter callsPrevented = registry.counter("ft." + methodName + ".circuitbreaker.callsPrevented.total");
+
+        // Note: Circuit Breaker under test will open if 2/4 requests are failures
+        // Only requests which throw a TestException are considered failures
+
+        // Failing call (exception is in failOn)
+        try {
+            testBean.doWorkWithExeception(new TestException());
+        } catch (TestException e) {
+        }
+        assertEquals("incorrect calls succeeded", 0, callsSucceeded.getCount());
+        assertEquals("incorrect calls failed", 1, callsFailed.getCount());
+        assertEquals("incorrect calls prevented", 0, callsPrevented.getCount());
+
+        // Succeeding call that threw exception (exception is not in failOn)
+        try {
+            testBean.doWorkWithExeception(new RuntimeException());
+        } catch (RuntimeException e) {
+        }
+        assertEquals("incorrect calls succeeded", 1, callsSucceeded.getCount());
+        assertEquals("incorrect calls failed", 1, callsFailed.getCount());
+        assertEquals("incorrect calls prevented", 0, callsPrevented.getCount());
+
+        // Succeeding call (no exception)
+        testBean.doWorkWithExeception(null);
+        assertEquals("incorrect calls succeeded", 2, callsSucceeded.getCount());
+        assertEquals("incorrect calls failed", 1, callsFailed.getCount());
+        assertEquals("incorrect calls prevented", 0, callsPrevented.getCount());
+
+        // Failing call (to open the breaker)
+        try {
+            testBean.doWorkWithExeception(new TestException());
+        } catch (TestException e) {
+        }
+        assertEquals("incorrect calls succeeded", 2, callsSucceeded.getCount());
+        assertEquals("incorrect calls failed", 2, callsFailed.getCount());
+        assertEquals("incorrect calls prevented", 0, callsPrevented.getCount());
+
+        // Prevented call (breaker is open)
+        try {
+            testBean.doWorkWithExeception(new TestException());
+        } catch (CircuitBreakerOpenException e) {
+        }
+        assertEquals("incorrect calls succeeded", 2, callsSucceeded.getCount());
+        assertEquals("incorrect calls failed", 2, callsFailed.getCount());
+        assertEquals("incorrect calls prevented", 1, callsPrevented.getCount());
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.circuitbreaker;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.microprofile.faulttolerance_fat.suite.RepeatFaultTolerance;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class CircuitBreakerMetricTest extends FATServletClient {
+
+    private static final String APP_NAME = "ftCircuitBreakerMetrics";
+    private static final String SERVER_NAME = "CDIFaultToleranceMetricsRemoval";
+
+    @Server(SERVER_NAME)
+    @TestServlet(contextRoot = APP_NAME, servlet = CircuitBreakerMetricServlet.class)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatFaultTolerance.repeatDefault(SERVER_NAME);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackage(CircuitBreakerMetricServlet.class.getPackage())
+                        .addAsManifestResource(CircuitBreakerMetricTest.class.getResource("permissions.xml"), "permissions.xml");
+
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+        server.deleteFileFromLibertyServerRoot("dropins/" + APP_NAME + ".war");
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/TestException.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/TestException.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.circuitbreaker;
+
+public class TestException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TestException() {
+        super("test exception");
+    }
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/permissions.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/permissions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+	version="7">
+	<permission>
+		<class-name>java.lang.RuntimePermission</class-name>
+		<name>getenv.*</name>
+	</permission>
+	
+	<!-- Needed until #4155 is fixed -->
+	<permission>
+		<class-name>java.lang.RuntimePermission</class-name>
+		<name>getClassLoader</name>
+	</permission>
+</permissions>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetrics/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetrics/server.xml
@@ -17,10 +17,10 @@
 		<feature>osgiconsole-1.0</feature>
 		<feature>localConnector-1.0</feature>
 		<feature>appSecurity-2.0</feature>
-		<feature>cdi-1.2</feature>
-		<feature>servlet-3.1</feature>
-		<feature>mpFaultTolerance-1.0</feature>
-		<feature>mpMetrics-1.0</feature>
+		<feature>cdi-2.0</feature>
+		<feature>servlet-4.0</feature>
+		<feature>mpFaultTolerance-2.0</feature>
+		<feature>mpMetrics-1.1</feature>
 	</featureManager>
 
 	<!-- Usually, we recommend customers not to change this, however our Async 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetricsRemoval/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/publish/servers/CDIFaultToleranceMetricsRemoval/server.xml
@@ -17,9 +17,9 @@
 		<feature>osgiconsole-1.0</feature>
 		<feature>localConnector-1.0</feature>
 		<feature>appSecurity-2.0</feature>
-		<feature>cdi-1.2</feature>
-		<feature>servlet-3.1</feature>
-		<feature>mpFaultTolerance-1.1</feature>
+		<feature>cdi-2.0</feature>
+		<feature>servlet-4.0</feature>
+		<feature>mpFaultTolerance-2.0</feature>
 		<feature>mpMetrics-1.1</feature>
 	</featureManager>
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/test-applications/CDIFaultToleranceMetrics.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/test-applications/CDIFaultToleranceMetrics.war/resources/META-INF/permissions.xml
@@ -12,4 +12,10 @@
 		<class-name>java.lang.RuntimePermission</class-name>
 		<name>accessDeclaredMembers</name>
 	</permission>
+	<!-- Needed for metrics-1.1 until #4155 is fixed -->
+	<permission>
+		<class-name>java.lang.RuntimePermission</class-name>
+		<name>getClassLoader</name>
+	</permission>
+	
 </permissions>


### PR DESCRIPTION
Adds test for #7079 and updates other metrics tests to also run against fault tolerance 2.0