### PR TITLE
Remove test report debug output incorrectly appearing in build

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -558,8 +558,6 @@ task zipTestReport(type: Zip) {
     props.setProperty('gradle.test.report.zip', archivePath.toString()) //set in memory props too
     File propsFile = rootProject.file('generated.properties')
     userProps.store(propsFile.newWriter(), null)
-    println "test report is at:"
-    println archivePath.toString()
 }
 
 


### PR DESCRIPTION
We are getting incorrect debug output in the build, saying `test report is at:
/...../openliberty_test_report-xxx.zip`, because the message is being printed from the configuration step of the build instead of the execution.  The message isn't needed, so I'm removing it.