### PR TITLE
Wait for FeatureManager in Jaxrs Security Annotations FAT

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/security/annotations/SecurityAnnotationsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/security/annotations/SecurityAnnotationsTest.java
@@ -92,6 +92,8 @@ public class SecurityAnnotationsTest {
             server.startServer(true);
             assertNotNull("The server did not start", server.waitForStringInLog("CWWKF0011I"));
             assertNotNull("The Security Service should be ready", server.waitForStringInLog("CWWKS0008I"));
+            assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
+            assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
         } catch (Exception e) {
             System.out.println(e.toString());
         }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagationTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagationTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.rest.client.fat;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -56,6 +58,7 @@ public class HeaderPropagationTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultApp(server, appName, "mpRestClient10.headerPropagation");
         server.startServer();
+        assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
     }
 
     @AfterClass


### PR DESCRIPTION
com.ibm.ws.jaxrs20.fat.security.annotations.SecurityAnnotationsTest.testMethodLevelRolesAllowedUserInRole_noWebXml_roleSameAsGroup_JAXRS-2.1 is failing intermittently with: ```CWWKS4000E: A configuration exception has occurred. The requested TokenService instance of type Ltpa2 could not be found.```

I reached out to the security team and they are aware of the problem. They have provided the workaround in this PR.