### PR TITLE
 add JDBC connection support to mock adapter for testing JCA validator

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator_fat/.classpath
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-resourceadapter/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -29,4 +29,7 @@ fat.project: true
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    com.ibm.ws.rest.handler.validator;version=latest,\
+    com.ibm.ws.rest.handler.validator.jca;version=latest,\
+    com.ibm.ws.rest.handler.validator.jdbc;version=latest,\
     com.ibm.ws.security.jaas.common;version=latest

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
@@ -201,7 +201,7 @@ public class ValidateJCATest extends FATServletClient {
         JsonArray json = request.method("GET").run(JsonArray.class);
         String err = "unexpected response: " + json;
 
-        assertEquals(err, 4, json.size()); // Increase this if you add more connection factories to server.xml
+        assertEquals(err, 5, json.size()); // Increase this if you add more connection factories to server.xml
 
         // Order is currently alphabetical based on config.displayId
 
@@ -299,6 +299,23 @@ public class ValidateJCATest extends FATServletClient {
         assertNull(err, j.get("info"));
         assertNotNull(err, j.getJsonObject("failure"));
         // connectionFactory[default-1] is already tested under testTopLevelConnectionFactoryWithoutIDWithChainedExceptions
+
+        // [4]: config.displayId=connectionFactory[ds5]
+        j = json.getJsonObject(4);
+        assertEquals(err, "ds5", j.getString("uid"));
+        assertEquals(err, "ds5", j.getString("id"));
+        assertEquals(err, "eis/ds5", j.getString("jndiName"));
+        assertTrue(err, j.getBoolean("successful"));
+        assertNull(err, j.get("failure"));
+        assertNotNull(err, j = j.getJsonObject("info"));
+        // TODO need to implement
+        //assertEquals(err, "TestValidationEIS", j.getString("databaseProductName"));
+        //assertEquals(err, "33.56.65", j.getString("databaseProductVersion"));
+        //assertEquals(err, "TestValidationJDBCAdapter", j.getString("driverName"));
+        //assertEquals(err, "36.77.85", j.getString("driverVersion"));
+        //assertEquals(err, "TestValDB", j.get("catalog"));
+        //assertEquals(err, "DEFAULTUSERNAME", j.getString("schema"));
+        //assertEquals(err, "DefaultUserName", j.getString("user"));
     }
 
     /**

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
@@ -27,19 +27,24 @@
 
   <connectionFactory id="cf1" jndiName="eis/cf1">
     <containerAuthData user="containerAuthUser1" password="1containerAuthUser"/>
-    <properties.TestValidationAdapter hostName="myhost.openliberty.io" portNumber="9876"/>
+    <properties.TestValidationAdapter.ConnectionFactory hostName="myhost.openliberty.io" portNumber="9876"/>
   </connectionFactory>
 
   <connectionFactory id="cf2" jndiName="eis/cf-invalid-host">
-    <properties.TestValidationAdapter hostName="notfound.rchland.ibm.com" portNumber="5432"/>
+    <properties.TestValidationAdapter.ConnectionFactory hostName="notfound.rchland.ibm.com" portNumber="5432"/>
   </connectionFactory>
 
   <connectionFactory jndiName="eis/cf-negative-port-number">
-    <properties.TestValidationAdapter hostName="myhost.openliberty.io" portNumber="-2020"/>
+    <properties.TestValidationAdapter.ConnectionFactory hostName="myhost.openliberty.io" portNumber="-2020"/>
   </connectionFactory>
 
   <connectionFactory jndiName="eis/cf-port-not-in-range">
-    <properties.TestValidationAdapter hostName="myhost.openliberty.io" portNumber="22"/>
+    <properties.TestValidationAdapter.ConnectionFactory hostName="myhost.openliberty.io" portNumber="22"/>
+  </connectionFactory>
+
+  <connectionFactory id="ds5" jndiName="eis/ds5">
+    <containerAuthData user="containerAuthUser5" password="5containerAuthUser"/>
+    <properties.TestValidationAdapter.DataSource hostName="myhost.openliberty.io" portNumber="2345"/>
   </connectionFactory>
 
   <javaPermission codebase="${server.config.dir}/dropins/TestValidationAdapter.rar"

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionSpecImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ConnectionSpecImpl.java
@@ -19,10 +19,13 @@ import javax.resource.spi.ConnectionRequestInfo;
  * Example ConnectionSpec implementation with UserName and Password.
  */
 public class ConnectionSpecImpl implements ConnectionSpec {
+    boolean isJDBC;
     private String user, password;
 
     ConnectionRequestInfoImpl createConnectionRequestInfo() {
         ConnectionRequestInfoImpl cri = new ConnectionRequestInfoImpl();
+        if (isJDBC)
+            cri.put("JDBC", isJDBC);
         if (user != null)
             cri.put("UserName", user);
         if (password != null)
@@ -32,6 +35,14 @@ public class ConnectionSpecImpl implements ConnectionSpec {
 
     public String getUserName() {
         return user;
+    }
+
+    public boolean isJDBC() {
+        return isJDBC;
+    }
+
+    public void setJDBC(boolean isJDBC) {
+        this.isJDBC = isJDBC;
     }
 
     public void setPassword(String pwd) {

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/DataSourceImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/DataSourceImpl.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLInvalidAuthorizationSpecException;
+import java.util.logging.Logger;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionManager;
+import javax.sql.DataSource;
+
+import org.test.validator.adapter.ConnectionSpecImpl.ConnectionRequestInfoImpl;
+
+public class DataSourceImpl implements DataSource {
+    private final ConnectionManager cm;
+    final ManagedConnectionFactoryImpl mcf;
+
+    DataSourceImpl(ConnectionManager cm, ManagedJDBCConnectionFactoryImpl mcf) {
+        this.cm = cm;
+        this.mcf = mcf;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return getConnection(null, null);
+    }
+
+    @Override
+    public Connection getConnection(String user, String password) throws SQLException {
+        ConnectionSpecImpl conSpec = new ConnectionSpecImpl();
+        conSpec.setJDBC(true);
+        if (user != null)
+            conSpec.setUserName(user);
+        if (password != null)
+            conSpec.setPassword(password);
+        ConnectionRequestInfoImpl cri = conSpec.createConnectionRequestInfo();
+        try {
+            return (Connection) cm.allocateConnection(mcf, cri);
+        } catch (SecurityException x) {
+            throw new SQLInvalidAuthorizationSpecException(x);
+        } catch (ResourceException x) {
+            throw new SQLException(x);
+        }
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return mcf.getLogWriter();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return null;
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> ifc) throws SQLException {
+        return ifc.isAssignableFrom(getClass());
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        mcf.setLogWriter(out);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> ifc) throws SQLException {
+        return isWrapperFor(ifc) ? ifc.cast(this) : null;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/JDBCConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/JDBCConnectionImpl.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLNonTransientConnectionException;
+
+/**
+ * Proxy for java.sql.Connection and java.sql.DatabaseMetaData
+ */
+public class JDBCConnectionImpl implements InvocationHandler {
+    private boolean closed;
+    private String user;
+
+    JDBCConnectionImpl(String user) {
+        this.user = user;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        String name = method.getName();
+
+        if ("hashCode".equals(name))
+            return System.identityHashCode(proxy);
+        if ("toString".equals(name))
+            return getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(proxy));
+
+        if ("close".equals(name)) {
+            closed = true;
+            return null;
+        }
+
+        if ("isValid".equals(name))
+            return !closed;
+
+        if (closed)
+            throw new SQLNonTransientConnectionException("Connection is closed.", "08003", 53);
+
+        if ("getCatalog".equals(name))
+            return "TestValDB";
+        if ("getConnection".equals(name) || "getMetaData".equals(name))
+            return proxy;
+        if ("getDatabaseProductName".equals(name))
+            return "TestValidationEIS";
+        if ("getDatabaseProductVersion".equals(name))
+            return "33.56.65";
+        if ("getDriverName".equals(name))
+            return "TestValidationJDBCAdapter";
+        if ("getDriverVersion".equals(name))
+            return "36.77.85";
+        if ("getSchema".equals(name))
+            return user.toUpperCase();
+        if ("getUserName".equals(name))
+            return user;
+
+        for (Class<?> c : method.getExceptionTypes())
+            if (SQLException.class.isAssignableFrom(c))
+                throw new SQLFeatureNotSupportedException(name);
+
+        throw new UnsupportedOperationException(name);
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionFactoryImpl.java
@@ -92,7 +92,7 @@ public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, R
     }
 
     @Override
-    public PrintWriter getLogWriter() throws ResourceException {
+    public PrintWriter getLogWriter() {
         return null;
     }
 
@@ -126,7 +126,8 @@ public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, R
     }
 
     @Override
-    public void setLogWriter(PrintWriter logWriter) throws ResourceException {}
+    public void setLogWriter(PrintWriter logWriter) {
+    }
 
     public void setPassword(String password) {
         this.password = password;

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionImpl.java
@@ -37,19 +37,24 @@ public class ManagedConnectionImpl implements ManagedConnection {
     }
 
     @Override
-    public void addConnectionEventListener(ConnectionEventListener listener) {}
+    public void addConnectionEventListener(ConnectionEventListener listener) {
+    }
 
     @Override
-    public void associateConnection(Object handle) throws ResourceException {}
+    public void associateConnection(Object handle) throws ResourceException {
+    }
 
     @Override
-    public void cleanup() throws ResourceException {}
+    public void cleanup() throws ResourceException {
+    }
 
     @Override
-    public void destroy() throws ResourceException {}
+    public void destroy() throws ResourceException {
+    }
 
     @Override
     public Object getConnection(Subject subject, ConnectionRequestInfo cri) throws ResourceException {
+        boolean isJDBC = (Boolean) ((ConnectionRequestInfoImpl) cri).getOrDefault("JDBC", Boolean.FALSE);
         String userName = mcf.getUserName();
         String password = mcf.getPassword();
         if (subject == null) {
@@ -76,7 +81,10 @@ public class ManagedConnectionImpl implements ManagedConnection {
         // Accept some user/password combinations and reject others
         if ("DefaultUserName".equals(userName) && "DefaultPassword".equals(password) ||
             userName != null && password != null && userName.charAt(userName.length() - 1) == password.charAt(0))
-            return new ConnectionImpl(userName);
+            if (isJDBC)
+                return new JDBCConnectionImpl(userName);
+            else
+                return new ConnectionImpl(userName);
         else
             throw new SecurityException("Unable to authenticate with " + userName, "ERR_AUTH");
     }
@@ -102,8 +110,10 @@ public class ManagedConnectionImpl implements ManagedConnection {
     }
 
     @Override
-    public void removeConnectionEventListener(ConnectionEventListener listener) {}
+    public void removeConnectionEventListener(ConnectionEventListener listener) {
+    }
 
     @Override
-    public void setLogWriter(PrintWriter logWriter) throws ResourceException {}
+    public void setLogWriter(PrintWriter logWriter) throws ResourceException {
+    }
 }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedJDBCConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedJDBCConnectionFactoryImpl.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.validator.adapter;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.util.Set;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.CommException;
+import javax.resource.spi.ConfigProperty;
+import javax.resource.spi.ConnectionDefinition;
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.InvalidPropertyException;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionFactory;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterAssociation;
+import javax.resource.spi.ResourceAllocationException;
+import javax.security.auth.Subject;
+import javax.sql.DataSource;
+
+/**
+ * Test managed connection factory for JDBC connections that don't connect to anything.
+ */
+@ConnectionDefinition(connectionFactory = DataSource.class,
+                      connectionFactoryImpl = DataSourceImpl.class,
+                      connection = Connection.class,
+                      connectionImpl = JDBCConnectionImpl.class)
+public class ManagedJDBCConnectionFactoryImpl extends ManagedConnectionFactoryImpl {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Object createConnectionFactory() throws ResourceException {
+        return createConnectionFactory(null);
+    }
+
+    @Override
+    public Object createConnectionFactory(ConnectionManager cm) throws ResourceException {
+        return new DataSourceImpl(cm, this);
+    }
+}


### PR DESCRIPTION
Update the mock resource adapter that is used for testing the JCA validator
so that the adapter also provides a JDBC managed connection factory.  This makes possible a different set of validation info (from DatabaseMetaData) and the connection.validate(timeout) mechanism for validating a connection.