### PR TITLE
New tests to confirm `@Context` and `@Inject` injection in sub-resources

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
@@ -24,6 +24,7 @@ src: \
   test-applications/subResourceApp
 
 fat.project: true
+tested.features: cdi-2.0, cdi-1.2, jaxrs-2.1, jaxrs-2.0
 
 javac.source: 1.8
 javac.target: 1.8

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/SubResourceTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/SubResourceTest.java
@@ -15,6 +15,7 @@ import java.io.File;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -22,6 +23,8 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jaxrs21.fat.subresource.SubResourceTestServlet;
@@ -29,6 +32,10 @@ import jaxrs21.fat.subresource.SubResourceTestServlet;
 @RunWith(FATRunner.class)
 public class SubResourceTest extends FATServletClient {
 
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+                                             .andWith(FeatureReplacementAction.EE7_FEATURES());
+                    
     private static final String appName = "subResourceApp";
 
     @Server("jaxrs21.fat.subResourceTest")

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.subResourceTest/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.subResourceTest/server.xml
@@ -2,6 +2,7 @@
   <featureManager>
     <feature>componenttest-1.0</feature>
     <feature>jaxrs-2.1</feature>
+    <feature>cdi-2.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>    

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/MyBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/MyBean.java
@@ -1,0 +1,14 @@
+/**
+ * 
+ */
+package jaxrs21.fat.subresource;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MyBean {
+
+    public String getSomeString() {
+        return "some string";
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/MyBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/MyBean.java
@@ -1,6 +1,13 @@
-/**
- * 
- */
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package jaxrs21.fat.subresource;
 
 import javax.enterprise.context.ApplicationScoped;

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/RootResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/RootResource.java
@@ -13,6 +13,7 @@ package jaxrs21.fat.subresource;
 import java.util.HashMap;
 
 import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -30,6 +31,16 @@ public class RootResource {
     @Path("sub")
     public SubResource getSubResource() {
         return rc.initResource(new SubResource());
+    }
+
+    @Path("subCdi")
+    public SubResource getSubResourceUsingCdiSelection() {
+        return rc.initResource(CDI.current().select(SubResource.class).get());
+    }
+
+    @Path("subGet")
+    public SubResource getSubResourceUsingGetResource() {
+        return rc.getResource(SubResource.class);
     }
 
     @GET

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/SubResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/SubResource.java
@@ -12,19 +12,42 @@ package jaxrs21.fat.subresource;
 
 import java.util.HashMap;
 
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 
+@RequestScoped
 public class SubResource {
 
+    @Context
+    UriInfo uriInfo;
+    
+    @Inject
+    MyBean myBean;
+    
     @GET
     @Path("id/{id}")
     public HashMap<String, String> getId(@PathParam("id") String id) {
         HashMap<String, String> map = new HashMap<>();
         map.put("subId", id);
         return map;
+    }
+    
+    @GET
+    @Path("context")
+    public String getUriFromContextInjectedField() {
+        return uriInfo.getRequestUri().toString();
+    }
+    
+    @GET
+    @Path("cdi")
+    public String getStringFromCdiInjectedField() {
+        return myBean.getSomeString();
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/SubResourceTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/SubResourceTestServlet.java
@@ -58,6 +58,42 @@ public class SubResourceTestServlet extends FATServlet {
         assertEquals("{\"subId\":\"1\"}", result);
     }
 
+    @Test
+    public void testSubResourceContextInjection(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        Response response = target(req, "sub/context").request().get();
+        String result = response.readEntity(String.class);
+        assertEquals(200, response.getStatus());
+        System.out.println("result=" + result);
+        assertTrue(result.contains("/sub/context"));
+    }
+
+    @Test
+    public void testSubResourceCdiInjection(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        Response response = target(req, "subCdi/cdi").request().get();
+        String result = response.readEntity(String.class);
+        assertEquals(200, response.getStatus());
+        System.out.println("result=" + result);
+        assertTrue(result.contains("some string"));
+    }
+
+    @Test
+    public void testSubResourceContextInjectionWithGetResource(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        Response response = target(req, "subGet/context").request().get();
+        String result = response.readEntity(String.class);
+        assertEquals(200, response.getStatus());
+        System.out.println("result=" + result);
+        assertTrue(result.contains("/subGet/context"));
+    }
+
+//    @Test
+//    public void testSubResourceCdiInjectionWithGetResource(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+//        Response response = target(req, "subGet/cdi").request().get();
+//        String result = response.readEntity(String.class);
+//        assertEquals(200, response.getStatus());
+//        System.out.println("result=" + result);
+//        assertTrue(result.contains("some string"));
+//    }
+
     private WebTarget target(HttpServletRequest request, String path) {
         String base = "http://" + request.getServerName() + ':' + request.getServerPort() + "/subResourceApp/root/";
         return client.target(base + path);

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/SubResourceTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/subResourceApp/src/jaxrs21/fat/subresource/SubResourceTestServlet.java
@@ -85,6 +85,8 @@ public class SubResourceTestServlet extends FATServlet {
         assertTrue(result.contains("/subGet/context"));
     }
 
+// This scenario is not expected to succeed.  The ResourceContext.getResource(...) method only takes a Class<?> object as a parameter
+// which won't work with a CDI bean lookup.  It will work for JAX-RS @Context-injected resources, however. 
 //    @Test
 //    public void testSubResourceCdiInjectionWithGetResource(HttpServletRequest req, HttpServletResponse resp) throws Exception {
 //        Response response = target(req, "subGet/cdi").request().get();


### PR DESCRIPTION
Adding new tests to confirm injection works as expected in sub-resources.  Tests only - not a release bug.