### PR TITLE
Fix gathering of test results

### DIFF
--- a/dev/gradle/java.gradle
+++ b/dev/gradle/java.gradle
@@ -64,7 +64,8 @@ task testReport(type: TestReport) {
   destinationDir = cnf.file('generated/testReports/allUnitTests')
 
   // Include the results from the `test` task in all subprojects
-  reportOn subprojects*.test.binResultsDir
+  //reportOn subprojects*.test.binResultsDir
+  reportOn subprojects*.test
 
   doLast {
     // Save test count properties to a file, so they can be loaded by subsequent builds

--- a/dev/gradle/java.gradle
+++ b/dev/gradle/java.gradle
@@ -64,7 +64,6 @@ task testReport(type: TestReport) {
   destinationDir = cnf.file('generated/testReports/allUnitTests')
 
   // Include the results from the `test` task in all subprojects
-  //reportOn subprojects*.test.binResultsDir
   reportOn subprojects*.test
 
   doLast {


### PR DESCRIPTION
The test results for personal builds haven't been publishing to DHE.  The problem was with the testReport task not gathering the results into the directory that ends up getting published.  

#build