### PR TITLE
Skip copying server dump temp files during dump processing.

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -2616,7 +2616,7 @@ public class LibertyServer implements LogMonitorClient {
         runJextract(serverFolder);
 
         // Copy the log files: try to move them instead if we can
-        recursivelyCopyDirectory(serverFolder, logFolder, false, true, true);
+        recursivelyCopyDirectory(serverFolder, logFolder, true, true, true);
 
         deleteServerMarkerFile();
 


### PR DESCRIPTION
Test infrastructure fix - this resolves a problem where a server dump is occurring when the LibertyServer test infrastructure is attempting to copy the server directory.  It results in an exception which causes a test failure.  The exception looks like:
```
java.lang.Exception: Cannot copy a file or directory that does not exist: /home/jazz_build/_U_kFAFSgEem8NdNdaSGUMw-EBC.PROD.WASRTC-6CX-000-00-00/jbe/build/dev/image/output/wlp/usr/servers/mpRestClient11.async/dump_19.04.01_21.07.41/introspections/RegionIntrospection.txt: localhost
at com.ibm.websphere.simplicity.RemoteFile.copy(RemoteFile.java:841)
at com.ibm.websphere.simplicity.RemoteFile.copyFromSource(RemoteFile.java:513)
at componenttest.topology.impl.LibertyServer.recursivelyCopyDirectory(LibertyServer.java:2722)
at componenttest.topology.impl.LibertyServer.recursivelyCopyDirectory(LibertyServer.java:2685)
at componenttest.topology.impl.LibertyServer.recursivelyCopyDirectory(LibertyServer.java:2685)
at componenttest.topology.impl.LibertyServer.postStopServerArchive(LibertyServer.java:2612)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:2422)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:2214)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:2189)
at com.ibm.ws.microprofile.rest.client.fat.AsyncMethodTest.afterClass(AsyncMethodTest.java:75)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:115)
at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:314)
at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:167)
```

The fix is to avoid copying the `dump_*` directory during the post stop server archive step.  This is test infrastructure code, and therefore not a release bug.