### PR TITLE
Enabling attach in jvm options

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServer/jvm.options
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServer/jvm.options
@@ -1,1 +1,2 @@
 -DUSE_MOCK_TRACER=true
+-Dcom.ibm.tools.attach.enable=yes


### PR DESCRIPTION
Fix: #7122 
Enabling attach in jvm options as done in previous Open Tracing Fat projects as seen in PR #6778 