### PR TITLE
rename validator to validation

### DIFF
--- a/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
+++ b/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
@@ -125,7 +125,7 @@ public abstract class ConfigBasedRESTHandler implements RESTHandler {
         //String uid = request.getPathVariable("uid");
         //String elementName = request.getPathVariable("elementName");
 
-        String apiRoot = "/validator";
+        String apiRoot = "/validation"; // TODO get this from subclass. Should not be hard-coded here
         String uid = null;
         int endElementName = path.indexOf('/', apiRoot.length() + 1);
         if (endElementName < 0) { // uid not specified

--- a/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
+++ b/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
@@ -68,6 +68,16 @@ public abstract class ConfigBasedRESTHandler implements RESTHandler {
     }
 
     /**
+     * Returns the portion of the API root following /ibm/api.
+     * For example, for /ibm/api/validation/dataSource/ds1, this should return /validation
+     *
+     * @return the portion of the API root following /ibm/api
+     */
+    public String getAPIRoot() {
+        return "/validator"; // TODO remove this and make abstract once all other code is updated
+    }
+
+    /**
      * Returns the most deeply nested element name.
      *
      * @param configDisplayId config.displayId
@@ -125,7 +135,7 @@ public abstract class ConfigBasedRESTHandler implements RESTHandler {
         //String uid = request.getPathVariable("uid");
         //String elementName = request.getPathVariable("elementName");
 
-        String apiRoot = "/validation"; // TODO get this from subclass. Should not be hard-coded here
+        String apiRoot = getAPIRoot();
         String uid = null;
         int endElementName = path.indexOf('/', apiRoot.length() + 1);
         if (endElementName < 0) { // uid not specified

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
@@ -1655,7 +1655,7 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
                         }
                     });
                 } catch (PrivilegedActionException e) {
-                    FFDCFilter.processException(e, getClass().getName(), "3070", this, new Object[] { this });
+                    FFDCFilter.processException(e.getCause(), getClass().getName(), "3070", this, new Object[] { this });
                     ResourceException r = new ResourceException(e.getCause());
                     throw r;
                 }

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2018 IBM Corporation and others.
+ * Copyright (c) 1997, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ package com.ibm.ejs.j2c;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -50,6 +52,7 @@ import com.ibm.ws.jca.cm.AppDefinedResource;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.security.jca.AuthDataService;
 import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
 import com.ibm.ws.tx.rrs.RRSXAResourceFactory;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
@@ -1622,22 +1625,19 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
      * @throws ResourceException
      */
     private final Subject getFinalSubject(ConnectionRequestInfo requestInfo,
-                                          ManagedConnectionFactory mangedConnectionFactory, Object CM) throws ResourceException {
+                                          final ManagedConnectionFactory mangedConnectionFactory, Object CM) throws ResourceException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         Subject subj = null;
         if (this.containerManagedAuth) {
-            Map<String, Object> loginConfigProps = (Map<String, Object>) this.cmConfig.getLoginConfigProperties().clone();
-            String loginConfigurationName = this.cmConfig.getLoginConfigurationName();
+            final Map<String, Object> loginConfigProps = (Map<String, Object>) this.cmConfig.getLoginConfigProperties().clone();
+            String name = this.cmConfig.getLoginConfigurationName();
+            final String loginConfigurationName = name == null ? connectionFactorySvc.getJaasLoginContextEntryName() : name;
 
             String authDataID = (String) loginConfigProps.get("DefaultPrincipalMapping");
 
             // If no authentication-alias is found in the bindings, then use the default container managed auth alias (if any)
             if (authDataID == null)
                 authDataID = connectionFactorySvc.getContainerAuthDataID();
-
-            if (loginConfigurationName == null) {
-                loginConfigurationName = connectionFactorySvc.getJaasLoginContextEntryName();
-            }
 
             if (isTraceOn && tc.isDebugEnabled()) {
                 Tr.debug(this, tc, "login configuration name", loginConfigurationName);
@@ -1646,11 +1646,17 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
 
             if (authDataID != null || loginConfigurationName != null) {
                 loginConfigProps.put("com.ibm.mapping.authDataAlias", authDataID);
+                final AuthDataService authSvc = _pm.connectorSvc.authDataServiceRef.getServiceWithException();
                 try {
-                    subj = _pm.connectorSvc.authDataServiceRef.getServiceWithException().getSubject(mangedConnectionFactory, loginConfigurationName, loginConfigProps);
-                } catch (LoginException e) {
+                    subj = AccessController.doPrivileged(new PrivilegedExceptionAction<Subject>() {
+                        @Override
+                        public Subject run() throws LoginException {
+                            return authSvc.getSubject(mangedConnectionFactory, loginConfigurationName, loginConfigProps);
+                        }
+                    });
+                } catch (PrivilegedActionException e) {
                     FFDCFilter.processException(e, getClass().getName(), "3070", this, new Object[] { this });
-                    ResourceException r = new ResourceException(e);
+                    ResourceException r = new ResourceException(e.getCause());
                     throw r;
                 }
             }

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
@@ -64,7 +64,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         // Lacking this fix, transaction manager will experience an auth failure and log FFDC for it.
         // The following line causes an XA-capable data source to be used for the first time outside of a test method execution,
         // so that the FFDC is not considered a test failure.
-        new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource").run(JsonObject.class);
+        new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource").run(JsonObject.class);
     }
 
     @AfterClass
@@ -219,7 +219,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNotNull(err, ja = j.getJsonArray("api"));
         boolean found = false;
         for (JsonValue jv : ja)
-            if ("/ibm/api/validator/dataSource/DataSourceWithoutJDBCDriver".equals(((JsonString) jv).getString()))
+            if ("/ibm/api/validation/dataSource/DataSourceWithoutJDBCDriver".equals(((JsonString) jv).getString()))
                 if (found)
                     fail("Duplicate value in api list");
                 else
@@ -268,7 +268,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNotNull(err, ja = j.getJsonArray("api"));
         found = false;
         for (JsonValue jv : ja)
-            if ("/ibm/api/validator/dataSource/DefaultDataSource".equals(((JsonString) jv).getString()))
+            if ("/ibm/api/validation/dataSource/DefaultDataSource".equals(((JsonString) jv).getString()))
                 if (found)
                     fail("Duplicate value in api list");
                 else
@@ -349,7 +349,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNotNull(ja = j.getJsonArray("api"));
         found = false;
         for (JsonValue jv : ja)
-            if ("/ibm/api/validator/dataSource/WrongDefaultAuth".equals(((JsonString) jv).getString()))
+            if ("/ibm/api/validation/dataSource/WrongDefaultAuth".equals(((JsonString) jv).getString()))
                 if (found)
                     fail("Duplicate value in api list");
                 else
@@ -394,7 +394,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNotNull(ja = j.getJsonArray("api"));
         found = false;
         for (JsonValue jv : ja)
-            if ("/ibm/api/validator/dataSource/dataSource%5Bdefault-0%5D".equals(((JsonString) jv).getString()))
+            if ("/ibm/api/validation/dataSource/dataSource%5Bdefault-0%5D".equals(((JsonString) jv).getString()))
                 if (found)
                     fail("Duplicate value in api list");
                 else
@@ -461,7 +461,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNotNull(ja = j.getJsonArray("api"));
         found = false;
         for (JsonValue jv : ja)
-            if ("/ibm/api/validator/dataSource/jdbc%2Fnonexistentdb".equals(((JsonString) jv).getString()))
+            if ("/ibm/api/validation/dataSource/jdbc%2Fnonexistentdb".equals(((JsonString) jv).getString()))
                 if (found)
                     fail("Duplicate value in api list");
                 else
@@ -527,7 +527,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNotNull(ja = j.getJsonArray("api"));
         found = false;
         for (JsonValue jv : ja)
-            if ("/ibm/api/validator/dataSource/transaction%2FdataSource%5Bdefault-0%5D".equals(((JsonString) jv).getString()))
+            if ("/ibm/api/validation/dataSource/transaction%2FdataSource%5Bdefault-0%5D".equals(((JsonString) jv).getString()))
                 if (found)
                     fail("Duplicate value in api list");
                 else
@@ -578,7 +578,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNotNull(ja = j.getJsonArray("api"));
         boolean found = false;
         for (JsonValue jv : ja)
-            if ("/ibm/api/validator/dataSource/DataSourceWithoutJDBCDriver".equals(((JsonString) jv).getString()))
+            if ("/ibm/api/validation/dataSource/DataSourceWithoutJDBCDriver".equals(((JsonString) jv).getString()))
                 if (found)
                     fail("Duplicate value in api list");
                 else

--- a/dev/com.ibm.ws.rest.handler.validator.cloudant/src/com/ibm/ws/rest/handler/validator/cloudant/CloudantDatabaseValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.cloudant/src/com/ibm/ws/rest/handler/validator/cloudant/CloudantDatabaseValidator.java
@@ -28,7 +28,7 @@ import com.ibm.wsspi.validator.Validator;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
            service = { Validator.class },
-           property = { "service.vendor=IBM", "com.ibm.wsspi.rest.handler.root=/validator", "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.cloudant.cloudantDatabase" })
+           property = { "service.vendor=IBM", "com.ibm.wsspi.rest.handler.root=/validation", "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.cloudant.cloudantDatabase" })
 public class CloudantDatabaseValidator implements Validator {
     private final static TraceComponent tc = Tr.register(CloudantDatabaseValidator.class);
 

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
@@ -121,10 +121,11 @@ public class ConnectionFactoryValidator implements Validator {
                             JSONObject loginConfigProps = (JSONObject) loginConfigProperties;
                             for (Object entry : loginConfigProps.entrySet()) {
                                 @SuppressWarnings("unchecked")
-                                Entry<String, String> e = (Entry<String, String>) entry;
+                                Entry<String, Object> e = (Entry<String, Object>) entry;
                                 if (trace && tc.isDebugEnabled())
                                     Tr.debug(tc, "Adding custom login module property with key=" + e.getKey());
-                                config.addLoginProperty(e.getKey(), e.getValue());
+                                Object value = e.getValue();
+                                config.addLoginProperty(e.getKey(), value == null ? null : value.toString());
                             }
                         }
                     }

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
@@ -49,7 +49,7 @@ import com.ibm.wsspi.validator.Validator;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
            service = { Validator.class },
-           property = { "service.vendor=IBM", "com.ibm.wsspi.rest.handler.root=/validator", "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.connectionFactory.supertype" })
+           property = { "service.vendor=IBM", "com.ibm.wsspi.rest.handler.root=/validation", "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.connectionFactory.supertype" })
 public class ConnectionFactoryValidator implements Validator {
     private final static TraceComponent tc = Tr.register(ConnectionFactoryValidator.class);
 

--- a/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
@@ -38,7 +38,7 @@ import com.ibm.wsspi.validator.Validator;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
            service = { Validator.class },
-           property = { "service.vendor=IBM", "com.ibm.wsspi.rest.handler.root=/validator", "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jdbc.dataSource" })
+           property = { "service.vendor=IBM", "com.ibm.wsspi.rest.handler.root=/validation", "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jdbc.dataSource" })
 public class DataSourceValidator implements Validator {
     private final static TraceComponent tc = Tr.register(DataSourceValidator.class);
 

--- a/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
@@ -86,7 +86,8 @@ public class DataSourceValidator implements Validator {
                                 Entry<String, String> e = (Entry<String, String>) entry;
                                 if (trace && tc.isDebugEnabled())
                                     Tr.debug(tc, "Adding custom login module property with key=" + e.getKey());
-                                config.addLoginProperty(e.getKey(), e.getValue());
+                                Object value = e.getValue();
+                                config.addLoginProperty(e.getKey(), value == null ? null : value.toString());
                             }
                         }
                     }

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
@@ -81,6 +81,11 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
     }
 
     @Override
