### PR TITLE
rebase ConfigRESTHandler onto ConfigBasedRESTHandler

### DIFF
--- a/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
+++ b/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
@@ -73,9 +73,7 @@ public abstract class ConfigBasedRESTHandler implements RESTHandler {
      *
      * @return the portion of the API root following /ibm/api
      */
-    public String getAPIRoot() {
-        return "/validator"; // TODO remove this and make abstract once all other code is updated
-    }
+    public abstract String getAPIRoot();
 
     /**
      * Returns the most deeply nested element name.
@@ -167,7 +165,7 @@ public abstract class ConfigBasedRESTHandler implements RESTHandler {
             if (uid.length() == 0)
                 uid = null;
         }
-        String elementName = URLDecoder.decode(path.substring(apiRoot.length() + 1, endElementName), "UTF-8");
+        String elementName = path.length() < (apiRoot.length() + 1) ? "" : URLDecoder.decode(path.substring(apiRoot.length() + 1, endElementName), "UTF-8");
 
         StringBuilder filter = new StringBuilder("(&");
         if (uid != null && (uid.startsWith(elementName + "[default-") || uid.matches(".*/.*\\[.*\\].*")))


### PR DESCRIPTION
ConfigRESTHandler duplicates a lot of code from ConfigBasedRESTHandler.  The latter was intended to be a common implementation for configuration-based REST endpoints, so we ought to be using it for the former. This will also eliminate the possibility that the two become out of sync again.