### PR TITLE
update test JavaDoc that still refers to MP Concurrency

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -4877,7 +4877,7 @@ public class MPConcurrentTestServlet extends FATServlet {
     }
 
     /**
-     * Verify toString output for our MicroProfile Concurrency ThreadContext implementation.
+     * Verify toString output for our ThreadContext implementation.
      */
     @Test
     public void testToStringThreadContext() throws Exception {

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/ConcurrencyConfigBean.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/ConcurrencyConfigBean.java
@@ -18,9 +18,9 @@ import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Named;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
 public class ConcurrencyConfigBean {
@@ -32,7 +32,7 @@ public class ConcurrencyConfigBean {
         return ManagedExecutor.builder().maxAsync(a).maxQueued(q).propagated(ThreadContext.SECURITY, ThreadContext.APPLICATION).build();
     }
 
-    // MicroProfile Concurrency automatically shuts down ManagedExecutors when the application stops.
+    // MicroProfile Context Propagation automatically shuts down ManagedExecutors when the application stops.
     // But even if the application writes its own disposer, it shouldn't get an error.
     void disposeExecutor(@Disposes @Named("securityAndAppContextExecutor") ManagedExecutor exec) {
         exec.shutdownNow();

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
@@ -116,7 +116,7 @@ public class MPConcurrentTxTestServlet extends FATServlet {
     }
 
     /**
-     * This case demonstrates that the com.ibm.tx.jta.TransactionManagerFactory public API, even without MP Concurrency,
+     * This case demonstrates that the com.ibm.tx.jta.TransactionManagerFactory public API, even without MP Context Propagation,
      * already enables applications to concurrently run multiple operations within a single transaction
      * by resuming the transaction onto another thread and performing transactional operations in it
      * while it simultaneously remains actively in use on the main thread.
@@ -853,7 +853,7 @@ public class MPConcurrentTxTestServlet extends FATServlet {
 
     /**
      * Serially use an unshared connection handle across multiple threads in a resource local transaction,
-     * where transaction context is left unchanged by MicroProfile Concurrency.
+     * where transaction context is left unchanged by MicroProfile Context Propagation.
      * Commit the transaction and verify the updates.
      */
     @Test
@@ -910,7 +910,7 @@ public class MPConcurrentTxTestServlet extends FATServlet {
 
     /**
      * Serially use an unshared connection handle across multiple threads in a resource local transaction,
-     * where transaction context is left unchanged by MicroProfile Concurrency.
+     * where transaction context is left unchanged by MicroProfile Context Propagation.
      * Roll back the transaction and verify that no updates were made.
      */
     @Test


### PR DESCRIPTION
JavaDocs for various test cases still refer to MP Concurrency or MicroProfile Concurrency.  These need to be updated to instead refer to MP Context Propagation, so as not to cause confusion for developers who are maintaining these tests in the future.