### PR TITLE
Enabling connleaklogic showPoolContents cm mbeans

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
@@ -35,6 +35,7 @@ import com.ibm.ws.jca.cm.mbean.ConnectionManagerMBean;
 
 public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionManagerMBean {
     private static final TraceComponent tc = Tr.register(PoolManagerMBeanImpl.class, J2CConstants.traceSpec, J2CConstants.messageFile);
+    private static final TraceComponent ConnLeakLogic = Tr.register(ConnectionManager.class, "ConnLeakLogic", J2CConstants.messageFile);
 
     private transient PoolManager _pm = null;
     private transient Version jdbcRuntimeVersion;
@@ -376,6 +377,14 @@ public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionMan
 
     @Override
     public String showPoolContents() {
-        return toStringExternal();
+        StringBuffer buf = new StringBuffer();
+        buf.append(toStringExternal());
+        if (TraceComponent.isAnyTracingEnabled() && ConnLeakLogic.isEntryEnabled()) {
+            buf.append(nl);
+            buf.append("Extended ConnLeakLogic infromation");
+            buf.append(nl);
+            buf.append(_pm.toString());
+        }
+        return buf.toString();
     }
 }

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
@@ -381,7 +381,7 @@ public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionMan
         buf.append(toStringExternal());
         if (TraceComponent.isAnyTracingEnabled() && ConnLeakLogic.isEntryEnabled()) {
             buf.append(nl);
-            buf.append("Extended ConnLeakLogic infromation");
+            buf.append("Extended ConnLeakLogic information");
             buf.append(nl);
             buf.append(_pm.toString());
         }

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/mbean/ConnectionManagerMBean.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/mbean/ConnectionManagerMBean.java
@@ -105,7 +105,7 @@ public interface ConnectionManagerMBean {
      * @return A non-localized string displaying the current state of the connection pool including detailed information
      *         about each shared, unshared and free pool connection, the number of waiters, the total number of connections,
      *         and many other details which are useful for monitoring the state of the ConnectionManager and its pool, and debugging
-     *         problems.
+     *         problems. Note, this information is not NLS and the format is subject to change.
      *
      */
     public String showPoolContents();


### PR DESCRIPTION
Adding extended information to showPoolContents to retrieve of ConnLeakLogic=all information without enable full WAS.j2c=all trace.

With trace enabled ConnLeakLogic=all and using mbean showPoolContents at string will be returned with information for debugging connection pooling issues.

Example output   (New information start at "Extended ConnLeakLogic information")

PoolManager@c16efaf
name=WebSphere:type=com.ibm.ws.jca.cm.mbean.ConnectionManagerMBean,jndiName=jdbc/test,name=dataSource[DefaultDataSource]/connectionManager[default-0]
jndiName=jdbc/test
maxPoolSize=3
size=3
waiting=3
unshared=3
 ManagedConnection@14aec207=ActiveInUse thread=000001ba
 ManagedConnection@672fc4e3=ActiveInUse thread=000001b9
 ManagedConnection@4f60b195=ActiveInUse thread=0000002a
shared=0
available=0

Extended ConnLeakLogic information
JNDI name:jdbc/test
PoolManager object:1691264332
Total number of connections: 3 (max/min 3/0, reap/unused/aged 180/1800/-1, connectiontimeout/purge 20/EntirePool)
The waiter count is 3
The mcWrappers in waiter queue []
Shared Connection information (shared partitions 200)
  No shared connections

Free Connection information (free distribution table 100)

  No free connections

UnShared Connection information
    MCWrapper id 14aec207  Managed connection WSRdbManagedConnectionImpl@2fdb78e7  State:STATE_ACTIVE_INUSE Thread Id: 000001ba Thread Name: Thread-24 Connections being held 1 Start time inuse Fri Apr 05 10:24:35 CDT 2019 Time inuse 19 (seconds)  Start time same as last allocation time 
    MCWrapper id 672fc4e3  Managed connection WSRdbManagedConnectionImpl@167ef136  State:STATE_ACTIVE_INUSE Thread Id: 000001b9 Thread Name: Thread-23 Connections being held 1 Start time inuse Fri Apr 05 10:24:35 CDT 2019 Time inuse 19 (seconds)  Start time same as last allocation time 
    MCWrapper id 4f60b195  Managed connection WSRdbManagedConnectionImpl@2e760e0e  State:STATE_ACTIVE_INUSE Thread Id: 0000002a Thread Name: Default Executor-thread-10 Connections being held 1 Start time inuse Fri Apr 05 10:24:35 CDT 2019 Time inuse 19 (seconds)  Start time same as last allocation time 
  Total number of connection in unshared pool: 3

Connection Leak Logic Information: (Note, applications using managed connections in this list may not be following the recommended getConnection(), use connection, close() connection  programming model pattern)
  MCWrapper id 14aec207  Managed connection WSRdbManagedConnectionImpl@2fdb78e7  State:STATE_ACTIVE_INUSE Thread Id: 000001ba Thread Name: Thread-24 Connections being held 1
     Start time inuse Fri Apr 05 10:24:35 CDT 2019 Time inuse 19 (seconds)
     Start time same as last allocation time 
       getConnection stack trace information:          Stack number 1
          com.ibm.ejs.j2c.ConnectionManager.allocateConnection(ConnectionManager.java:492)
          com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:138)
          com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:200)
          QuickTestConnection.jndiConnection_performanceTest(QuickTestConnection.java:292)
          QuickTestConnection.jndiConnection_performanceTest_from_Thread(QuickTestConnection.java:273)
          QuickTestConnection.access$0(QuickTestConnection.java:272)
          QuickTestConnection$JndiConnection_performanceTest_thread.run(QuickTestConnection.java:524)

  MCWrapper id 672fc4e3  Managed connection WSRdbManagedConnectionImpl@167ef136  State:STATE_ACTIVE_INUSE Thread Id: 000001b9 Thread Name: Thread-23 Connections being held 1
     Start time inuse Fri Apr 05 10:24:35 CDT 2019 Time inuse 19 (seconds)
     Start time same as last allocation time 
       getConnection stack trace information:          Matches stack number 1 occurred 2 times

  MCWrapper id 4f60b195  Managed connection WSRdbManagedConnectionImpl@2e760e0e  State:STATE_ACTIVE_INUSE Thread Id: 0000002a Thread Name: Default Executor-thread-10 Connections being held 1
     Start time inuse Fri Apr 05 10:24:35 CDT 2019 Time inuse 19 (seconds)
     Start time same as last allocation time 
       getConnection stack trace information:          Stack number 2
          com.ibm.ejs.j2c.ConnectionManager.allocateConnection(ConnectionManager.java:492)
          com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:138)
          com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:200)
          QuickTestConnection.jndiConnection_performanceTest(QuickTestConnection.java:292)
          ....