### PR TITLE
app-defined connectionfactory props for config rest endpoint

### DIFF
--- a/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
+++ b/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
@@ -148,6 +148,8 @@ public abstract class ConfigBasedRESTHandler implements RESTHandler {
 
         if (requireAdministratorRole() && !request.isUserInRole("Administrator")) {
             response.sendError(403, "Forbidden");
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "handleRequest", "403 Forbidden");
             return;
         }
 

--- a/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/package-info.java
+++ b/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@
  * This package contains the SPI for the configuration-based REST handler extensions.
  */
 @org.osgi.annotation.versioning.Version("1.0")
-@TraceOptions(traceGroup = "config.rest")
+@TraceOptions(traceGroup = "rest.configbased")
 package com.ibm.wsspi.rest.config;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.jca.1.7/src/com/ibm/ws/jca17/processor/service/ConnectionFactoryResourceBuilder.java
+++ b/dev/com.ibm.ws.jca.1.7/src/com/ibm/ws/jca17/processor/service/ConnectionFactoryResourceBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -206,24 +206,37 @@ public class ConnectionFactoryResourceBuilder implements ResourceFactoryBuilder 
 
         Dictionary<String, Object> connectionFactoryDefaultProps = getDefaultProperties(resourceAdapter, interfaceName);
 
+        String configPropsPid = null;
         for (Enumeration<String> keys = connectionFactoryDefaultProps.keys(); keys.hasMoreElements();) {
             String key = keys.nextElement();
             Object value = connectionFactoryDefaultProps.get(key);
 
             //Override the managed connection factory class default property values with values provided annotation
             if (annotationProps.containsKey(key))
-                value = annotationProps.get(key);
+                value = annotationProps.remove(key);
 
             if (value instanceof String)
                 value = variableRegistry.resolveString((String) value);
 
-            connectionFactorySvcProps.put(BASE_PROPERTIES_KEY + key, value);
+            if ("config.displayId".equals(key))
+                connectionFactorySvcProps.put(BASE_PROPERTIES_KEY + "config.referenceType", configPropsPid = (String) value);
+            else
+                connectionFactorySvcProps.put(BASE_PROPERTIES_KEY + key, value);
         }
 
         Object value;
         for (String name : ConnectionManagerService.CONNECTION_MANAGER_PROPS)
             if ((value = annotationProps.remove(name)) != null)
                 cmSvcProps.put(name, value);
+
+        // Add remaining properties
+        WSConfigurationHelper configHelper = wsConfigurationHelperRef.getServiceWithException();
+        for (Map.Entry<String, Object> entry : annotationProps.entrySet()) {
+            String key = entry.getKey();
+            String attrName = configHelper.getMetaTypeAttributeName(configPropsPid, key);
+            if (attrName != null && !"INTERNAL".equalsIgnoreCase(attrName))
+                connectionFactorySvcProps.put(BASE_PROPERTIES_KEY + key, entry.getValue());
+        }
 
         BundleContext bundleContext = AdministeredObjectResourceFactoryBuilder.priv.getBundleContext(FrameworkUtil.getBundle(ConnectionFactoryService.class));
 
@@ -294,9 +307,9 @@ public class ConnectionFactoryResourceBuilder implements ResourceFactoryBuilder 
      * application[MyApp]/module[MyModule]/connectionFactory[java:module/env/jdbc/cf1]
      *
      * @param application application name if data source is in java:app, java:module, or java:comp. Otherwise null.
