### PR TITLE
Add start time to server started message

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
@@ -70,7 +70,7 @@ BUNDLE_MATCH_WARNING=CWWKF0010W: More than one bundle matched the specified filt
 BUNDLE_MATCH_WARNING.explanation=A feature definition element matched more than one bundle. This could be because the filter is too general, or because there are old bundles in the image that match the filter.
 BUNDLE_MATCH_WARNING.useraction=Make sure that the filter is sufficiently specific, and that a clean install image is being used.
 
-SERVER_STARTED=CWWKF0011I: The server {0} is ready to run a smarter planet.
+SERVER_STARTED=CWWKF0011I: The server {0} started in {1} seconds and is ready to run a smarter planet.
 SERVER_STARTED.explanation=The server has started successfully.
 SERVER_STARTED.useraction=No action is required.
 

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -12,6 +12,7 @@ package com.ibm.ws.kernel.feature.internal;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.management.ManagementFactory;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -910,7 +911,8 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
                 if (supportedProcessTypes.contains(ProcessType.CLIENT)) {
                     Tr.audit(tc, "CLIENT_STARTED", locationService.getServerName());
                 } else {
-                    Tr.audit(tc, "SERVER_STARTED", locationService.getServerName());
+                    long upTime = ManagementFactory.getRuntimeMXBean().getUptime();
+                    Tr.audit(tc, "SERVER_STARTED", locationService.getServerName(), String.format("%.3f", upTime / 1000.0));
                 }
             }
         }

--- a/dev/com.ibm.ws.kernel.feature/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.feature/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
@@ -70,7 +70,7 @@ BUNDLE_MATCH_WARNING=CWWKF0010W: More than one bundle matched the specified filt
 BUNDLE_MATCH_WARNING.explanation=A feature definition element matched more than one bundle. This could be because the filter is too general, or because there are old bundles in the image that match the filter.
 BUNDLE_MATCH_WARNING.useraction=Make sure that the filter is sufficiently specific, and that a clean install image is being used.
 
-SERVER_STARTED=CWWKF0011I: The server {0} is ready to run a smarter planet.
+SERVER_STARTED=CWWKF0011I: The server {0} started in {1} seconds and is ready to run a smarter planet.
 SERVER_STARTED.explanation=The server has started successfully.
 SERVER_STARTED.useraction=No action is required.
 


### PR DESCRIPTION
Startup time is becoming important for us to monitor.  This PR adds to the server started message the time taken to start.  The message now looks like this:

`[AUDIT   ] CWWKF0011I: The server defaultServer started in 1.054 seconds and is ready to run a smarter planet.`