### PR TITLE
test case for config REST endpoint and app-defined data source

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
@@ -195,6 +195,11 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
             dsSvcProps.put("recoveryAuthData.cardinality.minimum", 1);
         }
 
+        // Must use array to remain consistent with multiple cardinality of onConnect attribute in metatype
+        String onConnect = (String) vendorProps.remove(DSConfig.ON_CONNECT);
+        if (onConnect != null)
+            dsSvcProps.put(DSConfig.ON_CONNECT, new String[] { onConnect });
+
         if (application != null) {
             dsSvcProps.put(AppDefinedResource.APPLICATION, application);
             if (module != null) {

--- a/dev/com.ibm.ws.rest.handler.config_fat/.classpath
+++ b/dev/com.ibm.ws.rest.handler.config_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/AppDefResourcesApp/src"/>
 	<classpathentry kind="src" path="test-resourceadapter/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
@@ -16,6 +16,7 @@ javac.target: 1.8
 
 src: \
 	fat/src,\
+	test-applications/AppDefResourcesApp/src,\
 	test-resourceadapter/src
 
 fat.project: true

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.rest.handler.config.fat;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.json.JsonArray;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpsRequest;
+
+@RunWith(FATRunner.class)
+public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
+    private static final String APP_NAME = "AppDefResourcesApp";
+
+    @Server("com.ibm.ws.rest.handler.config.appdef.fat")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, "test.resthandler.config.appdef.web");
+
+        server.startServer();
+
+        // Wait for the API to become available
+        List<String> messages = new ArrayList<>();
+        messages.add("CWWKS0008I"); // CWWKS0008I: The security service is ready.
+        messages.add("CWWKS4105I"); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        messages.add("CWPKI0803A"); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
+        messages.add("CWWKO0219I: .* defaultHttpEndpoint-ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        messages.add("CWWKT0016I"); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
+
+        server.waitForStringsInLogUsingMark(messages);
+
+        // Invoke the servlet to ensure that the web module containing the app-defined data source is processed.
+        FATServletClient.runTest(server, "AppDefResourcesApp/AppDefinedResourcesServlet", "doSomething");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    @Test
+    public void testConfigDataSourcesIncludingAppDefined() throws Exception {
+        JsonArray dataSources = new HttpsRequest(server, "/ibm/api/config/dataSource").run(JsonArray.class);
+        String err = "unexpected response: " + dataSources;
+        assertEquals(err, 1, dataSources.size()); // TODO app-defined codepath is not implemented
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/FATSuite.java
@@ -19,6 +19,7 @@ import componenttest.topology.utils.HttpUtils;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+                ConfigRESTHandlerAppDefinedResourcesTest.class,
                 ConfigRESTHandlerJCATest.class,
                 ConfigRESTHandlerJMSTest.class,
                 ConfigRESTHandlerTest.class

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:rest.config=all:RRA=all
+com.ibm.ws.logging.max.file.size=0
+ds.loglevel=debug
+derby.connection.requireAuthentication=true
+derby.user.dbuser1=dbpwd1
+derby.user.dbuser2=dbpwd2

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
@@ -1,0 +1,36 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <include location="../fatTestPorts.xml" />
+
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>configValidator-1.0</feature> <!-- TODO replace when functionality is enabled via auto-feature -->
+    <feature>jdbc-4.2</feature>
+  </featureManager>
+
+  <variable name="onError" value="FAIL"/>
+
+  <keyStore id="defaultKeyStore" password="Liberty"/>
+  <quickStartSecurity userName="adminuser" userPassword="adminpwd"/>
+
+  <application location="AppDefResourcesApp.war">
+    <classloader commonLibraryRef="Derby"/>
+  </application>
+
+  <authData id="derbyAuth1" user="dbuser1" password="dbpwd1"/>
+
+  <library id="Derby">
+    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  </library>
+  
+  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -35,9 +35,6 @@ import componenttest.app.FATServlet;
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/AppDefinedResourcesServlet")
 public class AppDefinedResourcesServlet extends FATServlet {
-    //@Resource
-    //private DataSource defaultDataSource;
-
     /**
      * No-op servlet method that the test case uses to ensure the web module is loaded.
      */

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.resthandler.config.appdef.web;
+
+import java.sql.Connection;
+
+import javax.annotation.sql.DataSourceDefinition;
+import javax.servlet.annotation.WebServlet;
+
+import componenttest.app.FATServlet;
+
+@DataSourceDefinition(name = "java:module/env/jdbc/ds2",
+                      className = "org.apache.derby.jdbc.EmbeddedXADataSource",
+                      databaseName = "${shared.resource.dir}/data/configRHTestDB",
+                      isolationLevel = Connection.TRANSACTION_READ_COMMITTED,
+                      loginTimeout = 220,
+                      maxPoolSize = 2,
+                      properties = {
+                                     "connectionTimeout=0",
+                                     "containerAuthDataRef=derbyAuth1",
+                                     "createDatabase=create",
+                                     "onConnect=DECLARE GLOBAL TEMPORARY TABLE TEMP2 (COL1 VARCHAR(80)) ON COMMIT PRESERVE ROWS NOT LOGGED",
+                                     "queryTimeout=1m22s",
+                                     "reapTime=2200ms"
+                      })
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/AppDefinedResourcesServlet")
+public class AppDefinedResourcesServlet extends FATServlet {
+    //@Resource
+    //private DataSource defaultDataSource;
+
+    /**
+     * No-op servlet method that the test case uses to ensure the web module is loaded.
+     */
+    public void doSomething() {
+        System.out.println("Servlet is running.");
+    }
+}


### PR DESCRIPTION
Add a test case that defines an app-defined data source and attempts to display its configuration via the /ibm/api/config REST endpoint.  Currently, much of this won't work because we haven't implemented it, so parts of the test are disabled.