### PR TITLE
Handle async case where app shuts down

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncRequestWaitingServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncRequestWaitingServlet.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.asyncshutdown;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.inject.Inject;
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ *
+ */
+@WebServlet(value = "/async-task-wait", asyncSupported = true)
+public class AsyncRequestWaitingServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    AsyncShutdownBean bean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        AsyncContext ctx = req.startAsync();
+        PrintWriter writer = ctx.getResponse().getWriter();
+        // Start async task which will complete the request when it finishes
+        bean.runFiniteAsyncTask(5)
+                        .exceptionally(Throwable::toString)
+                        .thenAccept(s -> {
+                            System.out.println("Got result: " + s);
+                            writer.println("Got result: " + s);
+                            ctx.complete();
+                        });
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncShutdownBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncShutdownBean.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.websphere.microprofile.faulttolerance_fat.tests.asyncshutdown;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -32,6 +33,16 @@ public class AsyncShutdownBean {
             throw new RuntimeException(ex);
         }
         return self.runAsyncTask();
+    }
+
+    @Asynchronous
+    public CompletionStage<String> runFiniteAsyncTask(int repeats) {
+        System.out.println("Running finite async task");
+        if (repeats > 0) {
+            return this.runFiniteAsyncTask(repeats - 1);
+        } else {
+            return CompletableFuture.completedFuture("OK");
+        }
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncShutdownBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncShutdownBean.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.asyncshutdown;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+@ApplicationScoped
+public class AsyncShutdownBean {
+
+    @Inject
+    AsyncShutdownBean self;
+
+    @Asynchronous
+    public CompletionStage<String> runAsyncTask() {
+        System.out.println("Running async task");
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+        return self.runAsyncTask();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncShutdownServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncShutdownServlet.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.asyncshutdown;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/begin-async-task")
+public class AsyncShutdownServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    AsyncShutdownBean bean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        // Start async task
+        bean.runAsyncTask()
+                        .exceptionally(Throwable::toString)
+                        .thenAccept(s -> System.out.println("Got result: " + s));
+
+        // Once the async task is kicked off, return
+        // Async task should continue in the background until app is shut down
+        resp.getWriter().println("OK");
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncShutdownTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncShutdownTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.asyncshutdown;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+/**
+ * Test for an application shutting down while an asynchronous method is running
+ */
+@RunWith(FATRunner.class)
+public class AsyncShutdownTest {
+
+    private static final String SERVER_NAME = "FaultToleranceMultiModule";
+    private static final String APP_NAME = "ftAsyncShutdown";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        server.startServer();
+    }
+
+    @Test
+    public void testAsyncShutdown() throws Exception {
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackage(AsyncShutdownTest.class.getPackage());
+        ShrinkHelper.exportDropinAppToServer(server, app, SERVER_ONLY);
+
+        beginAsyncTask();
+
+        // Async task should keep starting new async methods until one of them fails with the expected error because the application has shut down
+        server.deleteDirectoryFromLibertyServerRoot("dropins/" + APP_NAME + ".war");
+        assertNotNull("application did not stop", server.waitForStringInLog("CWWKZ0009I.*" + APP_NAME));
+        assertNotNull("Error was not logged", server.waitForStringInLog("CWMFT0002W"));
+    }
+
+    private void beginAsyncTask() throws Exception {
+        HttpUtils.findStringInReadyUrl(server, APP_NAME + "/begin-async-task", "OK");
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer("CWMFT0002W");
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncShutdownWaitingServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/AsyncShutdownWaitingServlet.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.asyncshutdown;
+
+import java.io.IOException;
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ *
+ */
+@WebServlet("/async-task-wait-at-shutdown")
+public class AsyncShutdownWaitingServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    AsyncShutdownBean bean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        // Start async task which will complete the request when it finishes
+        CompletionStage<?> stage = bean.runFiniteAsyncTask(5)
+                        .exceptionally(Throwable::toString)
+                        .thenAccept(s -> {
+                            System.out.println("Got result: " + s);
+                        });
+
+        bean.waitBeforeShutdown(stage);
+
+        resp.getWriter().println("OK");
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/package-info.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/asyncshutdown/package-info.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ *
+ */
+package com.ibm.websphere.microprofile.faulttolerance_fat.tests.asyncshutdown;

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FaultToleranceMultiModule/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/FaultToleranceMultiModule/server.xml
@@ -22,6 +22,6 @@
 		<feature>mpFaultTolerance-2.0</feature>
 	</featureManager>
 	
-	<logging traceSpecification="FAULTTOLERANCE=event"/>
+	<logging traceSpecification="FAULTTOLERANCE=event:org.jboss.weld.*=fine"/>
 	
 </server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance/resources/com/ibm/ws/microprofile/faulttolerance/resources/FaultTolerance.nlsprops
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/resources/com/ibm/ws/microprofile/faulttolerance/resources/FaultTolerance.nlsprops
@@ -34,6 +34,10 @@ bulkhead.no.threads.CWMFT0001E=CWMFT0001E: No free capacity is available in the 
 bulkhead.no.threads.CWMFT0001E.explanation=A call to the method did not succeed because the bulkhead for the method is full.
 bulkhead.no.threads.CWMFT0001E.useraction=Increase availability in the bulkhead by increasing the capacity of the bulkhead or reducing the concurrent workload of this service.
 
+application.shutdown.CWMFT0002W=CWMFT0002W: Cannot complete the asynchronous execution of method {0} because the application or component which called it has stopped
+application.shutdown.CWMFT0002W.explanation=Asynchronous methods run in the context of the component that started them. The application or component that called the asynchronous method is no longer running and this has prevented the asynchronous method from running completely.
+application.shutdown.CWMFT0002W.useraction=This warning usually occurs when the application or server is shutting down. If it's important that all started Asynchronous methods are completed, then the running application should wait for the result.
+
 #An internal error occurred. The exception is {0}.
 internal.error.CWMFT4998E=CWMFT4998E: An internal error occurred. The exception is {0}.
 internal.error.CWMFT4998E.explanation=The application server experienced an internal error.

--- a/dev/com.ibm.ws.microprofile.faulttolerance/resources/com/ibm/ws/microprofile/faulttolerance/resources/FaultTolerance.nlsprops
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/resources/com/ibm/ws/microprofile/faulttolerance/resources/FaultTolerance.nlsprops
@@ -6,7 +6,7 @@
 #ISMESSAGEFILE true
 # #########################################################################
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -34,9 +34,9 @@ bulkhead.no.threads.CWMFT0001E=CWMFT0001E: No free capacity is available in the 
 bulkhead.no.threads.CWMFT0001E.explanation=A call to the method did not succeed because the bulkhead for the method is full.
 bulkhead.no.threads.CWMFT0001E.useraction=Increase availability in the bulkhead by increasing the capacity of the bulkhead or reducing the concurrent workload of this service.
 
-application.shutdown.CWMFT0002W=CWMFT0002W: Cannot complete the asynchronous execution of method {0} because the application or component which called it has stopped
-application.shutdown.CWMFT0002W.explanation=Asynchronous methods run in the context of the component that started them. The application or component that called the asynchronous method is no longer running and this has prevented the asynchronous method from running completely.
-application.shutdown.CWMFT0002W.useraction=This warning usually occurs when the application or server is shutting down. If it's important that all started Asynchronous methods are completed, then the running application should wait for the result.
+application.shutdown.CWMFT0002W=CWMFT0002W: The {0} asynchronous method cannot complete because the application or component that called it stopped.
+application.shutdown.CWMFT0002W.explanation=Asynchronous methods run in the context of the component that started them. The application or component that called the asynchronous method stopped, which prevented the asynchronous method from completing.
+application.shutdown.CWMFT0002W.useraction= This warning usually occurs when an application, component, or server is shutting down. If all running asynchronous methods must complete, then the application or component must wait for the results before stopping.
 
 #An internal error occurred. The exception is {0}.
 internal.error.CWMFT4998E=CWMFT4998E: An internal error occurred. The exception is {0}.


### PR DESCRIPTION
If an application shuts down, no more asynchronous operations can be
started for that application. With FT and async, new async operations
can be started at several points for one method call.

This change ensures that in this case, the user gets a sensible error
message, rather than an FFDC and an internal error exception.
