### PR TITLE
Removed the LogRecord.inferCaller calls that's plaguing System.out performance

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
@@ -198,10 +198,10 @@ public class BaseTraceFormatter extends Formatter {
      *
      * @param logRecord
      * @param id
-     * @param formattedMsg        the result of {@link #formatMessage}, or null if that
-     *                                method was not previously called
+     * @param formattedMsg the result of {@link #formatMessage}, or null if that
+     *            method was not previously called
      * @param formattedVerboseMsg the result of {@link #formatVerboseMessage},
-     *                                or null if that method was not previously called
+     *            or null if that method was not previously called
      * @return
      */
     public String traceLogFormat(LogRecord logRecord, Object id, String formattedMsg, String formattedVerboseMsg) {
@@ -249,7 +249,7 @@ public class BaseTraceFormatter extends Formatter {
      * formatObj(...) to the log record message.
      *
      * @param logRecord
-     * @param logParams         the parameters for the message
+     * @param logParams the parameters for the message
      * @param useResourceBundle
      * @return
      */
@@ -302,8 +302,8 @@ public class BaseTraceFormatter extends Formatter {
      * reused if specified and no parameters need to be modified.
      *
      * @param logRecord
-     * @param msg       the result of {@link #formatMessage}, or null if that method
-     *                      was not previously called
+     * @param msg the result of {@link #formatMessage}, or null if that method
+     *            was not previously called
      * @return
      */
     public String formatVerboseMessage(LogRecord logRecord, String msg) {
@@ -317,8 +317,8 @@ public class BaseTraceFormatter extends Formatter {
      * reused if specified and no parameters need to be modified.
      *
      * @param logRecord
-     * @param formattedMsg      the result of {@link #formatMessage}, or null if that
-     *                              method was not previously called
+     * @param formattedMsg the result of {@link #formatMessage}, or null if that
+     *            method was not previously called
      * @param useResourceBundle
      * @return the formatted message
      */
@@ -390,7 +390,7 @@ public class BaseTraceFormatter extends Formatter {
      * messages
      *
      * @param logRecord
-     * @param txt       the result of {@link #formatMessage}
+     * @param txt the result of {@link #formatMessage}
      * @return Formatted string for the console
      */
     public String consoleLogFormat(LogRecord logRecord, String txt) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
@@ -466,7 +466,7 @@ public class BaseTraceFormatter extends Formatter {
                                                  logRecord.getLoggerName().equals(SYSERR)))
             name = nonNullString(logRecord.getLoggerName(), null);
         else
-            name = nonNullString(logRecord.getLoggerName(), logRecord.getLoggerName());
+            name = nonNullString(logRecord.getLoggerName(), logRecord.getSourceClassName());
 
         sb.append('[').append(DateFormatHelper.formatTime(logRecord.getMillis(), useIsoDateFormat)).append("] ");
         sb.append(DataFormatHelper.getThreadId()).append(' ');

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
@@ -198,10 +198,10 @@ public class BaseTraceFormatter extends Formatter {
      *
      * @param logRecord
      * @param id
-     * @param formattedMsg the result of {@link #formatMessage}, or null if that
-     *            method was not previously called
+     * @param formattedMsg        the result of {@link #formatMessage}, or null if that
+     *                                method was not previously called
      * @param formattedVerboseMsg the result of {@link #formatVerboseMessage},
-     *            or null if that method was not previously called
+     *                                or null if that method was not previously called
      * @return
      */
     public String traceLogFormat(LogRecord logRecord, Object id, String formattedMsg, String formattedVerboseMsg) {
@@ -249,7 +249,7 @@ public class BaseTraceFormatter extends Formatter {
      * formatObj(...) to the log record message.
      *
      * @param logRecord
-     * @param logParams the parameters for the message
+     * @param logParams         the parameters for the message
      * @param useResourceBundle
      * @return
      */
@@ -302,8 +302,8 @@ public class BaseTraceFormatter extends Formatter {
      * reused if specified and no parameters need to be modified.
      *
      * @param logRecord
-     * @param msg the result of {@link #formatMessage}, or null if that method
-     *            was not previously called
+     * @param msg       the result of {@link #formatMessage}, or null if that method
+     *                      was not previously called
      * @return
      */
     public String formatVerboseMessage(LogRecord logRecord, String msg) {
@@ -317,8 +317,8 @@ public class BaseTraceFormatter extends Formatter {
      * reused if specified and no parameters need to be modified.
      *
      * @param logRecord
-     * @param formattedMsg the result of {@link #formatMessage}, or null if that
-     *            method was not previously called
+     * @param formattedMsg      the result of {@link #formatMessage}, or null if that
+     *                              method was not previously called
      * @param useResourceBundle
      * @return the formatted message
      */
@@ -390,7 +390,7 @@ public class BaseTraceFormatter extends Formatter {
      * messages
      *
      * @param logRecord
-     * @param txt the result of {@link #formatMessage}
+     * @param txt       the result of {@link #formatMessage}
      * @return Formatted string for the console
      */
     public String consoleLogFormat(LogRecord logRecord, String txt) {
@@ -462,8 +462,8 @@ public class BaseTraceFormatter extends Formatter {
         StringBuilder sb = new StringBuilder(256);
         String sym = getMarker(logRecord);
         String name = null;
-        if (logRecord.getLoggerName() != null & (logRecord.getLoggerName().equals(SYSOUT) ||
-                                                 logRecord.getLoggerName().equals(SYSERR)))
+        if (logRecord.getLoggerName() != null && (logRecord.getLoggerName().equals(SYSOUT) ||
+                                                  logRecord.getLoggerName().equals(SYSERR)))
             name = nonNullString(logRecord.getLoggerName(), null);
         else
             name = nonNullString(logRecord.getLoggerName(), logRecord.getSourceClassName());

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
@@ -198,10 +198,10 @@ public class BaseTraceFormatter extends Formatter {
      *
      * @param logRecord
      * @param id
-     * @param formattedMsg the result of {@link #formatMessage}, or null if that
-     *            method was not previously called
+     * @param formattedMsg        the result of {@link #formatMessage}, or null if that
+     *                                method was not previously called
      * @param formattedVerboseMsg the result of {@link #formatVerboseMessage},
-     *            or null if that method was not previously called
+     *                                or null if that method was not previously called
      * @return
      */
     public String traceLogFormat(LogRecord logRecord, Object id, String formattedMsg, String formattedVerboseMsg) {
@@ -249,7 +249,7 @@ public class BaseTraceFormatter extends Formatter {
      * formatObj(...) to the log record message.
      *
      * @param logRecord
-     * @param logParams the parameters for the message
+     * @param logParams         the parameters for the message
      * @param useResourceBundle
      * @return
      */
@@ -302,8 +302,8 @@ public class BaseTraceFormatter extends Formatter {
      * reused if specified and no parameters need to be modified.
      *
      * @param logRecord
-     * @param msg the result of {@link #formatMessage}, or null if that method
-     *            was not previously called
+     * @param msg       the result of {@link #formatMessage}, or null if that method
+     *                      was not previously called
      * @return
      */
     public String formatVerboseMessage(LogRecord logRecord, String msg) {
@@ -317,8 +317,8 @@ public class BaseTraceFormatter extends Formatter {
      * reused if specified and no parameters need to be modified.
      *
      * @param logRecord
-     * @param formattedMsg the result of {@link #formatMessage}, or null if that
-     *            method was not previously called
+     * @param formattedMsg      the result of {@link #formatMessage}, or null if that
+     *                              method was not previously called
      * @param useResourceBundle
      * @return the formatted message
      */
@@ -390,7 +390,7 @@ public class BaseTraceFormatter extends Formatter {
      * messages
      *
      * @param logRecord
-     * @param txt the result of {@link #formatMessage}
+     * @param txt       the result of {@link #formatMessage}
      * @return Formatted string for the console
      */
     public String consoleLogFormat(LogRecord logRecord, String txt) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
@@ -459,7 +459,7 @@ public class BaseTraceFormatter extends Formatter {
         // This is a very light trace format, based on enhanced:
         StringBuilder sb = new StringBuilder(256);
         String sym = getMarker(logRecord);
-        String name = nonNullString(logRecord.getLoggerName(), logRecord.getSourceClassName());
+        String name = nonNullString(logRecord.getLoggerName(), null);
 
         sb.append('[').append(DateFormatHelper.formatTime(logRecord.getMillis(), useIsoDateFormat)).append("] ");
         sb.append(DataFormatHelper.getThreadId()).append(' ');

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
@@ -58,6 +58,8 @@ public class BaseTraceFormatter extends Formatter {
     static final String emptyStringReplacement = "\"\"";
     static final String ENTRY = "Entry ";
     static final String EXIT = "Exit ";
+    static final String SYSOUT = "SystemOut";
+    static final String SYSERR = "SystemErr";
 
     /**
      * Array used to convert integers to hex values
@@ -196,10 +198,10 @@ public class BaseTraceFormatter extends Formatter {
      *
      * @param logRecord
      * @param id
-     * @param formattedMsg the result of {@link #formatMessage}, or null if that
-     *            method was not previously called
+     * @param formattedMsg        the result of {@link #formatMessage}, or null if that
+     *                                method was not previously called
      * @param formattedVerboseMsg the result of {@link #formatVerboseMessage},
-     *            or null if that method was not previously called
+     *                                or null if that method was not previously called
      * @return
      */
     public String traceLogFormat(LogRecord logRecord, Object id, String formattedMsg, String formattedVerboseMsg) {
@@ -247,7 +249,7 @@ public class BaseTraceFormatter extends Formatter {
      * formatObj(...) to the log record message.
      *
      * @param logRecord
-     * @param logParams the parameters for the message
+     * @param logParams         the parameters for the message
      * @param useResourceBundle
      * @return
      */
@@ -300,8 +302,8 @@ public class BaseTraceFormatter extends Formatter {
      * reused if specified and no parameters need to be modified.
      *
      * @param logRecord
-     * @param msg the result of {@link #formatMessage}, or null if that method
-     *            was not previously called
+     * @param msg       the result of {@link #formatMessage}, or null if that method
+     *                      was not previously called
      * @return
      */
     public String formatVerboseMessage(LogRecord logRecord, String msg) {
@@ -315,8 +317,8 @@ public class BaseTraceFormatter extends Formatter {
      * reused if specified and no parameters need to be modified.
      *
      * @param logRecord
-     * @param formattedMsg the result of {@link #formatMessage}, or null if that
-     *            method was not previously called
+     * @param formattedMsg      the result of {@link #formatMessage}, or null if that
+     *                              method was not previously called
      * @param useResourceBundle
      * @return the formatted message
      */
@@ -388,7 +390,7 @@ public class BaseTraceFormatter extends Formatter {
      * messages
      *
      * @param logRecord
-     * @param txt the result of {@link #formatMessage}
+     * @param txt       the result of {@link #formatMessage}
      * @return Formatted string for the console
      */
     public String consoleLogFormat(LogRecord logRecord, String txt) {
@@ -459,7 +461,12 @@ public class BaseTraceFormatter extends Formatter {
         // This is a very light trace format, based on enhanced:
         StringBuilder sb = new StringBuilder(256);
         String sym = getMarker(logRecord);
-        String name = nonNullString(logRecord.getLoggerName(), null);
+        String name = null;
+        if (logRecord.getLoggerName() != null & (logRecord.getLoggerName().equals(SYSOUT) ||
+                                                 logRecord.getLoggerName().equals(SYSERR)))
+            name = nonNullString(logRecord.getLoggerName(), null);
+        else
+            name = nonNullString(logRecord.getLoggerName(), logRecord.getLoggerName());
 
         sb.append('[').append(DateFormatHelper.formatTime(logRecord.getMillis(), useIsoDateFormat)).append("] ");
         sb.append(DataFormatHelper.getThreadId()).append(' ');

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceFormatter.java
@@ -198,10 +198,10 @@ public class BaseTraceFormatter extends Formatter {
      *
      * @param logRecord
      * @param id
-     * @param formattedMsg        the result of {@link #formatMessage}, or null if that
-     *                                method was not previously called
+     * @param formattedMsg the result of {@link #formatMessage}, or null if that
+     *            method was not previously called
      * @param formattedVerboseMsg the result of {@link #formatVerboseMessage},
-     *                                or null if that method was not previously called
+     *            or null if that method was not previously called
      * @return
      */
     public String traceLogFormat(LogRecord logRecord, Object id, String formattedMsg, String formattedVerboseMsg) {
@@ -249,7 +249,7 @@ public class BaseTraceFormatter extends Formatter {
      * formatObj(...) to the log record message.
      *
      * @param logRecord
-     * @param logParams         the parameters for the message
+     * @param logParams the parameters for the message
      * @param useResourceBundle
      * @return
      */
@@ -302,8 +302,8 @@ public class BaseTraceFormatter extends Formatter {
      * reused if specified and no parameters need to be modified.
      *
      * @param logRecord
-     * @param msg       the result of {@link #formatMessage}, or null if that method
-     *                      was not previously called
+     * @param msg the result of {@link #formatMessage}, or null if that method
+     *            was not previously called
      * @return
      */
     public String formatVerboseMessage(LogRecord logRecord, String msg) {
@@ -317,8 +317,8 @@ public class BaseTraceFormatter extends Formatter {
      * reused if specified and no parameters need to be modified.
      *
      * @param logRecord
-     * @param formattedMsg      the result of {@link #formatMessage}, or null if that
-     *                              method was not previously called
+     * @param formattedMsg the result of {@link #formatMessage}, or null if that
+     *            method was not previously called
      * @param useResourceBundle
      * @return the formatted message
      */
@@ -390,7 +390,7 @@ public class BaseTraceFormatter extends Formatter {
      * messages
      *
      * @param logRecord
-     * @param txt       the result of {@link #formatMessage}
+     * @param txt the result of {@link #formatMessage}
      * @return Formatted string for the console
      */
     public String consoleLogFormat(LogRecord logRecord, String txt) {
@@ -463,7 +463,7 @@ public class BaseTraceFormatter extends Formatter {
         String sym = getMarker(logRecord);
         String name = null;
         if (logRecord.getLoggerName() != null && (logRecord.getLoggerName().equals(SYSOUT) ||
-                                                  logRecord.getLoggerName().equals(SYSERR)))
+                                                 logRecord.getLoggerName().equals(SYSERR)))
             name = nonNullString(logRecord.getLoggerName(), null);
         else
             name = nonNullString(logRecord.getLoggerName(), logRecord.getSourceClassName());

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
@@ -131,8 +131,8 @@ public class LogSource implements Source {
         logData.setModule(logRecord.getLoggerName());
         logData.setSeverity(LogFormatUtils.mapLevelToType(logRecord));
         logData.setLoglevel(LogFormatUtils.mapLevelToRawType(logRecord));
-        String loggerName = logRecord.getLoggerName();
-        if (loggerName != null & loggerName.equals(SYSOUT)) {
+
+        if (logRecord.getLoggerName() != null & logRecord.getLoggerName().equals(SYSOUT)) {
             logData.setMethodName("");
             logData.setClassName("");
         } else {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
@@ -36,6 +36,7 @@ public class LogSource implements Source {
     private final String sourceName = "com.ibm.ws.logging.source.message";
     private final String location = "memory";
     private final String SYSOUT = "SystemOut";
+    private final String SYSERR = "SystemErr";
     private BufferManager bufferMgr = null;
     private final SequenceNumber sequenceNumber = new SequenceNumber();
 
@@ -132,7 +133,8 @@ public class LogSource implements Source {
         logData.setSeverity(LogFormatUtils.mapLevelToType(logRecord));
         logData.setLoglevel(LogFormatUtils.mapLevelToRawType(logRecord));
 
-        if (logRecord.getLoggerName() != null & logRecord.getLoggerName().equals(SYSOUT)) {
+        if (logRecord.getLoggerName() != null & (logRecord.getLoggerName().equals(SYSOUT) ||
+                                                 logRecord.getLoggerName().equals(SYSERR))) {
             logData.setMethodName("");
             logData.setClassName("");
         } else {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
@@ -130,8 +130,8 @@ public class LogSource implements Source {
         logData.setModule(logRecord.getLoggerName());
         logData.setSeverity(LogFormatUtils.mapLevelToType(logRecord));
         logData.setLoglevel(LogFormatUtils.mapLevelToRawType(logRecord));
-        logData.setMethodName(logRecord.getSourceMethodName());
-        logData.setClassName(logRecord.getSourceClassName());
+        logData.setMethodName("");
+        logData.setClassName("");
 
         logData.setLevelValue(logRecord.getLevel().intValue());
         String threadName = Thread.currentThread().getName();

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
@@ -37,6 +37,7 @@ public class LogSource implements Source {
     private final String location = "memory";
     private final String SYSOUT = "SystemOut";
     private final String SYSERR = "SystemErr";
+
     private BufferManager bufferMgr = null;
     private final SequenceNumber sequenceNumber = new SequenceNumber();
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
@@ -134,8 +134,8 @@ public class LogSource implements Source {
         logData.setSeverity(LogFormatUtils.mapLevelToType(logRecord));
         logData.setLoglevel(LogFormatUtils.mapLevelToRawType(logRecord));
 
-        if (logRecord.getLoggerName() != null & (logRecord.getLoggerName().equals(SYSOUT) ||
-                                                 logRecord.getLoggerName().equals(SYSERR))) {
+        if (logRecord.getLoggerName() != null && (logRecord.getLoggerName().equals(SYSOUT) ||
+                                                  logRecord.getLoggerName().equals(SYSERR))) {
             logData.setMethodName("");
             logData.setClassName("");
         } else {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
@@ -35,6 +35,7 @@ public class LogSource implements Source {
 
     private final String sourceName = "com.ibm.ws.logging.source.message";
     private final String location = "memory";
+    private final String SYSOUT = "SystemOut";
     private BufferManager bufferMgr = null;
     private final SequenceNumber sequenceNumber = new SequenceNumber();
 
@@ -130,8 +131,14 @@ public class LogSource implements Source {
         logData.setModule(logRecord.getLoggerName());
         logData.setSeverity(LogFormatUtils.mapLevelToType(logRecord));
         logData.setLoglevel(LogFormatUtils.mapLevelToRawType(logRecord));
-        logData.setMethodName("");
-        logData.setClassName("");
+        String loggerName = logRecord.getLoggerName();
+        if (loggerName != null & loggerName.equals(SYSOUT)) {
+            logData.setMethodName("");
+            logData.setClassName("");
+        } else {
+            logData.setMethodName(logRecord.getSourceMethodName());
+            logData.setClassName(logRecord.getSourceClassName());
+        }
 
         logData.setLevelValue(logRecord.getLevel().intValue());
         String threadName = Thread.currentThread().getName();

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
LogRecord.getSourceClassName() and LogRecord.getSourceMethodName(). This
will improve the overall sysout performance by 300%

fixes #7433 