+    public final String getAPIRoot() {
+        return "/validation";
+    }
+
+    @Override
     public Object handleError(RESTRequest request, String uid, String errorMessage) {
         JSONObject failure = toJSONObject("message", errorMessage);
         if (uid == null)

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
@@ -61,7 +61,7 @@ import com.ibm.wsspi.validator.Validator;
 @Component(name = "com.ibm.ws.rest.handler.validator",
            configurationPolicy = ConfigurationPolicy.IGNORE,
            service = { RESTHandler.class },
-           property = { "com.ibm.wsspi.rest.handler.context.root=/ibm/api", "com.ibm.wsspi.rest.handler.root=/validator" }) // TODO switch to /openapi/platform
+           property = { "com.ibm.wsspi.rest.handler.context.root=/ibm/api", "com.ibm.wsspi.rest.handler.root=/validation" })
 public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
     private static final TraceComponent tc = Tr.register(ValidatorRESTHandler.class);
 
@@ -201,10 +201,10 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
             for (String key : request.getParameterMap().keySet()) {
                 params.put(key, resolvePotentialVariable(request.getParameter(key))); // TODO only add valid parameters (auth, authData)? And if we want any validation of values, this is the central place for it
             }
-            String user = request.getHeader("X-Validator-User");
+            String user = request.getHeader("X-Validation-User");
             if (user != null)
                 params.put("user", resolvePotentialVariable(user));
