### PR TITLE
Create a collection of built-in classes/interfaces used as Providers.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="test" output="bin_test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -195,3 +195,10 @@ instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.ws.jaxrs.2.x.config;version=latest,\
 	javax.activation:activation;version=1.1
+
+-testpath: \
+	org.hamcrest:hamcrest-all;version=1.3, \
+	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
+	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
+	com.ibm.ws.junit.extensions;version=latest, \
+	com.ibm.websphere.org.eclipse.microprofile.rest.client.1.1;version=latest

--- a/dev/com.ibm.ws.jaxrs.2.0.common/test/com/ibm/ws/jaxrs/providers/test/ProviderContextInfoTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/test/com/ibm/ws/jaxrs/providers/test/ProviderContextInfoTest.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.providers.test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+/**
+ *
+ */
+public class ProviderContextInfoTest {
+
+    static Field processingRequiredField;
+    static Field fieldNamesField;
+    static Field methodNamesField;
+    static {
+        Class<?> providerContextInfoClass = null;
+        try {
+            providerContextInfoClass = Class.forName("org.apache.cxf.jaxrs.model.AbstractResourceInfo$ProviderContextInfo");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        Field[] fields = providerContextInfoClass.getDeclaredFields();
+        for (Field field : fields) {
+            if (field.getName().equals("processingRequired")) {
+                processingRequiredField = field;
+                processingRequiredField.setAccessible(true);
+            } else if (field.getName().equals("fieldNames")) {
+                fieldNamesField = field;
+                fieldNamesField.setAccessible(true);
+            } else if (field.getName().equals("methodNames")) {
+                methodNamesField = field;
+                methodNamesField.setAccessible(true);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void validateProviderContextInfo() throws Exception {
+        Field contextPropsField = org.apache.cxf.jaxrs.model.AbstractResourceInfo.class.getDeclaredField("CONTEXT_PROPS");
+        contextPropsField.setAccessible(true);
+        Map<String, Object> contextProps = (Map<String, Object>) contextPropsField.get(null);
+        for (String className : contextProps.keySet()) {
+            System.out.println("Checking " + className);
+            Class<?> clazz = Class.forName(className);
+            Node rootNode = getContextInfo(clazz, null);
+            checkNode(contextProps, rootNode);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void checkNode(Map<String, Object> contextProps, Node node) throws Exception {
+        Object contextProp = contextProps.get(node.className);
+        if (contextProp == null) {
+            Assert.assertTrue(node.parent != null && !node.parent.needsProcessing);
+        } else {
+            Assert.assertEquals(node.needsProcessing, processingRequiredField.get(contextProp));
+            Assert.assertTrue(compareCollections(node.fieldNames, (Collection<String>) fieldNamesField.get(contextProp)));
+            Assert.assertTrue(compareCollections(node.methodNames, (Collection<String>) methodNamesField.get(contextProp)));
+        }
+        List<Node> children = node.children;
+        if (children != null) {
+            for (Node child : children) {
+                checkNode(contextProps, child);
+            }
+        }
+    }
+
+    private boolean compareCollections(Collection<String> expected, Collection<String> actual) {
+        if (expected == actual) {
+            return true;
+        }
+
+        if (expected == null || actual == null) {
+            System.out.println(expected + " " + actual);
+            return false;
+        }
+        if (expected.size() != actual.size()) {
+            System.out.println(expected + " " + actual);
+            return false;
+        }
+
+        for (String exp : expected) {
+            if (!actual.contains(exp)) {
+                System.out.println(expected + " " + actual);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Node getContextInfo(Class<?> clazz, Node parent) {
+        Set<String> fContexts = null;
+        Set<String> mContexts = null;
+        Field[] contextFields = clazz.getDeclaredFields();
+        for (Field field : contextFields) {
+            Annotation[] annos = field.getAnnotations();
+            for (Annotation anno : annos) {
+                if (anno.annotationType() == Context.class) {
+                    if (fContexts == null) {
+                        fContexts = new HashSet<String>();
+                    }
+                    fContexts.add(field.getName());
+                }
+            }
+        }
+        Method[] contextMethods = clazz.getMethods();
+        for (Method method : contextMethods) {
+            if (!method.getName().startsWith("set") || method.getParameterTypes().length != 1) {
+                continue;
+            }
+            Annotation[] annos = method.getAnnotations();
+            for (Annotation anno : annos) {
+                if (anno.annotationType() == Context.class) {
+                    Class<?> parm = method.getParameterTypes()[0];
+                    if (parm.isInterface() || parm == Application.class) {
+                        if (mContexts == null) {
+                            mContexts = new HashSet<String>();
+                        }
+                        mContexts.add(method.getName());
+                    }
+                }
+            }
+        }
+        Node node = new Node(clazz.getName(), fContexts, mContexts, parent);
+
+        Class<?> superClazz = clazz.getSuperclass();
+        if (superClazz != null && superClazz != Object.class) {
+            node.addChild(getContextInfo(superClazz, node));
+        }
+        Class<?>[] intfs = clazz.getInterfaces();
+        for (Class<?> intf : intfs) {
+            node.addChild(getContextInfo(intf, node));
+        }
+        return node;
+    }
+
+    private static class Node {
+        final String className;
+        final Set<String> fieldNames;
+        final Set<String> methodNames;
+        final Node parent;
+        List<Node> children;
+        boolean needsProcessing = false;
+
+        /**
+         * @param className
+         * @param fieldNames
+         * @param methodNames
+         */
+        Node(String className, Set<String> fieldNames, Set<String> methodNames, Node parent) {
+            super();
+            this.className = className;
+            this.fieldNames = fieldNames;
+            this.methodNames = methodNames;
+            this.parent = parent;
+            if (fieldNames != null || methodNames != null) {
+                needsProcessing = true;
+                Node currentParent = parent;
+                while (currentParent != null) {
+                    if (currentParent.needsProcessing) {
+                        break;
+                    }
+                    currentParent.needsProcessing = true;
+                    currentParent = currentParent.parent;
+                }
+            }
+        }
+
+        void addChild(Node child) {
+            if (children == null) {
+                children = new ArrayList<>();
+            }
+            children.add(child);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
@@ -123,9 +123,9 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
      * subclass itself since this would create a circular dependency.
      *
      * @param app
+     * @param appinfo
      */
-    void injectContextApplication(Application app) {
-        ApplicationInfo appinfo = new ApplicationInfo(app, this.getBus());
+    void injectContextApplication(Application app, ApplicationInfo appinfo) {
         if (appinfo.contextsAvailable()) {
             InjectionRuntimeContext irc = InjectionRuntimeContextHelper.getRuntimeContext();
             for (Map.Entry<Class<?>, Method> entry : appinfo.getContextMethods().entrySet()) {
@@ -154,7 +154,8 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
         Class<?> appClass = this.moduleMetadata.getAppContextClassLoader().loadClass(endpointInfo.getAppClassName());
         Application app = (Application) createSingletonInstance(appClass, servletConfig);
 
-        injectContextApplication(app);
+        ApplicationInfo appinfo = new ApplicationInfo(app, this.getBus());
+        injectContextApplication(app, appinfo);
 
         /**
          * step 2: Application can be init only once, the init order depends on the priority of beanCustomizer
@@ -206,9 +207,9 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
         }
 
         /**
-         * step 5: set Application object to ServerFactoryBean
+         * step 5: set ApplicationInfo object to ServerFactoryBean
          */
-        super.setApplication(app);
+        super.setApplicationInfo(appinfo);
         endpointInfo.setApp(app);
     }
 

--- a/dev/com.ibm.ws.jaxrs.2.1.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/bnd.bnd
@@ -187,4 +187,5 @@ instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class
   javax.xml.bind:jaxb-api;version=latest,\
   org.jmock:jmock;strategy=exact;version=2.5.1,\
   org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
-  org.hamcrest:hamcrest-all;version=1.3
+  org.hamcrest:hamcrest-all;version=1.3,\
+  com.ibm.websphere.org.eclipse.microprofile.rest.client.1.2;version=latest

--- a/dev/com.ibm.ws.jaxrs.2.1.common/test/com/ibm/ws/jaxrs/providers/test/ProviderContextInfoTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.common/test/com/ibm/ws/jaxrs/providers/test/ProviderContextInfoTest.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.providers.test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+/**
+ *
+ */
+public class ProviderContextInfoTest {
+
+    static Field processingRequiredField;
+    static Field fieldNamesField;
+    static Field methodNamesField;
+    static {
+        Class<?> providerContextInfoClass = null;
+        try {
+            providerContextInfoClass = Class.forName("org.apache.cxf.jaxrs.model.AbstractResourceInfo$ProviderContextInfo");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        Field[] fields = providerContextInfoClass.getDeclaredFields();
+        for (Field field : fields) {
+            if (field.getName().equals("processingRequired")) {
+                processingRequiredField = field;
+                processingRequiredField.setAccessible(true);
+            } else if (field.getName().equals("fieldNames")) {
+                fieldNamesField = field;
+                fieldNamesField.setAccessible(true);
+            } else if (field.getName().equals("methodNames")) {
+                methodNamesField = field;
+                methodNamesField.setAccessible(true);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void validateProviderContextInfo() throws Exception {
+        Field contextPropsField = org.apache.cxf.jaxrs.model.AbstractResourceInfo.class.getDeclaredField("CONTEXT_PROPS");
+        contextPropsField.setAccessible(true);
+        Map<String, Object> contextProps = (Map<String, Object>) contextPropsField.get(null);
+        for (String className : contextProps.keySet()) {
+            System.out.println("Checking " + className);
+            Class<?> clazz = Class.forName(className);
+            Node rootNode = getContextInfo(clazz, null);
+            checkNode(contextProps, rootNode);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void checkNode(Map<String, Object> contextProps, Node node) throws Exception {
+        Object contextProp = contextProps.get(node.className);
+        if (contextProp == null) {
+            Assert.assertTrue(node.parent != null && !node.parent.needsProcessing);
+        } else {
+            Assert.assertEquals(node.needsProcessing, processingRequiredField.get(contextProp));
+            Assert.assertTrue(compareCollections(node.fieldNames, (Collection<String>) fieldNamesField.get(contextProp)));
+            Assert.assertTrue(compareCollections(node.methodNames, (Collection<String>) methodNamesField.get(contextProp)));
+        }
+        List<Node> children = node.children;
+        if (children != null) {
+            for (Node child : children) {
+                checkNode(contextProps, child);
+            }
+        }
+    }
+
+    private boolean compareCollections(Collection<String> expected, Collection<String> actual) {
+        if (expected == actual) {
+            return true;
+        }
+
+        if (expected == null || actual == null) {
+            System.out.println(expected + " " + actual);
+            return false;
+        }
+        if (expected.size() != actual.size()) {
+            System.out.println(expected + " " + actual);
+            return false;
+        }
+
+        for (String exp : expected) {
+            if (!actual.contains(exp)) {
+                System.out.println(expected + " " + actual);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Node getContextInfo(Class<?> clazz, Node parent) {
+        Set<String> fContexts = null;
+        Set<String> mContexts = null;
+        Field[] contextFields = clazz.getDeclaredFields();
+        for (Field field : contextFields) {
+            Annotation[] annos = field.getAnnotations();
+            for (Annotation anno : annos) {
+                if (anno.annotationType() == Context.class) {
+                    if (fContexts == null) {
+                        fContexts = new HashSet<String>();
+                    }
+                    fContexts.add(field.getName());
+                }
+            }
+        }
+        Method[] contextMethods = clazz.getMethods();
+        for (Method method : contextMethods) {
+            if (!method.getName().startsWith("set") || method.getParameterTypes().length != 1) {
+                continue;
+            }
+            Annotation[] annos = method.getAnnotations();
+            for (Annotation anno : annos) {
+                if (anno.annotationType() == Context.class) {
+                    Class<?> parm = method.getParameterTypes()[0];
+                    if (parm.isInterface() || parm == Application.class) {
+                        if (mContexts == null) {
+                            mContexts = new HashSet<String>();
+                        }
+                        mContexts.add(method.getName());
+                    }
+                }
+            }
+        }
+        Node node = new Node(clazz.getName(), fContexts, mContexts, parent);
+
+        Class<?> superClazz = clazz.getSuperclass();
+        if (superClazz != null && superClazz != Object.class) {
+            node.addChild(getContextInfo(superClazz, node));
+        }
+        Class<?>[] intfs = clazz.getInterfaces();
+        for (Class<?> intf : intfs) {
+            node.addChild(getContextInfo(intf, node));
+        }
+        return node;
+    }
+
+    private static class Node {
+        final String className;
+        final Set<String> fieldNames;
+        final Set<String> methodNames;
+        final Node parent;
+        List<Node> children;
+        boolean needsProcessing = false;
+
+        /**
+         * @param className
+         * @param fieldNames
+         * @param methodNames
+         */
+        Node(String className, Set<String> fieldNames, Set<String> methodNames, Node parent) {
+            super();
+            this.className = className;
+            this.fieldNames = fieldNames;
+            this.methodNames = methodNames;
+            this.parent = parent;
+            if (fieldNames != null || methodNames != null) {
+                needsProcessing = true;
+                Node currentParent = parent;
+                while (currentParent != null) {
+                    if (currentParent.needsProcessing) {
+                        break;
+                    }
+                    currentParent.needsProcessing = true;
+                    currentParent = currentParent.parent;
+                }
+            }
+        }
+
+        void addChild(Node child) {
+            if (children == null) {
+                children = new ArrayList<>();
+            }
+            children.add(child);
+        }
+    }
+
+}


### PR DESCRIPTION
Presently there is a lot of processing that is done to determine if a
Provider has a `@Context` annotation on a field and/or method.  This
affects start up time.  This change creates a collection of CXF and
JAX-RS classes and interfaces so that we know if we need to do the
expensive reflection processing to find `@Context` annotations.  If the
known classes do not have method and/or field `@Context` annotations, we
can skip one or both of the field or method processing, or not process
the Provider class at all.
