### PR TITLE
Issue #7724: Update mongo_fat with new SSL error message

### DIFF
--- a/dev/com.ibm.ws.mongo_fat/fat/src/com/ibm/ws/mongo/fat/MongoSSLInvalidTrustTest.java
+++ b/dev/com.ibm.ws.mongo_fat/fat/src/com/ibm/ws/mongo/fat/MongoSSLInvalidTrustTest.java
@@ -47,7 +47,7 @@ public class MongoSSLInvalidTrustTest extends FATServletClient {
         // com.ibm.wsspi.logging.Introspector,
         // com.ibm.ws.runtime.update.RuntimeUpdateListener,
         // com.ibm.wsspi.application.lifecycle.ApplicationRecycleCoordinator}
-        server.stopServer("CWPKI0022E:.*", // SSL HANDSHAKE FAILURE
+        server.stopServer("CWPKI0823E:.*", // SSL HANDSHAKE FAILURE
                           "CWWKE0701E",
                           "CWWKG0033W");
     }


### PR DESCRIPTION
Update list of expected exceptions with new SSL handshake failure error.