### PR TITLE
Changes to audit code to add SECURITY_SAF_AUTHZ

### DIFF
--- a/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/audit/AuditConstants.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/audit/AuditConstants.java
@@ -117,7 +117,7 @@ public class AuditConstants {
                                                                          "SECURITY_RUNTIME_KEY", "SECURITY_JMS_AUTHN", "SECURITY_JMS_AUTHZ", "SECURITY_JMS_AUTHN_TERMINATE",
                                                                          "SECURITY_JMS_CLOSED_CONNECTION",
                                                                          "JMX_MBEAN", "JMX_NOTIFICATION", "JMX_MBEAN_ATTRIBUTES", "JMX_MBEAN_REGISTER", "JMS",
-                                                                         "SECURITY_SAF_AUTHZ_DETAILS", "APPLICATION_TOKEN_MANAGEMENT", "CUSTOM");
+                                                                         "SECURITY_SAF_AUTHZ_DETAILS", "SECURITY_SAF_AUTHZ", "APPLICATION_TOKEN_MANAGEMENT", "CUSTOM");
 
     static public final String SUCCESS = "success";
     static public final String FAILURE = "failure";

--- a/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/audit/AuditConstants.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/audit/AuditConstants.java
@@ -65,6 +65,7 @@ public class AuditConstants {
     static public final String SECURITY_JMS_AUTHZ = "SECURITY_JMS_AUTHZ";
     static public final String SECURITY_JMS_AUTHN_TERMINATE = "SECURITY_JMS_AUTHN_TERMINATE";
     static public final String SECURITY_JMS_CLOSED_CONNECTION = "SECURITY_JMS_CLOSED_CONNECTION";
+    static public final String SECURITY_SAF_AUTHZ = "SECURITY_SAF_AUTHZ";
     static public final String SECURITY_SAF_AUTHZ_DETAILS = "SECURITY_SAF_AUTHZ_DETAILS";
     static public final String JMX_MBEAN = "JMX_MBEAN";
     static public final String JMX_NOTIFICATION = "JMX_NOTIFICATION";

--- a/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/audit/AuditEvent.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/audit/AuditEvent.java
@@ -131,7 +131,8 @@ public class AuditEvent {
     public static final String TARGET_SAF_PROFILE = "target.saf.profile";
     public static final String TARGET_SAF_CLASS = "target.saf.class";
     public static final String TARGET_AUTHORIZATION_DECISION = "target.authorization.decision";
-
+    public static final String TARGET_ACCESS_LEVEL = "target.access.level";
+    
     public final static String INITIATOR = "initiator";
     public final static String INITIATOR_ID = "initiator.id";
     public final static String INITIATOR_NAME = "initiator.name";

--- a/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/audit/AuditEvent.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/audit/AuditEvent.java
@@ -132,7 +132,8 @@ public class AuditEvent {
     public static final String TARGET_SAF_CLASS = "target.saf.class";
     public static final String TARGET_AUTHORIZATION_DECISION = "target.authorization.decision";
     public static final String TARGET_ACCESS_LEVEL = "target.access.level";
-    
+    public static final String TARGET_SAF_ERROR_MESSAGE = "target.saf.error.message";
+
     public final static String INITIATOR = "initiator";
     public final static String INITIATOR_ID = "initiator.id";
     public final static String INITIATOR_NAME = "initiator.name";

--- a/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
+++ b/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
@@ -726,9 +726,9 @@ public class AuditPE implements ProbeExtension {
         String principleName = (String) varargs[7];
         String applid = (String) varargs[8];
         String accessLevel = (String) varargs[9];
-
+        String errorMessage = (String) varargs[10];
         if (auditServiceRef.getService() != null && auditServiceRef.getService().isAuditRequired(AuditConstants.SECURITY_SAF_AUTHZ, AuditConstants.SUCCESS)) {
-            SAFAuthorizationEvent safAuth = new SAFAuthorizationEvent(safReturnCode, racfReturnCode, racfReasonCode, userSecurityName, applid, safProfile, safClass, authDecision, principleName, accessLevel);
+            SAFAuthorizationEvent safAuth = new SAFAuthorizationEvent(safReturnCode, racfReturnCode, racfReasonCode, userSecurityName, applid, safProfile, safClass, authDecision, principleName, accessLevel, errorMessage);
             auditServiceRef.getService().sendEvent(safAuth);
         }
     }

--- a/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
+++ b/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
@@ -62,6 +62,7 @@ import com.ibm.ws.security.audit.event.JMXMBeanEvent;
 import com.ibm.ws.security.audit.event.JMXMBeanRegisterEvent;
 import com.ibm.ws.security.audit.event.JMXNotificationEvent;
 import com.ibm.ws.security.audit.event.MemberManagementEvent;
+import com.ibm.ws.security.audit.event.SAFAuthorizationEvent;
 import com.ibm.ws.security.audit.event.SAFAuthorizationDetailsEvent;
 //import com.ibm.ws.security.audit.utils.AuditConstants;
 import com.ibm.ws.webcontainer.security.AuthenticationResult;
@@ -238,6 +239,9 @@ public class AuditPE implements ProbeExtension {
 					break;
 				case APPLICATION_PASSWORD_TOKEN_01:
 					auditEventApplicationPasswordToken(methodParams);
+					break;
+				case SECURITY_SAF_AUTHZ_DETAILS:
+					auditEventSafAuthDetails(methodParams);
 					break;
 				default:
 					// TODO: emit error message
@@ -708,4 +712,24 @@ public class AuditPE implements ProbeExtension {
 			auditServiceRef.getService().sendEvent(safAuthDetails);
 		}
 	}
+
+    private void auditEventSafAuth(Object[] methodParams) {
+        Object[] varargs = (Object[]) methodParams[1];
+
+        int safReturnCode = (Integer) varargs[0];
+        int racfReturnCode = (Integer) varargs[1];
+        int racfReasonCode = (Integer) varargs[2];
+        String userSecurityName = (String) varargs[3];
+        String safProfile = (String) varargs[4];
+        String safClass = (String) varargs[5];
+        Boolean authDecision = (Boolean) varargs[6];
+        String principleName = (String) varargs[7];
+        String applid = (String) varargs[8];
+        String accessLevel = (String) varargs[9];
+
+        if (auditServiceRef.getService() != null && auditServiceRef.getService().isAuditRequired(AuditConstants.SECURITY_SAF_AUTHZ, AuditConstants.SUCCESS)) {
+            SAFAuthorizationEvent safAuth = new SAFAuthorizationEvent(safReturnCode, racfReturnCode, racfReasonCode, userSecurityName, applid, safProfile, safClass, authDecision, principleName, accessLevel);
+            auditServiceRef.getService().sendEvent(safAuth);
+        }
+    }
 }

--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/event/SAFAuthorizationEvent.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/event/SAFAuthorizationEvent.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.audit.event;
+
+import java.util.Map;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.security.audit.AuditConstants;
+import com.ibm.websphere.security.audit.AuditEvent;
+
+/**
+ * Creates Audit report for SAF Authorization
+ */
+public class SAFAuthorizationEvent extends AuditEvent {
+
+    private static final TraceComponent tc = Tr.register(SAFAuthorizationEvent.class);
+
+    @SuppressWarnings("unchecked")
+    public SAFAuthorizationEvent() {
+        set(AuditEvent.EVENTNAME, AuditConstants.SECURITY_SAF_AUTHZ);
+        setInitiator((Map<String, Object>) AuditEvent.STD_INITIATOR.clone());
+        setObserver((Map<String, Object>) AuditEvent.STD_OBSERVER.clone());
+        setTarget((Map<String, Object>) AuditEvent.STD_TARGET.clone());
+    }
+
+    public SAFAuthorizationEvent(int safReturnCode,
+                                        int racfReturnCode,
+                                        int racfReasonCode,
+                                        String userSecurityName,
+                                        String applID,
+                                        String safProfile,
+                                        String safClass,
+                                        Boolean authDecision,
+                                        String principalName,
+                                        String accessLevel) {
+        this();
+
+        // This is put in by default from AuditEvent, not needed so removing
+        AuditEvent.STD_TARGET.remove(AuditEvent.TARGET_TYPEURI);
+
+        set(AuditEvent.TARGET_SAF_RETURN_CODE, safReturnCode);
+        set(AuditEvent.TARGET_RACF_RETURN_CODE, racfReturnCode);
+        set(AuditEvent.TARGET_RACF_REASON_CODE, racfReasonCode);
+
+        if (userSecurityName != null) {
+            set(AuditEvent.TARGET_USER_SECURITY_NAME, userSecurityName);
+        }
+        if (applID != null) {
+            set(AuditEvent.TARGET_APPLID, applID);
+        }
+        if (safProfile != null) {
+            set(AuditEvent.TARGET_SAF_PROFILE, safProfile);
+        }
+        if (safClass != null) {
+            set(AuditEvent.TARGET_SAF_CLASS, safClass);
+        }
+        if (authDecision != null) {
+            if (authDecision == true) {
+                set(AuditEvent.OUTCOME, AuditEvent.OUTCOME_SUCCESS);
+                set(AuditEvent.TARGET_AUTHORIZATION_DECISION, true);
+            } else {
+                set(AuditEvent.OUTCOME, AuditEvent.OUTCOME_FAILURE);
+                set(AuditEvent.TARGET_AUTHORIZATION_DECISION, false);
+            }
+        }
+        if (principalName != null) {
+            set(AuditEvent.TARGET_CREDENTIAL_TOKEN, principalName);
+        }
+        if (accessLevel != null) {
+            set(AuditEvent.TARGET_ACCESS_LEVEL, accessLevel);
+        }
+    }
+}

--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/event/SAFAuthorizationEvent.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/event/SAFAuthorizationEvent.java
@@ -41,16 +41,21 @@ public class SAFAuthorizationEvent extends AuditEvent {
                                         String safClass,
                                         Boolean authDecision,
                                         String principalName,
-                                        String accessLevel) {
+                                        String accessLevel,
+                                        String errorMessage) {
         this();
 
         // This is put in by default from AuditEvent, not needed so removing
         AuditEvent.STD_TARGET.remove(AuditEvent.TARGET_TYPEURI);
-
-        set(AuditEvent.TARGET_SAF_RETURN_CODE, safReturnCode);
-        set(AuditEvent.TARGET_RACF_RETURN_CODE, racfReturnCode);
-        set(AuditEvent.TARGET_RACF_REASON_CODE, racfReasonCode);
-
+        if (safReturnCode != -1) {
+            set(AuditEvent.TARGET_SAF_RETURN_CODE, safReturnCode);
+        }
+        if (racfReturnCode != -1) {
+            set(AuditEvent.TARGET_RACF_RETURN_CODE, racfReturnCode);
+        }
+        if (racfReasonCode != -1) {
+            set(AuditEvent.TARGET_RACF_REASON_CODE, racfReasonCode);
+        }
         if (userSecurityName != null) {
             set(AuditEvent.TARGET_USER_SECURITY_NAME, userSecurityName);
         }
@@ -77,6 +82,9 @@ public class SAFAuthorizationEvent extends AuditEvent {
         }
         if (accessLevel != null) {
             set(AuditEvent.TARGET_ACCESS_LEVEL, accessLevel);
+        }
+        if (errorMessage != null) {
+            set(AuditEvent.TARGET_SAF_ERROR_MESSAGE, errorMessage);
         }
     }
 }

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/audit/Audit.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/audit/Audit.java
@@ -37,6 +37,7 @@ public class Audit {
         SECURITY_JMS_AUTHZ_01,
         SECURITY_JMS_AUTHN_TERMINATE_01,
         SECURITY_JMS_CLOSED_CONNECTION_01,
+        SECURITY_SAF_AUTHZ,
         SECURITY_SAF_AUTHZ_DETAILS,
         JMX_NOTIFICATION_01,
         JMX_MBEAN_01,
@@ -54,12 +55,12 @@ public class Audit {
      * audit feature is enabled and this method is invoked.
      *
      * @param eventId -
-     *            The unique ID identifying the ProbeExtension method to be
-     *            called to generate the audit record. The ID should be defined
-     *            in the Audit.EventID enumeration. An ID should be defined
-     *            for each unique set of params to be passed to the ProbeExtension.
-     * @param params -
-     *            The objects needed to produce the audit record.
+     *                    The unique ID identifying the ProbeExtension method to be
+     *                    called to generate the audit record. The ID should be defined
+     *                    in the Audit.EventID enumeration. An ID should be defined
+     *                    for each unique set of params to be passed to the ProbeExtension.
+     * @param params  -
+     *                    The objects needed to produce the audit record.
      */
     @Trivial
     public static void audit(EventID eventId, Object... params) {}


### PR DESCRIPTION
Changes to audit code in OL to add better auditing for SAF Security in CL. Added the following:
- In Audit.java, added SECURITY_SAF_AUTHZ
- In AuditEvent.java, add TARGET_ACCESS_LEVEL for auditing access level and TARGET_SAF_ERROR_MESSAGE for showing error messages.
- Made it so that if WAS_INTERNAL error, saf/racf codes will not appear and message from safServiceResults is given.
- Created SAFAuthorizationEvent.java in com.ibm.security.audit.source 
- Added code in AuditPE.java in com.ibm.ws.request.probe.audit.servlet to handle audit event
- Added SECURITY_SAF_AUTHZ constant to AuditConstants.java
