### PR TITLE
validate connectionfactory with application auth

### DIFF
--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corporation and others.
+ * Copyright (c) 2011, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -97,6 +97,11 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
     private final AtomicServiceReference<BootstrapContextImpl> bootstrapContextRef = new AtomicServiceReference<BootstrapContextImpl>("bootstrapContext");
 
     /**
+     * Connection factory interface name.
+     */
+    private String cfInterfaceName;
+
+    /**
      * Component context.
      */
     private ComponentContext componentContext;
@@ -161,6 +166,7 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
         String sourcePID = (String) props.get("ibm.extends.source.pid"); // com.ibm.ws.jca.jmsQueueConnectionFactory_gen_3f3cb305-4146-41f9-8a57-b231d09013e6
         configElementName = sourcePID == null ? "connectionFactory" : sourcePID.substring(15, sourcePID.indexOf('_', 15));
 
+        cfInterfaceName = ((String[]) props.get(CONFIG_PROPS_PREFIX + "creates.objectClass"))[0];
         mcfImplClassName = (String) props.get(CONFIG_PROPS_PREFIX + "managedconnectionfactory-class");
         jndiName = (String) props.get(JNDI_NAME);
         id = (String) props.get("config.displayId");
@@ -197,6 +203,15 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
     protected void deactivate(ComponentContext context) {
         destroyConnectionFactories(true);
         bootstrapContextRef.deactivate(context);
+    }
+
+    /**
+     * This method is provided for the connection factory validator.
+     *
+     * @return fully qualified name of the connection factory interface that this resource factory creates.
+     */
+    public final String getConnectionFactoryInterfaceName() {
+        return cfInterfaceName;
     }
 
     @Override

--- a/dev/com.ibm.ws.rest.handler.validator.jca/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/bnd.bnd
@@ -30,6 +30,7 @@ Private-Package:\
 
 -buildpath:\
   com.ibm.json4j;version=latest,\
+  com.ibm.tx.jta;version=latest,\
   com.ibm.websphere.appserver.spi.kernel.service,\
   com.ibm.websphere.appserver.spi.logging,\
   com.ibm.websphere.javaee.connector.1.7;version=latest,\
@@ -37,6 +38,9 @@ Private-Package:\
   com.ibm.websphere.org.osgi.service.cm,\
   com.ibm.websphere.org.osgi.service.component,\
   com.ibm.wsspi.org.osgi.service.component.annotations,\
+  com.ibm.ws.app.manager.lifecycle,\
+  com.ibm.ws.jca;version=latest,\
+  com.ibm.ws.jca.cm;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.resource;version=latest,\
   com.ibm.ws.rest.handler.validator;version=latest

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.resource.NotSupportedException;
@@ -22,14 +23,19 @@ import javax.resource.ResourceException;
 import javax.resource.cci.Connection;
 import javax.resource.cci.ConnectionFactory;
 import javax.resource.cci.ConnectionMetaData;
+import javax.resource.cci.ConnectionSpec;
 import javax.resource.cci.ResourceAdapterMetaData;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
+import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.jca.service.ConnectionFactoryService;
 import com.ibm.wsspi.resource.ResourceConfig;
 import com.ibm.wsspi.resource.ResourceConfigFactory;
 import com.ibm.wsspi.resource.ResourceFactory;
@@ -44,18 +50,44 @@ public class ConnectionFactoryValidator implements Validator {
     @Reference
     private ResourceConfigFactory resourceConfigFactory;
 
+    /**
+     * Utility method that attempts to construct a ConnectionSpec impl of the specified name,
+     * which might or might not exist in the resource adapter.
+     *
+     * @param cciConFactory the connection factory class
+     * @param conSpecClassName possible connection spec impl class name to try
+     * @param userName user name to set on the connection spec
+     * @param password password to set on the connection spec
+     * @return ConnectionSpec instance if successful. Otherwise null.
+     */
+    @FFDCIgnore(Throwable.class)
+    private ConnectionSpec createConnectionSpec(ConnectionFactory cciConFactory, String conSpecClassName, String userName, @Sensitive String password) {
+        try {
+            @SuppressWarnings("unchecked")
+            Class<ConnectionSpec> conSpecClass = (Class<ConnectionSpec>) cciConFactory.getClass().getClassLoader().loadClass(conSpecClassName);
+            ConnectionSpec conSpec = conSpecClass.newInstance();
+            conSpecClass.getMethod("setPassword", String.class).invoke(conSpec, password);
+            conSpecClass.getMethod("setUserName", String.class).invoke(conSpec, userName);
+            return conSpec;
+        } catch (Throwable x) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "Unable to create or populate ConnectionSpec", x.getMessage());
+            return null;
+        }
+    }
+
     @Override
     public LinkedHashMap<String, ?> validate(Object instance, Map<String, Object> props, Locale locale) {
         final String methodName = "validate";
         String user = (String) props.get("user");
-        String pass = (String) props.get("password");
+        String password = (String) props.get("password");
         String auth = (String) props.get("auth");
         String authAlias = (String) props.get("authAlias");
         String loginConfig = (String) props.get("loginConfig");
 
         boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, methodName, user, pass == null ? null : "******", auth, authAlias, loginConfig);
