### PR TITLE
tests for jms admin objects via config endpoint

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
@@ -25,6 +25,7 @@ fat.project: true
 -buildpath: \
     com.ibm.websphere.javaee.annotation.1.2;version=latest,\
     com.ibm.websphere.javaee.connector.1.7;version=latest,\
+    com.ibm.websphere.javaee.jms.2.0;version=latest,\
     com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
     com.ibm.websphere.javaee.servlet.4.0;version=latest,\
     com.ibm.websphere.javaee.transaction.1.2;version=latest,\

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
@@ -1,0 +1,248 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.rest.handler.config.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpsRequest;
+
+@RunWith(FATRunner.class)
+public class ConfigRESTHandlerJMSTest extends FATServletClient {
+    @Server("com.ibm.ws.rest.handler.config.jms.fat")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "TestConfigJMSAdapter.rar")
+                        .addAsLibraries(ShrinkWrap.create(JavaArchive.class)
+                                        .addPackage("org.test.config.adapter")
+                                        .addPackage("org.test.config.jmsadapter"));
+        ShrinkHelper.exportToServer(server, "connectors", rar);
+
+        server.startServer();
+
+        // Wait for the API to become available
+        List<String> messages = new ArrayList<>();
+        messages.add("CWWKS0008I"); // CWWKS0008I: The security service is ready.
+        messages.add("CWWKS4105I"); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        messages.add("CWPKI0803A"); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
+        messages.add("CWWKO0219I: .* defaultHttpEndpoint-ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        messages.add("CWWKT0016I"); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
+        messages.add("J2CA7001I: .* jmsra"); // J2CA7001I: Resource adapter tca installed in # seconds.
+
+        server.waitForStringsInLogUsingMark(messages);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    // Test the output of the /ibm/api/config/jmsConnectionFactory/{uid} REST endpoint.
+    @Test
+    public void testJMSConnectionFactory() throws Exception {
+        JsonObject cf = new HttpsRequest(server, "/ibm/api/config/jmsConnectionFactory/cf1").run(JsonObject.class);
+        String err = "unexpected response: " + cf;
+        assertEquals(err, "jmsConnectionFactory", cf.getString("configElementName"));
+        assertEquals(err, "cf1", cf.getString("uid"));
+        assertEquals(err, "cf1", cf.getString("id"));
+        assertEquals(err, "jms/cf1", cf.getString("jndiName"));
+
+        JsonArray array;
+        JsonObject cm;
+        assertNotNull(err, array = cf.getJsonArray("connectionManagerRef"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, cm = array.getJsonObject(0));
+        assertEquals(err, "connectionManager", cm.getString("configElementName"));
+        assertEquals(err, "jmsConnectionFactory[cf1]/connectionManager[cm]", cm.getString("uid"));
+        assertEquals(err, "cm", cm.getString("id"));
+        assertEquals(err, 1800, cm.getInt("maxIdleTime"));
+        assertEquals(err, 14, cm.getInt("maxPoolSize"));
+        assertEquals(err, 4, cm.getInt("minPoolSize"));
+
+        JsonObject authData;
+        assertNotNull(err, array = cf.getJsonArray("containerAuthDataRef"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, authData = array.getJsonObject(0));
+        assertEquals(err, "authData", authData.getString("configElementName"));
+        assertEquals(err, "jmsUser1", authData.getString("uid"));
+        assertEquals(err, "jmsUser1", authData.getString("id"));
+        assertEquals(err, "jmsU1", authData.getString("user"));
+        assertEquals(err, "******", authData.getString("password"));
+
+        assertNotNull(err, array = cf.getJsonArray("recoveryAuthDataRef"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, authData = array.getJsonObject(0));
+        assertEquals(err, "authData", authData.getString("configElementName"));
+        assertEquals(err, "jmsUser1", authData.getString("uid"));
+        assertEquals(err, "jmsUser1", authData.getString("id"));
+        assertEquals(err, "jmsU1", authData.getString("user"));
+        assertEquals(err, "******", authData.getString("password"));
+
+        JsonObject props;
+        assertNotNull(err, array = cf.getJsonArray("properties.jmsra"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        assertEquals(err, 3, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "^", props.getString("escapeChar"));
+        assertEquals(err, "localhost", props.getString("hostName"));
+        assertEquals(err, 4455, props.getInt("portNumber"));
+    }
+
+    // Test the output of the /ibm/api/config/jmsConnectionFactory REST endpoint.
+    @Test
+    public void testJMSConnectionFactories() throws Exception {
+        JsonArray cfs = new HttpsRequest(server, "/ibm/api/config/jmsConnectionFactory").run(JsonArray.class);
+        String err = "unexpected response: " + cfs;
+        assertEquals(err, 2, cfs.size());
+
+        JsonObject cf;
+        assertNotNull(err, cf = cfs.getJsonObject(0));
+        assertEquals(err, "jmsConnectionFactory", cf.getString("configElementName"));
+        assertEquals(err, "DefaultJMSConnectionFactory", cf.getString("uid"));
+        assertEquals(err, "DefaultJMSConnectionFactory", cf.getString("id"));
+        assertNull(err, cf.get("jndiName"));
+
+        assertNotNull(err, cf = cfs.getJsonObject(1));
+        assertEquals(err, "jmsConnectionFactory", cf.getString("configElementName"));
+        assertEquals(err, "cf1", cf.getString("uid"));
+        assertEquals(err, "cf1", cf.getString("id"));
+        assertEquals(err, "jms/cf1", cf.getString("jndiName"));
+        // cf1 is already tested by testJMSConnectionFactory
+    }
+
+    // Test the output of the /ibm/api/config/jmsQueueConnectionFactory/{uid} REST endpoint.
+    @Test
+    public void testJMSQueueConnectionFactory() throws Exception {
+        JsonObject cf = new HttpsRequest(server, "/ibm/api/config/jmsQueueConnectionFactory/jmsQueueConnectionFactory[default-0]").run(JsonObject.class);
+        String err = "unexpected response: " + cf;
+        assertEquals(err, "jmsQueueConnectionFactory", cf.getString("configElementName"));
+        assertEquals(err, "jmsQueueConnectionFactory[default-0]", cf.getString("uid"));
+        assertNull(err, cf.get("id"));
+        assertEquals(err, "jms/qcf2", cf.getString("jndiName"));
+
+        assertNull(err, cf.get("containerAuthDataRef"));
+        assertNull(err, cf.get("recoveryAuthDataRef"));
+
+        JsonArray array;
+        JsonObject props;
+        assertNotNull(err, array = cf.getJsonArray("properties.jmsra"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "localhost", props.getString("hostName"));
+    }
+
+    // Test the output of the /ibm/api/config/jmsQueueConnectionFactory REST endpoint.
+    @Test
+    public void testJMSQueueConnectionFactories() throws Exception {
+        JsonArray cfs = new HttpsRequest(server, "/ibm/api/config/jmsQueueConnectionFactory").run(JsonArray.class);
+        String err = "unexpected response: " + cfs;
+        assertEquals(err, 1, cfs.size());
+
+        JsonObject cf;
+        assertNotNull(err, cf = cfs.getJsonObject(0));
+        assertEquals(err, "jmsQueueConnectionFactory", cf.getString("configElementName"));
+        assertEquals(err, "jmsQueueConnectionFactory[default-0]", cf.getString("uid"));
+        assertNull(err, cf.get("id"));
+        assertEquals(err, "jms/qcf2", cf.getString("jndiName"));
+        // cf1 is already tested by testJMSConnectionFactory
+    }
+
+    // Test the output of the /ibm/api/config/jmsTopicConnectionFactory/{uid} REST endpoint.
+    @Test
+    public void testJMSTopicConnectionFactory() throws Exception {
+        JsonObject cf = new HttpsRequest(server, "/ibm/api/config/jmsTopicConnectionFactory/cf3").run(JsonObject.class);
+        String err = "unexpected response: " + cf;
+        assertEquals(err, "jmsTopicConnectionFactory", cf.getString("configElementName"));
+        assertEquals(err, "cf3", cf.getString("uid"));
+        assertEquals(err, "cf3", cf.getString("id"));
+        assertEquals(err, "jms/tcf3", cf.getString("jndiName"));
+
+        assertNull(err, cf.get("containerAuthDataRef"));
+        assertNull(err, cf.get("recoveryAuthDataRef"));
+
+        JsonArray array;
+        JsonObject props;
+        assertNotNull(err, array = cf.getJsonArray("properties.jmsra"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        assertEquals(err, 4, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "%", props.getString("escapeChar"));
+        assertEquals(err, "localhost", props.getString("hostName"));
+        assertEquals(err, "user3", props.getString("userName"));
+        assertEquals(err, "******", props.getString("password"));
+    }
+
+    // Test the output of the /ibm/api/config/jmsTopicConnectionFactory REST endpoint.
+    @Test
+    public void testJMSTopicConnectionFactories() throws Exception {
+        JsonArray cfs = new HttpsRequest(server, "/ibm/api/config/jmsTopicConnectionFactory").run(JsonArray.class);
+        String err = "unexpected response: " + cfs;
+        assertEquals(err, 2, cfs.size());
+
+        JsonObject cf;
+        assertNotNull(err, cf = cfs.getJsonObject(0));
+        assertEquals(err, "jmsTopicConnectionFactory", cf.getString("configElementName"));
+        assertEquals(err, "cf3", cf.getString("uid"));
+        assertEquals(err, "cf3", cf.getString("id"));
+        assertEquals(err, "jms/tcf3", cf.getString("jndiName"));
+        // cf3 is already tested by testJMSTopicConnectionFactory
+
+        assertNotNull(err, cf = cfs.getJsonObject(1));
+        assertEquals(err, "jmsTopicConnectionFactory", cf.getString("configElementName"));
+        assertEquals(err, "cf4", cf.getString("uid"));
+        assertEquals(err, "cf4", cf.getString("id"));
+        assertEquals(err, "jms/tcf4", cf.getString("jndiName"));
+
+        JsonObject authData;
+        JsonArray array;
+        assertNotNull(err, array = cf.getJsonArray("containerAuthDataRef"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, authData = array.getJsonObject(0));
+        assertEquals(err, "authData", authData.getString("configElementName"));
+        assertEquals(err, "jmsUser1", authData.getString("uid"));
+        assertEquals(err, "jmsUser1", authData.getString("id"));
+        assertEquals(err, "jmsU1", authData.getString("user"));
+        assertEquals(err, "******", authData.getString("password"));
+
+        assertNull(err, cf.get("recoveryAuthDataRef"));
+
+        JsonObject props;
+        assertNotNull(err, array = cf.getJsonArray("properties.jmsra"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "host4.rchland.ibm.com", props.getString("hostName"));
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
@@ -141,6 +141,106 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         // cf1 is already tested by testJMSConnectionFactory
     }
 
+    // Test the output of the /ibm/api/config/jmsDestination/{uid} REST endpoint.
+    @Test
+    public void testJMSDestination() throws Exception {
+        JsonObject dest = new HttpsRequest(server, "/ibm/api/config/jmsDestination/dest1").run(JsonObject.class);
+        String err = "unexpected response: " + dest;
+        assertEquals(err, "jmsDestination", dest.getString("configElementName"));
+        assertEquals(err, "dest1", dest.getString("uid"));
+        assertEquals(err, "dest1", dest.getString("id"));
+        assertEquals(err, "jms/dest1", dest.getString("jndiName"));
+
+        JsonArray array;
+        JsonObject props;
+        assertNotNull(err, array = dest.getJsonArray("properties.jmsra.JMSDestinationImpl"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "3605 Hwy 52N, Rochester, MN 55901", props.getString("destinationName"));
+    }
+
+    // Test the output of the /ibm/api/config/jmsDestination REST endpoint,
+    // which should return all configured JMS destinations.
+    @Test
+    public void testJMSDestinations() throws Exception {
+        JsonArray destinations = new HttpsRequest(server, "/ibm/api/config/jmsDestination").run(JsonArray.class);
+        String err = "unexpected response: " + destinations;
+        assertEquals(err, 2, destinations.size());
+
+        JsonObject dest;
+        assertNotNull(err, dest = destinations.getJsonObject(0));
+        assertEquals(err, "jmsDestination", dest.getString("configElementName"));
+        assertEquals(err, "dest1", dest.getString("uid"));
+        assertEquals(err, "dest1", dest.getString("id"));
+        assertEquals(err, "jms/dest1", dest.getString("jndiName"));
+        // dest1 already tested by testJMSDestination
+
+        assertNotNull(err, dest = destinations.getJsonObject(1));
+        assertEquals(err, "jmsDestination", dest.getString("configElementName"));
+        assertEquals(err, "dest2", dest.getString("uid"));
+        assertEquals(err, "dest2", dest.getString("id"));
+        assertEquals(err, "jms/dest2", dest.getString("jndiName"));
+        JsonArray array;
+        JsonObject props;
+        assertNotNull(err, array = dest.getJsonArray("properties.jmsra.JMSQueueImpl"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        assertEquals(err, 2, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "201 4th St SE, Rochester, MN 55904", props.getString("destinationName"));
+        assertEquals(err, "D2", props.getString("queueName"));
+    }
+
+    // Test the output of the /ibm/api/config/jmsQueue/{uid} REST endpoint.
+    @Test
+    public void testJMSQueue() throws Exception {
+        JsonObject q = new HttpsRequest(server, "/ibm/api/config/jmsQueue/q1").run(JsonObject.class);
+        String err = "unexpected response: " + q;
+        assertEquals(err, "jmsQueue", q.getString("configElementName"));
+        assertEquals(err, "q1", q.getString("uid"));
+        assertEquals(err, "q1", q.getString("id"));
+        assertEquals(err, "jms/q1", q.getString("jndiName"));
+
+        JsonArray array;
+        JsonObject props;
+        assertNotNull(err, array = q.getJsonArray("properties.jmsra.JMSQueueImpl"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "Q1", props.getString("queueName"));
+    }
+
+    // Test the output of the /ibm/api/config/jmsQueue REST endpoint,
+    // which should return all configured JMS queues.
+    @Test
+    public void testJMSQueues() throws Exception {
+        JsonArray queues = new HttpsRequest(server, "/ibm/api/config/jmsQueue").run(JsonArray.class);
+        String err = "unexpected response: " + queues;
+        assertEquals(err, 2, queues.size());
+
+        JsonObject q;
+        assertNotNull(err, q = queues.getJsonObject(0));
+        assertEquals(err, "jmsQueue", q.getString("configElementName"));
+        assertEquals(err, "q1", q.getString("uid"));
+        assertEquals(err, "q1", q.getString("id"));
+        assertEquals(err, "jms/q1", q.getString("jndiName"));
+        // q1 already tested by testJMSQueue
+
+        assertNotNull(err, q = queues.getJsonObject(1));
+        assertEquals(err, "jmsQueue", q.getString("configElementName"));
+        assertEquals(err, "q2", q.getString("uid"));
+        assertEquals(err, "q2", q.getString("id"));
+        assertEquals(err, "jms/q2", q.getString("jndiName"));
+        JsonArray array;
+        JsonObject props;
+        assertNotNull(err, array = q.getJsonArray("properties.jmsra.JMSOtherQueueImpl"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        assertEquals(err, 2, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "qm", props.getString("queueManager"));
+        assertEquals(err, "Q2", props.getString("queueName"));
+    }
+
     // Test the output of the /ibm/api/config/jmsQueueConnectionFactory/{uid} REST endpoint.
     @Test
     public void testJMSQueueConnectionFactory() throws Exception {
@@ -177,6 +277,55 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertNull(err, cf.get("id"));
         assertEquals(err, "jms/qcf2", cf.getString("jndiName"));
         // cf1 is already tested by testJMSConnectionFactory
+    }
+
+    // Test the output of the /ibm/api/config/jmsTopic/{uid} REST endpoint.
+    @Test
+    public void testJMSTopic() throws Exception {
+        JsonObject topic = new HttpsRequest(server, "/ibm/api/config/jmsTopic/topic1").run(JsonObject.class);
+        String err = "unexpected response: " + topic;
+        assertEquals(err, "jmsTopic", topic.getString("configElementName"));
+        assertEquals(err, "topic1", topic.getString("uid"));
+        assertEquals(err, "topic1", topic.getString("id"));
+        assertEquals(err, "jms/topic1", topic.getString("jndiName"));
+
+        JsonArray array;
+        JsonObject props;
+        assertNotNull(err, array = topic.getJsonArray("properties.jmsra"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "What's for dinner?", props.getString("topicName"));
+    }
+
+    // Test the output of the /ibm/api/config/jmsQueue REST endpoint,
+    // which should return all configured JMS queues.
+    @Test
+    public void testJMSTopics() throws Exception {
+        JsonArray topics = new HttpsRequest(server, "/ibm/api/config/jmsTopic").run(JsonArray.class);
+        String err = "unexpected response: " + topics;
+        assertEquals(err, 2, topics.size());
+
+        JsonObject q;
+        assertNotNull(err, q = topics.getJsonObject(0));
+        assertEquals(err, "jmsTopic", q.getString("configElementName"));
+        assertEquals(err, "topic1", q.getString("uid"));
+        assertEquals(err, "topic1", q.getString("id"));
+        assertEquals(err, "jms/topic1", q.getString("jndiName"));
+        // topic1 already tested by testJMSTopic
+
+        assertNotNull(err, q = topics.getJsonObject(1));
+        assertEquals(err, "jmsTopic", q.getString("configElementName"));
+        assertEquals(err, "topic2", q.getString("uid"));
+        assertEquals(err, "topic2", q.getString("id"));
+        assertEquals(err, "jms/topic2", q.getString("jndiName"));
+        JsonArray array;
+        JsonObject props;
+        assertNotNull(err, array = q.getJsonArray("properties.jmsra"));
+        assertEquals(err, 1, array.size());
+        assertNotNull(err, props = array.getJsonObject(0));
+        assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "Who pays for free shipping?", props.getString("topicName"));
     }
 
     // Test the output of the /ibm/api/config/jmsTopicConnectionFactory/{uid} REST endpoint.

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/FATSuite.java
@@ -20,6 +20,7 @@ import componenttest.topology.utils.HttpUtils;
 @RunWith(Suite.class)
 @SuiteClasses({
                 ConfigRESTHandlerJCATest.class,
+                ConfigRESTHandlerJMSTest.class,
                 ConfigRESTHandlerTest.class
 })
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jms.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jms.fat/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:rest.config=all:rarInstall=all
+com.ibm.ws.logging.max.file.size=0
+ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jms.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jms.fat/server.xml
@@ -1,0 +1,51 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <include location="../fatTestPorts.xml" />
+
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>configValidator-1.0</feature> <!-- TODO replace when functionality is enabled via auto-feature -->
+    <feature>jms-2.0</feature>
+  </featureManager>
+
+  <variable name="onError" value="FAIL"/>
+
+  <keyStore id="defaultKeyStore" password="Liberty"/>
+  <quickStartSecurity userName="adminuser" userPassword="adminpwd"/>
+
+  <resourceAdapter id="jmsra" location="${server.config.dir}/connectors/TestConfigJMSAdapter.rar">
+    <properties.jmsra debugMode="true"/>
+  </resourceAdapter>
+
+  <authData id="jmsUser1" user="jmsU1" password="1jmsU"/>
+
+  <jmsConnectionFactory id="cf1" jndiName="jms/cf1" containerAuthDataRef="jmsUser1" recoveryAuthDataRef="jmsUser1">
+    <connectionManager id="cm" maxPoolSize="14" minPoolSize="4"/>
+    <properties.jmsra escapeChar="^" portNumber="4455"/>
+  </jmsConnectionFactory>
+
+  <!-- merges with above -->
+  <jmsConnectionFactory id="cf1" containerAuthDataRef="jmsUser1" recoveryAuthDataRef="jmsUser1"/>
+
+  <jmsQueueConnectionFactory jndiName="jms/qcf2">
+    <properties.jmsra/>
+  </jmsQueueConnectionFactory>
+
+  <jmsTopicConnectionFactory id="cf3" jndiName="jms/tcf3">
+    <properties.jmsra escapeChar="%" userName="user3" password="3user"/>
+  </jmsTopicConnectionFactory>
+
+  <jmsTopicConnectionFactory id="cf4" jndiName="jms/tcf4" containerAuthDataRef="jmsUser1">
+    <properties.jmsra hostName="host4.rchland.ibm.com"/>
+  </jmsTopicConnectionFactory>
+
+</server>

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jms.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jms.fat/server.xml
@@ -36,9 +36,33 @@
   <!-- merges with above -->
   <jmsConnectionFactory id="cf1" containerAuthDataRef="jmsUser1" recoveryAuthDataRef="jmsUser1"/>
 
+  <jmsDestination id="dest1" jndiName="jms/dest1">
+    <properties.jmsra.JMSDestinationImpl destinationName="3605 Hwy 52N, Rochester, MN 55901"/>
+  </jmsDestination>
+
+  <jmsDestination id="dest2" jndiName="jms/dest2">
+    <properties.jmsra.JMSQueueImpl destinationName="201 4th St SE, Rochester, MN 55904" queueName="D2"/>
+  </jmsDestination>
+
+  <jmsQueue id="q1" jndiName="jms/q1">
+    <properties.jmsra.JMSQueueImpl queueName="Q1"/>
+  </jmsQueue>
+
+  <jmsQueue id="q2" jndiName="jms/q2">
+    <properties.jmsra.JMSOtherQueueImpl queueName="Q2" queueManager="qm"/>
+  </jmsQueue>
+
   <jmsQueueConnectionFactory jndiName="jms/qcf2">
     <properties.jmsra/>
   </jmsQueueConnectionFactory>
+
+  <jmsTopic id="topic1" jndiName="jms/topic1">
+    <properties.jmsra topicName="What's for dinner?"/>
+  </jmsTopic>
+
+  <jmsTopic id="topic2" jndiName="jms/topic2">
+    <properties.jmsra topicName="Who pays for free shipping?"/>
+  </jmsTopic>
 
   <jmsTopicConnectionFactory id="cf3" jndiName="jms/tcf3">
     <properties.jmsra escapeChar="%" userName="user3" password="3user"/>

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSConnectionFactoryImpl.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSContext;
+import javax.jms.JMSException;
+
+public class JMSConnectionFactoryImpl implements ConnectionFactory {
+    @Override
+    public Connection createConnection() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Connection createConnection(String user, String password) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JMSContext createContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JMSContext createContext(int sessionMode) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JMSContext createContext(String user, String password) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JMSContext createContext(String user, String password, int sessionMode) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSDestinationImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSDestinationImpl.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.Destination;
+import javax.resource.spi.AdministeredObject;
+import javax.resource.spi.ConfigProperty;
+
+@AdministeredObject(adminObjectInterfaces = Destination.class)
+public class JMSDestinationImpl implements Destination {
+    @ConfigProperty
+    private String destinationName;
+
+    public String getDestinationName() {
+        return destinationName;
+    }
+
+    public void setDestinationName(String value) {
+        this.destinationName = value;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSOtherQueueImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSOtherQueueImpl.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.Queue;
+import javax.resource.spi.AdministeredObject;
+import javax.resource.spi.ConfigProperty;
+
+@AdministeredObject(adminObjectInterfaces = Queue.class)
+public class JMSOtherQueueImpl implements Queue {
+    @ConfigProperty(defaultValue = "qm")
+    private String queueManager;
+
+    @ConfigProperty
+    private String queueName;
+
+    public String getQueueManager() {
+        return queueManager;
+    }
+
+    @Override
+    public String getQueueName() {
+        return queueName;
+    }
+
+    public void setQueueManager(String value) {
+        this.queueManager = value;
+    }
+
+    public void setQueueName(String value) {
+        this.queueName = value;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSQueueConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSQueueConnectionFactoryImpl.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.JMSException;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+
+public class JMSQueueConnectionFactoryImpl extends JMSConnectionFactoryImpl implements QueueConnectionFactory {
+    @Override
+    public QueueConnection createQueueConnection() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public QueueConnection createQueueConnection(String user, String password) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSQueueImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSQueueImpl.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.Destination;
+import javax.jms.Queue;
+import javax.resource.spi.AdministeredObject;
+import javax.resource.spi.ConfigProperty;
+
+@AdministeredObject(adminObjectInterfaces = { Queue.class, Destination.class })
+public class JMSQueueImpl extends JMSDestinationImpl implements Queue {
+    @ConfigProperty
+    private String queueName;
+
+    @Override
+    public String getQueueName() {
+        return queueName;
+    }
+
+    public void setQueueName(String value) {
+        this.queueName = value;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSTopicConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSTopicConnectionFactoryImpl.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.JMSException;
+import javax.jms.TopicConnection;
+import javax.jms.TopicConnectionFactory;
+
+public class JMSTopicConnectionFactoryImpl extends JMSConnectionFactoryImpl implements TopicConnectionFactory {
+    @Override
+    public TopicConnection createTopicConnection() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TopicConnection createTopicConnection(String user, String password) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSTopicImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSTopicImpl.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.Topic;
+import javax.resource.spi.AdministeredObject;
+import javax.resource.spi.ConfigProperty;
+
+@AdministeredObject(adminObjectInterfaces = Topic.class)
+public class JMSTopicImpl extends JMSDestinationImpl implements Topic {
+    @ConfigProperty
+    private String topicName;
+
+    @Override
+    public String getTopicName() {
+        return topicName;
+    }
+
+    public void setTopicName(String value) {
+        this.topicName = value;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/ManagedJMSConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/ManagedJMSConnectionFactoryImpl.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionDefinition;
+import javax.resource.spi.ConnectionManager;
+
+import org.test.config.adapter.ConnectionImpl;
+import org.test.config.adapter.ManagedConnectionFactoryImpl;
+
+/**
+ * Mock managed connection factory which is only used to supply configuration.
+ */
+@ConnectionDefinition(connectionFactory = ConnectionFactory.class,
+                      connectionFactoryImpl = JMSConnectionFactoryImpl.class,
+                      connection = Connection.class,
+                      connectionImpl = ConnectionImpl.class)
+public class ManagedJMSConnectionFactoryImpl extends ManagedConnectionFactoryImpl {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Object createConnectionFactory() throws ResourceException {
+        return createConnectionFactory(null);
+    }
+
+    @Override
+    public Object createConnectionFactory(ConnectionManager cm) throws ResourceException {
+        return new JMSConnectionFactoryImpl();
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/ManagedJMSQueueConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/ManagedJMSQueueConnectionFactoryImpl.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionDefinition;
+import javax.resource.spi.ConnectionManager;
+
+import org.test.config.adapter.ConnectionImpl;
+import org.test.config.adapter.ManagedConnectionFactoryImpl;
+
+/**
+ * Mock managed connection factory which is only used to supply configuration.
+ */
+@ConnectionDefinition(connectionFactory = QueueConnectionFactory.class,
+                      connectionFactoryImpl = JMSQueueConnectionFactoryImpl.class,
+                      connection = QueueConnection.class,
+                      connectionImpl = ConnectionImpl.class)
+public class ManagedJMSQueueConnectionFactoryImpl extends ManagedConnectionFactoryImpl {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Object createConnectionFactory() throws ResourceException {
+        return createConnectionFactory(null);
+    }
+
+    @Override
+    public Object createConnectionFactory(ConnectionManager cm) throws ResourceException {
+        return new JMSQueueConnectionFactoryImpl();
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/ManagedJMSTopicConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/ManagedJMSTopicConnectionFactoryImpl.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.TopicConnection;
+import javax.jms.TopicConnectionFactory;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionDefinition;
+import javax.resource.spi.ConnectionManager;
+
+import org.test.config.adapter.ConnectionImpl;
+import org.test.config.adapter.ManagedConnectionFactoryImpl;
+
+/**
+ * Mock managed connection factory which is only used to supply configuration.
+ */
+@ConnectionDefinition(connectionFactory = TopicConnectionFactory.class,
+                      connectionFactoryImpl = JMSTopicConnectionFactoryImpl.class,
+                      connection = TopicConnection.class,
+                      connectionImpl = ConnectionImpl.class)
+public class ManagedJMSTopicConnectionFactoryImpl extends ManagedConnectionFactoryImpl {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Object createConnectionFactory() throws ResourceException {
+        return createConnectionFactory(null);
+    }
+
+    @Override
+    public Object createConnectionFactory(ConnectionManager cm) throws ResourceException {
+        return new JMSTopicConnectionFactoryImpl();
+    }
+}


### PR DESCRIPTION
Write tests for obtaining configuration of jmsDestination, jmsQueue, and jmsTopic via the /ibm/api/config/ REST endpoint.