### PR TITLE
tests for querying activationSpec via the config REST endpoint

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jca.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jca.fat/server.xml
@@ -26,6 +26,15 @@
     <properties.tca debugMode="true"/>
   </resourceAdapter>
 
+  <activationSpec id="App1/EJB1/MyMDB" autoStart="false">
+    <authData user="actspecU1" password="act1v5p3c"/>
+    <properties.tca maxSize="8192" messageSelector="*"/>
+  </activationSpec>
+
+  <activationSpec id="MyDefaultMessageListener">
+    <properties.tca/>
+  </activationSpec>
+
   <adminObject id="conspec1" jndiName="eis/conspec1">
     <properties.tca.ConnectionSpec connectionTimeout="10000" userName="1user" password="password1"/>
   </adminObject>

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ActivationSpecImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ActivationSpecImpl.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.adapter;
+
+import javax.resource.ResourceException;
+import javax.resource.cci.MessageListener;
+import javax.resource.spi.Activation;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.ConfigProperty;
+import javax.resource.spi.InvalidPropertyException;
+import javax.resource.spi.ResourceAdapter;
+
+@Activation(messageListeners = MessageListener.class)
+public class ActivationSpecImpl implements ActivationSpec {
+    private ResourceAdapter adapter;
+
+    @ConfigProperty
+    private Short maxSize;
+
+    @ConfigProperty
+    private String messageSelector;
+
+    @ConfigProperty(defaultValue = "8")
+    private Byte minSize;
+
+    @ConfigProperty(defaultValue = "1.618")
+    private Float multiplicationFactor;
+
+    public Short getMaxSize() {
+        return maxSize;
+    }
+
+    public String getMessageSelector() {
+        return messageSelector;
+    }
+
+    public Byte getMinSize() {
+        return minSize;
+    }
+
+    public Float getMultiplicationFactor() {
+        return multiplicationFactor;
+    }
+
+    @Override
+    public ResourceAdapter getResourceAdapter() {
+        return adapter;
+    }
+
+    public void setMaxSize(Short value) {
+        this.maxSize = value;
+    }
+
+    public void setMessageSelector(String value) {
+        this.messageSelector = value;
+    }
+
+    public void setMinSize(Byte value) {
+        this.minSize = value;
+    }
+
+    public void setMultiplicationFactor(Float value) {
+        this.multiplicationFactor = value;
+    }
+
+    @Override
+    public void setResourceAdapter(ResourceAdapter adapter) throws ResourceException {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public void validate() throws InvalidPropertyException {
+    }
+}


### PR DESCRIPTION
Create an activation spec for the mock resource adapter.
Configure a couple of activationSpec config elements in server configuration.
Write tests that access them via the /ibm/api/config REST endpoint and verify the output.