### PR TITLE
Make cpuinfo compile on Java 7/8

### DIFF
--- a/dev/com.ibm.ws.kernel.service/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.service/bnd.bnd
@@ -30,7 +30,7 @@ Export-Package: \
 Private-Package: \
  com.ibm.ws.kernel.server.internal, \
  com.ibm.ws.kernel.service.utils.resources, \
- !com.ibm.lang.management
+ !com.ibm.lang.management, !com.sun.management
 
 Import-Package: !com.sun.management, !com.ibm.lang.management, *
  

--- a/dev/com.ibm.ws.kernel.service/src/com/sun/management/OperatingSystemMXBean.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/sun/management/OperatingSystemMXBean.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - Mirror APIs on IBM Java OperatingSystemMXBean for compile
+ *******************************************************************************/
+package com.sun.management;
+
+public interface OperatingSystemMXBean extends java.lang.management.OperatingSystemMXBean {
+    public long getProcessCpuTime();
+    public double getSystemCpuLoad();
+}


### PR DESCRIPTION
While everyone was encouraged to upgrade to Java 11 not supporting Java 7/8 is causing some issues so delivering a fix (I hope).