### PR TITLE
 config REST endpoint support for vendor properties and authdata for app-defined datasource

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corporation and others.
+ * Copyright (c) 2011, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,14 +15,12 @@ import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -81,13 +79,6 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
      * Name of property used by config service to identify where the configuration of a component instance originates.
      */
     private static final String CONFIG_SOURCE = "config.source";
-
-    /**
-     * Interface names, including package, for supported data source types. 
-     */
-    private static final Collection<String> DS_INTERFACE_NAMES = Arrays.asList(XADataSource.class.getName(),
-                                                                               ConnectionPoolDataSource.class.getName(),
-                                                                               DataSource.class.getName());
 
     /**
      * Property value that indicates the configuration originated in a configuration file, such as server.xml,
@@ -181,9 +172,15 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
         dsSvcProps.put(DataSourceService.TARGET_JDBC_DRIVER, jdbcDriverFilter);
         dsSvcProps.put("connectionManager.cardinality.minimum", 1); // require exactly 1 connection manager (the one specified by the target)
 
+        BundleContext bundleContext = DataSourceService.priv.getBundleContext(FrameworkUtil.getBundle(DataSourceResourceFactoryBuilder.class));
+
         String containerAuthDataRef = (String) vendorProps.remove(DSConfig.CONTAINER_AUTH_DATA_REF);
         if (containerAuthDataRef != null) {
             String authDataFilter = FilterUtils.createPropertyFilter(ID, containerAuthDataRef);
+            ServiceReference<?>[] refs = DataSourceService.priv.getServiceReferences(bundleContext, "com.ibm.websphere.security.auth.data.AuthData", authDataFilter);
+            if (refs == null || refs.length == 0)
+                throw new IllegalArgumentException(Tr.formatMessage(tc, "PROP_SET_ERROR", DSConfig.CONTAINER_AUTH_DATA_REF, "", containerAuthDataRef));
+            dsSvcProps.put(DSConfig.CONTAINER_AUTH_DATA_REF, new String[] { (String) refs[0].getProperty("service.pid") });
             dsSvcProps.put(DataSourceService.TARGET_CONTAINER_AUTH_DATA, authDataFilter);
             dsSvcProps.put("containerAuthData.cardinality.minimum", 1);
         }
@@ -191,6 +188,10 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
         String recoveryAuthDataRef = (String) vendorProps.remove(DSConfig.RECOVERY_AUTH_DATA_REF);
         if (recoveryAuthDataRef != null) {
             String authDataFilter = FilterUtils.createPropertyFilter(ID, recoveryAuthDataRef);
+            ServiceReference<?>[] refs = DataSourceService.priv.getServiceReferences(bundleContext, "com.ibm.websphere.security.auth.data.AuthData", authDataFilter);
+            if (refs == null || refs.length == 0)
+                throw new IllegalArgumentException(Tr.formatMessage(tc, "PROP_SET_ERROR", DSConfig.RECOVERY_AUTH_DATA_REF, "", recoveryAuthDataRef));
+            dsSvcProps.put(DSConfig.RECOVERY_AUTH_DATA_REF, new String[] { (String) refs[0].getProperty("service.pid") });
             dsSvcProps.put(DataSourceService.TARGET_RECOVERY_AUTH_DATA, authDataFilter);
             dsSvcProps.put("recoveryAuthData.cardinality.minimum", 1);
         }
@@ -214,8 +215,6 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
         for (String name : DSConfig.DATA_SOURCE_PROPS)
             if ((value = vendorProps.remove(name)) != null)
                 dsSvcProps.put(name, value);
-
-        BundleContext bundleContext = DataSourceService.priv.getBundleContext(FrameworkUtil.getBundle(DataSourceResourceFactoryBuilder.class));
 
         // className
         String className = (String) vendorProps.remove(DataSourceDef.className.name());
@@ -269,6 +268,7 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
         PropertyService.parsePasswordProperties(vendorProps);
 
         // Add vendor properties to the data source properties as flattened config
+        dsSvcProps.put(BASE_PROPERTIES_KEY + "config.referenceType", PropertyService.FACTORY_PID);
         for (Map.Entry<String, Object> entry : vendorProps.entrySet())
             dsSvcProps.put(BASE_PROPERTIES_KEY + entry.getKey(), entry.getValue());
 

--- a/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
@@ -128,7 +128,6 @@ public class ConfigRESTHandler implements RESTHandler {
         // Mapping of pid to list of flat config prefixes which are of that pid type
         SortedMap<String, SortedSet<String>> flattenedPids = new TreeMap<String, SortedSet<String>>();
 
-        // TODO app defined resources
         SortedSet<String> keys = new TreeSet<String>();
         for (java.util.Enumeration<String> en = config.keys(); en.hasMoreElements();) {
             String key = en.nextElement();

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -90,18 +90,22 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "connectionManager", cm.getString("configElementName"));
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/dataSource[java:module/env/jdbc/ds2]/connectionManager", cm.getString("uid"));
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/dataSource[java:module/env/jdbc/ds2]/connectionManager", cm.getString("id"));
-        assertEquals(err, "0", cm.getString("connectionTimeout"));
-        assertEquals(err, 2, cm.getInt("maxPoolSize"));
-        assertEquals(err, "2200ms", cm.getString("reapTime"));
         // TODO default values are absent
+        //assertEquals(err, "-1", cm.getString("agedTimeout"));
+        assertEquals(err, "0", cm.getString("connectionTimeout"));
+        //assertTrue(err, cm.getBoolean("enableSharingForDirectLookups"));
+        //assertEquals(err, "30m", cm.getString("maxIdleTime"));
+        assertEquals(err, 2, cm.getInt("maxPoolSize"));
+        //assertEquals(err, "EntirePool", cm.getString("purgePolicy"));
+        assertEquals(err, "2200ms", cm.getString("reapTime"));
 
-        //TODO JsonObject authData;
-        //assertNotNull(err, authData = ds.getJsonObject("containerAuthDataRef"));
-        //assertEquals(err, "authData", authData.getString("configElementName"));
-        //assertEquals(err, "derbyAuth1", authData.getString("uid"));
-        //assertEquals(err, "derbyAuth1", authData.getJsonObject("id"));
-        //assertEquals(err, "dbuser1", authData.getString("user"));
-        //assertEquals(err, "******", authData.getString("password"));
+        JsonObject authData;
+        assertNotNull(err, authData = ds.getJsonObject("containerAuthDataRef"));
+        assertEquals(err, "authData", authData.getString("configElementName"));
+        assertEquals(err, "derbyAuth1", authData.getString("uid"));
+        assertEquals(err, "derbyAuth1", authData.getString("id"));
+        assertEquals(err, "dbuser1", authData.getString("user"));
+        assertEquals(err, "******", authData.getString("password"));
 
         assertEquals(err, Connection.TRANSACTION_READ_COMMITTED, ds.getInt("isolationLevel"));
 
@@ -133,15 +137,25 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, 1, onConnect.size());
         assertEquals(err, "DECLARE GLOBAL TEMPORARY TABLE TEMP2 (COL1 VARCHAR(80)) ON COMMIT PRESERVE ROWS NOT LOGGED", onConnect.getString(0));
 
-        //TODO JsonObject props;
-        //assertNotNull(err, props = ds.getJsonObject("properties"));
-        //assertEquals(err, 3, props.size());
-        //assertEquals(err, "create", props.getString("createDatabase"));
-        //assertEquals(err, "...", props.getString("databaseName"));
-        //assertEquals(err, 220, props.getInt("loginTimeout"));
+        JsonObject props;
+        assertNotNull(err, props = ds.getJsonObject("properties"));
+        assertEquals(err, 3, props.size());
+        assertEquals(err, "create", props.getString("createDatabase"));
+        String databaseName;
+        assertNotNull(err, databaseName = props.getString("databaseName"));
+        assertTrue(err, databaseName.endsWith("configRHTestDB"));
+        assertTrue(err, databaseName.contains("resources")); // must expand ${shared.resource.dir}
+        assertEquals(err, 220, props.getInt("loginTimeout"));
 
         assertEquals(err, "1m22s", ds.getString("queryTimeout"));
-        assertNull(err, ds.get("recoveryAuthDataRef"));
+
+        assertNotNull(err, authData = ds.getJsonObject("recoveryAuthDataRef"));
+        assertEquals(err, "authData", authData.getString("configElementName"));
+        assertEquals(err, "derbyAuth2", authData.getString("uid"));
+        assertEquals(err, "derbyAuth2", authData.getString("id"));
+        assertEquals(err, "dbuser2", authData.getString("user"));
+        assertEquals(err, "******", authData.getString("password"));
+
         assertEquals(err, "javax.sql.XADataSource", ds.getString("type"));
 
         JsonArray api;

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
@@ -27,6 +27,7 @@
   </application>
 
   <authData id="derbyAuth1" user="dbuser1" password="dbpwd1"/>
+  <authData id="derbyAuth2" user="dbuser2" password="dbpwd2"/>
 
   <library id="Derby">
     <file name="${shared.resource.dir}/derby/derby.jar"/>

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -29,7 +29,8 @@ import componenttest.app.FATServlet;
                                      "createDatabase=create",
                                      "onConnect=DECLARE GLOBAL TEMPORARY TABLE TEMP2 (COL1 VARCHAR(80)) ON COMMIT PRESERVE ROWS NOT LOGGED",
                                      "queryTimeout=1m22s",
-                                     "reapTime=2200ms"
+                                     "reapTime=2200ms",
+                                     "recoveryAuthDataRef=derbyAuth2"
                       })
 
 @SuppressWarnings("serial")


### PR DESCRIPTION
Vendor properties and authdata (both containerAuthDataRef and recoveryAuthDataRef) are not showing up on the /ibm/api/config REST endpoint output for app-defined data sources.  This pull makes the necessary updates/fixes and adds/enables tests.