### PR TITLE
NullPointerException when transaction support not specified by resource adapter

### DIFF
--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
@@ -375,6 +375,10 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
                                                    + ", " + Connector.class.getName() + ':' + ddTransactionSupport);
         }
 
+        // Otherwise choose NoTransaction
+        if (transactionSupport == null)
+            transactionSupport = TransactionSupportLevel.NoTransaction;
+
         if (connectionFactoryTransactionSupport != null) {
             if (connectionFactoryTransactionSupport.ordinal() > transactionSupport.ordinal())
                 throw new IllegalArgumentException(ManagedConnectionFactory.class.getName() + ':' + transactionSupport
@@ -383,8 +387,7 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
                 transactionSupport = connectionFactoryTransactionSupport;
         }
 
-        // Otherwise choose NoTransaction
-        return transactionSupport == null ? TransactionSupportLevel.NoTransaction : transactionSupport;
+        return transactionSupport;
     }
 
     @Override


### PR DESCRIPTION
NullPointerException occurs when a connection factory specifies transaction support, but the resource adapter does not specify transaction support  (meaning it should be considered to not support transactions).

In this case, the connection factory definition ought to be able to specify a transaction support level of none, but instead a NullPointerException occurs.
If the connection factory definition specifies a higher value, a meaningful error ought to be issued for the mismatch, but instead, a NullPointerException occurs.
This is especially problematic for `@ConnectionFactoryDefinition`, where there is always a value for transaction support level, making resource adapters that do not specify transaction support unusable.

```
java.lang.NullPointerException
	at com.ibm.ws.jca.service.ConnectionFactoryService.getTransactionSupport(ConnectionFactoryService.java:379)
	at com.ibm.ejs.j2c.J2CGlobalConfigProperties.<init>(J2CGlobalConfigProperties.java:395)
	at com.ibm.ejs.j2c.ConnectionManagerServiceImpl.processServerPoolManagerProperties(ConnectionManagerServiceImpl.java:553)
	at com.ibm.ejs.j2c.ConnectionManagerServiceImpl.createPoolManager(ConnectionManagerServiceImpl.java:189)
	at com.ibm.ejs.j2c.ConnectionManagerServiceImpl.getConnectionManager(ConnectionManagerServiceImpl.java:358)
	at com.ibm.ejs.j2c.ConnectionManagerServiceImpl.getConnectionManager(ConnectionManagerServiceImpl.java:51)
	at com.ibm.ws.jca.cm.AbstractConnectionFactoryService$1.run(AbstractConnectionFactoryService.java:155)
	at com.ibm.ws.jca.cm.AbstractConnectionFactoryService$1.run(AbstractConnectionFactoryService.java:152)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:703)
	at com.ibm.ws.jca.cm.AbstractConnectionFactoryService.createResource(AbstractConnectionFactoryService.java:152)
	at com.ibm.ws.rest.handler.validator.jca.ConnectionFactoryValidator.validate(ConnectionFactoryValidator.java:165)
	at com.ibm.ws.rest.handler.validator.internal.ValidatorRESTHandler.handleSingleInstance(ValidatorRESTHandler.java:231)
	at com.ibm.wsspi.rest.config.ConfigBasedRESTHandler.handleRequest(ConfigBasedRESTHandler.java:276)
	at com.ibm.ws.rest.handler.internal.service.RESTHandlerContainerImpl.handleRequest(RESTHandlerContainerImpl.java:453)
	at com.ibm.ws.rest.handler.internal.servlet.RESTProxyServlet.handleWithDelegate(RESTProxyServlet.java:119)
	at com.ibm.ws.rest.handler.internal.servlet.RESTProxyServlet.service(RESTProxyServlet.java:64)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1255)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:743)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:440)
	at com.ibm.ws.webcontainer.filter.WebAppFilterChain.invokeTarget(WebAppFilterChain.java:182)
	at com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:93)
	at com.ibm.ws.app.manager.wab.internal.OsgiDirectoryProtectionFilter.doFilter(OsgiDirectoryProtectionFilter.java:90)
	at com.ibm.ws.webcontainer.filter.FilterInstanceWrapper.doFilter(FilterInstanceWrapper.java:201)
	at com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:90)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.doFilter(WebAppFilterManager.java:996)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1134)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1005)
	at com.ibm.ws.webcontainer.servlet.CacheServletWrapper.handleRequest(CacheServletWrapper.java:75)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:938)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1061)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:417)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:376)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:532)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:466)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:331)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:302)
	at com.ibm.ws.channel.ssl.internal.SSLConnectionLink.determineNextChannel(SSLConnectionLink.java:1058)
	at com.ibm.ws.channel.ssl.internal.SSLConnectionLink$MyReadCompletedCallback.complete(SSLConnectionLink.java:644)
	at com.ibm.ws.channel.ssl.internal.SSLReadServiceContext$SSLReadCompletedCallback.complete(SSLReadServiceContext.java:1803)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:503)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:573)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:954)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1043)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:239)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:825)
```