### PR TITLE
config REST endpoint for app-defined JMS Topic, Queue & Destination

### DIFF
--- a/dev/com.ibm.ws.jca.1.7/src/com/ibm/ws/jca17/processor/service/AdministeredObjectResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jca.1.7/src/com/ibm/ws/jca17/processor/service/AdministeredObjectResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -210,7 +210,10 @@ public class AdministeredObjectResourceFactoryBuilder implements ResourceFactory
             if (value instanceof String)
                 value = variableRegistry.resolveString((String) value);
 
-            adminObjectSvcProps.put(BASE_PROPERTIES_KEY + key, value);
+            if ("config.displayId".equals(key))
+                adminObjectSvcProps.put(BASE_PROPERTIES_KEY + "config.referenceType", value);
+            else
+                adminObjectSvcProps.put(BASE_PROPERTIES_KEY + key, value);
         }
 
         adminObjectSvcProps.put(BOOTSTRAP_CONTEXT, "(id=" + resourceAdapter + ")");
@@ -287,9 +290,9 @@ public class AdministeredObjectResourceFactoryBuilder implements ResourceFactory
      * application[MyApp]/module[MyModule]/connectionFactory[java:module/env/jdbc/cf1]
      *
      * @param application application name if data source is in java:app, java:module, or java:comp. Otherwise null.
-     * @param module module name if data source is in java:module or java:comp. Otherwise null.
-     * @param component component name if data source is in java:comp and isn't in web container. Otherwise null.
-     * @param jndiName configured JNDI name for the data source. For example, java:module/env/jca/cf1
+     * @param module      module name if data source is in java:module or java:comp. Otherwise null.
+     * @param component   component name if data source is in java:comp and isn't in web container. Otherwise null.
+     * @param jndiName    configured JNDI name for the data source. For example, java:module/env/jca/cf1
      * @return the unique identifier
      */
     private static final String getadminObjectID(String application, String module, String component, String jndiName) {

--- a/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
@@ -172,8 +172,10 @@ public class ConfigRESTHandler extends ConfigBasedRESTHandler {
         SortedSet<String> keys = new TreeSet<String>();
         for (java.util.Enumeration<String> en = config.keys(); en.hasMoreElements();) {
             String key = en.nextElement();
-            //don't display items starting with config. or service. or ibm.extends (added by config service)
-            if (key.startsWith("config.") || key.startsWith("service.") || key.startsWith("ibm.extends")) {
+            // Don't display items starting with config. or service. or ibm.extends (added by config service)
+            // Also don't display items added by app-defined resources
+            if (key.startsWith("config.") || key.startsWith("service.") || key.startsWith("ibm.extends") ||
+                key.equals("creates.objectClass") || key.equals("jndiName.unique")) {
                 continue;
             }
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -93,6 +93,33 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
     }
 
     /**
+     * Use the /ibm/api/config REST endpoint to obtain configuration for an application-defined administered object.
+     */
+    @Test
+    public void testAppDefinedAdminObject() throws Exception {
+        JsonObject cspec = new HttpsRequest(server, "/ibm/api/config/adminObject/adminObject%5Bjava:global%2Fenv%2Feis%2FconSpec1%5D")
+                        .run(JsonObject.class);
+        String err = "unexpected response: " + cspec;
+
+        assertEquals(err, "adminObject", cspec.getString("configElementName"));
+        assertEquals(err, "adminObject[java:global/env/eis/conSpec1]", cspec.getString("uid"));
+        assertEquals(err, "adminObject[java:global/env/eis/conSpec1]", cspec.getString("id"));
+        assertEquals(err, "java:global/env/eis/conSpec1", cspec.getString("jndiName"));
+
+        assertNull(err, cspec.get("application"));
+        assertNull(err, cspec.get("module"));
+        assertNull(err, cspec.get("component"));
+
+        JsonObject props;
+        assertNotNull(err, props = cspec.getJsonObject("properties.ConfigTestAdapter.ConnectionSpec"));
+        assertEquals(err, 4, props.size());
+        assertEquals(err, 10203l, props.getJsonNumber("connectionTimeout").longValue());
+        assertFalse(err, props.getBoolean("readOnly"));
+        assertEquals(err, "aouser1", props.getString("userName"));
+        assertEquals(err, "******", props.getString("password"));
+    }
+
+    /**
      * Use the /ibm/api/config REST endpoint to obtain configuration for app-defined connection factories with the
      * jndiName that is supplied as a query parameter.
      */

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -120,6 +120,36 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
     }
 
     /**
+     * Use the /ibm/api/config REST endpoint to obtain configuration for application-defined administered objects,
+     * querying by component.
+     */
+    @Test
+    public void testAppDefinedAdminObjectsQueryByComponent() throws Exception {
+        JsonArray ispecs = new HttpsRequest(server, "/ibm/api/config/adminObject?component=AppDefinedResourcesBean")
+                        .run(JsonArray.class);
+        String err = "unexpected response: " + ispecs;
+        assertEquals(err, 1, ispecs.size());
+
+        JsonObject ispec;
+        assertNotNull(err, ispec = ispecs.getJsonObject(0));
+        assertEquals(err, "adminObject", ispec.getString("configElementName"));
+        assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesEJB.jar]/component[AppDefinedResourcesBean]/adminObject[java:comp/env/eis/iSpec1]",
+                     ispec.getString("uid"));
+        assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesEJB.jar]/component[AppDefinedResourcesBean]/adminObject[java:comp/env/eis/iSpec1]",
+                     ispec.getString("id"));
+        assertEquals(err, "java:comp/env/eis/iSpec1", ispec.getString("jndiName"));
+
+        assertEquals(err, "AppDefResourcesApp", ispec.getString("application"));
+        assertEquals(err, "AppDefResourcesEJB.jar", ispec.getString("module"));
+        assertEquals(err, "AppDefinedResourcesBean", ispec.getString("component"));
+
+        JsonObject props;
+        assertNotNull(err, props = ispec.getJsonObject("properties.ConfigTestAdapter.InteractionSpec"));
+        assertEquals(err, 1, props.size());
+        assertEquals(err, "doSomethingUseful", props.getString("functionName"));
+    }
+
+    /**
      * Use the /ibm/api/config REST endpoint to obtain configuration for app-defined connection factories with the
      * jndiName that is supplied as a query parameter.
      */

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -600,14 +600,14 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
 
         // support for containerAuthDataRef/recoveryAuthDataRef was never added to app-defined connection factories
 
