### PR TITLE
Add runtime update logging

### DIFF
--- a/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.brokenserver/bootstrap.properties
+++ b/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.brokenserver/bootstrap.properties
@@ -9,3 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.runtime.update.*=all


### PR DESCRIPTION
Enabling trace for com.ibm.ws.runtime.update to diagnose a shutdown issue related to the web container. 