-     * @param module module name if data source is in java:module or java:comp. Otherwise null.
-     * @param component component name if data source is in java:comp and isn't in web container. Otherwise null.
-     * @param jndiName configured JNDI name for the data source. For example, java:module/env/jca/cf1
+     * @param module      module name if data source is in java:module or java:comp. Otherwise null.
+     * @param component   component name if data source is in java:comp and isn't in web container. Otherwise null.
+     * @param jndiName    configured JNDI name for the data source. For example, java:module/env/jca/cf1
      * @return the unique identifier
      */
     private static final String getConnectionFactoryID(String application, String module, String component, String jndiName) {

--- a/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
@@ -121,10 +121,12 @@ public class ConfigRESTHandler extends ConfigBasedRESTHandler {
         String servicePid = isFactoryPid ? (String) config.get("service.factoryPid") : (String) config.get("service.pid");
         String extendsSourcePid = isFactoryPid ? (String) config.get("ibm.extends.source.factoryPid") : (String) config.get("ibm.extends.source.pid");
 
-        String metaTypeElementName = configHelper.getMetaTypeElementName(extendsSourcePid == null ? servicePid : extendsSourcePid);
-        // if the element's name is internal, no config should be added for that element
-        if (metaTypeElementName != null && metaTypeElementName.equalsIgnoreCase("internal"))
-            return null;
+        if (!isAppDefined) { // App-defined connectionFactory creates a single entry and uses the internal supertype pid
+            String metaTypeElementName = configHelper.getMetaTypeElementName(extendsSourcePid == null ? servicePid : extendsSourcePid);
+            // if the element's name is internal, no config should be added for that element
+            if (metaTypeElementName != null && metaTypeElementName.equalsIgnoreCase("internal"))
+                return null;
+        }
 
         JSONObject json = new OrderedJSONObject();
         json.put("configElementName", configElementName);

--- a/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
@@ -460,6 +460,7 @@ public class ConfigRESTHandler extends ConfigBasedRESTHandler {
     }
 
     @Override
+    @Trivial
     public void populateResponse(RESTResponse response, Object responseInfo) throws IOException {
         JSONArtifact json;
         if (responseInfo instanceof JSONArtifact)
@@ -476,6 +477,10 @@ public class ConfigRESTHandler extends ConfigBasedRESTHandler {
             throw new IllegalArgumentException(responseInfo.toString()); // should be unreachable
 
         String jsonString = json.serialize(true);
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "populateResponse", jsonString);
+
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.getOutputStream().write(jsonString.getBytes("UTF-8"));

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -125,11 +125,24 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "EntirePool", cm.getString("purgePolicy"));
         assertEquals(err, 61, cm.getJsonNumber("reapTime").longValue());
 
-        // TODO containerAuthDataRef?
+        // support for containerAuthDataRef/recoveryAuthDataRef was never added to app-defined connection factories
 
-        // TODO properties
+        // TODO properties should be an object, not an array of objects
+        JsonArray array;
+        assertNotNull(err, array = cf.getJsonArray("properties.ConfigTestAdapter.ConnectionFactory"));
+        assertEquals(err, 1, array.size());
+        JsonObject props;
+        assertNotNull(err, props = array.getJsonObject(0));
+        //assertTrue(err, props.getBoolean("enableBetaContent")); // TODO boolean data type
+        assertEquals(err, "`", props.getString("escapeChar"));
+        assertEquals(err, "localhost", props.getString("hostName"));
+        //assertEquals(err, 1515, props.getInt("portNubmer")); // TODO numeric data type
+        assertEquals(err, "cfuser1", props.getString("userName"));
+        //assertEquals(err, "******", props.getString("password")); // TODO password-named/confidential properties
 
-        // TODO omit internal attributes: creates.objectClass, jndiName.unique, transactionSupport?
+        // TODO api
+
+        // TODO should transactionSupport really show as an attribute of connectionFactory?
     }
 
     /**

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -127,18 +127,14 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
 
         // support for containerAuthDataRef/recoveryAuthDataRef was never added to app-defined connection factories
 
-        // TODO properties should be an object, not an array of objects
-        JsonArray array;
-        assertNotNull(err, array = cf.getJsonArray("properties.ConfigTestAdapter.ConnectionFactory"));
-        assertEquals(err, 1, array.size());
         JsonObject props;
-        assertNotNull(err, props = array.getJsonObject(0));
-        //assertTrue(err, props.getBoolean("enableBetaContent")); // TODO boolean data type
+        assertNotNull(err, props = cf.getJsonObject("properties.ConfigTestAdapter.ConnectionFactory"));
+        assertTrue(err, props.getBoolean("enableBetaContent"));
         assertEquals(err, "`", props.getString("escapeChar"));
         assertEquals(err, "localhost", props.getString("hostName"));
-        //assertEquals(err, 1515, props.getInt("portNubmer")); // TODO numeric data type
+        assertEquals(err, 1515, props.getInt("portNumber"));
         assertEquals(err, "cfuser1", props.getString("userName"));
-        //assertEquals(err, "******", props.getString("password")); // TODO password-named/confidential properties
+        assertEquals(err, "******", props.getString("password"));
 
         // TODO api
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all:com.ibm.ws.jca17.processor.service=all:rarInstall=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 derby.connection.requireAuthentication=true

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.config=all:rest.validator=all:RRA=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 derby.connection.requireAuthentication=true

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
@@ -14,7 +14,8 @@
   <featureManager>
     <feature>componenttest-1.0</feature>
     <feature>configValidator-1.0</feature> <!-- TODO replace when functionality is enabled via auto-feature -->
-    <feature>ejb-3.2</feature>
+    <feature>ejbLite-3.2</feature>
+    <feature>jca-1.7</feature>
     <feature>jdbc-4.2</feature>
   </featureManager>
 
@@ -27,6 +28,8 @@
     <classloader commonLibraryRef="Derby"/>
   </application>
 
+  <resourceAdapter id="ConfigTestAdapter" location="${server.config.dir}/connectors/ConfigTestAdapter.rar"/>
+
   <transaction>
     <DATASOURCE transactional="false">
       <connectionManager maxPoolSize="5" connectionTimeout="0s"/>
@@ -34,6 +37,8 @@
    	  <properties.derby.embedded databaseName="memory:recoverydb" createDatabase="create" user="dbuser1" password="dbpwd1"/>
     </DATASOURCE>
   </transaction>
+
+  <authData id="cfauth1" user="cfuser1" password="1cfuser"/>
 
   <authData id="derbyAuth1" user="dbuser1" password="dbpwd1"/>
   <authData id="derbyAuth2" user="dbuser2" password="dbpwd2"/>

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.fat/bootstrap.properties
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.config=all
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 derby.connection.requireAuthentication=true

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jca.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jca.fat/bootstrap.properties
@@ -9,6 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.config=all:rarInstall=all
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:rarInstall=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jms.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.jms.fat/bootstrap.properties
@@ -9,6 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.config=all:rarInstall=all
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:rarInstall=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -28,10 +28,12 @@ import componenttest.app.FATServlet;
                              resourceAdapter = "ConfigTestAdapter",
                              transactionSupport = TransactionSupportLevel.NoTransaction,
                              maxPoolSize = 101,
-                             properties = { "containerAuthDataRef=cfauth1",
-                                            "escapeCharacter=`",
+                             properties = { "enableBetaContent=true",
+                                            "escapeChar=`",
                                             "portNumber=1515",
-                                            "reapTime=1m1s"
+                                            "reapTime=1m1s",
+                                            "userName=cfuser1",
+                                            "password=cfpwd1"
                              })
 
 @DataSourceDefinitions({

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -16,9 +16,23 @@ import java.util.concurrent.Executor;
 import javax.annotation.sql.DataSourceDefinition;
 import javax.annotation.sql.DataSourceDefinitions;
 import javax.ejb.EJB;
+import javax.resource.ConnectionFactoryDefinition;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
 import javax.servlet.annotation.WebServlet;
 
 import componenttest.app.FATServlet;
+
+@ConnectionFactoryDefinition(name = "java:module/env/eis/cf1",
+                             description = "It is Test ConnectionFactory",
+                             interfaceName = "javax.resource.cci.ConnectionFactory",
+                             resourceAdapter = "ConfigTestAdapter",
+                             transactionSupport = TransactionSupportLevel.NoTransaction,
+                             maxPoolSize = 101,
+                             properties = { "containerAuthDataRef=cfauth1",
+                                            "escapeCharacter=`",
+                                            "portNumber=1515",
+                                            "reapTime=1m1s"
+                             })
 
 @DataSourceDefinitions({
                          @DataSourceDefinition(name = "java:app/env/jdbc/ds1",

--- a/dev/com.ibm.ws.rest.handler.validator.cloudant/src/com/ibm/ws/rest/handler/validator/cloudant/package-info.java
+++ b/dev/com.ibm.ws.rest.handler.validator.cloudant/src/com/ibm/ws/rest/handler/validator/cloudant/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 @Version("1.0.0")
-@TraceOptions(traceGroup = "rest.validator")
+@TraceOptions(traceGroup = "rest.validation")
 package com.ibm.ws.rest.handler.validator.cloudant;
 
 import org.osgi.annotation.versioning.Version;

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/package-info.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 @Version("1.0.0")
-@TraceOptions(traceGroup = "rest.validator")
+@TraceOptions(traceGroup = "rest.validation")
 package com.ibm.ws.rest.handler.validator.jca;
 
 import org.osgi.annotation.versioning.Version;

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jms/package-info.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jms/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 @Version("1.0.0")
-@TraceOptions(traceGroup = "rest.validator")
+@TraceOptions(traceGroup = "rest.validation")
 package com.ibm.ws.rest.handler.validator.jms;
 
 import org.osgi.annotation.versioning.Version;

--- a/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/package-info.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 @Version("1.0.0")
-@TraceOptions(traceGroup = "rest.validator")
+@TraceOptions(traceGroup = "rest.validation")
 package com.ibm.ws.rest.handler.validator.jdbc;
 
 import org.osgi.annotation.versioning.Version;

--- a/dev/com.ibm.ws.rest.handler.validator.openapi/src/com/ibm/ws/rest/handler/validator/openapi/package-info.java
+++ b/dev/com.ibm.ws.rest.handler.validator.openapi/src/com/ibm/ws/rest/handler/validator/openapi/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 @Version("1.0.0")
-@TraceOptions(traceGroup = "rest.validator")
+@TraceOptions(traceGroup = "rest.validation")
 package com.ibm.ws.rest.handler.validator.openapi;
 
 import org.osgi.annotation.versioning.Version;

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
@@ -255,6 +255,7 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
     }
 
     @Override
+    @Trivial
     public void populateResponse(RESTResponse response, Object responseInfo) throws IOException {
         JSONArtifact json;
         if (responseInfo instanceof JSONArtifact)
@@ -271,6 +272,10 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
             throw new IllegalArgumentException(responseInfo.toString()); // should be unreachable
 
         String jsonString = json.serialize(true);
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "populateResponse", jsonString);
+
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.getOutputStream().write(jsonString.getBytes("UTF-8"));

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/package-info.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 @Version("1.0.0")
-@TraceOptions(traceGroup = "rest.validator")
+@TraceOptions(traceGroup = "rest.validation")
 package com.ibm.ws.rest.handler.validator.internal;
 
 import org.osgi.annotation.versioning.Version;

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/wsspi/validator/package-info.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/wsspi/validator/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 @Version("1.0.0")
-@TraceOptions(traceGroup = "rest.validator")
+@TraceOptions(traceGroup = "rest.validation")
 package com.ibm.wsspi.validator;
 
 import org.osgi.annotation.versioning.Version;

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/bootstrap.properties
@@ -9,6 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:config.rest=all:rest.validator=all:com.ibm.ws.jca.service.ConnectionFactoryService=all:com.ibm.ejs.j2c.MCWrapper=all
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.validation=all:com.ibm.ws.jca.service.ConnectionFactoryService=all:com.ibm.ejs.j2c.MCWrapper=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/bootstrap.properties
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:config.rest=all:rest.validator=all:com.ibm.ws.jdbc.DataSourceService=all
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 derby.connection.requireAuthentication=true

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/bootstrap.properties
@@ -9,6 +9,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:config.rest=all:rest.validator=all:com.ibm.ws.jca.service.ConnectionFactoryService=all
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.validation=all:com.ibm.ws.jca.service.ConnectionFactoryService=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/bootstrap.properties
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:config.rest=all:rest.validator=all:com.ibm.ws.jdbc.DataSourceService=all
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.validation=all:com.ibm.ws.jdbc=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 derby.connection.requireAuthentication=true


### PR DESCRIPTION
Name/value pair properties that are specified via `@ConnectionFactoryDefinition(properties=...)` are all showing up as String instead of the proper types per the generated metatype.  Also, the JSON object containing all of the properties is being placed within an extra array, meaning it's not getting the cardinality correct.  Make these improvements and enable the tests for them.