### PR TITLE
Issue #7540: Fix EJB Remote FAT with Java 11

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/build.gradle
@@ -24,6 +24,8 @@ configurations {
 
 dependencies {
   ejbTools 'test:com.ibm.ws.ejbcontainer.fat_tools:1.+'
+  // Dependencies needed for when running on Java 9 (EE-type APIs were removed from JDK)
+  requiredLibs 'com.ibm.ws.org.apache.yoko:yoko-spec-corba:1.5.+'
 }
 
 task addEJBTools {


### PR DESCRIPTION
While the ejbRemote feature adds the CORBA APIs to the server process,
the junit client does not have access to them since they have been removed
from the JDK.

Updated to include the CORBA APIs on the junit classpath

fixes #7540 