### PR TITLE
Revert "Look up metatype entries for deleted elements correctly"

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigComparator.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigComparator.java
@@ -44,24 +44,16 @@ class ConfigComparator {
         this.metatypeRegistry = registry;
     }
 
-    private RegistryEntry getRegistry(RegistryEntry parent, String childNodeName) {
+    private RegistryEntry getRegistry(RegistryEntry parent, String name) {
         if (metatypeRegistry == null)
             return null;
 
         RegistryEntry entry = null;
         // Attempt to look up the registry entry by childAlias value
-        RegistryEntry pe = parent;
-        while (pe != null) {
-            // The parent entry must have ibm:supportsExtensions defined for ibm:childAlias to be valid here
-            if (pe.getObjectClassDefinition().supportsExtensions()) {
-                RegistryEntry childAliasEntry = metatypeRegistry.getRegistryEntry(pe.getPid(), childNodeName);
-                if (childAliasEntry != null)
-                    return childAliasEntry;
-            }
-            pe = pe.getExtendedRegistryEntry();
+        if (parent != null) {
+            entry = metatypeRegistry.getRegistryEntry(parent.getPid(), name);
         }
-
-        return (entry == null) ? metatypeRegistry.getRegistryEntryByPidOrAlias(childNodeName) : entry;
+        return (entry == null) ? metatypeRegistry.getRegistryEntryByPidOrAlias(name) : entry;
     }
 
     public ComparatorResult computeDelta() throws ConfigUpdateException {


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#6996

Reverting as this has introduced a hard break in the com.ibm.ws.config_bvt.parser BVT bucket.