### PR TITLE
Fix ignoreOutliers method in mpFT timeout tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/TimeoutServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/TimeoutServlet.java
@@ -93,12 +93,12 @@ public class TimeoutServlet extends FATServlet {
      */
     private <T> long getSampleOfConnectTimesAverage(int delayMillis, int sampleSize, TimedTestBean<T> targetBean) {
 
-        long startNanos = System.nanoTime();
         long totalNanos = 0;
         long averageMillis = 0;
 
         try {
             Thread.sleep(delayMillis);
+            long startNanos = System.nanoTime();
             for (int i = 0; i < sampleSize; i++) {
                 try {
                     targetBean.connect();


### PR DESCRIPTION
Bug in getSampleOfConnectTimesAverage meant that the time calculated
included the delay waited before running the test samples.