### PR TITLE
Rename opentracing-mock test bundle names

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATSuite.java
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATSuite.java
@@ -36,8 +36,8 @@ import componenttest.topology.impl.LibertyServerFactory;
 })
 public class FATSuite implements FATOpentracingConstants {
     private static final Class<? extends FATSuite> CLASS = FATSuite.class;
-    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.31.mf";
-    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-0.31.jar";
+    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-1.1.mf";
+    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-1.1.jar";
 
     private static void info(String methodName, String text) {
         FATLogging.info(CLASS, methodName, text);

--- a/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
@@ -27,8 +27,8 @@ import componenttest.topology.utils.MvnUtils;
 @RunWith(FATRunner.class)
 public class OpentracingTCKLauncher {
 
-    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.31.mf";
-    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-0.31.jar";
+    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-1.1.mf";
+    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-1.1.jar";
 
     @Server("OpentracingTCKServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.opentracing.1.1_fat/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/opentracing.mock.bnd
@@ -14,8 +14,8 @@ bVersion=1.0
 javac.source: 1.8
 javac.target: 1.8
 
-Bundle-Name: com.ibm.ws.opentracing.mock-0.31
-Bundle-SymbolicName: com.ibm.ws.opentracing.mock-0.31
+Bundle-Name: com.ibm.ws.opentracing.mock-1.1
+Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.1
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory

--- a/dev/com.ibm.ws.opentracing.1.1_fat/publish/files/features/com.ibm.ws.opentracing.mock-1.1.mf
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/publish/files/features/com.ibm.ws.opentracing.mock-1.1.mf
@@ -1,10 +1,9 @@
 IBM-Feature-Version: 2
-IBM-ShortName: opentracingMock-0.31
+IBM-ShortName: opentracingMock-1.1
 Subsystem-Content: com.ibm.websphere.appserver.opentracing-1.1; type="osgi.subsystem.feature",
- com.ibm.ws.opentracing.mock-0.31; version="[1.0.0,1.0.200)"
+ com.ibm.ws.opentracing.mock-1.1; version="[1.0.0,1.0.200)"
 Subsystem-License: https://www.eclipse.org/legal/epl-v10.html
 Subsystem-ManifestVersion: 1
-Subsystem-SymbolicName: com.ibm.ws.opentracing.mock-0.31; visibility:=public; singleton:=true
+Subsystem-SymbolicName: com.ibm.ws.opentracing.mock-1.1; visibility:=public; singleton:=true
 Subsystem-Type: osgi.subsystem.feature
 Subsystem-Version: 1.0.0
-

--- a/dev/com.ibm.ws.opentracing.1.1_fat/publish/servers/OpentracingTCKServer/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/publish/servers/OpentracingTCKServer/server.xml
@@ -15,7 +15,7 @@
         <feature>cdi-1.2</feature>
 	<feature>opentracing-1.1</feature>
 	<feature>mpOpenTracing-1.1</feature>
-	<feature>usr:opentracingMock-0.31</feature>
+	<feature>usr:opentracingMock-1.1</feature>
 	<feature>arquillian-support-1.0</feature>
     </featureManager>
 

--- a/dev/com.ibm.ws.opentracing.1.1_fat/publish/servers/opentracingFATServer1/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/publish/servers/opentracingFATServer1/server.xml
@@ -3,7 +3,7 @@
   <featureManager>
     <feature>servlet-3.1</feature>
     <feature>opentracing-1.1</feature>
-    <feature>usr:opentracingMock-0.31</feature>
+    <feature>usr:opentracingMock-1.1</feature>
     <feature>componenttest-1.0</feature>
   </featureManager>
 

--- a/dev/com.ibm.ws.opentracing.1.1_fat/publish/servers/opentracingFATServer3/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/publish/servers/opentracingFATServer3/server.xml
@@ -4,7 +4,7 @@
     <feature>componenttest-1.0</feature>
     <feature>jaxrs-2.0</feature>
     <feature>opentracing-1.1</feature>
-    <feature>usr:opentracingMock-0.31</feature>
+    <feature>usr:opentracingMock-1.1</feature>
     <feature>mpOpenTracing-1.1</feature>
   </featureManager>
 

--- a/dev/com.ibm.ws.opentracing.1.2_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATSuite.java
+++ b/dev/com.ibm.ws.opentracing.1.2_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATSuite.java
@@ -36,8 +36,8 @@ import componenttest.topology.impl.LibertyServerFactory;
 })
 public class FATSuite implements FATOpentracingConstants {
     private static final Class<? extends FATSuite> CLASS = FATSuite.class;
-    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.31.mf";
-    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-0.31.jar";
+    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-1.2.mf";
+    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-1.2.jar";
 
     private static void info(String methodName, String text) {
         FATLogging.info(CLASS, methodName, text);

--- a/dev/com.ibm.ws.opentracing.1.2_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.opentracing.1.2_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
@@ -27,8 +27,8 @@ import componenttest.topology.utils.MvnUtils;
 @RunWith(FATRunner.class)
 public class OpentracingTCKLauncher {
 
-    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.31.mf";
-    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-0.31.jar";
+    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-1.2.mf";
+    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-1.2.jar";
 
     @Server("OpentracingTCKServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.opentracing.1.2_fat/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.opentracing.1.2_fat/opentracing.mock.bnd
@@ -14,8 +14,8 @@ bVersion=1.0
 javac.source: 1.8
 javac.target: 1.8
 
-Bundle-Name: com.ibm.ws.opentracing.mock-0.31
-Bundle-SymbolicName: com.ibm.ws.opentracing.mock-0.31
+Bundle-Name: com.ibm.ws.opentracing.mock-1.2
+Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.2
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory

--- a/dev/com.ibm.ws.opentracing.1.2_fat/publish/files/features/com.ibm.ws.opentracing.mock-1.2.mf
+++ b/dev/com.ibm.ws.opentracing.1.2_fat/publish/files/features/com.ibm.ws.opentracing.mock-1.2.mf
@@ -1,10 +1,10 @@
 IBM-Feature-Version: 2
-IBM-ShortName: opentracingMock-0.31
+IBM-ShortName: opentracingMock-1.2
 Subsystem-Content: com.ibm.websphere.appserver.opentracing-1.2; type="osgi.subsystem.feature",
- com.ibm.ws.opentracing.mock-0.31; version="[1.0.0,1.0.200)"
+ com.ibm.ws.opentracing.mock-1.2; version="[1.0.0,1.0.200)"
 Subsystem-License: https://www.eclipse.org/legal/epl-v10.html
 Subsystem-ManifestVersion: 1
-Subsystem-SymbolicName: com.ibm.ws.opentracing.mock-0.31; visibility:=public; singleton:=true
+Subsystem-SymbolicName: com.ibm.ws.opentracing.mock-1.2; visibility:=public; singleton:=true
 Subsystem-Type: osgi.subsystem.feature
 Subsystem-Version: 1.0.0
 

--- a/dev/com.ibm.ws.opentracing.1.2_fat/publish/servers/OpentracingTCKServer/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.2_fat/publish/servers/OpentracingTCKServer/server.xml
@@ -1,11 +1,8 @@
-<!--Copyright (c) 2017 IBM Corporation and others. All rights reserved.
-    This program and the accompanying materials are made available under the 
-    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-    and is available at 
-        http://www.eclipse.org/legal/epl-v10.html 
-    Contributors: 
-        IBM Corporation - initial API and implementation
--->
+<!--Copyright (c) 2017 IBM Corporation and others. All rights reserved. This 
+    program and the accompanying materials are made available under the terms 
+    of the Eclipse Public License v1.0 which accompanies this distribution, and 
+    is available at http://www.eclipse.org/legal/epl-v10.html Contributors: IBM 
+    Corporation - initial API and implementation -->
 <server>
     <featureManager>
         <feature>servlet-3.1</feature>
@@ -13,16 +10,19 @@
         <feature>webProfile-7.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>cdi-1.2</feature>
-	<feature>opentracing-1.2</feature>
-	<feature>mpOpenTracing-1.2</feature>
-	<feature>usr:opentracingMock-0.31</feature>
-	<feature>arquillian-support-1.0</feature>
+        <feature>opentracing-1.2</feature>
+        <feature>mpOpenTracing-1.2</feature>
+        <feature>usr:opentracingMock-1.2</feature>
+        <feature>arquillian-support-1.0</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml" />
 
-    <!--Java2 security-->
-    <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
+    <!--Java2 security -->
+    <javaPermission
+        className="java.security.AllPermission" name="*" actions="*" />
 
-    <logging traceSpecification="*=info:com.ibm.ws.opentracing*=all:com.ibm.ws.microprofile.opentracing*=all" maxFileSize="100" maxFiles="1" />
+    <logging
+        traceSpecification="*=info:com.ibm.ws.opentracing*=all:com.ibm.ws.microprofile.opentracing*=all"
+        maxFileSize="100" maxFiles="1" />
 </server>

--- a/dev/com.ibm.ws.opentracing.1.2_fat/publish/servers/opentracingFATServer1/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.2_fat/publish/servers/opentracingFATServer1/server.xml
@@ -3,7 +3,7 @@
   <featureManager>
     <feature>servlet-3.1</feature>
     <feature>opentracing-1.2</feature>
-    <feature>usr:opentracingMock-0.31</feature>
+    <feature>usr:opentracingMock-1.2</feature>
     <feature>componenttest-1.0</feature>
   </featureManager>
 

--- a/dev/com.ibm.ws.opentracing.1.2_fat/publish/servers/opentracingFATServer3/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.2_fat/publish/servers/opentracingFATServer3/server.xml
@@ -4,7 +4,7 @@
     <feature>componenttest-1.0</feature>
     <feature>jaxrs-2.0</feature>
     <feature>opentracing-1.2</feature>
-    <feature>usr:opentracingMock-0.31</feature>
+    <feature>usr:opentracingMock-1.2</feature>
     <feature>mpOpenTracing-1.2</feature>
   </featureManager>
 

--- a/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATSuite.java
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATSuite.java
@@ -37,8 +37,8 @@ import componenttest.topology.impl.LibertyServerFactory;
 })
 public class FATSuite implements FATOpentracingConstants {
     private static final Class<? extends FATSuite> CLASS = FATSuite.class;
-    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.31.mf";
-    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-0.31.jar";
+    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-1.3.mf";
+    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-1.3.jar";
 
     private static void info(String methodName, String text) {
         FATLogging.info(CLASS, methodName, text);

--- a/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingRestClientTCKLauncher.java
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingRestClientTCKLauncher.java
@@ -29,8 +29,8 @@ import componenttest.topology.utils.MvnUtils;
 @RunWith(FATRunner.class)
 public class OpentracingRestClientTCKLauncher {
 
-    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.31.mf";
-    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-0.31.jar";
+    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-1.3.mf";
+    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-1.3.jar";
 
     @Server("OpentracingRestClientTCKServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
@@ -27,8 +27,8 @@ import componenttest.topology.utils.MvnUtils;
 @RunWith(FATRunner.class)
 public class OpentracingTCKLauncher {
 
-    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-0.31.mf";
-    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-0.31.jar";
+    private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-1.3.mf";
+    private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-1.3.jar";
 
     @Server("OpentracingTCKServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.opentracing.1.3_fat/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/opentracing.mock.bnd
@@ -14,8 +14,8 @@ bVersion=1.0
 javac.source: 1.8
 javac.target: 1.8
 
-Bundle-Name: com.ibm.ws.opentracing.mock-0.31
-Bundle-SymbolicName: com.ibm.ws.opentracing.mock-0.31
+Bundle-Name: com.ibm.ws.opentracing.mock-1.3
+Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.3
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/files/features/com.ibm.ws.opentracing.mock-1.3.mf
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/files/features/com.ibm.ws.opentracing.mock-1.3.mf
@@ -1,10 +1,10 @@
 IBM-Feature-Version: 2
-IBM-ShortName: opentracingMock-0.31
+IBM-ShortName: opentracingMock-1.3
 Subsystem-Content: com.ibm.websphere.appserver.opentracing-1.3; type="osgi.subsystem.feature",
- com.ibm.ws.opentracing.mock-0.31; version="[1.0.0,1.0.200)"
+ com.ibm.ws.opentracing.mock-1.3; version="[1.0.0,1.0.200)"
 Subsystem-License: https://www.eclipse.org/legal/epl-v10.html
 Subsystem-ManifestVersion: 1
-Subsystem-SymbolicName: com.ibm.ws.opentracing.mock-0.31; visibility:=public; singleton:=true
+Subsystem-SymbolicName: com.ibm.ws.opentracing.mock-1.3; visibility:=public; singleton:=true
 Subsystem-Type: osgi.subsystem.feature
 Subsystem-Version: 1.0.0
 

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingRestClientTCKServer/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingRestClientTCKServer/server.xml
@@ -9,7 +9,7 @@
 		<feature>webProfile-8.0</feature>
 		<feature>localConnector-1.0</feature>
 		<feature>mpOpenTracing-1.3</feature>
-		<feature>usr:opentracingMock-0.31</feature>
+		<feature>usr:opentracingMock-1.3</feature>
  		<feature>mpRestClient-1.2</feature>
  		<feature>arquillian-support-1.0</feature>
 	</featureManager>

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServer/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServer/server.xml
@@ -9,7 +9,7 @@
 		<feature>webProfile-8.0</feature>
 		<feature>localConnector-1.0</feature>
 		<feature>mpOpenTracing-1.3</feature>
-		<feature>usr:opentracingMock-0.31</feature>
+		<feature>usr:opentracingMock-1.3</feature>
 		<feature>arquillian-support-1.0</feature>
 	</featureManager>
 

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/opentracingFATServer1/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/opentracingFATServer1/server.xml
@@ -2,7 +2,7 @@
 
 	<featureManager>
 		<feature>opentracing-1.3</feature>
-		<feature>usr:opentracingMock-0.31</feature>
+		<feature>usr:opentracingMock-1.3</feature>
 		<feature>componenttest-1.0</feature>
 	</featureManager>
 

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/opentracingFATServer3/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/opentracingFATServer3/server.xml
@@ -2,7 +2,7 @@
 
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>usr:opentracingMock-0.31</feature>
+    <feature>usr:opentracingMock-1.3</feature>
     <feature>mpOpenTracing-1.3</feature>
   </featureManager>
 

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/tckRunner/tck/pom.xml
@@ -30,7 +30,6 @@
 
         <defaultSuiteFiles>tck-suite.xml</defaultSuiteFiles>
         <suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>
-        <secondSuiteXmlFile>rest-client-tck-suite.xml</secondSuiteXmlFile>
         <targetDirectory>${project.basedir}/target</targetDirectory>
     </properties>
 
@@ -197,7 +196,6 @@
                     </systemPropertyVariables>
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
-                        <suiteXmlFile>${secondSuiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
                     <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
                 </configuration>

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/tckRunner/tck/rest-client-tck-suite.xml
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/tckRunner/tck/rest-client-tck-suite.xml
@@ -10,7 +10,7 @@
 
 <suite name="microprofile-opentracing-1.3-rest-client-tck" verbose="2"
     configfailurepolicy="continue">
-    <test name="tck-package-org.eclipse.microprofile.opentracing.tck">
+    <test name="tck-package-org.eclipse.microprofile.opentracing.tck.rest.client">
         <packages>
             <package name="org.eclipse.microprofile.opentracing.tck.rest.client" />
         </packages>

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/tckRunner/tck/tck-suite.xml
@@ -12,7 +12,7 @@
     configfailurepolicy="continue">
     <test name="tck-package-org.eclipse.microprofile.opentracing.tck">
         <packages>
-         	<package name="org.eclipse.microprofile.opentracing.tck" />
+            <package name="org.eclipse.microprofile.opentracing.tck" />
         </packages>
     </test>
 </suite>


### PR DESCRIPTION
Fixes #7579 

Rename opentracing-mock-0.31 to 1.1, 1.2 and 1.3 to avoid duplication.