### PR TITLE
app-defined connectionManager jdbcDriver and parse error

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/websphere/config/WSConfigurationHelper.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/websphere/config/WSConfigurationHelper.java
@@ -70,6 +70,18 @@ public interface WSConfigurationHelper {
     boolean removeDefaultConfiguration(String pid, String id) throws ConfigUpdateException;
 
     /**
+     * Converts a String value to the data type (excluding pid type) that is defined in the metatype.
+     * This method is provided to be used by the config REST endpoint for evaluating generic string values
+     * in application-defined resource config.
+     *
+     * @param pid The pid or factory pid
+     * @param attributeID
+     * @param strValue the value in String form
+     * @return the value converted to the data type specified in metatype.
+     */
+    Object convert(String pid, String attributeID, String strValue);
+
+    /**
      * Returns the metatype attribute cardinality for the configuration with the specified pid and attribute id.
      *
      * @param pid The pid or factory pid

--- a/dev/com.ibm.ws.config/src/com/ibm/websphere/config/WSConfigurationHelper.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/websphere/config/WSConfigurationHelper.java
@@ -77,7 +77,8 @@ public interface WSConfigurationHelper {
      * @param pid The pid or factory pid
      * @param attributeID
      * @param strValue the value in String form
-     * @return the value converted to the data type specified in metatype.
+     * @return the value converted to the data type specified in metatype. The original value is returned
+     *         if it cannot be converted, for example, due to a parsing error.
      */
     Object convert(String pid, String attributeID, String strValue);
 

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/WSConfigurationHelperImpl.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/WSConfigurationHelperImpl.java
@@ -105,36 +105,40 @@ public class WSConfigurationHelperImpl implements WSConfigurationHelper {
                 if (ad != null) {
                     // The following is copied from ConfigEvaluator, excluding pid types, which are handled differently
                     int type = ad.getType();
-                    if (type == AttributeDefinition.BOOLEAN) {
-                        return Boolean.valueOf(strVal);
-                    } else if (type == AttributeDefinition.BYTE) {
-                        return Byte.valueOf(strVal);
-                    } else if (type == AttributeDefinition.CHARACTER) {
-                        return Character.valueOf(strVal.charAt(0));
-                    } else if (type == AttributeDefinition.DOUBLE) {
-                        return Double.valueOf(strVal);
-                    } else if (type == AttributeDefinition.FLOAT) {
-                        return Float.valueOf(strVal);
-                    } else if (type == AttributeDefinition.INTEGER) {
-                        return Integer.valueOf(strVal);
-                    } else if (type == AttributeDefinition.LONG) {
-                        return Long.valueOf(strVal);
-                    } else if (type == AttributeDefinition.SHORT) {
-                        return Short.valueOf(strVal);
-                    } else if (type == MetaTypeFactory.DURATION_TYPE) {
-                        return MetatypeUtils.evaluateDuration(strVal, TimeUnit.MILLISECONDS);
-                    } else if (type == MetaTypeFactory.DURATION_S_TYPE) {
-                        return MetatypeUtils.evaluateDuration(strVal, TimeUnit.SECONDS);
-                    } else if (type == MetaTypeFactory.DURATION_M_TYPE) {
-                        return MetatypeUtils.evaluateDuration(strVal, TimeUnit.MINUTES);
-                    } else if (type == MetaTypeFactory.DURATION_H_TYPE) {
-                        return MetatypeUtils.evaluateDuration(strVal, TimeUnit.HOURS);
-                    } else if (type == MetaTypeFactory.PASSWORD_TYPE || type == MetaTypeFactory.HASHED_PASSWORD_TYPE) {
-                        return new SerializableProtectedString(strVal.toCharArray());
-                    } else if (type == MetaTypeFactory.ON_ERROR_TYPE) {
-                        return Enum.valueOf(OnError.class, strVal.trim().toUpperCase());
-                    } else if (type == MetaTypeFactory.TOKEN_TYPE) {
-                        return MetatypeUtils.evaluateToken(strVal);
+                    try {
+                        if (type == AttributeDefinition.BOOLEAN) {
+                            return Boolean.valueOf(strVal);
+                        } else if (type == AttributeDefinition.BYTE) {
+                            return Byte.valueOf(strVal);
+                        } else if (type == AttributeDefinition.CHARACTER) {
+                            return Character.valueOf(strVal.charAt(0));
+                        } else if (type == AttributeDefinition.DOUBLE) {
+                            return Double.valueOf(strVal);
+                        } else if (type == AttributeDefinition.FLOAT) {
+                            return Float.valueOf(strVal);
+                        } else if (type == AttributeDefinition.INTEGER) {
+                            return Integer.valueOf(strVal);
+                        } else if (type == AttributeDefinition.LONG) {
+                            return Long.valueOf(strVal);
+                        } else if (type == AttributeDefinition.SHORT) {
+                            return Short.valueOf(strVal);
+                        } else if (type == MetaTypeFactory.DURATION_TYPE) {
+                            return MetatypeUtils.evaluateDuration(strVal, TimeUnit.MILLISECONDS);
+                        } else if (type == MetaTypeFactory.DURATION_S_TYPE) {
+                            return MetatypeUtils.evaluateDuration(strVal, TimeUnit.SECONDS);
+                        } else if (type == MetaTypeFactory.DURATION_M_TYPE) {
+                            return MetatypeUtils.evaluateDuration(strVal, TimeUnit.MINUTES);
+                        } else if (type == MetaTypeFactory.DURATION_H_TYPE) {
+                            return MetatypeUtils.evaluateDuration(strVal, TimeUnit.HOURS);
+                        } else if (type == MetaTypeFactory.PASSWORD_TYPE || type == MetaTypeFactory.HASHED_PASSWORD_TYPE) {
+                            return new SerializableProtectedString(strVal.toCharArray());
+                        } else if (type == MetaTypeFactory.ON_ERROR_TYPE) {
+                            return Enum.valueOf(OnError.class, strVal.trim().toUpperCase());
+                        } else if (type == MetaTypeFactory.TOKEN_TYPE) {
+                            return MetatypeUtils.evaluateToken(strVal);
+                        }
+                    } catch (Throwable x) {
+                        // auto FFDC, and value is returned without conversion
                     }
                 }
             }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/WSConfigurationHelperImpl.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/WSConfigurationHelperImpl.java
@@ -12,13 +12,22 @@ package com.ibm.ws.config.xml.internal;
 
 import java.io.InputStream;
 import java.util.Dictionary;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.osgi.service.metatype.AttributeDefinition;
 
 import com.ibm.websphere.config.ConfigEvaluatorException;
 import com.ibm.websphere.config.ConfigUpdateException;
 import com.ibm.websphere.config.WSConfigurationHelper;
+import com.ibm.websphere.metatype.MetaTypeFactory;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.config.xml.internal.ConfigEvaluator.EvaluationResult;
 import com.ibm.ws.config.xml.internal.MetaTypeRegistry.RegistryEntry;
+import com.ibm.ws.config.xml.internal.metatype.ExtendedAttributeDefinition;
+import com.ibm.wsspi.kernel.service.utils.MetatypeUtils;
+import com.ibm.wsspi.kernel.service.utils.OnErrorUtil.OnError;
+import com.ibm.wsspi.kernel.service.utils.SerializableProtectedString;
 
 /**
  *
@@ -82,6 +91,55 @@ public class WSConfigurationHelperImpl implements WSConfigurationHelper {
     @Override
     public boolean removeDefaultConfiguration(String pid, String id) throws ConfigUpdateException {
         return bundleProcessor.removeDefaultConfiguration(pid, id);
+    }
+
+    @Override
+    @Trivial
+    public Object convert(String pid, String attributeID, String strVal) {
+        RegistryEntry ent = metatypeRegistry.getRegistryEntryByPidOrAlias(pid);
+        if (ent != null) {
+            Map<String, ExtendedAttributeDefinition> attributeMap;
+            attributeMap = ent.getAttributeMap();
+            if (attributeMap != null) {
+                ExtendedAttributeDefinition ad = attributeMap.get(attributeID);
+                if (ad != null) {
+                    // The following is copied from ConfigEvaluator, excluding pid types, which are handled differently
+                    int type = ad.getType();
+                    if (type == AttributeDefinition.BOOLEAN) {
+                        return Boolean.valueOf(strVal);
+                    } else if (type == AttributeDefinition.BYTE) {
+                        return Byte.valueOf(strVal);
+                    } else if (type == AttributeDefinition.CHARACTER) {
+                        return Character.valueOf(strVal.charAt(0));
+                    } else if (type == AttributeDefinition.DOUBLE) {
+                        return Double.valueOf(strVal);
+                    } else if (type == AttributeDefinition.FLOAT) {
+                        return Float.valueOf(strVal);
+                    } else if (type == AttributeDefinition.INTEGER) {
+                        return Integer.valueOf(strVal);
+                    } else if (type == AttributeDefinition.LONG) {
+                        return Long.valueOf(strVal);
+                    } else if (type == AttributeDefinition.SHORT) {
+                        return Short.valueOf(strVal);
+                    } else if (type == MetaTypeFactory.DURATION_TYPE) {
+                        return MetatypeUtils.evaluateDuration(strVal, TimeUnit.MILLISECONDS);
+                    } else if (type == MetaTypeFactory.DURATION_S_TYPE) {
+                        return MetatypeUtils.evaluateDuration(strVal, TimeUnit.SECONDS);
+                    } else if (type == MetaTypeFactory.DURATION_M_TYPE) {
+                        return MetatypeUtils.evaluateDuration(strVal, TimeUnit.MINUTES);
+                    } else if (type == MetaTypeFactory.DURATION_H_TYPE) {
+                        return MetatypeUtils.evaluateDuration(strVal, TimeUnit.HOURS);
+                    } else if (type == MetaTypeFactory.PASSWORD_TYPE || type == MetaTypeFactory.HASHED_PASSWORD_TYPE) {
+                        return new SerializableProtectedString(strVal.toCharArray());
+                    } else if (type == MetaTypeFactory.ON_ERROR_TYPE) {
+                        return Enum.valueOf(OnError.class, strVal.trim().toUpperCase());
+                    } else if (type == MetaTypeFactory.TOKEN_TYPE) {
+                        return MetatypeUtils.evaluateToken(strVal);
+                    }
+                }
+            }
+        }
+        return strVal;
     }
 
     @Override

--- a/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
@@ -138,7 +138,11 @@ public class ConfigRESTHandler implements RESTHandler {
                     }
                     for (Enumeration<String> keys = config.keys(); keys.hasMoreElements();) {
                         String key = keys.nextElement();
-                        merged.put(key, config.get(key));
+                        Object value = config.get(key);
+                        // app-defined resources store custom property values as String, which might need conversion
+                        if (value instanceof String)
+                            value = configHelper.convert(extendsSourcePid == null ? servicePid : extendsSourcePid, key, (String) value);
+                        merged.put(key, value);
                     }
                     config = merged;
                 }

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.rest.handler.config.fat;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -85,18 +86,22 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "AppDefResourcesApp.war", ds.getString("module"));
         assertNull(err, ds.get("component"));
 
+        assertTrue(err, ds.getBoolean("beginTranForResultSetScrollingAPIs"));
+        assertTrue(err, ds.getBoolean("beginTranForVendorAPIs"));
+        assertEquals(err, "MatchOriginalRequest", ds.getString("connectionSharing"));
+
         JsonObject cm;
         assertNotNull(err, cm = ds.getJsonObject("connectionManagerRef"));
         assertEquals(err, "connectionManager", cm.getString("configElementName"));
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/dataSource[java:module/env/jdbc/ds2]/connectionManager", cm.getString("uid"));
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/dataSource[java:module/env/jdbc/ds2]/connectionManager", cm.getString("id"));
         assertEquals(err, -1, cm.getJsonNumber("agedTimeout").longValue());
-        assertEquals(err, "0", cm.getString("connectionTimeout")); // TODO app-defined config not converted from String to number
+        assertEquals(err, 0, cm.getJsonNumber("connectionTimeout").longValue());
         assertTrue(err, cm.getBoolean("enableSharingForDirectLookups"));
         assertEquals(err, 1800, cm.getJsonNumber("maxIdleTime").longValue());
         assertEquals(err, 2, cm.getInt("maxPoolSize"));
         assertEquals(err, "EntirePool", cm.getString("purgePolicy"));
-        assertEquals(err, "2200ms", cm.getString("reapTime")); // TODO app-defined config not converted from String to number
+        assertEquals(err, 2200, cm.getJsonNumber("reapTime").longValue());
 
         JsonObject authData;
         assertNotNull(err, authData = ds.getJsonObject("containerAuthDataRef"));
@@ -106,6 +111,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "dbuser1", authData.getString("user"));
         assertEquals(err, "******", authData.getString("password"));
 
+        assertFalse(err, ds.getBoolean("enableConnectionCasting"));
         assertEquals(err, Connection.TRANSACTION_READ_COMMITTED, ds.getInt("isolationLevel"));
 
         JsonObject driver;
@@ -146,7 +152,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertTrue(err, databaseName.contains("resources")); // must expand ${shared.resource.dir}
         assertEquals(err, 220, props.getInt("loginTimeout"));
 
-        assertEquals(err, "1m22s", ds.getString("queryTimeout"));
+        assertEquals(err, 82, ds.getInt("queryTimeout"));
 
         assertNotNull(err, authData = ds.getJsonObject("recoveryAuthDataRef"));
         assertEquals(err, "authData", authData.getString("configElementName"));
@@ -155,6 +161,9 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "dbuser2", authData.getString("user"));
         assertEquals(err, "******", authData.getString("password"));
 
+        assertEquals(err, 22, ds.getInt("statementCacheSize")); // = maxStatements / maxPoolSize
+        assertTrue(err, ds.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
+        assertTrue(err, ds.getBoolean("transactional"));
         assertEquals(err, "javax.sql.XADataSource", ds.getString("type"));
 
         JsonArray api;

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -90,14 +90,13 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "connectionManager", cm.getString("configElementName"));
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/dataSource[java:module/env/jdbc/ds2]/connectionManager", cm.getString("uid"));
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/dataSource[java:module/env/jdbc/ds2]/connectionManager", cm.getString("id"));
-        // TODO default values are absent
-        //assertEquals(err, "-1", cm.getString("agedTimeout"));
-        assertEquals(err, "0", cm.getString("connectionTimeout"));
-        //assertTrue(err, cm.getBoolean("enableSharingForDirectLookups"));
-        //assertEquals(err, "30m", cm.getString("maxIdleTime"));
+        assertEquals(err, -1, cm.getJsonNumber("agedTimeout").longValue());
+        assertEquals(err, "0", cm.getString("connectionTimeout")); // TODO app-defined config not converted from String to number
+        assertTrue(err, cm.getBoolean("enableSharingForDirectLookups"));
+        assertEquals(err, 1800, cm.getJsonNumber("maxIdleTime").longValue());
         assertEquals(err, 2, cm.getInt("maxPoolSize"));
-        //assertEquals(err, "EntirePool", cm.getString("purgePolicy"));
-        assertEquals(err, "2200ms", cm.getString("reapTime"));
+        assertEquals(err, "EntirePool", cm.getString("purgePolicy"));
+        assertEquals(err, "2200ms", cm.getString("reapTime")); // TODO app-defined config not converted from String to number
 
         JsonObject authData;
         assertNotNull(err, authData = ds.getJsonObject("containerAuthDataRef"));

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.config=all:RRA=all
+com.ibm.ws.logging.trace.specification=*=info:rest.config=all:RRA=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 derby.connection.requireAuthentication=true

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -13,28 +13,41 @@ package test.resthandler.config.appdef.web;
 import java.sql.Connection;
 
 import javax.annotation.sql.DataSourceDefinition;
+import javax.annotation.sql.DataSourceDefinitions;
 import javax.servlet.annotation.WebServlet;
 
 import componenttest.app.FATServlet;
 
-@DataSourceDefinition(name = "java:module/env/jdbc/ds2",
-                      className = "org.apache.derby.jdbc.EmbeddedXADataSource",
-                      databaseName = "${shared.resource.dir}/data/configRHTestDB",
-                      isolationLevel = Connection.TRANSACTION_READ_COMMITTED,
-                      loginTimeout = 220,
-                      maxPoolSize = 2,
-                      maxStatements = 45,
-                      properties = {
-                                     "connectionTimeout=0",
-                                     "containerAuthDataRef=derbyAuth1",
-                                     "createDatabase=create",
-                                     "onConnect=DECLARE GLOBAL TEMPORARY TABLE TEMP2 (COL1 VARCHAR(80)) ON COMMIT PRESERVE ROWS NOT LOGGED",
-                                     "queryTimeout=1m22s",
-                                     "reapTime=2200s",
-                                     "recoveryAuthDataRef=derbyAuth2",
-                                     "syncQueryTimeoutWithTransactionTimeout=true"
-                      })
-
+@DataSourceDefinitions({
+                         @DataSourceDefinition(name = "java:app/env/jdbc/ds1",
+                                               className = "org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource",
+                                               databaseName = "memory:firstdb",
+                                               properties = {
+                                                              "agedTimeout=1:05:30",
+                                                              "connectionSharing=MatchCurrentState",
+                                                              "createDatabase=create"
+                                               }),
+                         @DataSourceDefinition(name = "java:module/env/jdbc/ds2",
+                                               className = "org.apache.derby.jdbc.EmbeddedXADataSource",
+                                               databaseName = "${shared.resource.dir}/data/configRHTestDB",
+                                               isolationLevel = Connection.TRANSACTION_READ_COMMITTED,
+                                               loginTimeout = 220,
+                                               maxPoolSize = 2,
+                                               maxStatements = 45,
+                                               properties = {
+                                                              "connectionTimeout=0",
+                                                              "containerAuthDataRef=derbyAuth1",
+                                                              "createDatabase=create",
+                                                              "onConnect=DECLARE GLOBAL TEMPORARY TABLE TEMP2 (COL1 VARCHAR(80)) ON COMMIT PRESERVE ROWS NOT LOGGED",
+                                                              "queryTimeout=1m22s",
+                                                              "reapTime=2200s",
+                                                              "recoveryAuthDataRef=derbyAuth2",
+                                                              "syncQueryTimeoutWithTransactionTimeout=true"
+                                               }),
+                         @DataSourceDefinition(name = "java:comp/env/jdbc/ds3",
+                                               className = "org.apache.derby.jdbc.EmbeddedDataSource",
+                                               databaseName = "memory:thirddb;create=true")
+})
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/AppDefinedResourcesServlet")
 public class AppDefinedResourcesServlet extends FATServlet {

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -23,14 +23,16 @@ import componenttest.app.FATServlet;
                       isolationLevel = Connection.TRANSACTION_READ_COMMITTED,
                       loginTimeout = 220,
                       maxPoolSize = 2,
+                      maxStatements = 45,
                       properties = {
                                      "connectionTimeout=0",
                                      "containerAuthDataRef=derbyAuth1",
                                      "createDatabase=create",
                                      "onConnect=DECLARE GLOBAL TEMPORARY TABLE TEMP2 (COL1 VARCHAR(80)) ON COMMIT PRESERVE ROWS NOT LOGGED",
                                      "queryTimeout=1m22s",
-                                     "reapTime=2200ms",
-                                     "recoveryAuthDataRef=derbyAuth2"
+                                     "reapTime=2200s",
+                                     "recoveryAuthDataRef=derbyAuth2",
+                                     "syncQueryTimeoutWithTransactionTimeout=true"
                       })
 
 @SuppressWarnings("serial")


### PR DESCRIPTION
Add tests for application-define connectionManager and jdbcDriver being accessed with the /config/ REST endpoint.  Also handle and test what happens when there is a parsing error on a duration type attribute.  And include coverage of the /config/ endpoint for app-defined resources in the java:app and java:comp namespaces.