-            String pass = request.getHeader("X-Validator-Password");
+            String pass = request.getHeader("X-Validation-Password");
             if (pass != null)
                 params.put("password", resolvePotentialVariable(pass));
             String contentType = request.getContentType();
@@ -285,7 +285,7 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
      * Populate JSON object for a top level exception or error.
      *
      * @param errorInfo additional information to append to exceptions and causes
-     * @param error the top level exception or error.
+     * @param error     the top level exception or error.
      * @return JSON object representing the Throwable.
      */
     @SuppressWarnings("unchecked")

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -70,7 +70,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
         // Lacking this fix, transaction manager will experience an auth failure and log FFDC for it.
         // The following line causes an XA-capable data source to be used for the first time outside of a test method execution,
         // so that the FFDC is not considered a test failure.
-        JsonObject response = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource")
+        JsonObject response = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource")
                         .method("POST")
                         .run(JsonObject.class);
         Log.info(c, "setUp", "DefaultDataSource response: " + response);
@@ -95,7 +95,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
                     "javax.resource.spi.SecurityException",
                     "javax.resource.spi.ResourceAllocationException" })
     public void testCustomLoginModuleDirectLookupInvalid() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/customLoginDS")
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/customLoginDS")
                         .method("POST")
                         .run(JsonObject.class);
         Log.info(c, testName.getMethodName(), "HTTP response: " + json);
