### PR TITLE
Revert "Re-deliver improved version of PR #7356"

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/servers/MPConcurrencyTCKServer/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/servers/MPConcurrencyTCKServer/bootstrap.properties
@@ -9,5 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:concurrent=all:com.ibm.ws.cdi.mp.concurrent.context=all

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/servers/MPConcurrencyTCKServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/servers/MPConcurrencyTCKServer/server.xml
@@ -11,4 +11,12 @@
 
     <include location="../fatTestPorts.xml" />
     
+    <!-- Perms required by arquillian/testng -->
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+
+    <!-- Ain't nobody got time for this -->
+    <javaPermission className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -587,10 +587,10 @@ serverEnvDefaults()
     fi
   esac
 
-  # Add -Xquickstart -Xnoaot for client JVMs only.  AOT is ineffective if JVMs have conflicting
-  # options, and it's more important that the server JVMs be able to use AOT.
-  # Add -Dcom.ibm.tools.attach.enable=yes to allow self-attach on z/OS
-  IBM_JAVA_OPTIONS="-Xquickstart -Xnoaot -Dcom.ibm.tools.attach.enable=yes ${IBM_JAVA_OPTIONS}"
+  # Add -Xquickstart -Xnoaot for client JVMs only.  AOT is ineffective if JVMs
+  # have conflicting options, and it's more important that the server JVMs be
+  # able to use AOT.
+  IBM_JAVA_OPTIONS="-Xquickstart -Xnoaot ${IBM_JAVA_OPTIONS}"
   export IBM_JAVA_OPTIONS
 
   # Set a default file encoding if needed
@@ -623,8 +623,7 @@ serverEnvAndJVMOptions()
   serverEnv
 
   # Avoids HeadlessException on all platforms and Liberty JVMs appearing as applications and stealing focus on Mac.
-  # Declare allowAttachSelf=true so that the VM will permit a late self attach if localConnector-1.0 is enabled
-  JVM_OPTIONS_QUOTED="-Djava.awt.headless=true -Djdk.attach.allowAttachSelf=true"
+  JVM_OPTIONS_QUOTED=-Djava.awt.headless=true
   SERVER_JVM_OPTIONS_QUOTED=${JVM_OPTIONS_QUOTED}
 
   # Add -XX:MaxPermSize unless WLP_SKIP_MAXPERMSIZE is set.

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -518,8 +518,6 @@ goto:eof
   )
   @REM Avoid HeadlessException.
   set JVM_OPTIONS=-Djava.awt.headless=true !JVM_OPTIONS!
-  @REM allow late self attach for when the localConnector-1.0 feature is enabled
-  set JVM_OPTIONS=-Djdk.attach.allowAttachSelf=true !JVM_OPTIONS!
 
 
   @REM The order of merging the jvm.option files sets the precedence. 

--- a/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
@@ -1,10 +1,19 @@
 ### Exports
+# JMX Agent in LocalConnectorActivator
+--add-exports
+jdk.management.agent/jdk.internal.agent=ALL-UNNAMED
+# for JMX VMSupport in LocalConnectorActivator
+--add-exports
+java.base/jdk.internal.vm=ALL-UNNAMED
 # for com.ibm.crypto.ibmkeycert.jar
 --add-exports
 java.base/sun.security.action=ALL-UNNAMED
 # for com.ibm.ws.jndi.internal.WASInitialContextFactoryBuilder
 --add-exports
 java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+# for dump action: com.ibm.ws.kernel.boot.internal.commands.HotSpotJavaDumperImpl$VirtualMachine.remoteDataDump(HotSpotJavaDumperImpl.java:342)
+--add-exports
+jdk.attach/sun.tools.attach=ALL-UNNAMED
 ### Opens
 --add-opens
 java.base/java.util=ALL-UNNAMED

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -26,9 +26,7 @@
             <property name="verifyAppDeployTimeout">60</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">60</property>
-            <!-- com.ibm.tools.attach.enable=yes is for using the localConnector-1.0 feature on zOS -->
-            <!-- jdk.attach.allowAttachSelf is to allow late self-attach on JDK 11+ -->
-            <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes -Djdk.attach.allowAttachSelf=true</property>
+            <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes</property> <!-- this goes here because this tck project asks arquillian to start the server -->
         </configuration>
     </container>
 </arquillian>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/bnd.bnd
@@ -18,3 +18,15 @@ src: \
 	fat/src
 
 fat.project: true
+
+
+# To define a global minimum java level for the FAT, use the following property.
+# If unspecified, the default value is ${javac.source}
+runtime.minimum.java.level: 1.8
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+# Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
+#      or binaries from Artifactory (e.g. org.apache.derby:derbynet)
+# For all project names that match the pattern "*_fat*", dependencies for junit,
+# fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
+-buildpath: \

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -26,9 +26,7 @@
             <property name="verifyAppDeployTimeout">60</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">60</property>
-            <!-- com.ibm.tools.attach.enable=yes is for using the localConnector-1.0 feature on zOS -->
-            <!-- jdk.attach.allowAttachSelf is to allow late self-attach on JDK 11+ -->
-            <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes -Djdk.attach.allowAttachSelf=true</property>
+            <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes</property> <!-- this goes here because this tck project asks arquillian to start the server -->
         </configuration>
     </container>
 </arquillian>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -26,9 +26,7 @@
             <property name="verifyAppDeployTimeout">60</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">${tck_appUndeployTimeout}</property>
-            <!-- com.ibm.tools.attach.enable=yes is for using the localConnector-1.0 feature on zOS -->
-            <!-- jdk.attach.allowAttachSelf is to allow late self-attach on JDK 11+ -->
-            <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes -Djdk.attach.allowAttachSelf=true</property>
+            <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes</property> <!-- this goes here because this tck project asks arquillian to start the server -->
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#7648

#7648 appears to be the cause of #7542 and #7787 ... which is probably the root of a couple of thousand J2S failures.