### PR TITLE
 add validation for custom login modules for JCA connection factories

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2018 IBM Corporation and others.
+ * Copyright (c) 1997, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ package com.ibm.ejs.j2c;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -50,6 +52,7 @@ import com.ibm.ws.jca.cm.AppDefinedResource;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.security.jca.AuthDataService;
 import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
 import com.ibm.ws.tx.rrs.RRSXAResourceFactory;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
@@ -1622,22 +1625,19 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
      * @throws ResourceException
      */
     private final Subject getFinalSubject(ConnectionRequestInfo requestInfo,
-                                          ManagedConnectionFactory mangedConnectionFactory, Object CM) throws ResourceException {
+                                          final ManagedConnectionFactory mangedConnectionFactory, Object CM) throws ResourceException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         Subject subj = null;
         if (this.containerManagedAuth) {
-            Map<String, Object> loginConfigProps = (Map<String, Object>) this.cmConfig.getLoginConfigProperties().clone();
-            String loginConfigurationName = this.cmConfig.getLoginConfigurationName();
+            final Map<String, Object> loginConfigProps = (Map<String, Object>) this.cmConfig.getLoginConfigProperties().clone();
+            String name = this.cmConfig.getLoginConfigurationName();
+            final String loginConfigurationName = name == null ? connectionFactorySvc.getJaasLoginContextEntryName() : name;
 
             String authDataID = (String) loginConfigProps.get("DefaultPrincipalMapping");
 
             // If no authentication-alias is found in the bindings, then use the default container managed auth alias (if any)
             if (authDataID == null)
                 authDataID = connectionFactorySvc.getContainerAuthDataID();
-
-            if (loginConfigurationName == null) {
-                loginConfigurationName = connectionFactorySvc.getJaasLoginContextEntryName();
-            }
 
             if (isTraceOn && tc.isDebugEnabled()) {
                 Tr.debug(this, tc, "login configuration name", loginConfigurationName);
@@ -1646,11 +1646,17 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
 
             if (authDataID != null || loginConfigurationName != null) {
                 loginConfigProps.put("com.ibm.mapping.authDataAlias", authDataID);
+                final AuthDataService authSvc = _pm.connectorSvc.authDataServiceRef.getServiceWithException();
                 try {
-                    subj = _pm.connectorSvc.authDataServiceRef.getServiceWithException().getSubject(mangedConnectionFactory, loginConfigurationName, loginConfigProps);
-                } catch (LoginException e) {
+                    subj = AccessController.doPrivileged(new PrivilegedExceptionAction<Subject>() {
+                        @Override
+                        public Subject run() throws LoginException {
+                            return authSvc.getSubject(mangedConnectionFactory, loginConfigurationName, loginConfigProps);
+                        }
+                    });
+                } catch (PrivilegedActionException e) {
                     FFDCFilter.processException(e, getClass().getName(), "3070", this, new Object[] { this });
-                    ResourceException r = new ResourceException(e);
+                    ResourceException r = new ResourceException(e.getCause());
                     throw r;
                 }
             }

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
@@ -121,10 +121,11 @@ public class ConnectionFactoryValidator implements Validator {
                             JSONObject loginConfigProps = (JSONObject) loginConfigProperties;
                             for (Object entry : loginConfigProps.entrySet()) {
                                 @SuppressWarnings("unchecked")
-                                Entry<String, String> e = (Entry<String, String>) entry;
+                                Entry<String, Object> e = (Entry<String, Object>) entry;
                                 if (trace && tc.isDebugEnabled())
                                     Tr.debug(tc, "Adding custom login module property with key=" + e.getKey());
-                                config.addLoginProperty(e.getKey(), e.getValue());
+                                Object value = e.getValue();
+                                config.addLoginProperty(e.getKey(), value == null ? null : value.toString());
                             }
                         }
                     }

--- a/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
@@ -86,7 +86,8 @@ public class DataSourceValidator implements Validator {
                                 Entry<String, String> e = (Entry<String, String>) entry;
                                 if (trace && tc.isDebugEnabled())
                                     Tr.debug(tc, "Adding custom login module property with key=" + e.getKey());
-                                config.addLoginProperty(e.getKey(), e.getValue());
+                                Object value = e.getValue();
+                                config.addLoginProperty(e.getKey(), value == null ? null : value.toString());
                             }
                         }
                     }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -177,7 +177,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
      * Test specifyig a non-existant customLoginConfig
      */
     @Test
-    @ExpectedFFDC({ "javax.security.auth.login.LoginException",
+    @ExpectedFFDC({ "java.security.PrivilegedActionException",
                     "javax.resource.ResourceException",
                     "java.sql.SQLException" })
     public void testCustomLoginIBMWebBndWrongName() throws Exception {

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -402,7 +402,7 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 
-    @ExpectedFFDC(value = { "javax.security.auth.login.LoginException", "javax.resource.ResourceException", "java.sql.SQLException" })
+    @ExpectedFFDC(value = { "java.security.PrivilegedActionException", "javax.resource.ResourceException", "java.sql.SQLException" })
     @Test
     public void testProvidedAuthDoesNotExist() throws Exception {
         JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource?auth=container&authAlias=authDoesntExist").run(JsonObject.class);

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
@@ -12,6 +12,7 @@
   <include location="../fatTestPorts.xml" />
 
   <featureManager>
+    <feature>appSecurity-2.0</feature>
     <feature>componenttest-1.0</feature>
     <feature>configValidator-1.0</feature> <!-- TODO replace when functionality is enabled via auto-feature -->
     <feature>jca-1.7</feature>
@@ -47,6 +48,13 @@
     <properties.TestValidationAdapter.DataSource hostName="myhost.openliberty.io" portNumber="2345"/>
   </connectionFactory>
 
+  <jaasLoginContextEntry id="customLoginEntry" name="customLoginEntry" loginModuleRef="customLoginModule" />
+  <jaasLoginModule id="customLoginModule" className="com.ibm.ws.rest.handler.validator.loginmodule.TestLoginModule" controlFlag="REQUIRED">
+    <library>
+      <file name="${server.config.dir}/customLoginModule.jar"/>
+    </library>
+  </jaasLoginModule>
+
   <javaPermission codebase="${server.config.dir}/dropins/TestValidationAdapter.rar"
                   className="java.lang.RuntimePermission" name="getClassLoader"/>
 
@@ -54,4 +62,10 @@
                   className="javax.security.auth.PrivateCredentialPermission"
                   signedBy="javax.resource.spi.security.PasswordCredential"
                   principalType="*" principalName="*" actions="read"/>
+
+  <javaPermission codebase="${server.config.dir}/customLoginModule.jar"
+                  className="javax.security.auth.AuthPermission" name="createLoginContext.customLoginEntry"/>
+
+  <javaPermission codebase="${server.config.dir}/customLoginModule.jar"
+                  className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
 </server>


### PR DESCRIPTION
Add test case to cover validation of custom login module/login properties for JCA connection factories.
Make updates to validator code to support this. It was mostly previously copied from the JDBC data source validator, but needs minor updates which will also be added to the data source validator. 
Fix the JCA code on a path where doPrivileged is lacking, which I found to be failing when running the tests for this.