@@ -126,7 +126,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
      */
     @Test
     public void testCustomLoginContainerAuth() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/customLoginDS?auth=container")
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/customLoginDS?auth=container")
                         .method("POST")
                         .run(JsonObject.class);
         Log.info(c, testName.getMethodName(), "HTTP response: " + json);
@@ -142,7 +142,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
      */
     @Test
     public void testCustomLoginIBMWebBnd() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/customLoginDSWebBnd?auth=container&loginConfig=customLoginEntry")
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/customLoginDSWebBnd?auth=container&loginConfig=customLoginEntry")
                         .method("POST")
                         .run(JsonObject.class);
         Log.info(c, testName.getMethodName(), "HTTP response: " + json);
@@ -160,7 +160,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
      */
     @Test
     public void testCustomLoginModuleProperties() throws Exception {
-        String URL = "/ibm/api/validator/dataSource/customLoginDSWebBnd?auth=container&loginConfig=customLoginEntry";
+        String URL = "/ibm/api/validation/dataSource/customLoginDSWebBnd?auth=container&loginConfig=customLoginEntry";
         String propsJson = "{ \"loginConfigProperties\": { \"" + TestLoginModule.CUSTOM_PROPERTY_KEY + "\": \"foo\" } }";
         JsonObject json = new HttpsRequest(server, URL)
                         .method("POST")
@@ -181,7 +181,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
                     "javax.resource.ResourceException",
                     "java.sql.SQLException" })
     public void testCustomLoginIBMWebBndWrongName() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/customLoginDSWebBnd?auth=container&loginConfig=bogus")
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/customLoginDSWebBnd?auth=container&loginConfig=bogus")
                         .method("POST")
                         .run(JsonObject.class);
         Log.info(c, testName.getMethodName(), "HTTP response: " + json);

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -177,7 +177,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
      * Test specifyig a non-existant customLoginConfig
      */
     @Test
