### PR TITLE
jmsActivationSpec via config REST endpoint

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
@@ -98,9 +98,10 @@ public class ConfigRESTHandler implements RESTHandler {
 
         //Get pid to use with config service
         String servicePid = isFactoryPid ? (String) config.get("service.factoryPid") : (String) config.get("service.pid");
+        String extendsSourcePid = isFactoryPid ? (String) config.get("ibm.extends.source.factoryPid") : (String) config.get("ibm.extends.source.pid");
 
-        String metaTypeElementName = configHelper.getMetaTypeElementName(servicePid);
-        // if the element's name is internal no config should be added for that element
+        String metaTypeElementName = configHelper.getMetaTypeElementName(extendsSourcePid == null ? servicePid : extendsSourcePid);
+        // if the element's name is internal, no config should be added for that element
         if (metaTypeElementName != null && metaTypeElementName.equalsIgnoreCase("internal"))
             return null;
 
@@ -131,7 +132,7 @@ public class ConfigRESTHandler implements RESTHandler {
                 continue;
             }
 
-            String metaTypeName = configHelper.getMetaTypeAttributeName(servicePid, key);
+            String metaTypeName = configHelper.getMetaTypeAttributeName(extendsSourcePid == null ? servicePid : extendsSourcePid, key);
             if ("id".equals(key) && "library".equals(configElementName)) {
                 // Work around the <library> element marking its id attribute as internal when its
                 // id is actually a configurable external.

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jms.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jms.fat/server.xml
@@ -72,4 +72,11 @@
     <properties.jmsra hostName="host4.rchland.ibm.com"/>
   </jmsTopicConnectionFactory>
 
+  <jmsActivationSpec id="App1/EJB1/MessageDrivenBean1" authDataRef="jmsUser1">
+    <properties.jmsra destinationRef="dest1"/>
+  </jmsActivationSpec>
+
+  <jmsActivationSpec id="App1/EJB1/MessageDrivenBean2">
+    <properties.jmsra destinationRef="topic1"/>
+  </jmsActivationSpec>
 </server>

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSActivationSpecImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSActivationSpecImpl.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import javax.jms.MessageListener;
+import javax.resource.ResourceException;
+import javax.resource.spi.Activation;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.ConfigProperty;
+import javax.resource.spi.InvalidPropertyException;
+import javax.resource.spi.ResourceAdapter;
+
+@Activation(messageListeners = MessageListener.class)
+public class JMSActivationSpecImpl implements ActivationSpec {
+    private ResourceAdapter adapter;
+
+    @ConfigProperty(type = String.class)
+    private String destination;
+
+    @ConfigProperty(type = String.class, defaultValue = "javax.jms.Topic")
+    private String destinationType;
+
+    @ConfigProperty
+    private String messageSelector;
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public String getDestinationType() {
+        return destinationType;
+    }
+
+    public String getMessageSelector() {
+        return messageSelector;
+    }
+
+    @Override
+    public ResourceAdapter getResourceAdapter() {
+        return adapter;
+    }
+
+    public void setDestination(String value) {
+        this.destination = value;
+    }
+
+    public void setDestinationType(String value) {
+        this.destinationType = value;
+    }
+
+    public void setMessageSelector(String value) {
+        this.messageSelector = value;
+    }
+
+    @Override
+    public void setResourceAdapter(ResourceAdapter adapter) throws ResourceException {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public void validate() throws InvalidPropertyException {
+    }
+}


### PR DESCRIPTION
Add tests and updated code to support the displaying of jmsActivationSpec and referenced configuration via the /ibm/api/config REST API.