### PR TITLE
Increased duration of timeout for waitForMetricsEndpoint and decreased sleep time before running test.

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
@@ -99,7 +99,11 @@ public class MetricsAuthenticationTest {
 
         //check that opening connection to /metrics requires authentication by default
 
+<<<<<<< Updated upstream
         Thread.sleep(10000);
+=======
+        Thread.sleep(8000);
+>>>>>>> Stashed changes
 
         MetricsConnection authenticationNotSpecified = MetricsConnection.connection_administratorRole(server);
         authenticationNotSpecified.expectedResponseCode(HttpURLConnection.HTTP_OK).getConnection();

--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -79,7 +79,7 @@ public class MetricsAuthenticationTest {
     }
 
     private void waitForMetricsEndpoint(LibertyServer server) throws Exception {
-        assertNotNull("Web application is not available at */metrics/", server.waitForStringInLog("CWWKT0016I.*/metrics/", TIMEOUT * 2, server.getDefaultLogFile()));
+        assertNotNull("Web application is not available at */metrics/", server.waitForStringInLog("CWWKT0016I.*/metrics/", TIMEOUT * 3, server.getDefaultLogFile()));
     }
 
     private static void setMetricsAuthConfig(LibertyServer server, Boolean authentication) throws Exception {
@@ -99,11 +99,7 @@ public class MetricsAuthenticationTest {
 
         //check that opening connection to /metrics requires authentication by default
 
-<<<<<<< Updated upstream
-        Thread.sleep(10000);
-=======
         Thread.sleep(8000);
->>>>>>> Stashed changes
 
         MetricsConnection authenticationNotSpecified = MetricsConnection.connection_administratorRole(server);
         authenticationNotSpecified.expectedResponseCode(HttpURLConnection.HTTP_OK).getConnection();


### PR DESCRIPTION
#build
#7667