### PR TITLE
Revert "Add Java SE 12 as a support Java level for feature doc"

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -88,7 +88,6 @@ public class FeatureList {
             addJVM(possibleJavaVersions, "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
-            addJVM(possibleJavaVersions, "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
 
             List<GenericMetadata> mostGeneralRange = ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.7))\"");
 
@@ -100,7 +99,6 @@ public class FeatureList {
             eeToCapability.put("JavaSE-1.7", mostGeneralRange);
             eeToCapability.put("JavaSE-1.8", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.8))\""));
             eeToCapability.put("JavaSE-11", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=11))\""));
-            eeToCapability.put("JavaSE-12", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=12))\""));
         }
 
         gaBuild = isGABuild();

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
@@ -232,9 +232,10 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
             return;
         }
 
-        String minJava11 = "Java SE 11, Java SE 12";
-        String minJava8 = "Java SE 8, Java SE 11, Java SE 12";
-        String minJava7 = "Java SE 7, Java SE 8, Java SE 11, Java SE 12";
+        String minJava11 = "Java SE 11";
+        String minJava8 = "Java SE 8, Java SE 11";
+        String minJava7 = "Java SE 7, Java SE 8, Java SE 11";
+        String minJava6 = "Java SE 6, Java SE 7, Java SE 8, Java SE 11";
 
         // TODO: Temporary special case for jdbc-4.3 (the first feature to require Java >8)
         // Once all builds are upgrade to Java 11+, we can remove this workaround
@@ -245,7 +246,11 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
 
         // The min version should have been validated when the ESA was constructed
         // so checking for the version string should be safe
-        if (minVersion.equals("1.6.0") || minVersion.equals("1.7.0")) {
+        if (minVersion.equals("1.6.0")) {
+            reqs.setVersionDisplayString(minJava6);
+            return;
+        }
+        if (minVersion.equals("1.7.0")) {
             reqs.setVersionDisplayString(minJava7);
             return;
         }


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#7370

Caused hard breaks in `com.ibm.ws.repository.uploaders_fat` FAT tests