### PR TITLE
 test case for JAX-RS context propagation

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/.classpath
+++ b/dev/com.ibm.ws.concurrent.mp_fat/.classpath
@@ -4,6 +4,7 @@
 	<classpathentry kind="src" path="test-applications/MPConcurrentApp/src"/>
 	<classpathentry kind="src" path="test-applications/MPConcurrentCDIApp/src"/>
 	<classpathentry kind="src" path="test-applications/MPConcurrentConfigApp/src"/>
+	<classpathentry kind="src" path="test-applications/MPConcurrentJAXRSApp/src"/>
 	<classpathentry kind="src" path="test-applications/MPConcurrentTxApp/src"/>
 	<classpathentry kind="src" path="test-applications/customcontext/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2018 IBM Corporation and others.
+# Copyright (c) 2017,2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ src: \
 	test-applications/MPConcurrentApp/src,\
 	test-applications/MPConcurrentCDIApp/src,\
 	test-applications/MPConcurrentConfigApp/src,\
+	test-applications/MPConcurrentJAXRSApp/src,\
 	test-applications/MPConcurrentTxApp/src,\
 	test-applications/customcontext/src
 
@@ -29,6 +30,8 @@ fat.project: true
 	com.ibm.tx.core;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
+	com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
+	com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
@@ -19,6 +19,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 MPConcurrentTest.class,
                 MPConcurrentCDITest.class,
                 MPConcurrentConfigTest.class,
+                MPConcurrentJAXRSTest.class,
                 MPConcurrentTxTest.class
 })
