### PR TITLE
FT 2.0: Make circuit breaker limit executions when half-open

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerRollingWindow.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerRollingWindow.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance20.state.impl;
+
+import static com.ibm.ws.microprofile.faulttolerance20.state.impl.CircuitBreakerStateImpl.CircuitBreakerResult.FAILURE;
+
+import java.util.BitSet;
+
+/**
+ * Implements the rolling window for a Fault Tolerance Circuit Breaker
+ * <p>
+ * This class is not thread safe, the caller must ensure all access is synchronized.
+ * <p>
+ * The rolling window has a set size but starts empty. As results are recorded, it fills up. Once it is full, recording a new result will result in the oldest result being removed
+ * from the window.
+ */
+public class CircuitBreakerRollingWindow {
+
+    /**
+     * The size of the rolling window
+     */
+    private final int size;
+
+    /**
+     * The failure threshold of the rolling window
+     * <p>
+     * If this number of failures are in a full rolling window, it's over the threshold
+     */
+    private final int threshold;
+
+    /**
+     * Circular buffer of results in the rolling window
+     * <p>
+     * A set bit indicates a failure, an unset bit represents a success.
+     * <p>
+     * If {@code resultCount < size}, then only the first {@code resultCount} bits are meaningful.
+     */
+    private final BitSet results;
+
+    /**
+     * Index indicating where in {@link #results} the next result should be stored
+     * <p>
+     * If the window is full (i.e. {@code resultCount == size}), this also points to the oldest result in the window
+     */
+    private int nextResultIndex;
+
+    /**
+     * Running total of the number of failures in the rolling window
+     */
+    private int failures;
+
+    /**
+     * Count of the number of results in the rolling window
+     * <p>
+     * When the window is first created or is cleared, this is zero because the window is empty.
+     * <p>
+     * If {@code resultCount == size} then the window is full and recording a new result will result in the oldest result being pushed out of the window.
+     */
+    private int resultCount;
+
+    /**
+     * @param size         the size of the rolling window
+     * @param failureRatio the ratio of failures required to be over the threshold
+     */
+    public CircuitBreakerRollingWindow(int size, double failureRatio) {
+        this.size = size;
+        this.threshold = (int) Math.ceil(size * failureRatio);
+        results = new BitSet(size);
+        nextResultIndex = 0;
+        failures = 0;
+        resultCount = 0;
+    }
+
+    /**
+     * Record a result in the rolling window
+     *
+     * @param result the result to record
+     */
+    public void record(CircuitBreakerStateImpl.CircuitBreakerResult result) {
+        boolean isFailure = (result == FAILURE);
+        if (resultCount < size) {
+            // Window is not yet full
+            resultCount++;
+        } else {
+            // Window is full, roll off the oldest result
+            boolean oldestResultIsFailure = results.get(nextResultIndex);
+            if (oldestResultIsFailure) {
+                failures--;
+            }
+        }
+
+        results.set(nextResultIndex, isFailure);
+        if (isFailure) {
+            failures++;
+        }
+
+        nextResultIndex++;
+        if (nextResultIndex >= size) {
+            nextResultIndex = 0;
+        }
+    }
+
+    /**
+     * Whether the number of failures is over the configured threshold
+     * <p>
+     * The rolling window is only over the threshold if
+     * <ul>
+     * <li>the window has been filled</li>
+     * <li>the proportion of failures in the rolling window is greater than the {@code failureRatio} passed in the constructor</li>
+     * </ul>
+     *
+     * @return {@code true} if the number failures in the rolling window is over the configured threshold
+     */
+    public boolean isOverThreshold() {
+        return (size == resultCount) && (failures >= threshold);
+    }
+
+    /**
+     * Clear all the results in the rolling window
+     * <p>
+     * After calling this, {@link #isOverThreshold()} will not return {@code false} until enough new results have come in to fill the window.
+     */
+    public void clear() {
+        results.clear();
+        nextResultIndex = 0;
+        failures = 0;
+        resultCount = 0;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder().append("[Rolling window:");
+        sb.append(" current failures: (").append(failures).append('/').append(resultCount).append(')');
+        sb.append(" limit (").append(threshold).append('/').append(size).append(')');
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImpl.java
@@ -85,16 +85,23 @@ public class CircuitBreakerStateImpl implements CircuitBreakerState {
 
     @Override
     public boolean requestPermissionToExecute() {
+        boolean result;
         if (state.get() == State.CLOSED) {
             // If breaker is closed then the result is simple
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "Allowing execution in closed state");
             }
-            return true;
+            result = true;
         } else {
             // Other cases are more complex and require synchronization
-            return synchronizedRequestPermissionToExecute();
+            result = synchronizedRequestPermissionToExecute();
         }
+
+        if (result == false) {
+            metricRecorder.incrementCircuitBreakerCallsCircuitOpenCount();
+        }
+
+        return result;
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance20.state.impl;
 
-import com.ibm.ws.microprofile.faulttolerance.impl.CircuitBreakerImpl;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.microprofile.faulttolerance.spi.CircuitBreakerPolicy;
 import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance20.impl.MethodResult;
@@ -18,41 +22,273 @@ import com.ibm.ws.microprofile.faulttolerance20.state.CircuitBreakerState;
 
 public class CircuitBreakerStateImpl implements CircuitBreakerState {
 
-    private final CircuitBreakerImpl circuitBreaker;
+    private final static TraceComponent tc = Tr.register(CircuitBreakerStateImpl.class);
+
+    private final CircuitBreakerPolicy policy;
     private final MetricRecorder metricRecorder;
 
+    /**
+     * Current CB state
+     */
+    private final AtomicReference<State> state;
+
+    /**
+     * Cached value of policy.getDelay().toNanos()
+     */
+    private final long policyDelayNanos;
+
+    /**
+     * Rolling window tracking results in closed state
+     * <p>
+     * Access must be synchronized
+     */
+    private final CircuitBreakerRollingWindow rollingWindow;
+
+    /**
+     * Currently running executions in half-open state
+     * <p>
+     * Access must be synchronized
+     */
+    private int halfOpenRunningExecutions;
+
+    /**
+     * Successful executions in half-open state
+     * <p>
+     * Access must be synchronized
+     */
+    private int halfOpenSuccessfulExecutions;
+
+    /**
+     * Value of System.nanoTime() when the last execution was permitted in half-open state
+     */
+    private long halfOpenLastExecutionStarted;
+
+    /**
+     * Value of System.nanoTime() when the circuit breaker last transitioned to open state
+     * <p>
+     * Access must be synchronized
+     */
+    private long openStateStartTime;
+
     public CircuitBreakerStateImpl(CircuitBreakerPolicy policy, MetricRecorder metricRecorder) {
-        circuitBreaker = new CircuitBreakerImpl(policy);
+        this.policy = policy;
         this.metricRecorder = metricRecorder;
-        circuitBreaker.onClose(metricRecorder::reportCircuitClosed);
-        circuitBreaker.onOpen(metricRecorder::reportCircuitOpen);
-        circuitBreaker.onHalfOpen(metricRecorder::reportCircuitHalfOpen);
+        this.policyDelayNanos = policy.getDelay().toNanos();
+
+        state = new AtomicReference<>(State.CLOSED);
+        rollingWindow = new CircuitBreakerRollingWindow(policy.getRequestVolumeThreshold(), policy.getFailureRatio());
+        halfOpenRunningExecutions = 0;
+        halfOpenSuccessfulExecutions = 0;
+        halfOpenLastExecutionStarted = 0;
+        openStateStartTime = 0;
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean requestPermissionToExecute() {
-        boolean allowsExecution = circuitBreaker.allowsExecution();
-        if (!allowsExecution) {
-            metricRecorder.incrementCircuitBreakerCallsCircuitOpenCount();
+        if (state.get() == State.CLOSED) {
+            // If breaker is closed then the result is simple
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Allowing execution in closed state");
+            }
+            return true;
+        } else {
+            // Other cases are more complex and require synchronization
+            return synchronizedRequestPermissionToExecute();
         }
-        return allowsExecution;
     }
 
-    /** {@inheritDoc} */
     @Override
     public void recordResult(MethodResult<?> result) {
-        if (result.getFailure() == null) {
-            circuitBreaker.recordResult(result.getResult());
+        CircuitBreakerResult cbResult = getCircuitBreakerResult(result);
+        if (state.get() == State.OPEN) {
+            // Nothing to do
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Recording result {0} in open state", cbResult);
+            }
+        } else {
+            // Other cases are more complex and require synchronization
+            synchronizedRecordResult(cbResult);
+        }
+
+        if (cbResult == CircuitBreakerResult.SUCCESS) {
             metricRecorder.incrementCircuitBreakerCallsSuccessCount();
         } else {
-            circuitBreaker.recordFailure(result.getFailure());
-            if (circuitBreaker.isFailure(null, result.getFailure())) {
-                metricRecorder.incrementCircuitBreakerCallsFailureCount();
-            } else {
-                metricRecorder.incrementCircuitBreakerCallsSuccessCount();
+            metricRecorder.incrementCircuitBreakerCallsFailureCount();
+        }
+    }
+
+    /**
+     * Implements the logic for requestPermissionToExecute for the cases where synchronization is required
+     *
+     * @return whether execution is permitted
+     */
+    private boolean synchronizedRequestPermissionToExecute() {
+        boolean result = false;
+        synchronized (this) {
+            switch (state.get()) {
+                case CLOSED:
+                    result = true;
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Allowing execution in closed state");
+                    }
+                    break;
+                case HALF_OPEN:
+                    // Limit the number of concurrent executions when we're half-open
+                    if (halfOpenRunningExecutions < policy.getSuccessThreshold()) {
+                        halfOpenRunningExecutions++;
+                        halfOpenLastExecutionStarted = System.nanoTime();
+                        result = true;
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Allowing execution in half-open state. Now running ({0}/{1})", halfOpenRunningExecutions, policy.getSuccessThreshold());
+                        }
+                    } else {
+                        // If the user runs an operation which never returns (possible using CompletionStage), we might end up stuck in half-open state
+                        // denying all executions forever. For this reason, if we stay in half-open state for longer than the open state delay time,
+                        // allow another execution
+                        if (System.nanoTime() - halfOpenLastExecutionStarted > policyDelayNanos) {
+                            halfOpenLastExecutionStarted = System.nanoTime();
+                            result = true;
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                                Tr.debug(tc, "Allowing execution in half-open state because enough time has passed without a trial executions completing");
+                            }
+                        } else {
+                            result = false;
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                                Tr.debug(tc, "Denying execution in half-open state, trial execution limit reached");
+                            }
+                        }
+                    }
+                    break;
+                case OPEN:
+                    if (System.nanoTime() - openStateStartTime > policyDelayNanos) {
+                        // We've been in open state for long enough, transition to half-open
+                        stateHalfOpen();
+                        halfOpenRunningExecutions++;
+                        halfOpenLastExecutionStarted = System.nanoTime();
+                        result = true;
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Allowing execution because we just changed to half-open state");
+                        }
+                    } else {
+                        result = false;
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Denying execution in open state");
+                        }
+                    }
+                    break;
             }
         }
