### PR TITLE
Update .classpath to remove reference to library.

### DIFF
--- a/dev/com.ibm.ws.security.audit.source/.classpath
+++ b/dev/com.ibm.ws.security.audit.source/.classpath
@@ -4,21 +4,5 @@
 	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-	<classpathentry kind="lib" path="C:/Users/IBM_ADMIN/.ibmdhe/repository/com/ibm/ws/javax/j2ee/servlet/3.1/servlet-3.1.jar">
-		<attributes>
-			<attribute name="bsn" value="com.ibm.ws.javaee.servlet.3.1"/>
-			<attribute name="type" value="REPO"/>
-			<attribute name="project" value="com.ibm.websphere.javaee.servlet.3.1"/>
-			<attribute name="version" value="1.0.10.201509101149"/>
-		</attributes>
-		<accessrules>
-			<accessrule kind="accessible" pattern="javax/servlet/*"/>
-			<accessrule kind="accessible" pattern="javax/servlet/annotation/*"/>
-			<accessrule kind="accessible" pattern="javax/servlet/descriptor/*"/>
-			<accessrule kind="accessible" pattern="javax/servlet/http/*"/>
-			<accessrule kind="accessible" pattern="javax/servlet/resources/*"/>
-			<accessrule ignoreifbetter="true" kind="discouraged" pattern="**"/>
-		</accessrules>
-	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
- .classpath should only reference bnd which pulls in the needed
libraries for that project.  What is worse is the library was the full
path for Windows and wouldn't be found on other platforms.
