### PR TITLE
validator can use vendor-specific testConnection method for CICS and IMS

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectionManagerService.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectionManagerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 IBM Corporation and others.
+ * Copyright (c) 2011, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import javax.resource.spi.ConnectionManager;
 
 import com.ibm.ejs.j2c.ConnectionManagerServiceImpl;
 import com.ibm.ejs.j2c.J2CConstants;
+import com.ibm.ejs.j2c.MCWrapper;
 import com.ibm.wsspi.resource.ResourceInfo;
 
 /**
@@ -122,4 +123,15 @@ public abstract class ConnectionManagerService extends Observable {
      */
     public abstract void addRaClassLoader(ClassLoader raClassLoader);
 
+    /**
+     * Indicates to the connection manager whether validation is occurring on the current thread.
+     *
+     * @param isValidating true if validation is occurring on the current thread. Otherwise false.
+     */
+    public void setValidating(boolean isValidating) {
+        if (isValidating)
+            MCWrapper.isValidating.set(true);
+        else
+            MCWrapper.isValidating.remove();
+    }
 }

--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
@@ -442,7 +442,17 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
      *
      * @param ref reference to the service
      */
-    protected void setSslConfig(ServiceReference<?> ref) {}
+    protected void setSslConfig(ServiceReference<?> ref) {
+    }
+
+    /**
+     * Indicates to the connection manager whether validation is occurring on the current thread.
+     *
+     * @param isValidating true if validation is occurring on the current thread. Otherwise false.
+     */
+    public void setValidating(boolean isValidating) {
+        conMgrSvc.setValidating(isValidating);
+    }
 
     /**
      * Declarative Services method for unsetting the BootstrapContext reference
@@ -467,7 +477,8 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
      *
      * @param ref reference to the service
      */
-    protected void unsetSslConfig(ServiceReference<?> ref) {}
+    protected void unsetSslConfig(ServiceReference<?> ref) {
+    }
 
     /** {@inheritDoc} */
     @Override


### PR DESCRIPTION
CICS and IMS ManagedConnection classes have a vendor-specific method named testConnection, which takes no parameters, which must be used to validate a connection.  It is not enough just to use the CCI API to obtain a Connection and Interaction. These do not actually cause a connection to be established to the backend, and would thus result in false positives for the validator.