-    @ExpectedFFDC({ "java.security.PrivilegedActionException",
+    @ExpectedFFDC({ "javax.security.auth.login.LoginException",
                     "javax.resource.ResourceException",
                     "java.sql.SQLException" })
     public void testCustomLoginIBMWebBndWrongName() throws Exception {

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -177,7 +177,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
      * Test specifyig a non-existant customLoginConfig
      */
     @Test
-    @ExpectedFFDC({ "javax.security.auth.login.LoginException",
+    @ExpectedFFDC({ "java.security.PrivilegedActionException",
                     "javax.resource.ResourceException",
                     "java.sql.SQLException" })
     public void testCustomLoginIBMWebBndWrongName() throws Exception {

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -402,7 +402,7 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 
-    @ExpectedFFDC(value = { "javax.security.auth.login.LoginException", "javax.resource.ResourceException", "java.sql.SQLException" })
+    @ExpectedFFDC(value = { "java.security.PrivilegedActionException", "javax.resource.ResourceException", "java.sql.SQLException" })
     @Test
     public void testProvidedAuthDoesNotExist() throws Exception {
         JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource?auth=container&authAlias=authDoesntExist").run(JsonObject.class);

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -63,7 +63,7 @@ public class ValidateDataSourceTest extends FATServletClient {
         // Lacking this fix, transaction manager will experience an auth failure and log FFDC for it.
         // The following line causes an XA-capable data source to be used for the first time outside of a test method execution,
         // so that the FFDC is not considered a test failure.
-        JsonObject response = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource").run(JsonObject.class);
+        JsonObject response = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource").run(JsonObject.class);
         Log.info(c, "setUp", "DefaultDataSource response: " + response);
     }
 
@@ -77,9 +77,9 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testAppAuth() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource")
-                        .requestProp("X-Validator-User", "dbuser")
-                        .requestProp("X-Validator-Password", "dbpass");
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource")
+                        .requestProp("X-Validation-User", "dbuser")
+                        .requestProp("X-Validation-Password", "dbpass");
         JsonObject json = request.run(JsonObject.class);
         String err = "Unexpected json response: " + json.toString();
         assertEquals(err, "DefaultDataSource", json.getString("uid"));
@@ -110,9 +110,9 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testVariableSubstitution() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource?user=bogus")
-                        .requestProp("X-Validator-User", "${DB_USER}")
-                        .requestProp("X-Validator-Password", "${DB_PASS}");
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource?user=bogus")
+                        .requestProp("X-Validation-User", "${DB_USER}")
+                        .requestProp("X-Validation-Password", "${DB_PASS}");
         JsonObject json = request.run(JsonObject.class);
         assertSuccessResponse(json, "DefaultDataSource", "DefaultDataSource");
         request.method("POST");
@@ -122,9 +122,9 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testEnvVariableSubstitution() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource?user=bogus")
-                        .requestProp("X-Validator-User", "${env.DB_USER_ENV}")
-                        .requestProp("X-Validator-Password", "${env.DB_PASS_ENV}");
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource?user=bogus")
+                        .requestProp("X-Validation-User", "${env.DB_USER_ENV}")
+                        .requestProp("X-Validation-Password", "${env.DB_PASS_ENV}");
         JsonObject json = request.run(JsonObject.class);
         assertSuccessResponse(json, "DefaultDataSource", "DefaultDataSource");
 
@@ -139,9 +139,9 @@ public class ValidateDataSourceTest extends FATServletClient {
                     "javax.resource.spi.SecurityException",
                     "javax.resource.spi.ResourceAllocationException" })
     public void testAppAuthFails() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource")
-                        .requestProp("X-Validator-User", "bogus")
-                        .requestProp("X-Validator-Password", "bogus")
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource")
+                        .requestProp("X-Validation-User", "bogus")
+                        .requestProp("X-Validation-Password", "bogus")
                         .run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "DefaultDataSource", json.getString("uid"));
@@ -166,7 +166,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testDataSourceWithoutJDBCDriver() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/DataSourceWithoutJDBCDriver").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/DataSourceWithoutJDBCDriver").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "DataSourceWithoutJDBCDriver", json.getString("uid"));
         assertEquals(err, "DataSourceWithoutJDBCDriver", json.getString("id"));
@@ -179,7 +179,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testDefaultAuth() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/dataSource[default-0]?auth=container").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/dataSource[default-0]?auth=container").run(JsonObject.class);
         String err = "Unexpected json response: " + json;
         assertEquals(err, "dataSource[default-0]", json.getString("uid"));
         assertNull(err, json.get("id"));
@@ -195,7 +195,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testFeatureOfParentConfigNotEnabled() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/databaseStore[unavailableDBStore]%2FdataSource[unavailableDS]").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/databaseStore[unavailableDBStore]%2FdataSource[unavailableDS]").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "databaseStore[unavailableDBStore]/dataSource[unavailableDS]", json.getString("uid"));
         assertFalse(err, json.getBoolean("successful"));
@@ -207,7 +207,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testFeatureNotEnabled() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/cloudantDatabase/CloudantDBNotEnabled").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/cloudantDatabase/CloudantDBNotEnabled").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "CloudantDBNotEnabled", json.getString("uid"));
         assertEquals(err, "CloudantDBNotEnabled", json.getString("id"));
@@ -223,9 +223,9 @@ public class ValidateDataSourceTest extends FATServletClient {
                             "javax.resource.spi.ResourceAllocationException",
                             "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException" })
     public void testMultiple() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validator/dataSource?auth=application")
-                        .requestProp("X-Validator-User", "dbuser")
-                        .requestProp("X-Validator-Password", "dbpass");
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/dataSource?auth=application")
+                        .requestProp("X-Validation-User", "dbuser")
+                        .requestProp("X-Validation-Password", "dbpass");
         JsonArray json = request.method("POST").run(JsonArray.class);
         String err = "unexpected response: " + json;
 
@@ -324,14 +324,14 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testMultipleWithNoResults() throws Exception {
-        JsonArray json = new HttpsRequest(server, "/ibm/api/validator/mongoDB").run(JsonArray.class);
+        JsonArray json = new HttpsRequest(server, "/ibm/api/validation/mongoDB").run(JsonArray.class);
 
         assertEquals("unexpected response: " + json, 0, json.size());
     }
 
     @Test
     public void testNestedUnderTransaction() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/transaction%2FdataSource[default-0]?auth=container").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/transaction%2FdataSource[default-0]?auth=container").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "transaction/dataSource[default-0]", json.getString("uid"));
         assertNull(err, json.get("id"));
@@ -347,7 +347,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testNotFound() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/NotAConfiguredDataSource").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/NotAConfiguredDataSource").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "NotAConfiguredDataSource", json.getString("uid"));
         assertNull(err, json.get("id"));
@@ -360,7 +360,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testNotValidatable() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/library/Derby").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/library/Derby").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "Derby", json.getString("uid"));
         assertEquals(err, "Derby", json.getString("id"));
@@ -372,7 +372,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testProvidedAuth() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource?auth=container&authAlias=auth1").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource?auth=container&authAlias=auth1").run(JsonObject.class);
         String err = "Unexpected json response: " + json;
         assertEquals(err, "DefaultDataSource", json.getString("uid"));
         assertEquals(err, "DefaultDataSource", json.getString("id"));
