### PR TITLE
validation for app-defined JMS connection factories

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
@@ -315,7 +315,10 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
             if (properties != null) {
                 Object enableSharingForDirectLookups = properties.get("enableSharingForDirectLookups");
                 sharingScope = enableSharingForDirectLookups == null
-                               || (Boolean) enableSharingForDirectLookups ? ResourceRefInfo.SHARING_SCOPE_SHAREABLE : ResourceRefInfo.SHARING_SCOPE_UNSHAREABLE;
+                               || Boolean.TRUE.equals(enableSharingForDirectLookups)
+                               || enableSharingForDirectLookups instanceof String && Boolean.parseBoolean((String) enableSharingForDirectLookups) //
+                                               ? ResourceRefInfo.SHARING_SCOPE_SHAREABLE //
+                                               : ResourceRefInfo.SHARING_SCOPE_UNSHAREABLE;
             } else {
                 sharingScope = ResourceRefInfo.SHARING_SCOPE_SHAREABLE;
             }

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -1111,4 +1111,43 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "DBUSER3", info.getString("schema"));
         assertEquals(err, "dbuser3", info.getString("user"));
     }
+
+    /**
+     * Use the /ibm/api/validator REST endpoint to validate an application-defined JMS connection factory
+     */
+    @Test
+    public void testValidateAppDefinedJMSConnectionFactory() throws Exception {
+        JsonObject j = new HttpsRequest(server, "/ibm/api/validation/jmsConnectionFactory/application%5BAppDefResourcesApp%5D%2Fmodule%5BAppDefResourcesApp.war%5D%2FjmsConnectionFactory%5Bjava%3Acomp%2Fenv%2Fjms%2Fcf%5D")
+                        .run(JsonObject.class);
+        String err = "unexpected response: " + j;
+
+        assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/jmsConnectionFactory[java:comp/env/jms/cf]", j.getString("uid"));
+        assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/jmsConnectionFactory[java:comp/env/jms/cf]", j.getString("id"));
+        assertEquals(err, "java:comp/env/jms/cf", j.getString("jndiName"));
+        assertTrue(err, j.getBoolean("successful"));
+        assertNull(err, j.get("failure"));
+        assertNotNull(err, j = j.getJsonObject("info"));
+        assertEquals(err, "IBM", j.getString("jmsProviderName"));
+        assertEquals(err, "1.0", j.getString("jmsProviderVersion"));
+        assertEquals(err, "clientID", j.getString("clientID"));
+    }
+
+    /**
+     * Use the /ibm/api/validator REST endpoint to validate an application-defined JMS queue connection factory
+     */
+    @Test
+    public void testValidateAppDefinedJMSQueueConnectionFactory() throws Exception {
+        JsonObject j = new HttpsRequest(server, "/ibm/api/validation/jmsQueueConnectionFactory/application%5BAppDefResourcesApp%5D%2Fmodule%5BAppDefResourcesApp.war%5D%2FjmsQueueConnectionFactory%5Bjava%3Amodule%2Fenv%2Fjms%2Fqcf%5D")
+                        .run(JsonObject.class);
+        String err = "unexpected response: " + j;
+
+        assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/jmsQueueConnectionFactory[java:module/env/jms/qcf]", j.getString("uid"));
+        assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/jmsQueueConnectionFactory[java:module/env/jms/qcf]", j.getString("id"));
+        assertEquals(err, "java:module/env/jms/qcf", j.getString("jndiName"));
+        assertTrue(err, j.getBoolean("successful"));
+        assertNull(err, j.get("failure"));
+        assertNotNull(err, j = j.getJsonObject("info"));
+        assertEquals(err, "IBM", j.getString("jmsProviderName"));
+        assertEquals(err, "1.0", j.getString("jmsProviderVersion"));
+    }
 }

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -974,7 +974,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "60.91.109", j.getString("resourceAdapterVersion"));
         assertEquals(err, "OpenLiberty", j.getString("resourceAdapterVendor"));
         assertEquals(err, "This tiny resource adapter doesn't do much at all.", j.getString("resourceAdapterDescription"));
-        assertEquals(err, "1.7", j.getString("resourceAdapterJCASupport")); // TODO change to specVersion so that we avoid using the JCA acronym from Java EE
+        assertEquals(err, "1.7", j.getString("connectorSpecVersion"));
         assertEquals(err, "cfuser1", j.getString("user"));
 
         assertNotNull(err, j = array.getJsonObject(1)); // a javax.sql.DataSource

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
@@ -236,10 +236,6 @@ public class ConnectionFactoryValidator implements Validator {
             result.put("resourceAdapterName", adapterData.getAdapterName());
             result.put("resourceAdapterVersion", adapterData.getAdapterVersion());
 
-            String spec = adapterData.getSpecVersion();
-            if (spec != null && spec.length() > 0)
-                result.put("resourceAdapterJCASupport", spec);
-
             String vendor = adapterData.getAdapterVendorName();
             if (vendor != null && vendor.length() > 0)
                 result.put("resourceAdapterVendor", vendor);
@@ -247,6 +243,10 @@ public class ConnectionFactoryValidator implements Validator {
             String desc = adapterData.getAdapterShortDescription();
             if (desc != null && desc.length() > 0)
                 result.put("resourceAdapterDescription", desc);
+
+            String spec = adapterData.getSpecVersion();
+            if (spec != null && spec.length() > 0)
+                result.put("connectorSpecVersion", spec);
         } catch (NotSupportedException ignore) {
         } catch (UnsupportedOperationException ignore) {
         }
@@ -260,7 +260,7 @@ public class ConnectionFactoryValidator implements Validator {
 
             if (conSpec == null) {
                 // TODO find ConnectionSpec impl another way?
-                throw new RuntimeException("Unable to locate javax.resource.cci.ConnectionSpec impl from resource adapter.");
+                throw new RuntimeException("Unable to locate " + ConnectionSpec.class.getName() + " impl from resource adapter.");
             }
         }
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
@@ -95,7 +95,7 @@ public class ValidateJCATest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "TestValidationAdapter", json.getString("resourceAdapterName"));
         assertEquals(err, "28.45.53", json.getString("resourceAdapterVersion"));
