### PR TITLE
REST endpoint for app-defined JMS connection factory

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectionManagerService.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectionManagerService.java
@@ -75,6 +75,7 @@ public abstract class ConnectionManagerService extends Observable {
     public static final List<String> CONNECTION_MANAGER_PROPS = Collections.unmodifiableList(Arrays.asList(
                                                                                                            J2CConstants.POOL_AgedTimeout,
                                                                                                            J2CConstants.POOL_ConnectionTimeout,
+                                                                                                           "enableSharingForDirectLookups",
                                                                                                            MAX_IDLE_TIME,
                                                                                                            MAX_CONNECTIONS_PER_THREAD,
                                                                                                            MAX_POOL_SIZE,

--- a/dev/com.ibm.ws.jca.resourcedefinition.jms.2.0/src/com/ibm/ws/jca/processor/jms/service/JMSConnectionFactoryResourceBuilder.java
+++ b/dev/com.ibm.ws.jca.resourcedefinition.jms.2.0/src/com/ibm/ws/jca/processor/jms/service/JMSConnectionFactoryResourceBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -168,8 +168,9 @@ public class JMSConnectionFactoryResourceBuilder implements ResourceFactoryBuild
         String module = (String) annotationDDProps.remove(AppDefinedResource.MODULE);
         String component = (String) annotationDDProps.remove(AppDefinedResource.COMPONENT);
         String jndiName = (String) annotationDDProps.remove(ResourceFactory.JNDI_NAME);
+        String interfaceName = (String) annotationDDProps.remove(INTERFACE_NAME);
 
-        String connectionFactoryID = getConnectionFactoryID(application, module, component, jndiName);
+        String connectionFactoryID = getConnectionFactoryID(application, module, component, jndiName, interfaceName);
         String conManagerID = connectionFactoryID + '/' + ConnectionManagerService.CONNECTION_MANAGER;
 
         String conManagerFilter = FilterUtils.createPropertyFilter(ID, conManagerID);
@@ -203,7 +204,6 @@ public class JMSConnectionFactoryResourceBuilder implements ResourceFactoryBuild
             }
         }
         String resourceAdapter = (String) annotationDDProps.remove(RESOURCE_ADAPTER);
-        String interfaceName = (String) annotationDDProps.remove(INTERFACE_NAME);
 
         connectionFactorySvcProps.put(BOOTSTRAP_CONTEXT, "(id=" + resourceAdapter + ")");
         connectionFactorySvcProps.put(CREATES_OBJECTCLASS, interfaceName);
@@ -212,6 +212,7 @@ public class JMSConnectionFactoryResourceBuilder implements ResourceFactoryBuild
         //Note: Its not necessary for the user to specify the props which has default value, so we set them in here.
         Dictionary<String, Object> connectionFactoryDefaultProps = getDefaultProperties(resourceAdapter, interfaceName);
 
+        String configPropsPid = null;
         for (Enumeration<String> keys = connectionFactoryDefaultProps.keys(); keys.hasMoreElements();) {
             String key = keys.nextElement();
             Object value = connectionFactoryDefaultProps.get(key);
@@ -223,7 +224,10 @@ public class JMSConnectionFactoryResourceBuilder implements ResourceFactoryBuild
             if (value instanceof String)
                 value = variableRegistry.resolveString((String) value);
 
-            connectionFactorySvcProps.put(JMSResourceDefinitionConstants.PROPERTIES_REF_KEY + key, value);
+            if ("config.displayId".equals(key))
+                connectionFactorySvcProps.put(JMSResourceDefinitionConstants.PROPERTIES_REF_KEY + "config.referenceType", configPropsPid = (String) value);
+            else
+                connectionFactorySvcProps.put(JMSResourceDefinitionConstants.PROPERTIES_REF_KEY + key, value);
         }
 
         //Additional property handling due to naming inconsistency between JEE specification and wasJms & wmqJms resource adapter
@@ -252,6 +256,20 @@ public class JMSConnectionFactoryResourceBuilder implements ResourceFactoryBuild
         for (String name : ConnectionManagerService.CONNECTION_MANAGER_PROPS)
             if ((value = annotationDDProps.remove(name)) != null)
                 cmSvcProps.put(name, value);
+
+        // TODO it seems like JMSConnectionFactoryDefinition would need the same fix as JCA ConnectionFactoryDefinition
+        // with respect to configured properties that don't have defaults, however the built-in wasJms doesn't exhibit any
+        // failures here. Is that because it has defaults for all properties? Need to write a test with a different
+        // JMS resource adapter that lacks defaults in order to verify that we need the following code:
+
+        // Add remaining properties
+        //WSConfigurationHelper configHelper = wsConfigurationHelperRef.getServiceWithException();
+        //for (Map.Entry<String, Object> entry : annotationDDProps.entrySet()) {
+        //    String key = entry.getKey();
+        //    String attrName = configHelper.getMetaTypeAttributeName(configPropsPid, key);
+        //    if (attrName != null && !"INTERNAL".equalsIgnoreCase(attrName))
+        //        connectionFactorySvcProps.put(JMSResourceDefinitionConstants.PROPERTIES_REF_KEY + key, entry.getValue());
+        //}
 
         BundleContext bundleContext = FrameworkUtil.getBundle(ConnectionFactoryService.class).getBundleContext();
 
@@ -304,7 +322,7 @@ public class JMSConnectionFactoryResourceBuilder implements ResourceFactoryBuild
      * Get Properties only those have default value
      *
      * @param resourceAdapter type of the resource adapter
-     * @param interfaceName the resource type provided by the resource adapter
+     * @param interfaceName   the resource type provided by the resource adapter
      * @return properties which has default values.
      * @throws ConfigEvaluatorException
      * @throws ResourceException
@@ -338,7 +356,7 @@ public class JMSConnectionFactoryResourceBuilder implements ResourceFactoryBuild
      * Get all the AttributeDefinition defined for the given Resource Adapter and Interface Name.
      *
      * @param resourceAdapter type of the resource adapter
-     * @param interfaceName the resource type provided by the resource adapter
+     * @param interfaceName   the resource type provided by the resource adapter
      * @return all the AttributeDefinition defined for the given resource adapter and interface
      * @throws ConfigEvaluatorException
      * @throws ResourceException
@@ -373,13 +391,14 @@ public class JMSConnectionFactoryResourceBuilder implements ResourceFactoryBuild
      * For example,
      * application[MyApp]/module[MyModule]/connectionFactory[java:module/env/jdbc/cf1]
      *
-     * @param application application name if data source is in java:app, java:module, or java:comp. Otherwise null.
-     * @param module module name if data source is in java:module or java:comp. Otherwise null.
-     * @param component component name if data source is in java:comp and isn't in web container. Otherwise null.
-     * @param jndiName configured JNDI name for the data source. For example, java:module/env/jca/cf1
+     * @param application   application name if data source is in java:app, java:module, or java:comp. Otherwise null.
+     * @param module        module name if data source is in java:module or java:comp. Otherwise null.
+     * @param component     component name if data source is in java:comp and isn't in web container. Otherwise null.
+     * @param jndiName      configured JNDI name for the data source. For example, java:module/env/jca/cf1
+     * @param interfaceName fully qualified name of the JMS connection factory interface.
      * @return the unique identifier
      */
-    private static final String getConnectionFactoryID(String application, String module, String component, String jndiName) {
+    private static final String getConnectionFactoryID(String application, String module, String component, String jndiName, String interfaceName) {
         StringBuilder sb = new StringBuilder(jndiName.length() + 80);
         if (application != null) {
             sb.append(AppDefinedResource.APPLICATION).append('[').append(application).append(']').append('/');
@@ -389,7 +408,15 @@ public class JMSConnectionFactoryResourceBuilder implements ResourceFactoryBuild
                     sb.append(AppDefinedResource.COMPONENT).append('[').append(component).append(']').append('/');
             }
         }
-        return sb.append(ConnectionFactoryService.CONNECTION_FACTORY).append('[').append(jndiName).append(']').toString();
+
+        if ("javax.jms.QueueConnectionFactory".equals(interfaceName))
+            sb.append("jmsQueueConnectionFactory");
+        else if ("javax.jms.JMSTopicConnectionFactory".equals(interfaceName))
+            sb.append("jmsTopicConnectionFactory");
+        else
+            sb.append("jmsConnectionFactory");
+
+        return sb.append('[').append(jndiName).append(']').toString();
     }
 
     /**

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -618,6 +618,60 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         // TODO api
     }
 
+    /**
+     * Use the /ibm/api/config REST endpoint to obtain configuration for an app-defined JMS QueueConnectionFactory.
+     */
+    @Test
+    public void testAppDefinedJMSQueueConnectionFactory() throws Exception {
+        JsonObject cf = new HttpsRequest(server, "/ibm/api/config/jmsQueueConnectionFactory/application[AppDefResourcesApp]%2Fmodule[AppDefResourcesApp.war]%2FjmsQueueConnectionFactory[java:module%2Fenv%2Fjms%2Fqcf]")
+                        .run(JsonObject.class);
+        String err = "unexpected response: " + cf;
+
+        assertEquals(err, "jmsQueueConnectionFactory", cf.getString("configElementName"));
+        assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/jmsQueueConnectionFactory[java:module/env/jms/qcf]", cf.getString("uid"));
+        assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/jmsQueueConnectionFactory[java:module/env/jms/qcf]", cf.getString("id"));
+        assertEquals(err, "java:module/env/jms/qcf", cf.getString("jndiName"));
+
+        assertEquals(err, "AppDefResourcesApp", cf.getString("application"));
+        assertEquals(err, "AppDefResourcesApp.war", cf.getString("module"));
+        assertNull(err, cf.get("component"));
+
+        JsonObject cm;
+        assertNotNull(err, cm = cf.getJsonObject("connectionManagerRef"));
+        assertEquals(err, "connectionManager", cm.getString("configElementName"));
+        assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/jmsQueueConnectionFactory[java:module/env/jms/qcf]/connectionManager",
+                     cm.getString("uid"));
+        assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/jmsQueueConnectionFactory[java:module/env/jms/qcf]/connectionManager",
+                     cm.getString("id"));
+        assertEquals(err, 25790, cm.getJsonNumber("agedTimeout").longValue());
+        assertEquals(err, 70, cm.getJsonNumber("connectionTimeout").longValue());
+        assertFalse(err, cm.getBoolean("enableSharingForDirectLookups"));
+        assertEquals(err, 450, cm.getJsonNumber("maxIdleTime").longValue());
+        assertEquals(err, 7, cm.getInt("maxPoolSize"));
+        assertEquals(err, 3, cm.getInt("minPoolSize"));
+        assertEquals(err, "ValidateAllConnections", cm.getString("purgePolicy"));
+        assertEquals(err, 72, cm.getJsonNumber("reapTime").longValue());
+
+        // support for containerAuthDataRef/recoveryAuthDataRef was never added to app-defined connection factories
+
+        // TODO internal properties should not be included (also a problem for dataSource and connectionFactory)
+        // assertNull(err, cf.get("creates.objectClass"));
+        // assertNull(err, cf.get("jndiName.unique"));
+
+        JsonObject props;
+        assertNotNull(err, props = cf.getJsonObject("properties.wasJms"));
+        assertEquals(err, "qcfBus", props.getString("busName"));
+        assertEquals(err, "ExpressNonPersistent", props.getString("nonPersistentMapping"));
+        assertEquals(err, "ReliablePersistent", props.getString("persistentMapping"));
+        assertEquals(err, "Default", props.getString("readAhead"));
+        assertEquals(err, "tempq", props.getString("temporaryQueueNamePrefix"));
+        assertNull(err, props.get("temporaryTopicNamePrefix"));
+        assertNull(err, props.get("userName"));
+        assertNull(err, props.get("password"));
+
+        // TODO api
+    }
+
     /*
      * Test that a data source nested under a transaction with an atypical case can be accessed
      * by calling the config endpoint matching with the case matching server config.

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all:com.ibm.ws.jca17.processor.service=all:rarInstall=all
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all:com.ibm.ws.jca17.processor.service=all:com.ibm.ws.jca.processor.jms.*=all:rarInstall=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 derby.connection.requireAuthentication=true

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
@@ -17,6 +17,9 @@
     <feature>ejbLite-3.2</feature>
     <feature>jca-1.7</feature>
     <feature>jdbc-4.2</feature>
+    <feature>jms-2.0</feature>
+    <feature>wasJmsClient-2.0</feature>
+    <feature>wasJmsServer-1.0</feature>
   </featureManager>
 
   <variable name="onError" value="FAIL"/>
@@ -27,6 +30,8 @@
   <application location="AppDefResourcesApp.ear">
     <classloader commonLibraryRef="Derby"/>
   </application>
+
+  <messagingEngine id="defaultME"/>
 
   <resourceAdapter id="ConfigTestAdapter" location="${server.config.dir}/connectors/ConfigTestAdapter.rar"/>
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -16,6 +16,8 @@ import java.util.concurrent.Executor;
 import javax.annotation.sql.DataSourceDefinition;
 import javax.annotation.sql.DataSourceDefinitions;
 import javax.ejb.EJB;
+import javax.jms.JMSConnectionFactoryDefinition;
+import javax.jms.JMSConnectionFactoryDefinitions;
 import javax.resource.ConnectionFactoryDefinition;
 import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
 import javax.servlet.annotation.WebServlet;
@@ -71,6 +73,22 @@ import componenttest.app.FATServlet;
                                                properties = "createDatabase=create",
                                                user = "dbuser4",
                                                password = "dbpwd4")
+})
+
+@JMSConnectionFactoryDefinitions({
+                                   @JMSConnectionFactoryDefinition(name = "java:comp/env/jms/cf",
+                                                                   interfaceName = "javax.jms.ConnectionFactory",
+                                                                   resourceAdapter = "wasJms",
+                                                                   clientId = "JMSClientID6",
+                                                                   maxPoolSize = 6,
+                                                                   user = "jmsuser",
+                                                                   password = "jmspwd",
+                                                                   properties = {
+                                                                                  "busName=cfBus",
+                                                                                  "readAhead=AlwaysOff",
+                                                                                  "shareDurableSubscription=NeverShared",
+                                                                                  "temporaryQueueNamePrefix=cfq"
+                                                                   })
 })
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/AppDefinedResourcesServlet")

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -77,7 +77,7 @@ import componenttest.app.FATServlet;
 
 @JMSConnectionFactoryDefinitions({
                                    @JMSConnectionFactoryDefinition(name = "java:comp/env/jms/cf",
-                                                                   interfaceName = "javax.jms.ConnectionFactory",
+                                                                   // interfaceName = "javax.jms.ConnectionFactory", // already the default value
                                                                    resourceAdapter = "wasJms",
                                                                    clientId = "JMSClientID6",
                                                                    maxPoolSize = 6,
@@ -88,6 +88,21 @@ import componenttest.app.FATServlet;
                                                                                   "readAhead=AlwaysOff",
                                                                                   "shareDurableSubscription=NeverShared",
                                                                                   "temporaryQueueNamePrefix=cfq"
+                                                                   }),
+                                   @JMSConnectionFactoryDefinition(name = "java:module/env/jms/qcf",
+                                                                   interfaceName = "javax.jms.QueueConnectionFactory",
+                                                                   resourceAdapter = "wasJms",
+                                                                   maxPoolSize = 7,
+                                                                   minPoolSize = 3,
+                                                                   properties = {
+                                                                                  "agedTimeout=7h9m50s",
+                                                                                  "busName=qcfBus",
+                                                                                  "connectionTimeout=70s",
+                                                                                  "enableSharingForDirectLookups=false",
+                                                                                  "maxIdleTime=7m30s",
+                                                                                  "purgePolicy=ValidateAllConnections",
+                                                                                  "reapTime=72",
+                                                                                  "temporaryQueueNamePrefix=tempq"
                                                                    })
 })
 @SuppressWarnings("serial")


### PR DESCRIPTION
Add test case and update code to support using the /config/ REST endpoint to access information about an application-defined JMS connection factory (JMSConnectionFactoryDefinition)