### PR TITLE
Cache the claims from json.parse.

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/utils/JwtPrincipalMapping.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/utils/JwtPrincipalMapping.java
@@ -27,7 +27,7 @@ public class JwtPrincipalMapping {
     private static TraceComponent tc = Tr.register(JwtPrincipalMapping.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
     protected static final String REALM_CLAIM = "realm";
 
-    private Map claims;
+    private Map claims = null;
 
     String realm = null;
     //String uniqueSecurityName = null;
@@ -159,7 +159,6 @@ public class JwtPrincipalMapping {
         } catch (Exception e) {
             Tr.error(tc, "CANNOT_GET_CLAIM_FROM_JSON", new Object[] { claimAttr, e.getLocalizedMessage() });
         }
-
         if (tc.isDebugEnabled()) {
             Tr.exit(tc, methodName, claim);
         }

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/utils/JwtPrincipalMapping.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/utils/JwtPrincipalMapping.java
@@ -6,11 +6,12 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt.impl.utils;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -25,6 +26,9 @@ public class JwtPrincipalMapping {
 
     private static TraceComponent tc = Tr.register(JwtPrincipalMapping.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
     protected static final String REALM_CLAIM = "realm";
+
+    private Map claims;
+
     String realm = null;
     //String uniqueSecurityName = null;
     String userName = null;
@@ -139,11 +143,23 @@ public class JwtPrincipalMapping {
             Tr.entry(tc, methodName, jsonstr, claimAttr);
         }
         Object claim = null;
+
         try {
-            claim = JsonUtils.claimFromJsonObject(jsonstr, claimAttr);
+
+            if (claims != null) {
+                claim = claims.get(claimAttr);
+            } else {
+                claims = JsonUtils.claimsFromJsonObject(jsonstr);
+
+                if (claims != null) {
+                    claim = claims.get(claimAttr);
+                }
+            }
+
         } catch (Exception e) {
             Tr.error(tc, "CANNOT_GET_CLAIM_FROM_JSON", new Object[] { claimAttr, e.getLocalizedMessage() });
         }
+
         if (tc.isDebugEnabled()) {
             Tr.exit(tc, methodName, claim);
         }


### PR DESCRIPTION
Performance improvement for handling JWTs/parsing the json less often.

