### PR TITLE
Use more easily consumable output for checkForUpdates task

### DIFF
--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -413,8 +413,8 @@ task checkForUpdates() {
       totalArtifacts++
       def (g,a,v) = line.split(':').collect { it.trim() }
       g = g.replace('.','/')
-      println '### g=' + g + '   a=' + a + '  v=' + v
-      println '  checking http://central.maven.org/maven2/' + g + '/' + a + '/maven-metadata.xml'
+      //println '### g=' + g + '   a=' + a + '  v=' + v
+      //println '  checking http://central.maven.org/maven2/' + g + '/' + a + '/maven-metadata.xml'
       def response = new URL('http://central.maven.org/maven2/' + g + '/' + a + '/maven-metadata.xml').text
       def mavenMetadata = xmlParser.parseText(response)
       VersionString currentVersion = new VersionString(v)
@@ -427,9 +427,7 @@ task checkForUpdates() {
          }
       }
       if (!possibleUpdate.raw.equals(currentVersion.raw)) {
-        println '  current version: ' + v
-        println '  latest released: ' + mavenMetadata.versioning.release
-        println '  found possible update at version=' + possibleUpdate.raw
+        println(sprintf("%-60s --> %s", line, possibleUpdate.raw))
         possibleUpdates++;
       }
     }


### PR DESCRIPTION
Update the `./gradlew :cnf:checkForUpdates` task to produce nicer one-dep-per-line output such as:

```
$ ./gradlew :cnf:checkForUpdates

> Task :cnf:checkForUpdates
biz.aQute.bnd:biz.aQute.bnd:4.1.0                            --> 4.2.0
biz.aQute.bnd:biz.aQute.bnd.annotation:4.1.0                 --> 4.2.0
com.fasterxml:classmate:1.3.4                                --> 1.5.0
com.fasterxml.jackson.core:jackson-annotations:2.2.3         --> 2.9.9
com.fasterxml.jackson.core:jackson-annotations:2.4.1         --> 2.9.9
com.fasterxml.jackson.core:jackson-annotations:2.9.1         --> 2.9.9
com.fasterxml.jackson.core:jackson-core:2.2.3                --> 2.9.9
com.fasterxml.jackson.core:jackson-core:2.4.1                --> 2.9.9
com.fasterxml.jackson.core:jackson-core:2.9.1                --> 2.9.9
com.fasterxml.jackson.core:jackson-databind:2.2.3            --> 2.9.9
com.fasterxml.jackson.core:jackson-databind:2.4.1            --> 2.9.9
com.fasterxml.jackson.core:jackson-databind:2.9.1            --> 2.9.9
com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.1 --> 2.9.9
com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.4.1         --> 2.9.9
com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.4.1 --> 2.9.9
com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.4.1 --> 2.9.9
com.google.code.gson:gson:2.2.4                              --> 2.8.5
com.netflix.archaius:archaius2-api:2.1.10                    --> 2.3.14
```