### PR TITLE
resource adapter for testing config viewer api and initial test

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
@@ -351,7 +351,7 @@ public class ConfigRESTHandler implements RESTHandler {
 
         String elementName = path.length() < 8 ? "" : URLDecoder.decode(path.substring(8, endElementName), "UTF-8");
 
-        StringBuilder filter = new StringBuilder("(&");
+        StringBuilder filter = new StringBuilder("(&(!(ibm.extends.source.pid=*))");
         if (uid != null && (uid.startsWith(elementName + "[default-") || uid.matches(".*/.*\\[.*\\].*")))
             filter.append(FilterUtils.createPropertyFilter("config.displayId", uid));
         else if (elementName.length() > 0) {

--- a/dev/com.ibm.ws.rest.handler.config_fat/.classpath
+++ b/dev/com.ibm.ws.rest.handler.config_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-resourceadapter/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
@@ -15,17 +15,22 @@ javac.source: 1.8
 javac.target: 1.8
 
 src: \
-	fat/src
+	fat/src,\
+	test-resourceadapter/src
 
 fat.project: true
 
 -sub: *.bnd
 
 -buildpath: \
+    com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+    com.ibm.websphere.javaee.connector.1.7;version=latest,\
     com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-    org.apache.derby:derby;version=10.11.1.1
+    org.apache.derby:derby;version=10.11.1.1,\
+    com.ibm.ws.security.jaas.common;version=latest
+    

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJCATest.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.rest.handler.config.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpsRequest;
+
+@RunWith(FATRunner.class)
+public class ConfigRESTHandlerJCATest extends FATServletClient {
+    @Server("com.ibm.ws.rest.handler.config.jca.fat")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "TestConfigAdapter.rar")
+                        .addAsLibraries(ShrinkWrap.create(JavaArchive.class)
+                                        .addPackage("org.test.config.adapter"));
+        ShrinkHelper.exportToServer(server, "connectors", rar);
+
+        server.startServer();
+
+        // Wait for the API to become available
+        List<String> messages = new ArrayList<>();
+        messages.add("CWWKS0008I"); // CWWKS0008I: The security service is ready.
+        messages.add("CWWKS4105I"); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        messages.add("CWPKI0803A"); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
+        messages.add("CWWKO0219I: .* defaultHttpEndpoint-ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        messages.add("CWWKT0016I"); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
+        messages.add("J2CA7001I: .* tca"); // J2CA7001I: Resource adapter tca installed in # seconds.
+
+        server.waitForStringsInLogUsingMark(messages);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    // Test the output of the /ibm/api/config/connectionFactory/{uid} REST endpoint.
+    @Test
+    public void testConfigConnectionFactory() throws Exception {
+        JsonObject cf = new HttpsRequest(server, "/ibm/api/config/connectionFactory/cf1").run(JsonObject.class);
+        String err = "unexpected response: " + cf;
+        assertEquals(err, "connectionFactory", cf.getString("configElementName"));
+        assertEquals(err, "cf1", cf.getString("uid"));
+        assertEquals(err, "cf1", cf.getString("id"));
+        assertEquals(err, "eis/cf1", cf.getString("jndiName"));
+
+        JsonArray array;
+        JsonObject cm;
+        assertNotNull(err, array = cf.getJsonArray("connectionManagerRef"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, cm = array.getJsonObject(0));
+        assertEquals(err, "connectionManager", cm.getString("configElementName"));
+        assertEquals(err, "cm1", cm.getString("uid"));
+        assertEquals(err, "cm1", cm.getString("id"));
+        assertEquals(err, 101, cm.getInt("maxPoolSize"));
+        assertEquals(err, "EntirePool", cm.getString("purgePolicy"));
+
+        JsonObject authData;
+        assertNotNull(err, array = cf.getJsonArray("containerAuthDataRef"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, authData = array.getJsonObject(0));
+        assertEquals(err, "containerAuthData", authData.getString("configElementName"));
+        assertEquals(err, "connectionFactory[cf1]/containerAuthData[default-0]", authData.getString("uid"));
+        assertNull(err, authData.getJsonObject("id"));
+        assertEquals(err, "containerUser1", authData.getString("user"));
+        assertEquals(err, "******", authData.getString("password"));
+
+        assertNotNull(err, array = cf.getJsonArray("recoveryAuthDataRef"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, authData = array.getJsonObject(0));
+        assertEquals(err, "recoveryAuthData", authData.getString("configElementName"));
+        assertEquals(err, "connectionFactory[cf1]/recoveryAuthData[default-0]", authData.getString("uid"));
+        assertNull(err, authData.getJsonObject("id"));
+        assertEquals(err, "recoveryUser1", authData.getString("user"));
+        assertEquals(err, "******", authData.getString("password"));
+
+        JsonObject props;
+        assertNotNull(err, array = cf.getJsonArray("properties.tca.ConnectionFactory"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        // TODO generated JCA properties
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/FATSuite.java
@@ -19,7 +19,8 @@ import componenttest.topology.utils.HttpUtils;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                ConfigRESTHandlerTest.class,
+                ConfigRESTHandlerJCATest.class,
+                ConfigRESTHandlerTest.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jca.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jca.fat/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:rest.config=all
+com.ibm.ws.logging.max.file.size=0
+ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jca.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jca.fat/server.xml
@@ -1,0 +1,35 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <include location="../fatTestPorts.xml" />
+
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>configValidator-1.0</feature> <!-- TODO replace when functionality is enabled via auto-feature -->
+    <feature>jca-1.7</feature>
+  </featureManager>
+
+  <variable name="onError" value="FAIL"/>
+
+  <keyStore id="defaultKeyStore" password="Liberty"/>
+  <quickStartSecurity userName="adminuser" userPassword="adminpwd"/>
+
+  <resourceAdapter id="tca" location="${server.config.dir}/connectors/TestConfigAdapter.rar"/>
+
+  <connectionFactory id="cf1" jndiName="eis/cf1" connectionManagerRef="cm1">
+    <containerAuthData user="containerUser1" password="pwd1"/>
+    <recoveryAuthData user="recoveryUser1" password="pwd1"/>
+    <properties.tca.ConnectionFactory enableBetaContent="true" portNumber="7766"/>
+  </connectionFactory>
+
+  <connectionManager id="cm1" maxPoolSize="101"/>
+
+</server>

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionFactoryImpl.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.adapter;
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.cci.Connection;
+import javax.resource.cci.ConnectionFactory;
+import javax.resource.cci.ConnectionSpec;
+import javax.resource.cci.RecordFactory;
+import javax.resource.cci.ResourceAdapterMetaData;
+
+public class ConnectionFactoryImpl implements ConnectionFactory {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Connection getConnection() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public Connection getConnection(ConnectionSpec conSpec) throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public ResourceAdapterMetaData getMetaData() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public RecordFactory getRecordFactory() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public Reference getReference() throws NamingException {
+        return null;
+    }
+
+    @Override
+    public void setReference(Reference ref) {
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionImpl.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.adapter;
+
+public class ConnectionImpl {
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionSpecImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionSpecImpl.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.adapter;
+
+import javax.resource.cci.ConnectionSpec;
+import javax.resource.spi.AdministeredObject;
+import javax.resource.spi.ConfigProperty;
+
+/**
+ * Example ConnectionSpec implementation with a single property, readOnly,
+ * which determines whether or not the connection is in read only mode.
+ */
+@AdministeredObject
+public class ConnectionSpecImpl implements ConnectionSpec {
+    @ConfigProperty
+    private Long connectionTimeout;
+
+    @ConfigProperty
+    private String password;
+
+    @ConfigProperty
+    private Boolean readOnly = false;
+
+    @ConfigProperty
+    private String userName;
+
+    public Long getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public Boolean isReadOnly() {
+        return readOnly;
+    }
+
+    public void setConnectionTimeout(Long connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setReadOnly(Boolean readOnly) {
+        this.readOnly = readOnly;
+    }
+
+    public void setUserName(String user) {
+        this.userName = user;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/DataSourceImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/DataSourceImpl.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.adapter;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
+
+public class DataSourceImpl implements DataSource {
+    @Override
+    public Connection getConnection() throws SQLException {
+        return getConnection(null, null);
+    }
+
+    @Override
+    public Connection getConnection(String user, String password) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return null;
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> ifc) throws SQLException {
+        return ifc.isAssignableFrom(getClass());
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> ifc) throws SQLException {
+        return isWrapperFor(ifc) ? ifc.cast(this) : null;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ManagedConnectionFactoryImpl.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.adapter;
+
+import java.io.PrintWriter;
+import java.util.Set;
+
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.cci.Connection;
+import javax.resource.cci.ConnectionFactory;
+import javax.resource.spi.ConfigProperty;
+import javax.resource.spi.ConnectionDefinition;
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionFactory;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterAssociation;
+import javax.security.auth.Subject;
+
+/**
+ * Test managed connection factory that doesn't connect to anything.
+ */
+@ConnectionDefinition(connectionFactory = ConnectionFactory.class,
+                      connectionFactoryImpl = ConnectionFactoryImpl.class,
+                      connection = Connection.class,
+                      connectionImpl = ConnectionImpl.class)
+public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, ResourceAdapterAssociation {
+    private static final long serialVersionUID = 1L;
+
+    ResourceAdapterImpl adapter;
+
+    @ConfigProperty
+    private Boolean enableBetaContent;
+
+    @ConfigProperty
+    private Character escapeChar;
+
+    @ConfigProperty(defaultValue = "localhost")
+    private String hostName;
+
+    @ConfigProperty
+    private String password;
+
+    @ConfigProperty
+    private Integer portNumber = 7654;
+
+    @ConfigProperty
+    private String userName;
+
+    @Override
+    public Object createConnectionFactory() throws ResourceException {
+        return createConnectionFactory(null);
+    }
+
+    @Override
+    public Object createConnectionFactory(ConnectionManager cm) throws ResourceException {
+        return new ConnectionFactoryImpl();
+    }
+
+    @Override
+    public ManagedConnection createManagedConnection(Subject subject, ConnectionRequestInfo cri) throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    public Boolean getEnableBetaContent() {
+        return enableBetaContent;
+    }
+
+    public Character getEscapeChar() {
+        return escapeChar;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() {
+        return null;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public Integer getPortNumber() {
+        return portNumber;
+    }
+
+    @Override
+    public ResourceAdapter getResourceAdapter() {
+        return adapter;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    @Override
+    public ManagedConnection matchManagedConnections(@SuppressWarnings("rawtypes") Set connections, Subject subject, ConnectionRequestInfo cri) throws ResourceException {
+        return null;
+    }
+
+    public void setEnableBetaContent(Boolean enableBetaContent) {
+        this.enableBetaContent = enableBetaContent;
+    }
+
+    public void setEscapeChar(Character escapeChar) {
+        this.escapeChar = escapeChar;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter logWriter) {
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setPortNumber(Integer portNumber) {
+        this.portNumber = portNumber;
+    }
+
+    @Override
+    public void setResourceAdapter(ResourceAdapter adapter) throws ResourceException {
+        this.adapter = (ResourceAdapterImpl) adapter;
+    }
+
+    public void setUserName(String user) {
+        this.userName = user;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ManagedJDBCConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ManagedJDBCConnectionFactoryImpl.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.adapter;
+
+import java.sql.Connection;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionDefinition;
+import javax.resource.spi.ConnectionManager;
+import javax.sql.DataSource;
+
+/**
+ * Mock managed connection factory which is only used to supply configuration.
+ */
+@ConnectionDefinition(connectionFactory = DataSource.class,
+                      connectionFactoryImpl = DataSourceImpl.class,
+                      connection = Connection.class,
+                      connectionImpl = ConnectionImpl.class)
+public class ManagedJDBCConnectionFactoryImpl extends ManagedConnectionFactoryImpl {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Object createConnectionFactory() throws ResourceException {
+        return createConnectionFactory(null);
+    }
+
+    @Override
+    public Object createConnectionFactory(ConnectionManager cm) throws ResourceException {
+        return new DataSourceImpl();
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ResourceAdapterImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ResourceAdapterImpl.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.adapter;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.BootstrapContext;
+import javax.resource.spi.Connector;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterInternalException;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.transaction.xa.XAResource;
+
+/**
+ * Mock resource adapter for testing that configured JCA resources are viewable via the /config/ endpoint.
+ */
+@Connector
+public class ResourceAdapterImpl implements ResourceAdapter {
+    @Override
+    public void endpointActivation(MessageEndpointFactory endpointFactory, ActivationSpec activationSpec) throws ResourceException {
+    }
+
+    @Override
+    public void endpointDeactivation(MessageEndpointFactory endpointFactory, ActivationSpec activationSpec) {
+    }
+
+    @Override
+    public XAResource[] getXAResources(ActivationSpec[] activationSpecs) throws ResourceException {
+        return null;
+    }
+
+    @Override
+    public void start(BootstrapContext bootstrapContext) throws ResourceAdapterInternalException {
+    }
+
+    @Override
+    public void stop() {
+    }
+}


### PR DESCRIPTION
Create a mock resource adapter, from which configuration will be generated, which can be used to test the ibm/api/config REST endpoint with JCA connection factories (and later other JCA resources).  Write an initial test case, or at least what is reasonably possible without significant additional changes.