-        assertEquals(err, "1.7", json.getString("resourceAdapterJCASupport"));
+        assertEquals(err, "1.7", json.getString("connectorSpecVersion"));
         assertEquals(err, "OpenLiberty", json.getString("resourceAdapterVendor"));
         assertEquals(err, "This tiny resource adapter doesn't do much at all.", json.getString("resourceAdapterDescription"));
         assertEquals(err, "TestValidationEIS", json.getString("eisProductName"));
@@ -122,7 +122,7 @@ public class ValidateJCATest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "TestValidationAdapter", json.getString("resourceAdapterName"));
         assertEquals(err, "28.45.53", json.getString("resourceAdapterVersion"));
-        assertEquals(err, "1.7", json.getString("resourceAdapterJCASupport"));
+        assertEquals(err, "1.7", json.getString("connectorSpecVersion"));
         assertEquals(err, "OpenLiberty", json.getString("resourceAdapterVendor"));
         assertEquals(err, "This tiny resource adapter doesn't do much at all.", json.getString("resourceAdapterDescription"));
         assertEquals(err, "TestValidationEIS", json.getString("eisProductName"));
@@ -219,7 +219,7 @@ public class ValidateJCATest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "TestValidationAdapter", json.getString("resourceAdapterName"));
         assertEquals(err, "28.45.53", json.getString("resourceAdapterVersion"));
-        assertEquals(err, "1.7", json.getString("resourceAdapterJCASupport"));
+        assertEquals(err, "1.7", json.getString("connectorSpecVersion"));
         assertEquals(err, "OpenLiberty", json.getString("resourceAdapterVendor"));
         assertEquals(err, "This tiny resource adapter doesn't do much at all.", json.getString("resourceAdapterDescription"));
         assertEquals(err, "TestValidationEIS", json.getString("eisProductName"));
@@ -242,7 +242,7 @@ public class ValidateJCATest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "TestValidationAdapter", json.getString("resourceAdapterName"));
         assertEquals(err, "28.45.53", json.getString("resourceAdapterVersion"));
-        assertEquals(err, "1.7", json.getString("resourceAdapterJCASupport"));
+        assertEquals(err, "1.7", json.getString("connectorSpecVersion"));
         assertEquals(err, "OpenLiberty", json.getString("resourceAdapterVendor"));
         assertEquals(err, "This tiny resource adapter doesn't do much at all.", json.getString("resourceAdapterDescription"));
         assertEquals(err, "TestValidationEIS", json.getString("eisProductName"));
@@ -382,7 +382,7 @@ public class ValidateJCATest extends FATServletClient {
         assertNotNull(err, j = j.getJsonObject("info"));
         assertEquals(err, "TestValidationAdapter", j.getString("resourceAdapterName"));
         assertEquals(err, "28.45.53", j.getString("resourceAdapterVersion"));
-        assertEquals(err, "1.7", j.getString("resourceAdapterJCASupport"));
+        assertEquals(err, "1.7", j.getString("connectorSpecVersion"));
         assertEquals(err, "OpenLiberty", j.getString("resourceAdapterVendor"));
         assertEquals(err, "This tiny resource adapter doesn't do much at all.", j.getString("resourceAdapterDescription"));
         assertEquals(err, "TestValidationEIS", j.getString("eisProductName"));
@@ -584,7 +584,7 @@ public class ValidateJCATest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "TestValidationAdapter", json.getString("resourceAdapterName"));
         assertEquals(err, "28.45.53", json.getString("resourceAdapterVersion"));
-        assertEquals(err, "1.7", json.getString("resourceAdapterJCASupport"));
+        assertEquals(err, "1.7", json.getString("connectorSpecVersion"));
         assertEquals(err, "OpenLiberty", json.getString("resourceAdapterVendor"));
         assertEquals(err, "This tiny resource adapter doesn't do much at all.", json.getString("resourceAdapterDescription"));
         assertEquals(err, "TestValidationEIS", json.getString("eisProductName"));


### PR DESCRIPTION
Add test coverage for the /validation/ REST endpoint for app-defined JMS connection factories.
Also, fix a ClassCastException when enableSharingForDirectLookups is specified on app-defined resources.