@@ -388,7 +388,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testProvidedAuthAndDefaultAuth() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/WrongDefaultAuth?auth=container&authAlias=auth1").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/WrongDefaultAuth?auth=container&authAlias=auth1").run(JsonObject.class);
         String err = "Unexpected json response: " + json;
         assertEquals(err, "WrongDefaultAuth", json.getString("uid"));
         assertEquals(err, "WrongDefaultAuth", json.getString("id"));
@@ -405,7 +405,7 @@ public class ValidateDataSourceTest extends FATServletClient {
     @ExpectedFFDC(value = { "java.security.PrivilegedActionException", "javax.resource.ResourceException", "java.sql.SQLException" })
     @Test
     public void testProvidedAuthDoesNotExist() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource?auth=container&authAlias=authDoesntExist").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource?auth=container&authAlias=authDoesntExist").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "DefaultDataSource", json.getString("uid"));
         assertEquals(err, "DefaultDataSource", json.getString("id"));
@@ -429,9 +429,9 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testTopLevelConfigDisplayID() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validator/dataSource/dataSource[default-0]?auth=application")
-                        .requestProp("X-Validator-User", "dbuser")
-                        .requestProp("X-Validator-Password", "dbpass");
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/dataSource/dataSource[default-0]?auth=application")
+                        .requestProp("X-Validation-User", "dbuser")
+                        .requestProp("X-Validation-Password", "dbpass");
         JsonObject json = request.method("POST").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "dataSource[default-0]", json.getString("uid"));
@@ -448,7 +448,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testTopLevelID() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource").run(JsonObject.class);
         String err = "Unexpected json response: " + json;
         assertEquals(err, "DefaultDataSource", json.getString("uid"));
         assertEquals(err, "DefaultDataSource", json.getString("id"));
@@ -470,7 +470,7 @@ public class ValidateDataSourceTest extends FATServletClient {
                             "javax.resource.spi.ResourceAllocationException",
                             "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException" })
     public void testTopLevelIDSQLException() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/jdbc%2Fnonexistentdb").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/jdbc%2Fnonexistentdb").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "jdbc/nonexistentdb", json.getString("uid"));
         assertEquals(err, "jdbc/nonexistentdb", json.getString("id"));
@@ -514,7 +514,7 @@ public class ValidateDataSourceTest extends FATServletClient {
                             "javax.resource.spi.ResourceAllocationException", "java.sql.SQLNonTransientConnectionException" })
     @Test
     public void testWrongDefaultAuth() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/WrongDefaultAuth?auth=container").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/WrongDefaultAuth?auth=container").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "WrongDefaultAuth", json.getString("uid"));
         assertEquals(err, "WrongDefaultAuth", json.getString("id"));