+        return result;
+    }
+
+    /**
+     * Implements the logic for recordResult for the cases where synchronization is required
+     */
+    private void synchronizedRecordResult(CircuitBreakerResult result) {
+        synchronized (this) {
+            switch (state.get()) {
+                case CLOSED:
+                    rollingWindow.record(result);
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Recording result {0} in closed state: {1}", result, rollingWindow);
+                    }
+                    if (rollingWindow.isOverThreshold()) {
+                        stateOpen();
+                    }
+                    break;
+                case HALF_OPEN:
+                    if (result == CircuitBreakerResult.FAILURE) {
+                        stateOpen();
+                    } else {
+                        halfOpenRunningExecutions--;
+                        halfOpenSuccessfulExecutions++;
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Recording result {0} in half-open state. Running executions: {1}, Current results: ({2}/{3})",
+                                     result, halfOpenRunningExecutions, halfOpenSuccessfulExecutions, policy.getSuccessThreshold());
+                        }
+                        if (halfOpenSuccessfulExecutions >= policy.getSuccessThreshold()) {
+                            stateClosed();
+                        }
+                    }
+                    break;
+                case OPEN:
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Recording result {0} in open state", result);
+                    }
+                    // Nothing else to do
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Transition to closed state
+     */
+    @Trivial
+    private void stateClosed() {
+        rollingWindow.clear();
+        state.set(State.CLOSED);
+        metricRecorder.reportCircuitClosed();
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Transitioned to Closed state");
+        }
+    }
+
+    /**
+     * Transition to half open state
+     */
+    @Trivial
+    private void stateHalfOpen() {
+        halfOpenRunningExecutions = 0;
+        halfOpenSuccessfulExecutions = 0;
+        state.set(State.HALF_OPEN);
+        metricRecorder.reportCircuitHalfOpen();
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Transitioned to Half Open state");
+        }
+    }
+
+    /**
+     * Transition to open state
+     */
+    @Trivial
+    private void stateOpen() {
+        openStateStartTime = System.nanoTime();
+        state.set(State.OPEN);
+        metricRecorder.reportCircuitOpen();
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Transitioned to Open state");
+        }
+    }
+
+    @Trivial
+    private CircuitBreakerResult getCircuitBreakerResult(MethodResult<?> result) {
+        CircuitBreakerResult cbResult = CircuitBreakerResult.SUCCESS;
+
+        if (result.isFailure()) {
+            for (Class<?> exClazz : policy.getFailOn()) {
+                if (exClazz.isInstance(result.getFailure())) {
+                    cbResult = CircuitBreakerResult.FAILURE;
+                }
+            }
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Circuit breaker considers {0} to be {1}", result, cbResult);
+        }
+
+        return cbResult;
+    }
+
+    public enum CircuitBreakerResult {
+        SUCCESS,
+        FAILURE
+    }
+
+    private enum State {
+        OPEN,
+        HALF_OPEN,
+        CLOSED
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImplTest.java
@@ -21,6 +21,7 @@ import com.ibm.ws.microprofile.faulttolerance.impl.policy.CircuitBreakerPolicyIm
 import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance.utils.DummyMetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance20.impl.MethodResult;
+import com.ibm.ws.microprofile.faulttolerance20.state.CircuitBreakerState;
 
 public class CircuitBreakerStateImplTest {
 
@@ -150,11 +151,86 @@ public class CircuitBreakerStateImplTest {
         assertFalse(state.requestPermissionToExecute());
     }
 
-    private void runFailures(CircuitBreakerStateImpl state, int times) {
+    @Test
+    public void testHalfOpenLimit() throws InterruptedException {
+        CircuitBreakerPolicyImpl policy = new CircuitBreakerPolicyImpl();
+        policy.setDelay(Duration.ofMillis(100));
+        policy.setFailureRatio(0.75);
+        policy.setRequestVolumeThreshold(4);
+        policy.setSuccessThreshold(3);
+
+        // Summary:
+        // circuit opens if 75% of last 4 requests failed
+        // circuit half-closes after 100ms
+        // circuit fully closes after 3 successful requests
+
+        // Run 100% failures, results in circuit open
+        CircuitBreakerStateImpl state = new CircuitBreakerStateImpl(policy, dummyMetrics);
+        runFailures(state, 4);
+        assertFalse(state.requestPermissionToExecute());
+
+        // Wait >100ms, results in circuit half-open
+        Thread.sleep(150);
+        // While half open, we should be able to start only three executions
+        assertTrue(state.requestPermissionToExecute());
+        assertTrue(state.requestPermissionToExecute());
+        assertTrue(state.requestPermissionToExecute());
+        assertFalse(state.requestPermissionToExecute());
+
+        // As one finishes, we should be able to start one more
+        state.recordResult(MethodResult.success(null));
+        assertTrue(state.requestPermissionToExecute());
+        assertFalse(state.requestPermissionToExecute());
+
+        // As one finishes, we should be able to start one more
+        state.recordResult(MethodResult.success(null));
+        assertTrue(state.requestPermissionToExecute());
+        assertFalse(state.requestPermissionToExecute());
+
+        // After three complete successfully, circuit should be closed and we can run as many as we want
+        state.recordResult(MethodResult.success(null));
+        assertTrue(state.requestPermissionToExecute());
+        assertTrue(state.requestPermissionToExecute());
+        assertTrue(state.requestPermissionToExecute());
+        assertTrue(state.requestPermissionToExecute());
+    }
+
+    @Test
+    public void testHalfOpenStuck() throws InterruptedException {
+        CircuitBreakerPolicyImpl policy = new CircuitBreakerPolicyImpl();
+        policy.setDelay(Duration.ofMillis(100));
+        policy.setFailureRatio(0.75);
+        policy.setRequestVolumeThreshold(4);
+        policy.setSuccessThreshold(1);
+
+        // Summary:
+        // circuit opens if 75% of last 4 requests failed
+        // circuit half-closes after 100ms
+        // circuit fully closes after 1 successful request
+
+        // Run 100% failures, results in circuit open
+        CircuitBreakerStateImpl state = new CircuitBreakerStateImpl(policy, dummyMetrics);
+        runFailures(state, 4);
+        assertFalse(state.requestPermissionToExecute());
+
+        // Wait >100ms, results in circuit half-open
+        Thread.sleep(150);
+        // While half open, we should be able to start only one execution...
+        assertTrue(state.requestPermissionToExecute());
+        assertFalse(state.requestPermissionToExecute());
+
+        // ...unless we wait for the delay again
+        Thread.sleep(150);
+        // then we should get one more
+        assertTrue(state.requestPermissionToExecute());
+        assertFalse(state.requestPermissionToExecute());
+    }
+
+    private void runFailures(CircuitBreakerState state, int times) {
         runFailures(state, times, RuntimeException.class);
     }
 
-    private void runFailures(CircuitBreakerStateImpl state, int times, Class<? extends Exception> exClazz) {
+    private void runFailures(CircuitBreakerState state, int times, Class<? extends Exception> exClazz) {
         try {
             for (int i = 0; i < times; i++) {
                 assertTrue("No permission for attempt " + i, state.requestPermissionToExecute());
@@ -165,7 +241,7 @@ public class CircuitBreakerStateImplTest {
         }
     }
 
-    private void runSuccesses(CircuitBreakerStateImpl state, int times) {
+    private void runSuccesses(CircuitBreakerState state, int times) {
         for (int i = 0; i < times; i++) {
             assertTrue("No permission for attempt " + i, state.requestPermissionToExecute());
             state.recordResult(MethodResult.success(null));

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/CDIFaultTolerance/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/CDIFaultTolerance/server.xml
@@ -34,4 +34,7 @@
 	
 	<logging traceSpecification="FAULTTOLERANCE=all=enabled:METRICS=all=enabled"/>
 	
+	<!-- Allow the OpenJDK 11 ForkJoinPool to read its properties without raising exceptions until #7111 is resolved--> 
+	<javaPermission className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.common.maximumSpares" actions="read"/>
+	
 </server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FTFallback/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FTFallback/server.xml
@@ -34,4 +34,7 @@
 	
 	<logging traceSpecification="FAULTTOLERANCE=event"/>
 	
+	<!-- Allow the OpenJDK 11 ForkJoinPool to read its properties without raising exceptions until #7111 is resolved--> 
+	<javaPermission className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.common.maximumSpares" actions="read"/>
+	
 </server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/JaxRsFaultTolerance/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/JaxRsFaultTolerance/server.xml
@@ -23,4 +23,7 @@
 
 	<logging traceSpecification="FAULTTOLERANCE=event"/>
 	
+	<!-- Allow the OpenJDK 11 ForkJoinPool to read its properties without raising exceptions until #7111 is resolved--> 
+	<javaPermission className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.common.maximumSpares" actions="read"/>
+	
 </server>


### PR DESCRIPTION
When half-open, the circuit breaker should limit the number of concurrent executions to the success threshold.

Fixes #7080 