### PR TITLE
In jaxb-2.3 feature at IBM-API-Package, require-java:="9" is added fo…

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxb-2.3/com.ibm.websphere.appserver.jaxb-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxb-2.3/com.ibm.websphere.appserver.jaxb-2.3.feature
@@ -5,7 +5,7 @@ singleton=true
 IBM-App-ForceRestart: uninstall, \
  install
 IBM-API-Package: \
-  javax.activation; type="spec", \
+  javax.activation; type="spec"; require-java:="9", \
   javax.xml.bind;  type="spec", \
   javax.xml.bind.annotation;  type="spec", \
   javax.xml.bind.annotation.adapters;  type="spec", \


### PR DESCRIPTION
…r javax.activation since before java 9, java SDKs already came with this library. And loading same library twice was causing class loading issue

fixes #7117