### PR TITLE
Stop reading feature cache

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -847,7 +847,11 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
         writeServiceMessages();
 
         Set<String> postInstalledFeatures = new HashSet<>(featureRepository.getInstalledFeatures());
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "all installed features " + postInstalledFeatures);
+        }
 
+        //remove the pre-installed features from all installed features to show just the added features
         postInstalledFeatures.removeAll(preInstalledFeatures);
         Set<String> installedPublicFeatures = Collections.emptySet();
 

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/AutoFeaturesTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/AutoFeaturesTest.java
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.log.Log;
+
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -155,7 +156,6 @@ public class AutoFeaturesTest {
     private static final String TEST_MF = TEST_FEATURE + TEST_FEATURE_VERSION;
 
     private static final String CACHE_DIRECTORY = "workarea/platform/";
-    private static final String FEATURE_CACHE = CACHE_DIRECTORY + "feature.cache";
     private static final String FEATURE_BUNDLE_CACHE = CACHE_DIRECTORY + "feature.bundles.cache";
 
     /**
@@ -314,11 +314,9 @@ public class AutoFeaturesTest {
         server.setServerConfigurationFile("server_all_features.xml");
         server.startServer(testName.getMethodName() + ".log");
 
-        // When the features are installed during a server start we don't get messages issued to the logs about which features are
-        // installed, so we need to look in the feature.cache file to ensure the correct features have been installed.
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
-        assertNotNull("There is no installed features property in the feature.cache file",
+        assertNotNull("There are no installed features found in trace.log file",
                       installedFeatures);
 
         assertTrue("featureA-1.0 was not installed and should have been: " + installedFeatures, installedFeatures.contains("featureA-1.0"));
@@ -585,10 +583,9 @@ public class AutoFeaturesTest {
         server.setServerConfigurationFile("server_all_features.xml");
         server.startServer(testName.getMethodName() + ".log");
 
-        // When the features are installed during a server start we don't get messages issued to the logs about which features are
-        // installed, so we need to look in the feature.cache file to ensure the correct features have been installed.
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
-        assertNotNull("There is no installed features property in the feature.cache file",
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+
+        assertNotNull("There are no installed features found in trace.log file",
                       installedFeatures);
 
         assertTrue("featureA-1.0 was not installed and should have been: " + installedFeatures, installedFeatures.contains("featureA-1.0"));
@@ -620,10 +617,9 @@ public class AutoFeaturesTest {
         // restart the server
         server.startServer(testName.getMethodName() + "-2.log"); // clean start
 
-        // When the features are installed during a server start we don't get messages issued to the logs about which features are
-        // installed, so we need to look in the feature.cache file to ensure the correct features have been installed.
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
-        assertNotNull("There is no installed features property in the feature.cache file",
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+
+        assertNotNull("There are no installed features found in trace.log file",
                       installedFeatures);
 
         // feature names are stored in the cache as lower case.
@@ -671,11 +667,9 @@ public class AutoFeaturesTest {
         server.setServerConfigurationFile("server_usr_all_features.xml");
         server.startServer(testName.getMethodName() + ".log");
 
-        // When the features are installed during a server start we don't get messages issued to the logs about which features are
-        // installed, so we need to look in the feature.cache file to ensure the correct features have been installed.
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
-        assertNotNull("There is no installed features property in the feature.cache file",
+        assertNotNull("There are no installed features found in trace.log file",
                       installedFeatures);
 
         assertTrue("ufeatureA-1.0 was not installed and should have been: " + installedFeatures, installedFeatures.contains("ufeatureA-1.0"));
@@ -1035,11 +1029,10 @@ public class AutoFeaturesTest {
         // Now move the server xml with the all features available
         server.setServerConfigurationFile("server_usr_all_features.xml");
         server.startServer(testName.getMethodName() + ".log");
-        
-        // When the features are installed during a server start we don't get messages issued to the logs about which features are
-        // installed, so we need to look in the feature.cache file to ensure the correct features have been installed.
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
-        assertNotNull("There is no installed features property in the feature.cache file",
+
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+
+        assertNotNull("There are no installed features found in trace.log file",
                       installedFeatures);
 
         // feature names are stored in the cache as lower case.
@@ -1072,10 +1065,9 @@ public class AutoFeaturesTest {
         // restart the server
         server.startServer(testName.getMethodName() + "-2.log"); // clean start
 
-        // When the features are installed during a server start we don't get messages issued to the logs about which features are
-        // installed, so we need to look in the feature.cache file to ensure the correct features have been installed.
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
-        assertNotNull("There is no installed features property in the feature.cache file",
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+
+        assertNotNull("There are no installed features found in trace.log file",
                       installedFeatures);
 
         assertTrue("ufeatureA-1.0 was not installed and should have been: " + installedFeatures, installedFeatures.contains("ufeatureA-1.0"));
@@ -1122,11 +1114,9 @@ public class AutoFeaturesTest {
         server.setServerConfigurationFile("server_product_all_features.xml");
         server.startServer(testName.getMethodName() + ".log");
 
-        // When the features are installed during a server start we don't get messages issued to the logs about which features are
-        // installed, so we need to look in the feature.cache file to ensure the correct features have been installed.
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
-        assertNotNull("There is no installed features property in the feature.cache file",
+        assertNotNull("There are no installed features found in trace.log file",
                       installedFeatures);
 
         // feature names are stored in the cache as lower case.
@@ -1667,10 +1657,9 @@ public class AutoFeaturesTest {
         server.setServerConfigurationFile("server_product_all_features.xml");
         server.startServer(testName.getMethodName() + ".log");
 
-        // When the features are installed during a server start we don't get messages issued to the logs about which features are
-        // installed, so we need to look in the feature.cache file to ensure the correct features have been installed.
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
-        assertNotNull("There is no installed features property in the feature.cache file",
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+
+        assertNotNull("There are no installed features found in trace.log file",
                       installedFeatures);
 
         // feature names are stored in the cache as lower case.
@@ -1710,10 +1699,9 @@ public class AutoFeaturesTest {
         // restart the server
         server.startServer(testName.getMethodName() + "-2.log"); // clean start
 
-        // When the features are installed during a server start we don't get messages issued to the logs about which features are
-        // installed, so we need to look in the feature.cache file to ensure the correct features have been installed.
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
-        assertNotNull("There is no installed features property in the feature.cache file",
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+
+        assertNotNull("There are no installed features found in trace.log file",
                       installedFeatures);
 
         // feature names are stored in the cache as lower case.
@@ -1845,11 +1833,9 @@ public class AutoFeaturesTest {
         // Wait for the Feature Refresh servlet to start.
         String message = server.waitForStringInLog("CWWKT0016I.*http://.*/feature");
 
-        // When the features are installed during a server start we don't get messages issued to the logs about which features are
-        // installed, so we need to look in the feature.cache file to ensure the correct features have been installed.
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
-        assertNotNull("There is no installed features property in the feature.cache file",
+        assertNotNull("There are no installed features found in trace.log file",
                       installedFeatures);
 
         assertTrue("featureA-1.0 was not installed and should have been: " + installedFeatures, installedFeatures.contains("featureA-1.0"));
@@ -1875,7 +1861,10 @@ public class AutoFeaturesTest {
         server.setMarkToEndOfLog();
         server.waitForStringInLogUsingMark("CWWKF0008I");
 
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
 
         assertTrue("featureE-1.0 was not installed and should have been: " + installedFeatures, installedFeatures.contains("featureE-1.0"));
 
@@ -1892,7 +1881,10 @@ public class AutoFeaturesTest {
         server.setMarkToEndOfLog();
         server.waitForStringInLogUsingMark("CWWKF0008I");
 
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
         assertTrue("featureG-1.0 was not installed and should have been: " + installedFeatures, installedFeatures.contains("featureG-1.0"));
 
         // Now check that we have the expected bundles installed.
@@ -1909,7 +1901,9 @@ public class AutoFeaturesTest {
         server.setMarkToEndOfLog();
         server.waitForStringInLogUsingMark("CWWKF0008I");
 
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
         assertFalse("featureE-1.0 was installed and should not have been: " + installedFeatures, installedFeatures.contains("featureE-1.0"));
         assertFalse("featureG-1.0 was installed and should not have been: " + installedFeatures, installedFeatures.contains("featureG-1.0"));
 

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FeatureConflictUpgradeTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FeatureConflictUpgradeTest.java
@@ -55,8 +55,6 @@ public class FeatureConflictUpgradeTest {
     private static final String FEATURE_AUTO_A10_B10_1_0 = "auto-A10B10-1.0";
     private static final String FEATURE_AUTO_A11_B11_1_0 = "auto-A11B11-1.0";
 
-    private static final String FEATURE_CACHE = "workarea/platform/feature.cache";
-
     @BeforeClass
     public static void beforeClass() throws Exception {
         Log.info(c, "beforeClass", "Installing features");
@@ -131,7 +129,10 @@ public class FeatureConflictUpgradeTest {
 
         assertNotNull("No message indicating a conflict", server.waitForStringInLog("CWWKF0033E.*" + FEATURE_CAPABILITYA_1_0));
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         assertFalse("Expected capabilityA-1.1 feature not to be installed, but it was", installedFeatures.contains(FEATURE_CAPABILITYA_1_1));
         assertFalse("Expected capabilityA-1.0 feature not to be installed, but it was", installedFeatures.contains(FEATURE_CAPABILITYA_1_0));
 
@@ -155,7 +156,10 @@ public class FeatureConflictUpgradeTest {
 
         //assertNotNull("No message indicating that the lower version feature was not used", server.waitForStringInLog("CWWKF0031I.*" + FEATURE_CAPABILITYB_1_0));
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         assertTrue("Expected capabilityA-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_1_0));
         assertTrue("Expected capabilityB-1.1 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_1));
         assertFalse("Expected capabilityB-1.0 feature not to be installed, but it was", installedFeatures.contains(FEATURE_CAPABILITYB_1_0));
@@ -178,7 +182,10 @@ public class FeatureConflictUpgradeTest {
         server.setServerConfigurationFile("server_a10combo10.xml");
         server.startServer(m + ".log");
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         Log.info(c, m, "installedFeatures: " + installedFeatures);
         assertTrue("Pre-condition: Expected capabilityA-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_1_0));
         assertTrue("Pre-condition: Expected capabilityB-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_0));
@@ -192,7 +199,7 @@ public class FeatureConflictUpgradeTest {
         assertNotNull("Expected message indicating that capabilityB-1.1 feature was installed did not occur", server.waitForStringInLog("CWWKF0012I.*capabilityB-1.1"));
         assertNotNull("Expected message indicating that capabilityB-1.0 feature was uninstalled did not occur", server.waitForStringInLog("CWWKF0013I.*capabilityB-1.0"));
 
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        installedFeatures = TestUtils.getInstalledFeatures(server);
         Log.info(c, m, "installedFeatures: " + installedFeatures);
         assertTrue("Expected capabilityA-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_1_0));
         assertTrue("Expected capabilityB-1.1 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_1));
@@ -219,7 +226,9 @@ public class FeatureConflictUpgradeTest {
 
         // assertNotNull("No message indicating that the lower version feature was not used", server.waitForStringInLog("CWWKF0031I.*" + FEATURE_CAPABILITYB_1_0));
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
         Log.info(c, m, "installedFeatures: " + installedFeatures);
         assertTrue("Pre-condition: Expected capabilityA-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_1_0));
         assertTrue("Pre-condition: Expected capabilityB-1.1 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_1));
@@ -232,7 +241,9 @@ public class FeatureConflictUpgradeTest {
         assertNotNull("Expected message indicating that capabilityB-1.0 feature was installed did not occur", server.waitForStringInLog("CWWKF0012I.*capabilityB-1.0"));
         assertNotNull("Expected message indicating that capabilityB-1.1 feature was uninstalled did not occur", server.waitForStringInLog("CWWKF0013I.*capabilityB-1.1"));
 
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
         Log.info(c, m, "installedFeatures: " + installedFeatures);
         assertTrue("Expected capabilityA-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_1_0));
         assertTrue("Expected capabilityB-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_0));
@@ -260,7 +271,10 @@ public class FeatureConflictUpgradeTest {
 
         // server.xml specifies capabilityA-1.0 and capabilityB-1.0, so
         // we expect auto feature auto-A10B10 to be installed
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         Log.info(c, m, "installedFeatures: " + installedFeatures);
         assertTrue("Pre-condition: Expected capabilityA-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_1_0));
         assertTrue("Pre-condition: Expected capabilityB-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_0));
@@ -280,7 +294,10 @@ public class FeatureConflictUpgradeTest {
         // capabilityB-1.0, and capabilityB-1.1 -- the server should not install capabilityB-1.0
         // since capabilityB-1.1 is the upgrade -- that means that auto feature auto-A10B10 should
         // be uninstalled.
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         Log.info(c, m, "installedFeatures: " + installedFeatures);
         assertTrue("Expected capabilityA-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_1_0));
         assertTrue("Expected capabilityB-1.1 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_1));
@@ -304,7 +321,10 @@ public class FeatureConflictUpgradeTest {
         // No we've upgraded capabilityA-1.0 to 1.1- so we have A1.0, A1.1, B1.0, and B1.1 specified, and
         // the server should remove A1.0 and B1.0 since the are upgraded by A1.1 and B1.1 respectively.
         // This means that we should see auto feature, auto-A11B11 installed.
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         Log.info(c, m, "installedFeatures: " + installedFeatures);
         assertTrue("Expected capabilityA-1.1 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_1_1));
         assertTrue("Expected capabilityB-1.1 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_1));
@@ -333,7 +353,9 @@ public class FeatureConflictUpgradeTest {
 
         assertNotNull("No message indicating a conflict", server.waitForStringInLog("CWWKF0033E.*" + FEATURE_CAPABILITYA_1_0));
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
         assertTrue("Expected comboA10B10-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_COMBO_A10_B10_1_0));
         assertTrue("Expected capabilityB-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_0));
         assertTrue("Expected capabilityC-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYC_1_0));
@@ -348,7 +370,10 @@ public class FeatureConflictUpgradeTest {
         assertNotNull("Expected message indicating that capabilityC-1.0 feature was uninstalled did not occur", server.waitForStringInLog("CWWKF0013I.*capabilityC-1.0"));
         assertNotNull("Expected message indicating that capabilityD-1.0 feature was uninstalled did not occur", server.waitForStringInLog("CWWKF0013I.*capabilityD-1.0"));
 
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         Log.info(c, m, "installedFeatures: " + installedFeatures);
         assertTrue("Expected capabilityA-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_1_0));
         assertTrue("Expected capabilityB-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_0));
@@ -374,7 +399,10 @@ public class FeatureConflictUpgradeTest {
         server.setServerConfigurationFile("server_d10a10b10combo10.xml");
         server.startServer(m + ".log");
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         assertTrue("Expected comboA10B10-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_COMBO_A10_B10_1_0));
         assertTrue("Expected capabilityA-2.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_2_0));
         assertTrue("Expected capabilityB-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_0));
@@ -389,7 +417,10 @@ public class FeatureConflictUpgradeTest {
         assertNotNull("Expected message indicating that capabilityC-1.0 feature was uninstalled did not occur", server.waitForStringInLog("CWWKF0013I.*capabilityC-1.0"));
         assertNotNull("Expected message indicating that capabilityD-1.0 feature was uninstalled did not occur", server.waitForStringInLog("CWWKF0013I.*capabilityD-1.0"));
 
-        installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         Log.info(c, m, "installedFeatures: " + installedFeatures);
         assertTrue("Expected capabilityA-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYA_1_0));
         assertTrue("Expected capabilityB-1.0 feature to be installed but was not", installedFeatures.contains(FEATURE_CAPABILITYB_1_0));

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FeatureProcessTypeTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FeatureProcessTypeTest.java
@@ -43,8 +43,6 @@ public class FeatureProcessTypeTest {
 
     private static final String CLIENT_B_1_0 = "clientB-1.0";
 
-    private static final String FEATURE_CACHE = "workarea/platform/feature.cache";
-
     @BeforeClass
     public static void beforeClass() throws Exception {
         Log.info(c, "beforeClass", "Installing features");
@@ -96,7 +94,10 @@ public class FeatureProcessTypeTest {
 
         assertNotNull("No message indicating a conflict", server.waitForStringInLog("CWWKF0034E.*" + CLIENT_B_1_0));
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         assertFalse("Expected clientB-1.0 feature to not be installed, but it was: " + installedFeatures, installedFeatures.contains(CLIENT_B_1_0));
 
         Log.info(c, m, "successful exit");
@@ -113,7 +114,10 @@ public class FeatureProcessTypeTest {
 
         assertNotNull("No message indicating a conflict", server.waitForStringInLog("CWWKF0035E.*" + CLIENT_B_1_0));
 
-        String installedFeatures = TestUtils.getInstalledFeatures(server, FEATURE_CACHE);
+        String installedFeatures = TestUtils.getInstalledFeatures(server);
+        assertNotNull("There are no installed features found in trace.log file",
+                      installedFeatures);
+
         assertTrue("Expected serverA-1.0 feature to be installed, but it was not: " + installedFeatures, installedFeatures.contains(SERVER_A_1_0));
 
         Log.info(c, m, "successful exit");

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/TestUtils.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/TestUtils.java
@@ -30,7 +30,7 @@ public class TestUtils {
     /**
      * This method loads the feature.cache file as properties.
      *
-     * @param server    TODO
+     * @param server TODO
      * @param cacheFile - The cache file to read.
      *
      * @return - A properties object containing the properties from the feature.cache file.
@@ -59,33 +59,14 @@ public class TestUtils {
     }
 
     /**
-     * This method finds the installed features from the cache file.
-     * Note this is sleazy and evil and not something that is in general good practice,
-     * as the cache file contents should be able to change at any time.
+     * This method finds the installed features from the trace.log file
      *
-     * @param cacheFile - The cache file to read.
+     * @param server - Liberty Server
      * @return The installed features list as a string
      * @throws Exception
      */
-    public static String getInstalledFeatures(LibertyServer server, String cacheFile) throws Exception {
-        InputStream cacheStream = null;
-        BufferedReader reader = null;
-        String installedFeatures = null;
-        String line = null;
-        try {
-            cacheStream = server.getFileFromLibertyServerRoot(cacheFile).openForReading();
-            reader = new BufferedReader(new InputStreamReader(cacheStream, "UTF-8"));
-            while ((line = reader.readLine()) != null) {
-                if (line.startsWith("@=")) {
-                    installedFeatures = line.substring(2);
-                    break;
-                }
-            }
-        } finally {
-            tryToClose(reader);
-            tryToClose(cacheStream);
-        }
-
+    public static String getInstalledFeatures(LibertyServer server) throws Exception {
+        String installedFeatures = server.waitForStringInTraceUsingLastOffset("all installed features \\[");
         return installedFeatures;
     }
 

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.autofeature/bootstrap.properties
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.autofeature/bootstrap.properties
@@ -1,2 +1,4 @@
 com.ibm.ws.kernel.feature.enforce.public=true
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=com.ibm.ws.kernel.feature.internal.FeatureManager=FINEST
+show.all.installed.features=true

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.featureConflict/bootstrap.properties
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.featureConflict/bootstrap.properties
@@ -1,3 +1,4 @@
 com.ibm.ws.kernel.feature.enforce.public=true
 bootstrap.include=../testports.properties
 osgi.console=5678
+com.ibm.ws.logging.trace.specification=com.ibm.ws.kernel.feature.internal.FeatureManager=FINEST

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.featureConflict/override_tolerates_bootstrap.properties
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.featureConflict/override_tolerates_bootstrap.properties
@@ -2,3 +2,4 @@ com.ibm.ws.kernel.feature.enforce.public=true
 bootstrap.include=../testports.properties
 osgi.console=5678
 tolerates.com.ibm.websphere.appserver.capabilityA=2.0
+com.ibm.ws.logging.trace.specification=com.ibm.ws.kernel.feature.internal.FeatureManager=FINEST


### PR DESCRIPTION
Stop reading feature.cache file for the installed features. Add a trace message which displays all installed features in FeatureManager. Read the installed features from trace.log