### PR TITLE
Issue #7322: Remote EJB Server 2 Server Tests

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/.classpath
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/.classpath
@@ -11,6 +11,9 @@
 	<classpathentry kind="src" path="test-applications/AppExcExtendsThrowableErrBean.jar/src"/>
 	<classpathentry kind="src" path="test-applications/JitDeployEJB.jar/src"/>
 	<classpathentry kind="src" path="test-applications/JitDeployWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/RemoteClientWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/RemoteServerEJB.jar/src"/>
+	<classpathentry kind="src" path="test-applications/RemoteServerShared.jar/src"/>
 	<classpathentry kind="src" path="test-applications/StatelessAnnEJB.jar/src"/>
 	<classpathentry kind="src" path="test-applications/StatelessAnnWeb.war/src"/>
 	<classpathentry kind="src" path="test-applications/StatelessMixEJB.jar/src"/>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/bnd.bnd
@@ -23,6 +23,9 @@ src: \
 	test-applications/AppExcExtendsThrowableErrBean.jar/src, \
 	test-applications/JitDeployEJB.jar/src, \
 	test-applications/JitDeployWeb.war/src, \
+	test-applications/RemoteClientWeb.war/src, \
+	test-applications/RemoteServerEJB.jar/src, \
+	test-applications/RemoteServerShared.jar/src, \
 	test-applications/StatelessAnnEJB.jar/src, \
 	test-applications/StatelessAnnWeb.war/src, \
 	test-applications/StatelessMixEJB.jar/src, \

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/build.gradle
@@ -26,11 +26,19 @@ dependencies {
   ejbTools 'test:com.ibm.ws.ejbcontainer.fat_tools:1.+'
 }
 
