### PR TITLE
Increased timeout duration for waitForMetricsEndpoint

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
@@ -79,7 +79,7 @@ public class MetricsAuthenticationTest {
     }
 
     private void waitForMetricsEndpoint(LibertyServer server) throws Exception {
-        assertNotNull("Web application is not available at */metrics/", server.waitForStringInLog("CWWKT0016I.*/metrics/", TIMEOUT * 2, server.getDefaultLogFile()));
+        assertNotNull("Web application is not available at */metrics/", server.waitForStringInLog("CWWKT0016I.*/metrics/", TIMEOUT * 3, server.getDefaultLogFile()));
     }
 
     private static void setMetricsAuthConfig(LibertyServer server, Boolean authentication) throws Exception {


### PR DESCRIPTION
#build
#7667