### PR TITLE
Update jaxws-2.3 API component.

### DIFF
--- a/dev/com.ibm.websphere.javaee.jaxws.2.3/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jaxws.2.3/bnd.bnd
@@ -11,6 +11,12 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+publish.wlp.jar.disabled: true
+
+javac.source: 1.8
+javac.target: 1.8
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
 Bundle-SymbolicName: com.ibm.websphere.javaee.jaxws.2.3; singleton:=true
 
 Export-Package: javax.xml.ws.*; version="2.3"


### PR DESCRIPTION
- Rename bnd.bnd.disabled to bnd.bnd.
- Update to use Java 8 in bnd to match other Java 8 settings
- Update to not publish the bundle to the liberty image.
