### PR TITLE
Update to initialize Logger without application classloader on the thread context.

### DIFF
--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/utils/IDGeneratorImpl.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/utils/IDGeneratorImpl.java
@@ -65,6 +65,10 @@ public class IDGeneratorImpl implements IIDGenerator {
      */
     protected static Logger logger = Logger.getLogger("com.ibm.ws.util", "com.ibm.ws.session.resources.WASSessionCore");
 
+    public static void init() {
+        // nothing to do.  Just want to get the Class's Logger initialized
+    }
+
     // ----------------------------------------
     // Class Constructor
     // ----------------------------------------

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
@@ -109,6 +109,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.managedobject.ManagedObject;
 import com.ibm.ws.session.SessionCookieConfigImpl;
+import com.ibm.ws.session.utils.IDGeneratorImpl;
 import com.ibm.ws.session.utils.LoggingUtil;
 import com.ibm.ws.util.WSThreadLocal;
 import com.ibm.ws.webcontainer.WebContainer;
@@ -936,6 +937,11 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
         // PK63920 End
         serverInfo = getServerInfo(); // NEVER INVOKED BY WEBSPHERE APPLICATION
         // SERVER (Common Component Specific)
+
+        // Initialize the Logger for IDGeneratorImpl before setting Thread context ClassLoader
+        // in order to avoid using the application ClassLoader to load the Logger's resource bundle.
+        IDGeneratorImpl.init();
+
         ClassLoader origClassLoader = null; // NEVER INVOKED BY WEBSPHERE
         // APPLICATION SERVER (Common
         // Component Specific)


### PR DESCRIPTION
When a Logger is created for internal classes, it will use the thread
context classloader to try to load the resource bundle.  This will never
find the resource bundle, but will end up looking up 4 resources in
order to find that out.  resourceBundle.class, resourceBundle_en.class,
resourceBundle_en_US.class, and resourceBundle.properties.  Initializing
the classes before setting the application classloader will allow Logger
to skip the classloading of these resources from the application
classloader and only look in the caller classloader.

Also updated LoggerFactory to switch the context classloader in order to avoid looking at the application classloader.