### PR TITLE
reduce trace output for com.ibm.ws.microprofile.rest.client_fat

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
@@ -71,13 +71,7 @@ public class AsyncMethodTest extends FATServletClient {
             assertTrue("Found JsonBProvider errors in log file", 
                        jsonbProviderErrors == null || jsonbProviderErrors.isEmpty());
         } finally {
-            server.dumpServer("dump.zip");
             server.stopServer("CWWKF0033E"); //ignore this error for mismatch with jsonb-1.0 and Java EE 7
         }
-    }
-
-    @Before
-    public synchronized void obtainServerDumps() throws Exception {
-        server.dumpServerOnSchedule("dump", 3, 100, 1000, TimeUnit.MILLISECONDS);
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.cdi/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.cdi/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+#com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.ejb/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.ejb/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+#com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+#com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.handleresponses/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.handleresponses/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+#com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.headerPropagation/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.headerPropagation/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+#com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.multi.client.cdi/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.multi.client.cdi/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+#com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.props/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.props/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+#com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.remoteServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.remoteServer/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info
+#com.ibm.ws.logging.trace.specification=*=info
 com.ibm.ws.logging.max.file.size=0
 osgi.console=6789
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.tolerateEE8/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.tolerateEE8/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+#com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/bootstrap.properties
@@ -1,10 +1,10 @@
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs2*=all:\
-com.ibm.websphere.jaxrs2*=all:\
-org.apache.cxf.*=all:\
-com.ibm.ws.microprofile.rest.*=all:\
-com.ibm.websphere.microprofile.rest.*=all:\
-com.ibm.ws.threading.internal.ThreadPoolController=all
+#com.ibm.ws.logging.trace.specification=*=info:\
+#com.ibm.ws.jaxrs2*=all:\
+#com.ibm.websphere.jaxrs2*=all:\
+#org.apache.cxf.*=all:\
+#com.ibm.ws.microprofile.rest.*=all:\
+#com.ibm.websphere.microprofile.rest.*=all:\
+#com.ibm.ws.threading.internal.ThreadPoolController=all
 
 com.ibm.ws.logging.max.file.size=0
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
+#com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 bootstrap.include=../testports.properties


### PR DESCRIPTION
No product nor test changes, just reduce the amount of logging we do in the ```com.ibm.ws.microprofile.rest.client_fat``` test bucket to reduce IO load on the test machines.