### PR TITLE
Disable all trace for MP Config Cache test server

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/publish/servers/ClassLoaderCacheServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/publish/servers/ClassLoaderCacheServer/bootstrap.properties
@@ -1,2 +1,4 @@
+#This server intentionally has all trace disabled. Enabling trace may cause the test to intermittently fail.
+com.ibm.ws.logging.trace.specification=*=all=disabled
 bootstrap.include=../testports.properties
 osgi.console=7772


### PR DESCRIPTION
The trace sub-system keeps a soft reference to the config classes. That keeps the ClassLoader around too and therefore causes the Config ClassLoader Cache test to intermittently fail.

So this PR is to completely disable trace on that server to see if it fixes the problem. Only other choice is to delete the test completely.

#build 