### PR TITLE
validation for app-defined JCA connection factories

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
@@ -54,4 +54,13 @@
   </library>
   
   <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+
+  <javaPermission codebase="${server.config.dir}/connectors/ConfigTestAdapter.rar"
+                  className="java.lang.RuntimePermission" name="getClassLoader"/>
+
+  <javaPermission codebase="${server.config.dir}/connectors/ConfigTestAdapter.rar"
+                  className="javax.security.auth.PrivateCredentialPermission"
+                  signedBy="javax.resource.spi.security.PasswordCredential"
+                  principalType="*" principalName="*" actions="read"/>
+
 </server>

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionFactoryImpl.java
@@ -19,23 +19,33 @@ import javax.resource.cci.ConnectionFactory;
 import javax.resource.cci.ConnectionSpec;
 import javax.resource.cci.RecordFactory;
 import javax.resource.cci.ResourceAdapterMetaData;
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
 
 public class ConnectionFactoryImpl implements ConnectionFactory {
     private static final long serialVersionUID = 1L;
 
+    private final ConnectionManager cm;
+    private final ManagedConnectionFactoryImpl mcf;
+
+    ConnectionFactoryImpl(ConnectionManager cm, ManagedConnectionFactoryImpl mcf) {
+        this.cm = cm;
+        this.mcf = mcf;
+    }
+
     @Override
     public Connection getConnection() throws ResourceException {
-        throw new NotSupportedException();
+        return getConnection(new ConnectionSpecImpl());
     }
 
     @Override
     public Connection getConnection(ConnectionSpec conSpec) throws ResourceException {
-        throw new NotSupportedException();
+        return (Connection) cm.allocateConnection(mcf, (ConnectionRequestInfo) conSpec);
     }
 
     @Override
     public ResourceAdapterMetaData getMetaData() throws ResourceException {
-        throw new NotSupportedException();
+        return new ResourceAdapterMetaDataImpl();
     }
 
     @Override

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionImpl.java
@@ -10,5 +10,70 @@
  *******************************************************************************/
 package org.test.config.adapter;
 
-public class ConnectionImpl {
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLNonTransientConnectionException;
+
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+
+/**
+ * Proxy for java.sql.Connection, java.sql.DatabaseMetaData,
+ * javax.resource.cci.Connection, javax.resource.cci.ConnectionMetaData, javax.resource.cci.Interaction.
+ */
+public class ConnectionImpl implements InvocationHandler {
+    private boolean closed;
+    private String user;
+
+    ConnectionImpl(String user) {
+        this.user = user;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        String name = method.getName();
+
+        if ("hashCode".equals(name))
+            return System.identityHashCode(proxy);
+        if ("toString".equals(name))
+            return getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(proxy));
+
+        if ("close".equals(name)) {
+            closed = true;
+            return null;
+        }
+
+        if ("isValid".equals(name))
+            return !closed;
+
+        if (closed)
+            throw new SQLNonTransientConnectionException("Connection is closed.", "08003", 53);
+
+        if ("getCatalog".equals(name))
+            return "TestConfigDB";
+        if ("getConnection".equals(name) || "getMetaData".equals(name) || "createInteraction".equals(name))
+            return proxy;
+        if ("getDatabaseProductName".equals(name) || "getEISProductName".equals(name))
+            return "TestConfig Data Store, Enterprise Edition";
+        if ("getDatabaseProductVersion".equals(name) || "getEISProductVersion".equals(name))
+            return "48.55.72";
+        if ("getDriverName".equals(name))
+            return "TestConfigJDBCAdapter";
+        if ("getDriverVersion".equals(name))
+            return "65.72.97";
+        if ("getSchema".equals(name))
+            return user == null ? null : user.toUpperCase();
+        if ("getUserName".equals(name))
+            return user;
+
+        for (Class<?> c : method.getExceptionTypes())
+            if (SQLException.class.isAssignableFrom(c))
+                throw new SQLFeatureNotSupportedException(name);
+            else if (ResourceException.class.isAssignableFrom(c))
+                throw new NotSupportedException(name);
+
+        throw new UnsupportedOperationException(name);
+    }
 }

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionSpecImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ConnectionSpecImpl.java
@@ -13,11 +13,14 @@ package org.test.config.adapter;
 import javax.resource.cci.ConnectionSpec;
 import javax.resource.spi.AdministeredObject;
 import javax.resource.spi.ConfigProperty;
+import javax.resource.spi.ConnectionRequestInfo;
 
-@AdministeredObject
-public class ConnectionSpecImpl implements ConnectionSpec {
+@AdministeredObject(adminObjectInterfaces = ConnectionSpec.class)
+public class ConnectionSpecImpl implements ConnectionRequestInfo, ConnectionSpec {
     @ConfigProperty
     private Long connectionTimeout;
+
+    Class<?>[] interfaces = new Class<?>[] { javax.resource.cci.Connection.class, javax.resource.cci.ConnectionMetaData.class, javax.resource.cci.Interaction.class };
 
     @ConfigProperty(confidential = true)
     private String password;

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ManagedConnectionFactoryImpl.java
@@ -59,17 +59,17 @@ public class ManagedConnectionFactoryImpl implements ManagedConnectionFactory, R
 
     @Override
     public Object createConnectionFactory() throws ResourceException {
-        return createConnectionFactory(null);
+        throw new NotSupportedException();
     }
 
     @Override
     public Object createConnectionFactory(ConnectionManager cm) throws ResourceException {
-        return new ConnectionFactoryImpl();
+        return new ConnectionFactoryImpl(cm, this);
     }
 
     @Override
     public ManagedConnection createManagedConnection(Subject subject, ConnectionRequestInfo cri) throws ResourceException {
-        throw new NotSupportedException();
+        return new ManagedConnectionImpl(this);
     }
 
     public Boolean getEnableBetaContent() {

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ManagedConnectionImpl.java
@@ -1,0 +1,140 @@
+package org.test.config.adapter;
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionEventListener;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.LocalTransaction;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionMetaData;
+import javax.resource.spi.SecurityException;
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.transaction.xa.XAResource;
+
+public class ManagedConnectionImpl implements ManagedConnection {
+    private boolean destroyed;
+    private final ManagedConnectionFactoryImpl mcf;
+
+    ManagedConnectionImpl(ManagedConnectionFactoryImpl mcf) {
+        this.mcf = mcf;
+    }
+
+    @Override
+    public void addConnectionEventListener(ConnectionEventListener listener) {
+    }
+
+    @Override
+    public void associateConnection(Object handle) throws ResourceException {
+    }
+
+    @Override
+    public void cleanup() throws ResourceException {
+    }
+
+    @Override
+    public void destroy() {
+        destroyed = true;
+    }
+
+    @Override
+    public Object getConnection(Subject subject, ConnectionRequestInfo cri) throws ResourceException {
+        ConnectionSpecImpl conSpec = (ConnectionSpecImpl) cri;
+        String userName = mcf.getUserName();
+        String password = mcf.getPassword();
+        if (subject == null) {
+            userName = conSpec.getUserName() == null ? userName : conSpec.getUserName();
+            password = conSpec.getPassword() == null ? password : conSpec.getPassword();
+        } else { // oversimplified handling of Subject
+            PasswordCredential cred;
+            try {
+                cred = AccessController.doPrivileged((PrivilegedExceptionAction<PasswordCredential>) () -> {
+                    for (Object c : subject.getPrivateCredentials())
+                        if (c instanceof PasswordCredential && ((PasswordCredential) c).getManagedConnectionFactory() == mcf)
+                            return (PasswordCredential) c;
+                    return null;
+                });
+            } catch (PrivilegedActionException x) {
+                throw new SecurityException(x.getCause());
+            }
+            if (cred != null) {
+                userName = cred.getUserName();
+                password = new String(cred.getPassword());
+            }
+        }
+
+        // Accept some user/password combinations and reject others
+        if (userName == null && password == null ||
+            userName != null && userName.replace("user", "pwd").equals(password))
+            try {
+                InvocationHandler handler = new ConnectionImpl(userName);
+                return AccessController.doPrivileged((PrivilegedExceptionAction<?>) () -> {
+                    return Proxy.newProxyInstance(conSpec.interfaces[0].getClassLoader(),
+                                                  conSpec.interfaces,
+                                                  handler);
+                });
+            } catch (PrivilegedActionException x) {
+                Throwable cause = x.getCause();
+                if (cause instanceof ResourceException)
+                    throw (ResourceException) cause;
+                else
+                    throw new ResourceException(cause);
+            }
+        else
+            throw new SecurityException("Unable to authenticate as " + userName, "ERR_AUTH");
+    }
+
+    @Override
+    public LocalTransaction getLocalTransaction() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws ResourceException {
+        return null;
+    }
+
+    @Override
+    public ManagedConnectionMetaData getMetaData() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public XAResource getXAResource() throws ResourceException {
+        throw new NotSupportedException();
+    }
+
+    @Override
+    public void removeConnectionEventListener(ConnectionEventListener listener) {
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter logWriter) throws ResourceException {
+    }
+
+    /**
+     * Simulate the pattern used by CICS/IMS resource adapters to allow for a managed connection to be tested.
+     *
+     * @return true if validation is successful. False indicates validation is unsuccessful.
+     */
+    public boolean testConnection() {
+        return !destroyed;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ManagedJDBCConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ManagedJDBCConnectionFactoryImpl.java
@@ -34,6 +34,6 @@ public class ManagedJDBCConnectionFactoryImpl extends ManagedConnectionFactoryIm
 
     @Override
     public Object createConnectionFactory(ConnectionManager cm) throws ResourceException {
-        return new DataSourceImpl();
+        return new DataSourceImpl(cm, this);
     }
 }

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ResourceAdapterMetaDataImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/adapter/ResourceAdapterMetaDataImpl.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.adapter;
+
+import javax.resource.cci.ResourceAdapterMetaData;
+
+public class ResourceAdapterMetaDataImpl implements ResourceAdapterMetaData {
+    @Override
+    public String getAdapterName() {
+        return "TestConfigAdapter";
+    }
+
+    @Override
+    public String getAdapterShortDescription() {
+        return "This tiny resource adapter doesn't do much at all.";
+    }
+
+    @Override
+    public String getAdapterVendorName() {
+        return "OpenLiberty";
+    }
+
+    @Override
+    public String getAdapterVersion() {
+        return "60.91.109";
+    }
+
+    @Override
+    public String[] getInteractionSpecsSupported() {
+        return new String[] { InteractionSpecImpl.class.getName() };
+    }
+
+    @Override
+    public String getSpecVersion() {
+        return "1.7";
+    }
+
+    @Override
+    public boolean supportsExecuteWithInputAndOutputRecord() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsExecuteWithInputRecordOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsLocalTransactionDemarcation() {
+        return false;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
@@ -55,6 +55,7 @@ import com.ibm.wsspi.validator.Validator;
            service = { Validator.class },
            property = { "service.vendor=IBM", "com.ibm.wsspi.rest.handler.root=/validation",
                         "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.connectionFactory",
+                        "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.connectionFactory.supertype", // used by app-defined connection factory
                         "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.jmsConnectionFactory",
                         "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.jmsQueueConnectionFactory",
                         "com.ibm.wsspi.rest.handler.config.pid=com.ibm.ws.jca.jmsTopicConnectionFactory"


### PR DESCRIPTION
Test coverage for the validation REST endpoint for JCA connection factories (includes javax.resource.cci.ConnectionFactory and javax.sql.DataSource as a JCA connection factory).
This also includes code updates to make the validation REST endpoint possible for app-defined connection factories.