### PR TITLE
Allow internal ConfigSources to be provided using DS

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/impl/Config13BuilderImpl.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/impl/Config13BuilderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config13.impl;
 
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 
 import com.ibm.ws.microprofile.config.converters.PriorityConverterMap;
 import com.ibm.ws.microprofile.config.impl.ConversionManager;
@@ -23,14 +25,18 @@ import com.ibm.ws.microprofile.config13.sources.Config13DefaultSources;
 
 public class Config13BuilderImpl extends Config12BuilderImpl implements ConfigBuilder {
 
+    private final Set<ConfigSource> internalConfigSources;
+
     /**
      * Constructor
      *
-     * @param classLoader the classloader which scopes this config
-     * @param executor the executor to use for async update threads
+     * @param classLoader           the classloader which scopes this config
+     * @param executor              the executor to use for async update threads
+     * @param internalConfigSources
      */
-    public Config13BuilderImpl(ClassLoader classLoader, ScheduledExecutorService executor) {
+    public Config13BuilderImpl(ClassLoader classLoader, ScheduledExecutorService executor, Set<ConfigSource> internalConfigSources) {
         super(classLoader, executor);
+        this.internalConfigSources = internalConfigSources;
     }
 
 /////////////////////////////////////////////
@@ -54,8 +60,13 @@ public class Config13BuilderImpl extends Config12BuilderImpl implements ConfigBu
         if (addDiscoveredSourcesFlag()) {
             sources.addAll(Config13DefaultSources.getDiscoveredSources(getClassLoader()));
         }
+        sources.addAll(getInternalConfigSources());
         sources = sources.unmodifiable();
         return sources;
+    }
+
+    protected Set<ConfigSource> getInternalConfigSources() {
+        return this.internalConfigSources;
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/impl/Config13ProviderResolverImpl.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/impl/Config13ProviderResolverImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,15 +10,46 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config13.impl;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
 import com.ibm.ws.microprofile.config.impl.AbstractConfigBuilder;
 import com.ibm.ws.microprofile.config12.impl.Config12ProviderResolverImpl;
 
 public class Config13ProviderResolverImpl extends Config12ProviderResolverImpl {
 
+    private final HashSet<ConfigSource> internalConfigSources = new HashSet<>();
+
     /** {@inheritDoc} */
     @Override
     protected AbstractConfigBuilder newBuilder(ClassLoader classLoader) {
-        return new Config13BuilderImpl(classLoader, getScheduledExecutorService());
+        return new Config13BuilderImpl(classLoader, getScheduledExecutorService(), getInternalConfigSources());
     }
 
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    protected void setConfigSource(ConfigSource configSource) {
+        synchronized (internalConfigSources) {
+            internalConfigSources.add(configSource);
+        }
+    }
+
+    protected void unsetConfigSource(ConfigSource configSource) {
+        synchronized (internalConfigSources) {
+            internalConfigSources.remove(configSource);
+        }
+    }
+
+    protected Set<ConfigSource> getInternalConfigSources() {
+        Set<ConfigSource> sources = new HashSet<>();
+        synchronized (internalConfigSources) {
+            sources.addAll(internalConfigSources);
+        }
+        return sources;
+    }
 }

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14BuilderImpl.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14BuilderImpl.java
@@ -10,9 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config14.impl;
 
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 
 import com.ibm.ws.microprofile.config.converters.PriorityConverterMap;
 import com.ibm.ws.microprofile.config.impl.ConversionManager;
@@ -29,8 +31,8 @@ public class Config14BuilderImpl extends Config13BuilderImpl implements ConfigBu
      * @param classLoader the classloader which scopes this config
      * @param executor    the executor to use for async update threads
      */
-    public Config14BuilderImpl(ClassLoader classLoader, ScheduledExecutorService executor) {
-        super(classLoader, executor);
+    public Config14BuilderImpl(ClassLoader classLoader, ScheduledExecutorService executor, Set<ConfigSource> internalConfigSources) {
+        super(classLoader, executor, internalConfigSources);
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14ProviderResolverImpl.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14ProviderResolverImpl.java
@@ -18,7 +18,7 @@ public class Config14ProviderResolverImpl extends Config13ProviderResolverImpl {
     /** {@inheritDoc} */
     @Override
     protected AbstractConfigBuilder newBuilder(ClassLoader classLoader) {
-        return new Config14BuilderImpl(classLoader, getScheduledExecutorService());
+        return new Config14BuilderImpl(classLoader, getScheduledExecutorService(), getInternalConfigSources());
     }
 
 }


### PR DESCRIPTION
This PR is a prototype which allows other internal components to provide ConfigSources as DS Services. It is not yet tested and not yet ready for delivery.