### PR TITLE
Add start time to server started message

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -185,11 +185,11 @@ public class FrameworkManager {
      * Create and launch the OSGi framework
      *
      * @param config
-     *            BootstrapConfig object encapsulating active initial framework
-     *            properties
+     *                        BootstrapConfig object encapsulating active initial framework
+     *                        properties
      * @param logProvider
-     *            The initialized/active log provider that must be included in
-     *            framework management activities (start/stop/.. ), or null
+     *                        The initialized/active log provider that must be included in
+     *                        framework management activities (start/stop/.. ), or null
      * @param callback
      */
     public void launchFramework(BootstrapConfig config, LogProvider logProvider) {
@@ -197,7 +197,7 @@ public class FrameworkManager {
             throw new IllegalArgumentException("bootstrap config must not be null");
         boolean isClient = config.getProcessType().equals(BootstrapConstants.LOC_PROCESS_TYPE_CLIENT);
         try {
-            String nTime = config.remove(BootstrapConstants.LAUNCH_TIME);
+            String nTime = config.get(BootstrapConstants.LAUNCH_TIME);
             startTime = nTime == null ? System.nanoTime() : Long.parseLong(nTime);
             if (isClient) {
                 Tr.audit(tc, "audit.launchTime.client", config.getProcessName());
@@ -465,9 +465,9 @@ public class FrameworkManager {
      * launch the platform/runtime.
      *
      * @param systemBundleCtx
-     *            The framework system bundle context
+     *                            The framework system bundle context
      * @param config
-     *            The active bootstrap config
+     *                            The active bootstrap config
      */
     private void registerLibertyProcessService(BundleContext systemBundleCtx, BootstrapConfig config) {
         List<String> cmds = config.getCmdArgs();
@@ -482,7 +482,7 @@ public class FrameworkManager {
      * Register the instrumentation class as a service in the OSGi registry
      *
      * @param systemBundleCtx
-     *            The framework system bundle context
+     *                            The framework system bundle context
      */
     protected void registerInstrumentationService(BundleContext systemContext) {
         Instrumentation inst = config.getInstrumentation();
@@ -500,7 +500,7 @@ public class FrameworkManager {
      * Register the PauseableComponentController class as a service in the OSGi registry
      *
      * @param systemBundleCtx
-     *            The framework system bundle context
+     *                            The framework system bundle context
      */
     protected void registerPauseableComponentController(BundleContext systemContext) {
         PauseableComponentControllerImpl pauseableComponentController = new PauseableComponentControllerImpl(systemContext);
@@ -876,11 +876,11 @@ public class FrameworkManager {
      * the elapsed time, in milliseconds, to format
      *
      * @param factor
-     *            If true, the elapsed time will be factored into more detailed
-     *            units: days/hours/minutes/seconds
-     *            The decimal format of the seconds is #.### or #.## or #.# or # or 0
-     *            If false it will be returned as the total of seconds
-     *            The decimal format of the seconds is #.### or #.## or #.# or # or 0
+     *                   If true, the elapsed time will be factored into more detailed
+     *                   units: days/hours/minutes/seconds
+     *                   The decimal format of the seconds is #.### or #.## or #.# or # or 0
+     *                   If false it will be returned as the total of seconds
+     *                   The decimal format of the seconds is #.### or #.## or #.# or # or 0
      *
      * @return A String containing the formatted elapsed time.
      *         Examples when the English language 'en' is the 'Locale':
@@ -1054,9 +1054,9 @@ public class FrameworkManager {
      * server status from them.
      *
      * @param timestamp
-     *            Create a unique dump folder based on the time stamp string.
+     *                            Create a unique dump folder based on the time stamp string.
      * @param javaDumpActions
-     *            The java dumps to create, or null for the default set.
+     *                            The java dumps to create, or null for the default set.
      */
     public void introspectFramework(String timestamp, Set<JavaDumpAction> javaDumpActions) {
         Tr.audit(tc, "info.introspect.request.received");

--- a/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
@@ -70,7 +70,7 @@ BUNDLE_MATCH_WARNING=CWWKF0010W: More than one bundle matched the specified filt
 BUNDLE_MATCH_WARNING.explanation=A feature definition element matched more than one bundle. This could be because the filter is too general, or because there are old bundles in the image that match the filter.
 BUNDLE_MATCH_WARNING.useraction=Make sure that the filter is sufficiently specific, and that a clean install image is being used.
 
-SERVER_STARTED=CWWKF0011I: The server {0} is ready to run a smarter planet.
+SERVER_STARTED=CWWKF0011I: The {0} server is ready to run a smarter planet. The {0} server started in {1} seconds.
 SERVER_STARTED.explanation=The server has started successfully.
 SERVER_STARTED.useraction=No action is required.
 

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -910,7 +910,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
                 if (supportedProcessTypes.contains(ProcessType.CLIENT)) {
                     Tr.audit(tc, "CLIENT_STARTED", locationService.getServerName());
                 } else {
-                    Tr.audit(tc, "SERVER_STARTED", locationService.getServerName());
+                    Tr.audit(tc, "SERVER_STARTED", locationService.getServerName(), TimestampUtils.getElapsedTime());
                 }
             }
         }

--- a/dev/com.ibm.ws.kernel.feature/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.feature/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
@@ -70,7 +70,7 @@ BUNDLE_MATCH_WARNING=CWWKF0010W: More than one bundle matched the specified filt
 BUNDLE_MATCH_WARNING.explanation=A feature definition element matched more than one bundle. This could be because the filter is too general, or because there are old bundles in the image that match the filter.
 BUNDLE_MATCH_WARNING.useraction=Make sure that the filter is sufficiently specific, and that a clean install image is being used.
 
-SERVER_STARTED=CWWKF0011I: The server {0} is ready to run a smarter planet.
+SERVER_STARTED=CWWKF0011I: The {0} server is ready to run a smarter planet. The {0} server started in {1} seconds.
 SERVER_STARTED.explanation=The server has started successfully.
 SERVER_STARTED.useraction=No action is required.
 

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/TimestampUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/TimestampUtils.java
@@ -32,10 +32,10 @@ public class TimestampUtils {
     static {
         long start = OsgiPropertyUtils.getLong("kernel.launch.time", 0);
         if (start == 0)
-            start = System.currentTimeMillis();
+            start = System.nanoTime();
 
-        startTime = start;
-        startTimeNano = System.nanoTime();
+        startTime = System.currentTimeMillis();
+        startTimeNano = start;
     }
 
     public static void writeTimeToFile(File file, long timestamp) {
@@ -86,9 +86,9 @@ public class TimestampUtils {
 
     /**
      * @param nlsClass
-     *            Class from the calling bundle
+     *                     Class from the calling bundle
      * @param msgKey
-     *            Translated message key
+     *                     Translated message key
      */
     public static void auditElapsedTime(TraceComponent callingTc, String msgKey) {
         if (callingTc.isAuditEnabled())
@@ -96,7 +96,7 @@ public class TimestampUtils {
     }
 
     public static String getElapsedTime() {
-        return getElapsedTime(startTime);
+        return getElapsedTimeNanos(startTimeNano);
     }
 
     /**


### PR DESCRIPTION
Startup time is becoming important for us to monitor. This PR adds to the server started message the time taken to start. The message now looks like this:

`[AUDIT   ] CWWKF0011I: The server defaultServer is ready to run a smarter planet. It started in 0.933 seconds.`