### PR TITLE
Fix intermittent issue with config updates

### DIFF
--- a/dev/com.ibm.ws.config_fat/fat/src/test/server/config/DelayedVariableTests.java
+++ b/dev/com.ibm.ws.config_fat/fat/src/test/server/config/DelayedVariableTests.java
@@ -54,6 +54,7 @@ public class DelayedVariableTests extends ServletRunner {
         server.setServerConfigurationFile("delayedVar/cycle.xml");
         //CWWKG0011W: The configuration validation did not succeed. Variable evaluation loop detected: [${cycle2}, ${cycle3}, ${cycle1}andSomeText]
         server.waitForStringInLog("CWWKG0011W.*[${cycle2}, ${cycle3}, ${cycle1}andSomeText]");
+        server.waitForConfigUpdateInLogUsingMark(null);
         server.setServerConfigurationFile("delayedVar/original.xml");
         server.waitForConfigUpdateInLogUsingMark(null);
     }


### PR DESCRIPTION
It's possible for the delayed variable tests to fail because the test code isn't waiting for a config update to complete. 