-        // TODO internal properties should not be included (also a problem for dataSource and connectionFactory)
-        // assertNull(err, cf.get("creates.objectClass"));
-        // assertNull(err, cf.get("jndiName.unique"));
+        assertNull(err, cf.get("creates.objectClass"));
+        assertNull(err, cf.get("jndiName.unique"));
 
         JsonObject props;
         assertNotNull(err, props = cf.getJsonObject("properties.wasJms"));
         assertEquals(err, "cfBus", props.getString("busName"));
-        // assertEquals(err, "JMSClientID6", props.getString("clientID")); // TODO why isn't the configured value honored?
+        // TODO JMSConnectionFactoryResourceBuilder doesn't consider clientId (from annotation) and clientID (defined by resource adapter) to have the same meaning
+        // assertEquals(err, "JMSClientID6", props.getString("clientID"));
         assertEquals(err, "defaultME", props.getString("durableSubscriptionHome"));
         assertEquals(err, "ExpressNonPersistent", props.getString("nonPersistentMapping"));
         assertEquals(err, "ReliablePersistent", props.getString("persistentMapping"));
@@ -657,9 +657,8 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
 
         // support for containerAuthDataRef/recoveryAuthDataRef was never added to app-defined connection factories
 
-        // TODO internal properties should not be included (also a problem for dataSource and connectionFactory)
-        // assertNull(err, cf.get("creates.objectClass"));
-        // assertNull(err, cf.get("jndiName.unique"));
+        assertNull(err, cf.get("creates.objectClass"));
+        assertNull(err, cf.get("jndiName.unique"));
 
         JsonObject props;
         assertNotNull(err, props = cf.getJsonObject("properties.wasJms"));
@@ -708,13 +707,12 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
 
         // support for containerAuthDataRef/recoveryAuthDataRef was never added to app-defined connection factories
 
-        // TODO internal properties should not be included (also a problem for dataSource and connectionFactory)
-        // assertNull(err, cf.get("creates.objectClass"));
-        // assertNull(err, cf.get("jndiName.unique"));
+        assertNull(err, cf.get("creates.objectClass"));
+        assertNull(err, cf.get("jndiName.unique"));
 
         JsonObject props;
         assertNotNull(err, props = cf.getJsonObject("properties.ConfigTestAdapter"));
