### PR TITLE
Use alternate method to get IP to avoid RuntimeMXBean startup overhead

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/DateFormatProvider.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/DateFormatProvider.java
@@ -14,11 +14,13 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
 public class DateFormatProvider {
+    /** Simple date format for file names: use only while synchronized */
+    public final static SimpleDateFormat FILE_DATE = new SimpleDateFormat("_yy.MM.dd_HH.mm.ss");
 
     /**
      * Return a format string that will produce a reasonable standard way for
      * formatting time (but still using the current locale)
-     * 
+     *
      * @return The format string
      */
     public static DateFormat getDateFormat() {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/FileLogSet.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/FileLogSet.java
@@ -302,8 +302,8 @@ public class FileLogSet {
      * This method is intended to be overridden by unit tests.
      */
     protected String getDateString() {
-        synchronized (LoggingFileUtils.FILE_DATE) {
-            return LoggingFileUtils.FILE_DATE.format(new Date());
+        synchronized (DateFormatProvider.FILE_DATE) {
+            return DateFormatProvider.FILE_DATE.format(new Date());
         }
     }
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
@@ -12,6 +12,7 @@ package com.ibm.ws.logging.internal.impl;
 
 import java.io.File;
 import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -262,7 +263,23 @@ public class LogProviderConfigImpl implements LogProviderConfig {
 
         builder.append("os = ").append(System.getProperty("os.name")).append(" (").append(System.getProperty("os.version")).append("; ").append(System.getProperty("os.arch")).append(") (").append(Locale.getDefault()).append(")").append(LoggingConstants.nl);
 
-        builder.append("process = ").append(ManagementFactory.getRuntimeMXBean().getName()).append(LoggingConstants.nl);
+        // avoid the initialization overhead retrieving the RuntimeMXBean. Not guaranteed to work on all platforms, so fallback as appropriate
+        builder.append("process = ");
+        String pid = System.getProperty("sun.java.launcher.pid");
+
+        if (pid != null) {
+            try {
+                String ip = InetAddress.getLocalHost().getHostAddress();
+                builder.append(pid).append('@').append(ip);
+            } catch (Exception e) {
+                pid = null;
+            }
+        }
+        if (pid == null) {
+            builder.append(ManagementFactory.getRuntimeMXBean().getName());
+        }
+        builder.append(LoggingConstants.nl);
+
         return builder.toString();
     }
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LoggingFileUtils.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LoggingFileUtils.java
@@ -16,7 +16,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
-import java.text.SimpleDateFormat;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -27,8 +26,6 @@ import com.ibm.ws.logging.internal.TraceSpecification;
  *
  */
 public class LoggingFileUtils {
-    /** Simple date format for file names: use only while synchronized */
-    public final static SimpleDateFormat FILE_DATE = new SimpleDateFormat("_yy.MM.dd_HH.mm.ss");
 
     /**
      * Filter used to match filenames for pruning when file rolling is enabled.


### PR DESCRIPTION
Currently the log header "process" information is retrieved by instantiating the RuntimeMXBean. This overhead adds 10-20ms to startup. Use the java prop "sun.java.launcher.pid" to get the pid on supported platforms, otherwise fallback to the RuntimeMXBean method.

Also spotted a SimpleDateFormat instantiation that can be moved to a different file to avoid startup penalty