### PR TITLE
Tweaks to better handle Artifactory connection flakiness

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -46,3 +46,9 @@ systemProp.com.ibm.jsse2.overrideDefaultTLS=true
 
 # When the build cache is enabled, it will store build outputs in the Gradle user home.
 org.gradle.caching=true
+
+# Tweaks to better handle Artifactory connection flakiness.
+systemProp.org.gradle.internal.http.connectionTimeout=300000
+systemProp.org.gradle.internal.http.socketTimeout=300000
+systemProp.org.gradle.internal.repository.max.retries=11
+systemProp.org.gradle.internal.repository.initial.backoff=125


### PR DESCRIPTION
Add 4 new gradle.properties.

Set the connectionTimeout and socketTimeout to 5 minutes:
- `systemProp.org.gradle.internal.http.connectionTimeout=300000`
- `systemProp.org.gradle.internal.http.socketTimeout=300000`

Retry HTTP downloads with exponential backoffs 11 times starting at 125 ms resulting in retries at `125, 250, 500, 1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000`.
- `systemProp.org.gradle.internal.repository.max.retries=11`
- `systemProp.org.gradle.internal.repository.initial.backoff=125`