### PR TITLE
Use mininum jdkSourceLevel of 1.7 for JDK 12+

### DIFF
--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/inmemory/compiler/InMemoryJDTCompiler.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/inmemory/compiler/InMemoryJDTCompiler.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 import com.ibm.ws.jsp.JspCoreException;
 import com.ibm.ws.jsp.JspOptions;
 import com.ibm.ws.jsp.inmemory.resource.InMemoryResources;
+import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.wsspi.jsp.compiler.JspCompiler;
 import com.ibm.wsspi.jsp.compiler.JspCompilerResult;
 import com.ibm.wsspi.jsp.compiler.JspLineId;
@@ -63,7 +64,7 @@ public class InMemoryJDTCompiler implements JspCompiler {
 	private boolean isDebugEnabled = false;
 	private boolean isVerbose = false;
 	private boolean isDeprecation = false; 
-	private String jdkSourceLevel=null;
+	private int jdkSourceLevel;
 	private boolean useFullPackageNames = false;
     
     public InMemoryJDTCompiler(ClassLoader loader, JspOptions options) {
@@ -121,30 +122,30 @@ public class InMemoryJDTCompiler implements JspCompiler {
         compilerOptionsMap.put(CompilerOptions.OPTION_Encoding, javaEncoding);
         
         //487396.1 jdkSourceLevel is 15 by default now ... should get into if statement
-        if (jdkSourceLevel.equals("14")) {
+        if (jdkSourceLevel == 14) {
             compilerOptionsMap.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
             compilerOptionsMap.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_4);  //PM32704
             compilerOptionsMap.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_4);  //PM32704
         }
-        else if (jdkSourceLevel.equals("15")) {
+        else if (jdkSourceLevel == 15) {
             compilerOptionsMap.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
             compilerOptionsMap.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);  // 341708        
             compilerOptionsMap.put(CompilerOptions.OPTION_TargetPlatform,CompilerOptions.VERSION_1_5); // 412312
         }
         //PM04610 start
-        else if (jdkSourceLevel.equals("16")) {
+        else if (jdkSourceLevel == 16) {
             compilerOptionsMap.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_6);
             compilerOptionsMap.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_6);  // 341708        
             compilerOptionsMap.put(CompilerOptions.OPTION_TargetPlatform,CompilerOptions.VERSION_1_6); // 412312
         }
-        else if (jdkSourceLevel.equals("17")) {
+        else if (jdkSourceLevel == 17) {
             compilerOptionsMap.put(CompilerOptions.OPTION_Source, "1.7"); //??? does this work?
             compilerOptionsMap.put(CompilerOptions.OPTION_Compliance, "1.7");        
             compilerOptionsMap.put(CompilerOptions.OPTION_TargetPlatform, "1.7");
         }
         //PM04610 end
         //126902 start
-        else if (jdkSourceLevel.equals("18")) {
+        else if (jdkSourceLevel == 18) {
             compilerOptionsMap.put(CompilerOptions.OPTION_Source, "1.8");
             compilerOptionsMap.put(CompilerOptions.OPTION_Compliance, "1.8");        
             compilerOptionsMap.put(CompilerOptions.OPTION_TargetPlatform, "1.8");

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/taglib/config/TagLibCacheConfigParser.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/taglib/config/TagLibCacheConfigParser.java
@@ -23,6 +23,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jsp.JspCoreException;
 import com.ibm.ws.jsp.translator.visitor.xml.ParserFactory;
 import com.ibm.wsspi.jsp.taglib.config.GlobalTagLibConfig;
@@ -101,6 +102,7 @@ public class TagLibCacheConfigParser extends DefaultHandler {
         }
     }
     
+    @Trivial
     public void characters(char[] ch, int start, int length) throws SAXException {
         for (int i = 0; i < length; i++) {
             if (chars != null)

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/tools/AbstractJspModC.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/tools/AbstractJspModC.java
@@ -278,80 +278,29 @@ public abstract class AbstractJspModC {
                 // Normalize compileWithAssert and jdkSourceLevel; compileWithAssert with value true means compile with
                 // jdk 1.4 source level.  Only jdkSourceLevel will be used elsewhere in the JSP container.
                 Boolean assertProperty = (Boolean) this.optionOverrides.get(JspToolsOptionKey.compileWithAssertKey);
-                String jdkLevel = (String) this.optionOverrides.get(JspToolsOptionKey.jdkSourceLevelKey);
+                String rawJdkLevel = (String) this.optionOverrides.get(JspToolsOptionKey.jdkSourceLevelKey);
+                int jdkLevel = 16;
+                try {
+                    jdkLevel = Integer.parseInt(rawJdkLevel);
+                } catch(NumberFormatException e) {
+                }
                 if (assertProperty!=null && assertProperty.booleanValue()==true) {
                     if (logger!=null) {
                         if(doTraceCheck&&logger.isLoggable(Level.INFO)){
                             logger.logp(Level.INFO, CLASS_NAME,"compileApp", "compileWithAssert is deprecated.  Use jdkSourceLevel with value of '14' instead. ");
                         }
                     }
-                    // if jdkSourceLevel was not set, then set it to 1.5 level
-                    //487396.1 changed default from 1.3 to 1.5
-                    //F000743-28610 changed default from 1.5 to 1.6
-                    if (jdkLevel==null) {
-                        jdkLevel="16";
-                        if (logger!=null) {
-                            if(doTraceCheck&&logger.isLoggable(Level.INFO)){
-                                logger.logp(Level.INFO, CLASS_NAME,"compileApp", "Setting jdkSourceLevel to '16' because compileWithAssert is true.");
-                            }
-                        }
-                    }
-                    else if (jdkLevel.equals("13")){
+                    if (jdkLevel == 13) {
                         // if jdkSourceLevel was set to 1.3, then set it to 1.4 level to honor higher setting of compileWithAssert
-                        jdkLevel="14";
+                        jdkLevel = 14;
                         if (logger!=null) {
                             if(doTraceCheck&&logger.isLoggable(Level.INFO)){
                                 logger.logp(Level.INFO, CLASS_NAME,"compileApp", "jdkSourceLevel was set to '13'.  Setting jdkSourceLevel to '14' because compileWithAssert is true.");
                             }
                         }
                     }
-                    else if (jdkLevel.equals("15")){
-                        // if jdkSourceLevel was set to 1.5, then leave it and log situation
-                        if (logger!=null) {
-                            if(doTraceCheck&&logger.isLoggable(Level.INFO)){
-                                logger.logp(Level.INFO, CLASS_NAME,"compileApp", "jdkSourceLevel is set to '15' and compileWithAssert is 'true'.  Leaving jdkSourceLevel at higher '15' level.");
-                            }
-                        }
-                    }
-                    //PM04610 start
-                    else if (jdkLevel.equals("16")){
-                        // if jdkSourceLevel was set to 1.6, then leave it and log situation
-                        if (logger!=null) {
-                            if(doTraceCheck&&logger.isLoggable(Level.INFO)){
-                                logger.logp(Level.INFO, CLASS_NAME,"compileApp", "jdkSourceLevel is set to '16' and compileWithAssert is 'true'.  Leaving jdkSourceLevel at higher '16' level.");
-                            }
-                        }
-                    }
-                    //PM04610 end
-                    else if (jdkLevel.equals("17")){
-                        // if jdkSourceLevel was set to 1.7, then leave it and log situation
-                        if (logger!=null) {
-                            if(doTraceCheck&&logger.isLoggable(Level.INFO)){
-                                logger.logp(Level.INFO, CLASS_NAME,"compileApp", "jdkSourceLevel is set to '17' and compileWithAssert is 'true'.  Leaving jdkSourceLevel at higher '17' level.");
-                            }
-                        }
-                    }
-                    //126902 start
-                    else if (jdkLevel.equals("18")){
-                        // if jdkSourceLevel was set to 1.8, then leave it and log situation
-                        if (logger!=null) {
-                            if(doTraceCheck&&logger.isLoggable(Level.INFO)){
-                                logger.logp(Level.INFO, CLASS_NAME,"compileApp", "jdkSourceLevel is set to '18' and compileWithAssert is 'true'.  Leaving jdkSourceLevel at higher '18' level.");
-                            }
-                        }
-                    }
-                    //126902 end
                 }
-                if (jdkLevel!=null
-                  && !jdkLevel.equals("13")
-                  && !jdkLevel.equals("14")
-                  && !jdkLevel.equals("15")
-                  && !jdkLevel.equals("16") //PM04610
-                  && !jdkLevel.equals("17")
-                  && !jdkLevel.equals("18")) { //126902
-                    jdkLevel=null;
-                }
-                if (jdkLevel != null) {
+                if (jdkLevel >= 14) {
                     options.setJdkSourceLevel(jdkLevel);
                 }
                 booleanProperty = (Boolean) this.optionOverrides.get(JspToolsOptionKey.usePageTagPoolKey);

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/compiler/JDTCompiler.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/compiler/JDTCompiler.java
@@ -68,7 +68,7 @@ public class JDTCompiler implements JspCompiler {
         private boolean isDebugEnabled = false;
         private boolean isVerbose = false;
         private boolean isDeprecation = false; 
-        private String jdkSourceLevel=null;
+        private int jdkSourceLevel;
         private boolean useFullPackageNames = false;
         
         public JDTCompiler(ClassLoader loader, JspOptions options) {
@@ -111,30 +111,30 @@ public class JDTCompiler implements JspCompiler {
         compilerOptionsMap.put(CompilerOptions.OPTION_Encoding, javaEncoding);
         
         //487396.1 jdkSourceLevel is 15 by default now ... should get into if statement
-        if (jdkSourceLevel.equals("14")) {
+        if (jdkSourceLevel == 14) {
             compilerOptionsMap.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
             compilerOptionsMap.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_4);  //PM32704
             compilerOptionsMap.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_4);  //PM32704
         }
-        else if (jdkSourceLevel.equals("15")) {
+        else if (jdkSourceLevel == 15) {
             compilerOptionsMap.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
             compilerOptionsMap.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);  // 341708        
             compilerOptionsMap.put(CompilerOptions.OPTION_TargetPlatform,CompilerOptions.VERSION_1_5); // 412312
         }
         //PM04610 start
-        else if (jdkSourceLevel.equals("16")) {
+        else if (jdkSourceLevel == 16) {
             compilerOptionsMap.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_6);
             compilerOptionsMap.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_6);  // 341708        
             compilerOptionsMap.put(CompilerOptions.OPTION_TargetPlatform,CompilerOptions.VERSION_1_6); // 412312
         }
         //PM04610 end
-        else if (jdkSourceLevel.equals("17")) {
+        else if (jdkSourceLevel == 17) {
             compilerOptionsMap.put(CompilerOptions.OPTION_Source, "1.7"); //can I do this?? no CompilerOptions.VERSION_1_7 yet
             compilerOptionsMap.put(CompilerOptions.OPTION_Compliance, "1.7");       
             compilerOptionsMap.put(CompilerOptions.OPTION_TargetPlatform, "1.7");
         }
         //126902 start
-        else if (jdkSourceLevel.equals("18")) {
+        else if (jdkSourceLevel == 18) {
             compilerOptionsMap.put(CompilerOptions.OPTION_Source, "1.8"); //Verify, no CompilerOptions.VERSION_1_8 yet.
             compilerOptionsMap.put(CompilerOptions.OPTION_Compliance, "1.8");  
             compilerOptionsMap.put(CompilerOptions.OPTION_TargetPlatform, "1.8");

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/compiler/JikesJspCompiler.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/compiler/JikesJspCompiler.java
@@ -49,7 +49,7 @@ public class JikesJspCompiler implements JspCompiler {
     protected boolean isDebugEnabled = false;
     protected boolean isVerbose = false;
     protected boolean isDeprecation = false;
-    protected String jdkSourceLevel=null;
+    protected int jdkSourceLevel;
 
     protected boolean useOptimizedClasspath = false;
     protected String absouluteContextRoot = null;
@@ -200,22 +200,22 @@ public class JikesJspCompiler implements JspCompiler {
         // Jikes must default to -source 1.3; override if jdkSourceLevel is set 
         //487396.1 jdkSourceLevel is 15 by default now ... should get into if statement
         argList.add("-source");
-        if (jdkSourceLevel.equals("14")) {
+        if (jdkSourceLevel == 14) {
             argList.add("1.4");
         }
-        else if (jdkSourceLevel.equals("15")) {
+        else if (jdkSourceLevel == 15) {
             argList.add("1.5");
         }
         // PM04610 start
-        else if (jdkSourceLevel.equals("16")) {
+        else if (jdkSourceLevel == 16) {
             argList.add("1.6");
         }
         // PM04610 end
-        else if (jdkSourceLevel.equals("17")) {
+        else if (jdkSourceLevel == 17) {
             argList.add("1.7");
         }
         // 126902 start
-        else if (jdkSourceLevel.equals("18")) {
+        else if (jdkSourceLevel == 18) {
             argList.add("1.8");
         }
         // 126902 end

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/compiler/StandardJspCompiler.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/compiler/StandardJspCompiler.java
@@ -51,7 +51,7 @@ public class StandardJspCompiler implements JspCompiler  {
     protected boolean isDebugEnabled = false;
     protected boolean isVerbose = false;
     protected boolean isDeprecation = false; 
-    protected String jdkSourceLevel=null; 
+    protected int jdkSourceLevel; 
     protected String javaEncoding = null; 
     protected String outputDir = null;
     protected JavaCompiler compiler;
@@ -184,22 +184,22 @@ public class StandardJspCompiler implements JspCompiler  {
         
         //487396.1 jdkSourceLevel is 15 by default now ... should get into if statement
         argList.add("-source");
-        if (jdkSourceLevel.equals("14")) {
+        if (jdkSourceLevel == 14) {
             argList.add("1.4");
         }
-        else if (jdkSourceLevel.equals("15")) {
+        else if (jdkSourceLevel == 15) {
             argList.add("1.5");
         }
         //PM04610 start
-        else if (jdkSourceLevel.equals("16")) {
+        else if (jdkSourceLevel == 16) {
             argList.add("1.6");
         }
         //PM04610 end
-        else if (jdkSourceLevel.equals("17")) {
+        else if (jdkSourceLevel == 17) {
             argList.add("1.7");
         }
         //126902 start
-        else if (jdkSourceLevel.equals("18")) {
+        else if (jdkSourceLevel == 18) {
             argList.add("1.8");
         }
         //126902 end

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/document/JspEncodingScanner.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/document/JspEncodingScanner.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.StringTokenizer;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jsp.Constants;
 import com.ibm.ws.jsp.JspCoreException;
 
@@ -249,6 +250,7 @@ public class JspEncodingScanner
         }
     }
     
+    @Trivial
     private int readCharacter() throws IOException {
         int character = jspReader.read();
         charCount++;        

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/document/JspPageParser.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/document/JspPageParser.java
@@ -32,6 +32,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap; //248567
 import org.w3c.dom.Node;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jsp.Constants;
 import com.ibm.ws.jsp.JspCoreException;
 import com.ibm.ws.jsp.JspOptions;
@@ -1521,6 +1522,7 @@ public class JspPageParser {
         dependencyStack.pop();
     }
 
+    @Trivial
     private int readCharacter() throws IOException {
         int character = jspReader.read();
 
@@ -1535,6 +1537,7 @@ public class JspPageParser {
         return character;
     }
 
+    @Trivial
     private int readNextCharacter() throws IOException {
         jspReader.mark(1);
         int character = jspReader.read();

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/configuration/VisitorConfigParser.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/configuration/VisitorConfigParser.java
@@ -21,6 +21,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.jsp.JspCoreException;
 import com.ibm.ws.jsp.translator.visitor.xml.ParserFactory;
 
@@ -107,6 +108,7 @@ public class VisitorConfigParser extends DefaultHandler {
         }
     }
     
+    @Trivial
     public void characters(char[] ch, int start, int length) throws SAXException {
         for (int i = 0; i < length; i++) {
             if (chars != null)

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webxml/JspConfiguratorHelper.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webxml/JspConfiguratorHelper.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.container.service.config.ServletConfigurator;
 import com.ibm.ws.container.service.config.ServletConfiguratorHelper;
 import com.ibm.ws.container.service.config.WebFragmentInfo;
@@ -165,6 +166,7 @@ public class JspConfiguratorHelper implements ServletConfiguratorHelper, JspXmlE
         return getVersion(webAppVersion) >= 2.5;
     }
 
+    @Trivial
     public JspOptions getJspOptions() {
         return options;
     }        


### PR DESCRIPTION
In JDK 12, the minimum supported source target level is JDK 1.7. Normally, the JSP Engine defaults to the lowest (JDK 1.3), so we need to default to JDK 1.7 on JDK 12+.