### PR TITLE
objects should not be wrapped in json arrays when cardinality is 1

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/websphere/config/WSConfigurationHelper.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/websphere/config/WSConfigurationHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -68,6 +68,15 @@ public interface WSConfigurationHelper {
      * @throws ConfigUpdateException
      */
     boolean removeDefaultConfiguration(String pid, String id) throws ConfigUpdateException;
+
+    /**
+     * Returns the metatype attribute cardinality for the configuration with the specified pid and attribute id.
+     *
+     * @param pid The pid or factory pid
+     * @param attributeID
+     * @return the cardinality for the specified attribute or null if the attribute or configuration element doesn't exist.
+     */
+    Integer getMetaTypeAttributeCardinality(String pid, String attributeID);
 
     /**
      * Returns the metatype attribute name for the configuration with the specified pid and attribute id.

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/MetaTypeRegistry.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/MetaTypeRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2013 IBM Corporation and others.
+ * Copyright (c) 2009, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1673,6 +1673,17 @@ final class MetaTypeRegistry {
         RegistryEntry entry = getRegistryEntry(factoryPid);
         if (entry != null) {
             return entry.getAttributeMap();
+        }
+        return null;
+    }
+
+    Integer getAttributeCardinality(String pid, String attributeID) {
+        RegistryEntry ent = getRegistryEntryByPidOrAlias(pid);
+        if (ent != null) {
+            Map<String, ExtendedAttributeDefinition> attributeMap;
+            attributeMap = ent.getAttributeMap();
+            if (attributeMap != null && attributeMap.containsKey(attributeID))
+                return attributeMap.get(attributeID).getCardinality();
         }
         return null;
     }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/WSConfigurationHelperImpl.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/WSConfigurationHelperImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.Dictionary;
 import com.ibm.websphere.config.ConfigEvaluatorException;
 import com.ibm.websphere.config.ConfigUpdateException;
 import com.ibm.websphere.config.WSConfigurationHelper;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.config.xml.internal.ConfigEvaluator.EvaluationResult;
 import com.ibm.ws.config.xml.internal.MetaTypeRegistry.RegistryEntry;
 
@@ -81,6 +82,12 @@ public class WSConfigurationHelperImpl implements WSConfigurationHelper {
     @Override
     public boolean removeDefaultConfiguration(String pid, String id) throws ConfigUpdateException {
         return bundleProcessor.removeDefaultConfiguration(pid, id);
+    }
+
+    @Override
+    @Trivial
+    public Integer getMetaTypeAttributeCardinality(String pid, String attributeID) {
+        return metatypeRegistry.getAttributeCardinality(pid, attributeID);
     }
 
     /*

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJCATest.java
@@ -84,11 +84,8 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertEquals(err, "cf1", cf.getString("id"));
         assertEquals(err, "eis/cf1", cf.getString("jndiName"));
 
-        JsonArray array;
         JsonObject cm;
-        assertNotNull(err, array = cf.getJsonArray("connectionManagerRef"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, cm = array.getJsonObject(0));
+        assertNotNull(err, cm = cf.getJsonObject("connectionManagerRef"));
         assertEquals(err, "connectionManager", cm.getString("configElementName"));
         assertEquals(err, "cm1", cm.getString("uid"));
         assertEquals(err, "cm1", cm.getString("id"));
@@ -96,18 +93,14 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertEquals(err, "EntirePool", cm.getString("purgePolicy"));
 
         JsonObject authData;
-        assertNotNull(err, array = cf.getJsonArray("containerAuthDataRef"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, authData = array.getJsonObject(0));
+        assertNotNull(err, authData = cf.getJsonObject("containerAuthDataRef"));
         assertEquals(err, "containerAuthData", authData.getString("configElementName"));
         assertEquals(err, "connectionFactory[cf1]/containerAuthData[default-0]", authData.getString("uid"));
         assertNull(err, authData.getJsonObject("id"));
         assertEquals(err, "containerUser1", authData.getString("user"));
         assertEquals(err, "******", authData.getString("password"));
 
-        assertNotNull(err, array = cf.getJsonArray("recoveryAuthDataRef"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, authData = array.getJsonObject(0));
+        assertNotNull(err, authData = cf.getJsonObject("recoveryAuthDataRef"));
         assertEquals(err, "recoveryAuthData", authData.getString("configElementName"));
         assertEquals(err, "connectionFactory[cf1]/recoveryAuthData[default-0]", authData.getString("uid"));
         assertNull(err, authData.getJsonObject("id"));
@@ -115,9 +108,7 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertEquals(err, "******", authData.getString("password"));
 
         JsonObject props;
-        assertNotNull(err, array = cf.getJsonArray("properties.tca.ConnectionFactory"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = cf.getJsonObject("properties.tca.ConnectionFactory"));
         assertEquals(err, 3, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, true, props.getBoolean("enableBetaContent"));
         assertEquals(err, "localhost", props.getString("hostName"));
@@ -146,11 +137,8 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertNull(err, aspec.get("jndiName"));
         assertNull(err, aspec.get("containerAuthDataRef"));
         assertNull(err, aspec.get("recoveryAuthDataRef"));
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = aspec.getJsonArray("properties.tca"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = aspec.getJsonObject("properties.tca"));
         assertEquals(err, 2, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, 8, props.getInt("minSize"));
         assertEquals(err, 1.618, props.getJsonNumber("multiplicationFactor").doubleValue(), 0.0001);
@@ -169,11 +157,8 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertEquals(err, "conspec1", conspec.getString("uid"));
         assertEquals(err, "conspec1", conspec.getString("id"));
         assertEquals(err, "eis/conspec1", conspec.getString("jndiName"));
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = conspec.getJsonArray("properties.tca.ConnectionSpec"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = conspec.getJsonObject("properties.tca.ConnectionSpec"));
         assertEquals(err, 4, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, 10000, props.getInt("connectionTimeout"));
         assertEquals(err, false, props.getBoolean("readOnly"));
@@ -185,15 +170,14 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertEquals(err, "conspec2", conspec.getString("uid"));
         assertEquals(err, "conspec2", conspec.getString("id"));
         assertEquals(err, "eis/conspec2", conspec.getString("jndiName"));
-        assertNull(err, array = conspec.getJsonArray("properties.tca.ConnectionSpec"));
+        assertNull(err, conspec.get("properties.tca.ConnectionSpec"));
 
         assertNotNull(err, conspec = adminObjects.getJsonObject(2));
         assertEquals(err, "adminObject", conspec.getString("configElementName"));
         assertEquals(err, "adminObject[default-0]", conspec.getString("uid"));
         assertNull(err, conspec.get("id"));
         assertEquals(err, "eis/conspec3", conspec.getString("jndiName"));
-        assertNotNull(err, array = conspec.getJsonArray("properties.tca.ConnectionSpec"));
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = conspec.getJsonObject("properties.tca.ConnectionSpec"));
         assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, false, props.getBoolean("readOnly"));
     }
@@ -218,11 +202,8 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertEquals(err, "cf3", cf.getString("uid"));
         assertEquals(err, "cf3", cf.getString("id"));
         assertEquals(err, "eis/cf3", cf.getString("jndiName"));
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = cf.getJsonArray("properties.AnotherTestAdapter.ConnectionFactory"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = cf.getJsonObject("properties.AnotherTestAdapter.ConnectionFactory"));
         assertEquals(err, 2, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, false, props.getBoolean("enableBetaContent"));
         assertEquals(err, "localhost", props.getString("hostName"));
@@ -237,9 +218,7 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertNull(err, cf.get("containerAuthDataRef"));
         assertNull(err, cf.get("recoveryAuthDataRef"));
 
-        assertNotNull(err, array = cf.getJsonArray("properties.tca.DataSource"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = cf.getJsonObject("properties.tca.DataSource"));
         assertEquals(err, 4, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "$", props.getString("escapeChar"));
         assertEquals(err, "localhost", props.getString("hostName"));
@@ -258,11 +237,8 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertEquals(err, "tca", adapter.getString("id"));
         assertTrue(err, adapter.getString("location").endsWith("TestConfigAdapter.rar"));
 
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = adapter.getJsonArray("properties.tca"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = adapter.getJsonObject("properties.tca"));
         assertEquals(err, true, props.getBoolean("debugMode"));
         assertEquals(err, "host1.openliberty.io", props.getString("hostName"));
     }
@@ -314,11 +290,8 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertNull(err, adapter.get("id"));
         assertTrue(err, adapter.getString("location").endsWith("AnotherTestAdapter.rar"));
 
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = adapter.getJsonArray("properties.AnotherTestAdapter"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = adapter.getJsonObject("properties.AnotherTestAdapter"));
         assertNull(err, props.get("debugMode"));
         assertEquals(err, "host1.openliberty.io", props.getString("hostName"));
     }
@@ -334,11 +307,8 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertEquals(err, "App1/EJB1/MyMDB", aspec.getString("id"));
         assertNull(err, aspec.get("jndiName"));
 
-        JsonArray array;
         JsonObject authData;
-        assertNotNull(err, array = aspec.getJsonArray("authDataRef"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, authData = array.getJsonObject(0));
+        assertNotNull(err, authData = aspec.getJsonObject("authDataRef"));
         assertEquals(err, "authData", authData.getString("configElementName"));
         assertEquals(err, "activationSpec[App1/EJB1/MyMDB]/authData[default-0]", authData.getString("uid"));
         assertNull(err, authData.getJsonObject("id"));
@@ -346,9 +316,7 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertEquals(err, "******", authData.getString("password"));
 
         JsonObject props;
-        assertNotNull(err, array = aspec.getJsonArray("properties.tca"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = aspec.getJsonObject("properties.tca"));
         assertEquals(err, 4, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, 8192, props.getInt("maxSize"));
         assertEquals(err, "*", props.getString("messageSelector"));
@@ -367,10 +335,8 @@ public class ConfigRESTHandlerJCATest extends FATServletClient {
         assertNull(err, conspec.get("id"));
         assertEquals(err, "eis/conspec3", conspec.getString("jndiName"));
 
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = conspec.getJsonArray("properties.tca.ConnectionSpec"));
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = conspec.getJsonObject("properties.tca.ConnectionSpec"));
         assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, false, props.getBoolean("readOnly"));
     }

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
@@ -80,11 +80,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertNull(err, aspec.get("jndiName"));
         assertTrue(err, aspec.getBoolean("autoStart"));
 
-        JsonArray array;
         JsonObject authData;
-        assertNotNull(err, array = aspec.getJsonArray("authDataRef"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, authData = array.getJsonObject(0));
+        assertNotNull(err, authData = aspec.getJsonObject("authDataRef"));
         assertEquals(err, "authData", authData.getString("configElementName"));
         assertEquals(err, "jmsUser1", authData.getString("uid"));
         assertEquals(err, "jmsUser1", authData.getString("id"));
@@ -93,9 +90,7 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
 
         // properties.jmsra (under jmsActivationSpec)
         JsonObject props;
-        assertNotNull(err, array = aspec.getJsonArray("properties.jmsra"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = aspec.getJsonObject("properties.jmsra"));
         assertEquals(err, 2, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "javax.jms.Topic", props.getString("destinationType"));
 
@@ -107,11 +102,9 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "dest1", dest.getString("uid"));
         assertEquals(err, "dest1", dest.getString("id"));
         assertEquals(err, "jms/dest1", dest.getString("jndiName"));
-        assertNotNull(err, array = dest.getJsonArray("properties.jmsra.JMSDestinationImpl"));
 
         // properties.jmsra.JMSDestinationImpl (under jmsDestination)
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = dest.getJsonObject("properties.jmsra.JMSDestinationImpl"));
         assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values
         assertEquals(err, "3605 Hwy 52N, Rochester, MN 55901", props.getString("destinationName"));
     }
@@ -141,11 +134,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertNull(err, aspec.get("authDataRef"));
 
         // properties.jmsra (under jmsActivationSpec)
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = aspec.getJsonArray("properties.jmsra"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = aspec.getJsonObject("properties.jmsra"));
         assertEquals(err, 2, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "javax.jms.Topic", props.getString("destinationType"));
 
@@ -157,11 +147,9 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "topic1", dest.getString("uid"));
         assertEquals(err, "topic1", dest.getString("id"));
         assertEquals(err, "jms/topic1", dest.getString("jndiName"));
-        assertNotNull(err, array = dest.getJsonArray("properties.jmsra"));
 
         // properties.jmsra (under jmsTopic)
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = dest.getJsonObject("properties.jmsra"));
         assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values
         assertEquals(err, "What's for dinner?", props.getString("topicName"));
     }
@@ -176,11 +164,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "cf1", cf.getString("id"));
         assertEquals(err, "jms/cf1", cf.getString("jndiName"));
 
-        JsonArray array;
         JsonObject cm;
-        assertNotNull(err, array = cf.getJsonArray("connectionManagerRef"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, cm = array.getJsonObject(0));
+        assertNotNull(err, cm = cf.getJsonObject("connectionManagerRef"));
         assertEquals(err, "connectionManager", cm.getString("configElementName"));
         assertEquals(err, "jmsConnectionFactory[cf1]/connectionManager[cm]", cm.getString("uid"));
         assertEquals(err, "cm", cm.getString("id"));
@@ -189,18 +174,14 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, 4, cm.getInt("minPoolSize"));
 
         JsonObject authData;
-        assertNotNull(err, array = cf.getJsonArray("containerAuthDataRef"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, authData = array.getJsonObject(0));
+        assertNotNull(err, authData = cf.getJsonObject("containerAuthDataRef"));
         assertEquals(err, "authData", authData.getString("configElementName"));
         assertEquals(err, "jmsUser1", authData.getString("uid"));
         assertEquals(err, "jmsUser1", authData.getString("id"));
         assertEquals(err, "jmsU1", authData.getString("user"));
         assertEquals(err, "******", authData.getString("password"));
 
-        assertNotNull(err, array = cf.getJsonArray("recoveryAuthDataRef"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, authData = array.getJsonObject(0));
+        assertNotNull(err, authData = cf.getJsonObject("recoveryAuthDataRef"));
         assertEquals(err, "authData", authData.getString("configElementName"));
         assertEquals(err, "jmsUser1", authData.getString("uid"));
         assertEquals(err, "jmsUser1", authData.getString("id"));
@@ -208,9 +189,7 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "******", authData.getString("password"));
 
         JsonObject props;
-        assertNotNull(err, array = cf.getJsonArray("properties.jmsra"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = cf.getJsonObject("properties.jmsra"));
         assertEquals(err, 3, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "^", props.getString("escapeChar"));
         assertEquals(err, "localhost", props.getString("hostName"));
@@ -249,11 +228,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "dest1", dest.getString("id"));
         assertEquals(err, "jms/dest1", dest.getString("jndiName"));
 
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = dest.getJsonArray("properties.jmsra.JMSDestinationImpl"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = dest.getJsonObject("properties.jmsra.JMSDestinationImpl"));
         assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "3605 Hwy 52N, Rochester, MN 55901", props.getString("destinationName"));
     }
@@ -279,11 +255,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "dest2", dest.getString("uid"));
         assertEquals(err, "dest2", dest.getString("id"));
         assertEquals(err, "jms/dest2", dest.getString("jndiName"));
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = dest.getJsonArray("properties.jmsra.JMSQueueImpl"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = dest.getJsonObject("properties.jmsra.JMSQueueImpl"));
         assertEquals(err, 2, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "201 4th St SE, Rochester, MN 55904", props.getString("destinationName"));
         assertEquals(err, "D2", props.getString("queueName"));
@@ -299,11 +272,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "q1", q.getString("id"));
         assertEquals(err, "jms/q1", q.getString("jndiName"));
 
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = q.getJsonArray("properties.jmsra.JMSQueueImpl"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = q.getJsonObject("properties.jmsra.JMSQueueImpl"));
         assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "Q1", props.getString("queueName"));
     }
@@ -329,11 +299,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "q2", q.getString("uid"));
         assertEquals(err, "q2", q.getString("id"));
         assertEquals(err, "jms/q2", q.getString("jndiName"));
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = q.getJsonArray("properties.jmsra.JMSOtherQueueImpl"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = q.getJsonObject("properties.jmsra.JMSOtherQueueImpl"));
         assertEquals(err, 2, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "qm", props.getString("queueManager"));
         assertEquals(err, "Q2", props.getString("queueName"));
@@ -352,11 +319,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertNull(err, cf.get("containerAuthDataRef"));
         assertNull(err, cf.get("recoveryAuthDataRef"));
 
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = cf.getJsonArray("properties.jmsra"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = cf.getJsonObject("properties.jmsra"));
         assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "localhost", props.getString("hostName"));
     }
@@ -387,11 +351,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "topic1", topic.getString("id"));
         assertEquals(err, "jms/topic1", topic.getString("jndiName"));
 
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = topic.getJsonArray("properties.jmsra"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = topic.getJsonObject("properties.jmsra"));
         assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "What's for dinner?", props.getString("topicName"));
     }
@@ -417,11 +378,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "topic2", q.getString("uid"));
         assertEquals(err, "topic2", q.getString("id"));
         assertEquals(err, "jms/topic2", q.getString("jndiName"));
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = q.getJsonArray("properties.jmsra"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = q.getJsonObject("properties.jmsra"));
         assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "Who pays for free shipping?", props.getString("topicName"));
     }
@@ -439,11 +397,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertNull(err, cf.get("containerAuthDataRef"));
         assertNull(err, cf.get("recoveryAuthDataRef"));
 
-        JsonArray array;
         JsonObject props;
-        assertNotNull(err, array = cf.getJsonArray("properties.jmsra"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = cf.getJsonObject("properties.jmsra"));
         assertEquals(err, 4, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "%", props.getString("escapeChar"));
         assertEquals(err, "localhost", props.getString("hostName"));
@@ -473,10 +428,7 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertEquals(err, "jms/tcf4", cf.getString("jndiName"));
 
         JsonObject authData;
-        JsonArray array;
-        assertNotNull(err, array = cf.getJsonArray("containerAuthDataRef"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, authData = array.getJsonObject(0));
+        assertNotNull(err, authData = cf.getJsonObject("containerAuthDataRef"));
         assertEquals(err, "authData", authData.getString("configElementName"));
         assertEquals(err, "jmsUser1", authData.getString("uid"));
         assertEquals(err, "jmsUser1", authData.getString("id"));
@@ -486,9 +438,7 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
         assertNull(err, cf.get("recoveryAuthDataRef"));
 
         JsonObject props;
-        assertNotNull(err, array = cf.getJsonArray("properties.jmsra"));
-        assertEquals(err, 1, array.size());
-        assertNotNull(err, props = array.getJsonObject(0));
+        assertNotNull(err, props = cf.getJsonObject("properties.jmsra"));
         assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
         assertEquals(err, "host4.rchland.ibm.com", props.getString("hostName"));
     }

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
@@ -202,9 +202,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, true, j.getBoolean("beginTranForVendorAPIs"));
         assertNull(err, j.get("connectionManagerRef"));
         assertEquals(err, "MatchCurrentState", j.getString("connectionSharing"));
-        assertNotNull(err, ja = j.getJsonArray("containerAuthDataRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("containerAuthDataRef"));
         assertEquals(err, "containerAuthData", jj.getString("configElementName"));
         assertEquals(err, "dataSource[DataSourceWithoutJDBCDriver]/containerAuthData[dbuser-auth]", jj.getString("uid"));
         assertEquals(err, "dbuser-auth", jj.getString("id"));
@@ -224,9 +222,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                 else
                     found = true;
         assertTrue(err, found);
-        assertNotNull(err, ja = j.getJsonArray("properties.derby.embedded"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, j = ja.getJsonObject(0));
+        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
         assertEquals(err, "memory:withoutJDBCDriver", j.getString("databaseName"));
 
         j = json.getJsonObject(1);
@@ -241,15 +237,11 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNull(err, j.get("containerAuthDataRef"));
         assertEquals(err, false, j.getBoolean("enableConnectionCasting"));
         assertEquals(err, "TRANSACTION_READ_COMMITTED", j.getString("isolationLevel"));
-        assertNotNull(err, ja = j.getJsonArray("jdbcDriverRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("jdbcDriverRef"));
         assertEquals(err, "jdbcDriver", jj.getString("configElementName"));
         assertEquals(err, "dataSource[DefaultDataSource]/jdbcDriver[default-0]", jj.getString("uid"));
         assertNull(err, jj.get("id"));
-        assertNotNull(err, ja = jj.getJsonArray("libraryRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
         assertEquals(err, "Derby", jj.getString("uid"));
         assertEquals(err, "Derby", jj.getString("id"));
@@ -273,9 +265,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                 else
                     found = true;
         assertTrue(err, found);
-        assertNotNull(err, ja = j.getJsonArray("properties.derby.embedded"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, j = ja.getJsonObject(0));
+        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
         assertEquals(err, "create", j.getString("createDatabase"));
         assertEquals(err, "memory:defaultdb", j.getString("databaseName"));
         assertEquals(err, "dbuser", j.getString("user"));
@@ -289,9 +279,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, true, j.getBoolean("beginTranForResultSetScrollingAPIs"));
         assertEquals(err, true, j.getBoolean("beginTranForVendorAPIs"));
         assertEquals(err, "rollback", j.getString("commitOrRollbackOnCleanup"));
-        assertNotNull(err, ja = j.getJsonArray("connectionManagerRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("connectionManagerRef"));
         assertEquals(err, "connectionManager", jj.getString("configElementName"));
         assertEquals(err, "pool1", jj.getString("uid"));
         assertEquals(err, "pool1", jj.getString("id"));
@@ -303,9 +291,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "ValidateAllConnections", jj.getString("purgePolicy"));
         assertEquals(err, 180, jj.getJsonNumber("reapTime").longValue());
         assertEquals(err, "MatchOriginalRequest", j.getString("connectionSharing"));
-        assertNotNull(err, ja = j.getJsonArray("containerAuthDataRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("containerAuthDataRef"));
         assertEquals(err, "authData", jj.getString("configElementName"));
         assertEquals(err, "auth2", jj.getString("uid"));
         assertEquals(err, "auth2", jj.getString("id"));
@@ -313,15 +299,11 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "dbuser", jj.getString("user"));
         assertEquals(err, false, j.getBoolean("enableConnectionCasting"));
         assertEquals(err, "The property's value.", j.getString("invalidProperty"));
-        assertNotNull(err, ja = j.getJsonArray("jdbcDriverRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("jdbcDriverRef"));
         assertEquals(err, "jdbcDriver", jj.getString("configElementName"));
         assertEquals(err, "DerbyDriver", jj.getString("uid"));
         assertEquals(err, "DerbyDriver", jj.getString("id"));
-        assertNotNull(err, ja = jj.getJsonArray("libraryRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
         assertEquals(err, "Derby", jj.getString("uid"));
         assertEquals(err, "Derby", jj.getString("id"));
@@ -333,9 +315,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "library[Derby]/file[default-0]", jj.getString("uid"));
         assertTrue(err, jj.getString("name").endsWith("derby.jar"));
         assertEquals(err, 130, j.getInt("queryTimeout"));
-        assertNotNull(err, ja = j.getJsonArray("recoveryAuthDataRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("recoveryAuthDataRef"));
         assertEquals(err, "authData", jj.getString("configElementName"));
         assertEquals(err, "auth2", jj.getString("uid"));
         assertEquals(err, "auth2", jj.getString("id"));
@@ -354,9 +334,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                 else
                     found = true;
         assertTrue(err, found);
-        assertNotNull(err, ja = j.getJsonArray("properties"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, j = ja.getJsonObject(0));
+        assertNotNull(err, j = j.getJsonObject("properties"));
         assertEquals(err, "create", j.getString("createDatabase"));
         assertEquals(err, "memory:defaultdb", j.getString("databaseName"));
 
@@ -367,9 +345,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "jdbc/defaultauth", j.getString("jndiName"));
         assertEquals(err, true, j.getBoolean("beginTranForResultSetScrollingAPIs"));
         assertEquals(err, true, j.getBoolean("beginTranForVendorAPIs"));
-        assertNotNull(err, ja = j.getJsonArray("connectionManagerRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("connectionManagerRef"));
         assertEquals(err, "connectionManager", jj.getString("configElementName"));
         assertEquals(err, "dataSource[default-0]/connectionManager[default-0]", jj.getString("uid"));
         assertNull(err, jj.get("id"));
@@ -381,9 +357,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "EntirePool", jj.getString("purgePolicy"));
         assertEquals(err, 180, jj.getJsonNumber("reapTime").longValue());
         assertEquals(err, "MatchOriginalRequest", j.getString("connectionSharing"));
-        assertNotNull(err, ja = j.getJsonArray("containerAuthDataRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("containerAuthDataRef"));
         assertEquals(err, "authData", jj.getString("configElementName"));
         assertEquals(err, "auth1", jj.getString("uid"));
         assertEquals(err, "auth1", jj.getString("id"));
@@ -399,18 +373,14 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                 else
                     found = true;
         assertTrue(err, found);
-        assertNotNull(err, ja = j.getJsonArray("jdbcDriverRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("jdbcDriverRef"));
         assertEquals(err, "jdbcDriver", jj.getString("configElementName"));
         assertEquals(err, "dataSource[default-0]/jdbcDriver[NestedDerbyDriver]", jj.getString("uid"));
         assertEquals(err, "NestedDerbyDriver", jj.getString("id"));
         assertEquals(err, "org.apache.derby.jdbc.EmbeddedDataSource", jj.getString("javax.sql.DataSource"));
         assertEquals(err, "org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource", jj.getString("javax.sql.ConnectionPoolDataSource"));
         assertEquals(err, "org.apache.derby.jdbc.EmbeddedXADataSource", jj.getString("javax.sql.XADataSource"));
-        assertNotNull(err, ja = jj.getJsonArray("libraryRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
         assertEquals(err, "Derby", jj.getString("uid"));
         assertEquals(err, "Derby", jj.getString("id"));
@@ -428,9 +398,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, 10, j.getInt("statementCacheSize"));
         assertEquals(err, false, j.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
         assertEquals(err, true, j.getBoolean("transactional"));
-        assertNotNull(err, ja = j.getJsonArray("properties.derby.embedded"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, j = ja.getJsonObject(0));
+        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
         assertEquals(err, "create", j.getString("createDatabase"));
         assertEquals(err, "memory:defaultdb", j.getString("databaseName"));
 
@@ -441,9 +409,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "jdbc/nonexistentdb", j.getString("jndiName"));
         assertEquals(err, true, j.getBoolean("beginTranForResultSetScrollingAPIs"));
         assertEquals(err, true, j.getBoolean("beginTranForVendorAPIs"));
-        assertNotNull(err, ja = j.getJsonArray("connectionManagerRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("connectionManagerRef"));
         assertEquals(err, "connectionManager", jj.getString("configElementName"));
         assertEquals(err, "dataSource[jdbc/nonexistentdb]/connectionManager[NestedConPool]", jj.getString("uid"));
         assertEquals(err, "NestedConPool", jj.getString("id"));
@@ -466,15 +432,11 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                 else
                     found = true;
         assertTrue(err, found);
-        assertNotNull(err, ja = j.getJsonArray("jdbcDriverRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("jdbcDriverRef"));
         assertEquals(err, "jdbcDriver", jj.getString("configElementName"));
         assertEquals(err, "dataSource[jdbc/nonexistentdb]/jdbcDriver[default-0]", jj.getString("uid"));
         assertNull(err, jj.get("id"));
-        assertNotNull(err, ja = jj.getJsonArray("libraryRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
         assertEquals(err, "Derby", jj.getString("uid"));
         assertEquals(err, "Derby", jj.getString("id"));
@@ -488,9 +450,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, 10, j.getInt("statementCacheSize"));
         assertEquals(err, false, j.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
         assertEquals(err, true, j.getBoolean("transactional"));
-        assertNotNull(err, ja = j.getJsonArray("properties.derby.embedded"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, j = ja.getJsonObject(0));
+        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
         assertEquals(err, "memory:doesNotExist", j.getString("databaseName"));
 
         j = json.getJsonObject(5);
@@ -500,9 +460,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNull(err, j.get("jndiName"));
         assertEquals(err, true, j.getBoolean("beginTranForResultSetScrollingAPIs"));
         assertEquals(err, true, j.getBoolean("beginTranForVendorAPIs"));
-        assertNotNull(err, ja = j.getJsonArray("connectionManagerRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("connectionManagerRef"));
         assertEquals(err, "connectionManager", jj.getString("configElementName"));
         assertEquals(err, "transaction/dataSource[default-0]/connectionManager[default-0]", jj.getString("uid"));
         assertNull(err, jj.get("id"));
@@ -514,9 +472,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "EntirePool", jj.getString("purgePolicy"));
         assertEquals(err, 180, jj.getJsonNumber("reapTime").longValue());
         assertEquals(err, "MatchOriginalRequest", j.getString("connectionSharing"));
-        assertNotNull(err, ja = j.getJsonArray("containerAuthDataRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("containerAuthDataRef"));
         assertEquals(err, "authData", jj.getString("configElementName"));
         assertEquals(err, "auth1", jj.getString("uid"));
         assertEquals(err, "auth1", jj.getString("id"));
@@ -532,15 +488,11 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                 else
                     found = true;
         assertTrue(err, found);
-        assertNotNull(err, ja = j.getJsonArray("jdbcDriverRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = j.getJsonObject("jdbcDriverRef"));
         assertEquals(err, "jdbcDriver", jj.getString("configElementName"));
         assertEquals(err, "transaction/dataSource[default-0]/jdbcDriver[default-0]", jj.getString("uid"));
         assertNull(err, jj.get("id"));
-        assertNotNull(err, ja = jj.getJsonArray("libraryRef"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, jj = ja.getJsonObject(0));
+        assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
         assertEquals(err, "Derby", jj.getString("uid"));
         assertEquals(err, "Derby", jj.getString("id"));
@@ -554,9 +506,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, 10, j.getInt("statementCacheSize"));
         assertEquals(err, false, j.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
         assertEquals(err, false, j.getBoolean("transactional"));
-        assertNotNull(err, ja = j.getJsonArray("properties.derby.embedded"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, j = ja.getJsonObject(0));
+        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
         assertEquals(err, "memory:recoverydb", j.getString("databaseName"));
     }
 
@@ -583,9 +533,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                 else
                     found = true;
         assertTrue(err, found);
-        assertNotNull(err, ja = j.getJsonArray("properties.derby.embedded"));
-        assertEquals(err, 1, ja.size());
-        assertNotNull(err, j = ja.getJsonObject(0));
+        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
         assertEquals(err, "memory:withoutJDBCDriver", j.getString("databaseName"));
     }
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-bundles/test.config.nested.flat/resources/metatype/metatype.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-bundles/test.config.nested.flat/resources/metatype/metatype.xml
@@ -19,7 +19,7 @@
 
  <OCD id="com.ibm.ws.config.nested" ibm:alias="parent" ibm:supportExtensions="true" name="parent" description="parent">
   <AD id="name" type="String" required="false" name="name" description="name"/>
-  <AD id="child" type="String" required="false" ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.config.nested.child" name="child ref" description="child ref"/>
+  <AD id="child" type="String" required="false" cardinality="5" ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.config.nested.child" name="child ref" description="child ref"/>
  </OCD>
 
  
@@ -29,7 +29,7 @@
 
  <OCD id="com.ibm.ws.config.nested.child" ibm:alias="child" name="child" description="child"> 
   <AD id="value" type="String" required="false" name="value" description="value"/>  
-  <AD id="grandchild" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.config.nested.grandchild" ibm:flat="true" name="grandchild" description="grandchild"/>  
+  <AD id="grandchild" required="false" type="String" cardinality="-5" ibm:type="pid" ibm:reference="com.ibm.ws.config.nested.grandchild" ibm:flat="true" name="grandchild" description="grandchild"/>
  </OCD>
 
  <Designate factoryPid="com.ibm.ws.config.nested.grandchild"> 


### PR DESCRIPTION
JSON generated by the /config/ endpoint is inconsistent between cardinality 0 and 1, where from the user's perspective they are configuring a single value.  When cardinality is 1 (or -1), an array is being used to wrap the JSON object.  When cardinality is 0, the JSON object is not wrapped with an array.  We should detect the cardinality and generate the JSON consistently.  The array seems unnecessary for something that can never have more than one value, and so should be omitted.