### PR TITLE
Remove extra debug when updating test counts

### DIFF
--- a/dev/cnf/gradle/scripts/tasks.gradle
+++ b/dev/cnf/gradle/scripts/tasks.gradle
@@ -375,19 +375,11 @@ test {
   }
   afterSuite { desc, result ->
     if (!desc.parent) { // will match the outermost suite
-      println "ANDY Adding result totals:"
-      print result.testCount
-      println " tests"
-      print result.successfulTestCount
-      println " passing"
-      print result.failedTestCount
-      println " failing"
-      print result.skippedTestCount
-      println " skipped"
       rootProject.ext.testCountTotal = rootProject.ext.testCountTotal + result.testCount
       rootProject.ext.successfulTestCountTotal = rootProject.ext.successfulTestCountTotal + result.successfulTestCount
       rootProject.ext.failedTestCountTotal = rootProject.ext.failedTestCountTotal + result.failedTestCount
       rootProject.ext.skippedTestCountTotal = rootProject.ext.skippedTestCountTotal + result.skippedTestCount
+      println "Test counts so far:"
       print rootProject.ext.testCountTotal
       println " total tests"
       print rootProject.ext.successfulTestCountTotal


### PR DESCRIPTION
Removing some unnecessary debug I had added under #7337.  Just keeping the updated test counts in case there is another problem in the area in the future.