### PR TITLE
transaction times out and releases locks if whenComplete stage unable to run

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentTxTest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentTxTest.java
@@ -12,10 +12,12 @@ package com.ibm.ws.concurrent.mp.fat;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -40,6 +42,26 @@ public class MPConcurrentTxTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer(
+                          // From expected timeout of unresolved transaction with setRollbackOnly:
+                          "DSRA0302E.*XA_RBROLLBACK", // XAException occurred.  Error code is: XA_RBROLLBACK (100).  Exception is...
+                          "DSRA0304E" // XAException occurred. XAException contents and details are...
+        );
+    }
+
+    @AllowedFFDC({
+                   "java.lang.IllegalStateException", // attempt to use same transaction on 2 threads at once
+                   "javax.transaction.xa.XAException" // transaction marked rollback-only due to intentionally caused error
+    })
+    @Test
+    public void testTransactionTimesOutAndReleasesLocks() throws Exception {
+        server.setMarkToEndOfLog();
+
+        runTest(server, APP_NAME + "/MPConcurrentTestServlet", testName.getMethodName());
+
+        // This test involves an asynchronous transaction timeout, which can continue logging FFDC on another
+        // thread after the test's servlet method completes. Wait for the FFDC message to appear in the logs
+        // in order to prevent it from overlapping subsequent tests where it would be considered a test failure.
+        server.waitForStringInLogUsingMark("FFDC1015I.*IllegalStateException");
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/MPConcurrentCDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/MPConcurrentCDITestServlet.java
@@ -73,17 +73,20 @@ public class MPConcurrentCDITestServlet extends FATServlet {
     @Qualifier
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
-    public @interface AppContext {}
+    public @interface AppContext {
+    }
 
     @Qualifier
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
-    public @interface CDIContext {}
+    public @interface CDIContext {
+    }
 
     @Qualifier
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
-    public @interface TxContext {}
+    public @interface TxContext {
+    }
 
     @Produces
     @ApplicationScoped
@@ -294,7 +297,10 @@ public class MPConcurrentCDITestServlet extends FATServlet {
                     throw x;
             }
         } finally {
-            tx.commit();
+            if (tx.getStatus() == Status.STATUS_ACTIVE)
+                tx.commit();
+            else
+                tx.rollback();
         }
 
         // valid to propagate empty transaction context

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
@@ -19,6 +19,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLRecoverableException;
 import java.sql.Statement;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -1472,6 +1474,69 @@ public class MPConcurrentTxTestServlet extends FATServlet {
     }
 
     /**
+     * Simulate a user error scenario (assuming only serial access to a transaction is permitted)
+     * where completion stages are allowed to start in parallel to the original transaction and
+     * are consequently rejected, including the stage that would resolve the transaction.
+     * Verify that transaction timeout eventually rolls back the transactions and prevents locks
+     * from being held open.
+     */
+    public void testTransactionTimesOutAndReleasesLocks() throws Exception {
+        boolean supportsParallelUse = false;
+        CompletableFuture<Integer> stage1 = txExecutor.completedFuture(0);
+        CompletableFuture<Integer> stage2;
+        tx.setTransactionTimeout(20);
+        tx.begin();
+        try {
+            try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+                st.executeUpdate("INSERT INTO MNCOUNTIES VALUES ('Swift', 9783)");
+            } catch (SQLNonTransientConnectionException | SQLRecoverableException x) {
+                // ignore - this means the transaction timed out too soon
+            }
+
+            stage2 = stage1.thenApplyAsync(numUpdates -> {
+                try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+                    return numUpdates + st.executeUpdate("INSERT INTO IACOUNTIES VALUES ('Shelby', 12167)");
+                } catch (SQLException x) {
+                    throw new CompletionException(x);
+                }
+            }).whenComplete((result, failure) -> {
+                try {
+                    if (failure == null && tx.getStatus() == Status.STATUS_ACTIVE)
+                        tx.commit();
+                    else
+                        tx.rollback();
+                } catch (Exception x) {
+                    x.printStackTrace();
+                    if (failure == null)
+                        throw new CompletionException(x);
+                }
+            });
+
+            // Force propagation of the transaction to another thread in parallel
+            try {
+                assertEquals(Integer.valueOf(1), stage2.join());
+                supportsParallelUse = true;
+            } catch (CompletionException x) {
+                if (x.getCause() instanceof IllegalStateException) // transaction used on 2 threads at once
+                    ; // expected
+                else
+                    throw x;
+            }
+        } finally {
+            tm.suspend();
+        }
+
+        try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {
+            ResultSet result = st.executeQuery("SELECT SUM(POPULATION) FROM MNCOUNTIES WHERE NAME='Swift'");
+            assertTrue(result.next());
+            if (supportsParallelUse)
+                assertEquals(9783, result.getInt(1));
+            else // update must be rolled back
+                assertEquals(0, result.getInt(1));
+        }
+    }
+
+    /**
      * Use multiple two-phase capable resources in the same transaction at the same time on different threads.
      * Commit the transaction after all transactional operations are finished.
      */
@@ -1508,11 +1573,10 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                 else
                     throw x;
             }
-
+        } finally {
             if (tx.getStatus() == Status.STATUS_ACTIVE)
                 tx.commit();
-        } finally {
-            if (tx.getStatus() != Status.STATUS_NO_TRANSACTION)
+            else
                 tx.rollback();
         }
 
@@ -1746,7 +1810,10 @@ public class MPConcurrentTxTestServlet extends FATServlet {
                     throw x;
             }
         } finally {
-            tx.commit();
+            if (tx.getStatus() == Status.STATUS_ACTIVE)
+                tx.commit();
+            else
+                tx.rollback();
         }
 
         try (Connection con = defaultDataSource.getConnection(); Statement st = con.createStatement()) {

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile Context Propagation TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.context.propagation.version>1.0-RC1</microprofile.context.propagation.version>
+        <microprofile.context.propagation.version>1.0-RC2</microprofile.context.propagation.version>
         <!-- Switch to the following to test a local SNAPSHOT instead of a release candidate. -->
         <!-- <microprofile.context.propagation.version>1.0-SNAPSHOT</microprofile.context.propagation.version> -->
         <arquillian.version>1.3.0.Final</arquillian.version>

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/SerialTransactionContextImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/SerialTransactionContextImpl.java
@@ -83,8 +83,14 @@ public class SerialTransactionContextImpl implements ThreadContext {
         // TODO This current code is unlikely to be a fully reliable way of determining that a transaction
         // will be active on 2 threads at once. It should be replaced once the transaction manager is updated
         // to properly enforce the requirement.
-        if (tx != null && suspendCounts.get(tx).get() < 1)
+        if (tx != null && suspendCounts.get(tx).get() < 1) {
+            try {
+                tx.setRollbackOnly();
+            } catch (IllegalStateException x) {
+            } catch (SystemException x) {
+            }
             throw new IllegalStateException("Transaction cannot be propagated to thread because it is not permitted to be active on two threads at the same time.");
+        }
 
         // Suspend whatever is currently on the thread.
         try {


### PR DESCRIPTION
The limitation to reject propagation of a transaction to multiple threads in parallel can get it in the way of a whenComplete (or other) stage that is intended to resolve the transaction, when the app is poorly coded to allow the completion stage processing to happen while the transaction remains on the original thread.  In this case, we want to ensure that the transaction does eventually roll back (after the transaction timeout) so that locks are not kept on the data forever.  This pull adds a test for this scenario.