### PR TITLE
Fix inject trace

### DIFF
--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -44,14 +45,12 @@ import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
 import com.ibm.wsspi.application.handler.ApplicationInformation;
 import com.ibm.wsspi.kernel.service.location.WsResource;
 
-import junit.runner.Version;
-
 @Component(service = DeployedAppInfoFactory.class,
            property = { "service.vendor=IBM", "type:String=ear" })
 public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactory implements DeployedAppInfoFactory {
     private static final TraceComponent _tc = Tr.register(EARDeployedAppInfoFactoryImpl.class, new String[] { "webcontainer", "applications", "app.manager" },
                                                           "com.ibm.ws.app.manager.war.internal.resources.Messages",
-                                                          "com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl");
+                                                          "com.ibm.ws.app.manager.ear.internal.EARDeployedAppInfoFactoryImpl");
 
     @Reference
     protected DeployedAppServices deployedAppServices;

--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.osgi.framework.ServiceReference;
-import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -45,10 +44,14 @@ import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
 import com.ibm.wsspi.application.handler.ApplicationInformation;
 import com.ibm.wsspi.kernel.service.location.WsResource;
 
+import junit.runner.Version;
+
 @Component(service = DeployedAppInfoFactory.class,
            property = { "service.vendor=IBM", "type:String=ear" })
 public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactory implements DeployedAppInfoFactory {
-    private static final TraceComponent _tc = Tr.register(EARDeployedAppInfoFactoryImpl.class);
+    private static final TraceComponent _tc = Tr.register(EARDeployedAppInfoFactoryImpl.class, new String[] { "webcontainer", "applications", "app.manager" },
+                                                          "com.ibm.ws.app.manager.war.internal.resources.Messages",
+                                                          "com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl");
 
     @Reference
     protected DeployedAppServices deployedAppServices;
@@ -176,7 +179,7 @@ public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
      * time stamp.
      *
      * @param absPath The absolute path of the file which is to be tested.
-     * @param file The file which is to be tested.
+     * @param file    The file which is to be tested.
      *
      * @return The new time stamp of the file, if the file is to be expanded.
      *         Null if the file is not to be expanded.
@@ -272,11 +275,11 @@ public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
      * expand the application to the expanded applications location.
      *
      * @param appInfo Information for the application for which to create
-     *            deployment information.
+     *                    deployment information.
      * @return Deployment information for the application.
      *
      * @throws UnableToAdaptException Thrown if the deployment information
-     *             count not be created.
+     *                                    count not be created.
      */
     @Override
     public DeployedAppInfo createDeployedAppInfo(ApplicationInformation<DeployedAppInfo> appInfo) throws UnableToAdaptException {

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/monitor/ApplicationMonitor.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/monitor/ApplicationMonitor.java
@@ -334,9 +334,9 @@ public class ApplicationMonitor {
         /**
          * Constructs a new instance of this listener and creates the notifier to which we'll be registered. It does not actually start the listener though.
          *
-         * @param applicationProperties The properties for the application being monitored
+         * @param applicationProperties          The properties for the application being monitored
          * @param monitoringContainerInformation Information about which containers notification mechanism we should be using and which entries and containers within it we should
-         *            be listening to
+         *                                           be listening to
          * @throws UnableToAdaptException If we cannot adapt the root container to a {@link Notifier}
          */
         public BaseApplicationListener(Notification monitoringInformation,
@@ -372,6 +372,7 @@ public class ApplicationMonitor {
          *
          * @return This listener's ID.
          */
+        @Override
         public String getId() {
             return id;
         }
@@ -389,9 +390,9 @@ public class ApplicationMonitor {
         /**
          * Constructs a new instance of this listener and creates the notifier to which we'll be registered. It does not actually start the listener though.
          *
-         * @param applicationProperties The properties for the application being monitored
+         * @param applicationProperties          The properties for the application being monitored
          * @param monitoringContainerInformation Information about which containers notification mechanism we should be using and which entries and containers within it we should
-         *            be listening to
+         *                                           be listening to
          * @throws UnableToAdaptException If we cannot adapt the root container to a {@link Notifier}
          */
         public RootApplicationListener(Container container,
@@ -444,9 +445,9 @@ public class ApplicationMonitor {
         /**
          * Constructs a new instance of this listener and creates the notifier to which we'll be registered. It does not actually start the listener though.
          *
-         * @param applicationProperties The properties for the application being monitored
+         * @param applicationProperties          The properties for the application being monitored
          * @param monitoringContainerInformation Information about which containers notification mechanism we should be using and which entries and containers within it we should
-         *            be listening to
+         *                                           be listening to
          * @throws UnableToAdaptException If we cannot adapt the root container to a {@link Notifier} of if we cannot adapt the app's container to a ClassLoadingButler
          */
         public ApplicationListener(Notification monitoringInformation,
@@ -520,9 +521,9 @@ public class ApplicationMonitor {
         /**
          * Constructs a new instance of this listener and creates the notifier to which we'll be registered. It does not actually start the listener though.
          *
-         * @param applicationProperties The properties for the application being monitored
+         * @param applicationProperties          The properties for the application being monitored
          * @param monitoringContainerInformation Information about which containers notification mechanism we should be using and which entries and containers within it we should
-         *            be listening to
+         *                                           be listening to
          * @throws UnableToAdaptException If we cannot adapt the root container to a {@link Notifier}
          */
         public CompleteApplicationListener(Container container,

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/monitor/DropinMonitor.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/monitor/DropinMonitor.java
@@ -54,7 +54,9 @@ import com.ibm.wsspi.kernel.service.utils.FrameworkState;
            configurationPolicy = ConfigurationPolicy.IGNORE,
            property = "service.vendor=IBM")
 public class DropinMonitor {
-    private static final TraceComponent _tc = Tr.register(DropinMonitor.class);
+    private static final TraceComponent _tc = Tr.register(DropinMonitor.class, new String[] { "applications", com.ibm.ws.app.manager.internal.AppManagerConstants.TRACE_GROUP },
+                                                          com.ibm.ws.app.manager.internal.AppManagerConstants.TRACE_MESSAGES,
+                                                          "com.ibm.ws.app.manager.internal.monitor.DropinMonitor");
 
     private BundleContext _ctx;
     private WsLocationAdmin locationService;
@@ -347,7 +349,7 @@ public class DropinMonitor {
     /**
      * Returns the message helper for the specified application handler type.
      *
-     * @param type application handler type
+     * @param type     application handler type
      * @param fileName file name from which type can be inferred if not specified
      * @return the message helper for the specified application handler type.
      */
@@ -384,9 +386,9 @@ public class DropinMonitor {
      * Takes a file and an optional file type, and updates the file. If no type is given it will use the
      * extension of the file given.
      *
-     * @param ca the configuration admin service.
+     * @param ca          the configuration admin service.
      * @param currentFile the file of the application to install. Can be a directory
-     * @param type the type of the application.
+     * @param type        the type of the application.
      *
      */
     private void startApplication(File currentFile, String type) {

--- a/dev/com.ibm.ws.beanvalidation.core/src/com/ibm/ws/beanvalidation/service/Validation20ClassLoader.java
+++ b/dev/com.ibm.ws.beanvalidation.core/src/com/ibm/ws/beanvalidation/service/Validation20ClassLoader.java
@@ -31,7 +31,7 @@ import com.ibm.websphere.ras.TraceComponent;
  * It should return the correct validation.xml for the module currently under execution.
  */
 public class Validation20ClassLoader extends ClassLoader {
-    private static final TraceComponent tc = Tr.register(Validation20ClassLoader.class);
+    private static final TraceComponent tc = Tr.register(Validation20ClassLoader.class, null, null);
     String moduleHint;
 
     public Validation20ClassLoader(ClassLoader parent, String hint) {

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/Util.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/Util.java
@@ -29,7 +29,7 @@ import com.ibm.wsspi.kernel.service.utils.CompositeEnumeration;
 
 @Trivial
 final class Util {
-    static final TraceComponent tc = Tr.register(Util.class);
+    static final TraceComponent tc = Tr.register(Util.class,"ClassLoadingService","com.ibm.ws.classloading.internal.resources.ClassLoadingServiceMessages");
 
     private Util() {
         throw null;

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/library/internal/Util.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/library/internal/Util.java
@@ -26,7 +26,7 @@ import java.util.Hashtable;
 import java.util.zip.ZipFile;
 
 public enum Util {;
-    private static final TraceComponent tc = Tr.register(Util.class);
+    private static final TraceComponent tc = Tr.register(Util.class,SharedLibraryConstants.TR_GROUP, SharedLibraryConstants.NLS_PROPS);
 
     @FFDCIgnore(PrivilegedActionException.class)
     static boolean isArchive(final File f) {

--- a/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ApiType.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/wsspi/classloading/ApiType.java
@@ -39,7 +39,7 @@ public enum ApiType {
 
     // OSGi APIs are marked spec:api, which is obviously not in this enum.
     // This means that OSGi application API will not be visible to EE applications.
-    private static final TraceComponent tc = Tr.register(ApiType.class);
+    private static final TraceComponent tc = Tr.register(ApiType.class,"ClassLoadingService", "com.ibm.ws.classloading.internal.resources.ClassLoadingServiceMessages");
 
     private final String attributeName;
 

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/internal/HttpServiceContainer.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/internal/HttpServiceContainer.java
@@ -38,7 +38,7 @@ import com.ibm.wsspi.http.VirtualHost;
  * bundle.
  */
 public class HttpServiceContainer implements HttpContainer {
-    private static final TraceComponent tc = Tr.register(HttpServiceContainer.class);
+    private static final TraceComponent tc = Tr.register(HttpServiceContainer.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP, null);
 
     private static final class SingletonSessionManager {
         static final SessionManager instance = new SessionManager();
@@ -61,7 +61,7 @@ public class HttpServiceContainer implements HttpContainer {
 
     /**
      * Activate this DS component.
-     * 
+     *
      * @param context
      * @throws Exception
      */
@@ -77,7 +77,7 @@ public class HttpServiceContainer implements HttpContainer {
 
     /**
      * Deactivate this DS component.
-     * 
+     *
      * @param context
      * @throws Exception
      */
@@ -137,7 +137,7 @@ public class HttpServiceContainer implements HttpContainer {
     /**
      * DS method for runtime updates to configuration without stopping and
      * restarting the component.
-     * 
+     *
      * @param properties
      */
     protected void modified(Map<?, ?> properties) {
@@ -151,7 +151,7 @@ public class HttpServiceContainer implements HttpContainer {
 
     /**
      * Process configuration information.
-     * 
+     *
      * @param properties
      */
     protected synchronized void processConfig(Dictionary<?, ?> properties) {

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/internal/RegisteredHttpServiceImpl.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/internal/RegisteredHttpServiceImpl.java
@@ -45,7 +45,7 @@ import com.ibm.ws.httpsvc.servlet.internal.ServletContextManager;
  *
  */
 public class RegisteredHttpServiceImpl implements ExtHttpService {
-    private static final TraceComponent tc = Tr.register(RegisteredHttpServiceImpl.class);
+    private static final TraceComponent tc = Tr.register(RegisteredHttpServiceImpl.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP, null);
 
     /** DS-managed reference to the HTTP Container */
     private HttpServiceContainer container;
@@ -67,14 +67,12 @@ public class RegisteredHttpServiceImpl implements ExtHttpService {
     private Set<Filter> localFilters;
     private ServletContextManager contextManager;
 
-    private final Object servletLock = new Object()
-    {};
-    private final Object filterLock = new Object()
-    {};
+    private final Object servletLock = new Object() {};
+    private final Object filterLock = new Object() {};
 
     /**
      * Activate this component.
-     * 
+     *
      * @param ctxt
      */
     protected void activate(ComponentContext ctxt) {
@@ -92,7 +90,7 @@ public class RegisteredHttpServiceImpl implements ExtHttpService {
 
     /**
      * Deactivate this component.
-     * 
+     *
      * @param ctxt
      */
     protected void deactivate(ComponentContext ctxt, int reason) {

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/servlet/internal/RequestMessage.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/servlet/internal/RequestMessage.java
@@ -62,7 +62,7 @@ import com.ibm.wsspi.http.SSLContext;
  */
 public class RequestMessage implements HttpServletRequest {
     /** Debug variable */
-    private static final TraceComponent tc = Tr.register(RequestMessage.class);
+    private static final TraceComponent tc = Tr.register(RequestMessage.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP, null);
 
     // servlet spec has special case attribute names used in getAttribute
 
@@ -106,7 +106,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /**
      * Constructor.
-     * 
+     *
      * @param conn
      */
     public RequestMessage(HttpInboundConnection conn, SessionManager sessMgr) {
@@ -115,7 +115,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /**
      * Initialize this request with the input link.
-     * 
+     *
      * @param conn
      */
     public void init(HttpInboundConnection conn, SessionManager sessMgr) {
@@ -326,7 +326,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /**
      * Acces the raw request URI information.
-     * 
+     *
      * @return String
      */
     public String getRawRequestURI() {
@@ -371,7 +371,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /**
      * Set the servlet path of this request to the input value.
-     * 
+     *
      * @param path
      */
     public void setServletPath(String path) {
@@ -389,7 +389,7 @@ public class RequestMessage implements HttpServletRequest {
     /**
      * Access the possible session information wrapper. This will be null
      * if no session has been queried or created for this request.
-     * 
+     *
      * @return SessionInfo, may be null
      */
     SessionInfo getSessionInfo() {
@@ -645,7 +645,7 @@ public class RequestMessage implements HttpServletRequest {
     /**
      * Handle parsing the request query parameters. These may exist in the
      * URL based querystring and/or in certain types of POST body streams.
-     * 
+     *
      * This will always result in a query parameter map being created, even
      * if it's empty with no query data found in the request.
      */
@@ -687,7 +687,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /**
      * Read and parse the POST body data that represents query data.
-     * 
+     *
      * @throws IOException
      */
     private void parseQueryFormData() throws IOException {
@@ -715,9 +715,9 @@ public class RequestMessage implements HttpServletRequest {
      * Parse a query parameter's name out of the input character array. This
      * will undo any URLEncoding in the data (%20 is a space for example) and
      * return the resulting string.
-     * 
+     *
      * Input must be in ASCII encoding.
-     * 
+     *
      * @param ch
      * @param start
      * @param end
@@ -765,11 +765,11 @@ public class RequestMessage implements HttpServletRequest {
     /**
      * Parse a string of query parameters into a Map representing the values
      * stored using the name as the key.
-     * 
+     *
      * @param data
      * @return Map
      * @throws IllegalArgumentException
-     *             if the string is formatted incorrectly
+     *                                      if the string is formatted incorrectly
      */
     private Map<String, String[]> parseQueryString(String data) {
         Map<String, String[]> map = new Hashtable<String, String[]>();
@@ -813,7 +813,7 @@ public class RequestMessage implements HttpServletRequest {
     /**
      * In certain cases, the URL will contain query string information and the
      * POST body will as well. This method merges the two maps together.
-     * 
+     *
      * @param urlParams
      */
     private void mergeQueryParams(Map<String, String[]> urlParams) {
@@ -905,8 +905,7 @@ public class RequestMessage implements HttpServletRequest {
         if (null == this.inStream) {
             this.inStream = new RequestBody(this.request.getBody());
         }
-        this.inReader = new BufferedReader(
-                        new InputStreamReader(this.inStream, enc));
+        this.inReader = new BufferedReader(new InputStreamReader(this.inStream, enc));
         return this.inReader;
     }
 
@@ -959,7 +958,7 @@ public class RequestMessage implements HttpServletRequest {
     /**
      * Set the reference to the filter pipeline that is handling this
      * particular request.
-     * 
+     *
      * @param pipeline
      */
     public void setFilterPipeline(FilterPipeline pipeline) {
@@ -1079,7 +1078,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /**
      * Access the SSL cipher suite used in this connection.
-     * 
+     *
      * @return String - null if this is not a secure connection
      */
     private String getCipherSuite() {
@@ -1096,7 +1095,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /**
      * Access any client SSL certificates for this connection.
-     * 
+     *
      * @return X509Certificate[] - null if non-ssl or none exist
      */
     private X509Certificate[] getPeerCertificates() {
@@ -1137,7 +1136,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /**
      * Set the current servlet context on the message.
-     * 
+     *
      * @param context
      */
     public void setServletContext(ServletContext context) {
@@ -1145,8 +1144,7 @@ public class RequestMessage implements HttpServletRequest {
     }
 
     @Override
-    public boolean authenticate(HttpServletResponse arg0) throws IOException,
-                    ServletException {
+    public boolean authenticate(HttpServletResponse arg0) throws IOException, ServletException {
         // TODO Auto-generated method stub
         return false;
     }
@@ -1211,7 +1209,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see javax.servlet.ServletRequest#getContentLengthLong()
      */
     @Override
@@ -1222,7 +1220,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see javax.servlet.http.HttpServletRequest#changeSessionId()
      */
     @Override
@@ -1233,7 +1231,7 @@ public class RequestMessage implements HttpServletRequest {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see javax.servlet.http.HttpServletRequest#upgrade(java.lang.Class)
      */
     @Override

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/servlet/internal/ResponseMessage.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/servlet/internal/ResponseMessage.java
@@ -35,7 +35,7 @@ import com.ibm.wsspi.http.HttpResponse;
  */
 public class ResponseMessage implements HttpServletResponse {
     /** Debug variable */
-    private static final TraceComponent tc = Tr.register(ResponseMessage.class);
+    private static final TraceComponent tc = Tr.register(ResponseMessage.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP, null);
 
     /** HTTP response message wrapped by this servlet interface */
     private HttpResponse response = null;
@@ -59,7 +59,7 @@ public class ResponseMessage implements HttpServletResponse {
 
     /**
      * Constructor.
-     * 
+     *
      * @param conn
      * @param req
      */
@@ -69,7 +69,7 @@ public class ResponseMessage implements HttpServletResponse {
 
     /**
      * Initialize this response message with the input connection.
-     * 
+     *
      * @param conn
      * @param req
      */
@@ -233,7 +233,7 @@ public class ResponseMessage implements HttpServletResponse {
 
     /**
      * Convert a possible URI to a full URL.
-     * 
+     *
      * @param uri
      * @return String
      */
@@ -430,9 +430,7 @@ public class ResponseMessage implements HttpServletResponse {
             throw new IllegalStateException("Output stream already obtained");
         }
         if (null == this.outWriter) {
-            this.outWriter = new PrintWriter(
-                            new OutputStreamWriter(
-                                            this.outStream, getCharacterEncoding()), false);
+            this.outWriter = new PrintWriter(new OutputStreamWriter(this.outStream, getCharacterEncoding()), false);
         }
         return this.outWriter;
     }
@@ -485,7 +483,7 @@ public class ResponseMessage implements HttpServletResponse {
                 }
                 if (add) {
                     this.response.addCookie(
-                                    convertCookie(SessionInfo.encodeCookie(info)));
+                                            convertCookie(SessionInfo.encodeCookie(info)));
                 }
             }
         } // end-if-request-session-exists
@@ -665,7 +663,7 @@ public class ResponseMessage implements HttpServletResponse {
     /**
      * Convert from a J2EE spec cookie to the HTTP transport (non-servlet) cookie
      * object.
-     * 
+     *
      * @param cookie
      * @return HttpCookie
      */
@@ -718,12 +716,12 @@ public class ResponseMessage implements HttpServletResponse {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see javax.servlet.ServletResponse#setContentLengthLong(long)
      */
     @Override
     public void setContentLengthLong(long len) {
-        // TODO Servlet3.1 updates        
+        // TODO Servlet3.1 updates
     }
 
 }

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/servlet/internal/ServletContextImpl.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/servlet/internal/ServletContextImpl.java
@@ -56,7 +56,7 @@ import com.ibm.websphere.ras.TraceComponent;
  * Implementation of a servlet context object.
  */
 public class ServletContextImpl implements ExtServletContext {
-    private static final TraceComponent tc = Tr.register(ServletContextImpl.class);
+    private static final TraceComponent tc = Tr.register(ServletContextImpl.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP, null);
 
     private Bundle bundle;
     private ServletContext rootContext;
@@ -239,20 +239,17 @@ public class ServletContextImpl implements ExtServletContext {
     }
 
     @Override
-    public Dynamic addFilter(String arg0, String arg1)
-                    throws IllegalArgumentException, IllegalStateException {
+    public Dynamic addFilter(String arg0, String arg1) throws IllegalArgumentException, IllegalStateException {
         return null;
     }
 
     @Override
-    public Dynamic addFilter(String arg0, Filter arg1)
-                    throws IllegalArgumentException, IllegalStateException {
+    public Dynamic addFilter(String arg0, Filter arg1) throws IllegalArgumentException, IllegalStateException {
         return null;
     }
 
     @Override
-    public Dynamic addFilter(String arg0, Class<? extends Filter> arg1)
-                    throws IllegalArgumentException, IllegalStateException {
+    public Dynamic addFilter(String arg0, Class<? extends Filter> arg1) throws IllegalArgumentException, IllegalStateException {
         return null;
     }
 
@@ -267,40 +264,34 @@ public class ServletContextImpl implements ExtServletContext {
 
     @Override
     public javax.servlet.ServletRegistration.Dynamic addServlet(String arg0,
-                                                                String arg1)
-                    throws IllegalArgumentException, IllegalStateException {
+                                                                String arg1) throws IllegalArgumentException, IllegalStateException {
         return null;
     }
 
     @Override
     public javax.servlet.ServletRegistration.Dynamic addServlet(String arg0,
-                                                                Servlet arg1)
-                    throws IllegalArgumentException, IllegalStateException {
+                                                                Servlet arg1) throws IllegalArgumentException, IllegalStateException {
         return null;
     }
 
     @Override
     public javax.servlet.ServletRegistration.Dynamic addServlet(String arg0,
-                                                                Class<? extends Servlet> arg1)
-                    throws IllegalArgumentException, IllegalStateException {
+                                                                Class<? extends Servlet> arg1) throws IllegalArgumentException, IllegalStateException {
         return null;
     }
 
     @Override
-    public <T extends Filter> T createFilter(Class<T> arg0)
-                    throws ServletException {
+    public <T extends Filter> T createFilter(Class<T> arg0) throws ServletException {
         return null;
     }
 
     @Override
-    public <T extends EventListener> T createListener(Class<T> arg0)
-                    throws ServletException {
+    public <T extends EventListener> T createListener(Class<T> arg0) throws ServletException {
         return null;
     }
 
     @Override
-    public <T extends Servlet> T createServlet(Class<T> arg0)
-                    throws ServletException {
+    public <T extends Servlet> T createServlet(Class<T> arg0) throws ServletException {
         return null;
     }
 
@@ -381,14 +372,13 @@ public class ServletContextImpl implements ExtServletContext {
     }
 
     @Override
-    public boolean handleSecurity(HttpServletRequest req, HttpServletResponse res)
-                    throws IOException {
+    public boolean handleSecurity(HttpServletRequest req, HttpServletResponse res) throws IOException {
         return this.httpContext.handleSecurity(req, res);
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see javax.servlet.ServletContext#getVirtualServerName()
      */
     @Override

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/IDGenerator.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/IDGenerator.java
@@ -18,30 +18,28 @@ import com.ibm.websphere.ras.TraceComponent;
 /**
  * ID generator for HTTP session values, based on the WAS version created
  * by Aditya.
- * 
+ *
  */
 public class IDGenerator {
 
     /** Debug variable */
-    private static final TraceComponent tc = Tr.register(IDGenerator.class);
+    private static final TraceComponent tc = Tr.register(IDGenerator.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP, null);
 
-    private static final char[] sBitChars =
-        { 'G', '9', 'U', 'i', 'b', 'w',
-          '-', '8', '6', 'z', 'u', 'p', 'J',
-          'R', 'S', 'h', 'K', '5', 'n', 'c',
-          '4', 'C', 't', 'I', 'W', '7', 'F',
-          'e', 'M', 'g', 'q', '2', '3', 'V',
-          'Z', 'k', 'O', 'D', 'a', 'v', 'y',
-          'Y', 'P', 'X', 'E', 'N', '1', 'f',
-          'l', 'B', '0', 'L', 's', 'o', 'A',
-          'T', 'd', 'x', 'm', 'r', 'Q', '_',
-          'j', 'H' };
+    private static final char[] sBitChars = { 'G', '9', 'U', 'i', 'b', 'w',
+                                              '-', '8', '6', 'z', 'u', 'p', 'J',
+                                              'R', 'S', 'h', 'K', '5', 'n', 'c',
+                                              '4', 'C', 't', 'I', 'W', '7', 'F',
+                                              'e', 'M', 'g', 'q', '2', '3', 'V',
+                                              'Z', 'k', 'O', 'D', 'a', 'v', 'y',
+                                              'Y', 'P', 'X', 'E', 'N', '1', 'f',
+                                              'l', 'B', '0', 'L', 's', 'o', 'A',
+                                              'T', 'd', 'x', 'm', 'r', 'Q', '_',
+                                              'j', 'H' };
 
     /**
      * The mask for the second bytes
      */
-    private static final int[] sSecondByteMasks =
-        { 0x0, 0x1, 0x3, 0x7, 0xf, 0x1f, 0x3f };
+    private static final int[] sSecondByteMasks = { 0x0, 0x1, 0x3, 0x7, 0xf, 0x1f, 0x3f };
 
     /**
      * An instance of the SecureRandom class that will be used to generate
@@ -67,7 +65,7 @@ public class IDGenerator {
 
     /**
      * Constructor using the provided session-id size.
-     * 
+     *
      * @param sessionIDLength
      */
     public IDGenerator(int sessionIDLength) {
@@ -89,7 +87,7 @@ public class IDGenerator {
 
     /**
      * Request the next random ID field from the generator.
-     * 
+     *
      * @return String
      */
     public String getID() {
@@ -109,7 +107,7 @@ public class IDGenerator {
      * id. The conversion is performed breaking the byte array into groups of 6
      * bits, then taking each group (value 0-63) and converting to a character
      * 'A'-'Z', 'a'-'z','0'-'9',_,-.
-     * 
+     *
      * @param pBytes
      * @param sessionIdLength
      * @return String

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/SessionConfig.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/SessionConfig.java
@@ -21,7 +21,7 @@ import com.ibm.websphere.ras.TraceComponent;
 public class SessionConfig {
 
     /** Debug variable */
-    private static final TraceComponent tc = Tr.register(SessionConfig.class);
+    private static final TraceComponent tc = Tr.register(SessionConfig.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP, null);
 
     /** Property name for the session id name */
     private static final String PROP_IDNAME = "name";
@@ -65,7 +65,7 @@ public class SessionConfig {
 
     /**
      * Session configuration has been updated with the provided properties.
-     * 
+     *
      * @param props
      */
     public void updated(Dictionary<?, ?> props) {
@@ -126,7 +126,7 @@ public class SessionConfig {
 
     /**
      * Query the version of this running session manager.
-     * 
+     *
      * @return String
      */
     public String getSessionVersion() {
@@ -135,7 +135,7 @@ public class SessionConfig {
 
     /**
      * Query whether session cookies are enabled or not.
-     * 
+     *
      * @return boolean
      */
     public boolean usingCookies() {
@@ -145,7 +145,7 @@ public class SessionConfig {
     /**
      * Query whether session has been configured to use URL rewriting
      * instead of cookies.
-     * 
+     *
      * @return boolean
      */
     public boolean isURLRewriting() {
@@ -156,7 +156,7 @@ public class SessionConfig {
      * Query the marker found in the URL when URL rewriting is enabled. The
      * URL would look similar to /path;jsessionid=ID?querydata, where the
      * ";jsessionid=" is the marker.
-     * 
+     *
      * @return String, null if URL rewriting is not enabled
      */
     public String getURLRewritingMarker() {
@@ -165,7 +165,7 @@ public class SessionConfig {
 
     /**
      * Query the ID name for sessions (i.e. jsessionid).
-     * 
+     *
      * @return String
      */
     public String getIDName() {
@@ -175,7 +175,7 @@ public class SessionConfig {
     /**
      * Query whether the session cookies are configured to have the secure
      * flag or not.
-     * 
+     *
      * @return boolean
      */
     public boolean isCookieSecure() {
@@ -184,7 +184,7 @@ public class SessionConfig {
 
     /**
      * Query the configured max-age setting for session cookies.
-     * 
+     *
      * @return int
      */
     public int getCookieMaxAge() {
@@ -193,7 +193,7 @@ public class SessionConfig {
 
     /**
      * Query the configured path value for session cookies.
-     * 
+     *
      * @return String
      */
     public String getCookiePath() {
@@ -202,7 +202,7 @@ public class SessionConfig {
 
     /**
      * Query the configured domain value for session cookies.
-     * 
+     *
      * @return String
      */
     public String getCookieDomain() {

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/SessionEventHandler.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/SessionEventHandler.java
@@ -24,7 +24,7 @@ import com.ibm.websphere.ras.TraceComponent;
 public class SessionEventHandler implements EventHandler {
 
     /** trace variable */
-    private static final TraceComponent tc = Tr.register(SessionEventHandler.class);
+    private static final TraceComponent tc = Tr.register(SessionEventHandler.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP);
 
     protected static final Topic PURGE_EVENT = new Topic("com/ibm/ws/httpsvc/session/PURGE");
 
@@ -40,7 +40,7 @@ public class SessionEventHandler implements EventHandler {
 
     /**
      * DS method to activate this component.
-     * 
+     *
      * @param context
      */
     protected void activate(ComponentContext context) {
@@ -51,7 +51,7 @@ public class SessionEventHandler implements EventHandler {
 
     /**
      * DS method to deactivate this component.
-     * 
+     *
      * @param context
      */
     protected void deactivate(ComponentContext context) {
@@ -62,7 +62,7 @@ public class SessionEventHandler implements EventHandler {
 
     /**
      * DS method for setting the session manager service reference.
-     * 
+     *
      * @param mgr
      */
     protected void setSessionMgr(SessionManager mgr) {
@@ -71,7 +71,7 @@ public class SessionEventHandler implements EventHandler {
 
     /**
      * DS method for removing the session manager service reference.
-     * 
+     *
      * @param mgr
      */
     protected void unsetSessionMgr(SessionManager mgr) {

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/SessionImpl.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/SessionImpl.java
@@ -32,7 +32,7 @@ import com.ibm.websphere.ras.TraceComponent;
 public class SessionImpl implements HttpSession {
 
     /** Debug variable */
-    private static final TraceComponent tc = Tr.register(SessionImpl.class);
+    private static final TraceComponent tc = Tr.register(SessionImpl.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP);
 
     private static final long NO_TIMEOUT = -1L;
 
@@ -48,7 +48,7 @@ public class SessionImpl implements HttpSession {
 
     /**
      * Constructor.
-     * 
+     *
      * @param id
      * @param context
      */
@@ -110,7 +110,7 @@ public class SessionImpl implements HttpSession {
 
     /**
      * Query whether or not this session is still valid.
-     * 
+     *
      * @return boolean, true means invalid, false means valid
      */
     public boolean isInvalid() {
@@ -124,7 +124,7 @@ public class SessionImpl implements HttpSession {
      * re-used the session information). This will return true if the
      * session is expired or false if still valid. The caller should
      * start the invalidation process if this returned true.
-     * 
+     *
      * @param updateAccessTime
      * @return boolean
      */

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/SessionInfo.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/SessionInfo.java
@@ -26,7 +26,7 @@ import com.ibm.ws.httpsvc.servlet.internal.RequestMessage;
  */
 public class SessionInfo {
     /** Debug variable */
-    private static final TraceComponent tc = Tr.register(SessionInfo.class);
+    private static final TraceComponent tc = Tr.register(SessionInfo.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP);
 
     /** Client provided session id, might be null */
     private String id = null;
@@ -50,7 +50,7 @@ public class SessionInfo {
 
     /**
      * Constructor.
-     * 
+     *
      * @param request
      */
     public SessionInfo(RequestMessage request, SessionManager mgr) {
@@ -82,7 +82,7 @@ public class SessionInfo {
     /**
      * Look for the possible session ID in the URL of the input request
      * message.
-     * 
+     *
      * @param request
      */
     private void parseIDFromURL(RequestMessage request) {
@@ -109,7 +109,7 @@ public class SessionInfo {
     /**
      * Encode session information into the provided URL. This will replace
      * any existing session in that URL.
-     * 
+     *
      * @param url
      * @param info
      * @return String
@@ -163,7 +163,7 @@ public class SessionInfo {
 
     /**
      * Strip out any session id information from the input URL.
-     * 
+     *
      * @param url
      * @param info
      * @return String
@@ -192,7 +192,7 @@ public class SessionInfo {
      * Strip out any session id information from the input URL. This method
      * is provided for the request servlet spec that uses a StringBuffer for
      * the full URL value.
-     * 
+     *
      * @param url
      * @param info
      * @return String
@@ -219,7 +219,7 @@ public class SessionInfo {
 
     /**
      * Look for a possible session id in the cookies of the request message.
-     * 
+     *
      * @param request
      */
     private void parseIDFromCookies(RequestMessage request) {
@@ -248,7 +248,7 @@ public class SessionInfo {
 
     /**
      * Create a proper Cookie for the given session object.
-     * 
+     *
      * @param info
      * @return Cookie
      */
@@ -256,9 +256,7 @@ public class SessionInfo {
         // create a cookie using the configuration information
         HttpSession session = info.getSession();
         SessionConfig config = info.getSessionConfig();
-        Cookie cookie = new Cookie(
-                        config.getIDName(),
-                        config.getSessionVersion() + session.getId());
+        Cookie cookie = new Cookie(config.getIDName(), config.getSessionVersion() + session.getId());
         cookie.setSecure(config.isCookieSecure());
         cookie.setMaxAge(config.getCookieMaxAge());
         cookie.setPath(config.getCookiePath());
@@ -270,7 +268,7 @@ public class SessionInfo {
     /**
      * Query the configuration for this session. This could be scoped at the
      * server level, the app level, or an individual module level.
-     * 
+     *
      * @return SessionConfig
      */
     public SessionConfig getSessionConfig() {
@@ -279,7 +277,7 @@ public class SessionInfo {
 
     /**
      * Query the servlet context object. This may be null.
-     * 
+     *
      * @return ServletContext
      */
     public ServletContext getContext() {
@@ -290,7 +288,7 @@ public class SessionInfo {
      * Query the session ID found in the original request message. This may
      * be null if the client did not send one, and may or may not equal the
      * current session for this connection.
-     * 
+     *
      * @return String
      */
     public String getID() {
@@ -300,7 +298,7 @@ public class SessionInfo {
     /**
      * Query whether that optional session ID found in the original request
      * came from a cookie or not.
-     * 
+     *
      * @return boolean, false if not found or found outside of cookies
      */
     public boolean isFromCookie() {
@@ -310,7 +308,7 @@ public class SessionInfo {
     /**
      * Query whether that optional session ID found in the original request
      * came from the URL or not.
-     * 
+     *
      * @return boolean, false if not found or found outside the URL
      */
     public boolean isFromURL() {
@@ -320,7 +318,7 @@ public class SessionInfo {
     /**
      * Query whether the optional session ID found in the original request
      * pointed to a valid session initially.
-     * 
+     *
      * @return boolean, false if not found or was invalid
      */
     public boolean isValid() {
@@ -330,7 +328,7 @@ public class SessionInfo {
     /**
      * Access any existing session for this connection. It will not create
      * one if no session is found.
-     * 
+     *
      * @return HttpSession
      */
     public HttpSession getSession() {
@@ -342,7 +340,7 @@ public class SessionInfo {
      * if one was not found and the create flag was false. If a cached session
      * is found but it reports as invalid, then this will look for a new
      * session if the create flag is true.
-     * 
+     *
      * @param create
      * @return HttpSession
      */

--- a/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/SessionManager.java
+++ b/dev/com.ibm.ws.httpservice/src/com/ibm/ws/httpsvc/session/internal/SessionManager.java
@@ -35,7 +35,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 public class SessionManager {
 
     /** Debug variable */
-    private static final TraceComponent tc = Tr.register(SessionManager.class);
+    private static final TraceComponent tc = Tr.register(SessionManager.class, com.ibm.ws.httpsvc.internal.HttpSvcConstants.TRACE_GROUP);
 
     private final Object timerLock = new TimerLock();
     private ScheduledEventService scheduler = null;
@@ -57,7 +57,7 @@ public class SessionManager {
 
     /**
      * DS method to activate this component.
-     * 
+     *
      * @param context
      */
     public void activate(ComponentContext context) {
@@ -69,7 +69,7 @@ public class SessionManager {
 
     /**
      * DS method to deactivate this component.
-     * 
+     *
      * @param context
      */
     public void deactivate(ComponentContext context) {
@@ -91,7 +91,7 @@ public class SessionManager {
     /**
      * DS method for runtime updates to configuration without stopping and
      * restarting the component.
-     * 
+     *
      * @param properties
      */
     protected void modified(Map<?, ?> properties) {
@@ -106,7 +106,7 @@ public class SessionManager {
     /**
      * Method called when the properties for the session manager have been
      * found or udpated.
-     * 
+     *
      * @param props
      */
     public void processConfig(Dictionary<?, ?> props) {
@@ -148,7 +148,7 @@ public class SessionManager {
 
     /**
      * DS method for setting the timer service reference.
-     * 
+     *
      * @param ref
      */
     protected void setScheduledEventService(ScheduledEventService ref) {
@@ -159,7 +159,7 @@ public class SessionManager {
 
     /**
      * DS method for removing the timer service reference.
-     * 
+     *
      * @param mgr
      */
     protected void unsetScheduledEventService(ScheduledEventService ref) {
@@ -223,7 +223,7 @@ public class SessionManager {
      * Access the appropriate session configuration information for a given
      * context. If config does not exist for a given application, then the
      * common manager level config is returned.
-     * 
+     *
      * @param info
      * @return SessionConfig
      */
@@ -234,7 +234,7 @@ public class SessionManager {
     /**
      * Access, and possibly create if not found, a session for the given
      * client information.
-     * 
+     *
      * @param info
      * @param create
      * @return SessionImpl, null if not found and create flag is false

--- a/dev/com.ibm.ws.injection/bnd.bnd
+++ b/dev/com.ibm.ws.injection/bnd.bnd
@@ -41,7 +41,8 @@ Service-Component: \
     provide:=com.ibm.ws.serialization.DeserializationClassProvider;\
     properties:="service.vendor=IBM,classes=com.ibm.ws.injectionengine.osgi.internal.ResourceFactoryReference"
 
-instrument.classesExcludes: com/ibm/ws/injection/resources/*.class
+instrument.classesExcludes: com/ibm/ws/injection/resources/*.class, \
+	com/ibm/ws/injectionengine/osgi/internal/naming/InjectionJavaColonHelper.class
 
 -buildpath: \
 	com.ibm.ws.injection.core;version=latest,\

--- a/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/naming/InjectionJavaColonHelper.java
+++ b/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/naming/InjectionJavaColonHelper.java
@@ -39,6 +39,7 @@ import com.ibm.ws.container.service.naming.RemoteObjectInstanceFactory;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.injectionengine.InternalInjectionEngine;
 import com.ibm.ws.injectionengine.osgi.internal.IndirectReference;
+import com.ibm.ws.injectionengine.osgi.internal.OSGiInjectionConfigConstants;
 import com.ibm.ws.injectionengine.osgi.internal.OSGiInjectionEngineImpl;
 import com.ibm.ws.injectionengine.osgi.internal.OSGiInjectionScopeData;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
@@ -52,14 +53,14 @@ import com.ibm.wsspi.injectionengine.InjectionException;
 /**
  * This {@link JavaColonNamingHelper} implementation provides support for
  * the standard Java EE component naming context (java:comp/env). <p>
- * 
+ *
  * It is registered on the JNDI NamingHelper whiteboard and will be
  * consulted during object lookup in the appropriate namespace. <p>
  */
 @Component(service = { JavaColonNamingHelper.class, RemoteJavaColonNamingHelper.class })
 @Trivial
 public class InjectionJavaColonHelper implements JavaColonNamingHelper, RemoteJavaColonNamingHelper {
-    private static final TraceComponent tc = Tr.register(InjectionJavaColonHelper.class);
+    private static final TraceComponent tc = Tr.register(InjectionJavaColonHelper.class, OSGiInjectionConfigConstants.traceGroup, OSGiInjectionConfigConstants.messageBundle);
 
     private OSGiInjectionEngineImpl injectionEngine;
 
@@ -143,7 +144,7 @@ public class InjectionJavaColonHelper implements JavaColonNamingHelper, RemoteJa
     /**
      * Internal method to obtain the injection metadata associated with
      * the specified component metadata. <p>
-     * 
+     *
      * @return the associated injection metadata; or null if none exists
      */
     protected OSGiInjectionScopeData getInjectionScopeData(NamingConstants.JavaColonNamespace namespace) throws NamingException {
@@ -172,7 +173,7 @@ public class InjectionJavaColonHelper implements JavaColonNamingHelper, RemoteJa
     /**
      * Internal method that creates a NamingException that contains helpful
      * information regarding why a binding failed to resolve. <p>
-     * 
+     *
      * The returned exception will provide similar information as the
      * CannotInstantiateObjectException from traditional WAS.
      */
@@ -228,7 +229,7 @@ public class InjectionJavaColonHelper implements JavaColonNamingHelper, RemoteJa
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.container.service.naming.remote.RemoteJavaColonNamingHelper#getRemoteObjectInstance(com.ibm.ws.container.service.naming.NamingConstants.JavaColonNamespace,
      * java.lang.String)
      */
@@ -299,7 +300,7 @@ public class InjectionJavaColonHelper implements JavaColonNamingHelper, RemoteJa
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.container.service.naming.remote.RemoteJavaColonNamingHelper#hasRemoteObjectWithPrefix(com.ibm.ws.container.service.naming.NamingConstants.JavaColonNamespace,
      * java.lang.String)
      */
@@ -310,7 +311,7 @@ public class InjectionJavaColonHelper implements JavaColonNamingHelper, RemoteJa
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.container.service.naming.remote.RemoteJavaColonNamingHelper#listRemoteInstances(com.ibm.ws.container.service.naming.NamingConstants.JavaColonNamespace,
      * java.lang.String)
      */

--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -156,7 +156,8 @@ Include-Resource: \
 
 -dependson: com.ibm.ws.org.codehaus.jackson
 
-instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class
+instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class, \
+	org/apache/cxf/common/util/UrlUtils.class
 
 -buildpath: \
 	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/cm/logger/TraceWriter.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/cm/logger/TraceWriter.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ejs.cm.logger;
 
-import java.io.*;
+import java.io.StringWriter;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -20,7 +20,7 @@ public class TraceWriter extends StringWriter {
 
     /**
      * Class constructor
-     * 
+     *
      * @param dest TraceComponent: which is the trace component the destination intialized
      */
     public TraceWriter(TraceComponent dest) {
@@ -30,6 +30,7 @@ public class TraceWriter extends StringWriter {
     /**
      * @deprecated where possible, use com.ibm.websphere.ras package instead
      */
+    @Deprecated
     public TraceWriter(com.ibm.ejs.ras.TraceComponent dest) {
         this((TraceComponent) dest);
     }
@@ -40,6 +41,7 @@ public class TraceWriter extends StringWriter {
 
     // StringWriter overrides
 
+    @Override
     public void flush() {
         synchronized (lock) {
             super.flush();
@@ -47,6 +49,7 @@ public class TraceWriter extends StringWriter {
         }
     }
 
+    @Override
     public void write(char[] cbuf, int off, int len) {
         synchronized (lock) {
             super.write(cbuf, off, len);
@@ -54,6 +57,7 @@ public class TraceWriter extends StringWriter {
         }
     }
 
+    @Override
     public void write(int b) {
         synchronized (lock) {
             super.write(b);
@@ -63,6 +67,7 @@ public class TraceWriter extends StringWriter {
         }
     }
 
+    @Override
     public void write(String str) {
         synchronized (lock) {
             super.write(str);
@@ -70,6 +75,7 @@ public class TraceWriter extends StringWriter {
         }
     }
 
+    @Override
     public void write(String str, int off, int len) {
         synchronized (lock) {
             super.write(str, off, len);
@@ -105,5 +111,5 @@ public class TraceWriter extends StringWriter {
     private final TraceComponent destination;
 
     /** Trace component */
-    private static final TraceComponent tc = Tr.register(TraceWriter.class);
+    private static final TraceComponent tc = Tr.register(TraceWriter.class, null);
 }

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/AppDefinedResourceFactory.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/AppDefinedResourceFactory.java
@@ -32,7 +32,7 @@ import com.ibm.wsspi.resource.ResourceInfo;
  * delegates createResource to that resource factory.
  */
 public class AppDefinedResourceFactory implements com.ibm.ws.resource.ResourceFactory {
-    private static final TraceComponent tc = Tr.register(AppDefinedResourceFactory.class);
+    private static final TraceComponent tc = Tr.register(AppDefinedResourceFactory.class, null);
 
     /**
      * Name of the application that defines this resource.
@@ -56,12 +56,12 @@ public class AppDefinedResourceFactory implements com.ibm.ws.resource.ResourceFa
 
     /**
      * Construct a Future-like wrapper for an application-defined resource factory.
-     * 
-     * @param builder the resource factory builder
+     *
+     * @param builder       the resource factory builder
      * @param bundleContext the bundle context
-     * @param id unique identifier for the resource factory
-     * @param filter filter for the resource factory
-     * @param appName name of the application that defines the resource factory
+     * @param id            unique identifier for the resource factory
+     * @param filter        filter for the resource factory
+     * @param appName       name of the application that defines the resource factory
      * @throws InvalidSyntaxException if the filter has incorrect syntax
      */
     public AppDefinedResourceFactory(ResourceFactoryBuilder builder, BundleContext bundleContext, String id, String filter, String appName) throws InvalidSyntaxException {
@@ -119,7 +119,7 @@ public class AppDefinedResourceFactory implements com.ibm.ws.resource.ResourceFa
     /**
      * Destroy this application-defined resource by removing its configuration
      * and the configuration of all other services that were created for it.
-     * 
+     *
      * @throws Exception if an error occurs.
      */
     @Override

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/ApiRegion.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/ApiRegion.java
@@ -69,7 +69,8 @@ public enum ApiRegion {
      */
     THREAD_CONTEXT("thread-context", "liberty.thread.context.api", false);
 
-    private static final TraceComponent tc = Tr.register(ApiRegion.class);
+    private static final TraceComponent tc = Tr.register(ApiRegion.class, com.ibm.ws.kernel.feature.internal.ProvisionerConstants.TR_GROUP,
+                                                         com.ibm.ws.kernel.feature.internal.ProvisionerConstants.NLS_PROPS);
     private static final ApiRegion[] values = ApiRegion.values();
     private final String apiType;
     private final String regionName;
@@ -83,7 +84,7 @@ public enum ApiRegion {
 
     /**
      * Returns the api type granted by the region
-     * 
+     *
      * @return the api type
      */
     public String getApiType() {
@@ -93,7 +94,7 @@ public enum ApiRegion {
     /**
      * Returns the name of the region that grants access to the
      * api type.
-     * 
+     *
      * @return the region name
      */
     public String getRegionName() {
@@ -103,7 +104,7 @@ public enum ApiRegion {
     /**
      * Returns true if the region delegates to the internal region
      * to grant access to internal packages
-     * 
+     *
      * @return true if delegation to the internal region.
      */
     public boolean delegateInternal() {
@@ -112,7 +113,7 @@ public enum ApiRegion {
 
     /**
      * Returns the APIRegion type for the specified API type
-     * 
+     *
      * @param apiType the API type to get the region for
      * @return the APIRegion type for the specified API type
      * @throws IllegalArgumentException if the apiType is not valid
@@ -139,18 +140,18 @@ public enum ApiRegion {
      * which was created by calling {@link RegionDigraph#copy()} on the
      * specified region digraph. A {@code null} value
      * may be returned by the callable if no update is needed.
-     * 
-     * @param digraph The region digraph to update. Also the
-     *            region digraph used to make a copy to be returned by
-     *            the specified updateTo callable.
+     *
+     * @param digraph  The region digraph to update. Also the
+     *                     region digraph used to make a copy to be returned by
+     *                     the specified updateTo callable.
      * @param updateTo A callable that returns an updated copy of
-     *            the specified digraph. The returned digraph will be used to
-     *            call {@link RegionDigraph#replace(RegionDigraph)} on the
-     *            specified digraph.
-     * @throws BundleException if the update could not complete or if the
-     *             callable throws a BundleException it is rethrown.
+     *                     the specified digraph. The returned digraph will be used to
+     *                     call {@link RegionDigraph#replace(RegionDigraph)} on the
+     *                     specified digraph.
+     * @throws BundleException  if the update could not complete or if the
+     *                              callable throws a BundleException it is rethrown.
      * @throws RuntimeException if the callable throws any exception other
-     *             than a BundleException.
+     *                              than a BundleException.
      */
     @FFDCIgnore({ BundleException.class, InterruptedException.class })
     public static void update(RegionDigraph digraph, Callable<RegionDigraph> updateTo) throws BundleException {

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/Tr.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/Tr.java
@@ -277,6 +277,35 @@ public class Tr {
 
         return tc;
     }
+    
+    /**
+     * Register the provided class with the trace service and assign it to the
+     * provided group name. Translated messages will attempt to use the input
+     * message bundle source.
+     * 
+     * @param aClass
+     *            a valid <code>Class</code> to register a component for with
+     *            the trace manager. The className is obtained from the Class
+     *            and is used as the name in the registration process.
+     * @param groups
+     *            the name of the groups that the named component is a member of.
+     *            Null is allowed. If null is passed, the name is not added to a
+     *            group. Once added to a group, there is no corresponding
+     *            mechanism to remove a component from a group.
+     * @param bundle
+     *            the name of the message properties file to use when providing
+     *            national language support for messages logged by this
+     *            component. All messages for this component must be found in
+     *            this file.
+     * @return TraceComponent the <code>TraceComponent</code> corresponding to
+     *         the name of the specified class.
+     */
+    public static TraceComponent register(Class<?> aClass, String[] groups, String bundle, String name) {
+    	TraceComponent tc = new TraceComponent(name, aClass, groups, bundle);
+        registerTraceComponent(tc);
+
+        return tc;
+    }
 
     /**
      * Register the provided name with the trace service and assign it to the

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/TraceNLSResolver.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/TraceNLSResolver.java
@@ -79,7 +79,7 @@ public class TraceNLSResolver {
      * 
      * @see #makeNoise()
      */
-    private static final TraceComponent tc = com.ibm.websphere.ras.Tr.register(TraceNLSResolver.class);
+    private static final TraceComponent tc = com.ibm.websphere.ras.Tr.register(TraceNLSResolver.class,NLSConstants.GROUP, NLSConstants.LOGGING_NLS);
 
     /**
      * Name of property used to enable noise-making when messages can't be

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/TraceSpecification.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/TraceSpecification.java
@@ -33,7 +33,7 @@ public class TraceSpecification {
      * Lazy TraceComponent: don't initialize this unless/until we need to
      */
     private final static class TraceComponentHolder {
-        static final TraceComponent instance = Tr.register(TraceSpecification.class);
+        static final TraceComponent instance = Tr.register(TraceSpecification.class,NLSConstants.GROUP, NLSConstants.LOGGING_NLS);
     }
 
     private static Comparator<TraceElement> SPEC_COMPARATOR = new Comparator<TraceElement>() {

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/WsLogger.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/WsLogger.java
@@ -36,7 +36,7 @@ import com.ibm.ws.kernel.boot.logging.WsLogManager;
  */
 @SuppressWarnings("deprecation")
 public class WsLogger extends Logger implements TraceStateChangeListener {
-    private static final TraceComponent tc = Tr.register(WsLogger.class);
+    private static final TraceComponent tc = Tr.register(WsLogger.class,NLSConstants.GROUP, NLSConstants.LOGGING_NLS);
 
     //
     // ResourceBundle cached with this WsLogger

--- a/dev/com.ibm.ws.logging.hpel.osgi/src/com/ibm/ws/logging/internal/osgi/hpel/AbstractHPELConfigService.java
+++ b/dev/com.ibm.ws.logging.hpel.osgi/src/com/ibm/ws/logging/internal/osgi/hpel/AbstractHPELConfigService.java
@@ -30,7 +30,7 @@ import com.ibm.websphere.ras.TraceComponent;
  * updates to the different parts of HPEL configuration based on the PID.
  */
 abstract class AbstractHPELConfigService implements ManagedService {
-    private static final TraceComponent tc = Tr.register(AbstractHPELConfigService.class);
+    private static final TraceComponent tc = Tr.register(AbstractHPELConfigService.class,null);
 
     /** reference to registered HPEL config service */
     private final ServiceRegistration<ManagedService> configRef;

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/LoggingConfigurationService.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/LoggingConfigurationService.java
@@ -49,7 +49,7 @@ import com.ibm.ws.ffdc.FFDCConfigurator;
  * the RAS Tr configuration.
  */
 public class LoggingConfigurationService implements ManagedService {
-    private static final TraceComponent tc = Tr.register(LoggingConfigurationService.class);
+    private static final TraceComponent tc = Tr.register(LoggingConfigurationService.class,OsgiLogConstants.TRACE_GROUP,OsgiLogConstants.MESSAGE_BUNDLE);
 
     /** PID: identifies bundle to ConfigAdminService */
     public static final String RAS_TR_CFG_PID = "com.ibm.ws.logging";

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/TrOSGiLogForwarder.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/TrOSGiLogForwarder.java
@@ -33,7 +33,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 
 public class TrOSGiLogForwarder implements SynchronousLogListener, SynchronousBundleListener {
-    private static final TraceComponent _tc = Tr.register(TrOSGiLogForwarder.class);
+    private static final TraceComponent _tc = Tr.register(TrOSGiLogForwarder.class,OsgiLogConstants.TRACE_GROUP, OsgiLogConstants.MESSAGE_BUNDLE);
 
     final static class OSGiTraceComponent extends TraceComponent {
         private final String ffdcMe;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/JsonLogHandler.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/JsonLogHandler.java
@@ -23,6 +23,7 @@ import com.ibm.ws.logging.collector.CollectorConstants;
 import com.ibm.ws.logging.collector.CollectorJsonUtils;
 import com.ibm.ws.logging.collector.Formatter;
 import com.ibm.ws.logging.data.GenericData;
+import com.ibm.ws.logging.internal.NLSConstants;
 import com.ibm.wsspi.collector.manager.BufferManager;
 import com.ibm.wsspi.collector.manager.CollectorManager;
 import com.ibm.wsspi.collector.manager.SynchronousHandler;
@@ -32,7 +33,7 @@ import com.ibm.wsspi.collector.manager.SynchronousHandler;
  */
 public abstract class JsonLogHandler implements SynchronousHandler, Formatter {
 
-    private static final TraceComponent tc = Tr.register(JsonLogHandler.class);
+    private static final TraceComponent tc = Tr.register(JsonLogHandler.class, NLSConstants.GROUP, NLSConstants.LOGGING_NLS);
 
     protected String serverHostName = null;
     protected String serverName = null;
@@ -64,8 +65,8 @@ public abstract class JsonLogHandler implements SynchronousHandler, Formatter {
      * Constructor for the JsonLoghandler which will establish server information needed
      * to fill in the fields of the JSON data object
      *
-     * @param serverName The wlp servername
-     * @param wlpUserDir The wlp user directory
+     * @param serverName  The wlp servername
+     * @param wlpUserDir  The wlp user directory
      * @param sourcesList The first sourceList to subscribe to collectorManager with
      */
     public JsonLogHandler(String serverName, String wlpUserDir, List<String> sourcesList) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/LogProviderConfigImpl.java
@@ -24,6 +24,7 @@ import java.util.logging.Level;
 import com.ibm.websphere.logging.WsLevel;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.logging.internal.NLSConstants;
 import com.ibm.ws.logging.internal.impl.LoggingConstants.FFDCSummaryPolicy;
 import com.ibm.ws.logging.internal.impl.LoggingConstants.TraceFormat;
 import com.ibm.ws.logging.utils.FileLogHolder;
@@ -37,7 +38,7 @@ import com.ibm.wsspi.logprovider.TrService;
  */
 public class LogProviderConfigImpl implements LogProviderConfig {
 
-    private final static TraceComponent tc = Tr.register(LogProviderConfigImpl.class);
+    private final static TraceComponent tc = Tr.register(LogProviderConfigImpl.class, NLSConstants.GROUP, NLSConstants.LOGGING_NLS);
 
     /** TrService delegate */
     protected final TrService trDelegate;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/LogSource.java
@@ -23,6 +23,7 @@ import com.ibm.ws.logging.collector.CollectorJsonHelpers;
 import com.ibm.ws.logging.collector.LogFieldConstants;
 import com.ibm.ws.logging.data.KeyValuePairList;
 import com.ibm.ws.logging.data.LogTraceData;
+import com.ibm.ws.logging.internal.NLSConstants;
 import com.ibm.ws.logging.internal.WsLogRecord;
 import com.ibm.ws.logging.utils.LogFormatUtils;
 import com.ibm.ws.logging.utils.SequenceNumber;
@@ -31,7 +32,7 @@ import com.ibm.wsspi.collector.manager.Source;
 
 public class LogSource implements Source {
 
-    private static final TraceComponent tc = Tr.register(LogSource.class);
+    private static final TraceComponent tc = Tr.register(LogSource.class, NLSConstants.GROUP, NLSConstants.LOGGING_NLS);
 
     private final String sourceName = "com.ibm.ws.logging.source.message";
     private final String location = "memory";

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/TraceSource.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/source/TraceSource.java
@@ -28,7 +28,7 @@ import com.ibm.wsspi.collector.manager.BufferManager;
 import com.ibm.wsspi.collector.manager.Source;
 
 public class TraceSource implements Source {
-    private static final TraceComponent tc = Tr.register(TraceSource.class);
+    private static final TraceComponent tc = Tr.register(TraceSource.class, null, null);
     private final SequenceNumber sequenceNumber = new SequenceNumber();
     private final String sourceName = "com.ibm.ws.logging.source.trace";
     private final String location = "memory";

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.sse.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.sse.3.2/bnd.bnd
@@ -16,6 +16,8 @@ javac.target: 1.8
 -includeresource: \
    @${repo;org.apache.cxf:cxf-rt-rs-sse;3.3.0}!/!META-INF/*,\
    org/apache/cxf=${bin}/org/apache/cxf
+   
+instrument.classesExcludes: org/apache/cxf/jaxrs/sse/client/SseEventSourceImpl$InboundSseEventListenerImpl.class
 
 -buildpath: org.apache.cxf:cxf-rt-rs-sse;version=3.3.0,\
   com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/AbstractRasClassAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/AbstractRasClassAdapter.java
@@ -24,6 +24,7 @@ import org.objectweb.asm.commons.Method;
 
 import com.ibm.ws.ras.instrument.internal.introspect.TraceObjectFieldAnnotationVisitor;
 import com.ibm.ws.ras.instrument.internal.introspect.TraceOptionsAnnotationVisitor;
+import com.ibm.ws.ras.instrument.internal.main.LibertyTracePreprocessInstrumentation.ClassTraceInfo;
 import com.ibm.ws.ras.instrument.internal.model.ClassInfo;
 import com.ibm.ws.ras.instrument.internal.model.TraceOptionsData;
 
@@ -112,6 +113,8 @@ public abstract class AbstractRasClassAdapter extends CheckInstrumentableClassAd
      * Flag that indicates a class static initializer has been created.
      */
     private boolean staticInitializerGenerated = false;
+    
+    protected ClassTraceInfo traceInfo;
 
     /**
      * Constructor.
@@ -155,9 +158,13 @@ public abstract class AbstractRasClassAdapter extends CheckInstrumentableClassAd
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
         AnnotationVisitor av = super.visitAnnotation(desc, visible);
         observedAnnotations.add(Type.getType(desc));
+        TraceOptionsData od;
         if (classInfo == null) {
             if (TRACE_OPTIONS_TYPE.getDescriptor().equals(desc)) {
-                optionsAnnotationVisitor = new TraceOptionsAnnotationVisitor(av);
+            	if ((traceInfo != null) && ((od = traceInfo.getTraceOptionsData()) != null))
+            		optionsAnnotationVisitor = new TraceOptionsAnnotationVisitor(av,od);
+            	else
+            		optionsAnnotationVisitor = new TraceOptionsAnnotationVisitor(av);
                 av = optionsAnnotationVisitor;
             }
         }
@@ -438,12 +445,14 @@ public abstract class AbstractRasClassAdapter extends CheckInstrumentableClassAd
      * @return the effective trace options for this class
      */
     public TraceOptionsData getTraceOptionsData() {
-        if (classInfo != null) {
+        if ((classInfo != null) && (classInfo.getTraceOptionsData() != null)) {
             return classInfo.getTraceOptionsData();
         }
         if (optionsAnnotationVisitor != null) {
             return optionsAnnotationVisitor.getTraceOptionsData();
         }
+        if (traceInfo != null) 
+        	return traceInfo.getTraceOptionsData();
         return null;
     }
 

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/CheckInstrumentableClassAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/CheckInstrumentableClassAdapter.java
@@ -28,6 +28,11 @@ public class CheckInstrumentableClassAdapter extends ClassVisitor {
      * Indication of whether or not this class represents an interface.
      */
     private boolean isInterface;
+    
+    /**
+     * Indication of whether or not this class represents an enum.
+     */
+    private boolean isEnum;
 
     /**
      * Indication of whether or not this class was generated and not
@@ -53,6 +58,7 @@ public class CheckInstrumentableClassAdapter extends ClassVisitor {
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
         this.classInternalName = name;
         this.isInterface = (access & Opcodes.ACC_INTERFACE) != 0;
+        this.isEnum = (access & Opcodes.ACC_ENUM) != 0;
         this.isSynthetic = (access & Opcodes.ACC_SYNTHETIC) != 0;
 
         super.visit(version, access, name, signature, superName, interfaces);
@@ -73,6 +79,10 @@ public class CheckInstrumentableClassAdapter extends ClassVisitor {
     public boolean isInstrumentableClass() {
         // Don't instrument interfaces
         if (isInterface) {
+            return false;
+        }
+        // Don't instrument enums
+        if (isEnum) {
             return false;
         }
         // Don't instrument methods that are not in the source

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/FFDCClassAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/FFDCClassAdapter.java
@@ -16,6 +16,7 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 
 import com.ibm.ws.ras.instrument.annotation.InjectedFFDC;
+import com.ibm.ws.ras.instrument.internal.main.LibertyTracePreprocessInstrumentation.ClassTraceInfo;
 import com.ibm.ws.ras.instrument.internal.model.ClassInfo;
 
 /**
@@ -42,12 +43,19 @@ public class FFDCClassAdapter extends AbstractRasClassAdapter {
      * True if the class is already instrumented.
      */
     private boolean instrumented;
+    
+    private ClassTraceInfo traceInfo;
 
     public FFDCClassAdapter(ClassVisitor visitor, ClassInfo classInfo) {
         super(visitor, classInfo);
     }
 
-    @Override
+    public FFDCClassAdapter(ClassVisitor visitor, ClassInfo classInfo, ClassTraceInfo info) {
+    	super(visitor, classInfo);
+    	traceInfo = info;
+	}
+
+	@Override
     public RasMethodAdapter createRasMethodAdapter(MethodVisitor mv, int access, String name, String descriptor, String signature, String[] exceptions) {
         return new FFDCMethodAdapter(this, mv, access, name, descriptor, signature, exceptions);
     }

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/JSR47TracingClassAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/JSR47TracingClassAdapter.java
@@ -15,6 +15,7 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
+import com.ibm.ws.ras.instrument.internal.main.LibertyTracePreprocessInstrumentation.ClassTraceInfo;
 import com.ibm.ws.ras.instrument.internal.model.ClassInfo;
 import com.ibm.ws.ras.instrument.internal.model.FieldInfo;
 
@@ -56,7 +57,12 @@ public class JSR47TracingClassAdapter extends AbstractTracingRasClassAdapter imp
         }
     }
 
-    @Override
+    public JSR47TracingClassAdapter(ClassVisitor visitor, ClassInfo classInfo, ClassTraceInfo info) {
+    	super(visitor, classInfo);
+    	traceInfo = info;
+	}
+
+	@Override
     public RasMethodAdapter createRasMethodAdapter(MethodVisitor delegate, int access, String name, String descriptor, String signature, String[] exceptions) {
         return new JSR47TracingMethodAdapter(this, delegate, access, name, descriptor, signature, exceptions);
     }

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/LibertyTracePreprocessClassAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/LibertyTracePreprocessClassAdapter.java
@@ -19,6 +19,8 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 
 import com.ibm.ws.ras.instrument.internal.introspect.TraceObjectFieldAnnotationVisitor;
+import com.ibm.ws.ras.instrument.internal.main.LibertyTracePreprocessInstrumentation.ClassTraceInfo;
+import com.ibm.ws.ras.instrument.internal.model.ClassInfo;
 
 public class LibertyTracePreprocessClassAdapter extends AbstractTracingRasClassAdapter {
 
@@ -30,7 +32,13 @@ public class LibertyTracePreprocessClassAdapter extends AbstractTracingRasClassA
         this.initializeTraceObjectField = initializeTraceObjectField;
     }
 
-    @Override
+    public LibertyTracePreprocessClassAdapter(ClassVisitor visitor, boolean initializeTraceObjectField, ClassTraceInfo info) {
+    	super(visitor, null);
+    	this.initializeTraceObjectField = initializeTraceObjectField;
+    	traceInfo = info;
+	}
+
+	@Override
     public AnnotationVisitor visitAnnotation(String name, boolean visible) {
         AnnotationVisitor av = super.visitAnnotation(name, visible);
         if (name.equals(TRACE_OBJECT_FIELD_TYPE.getDescriptor())) {
@@ -71,4 +79,11 @@ public class LibertyTracePreprocessClassAdapter extends AbstractTracingRasClassA
     public boolean isTraceObjectFieldInitializationRequired() {
         return initializeTraceObjectField;
     }
+
+	@Override
+	public boolean isTrivial() {
+		
+		return false;
+	}
+
 }

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/LibertyTracingClassAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/LibertyTracingClassAdapter.java
@@ -17,8 +17,11 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 
+import com.ibm.websphere.ras.annotation.TraceOptions;
+import com.ibm.ws.ras.instrument.internal.main.LibertyTracePreprocessInstrumentation.ClassTraceInfo;
 import com.ibm.ws.ras.instrument.internal.model.ClassInfo;
 import com.ibm.ws.ras.instrument.internal.model.FieldInfo;
+import com.ibm.ws.ras.instrument.internal.model.TraceOptionsData;
 
 /**
  * A <code>RasClassAdapter</code> implementation that generates calls to
@@ -73,12 +76,18 @@ public class LibertyTracingClassAdapter extends AbstractTracingRasClassAdapter {
         }
     }
 
-    public LibertyTracingClassAdapter(ClassVisitor visitor, boolean onlyInstrumentPreprocessed) {
+	public LibertyTracingClassAdapter(ClassVisitor visitor, boolean onlyInstrumentPreprocessed) {
         this(visitor, null);
         this.onlyInstrumentPreprocessed = onlyInstrumentPreprocessed;
     }
 
-    @Override
+    public LibertyTracingClassAdapter(ClassVisitor visitor, ClassTraceInfo info, boolean onlyInstrumentPreprocessed) {
+    	this(visitor, null);
+    	this.onlyInstrumentPreprocessed = onlyInstrumentPreprocessed;
+    	traceInfo = info;
+	}
+
+	@Override
     public RasMethodAdapter createRasMethodAdapter(MethodVisitor mv, int access, String name, String descriptor, String signature, String[] exceptions) {
         // Use the super class's observation of the TraceObjectField annotation
         // to detect a pre-processed class. This is a little bit of a kludge but
@@ -160,4 +169,11 @@ public class LibertyTracingClassAdapter extends AbstractTracingRasClassAdapter {
 
         return false;
     }
+
+	public boolean isTraceComponentAlreadyDefined() {
+		return traceComponentAlreadyDefined;
+	}
+
+
+
 }

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/LibertyTracingMethodAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/LibertyTracingMethodAdapter.java
@@ -269,7 +269,7 @@ public class LibertyTracingMethodAdapter extends AbstractRasMethodAdapter<Abstra
     	            visitInsn(ACONST_NULL);
     	        }
     	        
-    	        String traceOptionName = getClassAdapter().getClassInternalName();
+    	        String traceOptionName = getClassAdapter().getClassName();
     	        if (traceOptionName != null) {
     	            visitLdcInsn(traceOptionName);
     	        } else {
@@ -386,7 +386,7 @@ public class LibertyTracingMethodAdapter extends AbstractRasMethodAdapter<Abstra
     	            visitInsn(ACONST_NULL);
     	        }
     	        
-    	        String traceOptionName = getClassAdapter().getClassInternalName();
+    	        String traceOptionName = getClassAdapter().getClassName();
     	        if (traceOptionName != null) {
     	            visitLdcInsn(traceOptionName);
     	        } else {

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/LibertyTracingMethodAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/LibertyTracingMethodAdapter.java
@@ -12,11 +12,20 @@ package com.ibm.ws.ras.instrument.internal.bci;
 
 import static com.ibm.ws.ras.instrument.internal.bci.LibertyTracingClassAdapter.TRACE_COMPONENT_TYPE;
 import static com.ibm.ws.ras.instrument.internal.bci.LibertyTracingClassAdapter.TR_TYPE;
+import static org.objectweb.asm.Opcodes.ICONST_0;
+
+import java.util.Iterator;
+import java.util.List;
 
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import com.ibm.ws.ras.instrument.internal.model.TraceOptionsData;
 
 public class LibertyTracingMethodAdapter extends AbstractRasMethodAdapter<AbstractTracingRasClassAdapter> {
 
@@ -227,23 +236,93 @@ public class LibertyTracingMethodAdapter extends AbstractRasMethodAdapter<Abstra
 
     @Override
     public void initializeTraceObjectField() {
-        if (!getClassAdapter().isTraceObjectFieldInitializationRequired() || isAlreadyTraced()) {
+    	if (!getClassAdapter().isTraceObjectFieldInitializationRequired() || isAlreadyTraced()) {
             return;
         }
+    	getClassAdapter().visitAnnotation(AbstractRasClassAdapter.TRACE_OPTIONS_TYPE.getDescriptor(), true);
+    	TraceOptionsData traceOptionsData = getClassAdapter().getTraceOptionsData();
+    	
+    	
+    	if (traceOptionsData.getTraceGroups().size() > 1) {
+    		
+    	        
+    	        visitGetClassForType(Type.getObjectType(getClassAdapter().getClassInternalName()));
 
-        visitGetClassForType(Type.getObjectType(getClassAdapter().getClassInternalName()));
-        visitMethodInsn(
-                        INVOKESTATIC,
-                        TR_TYPE.getInternalName(),
-                        "register",
-                        Type.getMethodDescriptor(
-                                                 TRACE_COMPONENT_TYPE,
-                                                 new Type[] { Type.getType(Class.class) }), false);
+    	        String[] traceGroups = traceOptionsData.getTraceGroups().toArray(new String[traceOptionsData.getTraceGroups().size()]);
+    	       
+    	        
+    	        visitInsn(ICONST_0 + traceGroups.length);
+    	        visitTypeInsn(ANEWARRAY, "java/lang/String");
+
+    	                for (int i = 0; i < traceGroups.length; ++i)
+    	                {     
+    	                    visitInsn(DUP);
+    	                    visitInsn(ICONST_0 + i);
+    	                    visitLdcInsn(traceGroups[i]);
+    	                    visitInsn(AASTORE);
+    	                }
+    	       
+    	        String messageBundle = traceOptionsData.getMessageBundle();
+    	        if (messageBundle != null) {
+    	            visitLdcInsn(messageBundle);
+    	        } else {
+    	            visitInsn(ACONST_NULL);
+    	        }
+    	        
+    	        String traceOptionName = getClassAdapter().getClassInternalName();
+    	        if (traceOptionName != null) {
+    	            visitLdcInsn(traceOptionName);
+    	        } else {
+    	            visitInsn(ACONST_NULL);
+    	        }
+    	        
+    	        visitMethodInsn(
+    	                        INVOKESTATIC,
+    	                        TR_TYPE.getInternalName(),
+    	                        "register",
+    	                        Type.getMethodDescriptor(TRACE_COMPONENT_TYPE, new Type[] {
+    	                                                                                   Type.getType(Class.class),
+    	                                                                                   Type.getType("[Ljava/lang/String;"),
+    	                                                                                   Type.getType(String.class),
+    	                                                                                   Type.getType(String.class)}), false);
+    	} else {
+    	
+    	
+		        visitGetClassForType(Type.getObjectType(getClassAdapter().getClassInternalName()));
+		
+		        List<String> traceGroups = traceOptionsData.getTraceGroups();
+		        String traceGroupName = traceGroups.isEmpty() ? null : traceGroups.get(0);
+		        if (traceGroupName != null) {
+		            visitLdcInsn(traceGroupName);
+		        } else {
+		            visitInsn(ACONST_NULL);
+		        }
+		
+		        String messageBundle = traceOptionsData.getMessageBundle();
+		        if (messageBundle != null) {
+		            visitLdcInsn(messageBundle);
+		        } else {
+		            visitInsn(ACONST_NULL);
+		        }
+		        visitMethodInsn(
+		                        INVOKESTATIC,
+		                        TR_TYPE.getInternalName(),
+		                        "register",
+		                        Type.getMethodDescriptor(TRACE_COMPONENT_TYPE, new Type[] {
+		                                                                                   Type.getType(Class.class),
+		                                                                                   Type.getType(String.class),
+		                                                                                   Type.getType(String.class) }), false);
+        
+    	}
+
         visitSetTraceObjectField();
+        
+        
         setModifiedMethod(true);
     }
 
-    private void visitInvokeTraceGuardMethod(String guardMethodName, Label skipTraceLabel) {
+
+	private void visitInvokeTraceGuardMethod(String guardMethodName, Label skipTraceLabel) {
         visitMethodInsn(
                         INVOKESTATIC,
                         TRACE_COMPONENT_TYPE.getInternalName(),
@@ -274,4 +353,83 @@ public class LibertyTracingMethodAdapter extends AbstractRasMethodAdapter<Abstra
             super.boxSensitive(type);
         }
     }
+
+	@Override
+	public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+		
+		//replace existing method with fully qualified version
+		if ((name.equals("register")) && (desc.equals("(Ljava/lang/Class;)Lcom/ibm/websphere/ras/TraceComponent;"))) {
+			
+			getClassAdapter().visitAnnotation(AbstractRasClassAdapter.TRACE_OPTIONS_TYPE.getDescriptor(), true);
+	    	TraceOptionsData traceOptionsData = getClassAdapter().getTraceOptionsData();
+	    	
+	    	if (traceOptionsData.getTraceGroups().size() > 1){
+    		
+    	        String[] traceGroups = traceOptionsData.getTraceGroups().toArray(new String[traceOptionsData.getTraceGroups().size()]);
+    	       
+    	        visitInsn(ICONST_0 + traceGroups.length);
+    	        visitTypeInsn(ANEWARRAY, "java/lang/String");
+
+    	                for (int i = 0; i < traceGroups.length; ++i)
+    	                {     
+    	                    visitInsn(DUP);
+    	                    visitInsn(ICONST_0 + i);
+    	                    visitLdcInsn(traceGroups[i]);
+    	                    visitInsn(AASTORE);
+    	                }
+    	        
+    	       
+    	        String messageBundle = traceOptionsData.getMessageBundle();
+    	        if (messageBundle != null) {
+    	            visitLdcInsn(messageBundle);
+    	        } else {
+    	            visitInsn(ACONST_NULL);
+    	        }
+    	        
+    	        String traceOptionName = getClassAdapter().getClassInternalName();
+    	        if (traceOptionName != null) {
+    	            visitLdcInsn(traceOptionName);
+    	        } else {
+    	            visitInsn(ACONST_NULL);
+    	        }
+    	        
+    	        visitMethodInsn(
+    	                        INVOKESTATIC,
+    	                        TR_TYPE.getInternalName(),
+    	                        "register",
+    	                        Type.getMethodDescriptor(TRACE_COMPONENT_TYPE, new Type[] {
+    	                                                                                   Type.getType(Class.class),
+    	                                                                                   Type.getType("[Ljava/lang/String;"),
+    	                                                                                   Type.getType(String.class),
+    	                                                                                   Type.getType(String.class)}), false);
+    	} else {
+
+	        List<String> traceGroups = traceOptionsData.getTraceGroups();
+	        
+	        String traceGroupName = traceGroups.isEmpty() ? null : traceGroups.get(0);
+	        if (traceGroupName != null) {
+	            visitLdcInsn(traceGroupName);
+	        } else {
+	            visitInsn(ACONST_NULL);
+	        }
+
+	        String messageBundle = traceOptionsData.getMessageBundle();
+	        if (messageBundle != null) {
+	            visitLdcInsn(messageBundle);
+	        } else {
+	            visitInsn(ACONST_NULL);
+	        }
+	        visitMethodInsn(
+	                        INVOKESTATIC,
+	                        TR_TYPE.getInternalName(),
+	                        "register",
+	                        Type.getMethodDescriptor(TRACE_COMPONENT_TYPE, new Type[] {
+	                                                                                   Type.getType(Class.class),
+	                                                                                   Type.getType(String.class),
+	                                                                                   Type.getType(String.class) }), false);
+    	}
+	        
+	        setModifiedMethod(true);
+		} else super.visitMethodInsn(opcode, owner, name, desc, itf);
+	}
 }

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/WebSphereTrTracingClassAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/WebSphereTrTracingClassAdapter.java
@@ -14,6 +14,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 
+import com.ibm.ws.ras.instrument.internal.main.LibertyTracePreprocessInstrumentation.ClassTraceInfo;
 import com.ibm.ws.ras.instrument.internal.model.ClassInfo;
 import com.ibm.ws.ras.instrument.internal.model.FieldInfo;
 
@@ -43,6 +44,7 @@ public class WebSphereTrTracingClassAdapter extends AbstractTracingRasClassAdapt
     private FieldInfo traceComponentField;
     private boolean traceComponentAlreadyDefined;
 
+
     public WebSphereTrTracingClassAdapter(ClassVisitor visitor, ClassInfo classInfo) {
         super(visitor, classInfo);
 
@@ -63,7 +65,12 @@ public class WebSphereTrTracingClassAdapter extends AbstractTracingRasClassAdapt
         }
     }
 
-    @Override
+    public WebSphereTrTracingClassAdapter(ClassVisitor visitor, ClassInfo classInfo, ClassTraceInfo info) {
+    	super(visitor, classInfo);
+    	traceInfo = info;
+	}
+
+	@Override
     public RasMethodAdapter createRasMethodAdapter(MethodVisitor mv, int access, String name, String descriptor, String signature, String[] exceptions) {
         return new WebSphereTrTracingMethodAdapter(this, mv, access, name, descriptor, signature, exceptions);
     }

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/WebSphereTrTracingMethodAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/WebSphereTrTracingMethodAdapter.java
@@ -169,6 +169,7 @@ public class WebSphereTrTracingMethodAdapter extends AbstractRasMethodAdapter<Ab
         }
 
         TraceOptionsData traceOptionsData = getClassAdapter().getTraceOptionsData();
+        if (traceOptionsData == null) return;
         visitGetClassForType(Type.getObjectType(getClassAdapter().getClassInternalName()));
 
         List<String> traceGroups = traceOptionsData.getTraceGroups();

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceOptionsAnnotationVisitor.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/introspect/TraceOptionsAnnotationVisitor.java
@@ -24,6 +24,7 @@ public class TraceOptionsAnnotationVisitor extends AnnotationVisitor {
     protected String messageBundle;
     protected boolean traceExceptionThrow;
     protected boolean traceExceptionHandling;
+    private TraceOptionsData packageData;
 
     public TraceOptionsAnnotationVisitor() {
         super(Opcodes.ASM7);
@@ -33,7 +34,12 @@ public class TraceOptionsAnnotationVisitor extends AnnotationVisitor {
         super(Opcodes.ASM7, av);
     }
 
-    @Override
+    public TraceOptionsAnnotationVisitor(AnnotationVisitor av, TraceOptionsData od) {
+    	super(Opcodes.ASM7, av);
+    	packageData = od;
+	}
+
+	@Override
     public void visit(String name, Object value) {
         if ("traceGroup".equals(name)) {
             String traceGroup = String.class.cast(value);
@@ -76,6 +82,9 @@ public class TraceOptionsAnnotationVisitor extends AnnotationVisitor {
     }
 
     public TraceOptionsData getTraceOptionsData() {
-        return new TraceOptionsData(traceGroups, messageBundle, traceExceptionThrow, traceExceptionHandling);
+    	if (traceGroups.isEmpty() && packageData != null)
+    		return packageData;
+    	else
+    		return new TraceOptionsData(traceGroups, messageBundle, traceExceptionThrow, traceExceptionHandling);
     }
 }

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyTracePreprocessInstrumentation.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyTracePreprocessInstrumentation.java
@@ -78,16 +78,18 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
 
     private boolean addFfdc = false;
     private boolean injectStatic = false;
+    private String defaultTraceComponentName = "$$$tc$$$";
 
-    private TraceType defaultTraceType = TraceType.LIBERTY;
+
+	private TraceType defaultTraceType = TraceType.LIBERTY;
 
     /**
      * Transient class that collects class information needed during
      * pre-processing.
      */
-    protected class ClassTraceInfo {
+    public class ClassTraceInfo {
         ClassNode classNode;
-        PackageInfo packageInfo;
+        public PackageInfo packageInfo;
 
         // Explicitly declared Liberty TraceComponent
         FieldNode libertyTraceComponentFieldNode;
@@ -107,6 +109,11 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
 
         List<String> warnings = new ArrayList<String>();
         boolean failInstrumentation;
+		public TraceOptionsData getTraceOptionsData() {
+			if (packageInfo != null)
+				return packageInfo.getTraceOptionsData();
+			return null;
+		}
     }
 
     /**
@@ -289,14 +296,24 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
                 info.warnings.add(sb.toString());
             }
 
+                     
             // Keep track of the first static TraceComponent
             if (traceComponentFields.size() > 0) {
                 info.libertyTraceComponentFieldNode = traceComponentFields.get(0);
             }
         }
     }
+    
+    public String getDefaultTraceComponentName() {
+		return defaultTraceComponentName;
+	}
 
-    /**
+    private void setDefaultTraceComponentName(String name) {
+    	defaultTraceComponentName = name;
+		
+	}
+
+	/**
      * Introspect the class to obtain the list of fields declared as {@code com.ibm.ejs.ras.TraceComponent}s. Only static declarations
      * are considered.
      * 
@@ -384,7 +401,7 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
     private void setupTraceStateObjectField(ClassTraceInfo info) {
         // Skip adding trace object field if it already exists
         AnnotationNode traceObjectAnnotation = getAnnotation(TRACE_OBJECT_FIELD_TYPE.getDescriptor(), info.classNode.visibleAnnotations);
-        if (traceObjectAnnotation != null) {
+        if (traceObjectAnnotation != null) {        	
             TraceObjectFieldAnnotationVisitor visitor = new TraceObjectFieldAnnotationVisitor();
             traceObjectAnnotation.accept(visitor);
             List<FieldNode> fields = getFieldsByDesc(visitor.getFieldDescriptor(), info.classNode.fields);
@@ -394,7 +411,9 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
                     break;
                 }
             }
-            return;
+            if (info.traceStateField != null) // Only return if matching field found
+            	return;
+            
         }
 
         // If a logger or trace component has been declared, use it.
@@ -424,7 +443,7 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
         } else if (defaultTraceType == TraceType.LIBERTY) {
             // TODO: Check for an outer class and a declared field
             int access = (Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC);
-            info.traceStateField = (FieldNode) info.classNode.visitField(access, "$$$tc$$$", LIBERTY_TRACE_COMPONENT_TYPE.getDescriptor(), null, null);
+            info.traceStateField = (FieldNode) info.classNode.visitField(access, getDefaultTraceComponentName(), LIBERTY_TRACE_COMPONENT_TYPE.getDescriptor(), null, null);
         }
 
         // Add the class annotation with the field name and descriptor
@@ -488,15 +507,17 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
         }
 
         Iterator<? extends AbstractInsnNode> instructionIterator = staticInitializer.instructions.iterator();
+        
         while (instructionIterator.hasNext()) {
             AbstractInsnNode insnNode = instructionIterator.next();
-
             // Determine if a Logger/TraceComponent field is being initialized.
             if (insnNode.getType() == AbstractInsnNode.FIELD_INSN) {
                 FieldInsnNode fieldInsn = (FieldInsnNode) insnNode;
                 if (fieldInsn.getOpcode() == Opcodes.PUTSTATIC) {
                     if (info.libertyTraceComponentFieldNode != null && fieldInsn.name.equals(info.libertyTraceComponentFieldNode.name)) {
-                        info.libertyTraceComponentFieldAlreadyInitialized = true;
+                    	if (fieldInsn.getPrevious().getOpcode() == Opcodes.INVOKESTATIC) {
+                    		info.libertyTraceComponentFieldAlreadyInitialized = true;
+                    	}
                     }
                     if (info.websphereTraceComponentFieldNode != null && fieldInsn.name.equals(info.websphereTraceComponentFieldNode.name)) {
                         info.websphereTraceComponentFieldAlreadyInitialized = true;
@@ -504,6 +525,7 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
                     if (info.loggerFieldNode != null && fieldInsn.name.equals(info.loggerFieldNode.name)) {
                         info.loggerFieldAlreadyInitialized = true;
                     }
+                    		
                 }
             }
         }
@@ -676,26 +698,29 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
         info.classNode = directory;
         info.packageInfo = getPackageInfo(directory.name.replaceAll("/[^/]+$", ""));
 
-        // #1: Check for a trivial annotation on the class.
-        if (isClassTrivial(info) || !checkInstrumentableAdapter.isInstrumentableClass()) {
-            return null;
-        }
 
-        // #2: Check for a trace options annotation
+        // #1: Check for a trace options annotation
         processClassTraceOptionsAnnotation(info);
 
-        // #3: Look for declared TraceComponents
+        // #2: Look for declared TraceComponents
         processLibertyTraceComponentDiscovery(info);
         processWebsphereTraceComponentDiscovery(info);
+       
 
-        // #4: Look for declared Logger fields
+        // #3: Look for declared Logger fields
         processJavaLoggerDiscovery(info);
 
-        // #5: See if TraceComponent and a Logger were defined
+        // #4: See if TraceComponent and a Logger were defined
         int declaredTraceStateFieldCount = 0;
         if (info.libertyTraceComponentFieldNode != null) {
             declaredTraceStateFieldCount++;
         }
+        
+        // #5: Check for a trivial annotation on the class - and if a static field exists - continue - otherwise return
+        if (!checkInstrumentableAdapter.isInstrumentableClass() && declaredTraceStateFieldCount == 0) {
+            return null;
+        }
+        
         if (info.websphereTraceComponentFieldNode != null) {
             declaredTraceStateFieldCount++;
         }
@@ -744,20 +769,20 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
         // If requested, inject tracing at invocation by chaining.
         // Static injection for JSR47 or WebSphere is always done our of
         // the pre-process class adpater.
-        if (injectStatic && LIBERTY_TRACE_COMPONENT_TYPE.getDescriptor().equals(info.traceStateField.desc)) {
-            cv = new LibertyTracingClassAdapter(cv, true);
+        if (injectStatic && info.traceStateField != null && LIBERTY_TRACE_COMPONENT_TYPE.getDescriptor().equals(info.traceStateField.desc)) {
+            cv = new LibertyTracingClassAdapter(cv, info, true);
         }
 
         // Pre-process the class and inject FFDC if requested
         if (info.traceStateField != null) {
-            cv = new LibertyTracePreprocessClassAdapter(cv, !info.traceStateFieldAlreadyInitialized);
+            cv = new LibertyTracePreprocessClassAdapter(cv, !info.traceStateFieldAlreadyInitialized,info);
         } else if (defaultTraceType == TraceType.TR) {
-            cv = new WebSphereTrTracingClassAdapter(cv, null);
+            cv = new WebSphereTrTracingClassAdapter(cv, null,info);
         } else if (defaultTraceType == TraceType.JAVA_LOGGING) {
-            cv = new JSR47TracingClassAdapter(cv, null);
+            cv = new JSR47TracingClassAdapter(cv, null,info);
         }
         if (addFfdc) {
-            cv = new FFDCClassAdapter(cv, null);
+            cv = new FFDCClassAdapter(cv, null,info);
         }
         directory.accept(cv);
 
@@ -775,6 +800,8 @@ public class LibertyTracePreprocessInstrumentation extends AbstractInstrumentati
         List<File> classFiles = new ArrayList<File>();
         List<File> jarFiles = new ArrayList<File>();
         String[] fileArgs = null;
+        
+       
 
         for (int i = 0; i < args.length; i++) {
             if (args[i].equalsIgnoreCase("--debug") || args[i].equals("-d")) {

--- a/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
+++ b/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
@@ -83,7 +83,8 @@ import com.ibm.wsspi.security.audit.AuditService;
            immediate = true)
 public class AuditPE implements ProbeExtension {
 
-	private static final TraceComponent tc = Tr.register(AuditPE.class);
+	private static final TraceComponent tc = Tr.register(AuditPE.class, "requestProbe",
+			"com.ibm.ws.request.probe.internal.resources.LoggingMessages");
 
 	private static final String requestProbeType = "websphere.security.audit.test";
 	private static final String KEY_AUDIT_SERVICE = "auditService";

--- a/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditRPTD.java
+++ b/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditRPTD.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.request.probe.audit.servlet;
 
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -19,8 +20,6 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.wsspi.request.probe.bci.RequestProbeTransformDescriptor;
 import com.ibm.wsspi.request.probe.bci.TransformDescriptorHelper;
-
-import org.osgi.service.component.ComponentContext;
 
 /**
  *
@@ -40,7 +39,8 @@ public class AuditRPTD implements RequestProbeTransformDescriptor {
     @Deactivate
     protected void deactivate(ComponentContext cc) {}
 
-    private static final TraceComponent tc = Tr.register(AuditRPTD.class);
+	private static final TraceComponent tc = Tr.register(AuditRPTD.class, "requestProbe",
+			"com.ibm.ws.request.probe.internal.resources.LoggingMessages");
 
 	private static final String classToInstrument = "com/ibm/ws/security/audit/Audit";
 	private static final String methodToInstrument = "audit";

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/RequestProbeIntrospector.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/RequestProbeIntrospector.java
@@ -33,7 +33,7 @@ import com.ibm.wsspi.requestContext.RequestContext;
  @SuppressWarnings("deprecation")
 public class RequestProbeIntrospector implements IntrospectableService {
 
-    private static final TraceComponent tc = Tr.register(RequestProbeIntrospector.class);
+    private static final TraceComponent tc = Tr.register(RequestProbeIntrospector.class,"requestProbe", "com.ibm.ws.request.probe.internal.resources.LoggingMessages");
     private static final int EXTRA_SPACE_REQUIRED = 2;
     
    

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/RequestProbeService.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/RequestProbeService.java
@@ -55,7 +55,7 @@ import com.ibm.wsspi.requestContext.RequestContext;
  */
 public class RequestProbeService {
 
-	private static final TraceComponent tc = Tr.register(RequestProbeService.class);
+	private static final TraceComponent tc = Tr.register(RequestProbeService.class,"requestProbe", "com.ibm.ws.request.probe.internal.resources.LoggingMessages");
 
 	/** Registered Probe Extensions **/
 	private static volatile List<ProbeExtension> probeExtensions = 

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/bci/internal/RequestProbeBCIManagerImpl.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/bci/internal/RequestProbeBCIManagerImpl.java
@@ -41,7 +41,7 @@ public class RequestProbeBCIManagerImpl {
     	return requestProbeTransformDescriptors;
 	}
 
-	private static final TraceComponent tc = Tr.register(RequestProbeBCIManagerImpl.class);
+	private static final TraceComponent tc = Tr.register(RequestProbeBCIManagerImpl.class,"requestProbe", "com.ibm.ws.request.probe.internal.resources.LoggingMessages");
 
     synchronized void activate(BundleContext bundleContext, Map<String, Object> properties) throws Exception {
         if (tc.isEntryEnabled()) {

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/bci/internal/RequestProbeClassVisitor.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/bci/internal/RequestProbeClassVisitor.java
@@ -28,7 +28,7 @@ public class RequestProbeClassVisitor extends ClassVisitor {
 
 	//private final RequestProbeTransformDescriptor metaobj;
 	private String classname = null;
-	private static final TraceComponent tc = Tr.register(RequestProbeClassVisitor.class);
+	private static final TraceComponent tc = Tr.register(RequestProbeClassVisitor.class,"requestProbe", "com.ibm.ws.request.probe.internal.resources.LoggingMessages");
 	String[] listOfMonitoredMethods = null;
 
 	/**

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/bci/internal/RequestProbeMethodAdapter.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/bci/internal/RequestProbeMethodAdapter.java
@@ -23,7 +23,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
 public class RequestProbeMethodAdapter extends AdviceAdapter {
-    private static final TraceComponent tc = Tr.register(RequestProbeMethodAdapter.class);
+    private static final TraceComponent tc = Tr.register(RequestProbeMethodAdapter.class,"requestProbe", "com.ibm.ws.request.probe.internal.resources.LoggingMessages");
 
     private final MethodVisitor visitor;
 

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/bci/internal/RequestProbeTransformer.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/ws/request/probe/bci/internal/RequestProbeTransformer.java
@@ -37,7 +37,7 @@ import com.ibm.wsspi.request.probe.bci.RequestProbeHelper;
 public class RequestProbeTransformer implements ClassFileTransformer {
 
     private Instrumentation inst = null;
-    private static final TraceComponent tc = Tr.register(RequestProbeTransformer.class);
+    private static final TraceComponent tc = Tr.register(RequestProbeTransformer.class,"requestProbe", "com.ibm.ws.request.probe.internal.resources.LoggingMessages");
 
     /**
      * @param instrumentation

--- a/dev/com.ibm.ws.security.csiv2/src/com/ibm/ws/security/csiv2/server/config/css/ClientSASITTDistinguishedName.java
+++ b/dev/com.ibm.ws.security.csiv2/src/com/ibm/ws/security/csiv2/server/config/css/ClientSASITTDistinguishedName.java
@@ -32,7 +32,7 @@ import com.ibm.ws.transport.iiop.security.util.Util;
 @TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
 public class ClientSASITTDistinguishedName implements CSSSASIdentityToken {
 
-    private static TraceComponent tc = Tr.register(ClientSASITTDistinguishedName.class);
+    private static TraceComponent tc = Tr.register(ClientSASITTDistinguishedName.class,TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     /** {@inheritDoc} */
     @FFDCIgnore(Exception.class)

--- a/dev/com.ibm.ws.security.csiv2/src/com/ibm/ws/security/csiv2/server/config/css/ClientSASITTX509CertChain.java
+++ b/dev/com.ibm.ws.security.csiv2/src/com/ibm/ws/security/csiv2/server/config/css/ClientSASITTX509CertChain.java
@@ -39,7 +39,7 @@ public class ClientSASITTX509CertChain implements CSSSASIdentityToken {
     private final String domain;
     private final String realm;
 
-    private static TraceComponent tc = Tr.register(ClientSASITTX509CertChain.class);
+    private static TraceComponent tc = Tr.register(ClientSASITTX509CertChain.class,TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     public ClientSASITTX509CertChain(String oid, Class principalClass, String domain, String realm) {
         this.oid = (oid == null ? GSSUPMechOID.value.substring(4) : oid);

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/GenericSSLConfigService.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/GenericSSLConfigService.java
@@ -21,7 +21,7 @@ import com.ibm.websphere.ras.TraceComponent;
  */
 public abstract class GenericSSLConfigService {
     /** Trace service */
-    private static final TraceComponent tc = Tr.register(GenericSSLConfigService.class);
+    private static final TraceComponent tc = Tr.register(GenericSSLConfigService.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     protected volatile Map<String, Object> config = null;
     private volatile Map<String, Object> myProps = null;

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/KeyStoreServiceImpl.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/KeyStoreServiceImpl.java
@@ -50,7 +50,7 @@ import com.ibm.ws.ssl.config.WSKeyStore;
 public class KeyStoreServiceImpl implements KeyStoreService {
     // Intentionally left package protected for unit test
     KeyStoreManager ksMgr;
-    private static final TraceComponent tc = Tr.register(KeyStoreServiceImpl.class);
+    private static final TraceComponent tc = Tr.register(KeyStoreServiceImpl.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     public KeyStoreServiceImpl() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/KeyringMonitorImpl.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/KeyringMonitorImpl.java
@@ -27,7 +27,7 @@ import com.ibm.ws.ssl.KeyringMonitor;
 public class KeyringMonitorImpl implements KeyringMonitor {
 
     /** Trace service */
-    private static final TraceComponent tc = Tr.register(KeyringMonitorImpl.class);
+    private static final TraceComponent tc = Tr.register(KeyringMonitorImpl.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     private final KeyringBasedActionable actionable;
 
@@ -39,7 +39,7 @@ public class KeyringMonitorImpl implements KeyringMonitor {
      * Registers this KeyringMonitor to start monitoring the specified keyrings
      * by mbean notification.
      *
-     * @param id of keyrings to monitor.
+     * @param id      of keyrings to monitor.
      * @param trigger what trigger the keyring update notification mbean
      * @return The <code>KeyringMonitor</code> service registration.
      */

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/KeystoreConfig.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/KeystoreConfig.java
@@ -29,7 +29,7 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
  */
 public class KeystoreConfig {
     /** Trace service */
-    private static final TraceComponent tc = Tr.register(KeystoreConfig.class);
+    private static final TraceComponent tc = Tr.register(KeystoreConfig.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     private final String pid;
     private final String id;

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/KeystoreConfigurationFactory.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/KeystoreConfigurationFactory.java
@@ -58,7 +58,7 @@ import com.ibm.wsspi.kernel.service.utils.FrameworkState;
            property = { "service.vendor=IBM", "service.pid=com.ibm.ws.ssl.keystore" })
 public class KeystoreConfigurationFactory implements ManagedServiceFactory, FileBasedActionable, KeyringBasedActionable {
     /** Trace service */
-    private static final TraceComponent tc = Tr.register(KeystoreConfigurationFactory.class);
+    private static final TraceComponent tc = Tr.register(KeystoreConfigurationFactory.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     private final AtomicServiceReference<WsLocationAdmin> locSvc = new AtomicServiceReference<WsLocationAdmin>("LocMgr");
     private final ConcurrentHashMap<String, KeystoreConfig> keyConfigs = new ConcurrentHashMap<String, KeystoreConfig>();

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/RepertoireConfigService.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/RepertoireConfigService.java
@@ -31,7 +31,7 @@ import com.ibm.ws.ssl.config.SSLConfigManager;
            service = { RepertoireConfigService.class, com.ibm.wsspi.ssl.SSLConfiguration.class },
            property = "service.vendor=IBM")
 public class RepertoireConfigService extends GenericSSLConfigService implements com.ibm.wsspi.ssl.SSLConfiguration {
-    private static final TraceComponent tc = Tr.register(RepertoireConfigService.class);
+    private static final TraceComponent tc = Tr.register(RepertoireConfigService.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     private String id = "unknownConfig";
 

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/SSLComponent.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/SSLComponent.java
@@ -69,7 +69,7 @@ public class SSLComponent extends GenericSSLConfigService implements SSLSupportO
     /** Key that reference clients use to target an active SSL component */
     private static final String SSL_SUPPORT_KEY = "SSLSupport";
 
-    private static final TraceComponent tc = Tr.register(SSLComponent.class);
+    private static final TraceComponent tc = Tr.register(SSLComponent.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     protected static final String MY_ALIAS = "sslDefault";
 
@@ -281,8 +281,7 @@ public class SSLComponent extends GenericSSLConfigService implements SSLSupportO
      * Remove the reference to the location manager:
      * required service, do nothing.
      */
-    protected void unsetLocMgr(ServiceReference<WsLocationAdmin> ref) {
-    }
+    protected void unsetLocMgr(ServiceReference<WsLocationAdmin> ref) {}
 
     @Reference(service = FeatureProvisioner.class)
     protected synchronized void setKernelProvisioner(FeatureProvisioner provisionerService) {

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/SSLSupportImpl.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/SSLSupportImpl.java
@@ -44,7 +44,7 @@ public class SSLSupportImpl implements SSLSupport {
     private SSLSupportOptional delegate;
     private Map<String, Object> props;
     private volatile ServiceRegistration<SSLSupport> registration;
-    private static final TraceComponent tc = Tr.register(SSLSupportImpl.class);
+    private static final TraceComponent tc = Tr.register(SSLSupportImpl.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
     public SSLSupportImpl() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {

--- a/dev/com.ibm.ws.timedexit/src/com/ibm/ws/timedexit/internal/TimedExitComponent.java
+++ b/dev/com.ibm.ws.timedexit/src/com/ibm/ws/timedexit/internal/TimedExitComponent.java
@@ -21,14 +21,14 @@ import com.ibm.wsspi.kernel.service.utils.FrameworkState;
 /**
  * A declarative services component can be completely POJO based
  * (no awareness/use of OSGi services).
- * 
+ *
  * OSGi methods (activate/deactivate) should be protected.
  */
 public class TimedExitComponent implements org.osgi.framework.BundleActivator {
 
     private final TimedExitThread mash = new TimedExitThread();
 
-    private static TraceComponent tc = Tr.register(TimedExitComponent.class);
+    private static TraceComponent tc = Tr.register(TimedExitComponent.class, "timedexit", "com.ibm.ws.timedexit.internal.resources.TimedExitMessages");
 
     @Override
     public void start(BundleContext context) {
@@ -56,10 +56,9 @@ public class TimedExitComponent implements org.osgi.framework.BundleActivator {
         // shutdown processing!
 
         if (!FrameworkState.isStopping()) {
-            Throwable ex = new RequiredTimedExitFeatureStoppedException(
-                            "The timedexit-1.0 feature is being stopped before the server is stopping.  " +
-                                            "It must be enabled during ALL FAT bucket runs; make sure that" +
-                                            " fatTestPorts.xml is included in the server.xml.");
+            Throwable ex = new RequiredTimedExitFeatureStoppedException("The timedexit-1.0 feature is being stopped before the server is stopping.  " +
+                                                                        "It must be enabled during ALL FAT bucket runs; make sure that" +
+                                                                        " fatTestPorts.xml is included in the server.xml.");
             FFDCFilter.processException(ex, getClass().getName(), "stop");
         }
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/upgrade/H2HandlerImpl.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/upgrade/H2HandlerImpl.java
@@ -32,7 +32,7 @@ import com.ibm.wsspi.http.ee8.Http2InboundConnection;
  */
 public class H2HandlerImpl implements H2Handler {
 
-    private static final TraceComponent tc = Tr.register(H2HandlerImpl.class);
+    private static final TraceComponent tc = Tr.register(H2HandlerImpl.class,null);
 
     /**
      * Determines if a given request is an http2 upgrade request

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/GeneratePluginConfigMBean.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/GeneratePluginConfigMBean.java
@@ -37,7 +37,8 @@ import com.ibm.wsspi.webcontainer.osgi.mbeans.GeneratePluginConfig;
 public class GeneratePluginConfigMBean extends StandardMBean implements GeneratePluginConfig, com.ibm.websphere.webcontainer.GeneratePluginConfigMBean, PluginUtilityConfigGenerator, ServerQuiesceListener  {
     private static final String DEFAULT_SERVER_NAME = "defaultServer";
     
-    private static final TraceComponent tc = Tr.register(GeneratePluginConfigMBean.class);
+    private static final TraceComponent tc = Tr.register(GeneratePluginConfigMBean.class,com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants.TR_GROUP,
+                                                         com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants.NLS_PROPS);
 
     /** Required, static reference to the module runtime container */
     private ModuleRuntimeContainer webContainer;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -83,7 +83,8 @@ import com.ibm.wsspi.webcontainer.osgi.mbeans.GeneratePluginConfig;
  */
 public class PluginGenerator {
 
-    private static final TraceComponent tc = Tr.register(PluginGenerator.class);
+    private static final TraceComponent tc = Tr.register(PluginGenerator.class,com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants.TR_GROUP,
+                                                         com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants.NLS_PROPS);
     private static final String styleSheet =
         " <xsl:stylesheet version=\"1.0\"                                   \n" +
         "     xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">           \n" +

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/webapp/WebApp.java
@@ -103,7 +103,7 @@ import com.ibm.wsspi.webcontainer.util.ThreadContextHelper;
 @SuppressWarnings("unchecked")
 public class WebApp extends com.ibm.ws.webcontainer.webapp.WebApp implements ComponentNameSpaceConfigurationProvider
 {
-  private static final TraceComponent tc = Tr.register(WebApp.class);
+  private static final TraceComponent tc = Tr.register(WebApp.class,com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants.TR_GROUP, com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants.NLS_PROPS);
   protected static final String CLASS_NAME = "com.ibm.ws.webcontainer.osgi.webapp.WebApp";
 
 


### PR DESCRIPTION
Trace injection perf fixes.

This PR changes the Trace instrumentation code to look for the Tr.register static calls, and change the signature used to pass the info gathered by the @TraceOptions annotation.  This change results in significant reduction in startup time because this is called by 1000's of classes.

This change encountered many obstacles because injection isn't always enabled - is also filtered out for different cases, and didn't behave properly for inherited classes for example.   So Many of these changes are manually changing the problematic classes to use the new signature.
