### PR TITLE
first step toward using standard MPConfig property names

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextManagerImpl.java
@@ -149,7 +149,7 @@ public class ContextManagerImpl implements ContextManager {
      * @param defaultValue value to use if not found in MicroProfile Config.
      * @return default value.
      */
-    <T> T getDefault(String mpConfigPropName, T defaultValue) {
+    <T> T getDefault(String mpConfigPropName, String oldName, T defaultValue) { // TODO remove the old name after spec change
         MPConfigAccessor accessor = cmProvider.mpConfigAccessor;
         if (accessor != null) {
             Object mpConfig = mpConfigRef.get();
@@ -157,8 +157,10 @@ public class ContextManagerImpl implements ContextManager {
                 if (!mpConfigRef.compareAndSet(Boolean.FALSE, mpConfig = accessor.getConfig()))
                     mpConfig = mpConfigRef.get();
 
-            if (mpConfig != null)
+            if (mpConfig != null) {
+                defaultValue = accessor.get(mpConfig, oldName, defaultValue); // TODO remove this line after spec change
                 defaultValue = accessor.get(mpConfig, mpConfigPropName, defaultValue);
+            }
         }
         return defaultValue;
     }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
@@ -55,10 +55,10 @@ public class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
 
     @Override
     public ManagedExecutor build() {
-        Set<String> cleared = this.cleared == null ? contextManager.getDefault("ManagedExecutor/cleared", DEFAULT_CLEARED) : this.cleared;
-        int maxAsync = this.maxAsync == UNDEFINED ? contextManager.getDefault("ManagedExecutor/maxAsync", -1) : this.maxAsync;
-        int maxQueued = this.maxQueued == UNDEFINED ? contextManager.getDefault("ManagedExecutor/maxQueued", -1) : this.maxQueued;
-        Set<String> propagated = this.propagated == null ? contextManager.getDefault("ManagedExecutor/propagated", DEFAULT_PROPAGATED) : this.propagated;
+        Set<String> cleared = this.cleared == null ? contextManager.getDefault("mp.context.ManagedExecutor.cleared", "ManagedExecutor/cleared", DEFAULT_CLEARED) : this.cleared;
+        int maxAsync = this.maxAsync == UNDEFINED ? contextManager.getDefault("mp.context.ManagedExecutor.maxAsync", "ManagedExecutor/maxAsync", -1) : this.maxAsync;
+        int maxQueued = this.maxQueued == UNDEFINED ? contextManager.getDefault("mp.context.ManagedExecutor.maxQueued", "ManagedExecutor/maxQueued", -1) : this.maxQueued;
+        Set<String> propagated = this.propagated == null ? contextManager.getDefault("mp.context.ManagedExecutor.propagated", "ManagedExecutor/propagated", DEFAULT_PROPAGATED) : this.propagated;
 
         // For detection of unknown and overlapping types,
         HashSet<String> unknown = new HashSet<String>(cleared);

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
@@ -53,9 +53,9 @@ public class ThreadContextBuilderImpl implements ThreadContext.Builder {
 
     @Override
     public ThreadContext build() {
-        Set<String> cleared = this.cleared == null ? contextManager.getDefault("ThreadContext/cleared", DEFAULT_CLEARED) : this.cleared;
-        Set<String> propagated = this.propagated == null ? contextManager.getDefault("ThreadContext/propagated", DEFAULT_PROPAGATED) : this.propagated;
-        Set<String> unchanged = this.unchanged == null ? contextManager.getDefault("ThreadContext/unchanged", DEFAULT_UNCHANGED) : this.unchanged;
+        Set<String> cleared = this.cleared == null ? contextManager.getDefault("mp.context.ThreadContext.cleared", "ThreadContext/cleared", DEFAULT_CLEARED) : this.cleared;
+        Set<String> propagated = this.propagated == null ? contextManager.getDefault("mp.context.ThreadContext.propagated", "ThreadContext/propagated", DEFAULT_PROPAGATED) : this.propagated;
+        Set<String> unchanged = this.unchanged == null ? contextManager.getDefault("mp.context.ThreadContext.unchanged", "ThreadContext/unchanged", DEFAULT_UNCHANGED) : this.unchanged;
 
         // For detection of unknown and overlapping types,
         HashSet<String> unknown = new HashSet<String>(cleared);

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/resources/META-INF/microprofile-config.properties
@@ -1,7 +1,7 @@
-ManagedExecutor/maxAsync=2
-ManagedExecutor/maxQueued=3
-ManagedExecutor/cleared=Transaction
-ManagedExecutor/propagated=City,Application
-ThreadContext/cleared=
-ThreadContext/propagated=State
-ThreadContext/unchanged=Remaining
+mp.context.ManagedExecutor.maxAsync=2
+mp.context.ManagedExecutor.maxQueued=3
+mp.context.ManagedExecutor.cleared=Transaction
+mp.context.ManagedExecutor.propagated=City,Application
+mp.context.ThreadContext.cleared=
+mp.context.ThreadContext.propagated=State
+mp.context.ThreadContext.unchanged=Remaining

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/MPConcurrentConfigTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentConfigApp/src/concurrent/mp/fat/config/web/MPConcurrentConfigTestServlet.java
@@ -220,8 +220,8 @@ public class MPConcurrentConfigTestServlet extends FATServlet {
     @Test
     public void testMPConfigSpecifiesDefaultAsyncAndQueuedMaximumsForManagedExecutor() throws Exception {
         // Defaults:
-        // ManagedExecutor/maxAsync=2
-        // ManagedExecutor/maxQueued=3
+        // mp.context.ManagedExecutor.maxAsync=2
+        // mp.context.ManagedExecutor.maxQueued=3
         ManagedExecutor executor = ManagedExecutor.builder().build();
 
         // schedule 2 tasks to block and wait for them to start
@@ -271,8 +271,8 @@ public class MPConcurrentConfigTestServlet extends FATServlet {
     @Test
     public void testMPConfigSpecifiesDefaultContextPropagationForManagedExecutor() throws Exception {
         // Defaults:
-        // ManagedExecutor/cleared=Transaction
-        // ManagedExecutor/propagated=City,Application
+        // mp.context.ManagedExecutor.cleared=Transaction
+        // mp.context.ManagedExecutor.propagated=City,Application
         ManagedExecutor executor = ManagedExecutor.builder()
                         .maxAsync(10)
                         .build();
@@ -304,9 +304,9 @@ public class MPConcurrentConfigTestServlet extends FATServlet {
     @Test
     public void testMPConfigSpecifiesDefaultContextPropagationForThreadContext() throws Exception {
         // Defaults:
-        // ThreadContext/cleared=
-        // ThreadContext/propagated=State
-        // ThreadContext/unchanged=Remaining
+        // mp.context.ThreadContext.cleared=
+        // mp.context.ThreadContext.propagated=State
+        // mp.context.ThreadContext.unchanged=Remaining
         ThreadContext threadContext = ThreadContext.builder().build();
 
         CurrentLocation.setLocation("Owatonna", "Minnesota");


### PR DESCRIPTION
In order to align with standards being defined for MicroProfile specs that define their own MicroProfile Config properties, we need to change the name of 7 properties that MicroProfile Context Propagation uses to supply default values for ManagedExecutor/ThreadContext instances.  Per https://github.com/eclipse/microprofile/pull/100 these property names should be prefixed with mp.[spec-name]. and per eclipse/microprofile-config#420 these property names should avoid the use of /.

This pull will make OpenLiberty tolerate either form of the property names for now.  Then, once the spec changes goes through, we can remove support for the old names.