@@ -541,7 +541,7 @@ public class ValidateDataSourceTest extends FATServletClient {
                             "javax.resource.spi.ResourceAllocationException", "java.sql.SQLNonTransientConnectionException" })
     @Test
     public void testWrongProvidedAuth() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/dataSource/DefaultDataSource?auth=container&authAlias=auth2").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource?auth=container&authAlias=auth2").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "DefaultDataSource", json.getString("uid"));
         assertEquals(err, "DefaultDataSource", json.getString("id"));

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -402,7 +402,7 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 
-    @ExpectedFFDC(value = { "java.security.PrivilegedActionException", "javax.resource.ResourceException", "java.sql.SQLException" })
+    @ExpectedFFDC(value = { "javax.security.auth.login.LoginException", "javax.resource.ResourceException", "java.sql.SQLException" })
     @Test
     public void testProvidedAuthDoesNotExist() throws Exception {
         JsonObject json = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource?auth=container&authAlias=authDoesntExist").run(JsonObject.class);

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
@@ -81,7 +81,7 @@ public class ValidateJCATest extends FATServletClient {
      */
     @Test
     public void testApplicationAuthForConnectionFactoryWithDefaultUser() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/connectionFactory/cf1?auth=application").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/connectionFactory/cf1?auth=application").run(JsonObject.class);
         String err = "Unexpected json response: " + json;
         assertEquals(err, "cf1", json.getString("uid"));
         assertEquals(err, "cf1", json.getString("id"));
@@ -104,9 +104,9 @@ public class ValidateJCATest extends FATServletClient {
      */
     @Test
     public void testApplicationAuthForConnectionFactoryWithSpecifiedUser() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validator/connectionFactory/cf1?auth=application")
-                        .requestProp("X-Validator-User", "user1")
-                        .requestProp("X-Validator-Password", "1user");
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/connectionFactory/cf1?auth=application")
+                        .requestProp("X-Validation-User", "user1")
+                        .requestProp("X-Validation-Password", "1user");
         JsonObject json = request.method("GET").run(JsonObject.class);
 
         String err = "Unexpected json response: " + json;
@@ -133,9 +133,9 @@ public class ValidateJCATest extends FATServletClient {
     @AllowedFFDC("java.sql.SQLNonTransientConnectionException")
     @Test
     public void testApplicationAuthForJCADataSourceWithSpecifiedUserFails() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validator/connectionFactory/ds5?auth=application")
-                        .requestProp("X-Validator-User", "user5")
-                        .requestProp("X-Validator-Password", "5user");
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/connectionFactory/ds5?auth=application")
+                        .requestProp("X-Validation-User", "user5")
+                        .requestProp("X-Validation-Password", "5user");
         JsonObject json = request.method("GET").run(JsonObject.class);
 
         String err = "Unexpected json response: " + json;
@@ -189,7 +189,7 @@ public class ValidateJCATest extends FATServletClient {
      */
     @Test
     public void testConnectionFactoryNotFound() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/connectionFactory/NotAConfiguredConnectionFactory").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/connectionFactory/NotAConfiguredConnectionFactory").run(JsonObject.class);
         String err = "unexpected response: " + json;
         assertEquals(err, "NotAConfiguredConnectionFactory", json.getString("uid"));
         assertNull(err, json.get("id"));
@@ -205,7 +205,7 @@ public class ValidateJCATest extends FATServletClient {
      */
     @Test
     public void testContainerAuthForConnectionFactoryWithDefaultAuthData() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/connectionFactory/cf1?auth=container").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/connectionFactory/cf1?auth=container").run(JsonObject.class);
         String err = "Unexpected json response: " + json;
         assertEquals(err, "cf1", json.getString("uid"));
         assertEquals(err, "cf1", json.getString("id"));
@@ -228,7 +228,7 @@ public class ValidateJCATest extends FATServletClient {
      */
     @Test
     public void testContainerAuthForConnectionFactoryWithSpecifiedAuthData() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/connectionFactory/cf1?auth=container&authAlias=auth2").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/connectionFactory/cf1?auth=container&authAlias=auth2").run(JsonObject.class);
         String err = "Unexpected json response: " + json;
         assertEquals(err, "cf1", json.getString("uid"));
         assertEquals(err, "cf1", json.getString("id"));
@@ -252,7 +252,7 @@ public class ValidateJCATest extends FATServletClient {
      */
     @Test
     public void testCustomLoginModuleForJCADataSource() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validator/connectionFactory/ds5?auth=container&loginConfig=customLoginEntry");
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/connectionFactory/ds5?auth=container&loginConfig=customLoginEntry");
         JsonObject json = request.method("GET")
                         .jsonBody("{ \"loginConfigProperties\": { \"loginName\": \"lmUser\", \"loginNum\": 6 } }")
                         .run(JsonObject.class);
@@ -274,7 +274,7 @@ public class ValidateJCATest extends FATServletClient {
     }
 
     /**
-     * Use /ibm/api/validator/connectionFactory to validate all connection factories
+     * Use /ibm/api/validation/connectionFactory to validate all connection factories
      */
     @AllowedFFDC({
                    "java.lang.IllegalArgumentException", // intentionally raised by mock resource adapter to cover exception paths
@@ -284,7 +284,7 @@ public class ValidateJCATest extends FATServletClient {
     })
     @Test
     public void testMultipleConnectionFactories() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validator/connectionFactory");
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/connectionFactory");
         JsonArray json = request.method("GET").run(JsonArray.class);
         String err = "unexpected response: " + json;
 
@@ -335,7 +335,7 @@ public class ValidateJCATest extends FATServletClient {
         //stack = j.getJsonArray("stack");
         //assertNotNull(err, stack);
         //assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
-        //assertTrue(err, stack.getString(0).startsWith("org.test.validator.adapter.ManagedConnectionFactoryImpl.createManagedConnection(ManagedConnectionFactoryImpl.java:"));
+        //assertTrue(err, stack.getString(0).startsWith("org.test.validation.adapter.ManagedConnectionFactoryImpl.createManagedConnection(ManagedConnectionFactoryImpl.java:"));
         //assertTrue(err, stack.getString(1).startsWith("com."));
         //assertTrue(err, stack.getString(2).startsWith("com."));
         assertNull(err, j.getJsonObject("cause"));
@@ -361,7 +361,7 @@ public class ValidateJCATest extends FATServletClient {
         //stack = j.getJsonArray("stack");
         //assertNotNull(err, stack);
         //assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
-        //assertTrue(err, stack.getString(0).startsWith("org.test.validator.adapter.ManagedConnectionFactoryImpl.createManagedConnection(ManagedConnectionFactoryImpl.java:"));
+        //assertTrue(err, stack.getString(0).startsWith("org.test.validation.adapter.ManagedConnectionFactoryImpl.createManagedConnection(ManagedConnectionFactoryImpl.java:"));
         //assertTrue(err, stack.getString(1).startsWith("com."));
         //assertTrue(err, stack.getString(2).startsWith("com."));
         // cause
@@ -409,7 +409,7 @@ public class ValidateJCATest extends FATServletClient {
      */
     @Test
     public void testTopLevelConnectionFactoryWithID() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/connectionFactory/cf1").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/connectionFactory/cf1").run(JsonObject.class);
         String err = "Unexpected json response: " + json;
         assertEquals(err, "cf1", json.getString("uid"));
         assertEquals(err, "cf1", json.getString("id"));
@@ -437,7 +437,7 @@ public class ValidateJCATest extends FATServletClient {
     })
     @Test
     public void testTopLevelConnectionFactoryWithoutIDWithChainedExceptions() throws Exception {
-        JsonObject json = new HttpsRequest(server, "/ibm/api/validator/connectionFactory/connectionFactory[default-1]").run(JsonObject.class);
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/connectionFactory/connectionFactory[default-1]").run(JsonObject.class);
         String err = "Unexpected json response: " + json;
         assertEquals(err, "connectionFactory[default-1]", json.getString("uid"));
         assertNull(err, json.get("id"));

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
@@ -335,7 +335,7 @@ public class ValidateJCATest extends FATServletClient {
         //stack = j.getJsonArray("stack");
         //assertNotNull(err, stack);
         //assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
-        //assertTrue(err, stack.getString(0).startsWith("org.test.validation.adapter.ManagedConnectionFactoryImpl.createManagedConnection(ManagedConnectionFactoryImpl.java:"));
+        //assertTrue(err, stack.getString(0).startsWith("org.test.validator.adapter.ManagedConnectionFactoryImpl.createManagedConnection(ManagedConnectionFactoryImpl.java:"));
         //assertTrue(err, stack.getString(1).startsWith("com."));
         //assertTrue(err, stack.getString(2).startsWith("com."));
         assertNull(err, j.getJsonObject("cause"));
@@ -361,7 +361,7 @@ public class ValidateJCATest extends FATServletClient {
         //stack = j.getJsonArray("stack");
         //assertNotNull(err, stack);
         //assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
-        //assertTrue(err, stack.getString(0).startsWith("org.test.validation.adapter.ManagedConnectionFactoryImpl.createManagedConnection(ManagedConnectionFactoryImpl.java:"));
+        //assertTrue(err, stack.getString(0).startsWith("org.test.validator.adapter.ManagedConnectionFactoryImpl.createManagedConnection(ManagedConnectionFactoryImpl.java:"));
         //assertTrue(err, stack.getString(1).startsWith("com."));
         //assertTrue(err, stack.getString(2).startsWith("com."));
         // cause

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
@@ -12,6 +12,7 @@
   <include location="../fatTestPorts.xml" />
 
   <featureManager>
+    <feature>appSecurity-2.0</feature>
     <feature>componenttest-1.0</feature>
     <feature>configValidator-1.0</feature> <!-- TODO replace when functionality is enabled via auto-feature -->
     <feature>jca-1.7</feature>
@@ -47,6 +48,13 @@
     <properties.TestValidationAdapter.DataSource hostName="myhost.openliberty.io" portNumber="2345"/>
   </connectionFactory>
 
+  <jaasLoginContextEntry id="customLoginEntry" name="customLoginEntry" loginModuleRef="customLoginModule" />
+  <jaasLoginModule id="customLoginModule" className="com.ibm.ws.rest.handler.validator.loginmodule.TestLoginModule" controlFlag="REQUIRED">
+    <library>
+      <file name="${server.config.dir}/customLoginModule.jar"/>
+    </library>
+  </jaasLoginModule>
+
   <javaPermission codebase="${server.config.dir}/dropins/TestValidationAdapter.rar"
                   className="java.lang.RuntimePermission" name="getClassLoader"/>
 
@@ -54,4 +62,10 @@
                   className="javax.security.auth.PrivateCredentialPermission"
                   signedBy="javax.resource.spi.security.PasswordCredential"
                   principalType="*" principalName="*" actions="read"/>
+
+  <javaPermission codebase="${server.config.dir}/customLoginModule.jar"
+                  className="javax.security.auth.AuthPermission" name="createLoginContext.customLoginEntry"/>
+
+  <javaPermission codebase="${server.config.dir}/customLoginModule.jar"
+                  className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
 </server>


### PR DESCRIPTION
The REST endpoint for validating a configuration and returning a result is being renamed from validator to validation, in order to reflect the fact that we are not returning the validator for the configured resource, we are returning the validation of it.

api/validator/dataSource/ds1
-->
api/validation/dataSource/ds1