### PR TITLE
Resolve bug in ORM Diagnostics handling of unexploded archives and im…

### DIFF
--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAApplInfo.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPAApplInfo.java
@@ -17,6 +17,7 @@ import static com.ibm.ws.jpa.management.JPAConstants.JPA_TRACE_GROUP;
 import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -315,11 +316,13 @@ public abstract class JPAApplInfo {
         }
     }
 
-    protected void doIntrospect(PrintWriter out) {
+    protected void doIntrospect(PrintWriter out, Set<String> archivesSet) {
         final Map<String, JPAScopeInfo> puScopesClone = new HashMap<String, JPAScopeInfo>();
         synchronized (puScopes) {
             puScopesClone.putAll(puScopes);
         }
+
+        JPAIntrospection.registerArchiveSet(archivesSet);
 
         for (Map.Entry<String, JPAScopeInfo> entry : puScopesClone.entrySet()) {
             final JPAScopeInfo scopeInfo = entry.getValue();

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/ormparser/EntityMappingsFactory.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/ormparser/EntityMappingsFactory.java
@@ -45,7 +45,7 @@ public class EntityMappingsFactory {
             final String pkg = determineJAXBPackage(bais).getJaxbPackage();
             bais.reset();
 
-            final JAXBContext jaxbCtx = JAXBContext.newInstance(pkg);
+            final JAXBContext jaxbCtx = JAXBContext.newInstance(pkg, EntityMappingsFactory.class.getClassLoader());
             final Unmarshaller unmarshaller = jaxbCtx.createUnmarshaller();
 
             MessageDigest md = MessageDigest.getInstance(digestType);

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puscanner/PersistenceUnitScanner.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puscanner/PersistenceUnitScanner.java
@@ -15,8 +15,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.JarURLConnection;
 import java.net.URL;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,6 +30,8 @@ import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import javax.persistence.spi.PersistenceUnitInfo;
 
@@ -159,37 +159,27 @@ public class PersistenceUnitScanner {
 
     private Set<ClassInfoType> processUnexplodedFile(Path path) throws ClassScannerException {
         final HashSet<ClassInfoType> citSet = new HashSet<ClassInfoType>();
-        final HashSet<Path> archiveFiles = new HashSet<Path>();
 
         if (path == null) {
             throw new ClassScannerException("Null argument is invalid for method processUnexplodedFile().");
         }
 
-        // URL referring to a jar file is the only legal option here.
         try {
-            try (FileSystem fs = FileSystems.getFileSystem(path.toUri())) {
-                for (Path jarRootPath : fs.getRootDirectories()) {
-                    Files.walkFileTree(jarRootPath, new SimpleFileVisitor<Path>() {
-                        @Override
-                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                            if (Files.isRegularFile(file) && Files.size(file) > 0
-                                && file.getFileName().toString().endsWith(".class")) {
-                                archiveFiles.add(file);
-                            }
+            try (ZipFile zf = new ZipFile(path.toFile())) {
+                final Enumeration<? extends ZipEntry> entryEnum = zf.entries();
+                while (entryEnum.hasMoreElements()) {
+                    final ZipEntry entry = entryEnum.nextElement();
+                    if (entry.isDirectory()) {
+                        continue;
+                    }
 
-                            return FileVisitResult.CONTINUE;
+                    final String entryName = entry.getName();
+                    if (entryName.endsWith(".class")) {
+                        try (InputStream is = zf.getInputStream(entry)) {
+                            String cName = entryName.replace("/", ".");
+                            cName = cName.substring(0, cName.length() - 6); // Remove ".class" from name
+                            citSet.add(scanByteCodeFromInputStream(cName, is));
                         }
-                    });
-                }
-
-                for (Path p : archiveFiles) {
-                    String cName = path.relativize(p).toString().replace("/", ".");
-                    cName = cName.substring(0, cName.length() - 6); // Remove ".class" from name
-
-                    try (InputStream is = Files.newInputStream(p)) {
-                        citSet.add(scanByteCodeFromInputStream(cName, is));
-                    } catch (Throwable t) {
-                        throw new ClassScannerException(t);
                     }
                 }
             }
@@ -471,10 +461,20 @@ public class PersistenceUnitScanner {
         final boolean isMetaInfoOrmXML = "META-INF/orm.xml".equals(ormFileName);
         final ArrayList<URL> retArr = new ArrayList<URL>();
 
+        final URL puu = pui.getPersistenceUnitRootUrl();
+
+        String puRootURL = pui.getPersistenceUnitRootUrl().toExternalForm();
+        if (puRootURL.startsWith("wsjpa:")) {
+            // The wsjpa protocol is a JPA runtime artifact, calling ClassLoader.getResource() will never
+            // return a URL using that protocol.
+            puRootURL = puRootURL.substring(6);
+        }
+
         Enumeration<URL> ormEnum = pui.getClassLoader().getResources(ormFileName);
         while (ormEnum.hasMoreElements()) {
             final URL url = ormEnum.nextElement();
-            final String urlExtern = url.toExternalForm(); //  ParserUtils.decode(url.toExternalForm());
+            final String urlExtern = url.toExternalForm();
+            final URL containerURL = new URL(urlExtern.substring(0, urlExtern.length() - "META-INF/orm.xml".length()));
 
             if (!isMetaInfoOrmXML) {
                 // If it's not "META-INF/orm.xml", then the mapping files may be present anywhere in the classpath.
@@ -483,15 +483,16 @@ public class PersistenceUnitScanner {
             }
 
             // Check against persistence unit root
-            if (urlExtern.startsWith(pui.getPersistenceUnitRootUrl().toExternalForm())) {
+            if (puu.sameFile(containerURL)) {
                 retArr.add(url);
                 continue;
             }
 
             // Check against Jar files, if any
             for (URL jarUrl : pui.getJarFileUrls()) {
-                final String jarExtern = jarUrl.toExternalForm();
-                if (urlExtern.startsWith(jarExtern)) {
+                final String jarUrlExtern = jarUrl.toExternalForm();
+                final URL jarContainerURL = new URL(jarUrlExtern.substring(0, jarUrlExtern.length() - "META-INF/orm.xml".length()));
+                if (puu.sameFile(jarContainerURL)) {
                     retArr.add(url);
                     continue;
                 }

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/ORMIntrospectorHelper.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/ORMIntrospectorHelper.java
@@ -47,6 +47,17 @@ public class ORMIntrospectorHelper {
         Assert.assertTrue(input.contains(targetString));
     }
 
+    public static void verifyApplicationArchives(final List<String> expectedArchives, final String input) {
+        boolean foundAll = true;
+        String content = "   Application Modules and Archives:" + newLine;
+
+        for (String ea : expectedArchives) {
+            content += "     " + ea + newLine;
+        }
+
+        Assert.assertTrue(foundAll);
+    }
+
     public static void verifyPersistentClasses(final List<JPAClass> classes, final String input) {
         boolean roots = true;
         for (JPAClass clazz : classes) {

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestBasicLibertyDump.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestBasicLibertyDump.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.jpa.ormdiagnostics.tests;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 import java.util.logging.Logger;
@@ -89,6 +90,10 @@ public class TestBasicLibertyDump extends FATServletClient {
         ORMIntrospectorHelper.verifyApplications("jpasimple", 0, 2,
                                                  new String[] { "jpasimple.war!/WEB-INF/classes/" },
                                                  introspectorData);
+
+        List<String> expectedArchives = new ArrayList<String>();
+        expectedArchives.add("jpasimple (WAR)");
+        ORMIntrospectorHelper.verifyApplicationArchives(expectedArchives, introspectorData);
 
         ORMIntrospectorHelper.verifyPersistenceUnit("JPAPU", introspectorData);
 

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestEARLibertyDump.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestEARLibertyDump.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.jpa.ormdiagnostics.tests;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
@@ -100,6 +101,13 @@ public class TestEARLibertyDump extends FATServletClient {
                                                  new String[] { "GuestBookJPA.jar",
                                                                 "GuestBookAPP.war/WEB-INF/lib/GuestBookJPA.jar" },
                                                  introspectorData);
+
+        List<String> expectedArchives = new ArrayList<String>();
+        expectedArchives.add("GuestBookEAR/GuestBookAPP.war");
+        expectedArchives.add("GuestBookEAR/GuestBookAPP.war/WEB-INF/lib/GuestBookEJB.jar");
+        expectedArchives.add("GuestBookEAR/GuestBookAPP.war/WEB-INF/lib/GuestBookJPA.jar");
+        expectedArchives.add("GuestBookEAR/lib/GuestBookJPA.jar");
+        ORMIntrospectorHelper.verifyApplicationArchives(expectedArchives, introspectorData);
 
         ORMIntrospectorHelper.verifyPersistenceUnit("SimpleApplicationPU", introspectorData);
 

--- a/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/OSGiJPAApplInfo.java
+++ b/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/OSGiJPAApplInfo.java
@@ -11,8 +11,16 @@
 package com.ibm.ws.jpa.container.osgi.internal;
 
 import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
+import com.ibm.ws.container.service.app.deploy.ApplicationClassesContainerInfo;
 import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
+import com.ibm.ws.container.service.app.deploy.ContainerInfo;
+import com.ibm.ws.container.service.app.deploy.ContainerInfo.Type;
+import com.ibm.ws.container.service.app.deploy.EARApplicationInfo;
+import com.ibm.ws.container.service.app.deploy.ModuleClassesContainerInfo;
 import com.ibm.ws.jpa.JPAPuId;
 import com.ibm.ws.jpa.management.AbstractJPAComponent;
 import com.ibm.ws.jpa.management.JPAApplInfo;
@@ -20,6 +28,8 @@ import com.ibm.ws.jpa.management.JPAPUnitInfo;
 import com.ibm.ws.jpa.management.JPAPXml;
 import com.ibm.ws.jpa.management.JPAScopeInfo;
 import com.ibm.wsspi.adaptable.module.Container;
+import com.ibm.wsspi.adaptable.module.Entry;
+import com.ibm.wsspi.adaptable.module.NonPersistentCache;
 
 public class OSGiJPAApplInfo extends JPAApplInfo {
     private final ApplicationInfo appInfo;
@@ -35,10 +45,94 @@ public class OSGiJPAApplInfo extends JPAApplInfo {
     }
 
     void introspect(PrintWriter out) {
-        doIntrospect(out);
+        final Set<String> archivesSet = introspectionIdentifyApplicationModules();
+        doIntrospect(out, archivesSet);
     }
 
     Container getContainer() {
         return appInfo.getContainer();
+    }
+
+    private Set<String> introspectionIdentifyApplicationModules() {
+        final Set<String> archivesSet = new HashSet<String>();
+
+        if (appInfo == null) {
+            return archivesSet;
+        }
+
+        final String applName = appInfo.getDeploymentName();
+        try {
+            if (appInfo instanceof EARApplicationInfo) {
+                final Container appContainer = ((EARApplicationInfo) appInfo).getContainer();
+                final NonPersistentCache cache = appContainer.adapt(NonPersistentCache.class);
+                if (cache != null) {
+                    final ApplicationClassesContainerInfo acci = (ApplicationClassesContainerInfo) cache.getFromCache(ApplicationClassesContainerInfo.class);
+                    final List<ModuleClassesContainerInfo> mcci = (acci == null) ? null : acci.getModuleClassesContainerInfo();
+
+                    if (mcci == null) {
+                        return archivesSet;
+                    }
+
+                    for (ModuleClassesContainerInfo m : mcci) {
+                        final List<ContainerInfo> moduleContainerInfos = m.getClassesContainerInfo();
+                        if (moduleContainerInfos != null && !moduleContainerInfos.isEmpty()) {
+                            final ContainerInfo moduleContainerInfo = moduleContainerInfos.get(0);
+                            final String archiveName = moduleContainerInfo.getName();
+                            archivesSet.add(applName + "/" + archiveName);
+
+                            if (moduleContainerInfo.getType() == Type.WEB_MODULE) {
+                                // Web modules can contain libraries in WEB-INF/lib
+                                final Container warContainer = moduleContainerInfo.getContainer();
+                                final Entry webInfLib = (warContainer == null) ? null : warContainer.getEntry("WEB-INF/lib/");
+                                if (webInfLib != null) {
+                                    try {
+                                        final Container webInfLibContainer = webInfLib.adapt(Container.class);
+                                        if (webInfLibContainer != null) {
+                                            final String pathRoot = applName + "/" + archiveName + "/WEB-INF/lib/";
+                                            for (Entry entry : webInfLibContainer) {
+                                                archivesSet.add(pathRoot + entry.getName());
+                                            }
+                                        }
+                                    } catch (Throwable t2) {
+                                        // Swallow
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Process EAR Library
+                final Container appLibContainer = ((EARApplicationInfo) appInfo).getLibraryDirectoryContainer();
+                if (appLibContainer != null) {
+                    final String pathRoot = applName + "/" + appLibContainer.getName() + "/";
+                    for (com.ibm.wsspi.adaptable.module.Entry entry : appLibContainer) {
+                        archivesSet.add(pathRoot + entry.getName());
+                    }
+                }
+            } else {
+                // Standalone WAR deployed to appserver
+                archivesSet.add(applName + " (WAR)");
+                final Container warContainer = appInfo.getContainer();
+                final Entry webInfLib = (warContainer == null) ? null : warContainer.getEntry("WEB-INF/lib/");
+                if (webInfLib != null) {
+                    try {
+                        final Container webInfLibContainer = webInfLib.adapt(Container.class);
+                        if (webInfLibContainer != null) {
+                            final String pathRoot = applName + "/WEB-INF/lib/";
+                            for (Entry entry : webInfLibContainer) {
+                                archivesSet.add(pathRoot + entry.getName());
+                            }
+                        }
+                    } catch (Throwable t2) {
+                        // Swallow
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            // Swallow for dump introspection.
+        }
+
+        return archivesSet;
     }
 }


### PR DESCRIPTION
Signed-off-by: Joe Grassel <jgrassel@us.ibm.com>

Resolve bug in ORM Diagnostics handling of unexploded archives and improve ORM Diagnostic Collection

Examples of Application Module Dump:

```
################################################################################
Application "GuestBookEAR":
   Total ORM Files: 0
   Total JPA Involved Classes: 4
   Persistence Unit Roots:
      wsjpa:wsjar:file:.../GuestBookAPP.war/WEB-INF/lib/GuestBookJPA.jar!/ (1 persistence units)
      wsjpa:wsjar:file:.../GuestBookJPA.jar!/ (1 persistence units)
   Persistence Units:
      At Persistence Unit Root: wsjpa:wsjar:file:.../GuestBookAPP.war/WEB-INF/lib/GuestBookJPA.jar!/
         SimpleApplicationPU
      At Persistence Unit Root: wsjpa:wsjar:file:.../GuestBookJPA.jar!/
         SimpleApplicationPU

   Application Modules and Archives:
     GuestBookEAR/GuestBookAPP.war
     GuestBookEAR/GuestBookAPP.war/WEB-INF/lib/GuestBookEJB.jar
     GuestBookEAR/GuestBookAPP.war/WEB-INF/lib/GuestBookJPA.jar
     GuestBookEAR/lib/GuestBookJPA.jar
```
and

```
################################################################################
Application "jpasimple":
   Total ORM Files: 0
   Total JPA Involved Classes: 2
   Persistence Unit Roots:
      wsjpa:wsjar:file:.../jpasimple.war!/WEB-INF/classes/ (1 persistence units)
   Persistence Units:
      At Persistence Unit Root: wsjpa:wsjar:file:.../jpasimple.war!/WEB-INF/classes/
         JPAPU

   Application Modules and Archives:
     jpasimple (WAR)
```