+            Tr.entry(this, tc, methodName, user, password == null ? null : "******", auth, authAlias, loginConfig);
 
         LinkedHashMap<String, Object> result = new LinkedHashMap<String, Object>();
         try {
@@ -63,8 +95,32 @@ public class ConnectionFactoryValidator implements Validator {
             int authType = "container".equals(auth) ? 0 //
                             : "application".equals(auth) ? 1 //
                                             : -1;
+
             if (authType >= 0) {
-                throw new UnsupportedOperationException("validation of connectionFactory with resource reference not supported yet");
+                String cfInterfaceName = ((ConnectionFactoryService) instance).getConnectionFactoryInterfaceName();
+                config = resourceConfigFactory.createResourceConfig(cfInterfaceName);
+                config.setResAuthType(authType);
+                if (authAlias != null)
+                    config.addLoginProperty("DefaultPrincipalMapping", authAlias); // set provided auth alias
+                if (loginConfig != null) {
+                    // Add custom login module name and properties
+                    config.setLoginConfigurationName(loginConfig);
+                    String requestBodyString = (String) props.get("json");
+                    JSONObject requestBodyJson = requestBodyString == null ? null : JSONObject.parse(requestBodyString);
+                    if (requestBodyJson != null && requestBodyJson.containsKey("loginConfigProperties")) {
+                        Object loginConfigProperties = requestBodyJson.get("loginConfigProperties");
+                        if (loginConfigProperties instanceof JSONObject) {
+                            JSONObject loginConfigProps = (JSONObject) loginConfigProperties;
+                            for (Object entry : loginConfigProps.entrySet()) {
+                                @SuppressWarnings("unchecked")
+                                Entry<String, String> e = (Entry<String, String>) entry;
+                                if (trace && tc.isDebugEnabled())
+                                    Tr.debug(tc, "Adding custom login module property with key=" + e.getKey());
+                                config.addLoginProperty(e.getKey(), e.getValue());
+                            }
+                        }
+                    }
+                }
             }
 
             Object cf = ((ResourceFactory) instance).createResource(config);
@@ -90,7 +146,20 @@ public class ConnectionFactoryValidator implements Validator {
                 } catch (UnsupportedOperationException ignore) {
                 }
 
-                Connection con = cciConFactory.getConnection(); // TODO use ConnectionSpec if user is non-null
+                ConnectionSpec conSpec = null;
+                if (user != null || password != null) {
+                    String conFactoryClassName = cciConFactory.getClass().getName();
+                    String conSpecClassName = conFactoryClassName.replace("ConnectionFactory", "ConnectionSpec");
+                    if (!conFactoryClassName.equals(conSpecClassName))
+                        conSpec = createConnectionSpec(cciConFactory, conSpecClassName, user, password);
+
+                    if (conSpec == null) {
+                        // TODO find ConnectionSpec impl another way?
+                        throw new RuntimeException("Unable to locate javax.resource.cci.ConnectionSpec impl from resource adapter.");
+                    }
+                }
+
+                Connection con = conSpec == null ? cciConFactory.getConnection() : cciConFactory.getConnection(conSpec);
                 try {
                     try {
                         ConnectionMetaData conData = con.getMetaData();

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/bootstrap.properties
@@ -9,6 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.validator=all
+com.ibm.ws.logging.trace.specification=*=info:rest.validator=all:com.ibm.ws.jca.service.ConnectionFactoryService=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionImpl.java
@@ -18,13 +18,11 @@ import javax.resource.cci.Interaction;
 import javax.resource.cci.LocalTransaction;
 import javax.resource.cci.ResultSetInfo;
 
-import org.test.validator.adapter.ConnectionSpecImpl.ConnectionRequestInfoImpl;
-
 public class ConnectionImpl implements Connection, ConnectionMetaData {
-    private final ConnectionRequestInfoImpl cri;
+    private final String userName;
 
-    ConnectionImpl(ManagedConnectionImpl mc, ConnectionRequestInfoImpl cri) {
-        this.cri = cri;
+    ConnectionImpl(String userName) {
+        this.userName = userName;
     }
 
     @Override
@@ -62,6 +60,6 @@ public class ConnectionImpl implements Connection, ConnectionMetaData {
 
     @Override
     public String getUserName() throws ResourceException {
-        return (String) cri.get("UserName");
+        return userName;
     }
 }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionSpecImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionSpecImpl.java
@@ -19,12 +19,14 @@ import javax.resource.spi.ConnectionRequestInfo;
  * Example ConnectionSpec implementation with UserName and Password.
  */
 public class ConnectionSpecImpl implements ConnectionSpec {
-    private String user = "DefaultUserName", password = "DefaultPassword";
+    private String user, password;
 
     ConnectionRequestInfoImpl createConnectionRequestInfo() {
         ConnectionRequestInfoImpl cri = new ConnectionRequestInfoImpl();
-        cri.put("UserName", user);
-        cri.put("Password", password);
+        if (user != null)
+            cri.put("UserName", user);
+        if (password != null)
+            cri.put("Password", password);
         return cri;
     }
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionFactoryImpl.java
@@ -44,8 +44,14 @@ public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, R
     @ConfigProperty
     private String hostName = "localhost";
 
+    @ConfigProperty(defaultValue = "DefaultPassword")
+    private String password;
+
     @ConfigProperty
     private Integer portNumber = 4321;
+
+    @ConfigProperty(defaultValue = "DefaultUserName")
+    private String userName;
 
     @Override
     public Object createConnectionFactory() throws ResourceException {
@@ -78,7 +84,7 @@ public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, R
         if (!hostName.equals("localhost") && !hostName.endsWith(".openliberty.io"))
             throw new CommException("Unable to connect to " + hostName);
 
-        return new ManagedConnectionImpl();
+        return new ManagedConnectionImpl(this);
     }
 
     public String getHostName() {
@@ -90,6 +96,10 @@ public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, R
         return null;
     }
 
+    public String getPassword() {
+        return password;
+    }
+
     public Integer getPortNumber() {
         return portNumber;
     }
@@ -97,6 +107,10 @@ public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, R
     @Override
     public ResourceAdapter getResourceAdapter() {
         return adapter;
+    }
+
+    public String getUserName() {
+        return userName;
     }
 
     @Override
@@ -114,6 +128,10 @@ public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, R
     @Override
     public void setLogWriter(PrintWriter logWriter) throws ResourceException {}
 
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
     public void setPortNumber(Integer portNumber) {
         this.portNumber = portNumber;
     }
@@ -121,5 +139,9 @@ public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, R
     @Override
     public void setResourceAdapter(ResourceAdapter adapter) throws ResourceException {
         this.adapter = (ResourceAdapterImpl) adapter;
+    }
+
+    public void setUserName(String user) {
+        this.userName = user;
     }
 }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionImpl.java
@@ -19,12 +19,19 @@ import javax.resource.spi.ConnectionRequestInfo;
 import javax.resource.spi.LocalTransaction;
 import javax.resource.spi.ManagedConnection;
 import javax.resource.spi.ManagedConnectionMetaData;
+import javax.resource.spi.SecurityException;
 import javax.security.auth.Subject;
 import javax.transaction.xa.XAResource;
 
 import org.test.validator.adapter.ConnectionSpecImpl.ConnectionRequestInfoImpl;
 
 public class ManagedConnectionImpl implements ManagedConnection {
+    private final ManagedConnectionFactoryImpl mcf;
+
+    ManagedConnectionImpl(ManagedConnectionFactoryImpl mcf) {
+        this.mcf = mcf;
+    }
+
     @Override
     public void addConnectionEventListener(ConnectionEventListener listener) {}
 
@@ -39,7 +46,14 @@ public class ManagedConnectionImpl implements ManagedConnection {
 
     @Override
     public Object getConnection(Subject subject, ConnectionRequestInfo cri) throws ResourceException {
-        return new ConnectionImpl(this, (ConnectionRequestInfoImpl) cri);
+        String userName = (String) ((ConnectionRequestInfoImpl) cri).getOrDefault("UserName", mcf.getUserName());
+        String password = (String) ((ConnectionRequestInfoImpl) cri).getOrDefault("Password", mcf.getPassword());
+        // Accept some user/password combinations and reject others
+        if ("DefaultUserName".equals(userName) && "DefaultPassword".equals(password) ||
+            userName != null && password != null && userName.charAt(userName.length() - 1) == password.charAt(0))
+            return new ConnectionImpl(userName);
+        else
+            throw new SecurityException("Unable to authenticate with " + userName, "ERR_AUTH");
     }
 
     @Override


### PR DESCRIPTION
Add the ability to validate a connection factory using application authentication and supplied user/password.