### PR TITLE
Use a faster way to get current application name

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.3/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing.1.3/bnd.bnd
@@ -64,5 +64,6 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
         com.ibm.ws.io.opentracing.opentracing-util.0.31.0;version=latest, \
         com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
         com.ibm.websphere.javaee.servlet.3.1; version=latest, \
-        com.ibm.websphere.org.eclipse.microprofile.opentracing.1.3;version=latest
+        com.ibm.websphere.org.eclipse.microprofile.opentracing.1.3;version=latest, \
+        com.ibm.ws.container.service;version=latest
         

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUtils.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUtils.java
@@ -6,6 +6,7 @@ import javax.naming.NamingException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.opentracing.Tracer;
 
@@ -49,7 +50,7 @@ public class OpentracingUtils {
      *         the name cannot be retrieved by doing a context lookup.
      */
     @Trivial
-    public static String lookupAppName() {
+    public static String lookupAppNameFallback() {
         String appName;
         try {
             appName = (String) new InitialContext().lookup("java:app/AppName");
@@ -59,4 +60,19 @@ public class OpentracingUtils {
         }
         return appName;
     }
+
+    /**
+     * This is a more efficient way to obtain the current application name.
+     *
+     * @return The current application name.
+     */
+    @Trivial
+    public static String lookupAppName() {
+        String appName = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData().getModuleMetaData().getApplicationMetaData().getName();
+        if (appName == null) {
+            appName = lookupAppNameFallback();
+        }
+        return appName;
+    }
+
 }

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUtils.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUtils.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package com.ibm.ws.opentracing;
 
 import javax.naming.InitialContext;


### PR DESCRIPTION
Use a faster way to get current application name.  Keeping the existing way as a fallback if the new way returns null.