### PR TITLE
Enabling connleaklogic with cm mbeans

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
@@ -116,6 +116,21 @@ public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionMan
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "Connection pool contents", o);
             }
+        } else if ("showExtendedPoolContents".equalsIgnoreCase(actionName)) {
+            if (params == null) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Default showExtendedPoolContents");
+                }
+                o = showExtendedPoolContents(null);
+            } else if (params.length == 1 && params[0] instanceof java.lang.String) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "showExtendedPoolContents using option", (String) params[0]);
+                }
+                o = showExtendedPoolContents((String) params[0]);
+            } else {
+                throw new MBeanException(new IllegalArgumentException(Arrays.toString(params)), Tr.formatMessage(tc, "INVALID_MBEAN_INVOKE_PARAM_J2CA8060", Arrays.toString(params),
+                                                                                                                 actionName));
+            }
         } else if ("purgePoolContents".equalsIgnoreCase(actionName)) {
             if (params == null) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -220,12 +235,7 @@ public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionMan
         StringBuffer sharedBuf = new StringBuffer();
         StringBuffer freeBuf = new StringBuffer();
 
-        buf.append("PoolManager@");
-        buf.append(Integer.toHexString(hashCode()));
-        buf.append(nl);
-        buf.append("name=");
-        buf.append(obn.toString());
-        buf.append(nl);
+        commonPoolStringHeader(buf);
         buf.append("jndiName=");
         if (_pm.gConfigProps == null || _pm.gConfigProps.getJNDIName() == null) {
             buf.append("none");
@@ -331,6 +341,18 @@ public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionMan
         return buf.toString();
     }
 
+    /**
+     * @param buf
+     */
+    private void commonPoolStringHeader(StringBuffer buf) {
+        buf.append("PoolManager@");
+        buf.append(Integer.toHexString(hashCode()));
+        buf.append(nl);
+        buf.append("name=");
+        buf.append(obn.toString());
+        buf.append(nl);
+    }
+
     private String translateStateString(String stateStr) {
         if (stateStr.equalsIgnoreCase("state_new")) {
             return "new";
@@ -377,5 +399,13 @@ public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionMan
     @Override
     public String showPoolContents() {
         return toStringExternal();
+    }
+
+    @Override
+    public String showExtendedPoolContents(String extendedOption) {
+        StringBuffer buf = new StringBuffer();
+        commonPoolStringHeader(buf);
+        buf.append(_pm.toString());
+        return buf.toString();
     }
 }

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
@@ -185,7 +185,13 @@ public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionMan
 
         final MBeanOperationInfo op0 = new MBeanOperationInfo("purgePoolContents", "Purges the contents of the Connection Manager.", purgeParams, Void.class.getCanonicalName(), MBeanOperationInfo.ACTION);
         final MBeanOperationInfo op1 = new MBeanOperationInfo("showPoolContents", "Displays the current contents of the Connection Manager in a human readable format.", null, String.class.getCanonicalName(), MBeanOperationInfo.INFO);
-        final MBeanOperationInfo[] ops = { op0, op1 };
+
+        String showExtendedPoolContentsParamDesc = "Available option null provides default trace level information.";
+        final MBeanParameterInfo p1 = new MBeanParameterInfo("arg0", String.class.getCanonicalName(), showExtendedPoolContentsParamDesc);
+        MBeanParameterInfo[] showExtendedPoolContentsParam = new MBeanParameterInfo[] { p1 };
+        final MBeanOperationInfo op2 = new MBeanOperationInfo("showExtendedPoolContents", "A string displaying the extended current state of the connection pool including detailed information.", showExtendedPoolContentsParam, String.class.getCanonicalName(), MBeanOperationInfo.INFO);
+
+        final MBeanOperationInfo[] ops = { op0, op1, op2 };
 
         final MBeanInfo nmbi = new MBeanInfo(cname, text, null, null, ops, null, null);
 

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/mbean/ConnectionManagerMBean.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/mbean/ConnectionManagerMBean.java
@@ -89,11 +89,11 @@ public interface ConnectionManagerMBean {
      * this Connection Manager.
      *
      * @param doImmediately The priority to be used to purge the connection pool.
-     *            Priority may be <code>"immediate"</code>, <code>"abort"</code> or <code>null</code>.
-     *            Immediate sets the total connection count to 0 and purges the pool
-     *            as quickly as possible but waits for transactions to complete.
-     *            Abort purges the pool by aborting connections without waiting for transactions to complete.
-     *            The default behavior if no value is specified is to purge the pool with normal priority.
+     *                          Priority may be <code>"immediate"</code>, <code>"abort"</code> or <code>null</code>.
+     *                          Immediate sets the total connection count to 0 and purges the pool
+     *                          as quickly as possible but waits for transactions to complete.
+     *                          Abort purges the pool by aborting connections without waiting for transactions to complete.
+     *                          The default behavior if no value is specified is to purge the pool with normal priority.
      * @throws MBeanException
      */
     public void purgePoolContents(String doImmediately) throws MBeanException;
@@ -123,7 +123,7 @@ public interface ConnectionManagerMBean {
      * @return A string displaying the extended current state of the connection pool including detailed information
      *         about each shared, unshared and free pool connection, the number of waiters, the total number of connections,
      *         and many other details which are useful for monitoring the state of the ConnectionManager and its pool, and debugging
-     *         problems.
+     *         problems. Note, the info is not NLS and the format is subject to change.
      *
      */
     public String showExtendedPoolContents(String extendedOption);

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/mbean/ConnectionManagerMBean.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/mbean/ConnectionManagerMBean.java
@@ -109,4 +109,22 @@ public interface ConnectionManagerMBean {
      *
      */
     public String showPoolContents();
+
+    /**
+     * Displays the contents of the connection pool associated with
+     * this Connection Manager with extended pool information from enabled trace.
+     *
+     * Trace strings that offer additional information
+     * ConnLeakLogic=all
+     *
+     * @param extendedOption Available option <code>null</code> provides default trace level
+     *                           information.
+     *
+     * @return A string displaying the extended current state of the connection pool including detailed information
+     *         about each shared, unshared and free pool connection, the number of waiters, the total number of connections,
+     *         and many other details which are useful for monitoring the state of the ConnectionManager and its pool, and debugging
+     *         problems.
+     *
+     */
+    public String showExtendedPoolContents(String extendedOption);
 }


### PR DESCRIPTION
Adding mbean showExtendedPoolContents to enable the retrieving of ConnLeakLogic=all information without enable full WAS.j2c=all trace.

With trace enabled  ConnLeakLogic=all and using mbean showExtendedPoolContents at string will be returned with this type of information for debugging connection pooling issues.

PoolManager@6c106aa7
name=WebSphere:type=com.ibm.ws.jca.cm.mbean.ConnectionManagerMBean,jndiName=jdbc/test,name=dataSource[DefaultDataSource]/connectionManager[default-0]
JNDI name:jdbc/test
PoolManager object:746094822
Total number of connections: 3 (max/min 3/0, reap/unused/aged 180/1800/-1, connectiontimeout/purge 20/EntirePool)
The waiter count is 3
The mcWrappers in waiter queue []
Shared Connection information (shared partitions 200)
  No shared connections

Free Connection information (free distribution table 100)

  No free connections

UnShared Connection information
    MCWrapper id 3c9517  Managed connection WSRdbManagedConnectionImpl@449d3f97  State:STATE_ACTIVE_INUSE Thread Id: 0000005b Thread Name: Thread-21 Connections being held 1 Start time inuse Thu Apr 04 10:31:59 CDT 2019 Time inuse 15 (seconds)  Start time same as last allocation time 
    MCWrapper id 17a0b15f  Managed connection WSRdbManagedConnectionImpl@3deb64b8  State:STATE_ACTIVE_INUSE Thread Id: 0000005a Thread Name: Thread-20 Connections being held 1 Start time inuse Thu Apr 04 10:31:59 CDT 2019 Time inuse 15 (seconds)  Start time same as last allocation time 
    MCWrapper id 54b33693  Managed connection WSRdbManagedConnectionImpl@1c9b0fc8  State:STATE_ACTIVE_INUSE Thread Id: 00000049 Thread Name: Default Executor-thread-35 Connections being held 1 Start time inuse Thu Apr 04 10:31:59 CDT 2019 Time inuse 15 (seconds)  Start time same as last allocation time 
  Total number of connection in unshared pool: 3

Connection Leak Logic Information: (Note, applications using managed connections in this list may not be following the recommended getConnection(), use connection, close() connection  programming model pattern)
  MCWrapper id 3c9517  Managed connection WSRdbManagedConnectionImpl@449d3f97  State:STATE_ACTIVE_INUSE Thread Id: 0000005b Thread Name: Thread-21 Connections being held 1
     Start time inuse Thu Apr 04 10:31:59 CDT 2019 Time inuse 15 (seconds)
     Start time same as last allocation time 
       getConnection stack trace information:          Stack number 1
          com.ibm.ejs.j2c.ConnectionManager.allocateConnection(ConnectionManager.java:492)
          com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:138)
          com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:200)
          QuickTestConnection.jndiConnection_performanceTest(QuickTestConnection.java:292)
          QuickTestConnection.jndiConnection_performanceTest_from_Thread(QuickTestConnection.java:273)
          QuickTestConnection.access$0(QuickTestConnection.java:272)
          QuickTestConnection$JndiConnection_performanceTest_thread.run(QuickTestConnection.java:524)

  MCWrapper id 17a0b15f  Managed connection WSRdbManagedConnectionImpl@3deb64b8  State:STATE_ACTIVE_INUSE Thread Id: 0000005a Thread Name: Thread-20 Connections being held 1
     Start time inuse Thu Apr 04 10:31:59 CDT 2019 Time inuse 15 (seconds)
     Start time same as last allocation time 
       getConnection stack trace information:          Matches stack number 1 occurred 2 times

  MCWrapper id 54b33693  Managed connection WSRdbManagedConnectionImpl@1c9b0fc8  State:STATE_ACTIVE_INUSE Thread Id: 00000049 Thread Name: Default Executor-thread-35 Connections being held 1
     Start time inuse Thu Apr 04 10:31:59 CDT 2019 Time inuse 15 (seconds)
     Start time same as last allocation time 
       getConnection stack trace information:          Stack number 2
          com.ibm.ejs.j2c.ConnectionManager.allocateConnection(ConnectionManager.java:492)
          com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:138)
          com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:200)
          QuickTestConnection.jndiConnection_performanceTest(QuickTestConnection.java:292)
          QuickTestConnection.jndiConnection_performanceTest_from_Servlet(QuickTestConnection.java:277)
          QuickTestConnection.performanceTest(QuickTestConnection.java:190)
          QuickTestConnection.doGet(QuickTestConnection.java:132)
          javax.servlet.http.HttpServlet.service(HttpServlet.java:686)
          javax.servlet.http.HttpServlet.service(HttpServlet.java:791)
          com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1255)
          com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:743)
          com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:440)
          com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1221)
          com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:4968)
          com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
          com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:992)
          com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
          com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1047)
          com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:417)
          com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:376)
          com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:532)
          com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:466)
          com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:331)
          com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:302)
          com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:165)
          com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:74)
          com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:503)
          com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:573)
          com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:954)
          com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1043)
          com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:239)
          java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
          java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
          java.lang.Thread.run(Thread.java:748)