### PR TITLE
Fix async test

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountsPayableService.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountsPayableService.java
@@ -15,6 +15,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.ws.rs.Consumes;
@@ -50,7 +53,10 @@ public class AccountsPayableService {
         accountBalances.put("12300444", 250.00);
         accountBalances.put("12300963", 2287.35);
         
-        bankAccountClient = RestClientBuilder.newBuilder().baseUri(URI.create(AsyncTestServlet.URI_CONTEXT_ROOT)).build(BankAccountClient.class);
+        bankAccountClient = RestClientBuilder.newBuilder()
+                                             .baseUri(URI.create(AsyncTestServlet.URI_CONTEXT_ROOT))
+                                             .executorService(App.executorService.get())
+                                             .build(BankAccountClient.class);
     }
     
     @GET
@@ -92,7 +98,19 @@ public class AccountsPayableService {
         }
 
         Double paymentAmt = payment.getAmount();
-        bankAccountClient.withdraw(paymentAmt);
+        try {
+            Double remainingBalanceInAccount = bankAccountClient.withdraw(paymentAmt)
+                                                                .toCompletableFuture()
+                                                                .get(AsyncTestServlet.TIMEOUT, TimeUnit.SECONDS);
+            _log.info("balance remaining in bank after withdrawal: " + remainingBalanceInAccount);
+        } catch (ExecutionException ex) {
+            Throwable t = ex.getCause();
+            if (t instanceof InsufficientFundsException) {
+                throw (InsufficientFundsException) t;
+            }
+            _log.log(Level.WARNING, "Caught unexpected exception: ", t);
+        }
+        
 
         Double remainingBalance = balance - paymentAmt;
         accountBalances.put(acctNumber, remainingBalance);

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountsPayableService.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AccountsPayableService.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -103,14 +104,13 @@ public class AccountsPayableService {
                                                                 .toCompletableFuture()
                                                                 .get(AsyncTestServlet.TIMEOUT, TimeUnit.SECONDS);
             _log.info("balance remaining in bank after withdrawal: " + remainingBalanceInAccount);
-        } catch (ExecutionException ex) {
+        } catch (ExecutionException | InterruptedException | TimeoutException ex) {
             Throwable t = ex.getCause();
-            if (t instanceof InsufficientFundsException) {
+            if (t != null && t instanceof InsufficientFundsException) {
                 throw (InsufficientFundsException) t;
             }
             _log.log(Level.WARNING, "Caught unexpected exception: ", t);
         }
-        
 
         Double remainingBalance = balance - paymentAmt;
         accountBalances.put(acctNumber, remainingBalance);

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/App.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/App.java
@@ -10,9 +10,13 @@
  *******************************************************************************/
 package mpRestClient11.async;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 @ApplicationPath("/")
 public class App extends Application {
+    static final AtomicReference<ExecutorService> executorService = new AtomicReference<>();
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AsyncTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AsyncTestServlet.java
@@ -49,13 +49,25 @@ import componenttest.app.FATServlet;
 @WebServlet(urlPatterns = "/AsyncTestServlet")
 public class AsyncTestServlet extends FATServlet {
     private final static Logger _log = Logger.getLogger(AsyncTestServlet.class.getName());
-    private final static int TIMEOUT = 10;
-    private final static int MULTISTAGE_TIMEOUT = 40;
+    final static int TIMEOUT = 10;
+    final static int MULTISTAGE_TIMEOUT = 40;
 
     final static String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/asyncApp/";
 
     @Resource
     ExecutorService executor;
+
+    @Override
+    public void before() {
+        assertNotNull(executor);
+        App.executorService.compareAndSet(null, executor);
+    }
+
+    @Override
+    public void after() {
+        assertNotNull(executor);
+        App.executorService.compareAndSet(executor, null);
+    }
 
     /**
      * Tests multi-stage CompletionStage (async) from a Rest Client.

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/CXFAuthenticator.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/CXFAuthenticator.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.transport.http;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedExceptionAction;
+
+import org.apache.cxf.common.util.ReflectionUtil;
+import org.apache.cxf.helpers.IOUtils;
+import org.apache.cxf.helpers.JavaUtils;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+import org.apache.cxf.transport.Conduit;
+
+/**
+ *
+ */
+public class CXFAuthenticator extends Authenticator {
+    static CXFAuthenticator instance;
+
+
+    public CXFAuthenticator() {
+    }
+
+    public static synchronized void addAuthenticator() {
+        if (instance == null) {
+            instance = new CXFAuthenticator();
+            Authenticator wrapped = null;
+            if (JavaUtils.isJava9Compatible()) {
+                try {
+                    Method m = ReflectionUtil.getMethod(Authenticator.class, "getDefault");
+                    // Liberty change added doPriv (should be in next CXF release)
+                    wrapped = AccessController.doPrivileged((PrivilegedExceptionAction<Authenticator>) () -> {
+                        return (Authenticator)m.invoke(null);
+                        });
+                } catch (Exception e) {
+                    // ignore
+                }
+                
+
+            } else {
+                for (final Field f : ReflectionUtil.getDeclaredFields(Authenticator.class)) {
+                    if (f.getType().equals(Authenticator.class)) {
+                        ReflectionUtil.setAccessible(f);
+                        try {
+                            wrapped = (Authenticator)f.get(null);
+                            if (wrapped != null && wrapped.getClass().getName()
+                                .equals(ReferencingAuthenticator.class.getName())) {
+                                Method m = wrapped.getClass().getMethod("check");
+                                m.setAccessible(true);
+                                m.invoke(wrapped);
+                            }
+                            wrapped = (Authenticator)f.get(null);
+                        } catch (Exception e) {
+                            // ignore
+                        }
+                    }
+                }
+            }
+
+            try {
+                Class<?> cls = null;
+                InputStream ins = ReferencingAuthenticator.class
+                    .getResourceAsStream("ReferencingAuthenticator.class");
+                byte[] b = IOUtils.readBytesFromStream(ins);
+                if (JavaUtils.isJava9Compatible()) {
+                    Class<?> methodHandles = Class.forName("java.lang.invoke.MethodHandles");
+                    Method m = ReflectionUtil.getMethod(methodHandles, "lookup");
+                    Object lookup = m.invoke(null);
+                    m = ReflectionUtil.getMethod(lookup.getClass(), "findClass", String.class);
+                    try {
+                        cls = (Class<?>)m.invoke(lookup, "org.apache.cxf.transport.http.ReferencingAuthenticator");
+                    } catch (InvocationTargetException e) {
+                        //use defineClass as fallback
+                        m = ReflectionUtil.getMethod(lookup.getClass(), "defineClass", byte[].class);
+                        cls = (Class<?>)m.invoke(lookup, b);
+                    }
+                } else {
+                    ClassLoader loader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                        public ClassLoader run() {
+                            return new URLClassLoader(new URL[0], ClassLoader.getSystemClassLoader());
+                        }
+                    }, null);
+                    Method m = ReflectionUtil.getDeclaredMethod(ClassLoader.class, "defineClass",
+                                                                String.class, byte[].class, Integer.TYPE,
+                                                                Integer.TYPE);
+
+                    
+
+                    ReflectionUtil.setAccessible(m).invoke(loader, ReferencingAuthenticator.class.getName(),
+                                                           b, 0, b.length);
+                    cls = loader.loadClass(ReferencingAuthenticator.class.getName());
+                    try {
+                        //clear the acc field that can hold onto the webapp classloader
+                        Field f = ReflectionUtil.getDeclaredField(loader.getClass(), "acc");
+                        ReflectionUtil.setAccessible(f).set(loader, null);
+                    } catch (Throwable t) {
+                        //ignore
+                    }
+                }
+                final Authenticator auth = (Authenticator)cls.getConstructor(Authenticator.class, Authenticator.class)
+                    .newInstance(instance, wrapped);
+
+                if (System.getSecurityManager() == null) {
+                    Authenticator.setDefault(auth);
+                } else {
+                    AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+                        public Boolean run() {
+                            Authenticator.setDefault(auth);
+                            return true;
+                        }
+                    });
+
+                }
+                
+            } catch (Throwable t) {
+                //ignore
+            }
+        }
+    }
+
+    protected PasswordAuthentication getPasswordAuthentication() {
+        PasswordAuthentication auth = null;
+        Message m = PhaseInterceptorChain.getCurrentMessage();
+        if (m != null) {
+            Exchange exchange = m.getExchange();
+            Conduit conduit = exchange.getConduit(m);
+            if (conduit instanceof HTTPConduit) {
+                HTTPConduit httpConduit = (HTTPConduit)conduit;
+                if (getRequestorType() == RequestorType.PROXY
+                    && httpConduit.getProxyAuthorization() != null) {
+                    String un = httpConduit.getProxyAuthorization().getUserName();
+                    String pwd = httpConduit.getProxyAuthorization().getPassword();
+                    if (un != null && pwd != null) {
+                        auth = new PasswordAuthentication(un, pwd.toCharArray());
+                    }
+                } else if (getRequestorType() == RequestorType.SERVER
+                    && httpConduit.getAuthorization() != null) {
+
+                    if ("basic".equals(getRequestingScheme()) || "digest".equals(getRequestingScheme())) {
+                        return null;
+                    }
+
+                    String un = httpConduit.getAuthorization().getUserName();
+                    String pwd = httpConduit.getAuthorization().getPassword();
+                    if (un != null && pwd != null) {
+                        auth = new PasswordAuthentication(un, pwd.toCharArray());
+                    }
+                }
+            }
+        }
+        // else PhaseInterceptorChain.getCurrentMessage() is null,
+        // this HTTP call has therefore not been generated by CXF
+        return auth;
+    }
+}


### PR DESCRIPTION
The async test case can run out of threads because the resource class in the test case does not specify the Liberty thread pool, so instead it uses the ForkJoinPool.commonPool().