### PR TITLE
REST endpoints for app-defined datasource in java:global

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
@@ -9,9 +9,11 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.config=all:RRA=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
+com.ibm.ws.logging.trace.specification=*=info:rest.config=all:rest.validator=all:RRA=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 derby.connection.requireAuthentication=true
 derby.user.dbuser1=dbpwd1
 derby.user.dbuser2=dbpwd2
+derby.user.dbuser3=dbpwd3
+derby.user.dbuser4=dbpwd4

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -46,7 +46,13 @@ import componenttest.app.FATServlet;
                                                }),
                          @DataSourceDefinition(name = "java:comp/env/jdbc/ds3",
                                                className = "org.apache.derby.jdbc.EmbeddedDataSource",
-                                               databaseName = "memory:thirddb;create=true")
+                                               databaseName = "memory:thirddb;create=true"),
+                         @DataSourceDefinition(name = "java:global/env/jdbc/ds4",
+                                               className = "", // infer class name
+                                               databaseName = "memory:fourthdb",
+                                               properties = "createDatabase=create",
+                                               user = "dbuser4",
+                                               password = "dbpwd4")
 })
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/AppDefinedResourcesServlet")


### PR DESCRIPTION
Test the /config/ and /validator/ REST endpoints for an app-defined DataSource in the java:global namespace.