### PR TITLE
validation endpoint for JMS connection factories

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator.jca/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/bnd.bnd
@@ -23,7 +23,15 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 WS-TraceGroup: validator.rest
 
 Private-Package:\
-  com.ibm.ws.rest.handler.validator.jca.*
+  com.ibm.ws.rest.handler.validator.jca.*,\
+  com.ibm.ws.rest.handler.validator.jms.*,\
+
+Import-Package:\
+  !javax.jms,\
+  *
+
+DynamicImport-Package:\
+  javax.jms
 
 -dsannotations:\
   com.ibm.ws.rest.handler.validator.jca.ConnectionFactoryValidator
@@ -34,6 +42,7 @@ Private-Package:\
   com.ibm.websphere.appserver.spi.kernel.service,\
   com.ibm.websphere.appserver.spi.logging,\
   com.ibm.websphere.javaee.connector.1.7;version=latest,\
+  com.ibm.websphere.javaee.jms.2.0;version=latest,\
   com.ibm.websphere.org.osgi.core,\
   com.ibm.websphere.org.osgi.service.cm,\
   com.ibm.websphere.org.osgi.service.component,\

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/JMSValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/JMSValidator.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.rest.handler.validator.jca;
+
+import java.util.LinkedHashMap;
+
+/**
+ * This interface defines various methods for validating JMS connection factories and interpreting JMS exceptions.
+ * An implementation of this interface will only be available when the JMS spec interfaces are available.
+ */
+public interface JMSValidator {
+    /**
+     * Returns the error code, if any, of the supplied JMSException.
+     *
+     * @param x a JMSException.
+     * @return the error code, if any, of the supplied JMSException.
+     */
+    public String getErrorCode(Throwable x);
+
+    /**
+     * Returns true if the specified exception is an instance of javax.jms.JMSException, otherwise false.
+     *
+     * @param x the exception.
+     * @return true if the specified exception is an instance of javax.jms.JMSException, otherwise false.
+     */
+    public boolean isJMSException(Throwable x);
+
+    /**
+     * Validates a JMS connection factory.
+     *
+     * @param cf       a JMS ConnectionFactory, QueueConnectionFactory, or TopicConnectionFactory.
+     * @param user     user name, if any, for application authentication.
+     * @param password password, if any, for application authentication.
+     * @param result   key/value pairs to include in the validation result.
+     * @throws Exception if an error occurs
+     */
+    public void validate(Object cf, String user, String password, LinkedHashMap<String, Object> result) throws Exception;
+}

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jms/JMSConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jms/JMSConnectionFactoryValidator.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.rest.handler.validator.jms;
+
+import java.util.LinkedHashMap;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.ConnectionMetaData;
+import javax.jms.JMSException;
+
+import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.rest.handler.validator.jca.JMSValidator;
+
+public class JMSConnectionFactoryValidator implements JMSValidator {
+    @Override
+    @Trivial
+    public String getErrorCode(Throwable x) {
+        return x instanceof JMSException ? ((JMSException) x).getErrorCode() : null;
+    }
+
+    @Override
+    @Trivial
+    public boolean isJMSException(Throwable x) {
+        return x instanceof JMSException;
+    }
+
+    @Override
+    public void validate(Object cf, String user, @Sensitive String password, LinkedHashMap<String, Object> result) throws JMSException {
+        ConnectionFactory jmscf = (ConnectionFactory) cf;
+
+        Connection con = user == null ? jmscf.createConnection() : jmscf.createConnection(user, password);
+        try {
+            try {
+                ConnectionMetaData conData = con.getMetaData();
+
+                String provName = conData.getJMSProviderName();
+                if (provName != null && provName.length() > 0)
+                    result.put("jmsProviderName", provName);
+
+                String provVersion = conData.getProviderVersion();
+                if (provVersion != null && provVersion.length() > 0)
+                    result.put("jmsProviderVersion", provVersion);
+            } catch (UnsupportedOperationException ignore) {
+            }
+
+            try {
+                String clientID = con.getClientID();
+                if (clientID != null && clientID.length() > 0)
+                    result.put("clientID", clientID);
+            } catch (UnsupportedOperationException ignore) {
+            }
+
+            try {
+                con.createSession().close();
+            } catch (UnsupportedOperationException ignore) {
+            }
+        } finally {
+            con.close();
+        }
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jms/package-info.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jms/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2017,2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+@Version("1.0.0")
+@TraceOptions(traceGroup = "rest.validator")
+package com.ibm.ws.rest.handler.validator.jms;
+
+import org.osgi.annotation.versioning.Version;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
@@ -21,6 +21,7 @@ import componenttest.topology.utils.HttpUtils;
 @SuiteClasses({
                 ValidateDataSourceTest.class,
                 ValidateJCATest.class,
+                ValidateJMSTest.class,
                 ValidateDSCustomLoginModuleTest.class
 })
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
@@ -11,11 +11,15 @@
 package com.ibm.ws.rest.handler.validator.fat;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.json.JsonArray;
 import javax.json.JsonObject;
 
 import org.junit.AfterClass;
@@ -23,6 +27,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -64,11 +69,194 @@ public class ValidateJMSTest extends FATServletClient {
         assertEquals(err, "jmscf1", json.getString("uid"));
         assertEquals(err, "jmscf1", json.getString("id"));
         assertEquals(err, "jms/cf1", json.getString("jndiName"));
-        // TODO complete this test once implementation is further along
-        //assertTrue(err, json.getBoolean("successful"));
-        //assertNull(err, json.get("failure"));
-        //assertNotNull(err, json = json.getJsonObject("info"));
-        // ...
+        assertTrue(err, json.getBoolean("successful"));
+        assertNull(err, json.get("failure"));
+        assertNotNull(err, json = json.getJsonObject("info"));
+        assertEquals(err, "IBM", json.getString("jmsProviderName"));
+        assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "TestClient1", json.getString("clientID"));
+    }
+
+    /**
+     * Use the validation REST endpoint to validate a single javax.jms.ConnectionFactory, where the validation indicates a failure.
+     */
+    @AllowedFFDC({ "com.ibm.websphere.sib.exception.SIResourceException",
+                   "com.ibm.wsspi.channelfw.exception.InvalidChainNameException",
+                   "javax.jms.JMSException",
+                   "javax.resource.ResourceException",
+                   "javax.resource.spi.ResourceAllocationException"
+    })
+    @Test
+    public void testJMSConnectionFactoryFailure() throws Exception {
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/jmsConnectionFactory/jmscf2").run(JsonObject.class);
+        JsonArray stack;
+        String err = "Unexpected json response: " + json;
+        assertEquals(err, "jmscf2", json.getString("uid"));
+        assertEquals(err, "jmscf2", json.getString("id"));
+        assertEquals(err, "jms/cf2", json.getString("jndiName"));
+        assertFalse(err, json.getBoolean("successful"));
+        assertNull(err, json.get("info"));
+
+        // Detail within the following could change if the resource adapter ever changes.
+        // If so, just update the expected values accordingly.
+
+        assertNotNull(err, json = json.getJsonObject("failure"));
+        assertEquals(err, "CWSIA0241", json.getString("errorCode"));
+        assertEquals(err, "javax.jms.JMSException", json.getString("class"));
+        assertTrue(err, json.getString("message").contains("CWSIA0241E"));
+        assertNotNull(err, stack = json.getJsonArray("stack"));
+        assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
+        assertTrue(err, stack.getString(0).startsWith("com.ibm.ws.sib.api.jms."));
+        assertTrue(err, stack.getString(1).startsWith("com."));
+        assertTrue(err, stack.getString(2).startsWith("com."));
+
+        assertNotNull(err, json = json.getJsonObject("cause"));
+        assertNull(err, json.get("errorCode"));
+        assertEquals(err, "com.ibm.websphere.sib.exception.SIResourceException", json.getString("class"));
+        assertTrue(err, json.getString("message").contains("CWSIT0127E"));
+        assertNotNull(err, stack = json.getJsonArray("stack"));
+        assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
+        assertTrue(err, stack.getString(0).startsWith("com.ibm.ws.sib."));
+        assertTrue(err, stack.getString(1).startsWith("com."));
+        assertTrue(err, stack.getString(2).startsWith("com."));
+
+        // In order to avoid testing internals too much, after this point, we will test only that the
+        // chain of exceptions ends after a reasonable amount and that required attributes are non-null.
+
+        for (int i = 2; i < 10 && (json = json.getJsonObject("cause")) != null; i++) {
+            String errMsg = "Cause depth " + i + " " + err;
+
+            assertNotNull(errMsg, json.get("class"));
+            assertNotNull(errMsg, json.get("message"));
+            assertNotNull(errMsg, stack = json.getJsonArray("stack"));
+            assertTrue(errMsg, stack.size() > 3);
+            assertNotNull(errMsg, stack.get(0));
+        }
+
+        // If the exception chain is unreasonably long, the validation impl might have missed detection of a cycle
+        // or might be improperly repeating the same cause.
+        assertNull(err, json);
+    }
+
+    /**
+     * Use /ibm/api/validation/jmsConnectionFactory to validate all connection factories.
+     */
+    @AllowedFFDC({ "com.ibm.websphere.sib.exception.SIResourceException",
+                   "com.ibm.wsspi.channelfw.exception.InvalidChainNameException",
+                   "javax.jms.JMSException",
+                   "javax.resource.ResourceException",
+                   "javax.resource.spi.ResourceAllocationException"
+    })
+    @Test
+    public void testMultipleConnectionFactories() throws Exception {
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/jmsConnectionFactory");
+        JsonArray json = request.method("GET").run(JsonArray.class);
+        String err = "unexpected response: " + json;
+
+        assertEquals(err, 3, json.size()); // Increase this if you add more connection factories to server.xml
+
+        // Order is currently alphabetical based on config.displayId
+
+        // [0]: config.displayId=DefaultJMSConnectionFactory
+        JsonObject j = json.getJsonObject(0);
+        assertEquals(err, "DefaultJMSConnectionFactory", j.getString("uid"));
+        assertEquals(err, "DefaultJMSConnectionFactory", j.getString("id"));
+        assertNull(err, j.get("jndiName"));
+        assertTrue(err, j.getBoolean("successful"));
+        assertNull(err, j.get("failure"));
+        assertNotNull(err, j = j.getJsonObject("info"));
+        assertEquals(err, "IBM", j.getString("jmsProviderName"));
+        assertEquals(err, "1.0", j.getString("jmsProviderVersion"));
+        assertEquals(err, "clientID", j.getString("clientID"));
+
+        // [1]: config.displayId=jmsConnectionFactory[jmscf1]
+        j = json.getJsonObject(1);
+        assertEquals(err, "jmscf1", j.getString("uid"));
+        assertEquals(err, "jmscf1", j.getString("id"));
+        assertEquals(err, "jms/cf1", j.getString("jndiName"));
+        assertTrue(err, j.getBoolean("successful"));
+        assertNull(err, j.get("failure"));
+        assertNotNull(err, j.getJsonObject("info"));
+        // jmscf1 is already covered by testJMSConnectionFactory
+
+        // [2]: config.displayId=jmsConnectionFactory[jmscf2]
+        j = json.getJsonObject(2);
+        assertEquals(err, "jmscf2", j.getString("uid"));
+        assertEquals(err, "jmscf2", j.getString("id"));
+        assertEquals(err, "jms/cf2", j.getString("jndiName"));
+        assertFalse(err, j.getBoolean("successful"));
+        assertNull(err, j.get("info"));
+        assertNotNull(err, j.getJsonObject("failure"));
+        // jmscf2 is already covered by testJMSConnectionFactoryFailure
+    }
+
+    /**
+     * Use /ibm/api/validation/jmsQueueConnectionFactory to validate all queue connection factories, where there is only one.
+     */
+    @Test
+    public void testMultipleQueueConnectionFactories() throws Exception {
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/jmsQueueConnectionFactory");
+        JsonArray qcfs = request.method("GET").run(JsonArray.class);
+        JsonObject json;
+        String err = "unexpected response: " + qcfs;
+
+        assertEquals(err, 1, qcfs.size());
+        assertNotNull(err, json = qcfs.getJsonObject(0));
+        assertEquals(err, "qcf1", json.getString("uid"));
+        assertEquals(err, "qcf1", json.getString("id"));
+        assertEquals(err, "jms/qcf1", json.getString("jndiName"));
+        assertTrue(err, json.getBoolean("successful"));
+        assertNull(err, json.get("failure"));
+        assertNotNull(err, json = json.getJsonObject("info"));
+        assertEquals(err, "IBM", json.getString("jmsProviderName"));
+        assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertNull(err, json.get("clientID"));
+    }
+
+    /**
+     * Use /ibm/api/validation/jmsTopicConnectionFactory to validate all 3 topic connection factories.
+     */
+    @Test
+    public void testMultipleTopicConnectionFactories() throws Exception {
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/jmsTopicConnectionFactory");
+        JsonArray tcfs = request.method("GET").run(JsonArray.class);
+        JsonObject json;
+        String err = "unexpected response: " + tcfs;
+
+        assertEquals(err, 3, tcfs.size());
+
+        assertNotNull(err, json = tcfs.getJsonObject(0));
+        assertEquals(err, "jmsTopicConnectionFactory[default-0]", json.getString("uid"));
+        assertNull(err, json.get("id"));
+        assertEquals(err, "jms/tcf1", json.getString("jndiName"));
+        assertTrue(err, json.getBoolean("successful"));
+        assertNull(err, json.get("failure"));
+        assertNotNull(err, json = json.getJsonObject("info"));
+        assertEquals(err, "IBM", json.getString("jmsProviderName"));
+        assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "clientID", json.getString("clientID"));
+
+        assertNotNull(err, json = tcfs.getJsonObject(1));
+        assertEquals(err, "tcf2", json.getString("uid"));
+        assertEquals(err, "tcf2", json.getString("id"));
+        assertEquals(err, "jms/tcf2", json.getString("jndiName"));
+        assertTrue(err, json.getBoolean("successful"));
+        assertNull(err, json.get("failure"));
+        assertNotNull(err, json = json.getJsonObject("info"));
+        assertEquals(err, "IBM", json.getString("jmsProviderName"));
+        assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "tcf2id", json.getString("clientID"));
+
+        assertNotNull(err, json = tcfs.getJsonObject(2));
+        assertEquals(err, "tcf3", json.getString("uid"));
+        assertEquals(err, "tcf3", json.getString("id"));
+        assertNull(err, json.get("jndiName"));
+        assertTrue(err, json.getBoolean("successful"));
+        assertNull(err, json.get("failure"));
+        assertNotNull(err, json = json.getJsonObject("info"));
+        assertEquals(err, "IBM", json.getString("jmsProviderName"));
+        assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "tcf3id", json.getString("clientID"));
     }
 
     /**
@@ -81,11 +269,12 @@ public class ValidateJMSTest extends FATServletClient {
         assertEquals(err, "qcf1", json.getString("uid"));
         assertEquals(err, "qcf1", json.getString("id"));
         assertEquals(err, "jms/qcf1", json.getString("jndiName"));
-        // TODO complete this test once implementation is further along
-        //assertTrue(err, json.getBoolean("successful"));
-        //assertNull(err, json.get("failure"));
-        //assertNotNull(err, json = json.getJsonObject("info"));
-        // ...
+        assertTrue(err, json.getBoolean("successful"));
+        assertNull(err, json.get("failure"));
+        assertNotNull(err, json = json.getJsonObject("info"));
+        assertEquals(err, "IBM", json.getString("jmsProviderName"));
+        assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertNull(err, json.get("clientID"));
     }
 
     /**
@@ -98,10 +287,11 @@ public class ValidateJMSTest extends FATServletClient {
         assertEquals(err, "jmsTopicConnectionFactory[default-0]", json.getString("uid"));
         assertNull(err, json.get("id"));
         assertEquals(err, "jms/tcf1", json.getString("jndiName"));
-        // TODO complete this test once implementation is further along
-        //assertTrue(err, json.getBoolean("successful"));
-        //assertNull(err, json.get("failure"));
-        //assertNotNull(err, json = json.getJsonObject("info"));
-        // ...
+        assertTrue(err, json.getBoolean("successful"));
+        assertNull(err, json.get("failure"));
+        assertNotNull(err, json = json.getJsonObject("info"));
+        assertEquals(err, "IBM", json.getString("jmsProviderName"));
+        assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "clientID", json.getString("clientID"));
     }
 }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.rest.handler.validator.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.json.JsonObject;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpsRequest;
+
+@RunWith(FATRunner.class)
+public class ValidateJMSTest extends FATServletClient {
+    @Server("com.ibm.ws.rest.handler.validator.jms.fat")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        server.startServer();
+
+        // Wait for the API to become available
+        List<String> messages = new ArrayList<>();
+        messages.add("CWWKS0008I"); // CWWKS0008I: The security service is ready.
+        messages.add("CWWKS4105I"); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        messages.add("CWPKI0803A"); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
+        messages.add("CWWKO0219I: .* defaultHttpEndpoint-ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        messages.add("CWWKT0016I"); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
+
+        server.waitForStringsInLogUsingMark(messages);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    /**
+     * Use the validation REST endpoint to validate a single javax.jms.ConnectionFactory, where the validation is successful.
+     */
+    @Test
+    public void testJMSConnectionFactory() throws Exception {
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/jmsConnectionFactory/jmscf1").run(JsonObject.class);
+        String err = "Unexpected json response: " + json;
+        assertEquals(err, "jmscf1", json.getString("uid"));
+        assertEquals(err, "jmscf1", json.getString("id"));
+        assertEquals(err, "jms/cf1", json.getString("jndiName"));
+        // TODO complete this test once implementation is further along
+        //assertTrue(err, json.getBoolean("successful"));
+        //assertNull(err, json.get("failure"));
+        //assertNotNull(err, json = json.getJsonObject("info"));
+        // ...
+    }
+
+    /**
+     * Use the validation REST endpoint to validate a single javax.jms.QueueConnectionFactory, where the validation is successful.
+     */
+    @Test
+    public void testQueueConnectionFactory() throws Exception {
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/jmsQueueConnectionFactory/qcf1").run(JsonObject.class);
+        String err = "Unexpected json response: " + json;
+        assertEquals(err, "qcf1", json.getString("uid"));
+        assertEquals(err, "qcf1", json.getString("id"));
+        assertEquals(err, "jms/qcf1", json.getString("jndiName"));
+        // TODO complete this test once implementation is further along
+        //assertTrue(err, json.getBoolean("successful"));
+        //assertNull(err, json.get("failure"));
+        //assertNotNull(err, json = json.getJsonObject("info"));
+        // ...
+    }
+
+    /**
+     * Use the validation REST endpoint to validate a single javax.jms.TopicConnectionFactory, where the validation is successful.
+     */
+    @Test
+    public void testTopicConnectionFactory() throws Exception {
+        JsonObject json = new HttpsRequest(server, "/ibm/api/validation/jmsTopicConnectionFactory/jmsTopicConnectionFactory[default-0]").run(JsonObject.class);
+        String err = "Unexpected json response: " + json;
+        assertEquals(err, "jmsTopicConnectionFactory[default-0]", json.getString("uid"));
+        assertNull(err, json.get("id"));
+        assertEquals(err, "jms/tcf1", json.getString("jndiName"));
+        // TODO complete this test once implementation is further along
+        //assertTrue(err, json.getBoolean("successful"));
+        //assertNull(err, json.get("failure"));
+        //assertNotNull(err, json = json.getJsonObject("info"));
+        // ...
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:rest.validator=all:com.ibm.ws.jca.service.ConnectionFactoryService=all
+com.ibm.ws.logging.max.file.size=0
+ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/server.xml
@@ -39,6 +39,10 @@
     <properties.wasJms clientID="TestClient1" userName="USER1" password="PWD1"/>
   </jmsConnectionFactory>
 
+  <jmsConnectionFactory id="jmscf2" jndiName="jms/cf2">
+    <properties.wasJms clientID="TestClient2" remoteServerAddress="host2.rchland.ibm.com:2121:DoesNotExist"/>
+  </jmsConnectionFactory>
+
   <jmsQueueConnectionFactory id="qcf1" jndiName="jms/qcf1">
     <containerAuthData user="QCFUSER1" password="QCFPWD1"/>
     <properties.wasJms temporaryQueueNamePrefix="TEMPQ"/>
@@ -46,5 +50,13 @@
 
   <jmsTopicConnectionFactory jndiName="jms/tcf1">
     <properties.wasJms temporaryTopicNamePrefix="TMP1"/>
+  </jmsTopicConnectionFactory>
+
+  <jmsTopicConnectionFactory id="tcf2" jndiName="jms/tcf2">
+    <properties.wasJms clientID="tcf2id"/>
+  </jmsTopicConnectionFactory>
+
+  <jmsTopicConnectionFactory id="tcf3">
+    <properties.wasJms clientID="tcf3id"/>
   </jmsTopicConnectionFactory>
 </server>

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/server.xml
@@ -1,0 +1,50 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <include location="../fatTestPorts.xml" />
+
+  <featureManager>
+    <feature>appSecurity-2.0</feature>
+    <feature>componenttest-1.0</feature>
+    <feature>configValidator-1.0</feature> <!-- TODO replace when functionality is enabled via auto-feature -->
+    <feature>jms-2.0</feature>
+    <feature>mpOpenApi-1.0</feature>
+    <feature>wasJmsClient-2.0</feature>
+    <feature>wasJmsServer-1.0</feature>
+  </featureManager>
+
+  <variable name="onError" value="FAIL"/>
+
+  <keyStore id="defaultKeyStore" password="Liberty"/>
+  <quickStartSecurity userName="adminuser" userPassword="adminpwd"/>
+
+  <messagingEngine id="defaultME">
+  <!--
+    <queue id="Q1"/>
+    <queue id="Q2"/>
+    <topicSpace id="TOPIC1">
+    <topicSpace id="TOPIC2">
+  -->
+  </messagingEngine>
+
+  <jmsConnectionFactory id="jmscf1" jndiName="jms/cf1">
+    <properties.wasJms clientID="TestClient1" userName="USER1" password="PWD1"/>
+  </jmsConnectionFactory>
+
+  <jmsQueueConnectionFactory id="qcf1" jndiName="jms/qcf1">
+    <containerAuthData user="QCFUSER1" password="QCFPWD1"/>
+    <properties.wasJms temporaryQueueNamePrefix="TEMPQ"/>
+  </jmsQueueConnectionFactory>
+
+  <jmsTopicConnectionFactory jndiName="jms/tcf1">
+    <properties.wasJms temporaryTopicNamePrefix="TMP1"/>
+  </jmsTopicConnectionFactory>
+</server>


### PR DESCRIPTION
Implement /ibm/api/validation REST endpoint to validate multiple or a single JMS connection factory.
Implement for:
jmsConnectionFactory
jmsQueueConnectionFactory
jmsTopicConnectionFactory