-
-task addEJBTools(type: Copy) {
-  from configurations.ejbTools
-  into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServer/lib/global"
-  rename 'com.ibm.ws.ejbcontainer.fat_tools-(.*).jar', 'com.ibm.ws.ejbcontainer.fat_tools.jar'
+task addEJBTools {
+  doLast {
+    copy {
+      from configurations.ejbTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServer/lib/global"
+      rename 'com.ibm.ws.ejbcontainer.fat_tools-(.*).jar', 'com.ibm.ws.ejbcontainer.fat_tools.jar'
+    }
+    copy {
+      from configurations.ejbTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient/lib/global"
+      rename 'com.ibm.ws.ejbcontainer.fat_tools-(.*).jar', 'com.ibm.ws.ejbcontainer.fat_tools.jar'
+    }
+  }
 }
 
 addRequiredLibraries {

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/Server2ServerTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/Server2ServerTests.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.fat.tests;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.ejbcontainer.remote.client.web.RemoteTxAttrServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Tests remote EJB method calls between two Liberty servers.
+ */
+@RunWith(FATRunner.class)
+public class Server2ServerTests extends AbstractTest {
+
+    @Server("com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient")
+    @TestServlets({ @TestServlet(servlet = RemoteTxAttrServlet.class, contextRoot = "RemoteClientWeb") })
+    public static LibertyServer clientServer;
+
+    @Server("com.ibm.ws.ejbcontainer.remote.fat.RemoteServer")
+    public static LibertyServer remoteServer;
+
+    @Override
+    public LibertyServer getServer() {
+        return clientServer;
+    }
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient",
+                                                                                                      "com.ibm.ws.ejbcontainer.remote.fat.RemoteServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient",
+                                                                                                                                                                                                                     "com.ibm.ws.ejbcontainer.remote.fat.RemoteServer"));
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Use ShrinkHelper to build the Ears
+
+        //#################### RemoteClientApp
+        JavaArchive RemoteServerSharedJar = ShrinkHelper.buildJavaArchive("RemoteServerShared.jar", "com.ibm.ws.ejbcontainer.remote.server.shared.", "test.");
+        WebArchive RemoteClientWeb = ShrinkHelper.buildDefaultApp("RemoteClientWeb.war", "com.ibm.ws.ejbcontainer.remote.client.web.");
+        RemoteClientWeb.addAsLibraries(RemoteServerSharedJar);
+
+        EnterpriseArchive RemoteClientApp = ShrinkWrap.create(EnterpriseArchive.class, "RemoteClientApp.ear");
+        RemoteClientApp.addAsModule(RemoteClientWeb);
+        RemoteClientApp = (EnterpriseArchive) ShrinkHelper.addDirectory(RemoteClientApp, "test-applications/RemoteClientApp.ear/resources");
+
+        ShrinkHelper.exportDropinAppToServer(clientServer, RemoteClientApp);
+
+        //#################### RemoteServerApp
+        JavaArchive RemoteServerEJBJar = ShrinkHelper.buildJavaArchive("RemoteServerEJB.jar", "com.ibm.ws.ejbcontainer.remote.server.ejb.");
+
+        EnterpriseArchive RemoteServerApp = ShrinkWrap.create(EnterpriseArchive.class, "RemoteServerApp.ear");
+        RemoteServerApp.addAsLibraries(RemoteServerSharedJar).addAsModule(RemoteServerEJBJar);
+        RemoteServerApp = (EnterpriseArchive) ShrinkHelper.addDirectory(RemoteServerApp, "test-applications/RemoteServerApp.ear/resources");
+
+        ShrinkHelper.exportDropinAppToServer(remoteServer, RemoteServerApp);
+
+        // Finally, start servers
+        remoteServer.startServer();
+        clientServer.useSecondaryHTTPPort();
+        clientServer.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        clientServer.stopServer();
+        remoteServer.stopServer("CNTR0019E");
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient/.gitignore
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient/.gitignore
@@ -1,0 +1,4 @@
+/apps
+/derby
+/dropins
+/lib

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:EJBContainer=all:JITDeploy=all:Injection=all

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient/server.xml
@@ -1,0 +1,24 @@
+<server>
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>ejbHome-3.2</feature>
+        <feature>ejbRemote-3.2</feature>
+        <feature>componenttest-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestCommon.xml"/>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="${bvt.prop.HTTP_secondary}"
+                  httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP.secondary}">
+        <iiopsOptions  iiopsPort="${bvt.prop.IIOP.secondary.secure}" sslRef="defaultSSLConfig"/>
+    </iiopEndpoint>
+
+    <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader + others -->	
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+	<javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+</server>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteClientApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteClientApp.ear/resources/META-INF/permissions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader + others -->
+    <permission>
+        <class-name>java.net.SocketPermission</class-name>
+        <name>*</name>
+        <actions>listen,connect,resolve</actions>
+    </permission> 
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission> 
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>accessDeclaredMembers</name>
+    </permission> 
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>*</name>
+      <actions>read,write</actions>
+   </permission>
+</permissions>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteClientWeb.war/src/com/ibm/ws/ejbcontainer/remote/client/web/RemoteTxAttrServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteClientWeb.war/src/com/ibm/ws/ejbcontainer/remote/client/web/RemoteTxAttrServlet.java
@@ -1,0 +1,801 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.client.web;
+
+import static javax.transaction.Status.STATUS_COMMITTED;
+import static javax.transaction.Status.STATUS_NO_TRANSACTION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Properties;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.ejb.EJBException;
+import javax.ejb.EJBTransactionRequiredException;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.rmi.PortableRemoteObject;
+import javax.servlet.annotation.WebServlet;
+import javax.transaction.UserTransaction;
+
+import org.junit.Test;
+import org.omg.CORBA.BAD_PARAM;
+
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
+import com.ibm.websphere.ejbcontainer.test.tools.FATTransactionHelper;
+import com.ibm.ws.ejbcontainer.remote.server.shared.TxAttrEJB;
+import com.ibm.ws.ejbcontainer.remote.server.shared.TxAttrEJBHome;
+import com.ibm.ws.ejbcontainer.remote.server.shared.TxAttrRemote;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.app.FATServlet;
+import test.TestRemoteInterface;
+
+/**
+ * Tests variations of looking up remote enterprise beans located on a different server
+ * and whether the EJB container performs the correct action for each of the possible TX
+ * attribute values that can be assigned to a method of an EJB when making remote EJB
+ * calls between two different servers.
+ */
+@WebServlet("/RemoteTxAttrServlet")
+public class RemoteTxAttrServlet extends FATServlet {
+    private static final long serialVersionUID = -5671511025293075382L;
+
+    private static final Logger logger = Logger.getLogger(RemoteTxAttrServlet.class.getName());
+    private static final Integer IIOPPort = Integer.getInteger("bvt.prop.IIOP");
+    private static final Integer IIOPSecurePort = Integer.getInteger("bvt.prop.IIOP.secure");
+
+    private static Context defaultContext;
+    private static Context providerContext;
+    private static Context remoteContext;
+
+    // Name of module... for lookup.
+    private static final String CorbaName = "corbaname::localhost:" + IIOPPort;
+    private static final String CorbaNameNS = CorbaName + "/NameService";
+    private static final String CorbaNameSecure = "corbaname::localhost:" + IIOPSecurePort;
+    private static final String App = "RemoteServerApp";
+    private static final String Module = "RemoteServerEJB";
+    private static final String TxAttrBean = "TxAttrBean";
+    private static final String TxAttrCompBean = "TxAttrCompBean";
+    private static final String TestRemoteSingleton = "TestRemoteSingletonBean";
+    private static final String TestRemoteStateful = "TestRemoteStatefulBean";
+    private static final String TestRemoteStateless = "TestRemoteStatelessBean";
+
+    private static final String TxAttrBeanJndi = "ejb/global/" + App + "/" + Module + "/" + TxAttrBean;
+    private static final String TxAttrCompBeanJndi = "ejb/global/" + App + "/" + Module + "/" + TxAttrCompBean;
+    private static final String TestRemoteSingletonJndi = "ejb/global/" + App + "/" + Module + "/" + TestRemoteSingleton;
+    private static final String TestRemoteStatefulJndi = "ejb/global/" + App + "/" + Module + "/" + TestRemoteStateful;
+    private static final String TestRemoteStatelessJndi = "ejb/global/" + App + "/" + Module + "/" + TestRemoteStateless;
+
+    private TxAttrRemote txAttrBean;
+
+    @Resource
+    private UserTransaction userTran;
+
+    /**
+     * Provides the default InitialContext.
+     *
+     * @return an InitialContext with no properties
+     * @throws NamingException if a NamingException is encountered
+     */
+    private static Context getDefaultContext() throws NamingException {
+        if (defaultContext == null) {
+            defaultContext = new InitialContext();
+        }
+        return defaultContext;
+    }
+
+    /**
+     * Provides InitialContext created with Context.PROVIDER_URL for the remote system.
+     *
+     * @return an InitialContext with Context.PROVIDER_URL
+     * @throws NamingException if a NamingException is encountered
+     */
+    private static Context getProviderContext() throws NamingException {
+        if (providerContext == null) {
+            logger.info("creating provider context with provider.url = corbaloc::127.0.0.1:" + IIOPPort + "/NameService");
+            Properties p = new Properties();
+            // TODO: remove or enable if testProviderUrlContextLookup is ever supported
+            // p.put(Context.INITIAL_CONTEXT_FACTORY, "com.ibm.ws.jndi.iiop.InitialContextFactoryImpl");
+            p.put(Context.PROVIDER_URL, "corbaloc::127.0.0.1:" + IIOPPort);
+            providerContext = new InitialContext(p);
+        }
+        return providerContext;
+    }
+
+    /**
+     * Provides the Context of the remote system NameService
+     *
+     * @return an InitialContext with Context.PROVIDER_URL
+     * @throws NamingException if a NamingException is encountered
+     */
+    private static Context getRemoteContext() throws NamingException {
+        if (remoteContext == null) {
+            logger.info("creating remote context with provider.url = corbaloc::127.0.0.1:" + IIOPPort + "/NameService");
+            Context context = new InitialContext();
+            remoteContext = (Context) context.lookup("corbaname::localhost:" + IIOPPort + "/NameService");
+        }
+        return remoteContext;
+    }
+
+    /**
+     * Provides an instance of the TxAttrBean. The first call to this method
+     * will perform a lookup using the default InitialContext and full corbaname.
+     */
+    private TxAttrRemote getTxAttrBean() throws NamingException {
+        if (txAttrBean == null) {
+            // lookup the bean using default context with corbaname (including NameService)
+            String jndiName = CorbaNameNS + "#" + TxAttrBeanJndi + "!" + TxAttrRemote.class.getName();
+            txAttrBean = lookupRemoteBean(getDefaultContext(), jndiName, TxAttrRemote.class);
+        }
+        return txAttrBean;
+    }
+
+    public static <T> T lookupRemoteBean(String jndiName, Class<T> interfaceClass) throws NamingException {
+        return lookupRemoteBean(getDefaultContext(), jndiName, interfaceClass);
+    }
+
+    public static <T> T lookupRemoteBean(Context context, String jndiName, Class<T> interfaceClass) throws NamingException {
+        logger.info("lookupRemoteBean: JNDI = " + jndiName + ", interface = " + interfaceClass.getName());
+        Object remoteObj = context.lookup(jndiName);
+        logger.info("lookupRemoteBean: found = " + ((remoteObj == null) ? "null" : remoteObj.getClass().getName()));
+        T remoteBean = interfaceClass.cast(PortableRemoteObject.narrow(remoteObj, interfaceClass));
+        logger.info("lookupRemoteBean: returning = " + ((remoteBean == null) ? remoteBean : remoteBean.getClass().getName()));
+        return remoteBean;
+    }
+
+    /**
+     * Test looking up a remote EJB located on a different server using the
+     * default InitialContext with the full corbaname (not including NameService).
+     *
+     * corbaname::localhost:<IIOPPort>#ejb/global/<App>/<Module>/<Bean>!<interface>
+     */
+    @Test
+    public void testDefaultContextLookupWithCorbaname() throws Exception {
+        // lookup the bean using default context with corbaname
+        String jndiName = CorbaName + "#" + TxAttrBeanJndi + "!" + TxAttrRemote.class.getName();
+        TxAttrRemote bean = lookupRemoteBean(getDefaultContext(), jndiName, TxAttrRemote.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works
+        boolean global = bean.txRequired();
+        assertTrue("Container did not begin global transaction for TX REQUIRED", global);
+    }
+
+    /**
+     * Test looking up a remote EJB located on a different server using the
+     * default InitialContext with the full corbaname (including NameService).
+     *
+     * corbaname::localhost:<IIOPPort>/NameService#ejb/global/<App>/<Module>/<Bean>!<interface>
+     */
+    @Test
+    public void testDefaultContextLookupWithCorbanameNameService() throws Exception {
+        // lookup the bean using default context with corbaname (including NameService)
+        String jndiName = CorbaNameNS + "#" + TxAttrBeanJndi + "!" + TxAttrRemote.class.getName();
+        TxAttrRemote bean = lookupRemoteBean(getDefaultContext(), jndiName, TxAttrRemote.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works
+        boolean global = bean.txRequired();
+        assertTrue("Container did not begin global transaction for TX REQUIRED", global);
+    }
+
+    /**
+     * Test looking up a remote EJB located on a different server using the
+     * default InitialContext with the corbaname, not including NameService or interface.
+     *
+     * corbaname::localhost:<IIOPPort>#ejb/global/<App>/<Module>/<Bean>
+     */
+    // @Test - TODO: enable or remove test once determined if this should be supported
+    public void testDefaultContextLookupWithCorbanameNoInterface() throws Exception {
+        // lookup the bean using default context with corbaname, minus interface
+        String jndiName = CorbaName + "#" + TxAttrBeanJndi;
+        TxAttrRemote bean = lookupRemoteBean(getDefaultContext(), jndiName, TxAttrRemote.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works
+        boolean global = bean.txRequired();
+        assertTrue("Container did not begin global transaction for TX REQUIRED", global);
+    }
+
+    /**
+     * Test looking up a remote EJB located on a different server using an InitialContext
+     * with java.naming.provider.url and the lookup name without corbaname prefix.
+     *
+     * java.naming.provider.url : corbaloc::127.0.0.1:<IIOPPort>
+     * ejb/global/<App>/<Module>/<Bean>!<interface>
+     */
+    // @Test - not supported
+    public void testProviderUrlContextLookup() throws Exception {
+        // lookup the bean using context with provider URL
+        String jndiName = TxAttrBeanJndi + "!" + TxAttrRemote.class.getName();
+        TxAttrRemote bean = lookupRemoteBean(getProviderContext(), jndiName, TxAttrRemote.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works
+        boolean global = bean.txRequired();
+        assertTrue("Container did not begin global transaction for TX REQUIRED", global);
+    }
+
+    /**
+     * Test looking up a remote EJB located on a different server using the
+     * context of the remote server NameService and the lookup name without corbaname prefix.
+     *
+     * remote NameService : corbaloc::127.0.0.1:<IIOPPort>
+     * ejb/global/<App>/<Module>/<Bean>!<interface>
+     */
+    @Test
+    public void testRemoteContextLookup() throws Exception {
+        // lookup the bean using context of remote NameService
+        String jndiName = TxAttrBeanJndi + "!" + TxAttrRemote.class.getName();
+        TxAttrRemote bean = lookupRemoteBean(getRemoteContext(), jndiName, TxAttrRemote.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works
+        boolean global = bean.txRequired();
+        assertTrue("Container did not begin global transaction for TX REQUIRED", global);
+    }
+
+    /**
+     * Test looking up a remote EJB located on a different server using the
+     * default InitialContext with the full corbaname (including NameService)
+     * and escaping the single period in the interface.
+     *
+     * An escape is required when the interface contains a single period, so also
+     * verify the lookup fails without the escape.
+     *
+     * corbaname::localhost:<IIOPPort>/NameService#ejb/global/<App>/<Module>/<Bean>!<interface>
+     */
+    @Test
+    public void testDefaultContextLookupWithEscape() throws Exception {
+        // lookup the bean using default context with corbaname, with escape for period (.)
+        String jndiName = CorbaNameNS + "#" + TestRemoteStatelessJndi + "!test%5c.TestRemoteInterface";
+        TestRemoteInterface bean = lookupRemoteBean(getDefaultContext(), jndiName, TestRemoteInterface.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works
+        assertEquals("Incorrect beanName returned", "TestRemoteStatelessBean", bean.getBeanName());
+
+        // Also confirm that the same lookup without an escape fails
+        jndiName = CorbaNameNS + "#" + TestRemoteStatelessJndi + "!test.TestRemoteInterface";
+        try {
+            bean = lookupRemoteBean(getDefaultContext(), jndiName, TestRemoteInterface.class);
+            fail("lookup did not fail : " + bean);
+        } catch (BAD_PARAM ex) {
+            logger.info("Excpected exception occurred : " + ex);
+        }
+    }
+
+    /**
+     * Test looking up a remote EJB located on a different server using the
+     * default InitialContext with the full corbaname (not including NameService)
+     * using he secure IIOP port.
+     *
+     * corbaname::localhost:<IIOPSecurePort>#ejb/global/<App>/<Module>/<Bean>!<interface>
+     */
+    // @Test - requires additional security configuration
+    public void testDefaultContextLookupWithSecurePort() throws Exception {
+        // lookup the bean using default context with corbaname on secure IIOP port
+        String jndiName = CorbaNameSecure + "#" + TxAttrBeanJndi + "!" + TxAttrRemote.class.getName();
+        TxAttrRemote bean = lookupRemoteBean(getDefaultContext(), jndiName, TxAttrRemote.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works
+        boolean global = bean.txRequired();
+        assertTrue("Container did not begin global transaction for TX REQUIRED", global);
+    }
+
+    /**
+     * Test looking up a remote EJBHome located on a different server using the
+     * default InitialContext with the full corbaname (not including NameService).
+     *
+     * corbaname::localhost:<IIOPPort>#ejb/global/<App>/<Module>/<Bean>!<interface>
+     */
+    @Test
+    public void testDefaultContextLookupWithEJBHome() throws Exception {
+        // lookup the bean using default context with corbaname of EJBHome
+        String jndiName = CorbaName + "#" + TxAttrCompBeanJndi + "!" + TxAttrEJBHome.class.getName();
+        TxAttrEJBHome home = lookupRemoteBean(getDefaultContext(), jndiName, TxAttrEJBHome.class);
+        assertNotNull("Remote home is null", home);
+
+        // Create an instance of the bean
+        TxAttrEJB bean = home.create();
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works
+        boolean global = bean.txRequired();
+        assertTrue("Container did not begin global transaction for TX REQUIRED", global);
+    }
+
+    /**
+     * Test that a remote reference to an EJB may be passed as a parameter to a remote
+     * EJB located on a different server.
+     */
+    @Test
+    public void testPassingRemoteInterfaceParameter() throws Exception {
+        // lookup the bean using default context with corbaname, with escape for period (.)
+        String jndiName = CorbaNameNS + "#" + TestRemoteStatelessJndi + "!test%5c.TestRemoteInterface";
+        TestRemoteInterface bean = lookupRemoteBean(getDefaultContext(), jndiName, TestRemoteInterface.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works; remote reference may be passed as parameter
+        assertTrue("Remote reference not passed as parameter correctly", bean.verifyRemoteBean(bean));
+    }
+
+    /**
+     * Test that method calls to a remote Singleton session bean on a different server
+     * are routed to the same bean instance (state is preserved).
+     */
+    @Test
+    public void testSingletonBeanState() throws Exception {
+        // lookup the bean using default context with corbaname, with escape for period (.)
+        String jndiName = CorbaNameNS + "#" + TestRemoteSingletonJndi + "!test%5c.TestRemoteInterface";
+        TestRemoteInterface bean = lookupRemoteBean(getDefaultContext(), jndiName, TestRemoteInterface.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works; remote state is preserved
+        assertEquals("Remote state is not correct", 8, bean.increment(8));
+        assertEquals("Remote state is not correct", (8 + 27), bean.increment(27));
+    }
+
+    /**
+     * Test that method calls to a remote Stateful session bean on a different server
+     * are routed to the same bean instance (state is preserved).
+     */
+    @Test
+    public void testStatefulBeanState() throws Exception {
+        // lookup the bean using default context with corbaname, with escape for period (.)
+        String jndiName = CorbaNameNS + "#" + TestRemoteStatefulJndi + "!test%5c.TestRemoteInterface";
+        TestRemoteInterface bean = lookupRemoteBean(getDefaultContext(), jndiName, TestRemoteInterface.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works; remote state is preserved
+        assertEquals("Remote state is not correct", 42, bean.increment(42));
+        assertEquals("Remote state is not correct", (42 + 27), bean.increment(27));
+    }
+
+    /**
+     * Test that method calls to a remote Stateless session bean on a different server
+     * are routed to any bean instance (state is not preserved).
+     */
+    @Test
+    public void testStatelessBeanState() throws Exception {
+        // lookup the bean using default context with corbaname, with escape for period (.)
+        String jndiName = CorbaNameNS + "#" + TestRemoteStatelessJndi + "!test%5c.TestRemoteInterface";
+        TestRemoteInterface bean = lookupRemoteBean(getDefaultContext(), jndiName, TestRemoteInterface.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works; remote state is not preserved
+        assertEquals("Remote state is not correct", 14, bean.increment(14));
+        assertEquals("Remote state is not correct", 35, bean.increment(35));
+    }
+
+    /**
+     * Test that asynchronous method calls to a remote Singleton session bean on a different
+     * server are routed properly and the result may be retrieved.
+     */
+    @Test
+    public void testSingletonAsyncMethod() throws Exception {
+        // lookup the bean using default context with corbaname, with escape for period (.)
+        String jndiName = CorbaNameNS + "#" + TestRemoteSingletonJndi + "!test%5c.TestRemoteInterface";
+        TestRemoteInterface bean = lookupRemoteBean(getDefaultContext(), jndiName, TestRemoteInterface.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works; async result may be retrieved
+        Future<String> nameFuture = bean.asynchMethodReturn();
+        assertEquals("Asynchronus method value incorrect", TestRemoteSingleton, nameFuture.get(60, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Test that asynchronous method calls to a remote Stateful session bean on a different
+     * server are routed properly and the result may be retrieved.
+     */
+    @Test
+    public void testStatefulAsyncMethod() throws Exception {
+        // lookup the bean using default context with corbaname, with escape for period (.)
+        String jndiName = CorbaNameNS + "#" + TestRemoteStatefulJndi + "!test%5c.TestRemoteInterface";
+        TestRemoteInterface bean = lookupRemoteBean(getDefaultContext(), jndiName, TestRemoteInterface.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works; async result may be retrieved
+        Future<String> nameFuture = bean.asynchMethodReturn();
+        assertEquals("Asynchronus method value incorrect", TestRemoteStateful, nameFuture.get(60, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Test that asynchronous method calls to a remote Stateless session bean on a different
+     * server are routed properly and the result may be retrieved.
+     */
+    @Test
+    public void testStatelessAsyncMethod() throws Exception {
+        // lookup the bean using default context with corbaname, with escape for period (.)
+        String jndiName = CorbaNameNS + "#" + TestRemoteStatelessJndi + "!test%5c.TestRemoteInterface";
+        TestRemoteInterface bean = lookupRemoteBean(getDefaultContext(), jndiName, TestRemoteInterface.class);
+        assertNotNull("Remote bean is null", bean);
+
+        // verify the bean works; async result may be retrieved
+        Future<String> nameFuture = bean.asynchMethodReturn();
+        assertEquals("Asynchronus method value incorrect", TestRemoteStateless, nameFuture.get(60, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Test the Required transaction attribute for a remote EJB on a different server
+     * when a transaction does not exist on the calling thread.
+     *
+     * While the thread is currently not associated with a transaction context, call a method
+     * that has a transaction attribute of REQUIRED and verify the container began a global
+     * transaction. Verify container completed global transaction prior to returning to caller
+     * of method.
+     */
+    @Test
+    public void testRequiredAttrib() throws Exception {
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        boolean global = bean.txRequired();
+        assertTrue("Container did not begin global transaction for TX REQUIRED", global);
+        assertFalse("Container did not complete global transaction for TX REQUIRED", FATTransactionHelper.isTransactionGlobal());
+    }
+
+    /**
+     * Test the Required transaction attribute for a remote EJB on a different server
+     * when a transaction does exist on the calling thread.
+     *
+     * While thread is currently associated with a transaction context, call a remote method
+     * that has a transaction attribute of REQUIRED and verify the container throws a
+     * EJBTransactionRequiredException indicating the global transaction has not been
+     * propagated to the remote server.
+     */
+    @Test
+    @ExpectedFFDC({ "com.ibm.websphere.csi.CSITransactionRequiredException" })
+    public void testRequiredAttribInGlobalTrans() throws Exception {
+        byte[] tid = null;
+        UserTransaction userTran = null;
+
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        try {
+            // Begin a global transaction
+            userTran = FATHelper.lookupUserTransaction();
+            userTran.begin();
+            tid = FATTransactionHelper.getTransactionId();
+            logger.info("user global transaction was started");
+
+            // call TX REQUIRED method
+            try {
+                boolean global = bean.txRequired(tid);
+                fail("Expected exception did not occur; Container used caller's global transaction for TX REQUIRED : " + global);
+            } catch (EJBTransactionRequiredException ex) {
+                logger.info("Expected exception occurred calling REQUIRED method : " + ex);
+            }
+
+            // Verify global tran still active.
+            assertTrue("container did not complete caller's transaction for TX REQUIRED", FATTransactionHelper.isSameTransactionId(tid));
+            userTran.commit();
+            tid = null;
+            logger.info("user global transaction committed");
+        } finally {
+            if (tid != null || (userTran != null && userTran.getStatus() != STATUS_NO_TRANSACTION && userTran.getStatus() != STATUS_COMMITTED)) {
+                userTran.rollback();
+            }
+        }
+    }
+
+    /**
+     * Test the RequiresNew transaction attribute for a remote EJB on a different server
+     * when a transaction does exist on the calling thread.
+     *
+     * While thread is currently associated with a transaction context, call a method that
+     * has a transaction attribute of REQUIRES_NEW and verify the container begins a new global
+     * transaction. Verify container completes global transaction prior to returning to caller
+     * of method. Verify caller's global transaction is still active when container returns to
+     * caller.
+     */
+    @Test
+    public void testRequiresNewAttribIfClientTranExists() throws Exception {
+        byte[] tid = null;
+        UserTransaction userTran = null;
+
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        try {
+            // Begin a global transaction
+            userTran = FATHelper.lookupUserTransaction();
+            userTran.begin();
+            tid = FATTransactionHelper.getTransactionId();
+            logger.info("user global transaction was started");
+
+            // call TX REQUIRES NEW method
+            boolean global = bean.txRequiresNew(tid);
+            assertTrue("Container began new global transaction for TX REQUIRES NEW", global);
+
+            // Verify global tran still active.
+            assertTrue("container did not complete caller's transaction for TX REQUIRES NEW", FATTransactionHelper.isSameTransactionId(tid));
+            userTran.commit();
+            tid = null;
+            logger.info("user global transaction committed");
+        } finally {
+            if (tid != null || (userTran != null && userTran.getStatus() != STATUS_NO_TRANSACTION && userTran.getStatus() != STATUS_COMMITTED)) {
+                userTran.rollback();
+            }
+        }
+    }
+
+    /**
+     * Test the RequiresNew transaction attribute for a remote EJB on a different server
+     * when a transaction does not exist on the calling thread.
+     *
+     * While thread is currently not associated with a transaction context, call a method that
+     * has a transaction attribute of REQUIRES NEW and verify the container began a global
+     * transaction. Verify container completed global transaction prior to returning to caller
+     * of method.
+     */
+    @Test
+    public void testRequiresNewAttribOnGlobalInt() throws Exception {
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        boolean global = bean.txRequiresNew();
+        assertTrue("Container did not begin global transaction for TX REQUIRES NEW", global);
+        assertFalse("container did not complete global transaction for TX REQUIRES NEW", FATTransactionHelper.isTransactionGlobal());
+    }
+
+    /**
+     * Test the Mandatory transaction attribute for a remote EJB on a different server
+     * when a transaction does not exist on the calling thread.
+     *
+     * While thread is currently not associated with a transaction context, call a method that
+     * has a transaction attribute of Mandatory and verify the container throws a
+     * javax.ejb.EJBTransactionRequiredException.
+     */
+    @Test
+    @ExpectedFFDC({ "com.ibm.websphere.csi.CSITransactionRequiredException" })
+    public void testMandatoryAttribThrowsExcp() throws Exception {
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        try {
+            bean.txMandatory();
+            fail("The container did NOT throw the expected EJBTransactionRequiredException for TX Mandatory");
+        } catch (EJBTransactionRequiredException ex) {
+            logger.info("Container threw expected EJBTransactionRequiredException for TX Mandatory");
+        }
+    }
+
+    /**
+     * Test the Mandatory transaction attribute for a remote EJB on a different server
+     * when a transaction does exist on the calling thread.
+     *
+     * While thread is currently associated with a transaction context, call a method that
+     * has a transaction attribute of Mandatory and verify the container throws a
+     * javax.ejb.EJBTransactionRequiredException.
+     */
+    @Test
+    @ExpectedFFDC({ "com.ibm.websphere.csi.CSITransactionRequiredException" })
+    public void testMandatoryAttribInGlobalTrans() throws Exception {
+        byte[] tid = null;
+        UserTransaction userTran = null;
+
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        try {
+            // Begin a global transaction
+            userTran = FATHelper.lookupUserTransaction();
+            userTran.begin();
+            tid = FATTransactionHelper.getTransactionId();
+            logger.info("user global transaction was started");
+
+            // call TX Mandatory method
+            try {
+                boolean global = bean.txMandatory(tid);
+                fail("Expected exception did not occur; Container used caller's global transaction for TX Mandatory : " + global);
+            } catch (EJBTransactionRequiredException ex) {
+                logger.info("Expected exception occurred calling MANDATORY method : " + ex);
+            }
+
+            // Verify global tran still active.
+            assertTrue("Container completed caller's transaction for TX Mandatory", FATTransactionHelper.isSameTransactionId(tid));
+            userTran.commit();
+            tid = null;
+            logger.info("user global transaction committed");
+        } finally {
+            if (tid != null || (userTran != null && userTran.getStatus() != STATUS_NO_TRANSACTION && userTran.getStatus() != STATUS_COMMITTED)) {
+                userTran.rollback();
+            }
+        }
+    }
+
+    /**
+     * Test the Never transaction attribute for a remote EJB on a different server
+     * when a transaction does not exist on the calling thread.
+     *
+     * While thread is currently not associated with a transaction context, call a method that
+     * has a transaction attribute of Never and verify the container begins a local transaction.
+     */
+    @Test
+    public void testNever() throws Exception {
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        boolean local = bean.txNever();
+        assertTrue("container did not begin a local transaction for TX Never", local);
+    }
+
+    /**
+     * Test the Never transaction attribute for a remote EJB on a different server
+     * when a transaction does exist on the calling thread.
+     *
+     * Used to verify when a method with a NEVER transaction attribute is called while
+     * the thread is currently associated with a global transaction the container throws
+     * a javax.ejb.EJBException.
+     */
+    @Test
+    @ExpectedFFDC({ "com.ibm.websphere.csi.CSIException" })
+    public void testNeverException() throws Exception {
+        byte[] tid = null;
+        UserTransaction userTran = null;
+
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        try {
+            // Begin a global transaction
+            userTran = FATHelper.lookupUserTransaction();
+            userTran.begin();
+            tid = FATTransactionHelper.getTransactionId();
+            logger.info("user global transaction was started");
+
+            // call TX NEVER method
+            try {
+                bean.txNever(tid);
+                fail("Container did not throw a javax.ejb.EJBException as expected for TX Never when transaction already existed.");
+            } catch (EJBException ex) {
+                logger.info("container threw expected EJBException for TX Never when transaction already existed.");
+            }
+
+            // Verify global tran still active.
+            assertTrue("container did not complete caller's transaction for TX NEVER", FATTransactionHelper.isSameTransactionId(tid));
+            userTran.commit();
+            tid = null;
+            logger.info("user global transaction committed");
+        } finally {
+            if (tid != null || (userTran != null && userTran.getStatus() != STATUS_NO_TRANSACTION && userTran.getStatus() != STATUS_COMMITTED)) {
+                userTran.rollback();
+            }
+        }
+    }
+
+    /**
+     * Test the NotSupported transaction attribute for a remote EJB on a different server
+     * when a transaction does not exist on the calling thread.
+     *
+     * While thread is currently not associated with a transaction context, call a method that
+     * has a transaction attribute of NotSupported and verify the container began a local
+     * transaction.
+     */
+    @Test
+    public void testNotSupported() throws Exception {
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        boolean local = bean.txNotSupported();
+        assertTrue("container did not begin a local transaction for TX NotSupported", local);
+    }
+
+    /**
+     * Test the NotSupported transaction attribute for a remote EJB on a different server
+     * when a transaction does exist on the calling thread.
+     *
+     * While thread is currently associated with a transaction context, call a method
+     * that has a transaction attribute of NotSupported and verify the container began a
+     * local transaction.
+     */
+    @Test
+    public void testNotSupportedGlobalTransExists() throws Exception {
+        byte[] tid = null;
+        UserTransaction userTran = null;
+
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        try {
+            // Begin a global transaction
+            userTran = FATHelper.lookupUserTransaction();
+            userTran.begin();
+            tid = FATTransactionHelper.getTransactionId();
+            logger.info("user global transaction was started");
+
+            boolean local = bean.txNotSupported();
+            assertTrue("container did not begin a local transaction for TX NotSupported", local);
+
+            // Verify global tran still active.
+            assertTrue("container did not complete caller's transaction for TX NotSupported", FATTransactionHelper.isSameTransactionId(tid));
+            userTran.commit();
+            tid = null;
+            logger.info("user global transaction committed");
+        } finally {
+            if (tid != null || (userTran != null && userTran.getStatus() != STATUS_NO_TRANSACTION && userTran.getStatus() != STATUS_COMMITTED)) {
+                userTran.rollback();
+            }
+        }
+    }
+
+    /**
+     * Test the Supports transaction attribute for a remote EJB on a different server
+     * when a transaction does not exist on the calling thread.
+     *
+     * While thread is currently not associated with a transaction context, call a method that
+     * has a transaction attribute of Supports and verify the container began a local transaction.
+     */
+    @Test
+    public void testSupportsAttrib() throws Exception {
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        boolean local = bean.txSupports();
+        assertTrue("container did not begin a local transaction for TX Supports", local);
+    }
+
+    /**
+     * Test the Supports transaction attribute for a remote EJB on a different server
+     * when a transaction does exist on the calling thread.
+     *
+     * While thread is currently associated with a transaction context, call a method that
+     * has a transaction attribute of Supports and verify the container executes in caller's
+     * global transaction. Verify container does not complete the caller's global
+     * transaction prior to returning to caller of method.
+     */
+    @Test
+    @ExpectedFFDC({ "com.ibm.websphere.csi.CSITransactionRequiredException" })
+    public void testSupportsAttribOnGlobalTrans() throws Exception {
+        byte[] tid = null;
+        UserTransaction userTran = null;
+
+        TxAttrRemote bean = getTxAttrBean();
+        assertNotNull("Remote bean is null", bean);
+
+        try {
+            // Begin a global transaction
+            userTran = FATHelper.lookupUserTransaction();
+            userTran.begin();
+            tid = FATTransactionHelper.getTransactionId();
+            logger.info("user global transaction was started");
+
+            // call TX Supports method
+            try {
+                boolean global = bean.txSupports(tid);
+                fail("Expected exception did not occur; Container used caller's global transaction for TX Supports : " + global);
+            } catch (EJBTransactionRequiredException ex) {
+                logger.info("Expected exception occurred calling SUPPORTS method : " + ex);
+            }
+
+            // Verify global tran still active.
+            assertTrue("container did not complete caller's transaction for TX Supports", FATTransactionHelper.isSameTransactionId(tid));
+            userTran.commit();
+            tid = null;
+            logger.info("user global transaction committed");
+        } finally {
+            if (tid != null || (userTran != null && userTran.getStatus() != STATUS_NO_TRANSACTION && userTran.getStatus() != STATUS_COMMITTED)) {
+                userTran.rollback();
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerApp.ear/resources/META-INF/permissions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission> 
+</permissions>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerEJB.jar/src/com/ibm/ws/ejbcontainer/remote/server/ejb/TestRemoteSingletonBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerEJB.jar/src/com/ibm/ws/ejbcontainer/remote/server/ejb/TestRemoteSingletonBean.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.server.ejb;
+
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+import javax.ejb.AsyncResult;
+import javax.ejb.Asynchronous;
+import javax.ejb.Remote;
+import javax.ejb.Singleton;
+
+import test.TestRemoteInterface;
+
+/**
+ * Singleton bean implementation for testing lookup of remote beans, remote asynchronous methods
+ * and remote bean state.
+ **/
+@Singleton
+@Remote(TestRemoteInterface.class)
+public class TestRemoteSingletonBean {
+    private static final Logger logger = Logger.getLogger(TestRemoteSingletonBean.class.getName());
+
+    private final String beanName = TestRemoteSingletonBean.class.getSimpleName();
+
+    private int state = 0;
+
+    /**
+     * Simple method that returns the bean name
+     */
+    public String getBeanName() {
+        return beanName;
+    }
+
+    /**
+     * Increments bean state, returning new value.
+     */
+    public int increment(int value) {
+        state += value;
+        return state;
+    }
+
+    /**
+     * Verifies the passed remote bean has the same bean name.
+     */
+    public boolean verifyRemoteBean(TestRemoteInterface remoteBean) {
+        String remoteName = (remoteBean == null) ? null : remoteBean.getBeanName();
+        if (beanName == null || !beanName.equals(remoteName)) {
+            logger.info("verifyRemoteBean: " + beanName + " != " + remoteName);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Asynchronous methods that returns the bean name.
+     */
+    @Asynchronous
+    public Future<String> asynchMethodReturn() {
+        return new AsyncResult<String>(getBeanName());
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerEJB.jar/src/com/ibm/ws/ejbcontainer/remote/server/ejb/TestRemoteStatefulBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerEJB.jar/src/com/ibm/ws/ejbcontainer/remote/server/ejb/TestRemoteStatefulBean.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.server.ejb;
+
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+import javax.ejb.AsyncResult;
+import javax.ejb.Asynchronous;
+import javax.ejb.Remote;
+import javax.ejb.Stateful;
+
+import test.TestRemoteInterface;
+
+/**
+ * Stateful bean implementation for testing lookup of remote beans, remote asynchronous methods
+ * and remote bean state.
+ **/
+@Stateful
+@Remote(TestRemoteInterface.class)
+public class TestRemoteStatefulBean {
+    private static final Logger logger = Logger.getLogger(TestRemoteStatefulBean.class.getName());
+
+    private final String beanName = TestRemoteStatefulBean.class.getSimpleName();
+
+    private int state = 0;
+
+    /**
+     * Simple method that returns the bean name
+     */
+    public String getBeanName() {
+        return beanName;
+    }
+
+    /**
+     * Increments bean state, returning new value.
+     */
+    public int increment(int value) {
+        state += value;
+        return state;
+    }
+
+    /**
+     * Verifies the passed remote bean has the same bean name.
+     */
+    public boolean verifyRemoteBean(TestRemoteInterface remoteBean) {
+        String remoteName = (remoteBean == null) ? null : remoteBean.getBeanName();
+        if (beanName == null || !beanName.equals(remoteName)) {
+            logger.info("verifyRemoteBean: " + beanName + " != " + remoteName);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Asynchronous methods that returns the bean name.
+     */
+    @Asynchronous
+    public Future<String> asynchMethodReturn() {
+        return new AsyncResult<String>(getBeanName());
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerEJB.jar/src/com/ibm/ws/ejbcontainer/remote/server/ejb/TestRemoteStatelessBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerEJB.jar/src/com/ibm/ws/ejbcontainer/remote/server/ejb/TestRemoteStatelessBean.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.server.ejb;
+
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+import javax.ejb.AsyncResult;
+import javax.ejb.Asynchronous;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+import test.TestRemoteInterface;
+
+/**
+ * Stateless bean implementation for testing lookup of remote beans, remote asynchronous methods
+ * and remote bean state.
+ **/
+@Stateless
+@Remote(TestRemoteInterface.class)
+public class TestRemoteStatelessBean {
+    private static final Logger logger = Logger.getLogger(TestRemoteStatelessBean.class.getName());
+
+    private final String beanName = TestRemoteStatelessBean.class.getSimpleName();
+
+    /**
+     * Simple method that returns the bean name
+     */
+    public String getBeanName() {
+        return beanName;
+    }
+
+    /**
+     * Increments bean state, returning new value.
+     */
+    public int increment(int value) {
+        return value;
+    }
+
+    /**
+     * Verifies the passed remote bean has the same bean name.
+     */
+    public boolean verifyRemoteBean(TestRemoteInterface remoteBean) {
+        String remoteName = (remoteBean == null) ? null : remoteBean.getBeanName();
+        if (beanName == null || !beanName.equals(remoteName)) {
+            logger.info("verifyRemoteBean: " + beanName + " != " + remoteName);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Asynchronous methods that returns the bean name.
+     */
+    @Asynchronous
+    public Future<String> asynchMethodReturn() {
+        return new AsyncResult<String>(getBeanName());
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerEJB.jar/src/com/ibm/ws/ejbcontainer/remote/server/ejb/TxAttrBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerEJB.jar/src/com/ibm/ws/ejbcontainer/remote/server/ejb/TxAttrBean.java
@@ -1,0 +1,237 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.server.ejb;
+
+import static javax.ejb.TransactionAttributeType.MANDATORY;
+import static javax.ejb.TransactionAttributeType.NEVER;
+import static javax.ejb.TransactionAttributeType.NOT_SUPPORTED;
+import static javax.ejb.TransactionAttributeType.REQUIRED;
+import static javax.ejb.TransactionAttributeType.REQUIRES_NEW;
+import static javax.ejb.TransactionAttributeType.SUPPORTS;
+import static javax.ejb.TransactionManagementType.CONTAINER;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionManagement;
+
+import com.ibm.websphere.ejbcontainer.test.tools.FATTransactionHelper;
+import com.ibm.ws.ejbcontainer.remote.server.shared.TxAttrRemote;
+
+/**
+ * Stateless bean implementation for testing container managed transaction attributes.
+ **/
+@Stateless
+@Remote(TxAttrRemote.class)
+@TransactionManagement(CONTAINER)
+public class TxAttrBean {
+    /**
+     * Used to verify that when a method with a REQUIRED transaction attribute
+     * is called while the calling thread is not currently associated with a
+     * transaction context causes the container to begin a global transaction.
+     *
+     * @return boolean true if method is dispatched in a global transaction.
+     *         boolean false if method is dispatched in a local transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(REQUIRED)
+    public boolean txRequired() {
+        return FATTransactionHelper.isTransactionGlobal();
+    }
+
+    /**
+     * Used to verify that when a method with a REQUIRED transaction attribute
+     * is called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the caller's
+     * global transaction context (e.g container does not begin a new
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in the same transaction
+     *         context with the same transaction ID as passed by tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(REQUIRED)
+    public boolean txRequired(byte[] tid) {
+        return FATTransactionHelper.isSameTransactionId(tid);
+    }
+
+    /**
+     * Used to verify when a method with a MANDATORY transaction attribute is
+     * called while thread is currently associated with a global transaction
+     * causes the container to dispatch the method in the callers global
+     * transaction context (e.g container does not begin a new transaction). The
+     * caller must begin a global transaction prior to calling this method.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(MANDATORY)
+    public boolean txMandatory(byte[] tid) {
+        return FATTransactionHelper.isSameTransactionId(tid);
+    }
+
+    /**
+     * Used to verify when a method with a MANDATORY transaction attribute is
+     * called while calling thread is not currently associated with a global
+     * transaction causes the container to throw a
+     * javax.ejb.EJBTransactionRequiredException
+     *
+     */
+    @TransactionAttribute(MANDATORY)
+    public void txMandatory() {
+    }
+
+    /**
+     * Used to verify when a method with a REQUIRES_NEW transaction attribute is
+     * called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the a new
+     * global transaction context (e.g container does begin a new global
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in a global tranaction with
+     *         a global transaction ID that does not match the tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(REQUIRES_NEW)
+    public boolean txRequiresNew(byte[] tid) {
+        byte[] myTid = FATTransactionHelper.getTransactionId();
+        if (myTid == null) {
+            return false;
+        }
+
+        return (FATTransactionHelper.isSameTransactionId(tid) == false);
+    }
+
+    /**
+     * Used to verify that when a method with a REQUIRES NEW transaction
+     * attribute is called while the calling thread is not currently associated
+     * with a transaction context causes the container to begin a global
+     * transaction.
+     *
+     * @return boolean true if method is dispatched in a global transaction.
+     *         boolean false if method is dispatched in a local transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(REQUIRES_NEW)
+    public boolean txRequiresNew() {
+        return FATTransactionHelper.isTransactionGlobal();
+    }
+
+    /**
+     * Used to verify that when a method with a NEVER transaction attribute is
+     * called causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(NEVER)
+    public boolean txNever() {
+        return FATTransactionHelper.isTransactionLocal();
+    }
+
+    /**
+     * Used to verify when a method with a NEVER transaction attribute is called
+     * while the thread is currently associated with a global transaction the
+     * container throws a javax.ejb.EJBException. The caller must begin a global
+     * transaction prior to calling this method.
+     *
+     */
+    @TransactionAttribute(NEVER)
+    public void txNever(byte[] tid) {
+    }
+
+    /**
+     * Used to verify that when a method with a NOT_SUPPORTED transaction
+     * attribute is called causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(NOT_SUPPORTED)
+    public boolean txNotSupported() {
+        return FATTransactionHelper.isTransactionLocal();
+    }
+
+    /**
+     * Used to verify that when a method with a SUPPORTS transaction attribute
+     * is called while the calling thread is not associated with a global
+     * transaction causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(SUPPORTS)
+    public boolean txSupports() {
+        return FATTransactionHelper.isTransactionLocal();
+    }
+
+    /**
+     * Used to verify that when a method with a SUPPORTS transaction attribute
+     * is called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the caller's
+     * global transaction context (e.g container does not begin a new
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in the same transaction
+     *         context with the same transaction ID as passed by tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(SUPPORTS)
+    public boolean txSupports(byte[] tid) {
+        return FATTransactionHelper.isSameTransactionId(tid);
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerEJB.jar/src/com/ibm/ws/ejbcontainer/remote/server/ejb/TxAttrCompBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerEJB.jar/src/com/ibm/ws/ejbcontainer/remote/server/ejb/TxAttrCompBean.java
@@ -1,0 +1,266 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.server.ejb;
+
+import static javax.ejb.TransactionAttributeType.MANDATORY;
+import static javax.ejb.TransactionAttributeType.NEVER;
+import static javax.ejb.TransactionAttributeType.NOT_SUPPORTED;
+import static javax.ejb.TransactionAttributeType.REQUIRED;
+import static javax.ejb.TransactionAttributeType.REQUIRES_NEW;
+import static javax.ejb.TransactionAttributeType.SUPPORTS;
+import static javax.ejb.TransactionManagementType.CONTAINER;
+
+import javax.ejb.CreateException;
+import javax.ejb.RemoteHome;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionManagement;
+
+import com.ibm.websphere.ejbcontainer.test.tools.FATTransactionHelper;
+import com.ibm.ws.ejbcontainer.remote.server.shared.TxAttrEJBHome;
+
+/**
+ * Stateless 2.x bean implementation for testing container managed transaction attributes.
+ **/
+@Stateless
+@RemoteHome(TxAttrEJBHome.class)
+@TransactionManagement(CONTAINER)
+public class TxAttrCompBean implements SessionBean {
+    private static final long serialVersionUID = 2338430782382980415L;
+
+    /**
+     * Used to verify that when a method with a REQUIRED transaction attribute
+     * is called while the calling thread is not currently associated with a
+     * transaction context causes the container to begin a global transaction.
+     *
+     * @return boolean true if method is dispatched in a global transaction.
+     *         boolean false if method is dispatched in a local transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(REQUIRED)
+    public boolean txRequired() {
+        return FATTransactionHelper.isTransactionGlobal();
+    }
+
+    /**
+     * Used to verify that when a method with a REQUIRED transaction attribute
+     * is called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the caller's
+     * global transaction context (e.g container does not begin a new
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in the same transaction
+     *         context with the same transaction ID as passed by tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(REQUIRED)
+    public boolean txRequired(byte[] tid) {
+        return FATTransactionHelper.isSameTransactionId(tid);
+    }
+
+    /**
+     * Used to verify when a method with a MANDATORY transaction attribute is
+     * called while thread is currently associated with a global transaction
+     * causes the container to dispatch the method in the callers global
+     * transaction context (e.g container does not begin a new transaction). The
+     * caller must begin a global transaction prior to calling this method.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(MANDATORY)
+    public boolean txMandatory(byte[] tid) {
+        return FATTransactionHelper.isSameTransactionId(tid);
+    }
+
+    /**
+     * Used to verify when a method with a MANDATORY transaction attribute is
+     * called while calling thread is not currently associated with a global
+     * transaction causes the container to throw a: -
+     * javax.ejb.EJBTransactionRequiredException if using the EJB3.0
+     * implementation; - javax.ejb.TransactionRequiredLocalExeption if using 2.1
+     * local client - javax.transaction.TransactionRequiredException if using
+     * a2.1 remote client
+     *
+     */
+    @TransactionAttribute(MANDATORY)
+    public void txMandatory() {
+    }
+
+    /**
+     * Used to verify when a method with a REQUIRES_NEW transaction attribute is
+     * called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the a new
+     * global transaction context (e.g container does begin a new global
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in a global tranaction with
+     *         a global transaction ID that does not match the tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(REQUIRES_NEW)
+    public boolean txRequiresNew(byte[] tid) {
+        byte[] myTid = FATTransactionHelper.getTransactionId();
+        if (myTid == null) {
+            return false;
+        }
+
+        return (FATTransactionHelper.isSameTransactionId(tid) == false);
+    }
+
+    /**
+     * Used to verify that when a method with a REQUIRES NEW transaction
+     * attribute is called while the calling thread is not currently associated
+     * with a transaction context causes the container to begin a global
+     * transaction.
+     *
+     * @return boolean true if method is dispatched in a global transaction.
+     *         boolean false if method is dispatched in a local transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(REQUIRES_NEW)
+    public boolean txRequiresNew() {
+        return FATTransactionHelper.isTransactionGlobal();
+    }
+
+    /**
+     * Used to verify that when a method with a NEVER transaction attribute is
+     * called causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(NEVER)
+    public boolean txNever() {
+        return FATTransactionHelper.isTransactionLocal();
+    }
+
+    /**
+     * Used to verify when a method with a NEVER transaction attribute is called
+     * while the thread is currently associated with a global transaction the
+     * container throws a: - javax.ejb.EJBException if using an EJB3.0
+     * implementation - java.rmi.RemoteException if using a 2.1 remote client -
+     * javax.ejb.EJBException if using a 2.1 local client The caller must begin
+     * a global transaction prior to calling this method.
+     *
+     */
+    @TransactionAttribute(NEVER)
+    public void txNever(byte[] tid) {
+    }
+
+    /**
+     * Used to verify that when a method with a NOT_SUPPORTED transaction
+     * attribute is called causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(NOT_SUPPORTED)
+    public boolean txNotSupported() {
+        return FATTransactionHelper.isTransactionLocal();
+    }
+
+    /**
+     * Used to verify that when a method with a SUPPORTS transaction attribute
+     * is called while the calling thread is not associated with a global
+     * transaction causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(SUPPORTS)
+    public boolean txSupports() {
+        return FATTransactionHelper.isTransactionLocal();
+    }
+
+    /**
+     * Used to verify that when a method with a SUPPORTS transaction attribute
+     * is called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the caller's
+     * global transaction context (e.g container does not begin a new
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in the same transaction
+     *         context with the same transaction ID as passed by tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    @TransactionAttribute(SUPPORTS)
+    public boolean txSupports(byte[] tid) {
+        return FATTransactionHelper.isSameTransactionId(tid);
+    }
+
+    public void ejbCreate() throws CreateException {
+    }
+
+    @Override
+    public void ejbRemove() {
+    }
+
+    @Override
+    public void ejbActivate() {
+    }
+
+    @Override
+    public void ejbPassivate() {
+    }
+
+    @Override
+    public void setSessionContext(SessionContext sc) {
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerShared.jar/src/com/ibm/ws/ejbcontainer/remote/server/shared/TxAttrEJB.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerShared.jar/src/com/ibm/ws/ejbcontainer/remote/server/shared/TxAttrEJB.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2007, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.server.shared;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBObject;
+
+/**
+ * Remote component interface for Container Managed Transaction Session beans.
+ **/
+public interface TxAttrEJB extends EJBObject {
+    /**
+     * Used to verify that when a method with a REQUIRED transaction attribute
+     * is called while the calling thread is not currently associated with a
+     * transaction context causes the container to begin a global transaction.
+     *
+     * @return boolean true if method is dispatched in a global transaction.
+     *         boolean false if method is dispatched in a local transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txRequired() throws RemoteException;
+
+    /**
+     * Used to verify that when a method with a REQUIRED transaction attribute
+     * is called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the caller's
+     * global transaction context (e.g container does not begin a new
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in the same transaction
+     *         context with the same transaction ID as passed by tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txRequired(byte[] tid) throws RemoteException;
+
+    /**
+     * Used to verify when a method with a REQUIRES_NEW transaction attribute is
+     * called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the a new
+     * global transaction context (e.g container does begin a new global
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in a global tranaction with
+     *         a global transaction ID the does not match the tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txRequiresNew(byte[] tid) throws RemoteException;
+
+    /**
+     * Used to verify that when a method with a REQUIRES NEW transaction
+     * attribute is called while the calling thread is not currently associated
+     * with a transaction context causes the container to begin a global
+     * transaction.
+     *
+     * @return boolean true if method is dispatched in a global transaction.
+     *         boolean false if method is dispatched in a local transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txRequiresNew() throws RemoteException;
+
+    /**
+     * Used to verify when a method with a MANDATORY transaction attribute is
+     * called while thread is currently associated with a global transaction
+     * causes the container to dispatch the method in the callers global
+     * transaction context (e.g container does not begin a new transaction). The
+     * caller must begin a global transaction prior to calling this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in the same transaction
+     *         context with the same transaction ID as passed by tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+
+    public boolean txMandatory(byte[] tid) throws RemoteException;
+
+    /**
+     * Used to verify when a method with a MANDATORY transaction attribute is
+     * called while calling thread is not currently associated with a global
+     * transaction causes the container to throw a
+     * javax.ejb.EJBTransactionRequiredException
+     */
+    public void txMandatory() throws RemoteException;
+
+    /**
+     * Used to verify that when a method with a NEVER transaction attribute is
+     * called causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txNever() throws RemoteException;
+
+    /**
+     * Used to verify when a method with a NEVER transaction attribute is called
+     * while the thread is currently associated with a global transaction the
+     * container throws a javax.ejb.EJBException. The caller must begin a global
+     * transaction prior to calling this method.
+     *
+     */
+    public void txNever(byte[] tid) throws RemoteException;
+
+    /**
+     * Used to verify that when a method with a NOT_SUPPORTED transaction
+     * attribute is called causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txNotSupported() throws RemoteException;
+
+    /**
+     * Used to verify that when a method with a SUPPORTS transaction attribute
+     * is called while the calling thread is not associated with a global
+     * transaction causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txSupports() throws RemoteException;
+
+    /**
+     * Used to verify that when a method with a SUPPORTS transaction attribute
+     * is called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the caller's
+     * global transaction context (e.g container does not begin a new
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in the same transaction
+     *         context with the same transaction ID as passed by tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txSupports(byte[] tid) throws RemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerShared.jar/src/com/ibm/ws/ejbcontainer/remote/server/shared/TxAttrEJBHome.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerShared.jar/src/com/ibm/ws/ejbcontainer/remote/server/shared/TxAttrEJBHome.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2007, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.server.shared;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+
+/**
+ * Remote Home interface for Container Managed Transaction Session beans.
+ **/
+public interface TxAttrEJBHome extends EJBHome {
+    /**
+     * Default create method with no parameters.
+     * <p>
+     *
+     * @return TxAttrEJB The StatelessBean EJB object.
+     * @exception javax.ejb.CreateException
+     *                StatelessBean EJB object was not created.
+     *                java.rmi.RemoteException - remote exception occurred.
+     */
+    public TxAttrEJB create() throws CreateException, RemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerShared.jar/src/com/ibm/ws/ejbcontainer/remote/server/shared/TxAttrRemote.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerShared.jar/src/com/ibm/ws/ejbcontainer/remote/server/shared/TxAttrRemote.java
@@ -1,0 +1,192 @@
+/*******************************************************************************
+ * Copyright (c) 2007, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.server.shared;
+
+import javax.ejb.EJBException;
+
+/**
+ * Remote business interface for Container Managed Transaction Session beans.
+ **/
+public interface TxAttrRemote {
+    /**
+     * Used to verify that when a method with a REQUIRED transaction attribute
+     * is called while the calling thread is not currently associated with a
+     * transaction context causes the container to begin a global transaction.
+     *
+     * @return boolean true if method is dispatched in a global transaction.
+     *         boolean false if method is dispatched in a local transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txRequired() throws EJBException;
+
+    /**
+     * Used to verify that when a method with a REQUIRED transaction attribute
+     * is called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the caller's
+     * global transaction context (e.g container does not begin a new
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in the same transaction
+     *         context with the same transaction ID as passed by tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txRequired(byte[] tid) throws EJBException;
+
+    /**
+     * Used to verify when a method with a REQUIRES_NEW transaction attribute is
+     * called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the a new
+     * global transaction context (e.g container does begin a new global
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in a global transaction with
+     *         a global transaction ID the does not match the tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txRequiresNew(byte[] tid) throws EJBException;
+
+    /**
+     * Used to verify that when a method with a REQUIRES NEW transaction
+     * attribute is called while the calling thread is not currently associated
+     * with a transaction context causes the container to begin a global
+     * transaction.
+     *
+     * @return boolean true if method is dispatched in a global transaction.
+     *         boolean false if method is dispatched in a local transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txRequiresNew() throws EJBException;
+
+    /**
+     * Used to verify when a method with a MANDATORY transaction attribute is
+     * called while thread is currently associated with a global transaction
+     * causes the container to dispatch the method in the callers global
+     * transaction context (e.g container does not begin a new transaction). The
+     * caller must begin a global transaction prior to calling this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in the same transaction
+     *         context with the same transaction ID as passed by tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txMandatory(byte[] tid) throws EJBException;
+
+    /**
+     * Used to verify when a method with a MANDATORY transaction attribute is
+     * called while calling thread is not currently associated with a global
+     * transaction causes the container to throw a
+     * javax.ejb.EJBTransactionRequiredException
+     */
+    public void txMandatory() throws EJBException;
+
+    /**
+     * Used to verify that when a method with a NEVER transaction attribute is
+     * called causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txNever() throws EJBException;
+
+    /**
+     * Used to verify when a method with a NEVER transaction attribute is called
+     * while the thread is currently associated with a global transaction the
+     * container throws a javax.ejb.EJBException. The caller must begin a global
+     * transaction prior to calling this method.
+     *
+     */
+    public void txNever(byte[] tid) throws EJBException;
+
+    /**
+     * Used to verify that when a method with a NOT_SUPPORTED transaction
+     * attribute is called causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txNotSupported() throws EJBException;
+
+    /**
+     * Used to verify that when a method with a SUPPORTS transaction attribute
+     * is called while the calling thread is not associated with a global
+     * transaction causes the container to begin a local transaction.
+     *
+     * @return boolean true if method is dispatched in a local transaction.
+     *         boolean false if method is dispatched in a global transaction.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txSupports() throws EJBException;
+
+    /**
+     * Used to verify that when a method with a SUPPORTS transaction attribute
+     * is called while calling thread is currently associated with a global
+     * transaction causes the container to dispatch the method in the caller's
+     * global transaction context (e.g container does not begin a new
+     * transaction). The caller must begin a global transaction prior to calling
+     * this method.
+     *
+     * @param tid
+     *            is the global transaction ID for the transaction that was
+     *            started prior to calling this method.
+     *
+     * @return boolean true if method is dispatched in the same transaction
+     *         context with the same transaction ID as passed by tid parameter.
+     *         Otherwise boolean false is returned.
+     *
+     * @throws java.lang.IllegalStateException
+     *             is thrown if method is dispatched while not in any
+     *             transaction context.
+     */
+    public boolean txSupports(byte[] tid) throws EJBException;
+
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerShared.jar/src/com/ibm/ws/ejbcontainer/remote/server/shared/UserTransactionRemote.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerShared.jar/src/com/ibm/ws/ejbcontainer/remote/server/shared/UserTransactionRemote.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,19 +8,15 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.ejbcontainer.remote.fat;
+package com.ibm.ws.ejbcontainer.remote.server.shared;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import javax.transaction.UserTransaction;
 
-import com.ibm.ws.ejbcontainer.remote.fat.tests.RemoteTests;
-import com.ibm.ws.ejbcontainer.remote.fat.tests.Server2ServerTests;
+/**
+ * Remote business interface for Bean Managed Transaction Session beans.
+ **/
+public interface UserTransactionRemote {
+    void test();
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                RemoteTests.class,
-                Server2ServerTests.class
-})
-public class FATSuite {
+    UserTransaction test(byte[] big, UserTransaction ut);
 }

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerShared.jar/src/test/TestRemoteInterface.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteServerShared.jar/src/test/TestRemoteInterface.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test;
+
+import java.util.concurrent.Future;
+
+/**
+ * EJB remote interface with a single period (.) in the package name
+ * and methods for testing remote asynchronous methods and remote bean state.
+ */
+public interface TestRemoteInterface {
+
+    /**
+     * Simple method that returns the bean name
+     */
+    String getBeanName();
+
+    /**
+     * Increments bean state, returning new value.
+     */
+    int increment(int value);
+
+    /**
+     * Verifies the passed remote bean has the same bean name.
+     */
+    boolean verifyRemoteBean(TestRemoteInterface remoteBean);
+
+    /**
+     * Asynchronous methods that returns the bean name.
+     */
+    Future<String> asynchMethodReturn();
+
+}


### PR DESCRIPTION
Added a vairous remote EJB tests that lookup and call methods on remote
EJBs between two servers; including:

- various ways to lookup EJBs (3.x & 2.x)
- verify all transaction attributes are handled properly
- verify bean state is retained for stateful/singleton
- verify remote asynchronous methods works properly/ results retrieved

fixes #7322 