### PR TITLE
Fix ability to run FATs without executing all unit tests

### DIFF
--- a/dev/gradle/java.gradle
+++ b/dev/gradle/java.gradle
@@ -76,10 +76,6 @@ task testReport(type: TestReport) {
   }
 }
 
-subprojects {
-  test.finalizedBy testReport
-}
-
 task testResults {
   dependsOn subprojects.test
 }

--- a/dev/gradle/java.gradle
+++ b/dev/gradle/java.gradle
@@ -78,4 +78,5 @@ task testReport(type: TestReport) {
 
 task testResults {
   dependsOn subprojects.test
+  dependsOn testReport
 }


### PR DESCRIPTION
We received reports that running the `buildandrun` task on fat projects suddenly also caused lots of unit tests to run across all of the OL projects, causing lots of wasted time executing FATs locally.

This change fixes the dependencies so that running `buildandrun` doesn't also try to execute the `test` task against all subprojects.  