### PR TITLE
fix authentication error on transaction recovery

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
@@ -31,7 +31,7 @@
     <DATASOURCE transactional="false">
       <connectionManager maxPoolSize="5" connectionTimeout="0s"/>
       <jdbcDriver libraryRef="Derby"/>
-   	  <properties.derby.embedded databaseName="memory:recoverydb" createDatabase="create"/>
+   	  <properties.derby.embedded databaseName="memory:recoverydb" createDatabase="create" user="dbuser1" password="dbpwd1"/>
     </DATASOURCE>
   </transaction>
 


### PR DESCRIPTION
After pulling in the latest changes from integration I found the following test to be failing:

com.ibm.ws.rest.handler.config.fat.ConfigRESTHandlerAppDefinedResourcesTest
```
Errors/warnings were found in server com.ibm.ws.rest.handler.config.appdef.fat logs: <br>[5/17/19, 9:18:34:865 CDT] 00000058 com.ibm.tx.jta.impl.RecoveryManager E WTRN0112E: An unexpected error occured whilst opening the recovery log. The log configuration was SQLMultiScopeRecoveryLog:serverName=com.ibm.ws.rest.handler.config.appdef.fat:clientName=transaction:clientVersion=1:logName=tranlog:logIdentifier=1 @1103141042 
```

This happens because a data source that was added under #7268 for transaction recovery fails to connect to the Derby database because it lacks a user/password.

```
[5/17/19, 9:05:34:932 CDT] 00000058 ibm.ws.recoverylog.custom.jdbc.impl.SQLMultiScopeRecoveryLog I CWRLS0009_RECOVERY_LOG_FAILED_DETAIL 
                                                                                                               java.sql.SQLNonTransientException: Connection authentication failure occurred.  Reason: Invalid authentication.. DSRA0010E: SQL State = 08004, Error Code = 40,000
	at org.apache.derby.impl.jdbc.SQLExceptionFactory.getSQLException(Unknown Source)
	at org.apache.derby.impl.jdbc.SQLExceptionFactory.getSQLException(Unknown Source)
	at org.apache.derby.impl.jdbc.Util.generateCsSQLException(Unknown Source)
	at org.apache.derby.impl.jdbc.Util.generateCsSQLException(Unknown Source)
	at org.apache.derby.impl.jdbc.EmbedConnection.newSQLException(Unknown Source)
	at org.apache.derby.impl.jdbc.EmbedConnection.checkUserCredentials(Unknown Source)
	at org.apache.derby.impl.jdbc.EmbedConnection.<init>(Unknown Source)
	at org.apache.derby.jdbc.InternalDriver.getNewEmbedConnection(Unknown Source)
	at org.apache.derby.jdbc.InternalDriver.connect(Unknown Source)
	at org.apache.derby.jdbc.BasicEmbeddedDataSource40.getConnection(Unknown Source)
	at org.apache.derby.jdbc.EmbedPooledConnection.openRealConnection(Unknown Source)
	at org.apache.derby.jdbc.EmbedPooledConnection.<init>(Unknown Source)
	at org.apache.derby.jdbc.InternalDriver.getNewPooledConnection(Unknown Source)
	at org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource.createPooledConnection(Unknown Source)
	at org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource.getPooledConnection(Unknown Source)
	at com.ibm.ws.rsadapter.impl.DatabaseHelper$1.run(DatabaseHelper.java:955)
	at com.ibm.ws.rsadapter.impl.DatabaseHelper$1.run(DatabaseHelper.java:941)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:703)
	at com.ibm.ws.rsadapter.impl.DatabaseHelper.getPooledConnection(DatabaseHelper.java:941)
	at com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl.getConnection(WSManagedConnectionFactoryImpl.java:824)
	at com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl.createManagedConnection(WSManagedConnectionFactoryImpl.java:665)
	at com.ibm.ejs.j2c.FreePool.createManagedConnectionWithMCWrapper(FreePool.java:1372)
	at com.ibm.ejs.j2c.FreePool.createOrWaitForConnection(FreePool.java:1246)
	at com.ibm.ejs.j2c.PoolManager.reserve(PoolManager.java:1465)
	at com.ibm.ejs.j2c.ConnectionManager.allocateMCWrapper(ConnectionManager.java:581)
	at com.ibm.ejs.j2c.ConnectionManager.allocateConnection(ConnectionManager.java:314)
	at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:138)
	at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:112)
	at com.ibm.ws.recoverylog.custom.jdbc.impl.SQLMultiScopeRecoveryLog.getConnection(SQLMultiScopeRecoveryLog.java:979)
	at com.ibm.ws.recoverylog.custom.jdbc.impl.SQLMultiScopeRecoveryLog.openLog(SQLMultiScopeRecoveryLog.java:480)
	at com.ibm.tx.jta.impl.RecoveryManager.run(RecoveryManager.java:1703)
	at java.base/java.lang.Thread.run(Thread.java:825)
Caused by: ERROR 08004: Connection authentication failure occurred.  Reason: Invalid authentication..
	at org.apache.derby.iapi.error.StandardException.newException(Unknown Source)
	at org.apache.derby.impl.jdbc.SQLExceptionFactory.wrapArgsForTransportAcrossDRDA(Unknown Source)
	... 32 more
```