-        assertTrue(err, props.getBoolean("enableBetaContent")); // TODO if JMS path had the same unfixed bug as JCA, this should have failed. Need to look into this.
+        assertTrue(err, props.getBoolean("enableBetaContent"));
         assertEquals(err, "localhost", props.getString("hostName"));
         assertEquals(err, 8765, props.getInt("portNumber"));
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
@@ -16,6 +16,8 @@ import javax.annotation.sql.DataSourceDefinition;
 import javax.ejb.Local;
 import javax.ejb.Stateless;
 import javax.jms.JMSConnectionFactoryDefinition;
+import javax.jms.JMSDestinationDefinition;
+import javax.jms.JMSDestinationDefinitions;
 import javax.resource.AdministeredObjectDefinition;
 import javax.resource.ConnectionFactoryDefinition;
 import javax.resource.ConnectionFactoryDefinitions;
@@ -47,6 +49,20 @@ import javax.resource.ConnectionFactoryDefinitions;
                                                "enableBetaContent=true",
                                                "portNumber=8765"
                                 })
+
+@JMSDestinationDefinitions({
+                             @JMSDestinationDefinition(name = "java:global/env/jms/dest1",
+                                                       interfaceName = "javax.jms.Destination",
+                                                       resourceAdapter = "ConfigTestAdapter",
+                                                       destinationName = "3605 Hwy 52N, Rochester, MN 55901"),
+                             @JMSDestinationDefinition(name = "java:comp/env/jms/topic1",
+                                                       interfaceName = "javax.jms.Topic",
+                                                       destinationName = "MyTopic",
+                                                       properties = {
+                                                                      "priority=8",
+                                                                      "timeToLive=4m6s"
+                                                       })
+})
 
 @Stateless
 @Local

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
@@ -16,8 +16,14 @@ import javax.annotation.sql.DataSourceDefinition;
 import javax.ejb.Local;
 import javax.ejb.Stateless;
 import javax.jms.JMSConnectionFactoryDefinition;
+import javax.resource.AdministeredObjectDefinition;
 import javax.resource.ConnectionFactoryDefinition;
 import javax.resource.ConnectionFactoryDefinitions;
+
+@AdministeredObjectDefinition(name = "java:comp/env/eis/iSpec1",
+                              resourceAdapter = "ConfigTestAdapter",
+                              className = "org.test.config.adapter.InteractionSpecImpl",
+                              properties = "functionName=doSomethingUseful")
 
 @ConnectionFactoryDefinitions({
                                 @ConnectionFactoryDefinition(name = "java:module/env/eis/cf1", // same JNDI name is used in WAR module, but okay because different scope

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -18,6 +18,7 @@ import javax.annotation.sql.DataSourceDefinitions;
 import javax.ejb.EJB;
 import javax.jms.JMSConnectionFactoryDefinition;
 import javax.jms.JMSConnectionFactoryDefinitions;
+import javax.jms.JMSDestinationDefinition;
 import javax.resource.AdministeredObjectDefinition;
 import javax.resource.ConnectionFactoryDefinition;
 import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
@@ -114,6 +115,13 @@ import componenttest.app.FATServlet;
                                                                                   "temporaryQueueNamePrefix=tempq"
                                                                    })
 })
+
+@JMSDestinationDefinition(name = "java:app/env/jms/queue1",
+                          interfaceName = "javax.jms.Queue",
+                          resourceAdapter = "wasJms",
+                          destinationName = "MyQueue",
+                          properties = "readAhead=AlwaysOff")
+
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/AppDefinedResourcesServlet")
 public class AppDefinedResourcesServlet extends FATServlet {

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -18,11 +18,20 @@ import javax.annotation.sql.DataSourceDefinitions;
 import javax.ejb.EJB;
 import javax.jms.JMSConnectionFactoryDefinition;
 import javax.jms.JMSConnectionFactoryDefinitions;
+import javax.resource.AdministeredObjectDefinition;
 import javax.resource.ConnectionFactoryDefinition;
 import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
 import javax.servlet.annotation.WebServlet;
 
 import componenttest.app.FATServlet;
+
+@AdministeredObjectDefinition(name = "java:global/env/eis/conSpec1",
+                              resourceAdapter = "ConfigTestAdapter",
+                              className = "org.test.config.adapter.ConnectionSpecImpl",
+                              properties = { "connectionTimeout=10203",
+                                             "userName=aouser1",
+                                             "password=aopwd1"
+                              })
 
 @ConnectionFactoryDefinition(name = "java:module/env/eis/cf1",
                              description = "It is Test ConnectionFactory",


### PR DESCRIPTION
Get the /config/ REST endpoint working for application-defined JMS Destination, Topic and Queue.
Write automated tests for all of these.