### PR TITLE
hide password values of JCA resources from config REST endpoint output

### DIFF
--- a/dev/com.ibm.ws.jca.utils/src/com/ibm/ws/jca/utils/metagen/MetatypeGenerator.java
+++ b/dev/com.ibm.ws.jca.utils/src/com/ibm/ws/jca/utils/metagen/MetatypeGenerator.java
@@ -1101,8 +1101,8 @@ public class MetatypeGenerator {
         else
             ad_configProperty.setRequired(false);
 
-        if (configProperty.getConfidential() != null && configProperty.getConfidential())
-            // || propName.toUpperCase().contains("PASSWORD")) // TODO add this once all tests are updated
+        if (configProperty.getConfidential() != null && configProperty.getConfidential()
+            || propName.toUpperCase().contains("PASSWORD"))
             ad_configProperty.setIbmType("password");
 
         if (configProperty.getIgnore() != null && configProperty.getIgnore()) {

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJCATest.java
@@ -213,7 +213,7 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertEquals(err, "localhost", props.getString("hostName"));
         // assertEquals(err, 7654, props.getInt("portNumber")); // TODO include the internal default for portNumber?
         assertEquals(err, "user2", props.getString("userName"));
-        // assertEquals(err, "******", props.getString("password")); // TODO enable once other tests are updated (16601) and this can be changed
+        assertEquals(err, "******", props.getString("password"));
     }
 
     // Test the output of the /ibm/api/config/resourceAdapter/{uid} REST endpoint.


### PR DESCRIPTION
Even if the resource adapter doesn't declare a property as confidential, if the property name contains "password", then don't include its value in the output of the /ibm/api/config/ REST endpoint.