### PR TITLE
catch block moved to prevent SOOB exception in jsf 2.2

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2/src/org/apache/myfaces/view/facelets/util/Classpath.java
+++ b/dev/com.ibm.ws.jsf.2.2/src/org/apache/myfaces/view/facelets/util/Classpath.java
@@ -88,20 +88,7 @@ public final class Classpath
             {
                 if (conn instanceof JarURLConnection)
                 {
-                    try
-                    {
                         jar = ((JarURLConnection) conn).getJarFile();
-                    }
-                    
-                    catch (Throwable e)
-                    {
-                        // This can happen if the classloader provided us a URL that it thinks exists
-                        // but really doesn't.  In particular, if a JAR contains META-INF/MANIFEST.MF
-                        // but not META-INF/, some classloaders may incorrectly report that META-INF/
-                        // exists and we'll end up here.  Just ignore this case.
-                        
-                        continue;
-                    }
                 }
                 else
                 {
@@ -119,6 +106,14 @@ public final class Classpath
                         _searchFromURL(result, prefix, suffix, url);
                     }
                 }    
+            }
+            catch (Throwable e)
+            { 
+                // This can happen if the classloader provided us a URL that it thinks exists
+                // but really doesn't.  In particular, if a JAR contains META-INF/MANIFEST.MF
+                // but not META-INF/, some classloaders may incorrectly report that META-INF/
+                // exists and we'll end up here.  Just ignore this case.
+                continue;
             }
             finally 
             {


### PR DESCRIPTION
Fixes issue #5898  

Fixed upstream in https://issues.apache.org/jira/browse/MYFACES-4292
