### PR TITLE
Always add metatype to work around issue 7448

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/BundleProcessor.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/BundleProcessor.java
@@ -395,10 +395,7 @@ class BundleProcessor implements SynchronousBundleListener, EventHandler, Runtim
                 Set<RegistryEntry> newEntries = new HashSet<RegistryEntry>();
                 for (Bundle b : bundles) {
                     if (b.getState() >= Bundle.RESOLVED) {
-                        Set<RegistryEntry> entries = metatypeRegistry.addMetaType(b);
-                        if (reprocessConfig || getExtendedBundle(b).needsReprocessing()) {
-                            newEntries.addAll(entries);
-                        }
+                        newEntries.addAll(metatypeRegistry.addMetaType(b));
                     }
                 }
 


### PR DESCRIPTION
For issue #7448 

Removing the optimization to only processing metatype config when things have changed because installUtility can wipe out cached configurations.