-public class FATSuite {}
+public class FATSuite {
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentJAXRSTest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentJAXRSTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.fat;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonStructure;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpUtils;
+
+@RunWith(FATRunner.class)
+public class MPConcurrentJAXRSTest extends FATServletClient {
+    private static final String APP_NAME = "MPConcurrentJAXRSApp";
+
+    /**
+     * Maximum number of nanoseconds to wait for a JAX-RS request to complete.
+     */
+    private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
+
+    private static ExecutorService testThreads;
+
+    @Server("MPConcurrentJAXRSTestServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, "concurrent.mp.fat.jaxrs.web");
+        server.startServer();
+        testThreads = Executors.newFixedThreadPool(5);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        try {
+            testThreads.shutdownNow();
+        } finally {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * Invoke JAX-RS methods that each run asynchronous operations that access URIInfo context of a class-level field.
+     * Verify that URIInfo context is propagated from the main request to the asynchronous tasks.
+     */
+    @Test
+    public void testURIInfoFromJAXRSMethodsInParallel() throws Exception {
+        List<Future<JsonStructure>> futures = new ArrayList<Future<JsonStructure>>(3);
+        for (String request : new String[] {
+                                             "/testapp/testUriInfo/path1?q=10",
+                                             "/testapp/testUriInfo/path2?q=20",
+                                             "/testapp/testUriInfo/path2?q=22"
+        }) {
+            futures.add(testThreads.submit(() -> {
+                HttpURLConnection con = HttpUtils.getHttpConnection(server, APP_NAME + request);
+                con.setDoOutput(true);
+                con.connect();
+                try (BufferedReader reader = HttpUtils.getConnectionStream(con)) {
+                    int rc = con.getResponseCode();
+                    if (rc == HttpURLConnection.HTTP_OK || rc == HttpURLConnection.HTTP_PARTIAL) {
+                        JsonStructure json = Json.createReader(reader).read();
+                        assertEquals(json.toString(), HttpURLConnection.HTTP_OK, rc);
+                        return json;
+                    }
+                    assertEquals(con.getResponseMessage(), HttpURLConnection.HTTP_OK, rc);
+                    return null;
+                } finally {
+                    con.disconnect();
+                }
+            }));
+        }
+
+        JsonObject json;
+        json = (JsonObject) futures.get(0).get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        String err = "Response is " + json.toString();
+
+        assertEquals(err, "testUriInfo/path1", json.getString("uriInfoPath"));
+        assertEquals(err, "10", json.getString("uriInfoQueryParam"));
+
+        json = (JsonObject) futures.get(1).get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals(err, "testUriInfo/path2", json.getString("uriInfoPath"));
+        assertEquals(err, "20", json.getString("uriInfoQueryParam"));
+
+        json = (JsonObject) futures.get(2).get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals(err, "testUriInfo/path2", json.getString("uriInfoPath"));
+        assertEquals(err, "22", json.getString("uriInfoQueryParam"));
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentJAXRSTestServer/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentJAXRSTestServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:concurrent=all

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentJAXRSTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentJAXRSTestServer/server.xml
@@ -1,0 +1,29 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>cdi-2.0</feature>
+        <feature>jaxrs-2.1</feature>
+        <feature>mpContextPropagation-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <application location="MPConcurrentJAXRSApp.war"/>
+
+    <!-- Needed for application to use a ForkJoinPool, access the thread context class loader, and shut down an unmanaged ExecutorService that the test application creates -->
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentJAXRSApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentJAXRSApp.war" className="java.lang.RuntimePermission" name="modifyThread"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentJAXRSApp.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentJAXRSApp.war" className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.*" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentJAXRSApp/src/concurrent/mp/fat/jaxrs/web/MPContextJAXRSTestApp.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentJAXRSApp/src/concurrent/mp/fat/jaxrs/web/MPContextJAXRSTestApp.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.jaxrs.web;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/testapp")
+public class MPContextJAXRSTestApp extends Application {
+    // TODO switching to singleton is one way to demonstrate that JAX-RS context is not propagated to other threads.
+    // Another way would be switching MPContextJAXRSURIInfo to CDI @ApplicationScoped.  If the injected URIInfo could be
+    // made into a CDI bean that is request scoped, then CDI context propagation should in theory allow the JAX-RS context to propagate.
+    public Set<Object> getSingletons_disabled() {
+        return Collections.singleton(new MPContextJAXRSURIInfo());
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentJAXRSApp/src/concurrent/mp/fat/jaxrs/web/MPContextJAXRSURIInfo.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentJAXRSApp/src/concurrent/mp/fat/jaxrs/web/MPContextJAXRSURIInfo.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.jaxrs.web;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+
+// @ApplicationScoped // TODO JAX-RS context for URIInfo (and probably other types) is currently not propagated.
+// If the injected URIInfo could be made into a CDI bean that is request scoped, then CDI context propagation
+// should in theory allow the JAX-RS context to propagate.
+@Path("/testUriInfo")
+public class MPContextJAXRSURIInfo {
+    /**
+     * Maximum number of nanoseconds to wait for a task to complete.
+     */
+    static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
+
+    // TODO add code to shut down this executor (otherwise, it will stay around until the Liberty application stops)
+    static final ManagedExecutor executor = ManagedExecutor.builder()
+                    .propagated(ThreadContext.APPLICATION, ThreadContext.CDI)
+                    .cleared(ThreadContext.ALL_REMAINING)
+                    .build();
+
+    @Context
+    UriInfo uriInfo;
+
+    private class CollectURIInfo implements Supplier<JsonObject> {
+        String requestUri;
+
+        CollectURIInfo(String requestUri) {
+            this.requestUri = requestUri;
+        }
+
+        @Override
+        public JsonObject get() {
+            System.out.println("Supplier.get for request " + requestUri);
+            JsonObject json = Json.createObjectBuilder()
+                            //.add("class", Integer.toHexString(MPContextJAXRSURIInfo.this.hashCode()))
+                            //.add("uriInfo", Integer.toHexString(uriInfo.hashCode()))
+                            .add("uriInfoPath", uriInfo.getPath())
+                            .add("uriInfoQueryParam", uriInfo.getQueryParameters().getFirst("q"))
+                            .build();
+            System.out.println("Response: " + json);
+            return json;
+        }
+    }
+
+    public Response failure(Throwable x) {
+        StringWriter sw = new StringWriter();
+        x.printStackTrace(new PrintWriter(sw));
+
+        JsonObject json = Json.createObjectBuilder()
+                        .add("failure", sw.toString())
+                        .build();
+
+        return Response.status(Status.PARTIAL_CONTENT).entity(json).encoding(MediaType.APPLICATION_JSON).build();
+    }
+
+    @GET
+    @Path("path1")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response path1() throws ExecutionException, InterruptedException, TimeoutException {
+        String request = uriInfo.getRequestUri().toString();
+        System.out.println("--> " + request);
+
+        Thread.sleep(500); // encourages requests to overlap when the test submits multiple
+
+        Response response;
+        try {
+            CompletableFuture<JsonObject> future = executor.supplyAsync(new CollectURIInfo(request));
+            JsonObject json = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+            response = Response.ok(json, MediaType.APPLICATION_JSON).build();
+        } catch (ExecutionException | InterruptedException | TimeoutException x) {
+            response = failure(x);
+        }
+
+        System.out.println("<-- " + request + "\r\n " + response.getEntity());
+        return response;
+    }
+
+    @GET
+    @Path("path2")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response path2() throws ExecutionException, InterruptedException, TimeoutException {
+        String request = uriInfo.getRequestUri().toString();
+        System.out.println("--> " + request);
+
+        Thread.sleep(500); // encourages requests to overlap when the test submits multiple
+
+        Response response;
+        try {
+            CompletableFuture<JsonObject> future = executor.supplyAsync(new CollectURIInfo(request));
+            JsonObject json = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+            response = Response.ok(json, MediaType.APPLICATION_JSON).build();
+        } catch (ExecutionException | InterruptedException | TimeoutException x) {
+            response = failure(x);
+        }
+
+        System.out.println("<-- " + request + "\r\n " + response.getEntity());
+        return response;
+    }
+}


### PR DESCRIPTION
Write a test for propagation of JAX-RS context.  The test will be delivered in working state where context propagation is not needed because JAX-RS creates a new instance of the `@Path` resource per request, which can then be used consistently from any thread.  The test case includes some TODOs for switching it to singleton or CDI usage patterns, where it will not work, along with comments regarding a possible solution involving CDI context propagation that would require the URIInfo (or other) to be a CDI request scoped bean, which could then be propagated by MP Context Propagation when CDI context propagation is enabled.

It should be noted that we are not currently trying to offer a solution that makes `@Context` work in all cases because there are plans to deprecate `@Context` from JAX-RS in favor of a CDI solution to be added in the future.