### PR TITLE
Add clear warning message and instructions that OpenLiberty build will soon req Java 11

### DIFF
--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -13,7 +13,6 @@
  *
  * Depends on bnd_* values from gradle.properties.
  */
-
 pluginManagement {
   def userProperties = {
     Properties props = new Properties()
@@ -232,6 +231,18 @@ pluginManagement {
     }
   }
 }
+
+// Require Java 11
+if (!JavaVersion.current().isJava11Compatible()) {
+  println "WARNING: Building this repository will soon require Java 11. To use Java 11 follow these steps:\n" + 
+                            "  1) You can download a copy for your OS here if you don't already have it: " + 
+                            "https://adoptopenjdk.net/index.html?variant=openjdk11&jvmVariant=openj9\n" + 
+                            "  2) run 'export JAVA_HOME=/path/to/your/java11' in the shell, or set in ~/.bashrc\n" + 
+                            "  3) [MACOS ONLY] Set 'ulimit -Sn 1024' in your ~/.bashrc\n" + 
+                            "  4) Restart your gradle daemon with './gradlew --stop'\n";
+}
+
+
 
 /* Construct a properties file to store build-time variables. generated.properties is used to pass information from
  * Gradle during initialization into bnd during configuration for use in cnf/build.bnd.


### PR DESCRIPTION
#build 

Since OpenLiberty now requires Java 11 to build, make it clear that people need to be using Java 11 or newer, in case they try to build with anything less. Sample output:
```
$ ./gradlew :build.example_fat:compileJava

FAILURE: Build failed with an exception.

* Where:
Settings file '/Users/aguibert/dev/git/open-liberty/dev/settings.gradle' line: 237

* What went wrong:
A problem occurred evaluating settings 'dev'.
> Building this repository requires Java 11. To use Java 11 follow these steps:
    1) You can download a copy for your OS here if you don't already have it: https://adoptopenjdk.net/index.html?variant=openjdk11&jvmVariant=openj9
    2) run 'export JAVA_HOME=/path/to/your/java11' in the shell, or set in ~/.bashrc
    3) [MACOS ONLY] Set 'ulimit -Sn 1024' in your ~/.bashrc
    4) Restart your gradle daemon with './gradlew --stop'
```