### PR TITLE
 tests for vendor-specific testConnection method used by validator

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/bootstrap.properties
@@ -9,6 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.validator=all:com.ibm.ws.jca.service.ConnectionFactoryService=all
+com.ibm.ws.logging.trace.specification=*=info:rest.validator=all:com.ibm.ws.jca.service.ConnectionFactoryService=all:com.ibm.ejs.j2c.MCWrapper=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-resourceadapter/src/org/test/validator/adapter/ManagedConnectionImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.test.validator.adapter;
 
+import java.io.IOError;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
@@ -17,14 +18,18 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
 
 import javax.resource.NotSupportedException;
 import javax.resource.ResourceException;
+import javax.resource.spi.CommException;
 import javax.resource.spi.ConnectionEventListener;
 import javax.resource.spi.ConnectionRequestInfo;
 import javax.resource.spi.LocalTransaction;
 import javax.resource.spi.ManagedConnection;
 import javax.resource.spi.ManagedConnectionMetaData;
+import javax.resource.spi.ResourceAdapterInternalException;
 import javax.resource.spi.SecurityException;
 import javax.resource.spi.security.PasswordCredential;
 import javax.security.auth.Subject;
@@ -34,6 +39,7 @@ import org.test.validator.adapter.ConnectionSpecImpl.ConnectionRequestInfoImpl;
 
 public class ManagedConnectionImpl implements ManagedConnection {
     private final ManagedConnectionFactoryImpl mcf;
+    private String mostRecentUser;
 
     ManagedConnectionImpl(ManagedConnectionFactoryImpl mcf) {
         this.mcf = mcf;
@@ -86,7 +92,7 @@ public class ManagedConnectionImpl implements ManagedConnection {
             userName != null && password != null && userName.charAt(userName.length() - 1) == password.charAt(0))
             if (isJDBC)
                 try {
-                    InvocationHandler handler = new JDBCConnectionImpl(userName);
+                    InvocationHandler handler = new JDBCConnectionImpl(mostRecentUser = userName);
                     return AccessController.doPrivileged((PrivilegedExceptionAction<?>) () -> {
                         return Proxy.newProxyInstance(java.sql.Connection.class.getClassLoader(),
                                                       new Class<?>[] { java.sql.Connection.class, DatabaseMetaData.class },
@@ -100,7 +106,7 @@ public class ManagedConnectionImpl implements ManagedConnection {
                         throw new ResourceException(cause);
                 }
             else
-                return new ConnectionImpl(userName);
+                return new ConnectionImpl(mostRecentUser = userName);
         else
             throw new SecurityException("Unable to authenticate with " + userName, "ERR_AUTH");
     }
@@ -131,5 +137,27 @@ public class ManagedConnectionImpl implements ManagedConnection {
 
     @Override
     public void setLogWriter(PrintWriter logWriter) throws ResourceException {
+    }
+
+    /**
+     * Simulate the pattern used by CICS/IMS resource adapters to allow for a managed connection to be tested.
+     *
+     * @return true if validation is successful. False indicates validation is unsuccessful.
+     * @throws ResourceException indicates the connection is not valid.
+     * @throws SQLException      indicates the connection is not valid.
+     */
+    public boolean testConnection() throws ResourceException, SQLException {
+        // The user name parameter is a convenient way to trigger rejection of test requests in variety of ways,
+        if (mostRecentUser.startsWith("testerruser"))
+            throw new IOError(new SQLNonTransientConnectionException("Database appears to be down.", "08006", -13579));
+        else if (mostRecentUser.startsWith("testfailuser"))
+            return false;
+        else if (mostRecentUser.startsWith("testresxuser"))
+            throw (ResourceAdapterInternalException) new ResourceAdapterInternalException("Something bad has happened. See cause.")
+                            .initCause(new CommException("Lost connection to host.", "ERR_CONNECT"));
+        else if (mostRecentUser.startsWith("testrunxuser"))
+            throw new IllegalStateException("Connection was dropped.");
+        else
+            return true;
     }
 }


### PR DESCRIPTION
Write test cases for a vendor-specific testConnection() method supplied by the ManagedConnection implementation that can be used by the validator of JCA connection factories to cover the case where the resource adapter lazily connects to the backend.