### PR TITLE
REST endpoint for app-defined TopicConnectionFactory

### DIFF
--- a/dev/com.ibm.ws.jca.resourcedefinition.jms.2.0/src/com/ibm/ws/jca/processor/jms/service/JMSConnectionFactoryResourceBuilder.java
+++ b/dev/com.ibm.ws.jca.resourcedefinition.jms.2.0/src/com/ibm/ws/jca/processor/jms/service/JMSConnectionFactoryResourceBuilder.java
@@ -411,7 +411,7 @@ public class JMSConnectionFactoryResourceBuilder implements ResourceFactoryBuild
 
         if ("javax.jms.QueueConnectionFactory".equals(interfaceName))
             sb.append("jmsQueueConnectionFactory");
-        else if ("javax.jms.JMSTopicConnectionFactory".equals(interfaceName))
+        else if ("javax.jms.TopicConnectionFactory".equals(interfaceName))
             sb.append("jmsTopicConnectionFactory");
         else
             sb.append("jmsConnectionFactory");

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
@@ -33,7 +33,7 @@
 
   <messagingEngine id="defaultME"/>
 
-  <resourceAdapter id="ConfigTestAdapter" location="${server.config.dir}/connectors/ConfigTestAdapter.rar"/>
+  <resourceAdapter location="${server.config.dir}/connectors/ConfigTestAdapter.rar"/>
 
   <transaction>
     <DATASOURCE transactional="false">

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Executor;
 import javax.annotation.sql.DataSourceDefinition;
 import javax.ejb.Local;
 import javax.ejb.Stateless;
+import javax.jms.JMSConnectionFactoryDefinition;
 import javax.resource.ConnectionFactoryDefinition;
 import javax.resource.ConnectionFactoryDefinitions;
 
@@ -31,6 +32,16 @@ import javax.resource.ConnectionFactoryDefinitions;
                       properties = {
                                      "createDatabase=create"
                       })
+
+@JMSConnectionFactoryDefinition(name = "java:app/env/jms/tcf",
+                                interfaceName = "javax.jms.TopicConnectionFactory",
+                                resourceAdapter = "ConfigTestAdapter",
+                                maxPoolSize = 8,
+                                properties = {
+                                               "enableBetaContent=true",
+                                               "portNumber=8765"
+                                })
+
 @Stateless
 @Local
 public class AppDefinedResourcesBean implements Executor {


### PR DESCRIPTION
Add test coverage for using the /config/ REST endpoint to access the configuration of an application-defined javax.jms.TopicConnectionFactory.  Also, update the implementation so that it works properly.