### PR TITLE
match up the impl for the config and validator REST handlers so that they can later be consolidated

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
@@ -53,7 +53,12 @@ import com.ibm.wsspi.validator.Validator;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
            service = { Validator.class },
-           property = { "service.vendor=IBM", "com.ibm.wsspi.rest.handler.root=/validation", "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.connectionFactory.supertype" })
+           property = { "service.vendor=IBM", "com.ibm.wsspi.rest.handler.root=/validation",
+                        "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.connectionFactory",
+                        "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.jmsConnectionFactory",
+                        "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.jmsQueueConnectionFactory",
+                        "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.jmsTopicConnectionFactory"
+           })
 public class ConnectionFactoryValidator implements Validator {
     private final static TraceComponent tc = Tr.register(ConnectionFactoryValidator.class);
 

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
@@ -123,6 +123,7 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
             try {
                 return AccessController.doPrivileged(new PrivilegedExceptionAction<ServiceReference<?>[]>() {
                     @Override
+                    @Trivial
                     public ServiceReference<?>[] run() throws InvalidSyntaxException {
                         return bCtx.getServiceReferences(clazz, filter);
                     }
@@ -143,6 +144,7 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
         } else
             return AccessController.doPrivileged(new PrivilegedAction<S>() {
                 @Override
+                @Trivial
                 public S run() {
                     BundleContext bCtx = ctx.getBundleContext();
                     return bCtx == null ? null : bCtx.getService(reference);
@@ -176,7 +178,9 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
         // Obtain the instance to validate
         ServiceReference<?>[] targetRefs;
         try {
-            String filter = FilterUtils.createPropertyFilter("service.pid", (String) config.get("service.pid"));
+            String filter = "(|" + FilterUtils.createPropertyFilter("service.pid", (String) config.get("service.pid")) // config without super type
+                           + FilterUtils.createPropertyFilter("ibm.extends.subtype.pid", (String) config.get("service.pid")) // config with super type
+                           + ")";
             targetRefs = getServiceReferences(context.getBundleContext(), (String) null, filter);
         } catch (InvalidSyntaxException x) {
             targetRefs = null; // same error handling as not found

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/bootstrap.properties
@@ -9,6 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.validator=all:com.ibm.ws.jca.service.ConnectionFactoryService=all:com.ibm.ejs.j2c.MCWrapper=all
+com.ibm.ws.logging.trace.specification=*=info:config.rest=all:rest.validator=all:com.ibm.ws.jca.service.ConnectionFactoryService=all:com.ibm.ejs.j2c.MCWrapper=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/bootstrap.properties
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.validator=all:com.ibm.ws.jdbc.DataSourceService=all
+com.ibm.ws.logging.trace.specification=*=info:config.rest=all:rest.validator=all:com.ibm.ws.jdbc.DataSourceService=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 derby.connection.requireAuthentication=true

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/bootstrap.properties
@@ -9,6 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.validator=all:com.ibm.ws.jca.service.ConnectionFactoryService=all
+com.ibm.ws.logging.trace.specification=*=info:config.rest=all:rest.validator=all:com.ibm.ws.jca.service.ConnectionFactoryService=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/bootstrap.properties
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.validator=all:com.ibm.ws.jdbc.DataSourceService=all
+com.ibm.ws.logging.trace.specification=*=info:config.rest=all:rest.validator=all:com.ibm.ws.jdbc.DataSourceService=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 derby.connection.requireAuthentication=true


### PR DESCRIPTION
As a first step toward consolidation of ConfigBasedRESTHandler and ConfigRESTHandler, merge the two approaches as much as possible such that the two are no longer taking divergent (and incompatible) paths for identifying the config elements to validator/display.  A future pull will perform the actual consolidation.