### PR TITLE
hide internal properties from config REST endpoint and remove TODO

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
@@ -172,8 +172,10 @@ public class ConfigRESTHandler extends ConfigBasedRESTHandler {
         SortedSet<String> keys = new TreeSet<String>();
         for (java.util.Enumeration<String> en = config.keys(); en.hasMoreElements();) {
             String key = en.nextElement();
-            //don't display items starting with config. or service. or ibm.extends (added by config service)
-            if (key.startsWith("config.") || key.startsWith("service.") || key.startsWith("ibm.extends")) {
+            // Don't display items starting with config. or service. or ibm.extends (added by config service)
+            // Also don't display items added by app-defined resources
+            if (key.startsWith("config.") || key.startsWith("service.") || key.startsWith("ibm.extends") ||
+                key.equals("creates.objectClass") || key.equals("jndiName.unique")) {
                 continue;
             }
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -600,14 +600,14 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
 
         // support for containerAuthDataRef/recoveryAuthDataRef was never added to app-defined connection factories
 
-        // TODO internal properties should not be included (also a problem for dataSource and connectionFactory)
-        // assertNull(err, cf.get("creates.objectClass"));
-        // assertNull(err, cf.get("jndiName.unique"));
+        assertNull(err, cf.get("creates.objectClass"));
+        assertNull(err, cf.get("jndiName.unique"));
 
         JsonObject props;
         assertNotNull(err, props = cf.getJsonObject("properties.wasJms"));
         assertEquals(err, "cfBus", props.getString("busName"));
-        // assertEquals(err, "JMSClientID6", props.getString("clientID")); // TODO why isn't the configured value honored?
+        // TODO JMSConnectionFactoryResourceBuilder doesn't consider clientId (from annotation) and clientID (defined by resource adapter) to have the same meaning
+        // assertEquals(err, "JMSClientID6", props.getString("clientID"));
         assertEquals(err, "defaultME", props.getString("durableSubscriptionHome"));
         assertEquals(err, "ExpressNonPersistent", props.getString("nonPersistentMapping"));
         assertEquals(err, "ReliablePersistent", props.getString("persistentMapping"));
@@ -657,9 +657,8 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
 
         // support for containerAuthDataRef/recoveryAuthDataRef was never added to app-defined connection factories
 
-        // TODO internal properties should not be included (also a problem for dataSource and connectionFactory)
-        // assertNull(err, cf.get("creates.objectClass"));
-        // assertNull(err, cf.get("jndiName.unique"));
+        assertNull(err, cf.get("creates.objectClass"));
+        assertNull(err, cf.get("jndiName.unique"));
 
         JsonObject props;
         assertNotNull(err, props = cf.getJsonObject("properties.wasJms"));
@@ -708,13 +707,12 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
 
         // support for containerAuthDataRef/recoveryAuthDataRef was never added to app-defined connection factories
 
-        // TODO internal properties should not be included (also a problem for dataSource and connectionFactory)
-        // assertNull(err, cf.get("creates.objectClass"));
-        // assertNull(err, cf.get("jndiName.unique"));
+        assertNull(err, cf.get("creates.objectClass"));
+        assertNull(err, cf.get("jndiName.unique"));
 
         JsonObject props;
         assertNotNull(err, props = cf.getJsonObject("properties.ConfigTestAdapter"));
-        assertTrue(err, props.getBoolean("enableBetaContent")); // TODO if JMS path had the same unfixed bug as JCA, this should have failed. Need to look into this.
+        assertTrue(err, props.getBoolean("enableBetaContent"));
         assertEquals(err, "localhost", props.getString("hostName"));
         assertEquals(err, 8765, props.getInt("portNumber"));
 


### PR DESCRIPTION
The application-defined resources path adds some internal properties (jndiName.unique and creates.objectClass) that are not identified within the metatype and thus were not being recognized as internal properties to omit from the /config/ REST endpoint output.  This pull adds handling for these properties.

Also, remove a TODO comment about a possible bug which turned out not to be the case.  JMS connection factory properties aren't ignored in the absence of defaults because code is already in place which steps through all of the properties that are defined in the metatype, looking for each within the annotation values.