### PR TITLE
Load CXF extensions using the bundle classloader instead of application classloader.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/bus/LibertyApplicationBusFactory.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/bus/LibertyApplicationBusFactory.java
@@ -84,7 +84,7 @@ public class LibertyApplicationBusFactory extends CXFBusFactory {
         extensions.put(JaxRsModuleMetaData.class, moduleMetaData);
         extensions.put(LibertyApplicationBus.Type.class, LibertyApplicationBus.Type.SERVER);
 
-        LibertyApplicationBus bus = createBus(extensions, properties, moduleInfo.getClassLoader());
+        LibertyApplicationBus bus = createBus(extensions, properties, LibertyApplicationBusFactory.class.getClassLoader());
 
         return bus;
     }
@@ -173,7 +173,7 @@ public class LibertyApplicationBusFactory extends CXFBusFactory {
 
     /**
      * register LibertyApplicationBusListener to bus factory, those methods will be invoked with the bus lifecycle
-     * 
+     *
      * @param initializer
      */
     public void registerApplicationBusListener(LibertyApplicationBusListener listener) {
@@ -204,7 +204,7 @@ public class LibertyApplicationBusFactory extends CXFBusFactory {
      * The static method from parent class BusFactory also tries to change the thread bus, which is not required.
      * Use BusFactory.class as the synchronized lock due to the signature of the BusFactory.setDefaultBus is
      * public static void synchronized setDefaultBus(Bus bus)
-     * 
+     *
      * @param bus
      */
     public static void setDefaultBus(Bus bus) {

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.cxf.jaxrs.provider;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -75,6 +76,7 @@ import org.apache.cxf.message.MessageUtils;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 public final class ServerProviderFactory extends ProviderFactory {
     private static final TraceComponent tc = Tr.register(ServerProviderFactory.class);
@@ -102,8 +104,37 @@ public final class ServerProviderFactory extends ProviderFactory {
         wadlGenerator = createWadlGenerator(bus);
     }
 
+    @FFDCIgnore(value = { Throwable.class })
     private static ProviderInfo<ContainerRequestFilter> createWadlGenerator(Bus bus) {
-        Object provider = createProvider(WADL_PROVIDER_NAME, bus);
+        // Don't use the application ClassLoader for creating the Wadl Provider because
+        // the class will not be in the application ClassLoader.
+        // Object provider = createProvider(WADL_PROVIDER_NAME, bus);
+        // Doing similar logic to what is done in createProvider
+        Object provider = null;
+        try {
+            Class<?> cls = Class.forName(WADL_PROVIDER_NAME);
+            for (Constructor<?> c : cls.getConstructors()) {
+                if (c.getParameterTypes().length == 1 && c.getParameterTypes()[0] == Bus.class) {
+                    provider = c.newInstance(bus);
+                    break;
+                }
+            }
+            if (provider == null) {
+                provider = cls.newInstance();
+            }
+        } catch (Throwable ex) {
+            String message = "Problem with creating the default provider " + WADL_PROVIDER_NAME;
+            if (ex.getMessage() != null) {
+                message += ": " + ex.getMessage();
+            } else {
+                message += ", exception class : " + ex.getClass().getName();
+            }
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, message);
+            }
+        }
+        // Liberty Change for CXF End
+
         if (provider == null) {
             return null;
         } else {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/bus/LibertyApplicationBusFactory.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/bus/LibertyApplicationBusFactory.java
@@ -84,7 +84,7 @@ public class LibertyApplicationBusFactory extends CXFBusFactory {
         extensions.put(JaxRsModuleMetaData.class, moduleMetaData);
         extensions.put(LibertyApplicationBus.Type.class, LibertyApplicationBus.Type.SERVER);
 
-        LibertyApplicationBus bus = createBus(extensions, properties, moduleInfo.getClassLoader());
+        LibertyApplicationBus bus = createBus(extensions, properties, LibertyApplicationBusFactory.class.getClassLoader());
 
         return bus;
     }


### PR DESCRIPTION
- When initializing the CXF extensions, use the CXF bundle classloader
instead of the application classloader for the server scoped Bus
- Don't use thread context classloader to try to load the WadlGenerator.
Just use the bundle classloader.