### PR TITLE
validation REST endpoint for app-defined topicConnectionFactory

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -68,7 +68,9 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
                                         .addClass("org.test.config.jmsadapter.JMSConnectionFactoryImpl")
                                         .addClass("org.test.config.jmsadapter.JMSDestinationImpl")
                                         .addClass("org.test.config.jmsadapter.JMSTopicConnectionFactoryImpl")
-                                        .addClass("org.test.config.jmsadapter.ManagedJMSTopicConnectionFactoryImpl"));
+                                        .addClass("org.test.config.jmsadapter.JMSTopicConnectionImpl")
+                                        .addClass("org.test.config.jmsadapter.ManagedJMSTopicConnectionFactoryImpl")
+                                        .addClass("org.test.config.jmsadapter.NoOpSessionImpl"));
         ShrinkHelper.exportToServer(server, "connectors", tca_rar);
 
         server.startServer();
@@ -1129,6 +1131,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertNotNull(err, j = j.getJsonObject("info"));
         assertEquals(err, "IBM", j.getString("jmsProviderName"));
         assertEquals(err, "1.0", j.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", j.getString("jmsProviderSpecVersion"));
         assertEquals(err, "clientID", j.getString("clientID"));
     }
 
@@ -1149,5 +1152,27 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertNotNull(err, j = j.getJsonObject("info"));
         assertEquals(err, "IBM", j.getString("jmsProviderName"));
         assertEquals(err, "1.0", j.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", j.getString("jmsProviderSpecVersion"));
+    }
+
+    /**
+     * Use the /ibm/api/validator REST endpoint to validate an application-defined JMS topic connection factory
+     */
+    @Test
+    public void testValidateAppDefinedJMSTopicConnectionFactory() throws Exception {
+        JsonObject j = new HttpsRequest(server, "/ibm/api/validation/jmsTopicConnectionFactory/application%5BAppDefResourcesApp%5D%2FjmsTopicConnectionFactory%5Bjava%3Aapp%2Fenv%2Fjms%2Ftcf%5D")
+                        .run(JsonObject.class);
+        String err = "unexpected response: " + j;
+
+        assertEquals(err, "application[AppDefResourcesApp]/jmsTopicConnectionFactory[java:app/env/jms/tcf]", j.getString("uid"));
+        assertEquals(err, "application[AppDefResourcesApp]/jmsTopicConnectionFactory[java:app/env/jms/tcf]", j.getString("id"));
+        assertEquals(err, "java:app/env/jms/tcf", j.getString("jndiName"));
+        assertTrue(err, j.getBoolean("successful"));
+        assertNull(err, j.get("failure"));
+        assertNotNull(err, j = j.getJsonObject("info"));
+        assertEquals(err, "TestConfig Messaging Provider", j.getString("jmsProviderName"));
+        assertEquals(err, "88.105.137", j.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", j.getString("jmsProviderSpecVersion"));
+        assertEquals(err, "AppDefinedClientId", j.getString("clientID"));
     }
 }

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerJMSTest.java
@@ -399,7 +399,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
 
         JsonObject props;
         assertNotNull(err, props = cf.getJsonObject("properties.jmsra"));
-        assertEquals(err, 4, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, 5, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "DefaultClientId", props.getString("clientId"));
         assertEquals(err, "%", props.getString("escapeChar"));
         assertEquals(err, "localhost", props.getString("hostName"));
         assertEquals(err, "user3", props.getString("userName"));
@@ -439,7 +440,8 @@ public class ConfigRESTHandlerJMSTest extends FATServletClient {
 
         JsonObject props;
         assertNotNull(err, props = cf.getJsonObject("properties.jmsra"));
-        assertEquals(err, 1, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, 2, props.size()); // increase this if we ever add additional configured values or default values
+        assertEquals(err, "DefaultClientId", props.getString("clientId"));
         assertEquals(err, "host4.rchland.ibm.com", props.getString("hostName"));
     }
 }

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
@@ -44,6 +44,7 @@ import javax.resource.ConnectionFactoryDefinitions;
 @JMSConnectionFactoryDefinition(name = "java:app/env/jms/tcf",
                                 interfaceName = "javax.jms.TopicConnectionFactory",
                                 resourceAdapter = "ConfigTestAdapter",
+                                clientId = "AppDefinedClientId",
                                 maxPoolSize = 8,
                                 properties = {
                                                "enableBetaContent=true",

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSTopicConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSTopicConnectionFactoryImpl.java
@@ -10,18 +10,38 @@
  *******************************************************************************/
 package org.test.config.jmsadapter;
 
+import javax.jms.Connection;
 import javax.jms.JMSException;
 import javax.jms.TopicConnection;
 import javax.jms.TopicConnectionFactory;
+import javax.resource.spi.ConnectionManager;
 
 public class JMSTopicConnectionFactoryImpl extends JMSConnectionFactoryImpl implements TopicConnectionFactory {
+    final ConnectionManager cm;
+    final ManagedJMSTopicConnectionFactoryImpl mcf;
+
+    JMSTopicConnectionFactoryImpl(ConnectionManager cm, ManagedJMSTopicConnectionFactoryImpl mcf) {
+        this.cm = cm;
+        this.mcf = mcf;
+    }
+
+    @Override
+    public Connection createConnection() throws JMSException {
+        return createTopicConnection();
+    }
+
+    @Override
+    public Connection createConnection(String user, String password) throws JMSException {
+        return createTopicConnection(user, password);
+    }
+
     @Override
     public TopicConnection createTopicConnection() throws JMSException {
-        throw new UnsupportedOperationException();
+        return createTopicConnection(null, null);
     }
 
     @Override
     public TopicConnection createTopicConnection(String user, String password) throws JMSException {
-        throw new UnsupportedOperationException();
+        return new JMSTopicConnectionImpl(this);
     }
 }

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSTopicConnectionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/JMSTopicConnectionImpl.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import java.lang.reflect.Proxy;
+import java.util.Enumeration;
+
+import javax.jms.ConnectionConsumer;
+import javax.jms.ConnectionMetaData;
+import javax.jms.Destination;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+import javax.jms.ServerSessionPool;
+import javax.jms.Session;
+import javax.jms.Topic;
+import javax.jms.TopicConnection;
+import javax.jms.TopicSession;
+
+public class JMSTopicConnectionImpl implements TopicConnection, ConnectionMetaData {
+    private final JMSTopicConnectionFactoryImpl tcf;
+
+    JMSTopicConnectionImpl(JMSTopicConnectionFactoryImpl tcf) {
+        this.tcf = tcf;
+    }
+
+    @Override
+    public void close() throws JMSException {
+    }
+
+    @Override
+    public ConnectionConsumer createConnectionConsumer(Destination destination, String messageSelector, ServerSessionPool sessionPool, int maxMessages) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConnectionConsumer createConnectionConsumer(Topic topic, String messageSelector, ServerSessionPool sessionPool, int maxMessages) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConnectionConsumer createDurableConnectionConsumer(Topic topic, String subscriptionName, String messageSelector, ServerSessionPool sessionPool, int maxMessages) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Session createSession() throws JMSException {
+        return (TopicSession) Proxy.newProxyInstance(TopicSession.class.getClassLoader(),
+                                                     new Class[] { TopicSession.class },
+                                                     new NoOpSessionImpl());
+    }
+
+    @Override
+    public Session createSession(int sessionMode) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Session createSession(boolean transacted, int acknowledgeMode) throws JMSException {
+        return createTopicSession(transacted, acknowledgeMode);
+    }
+
+    @Override
+    public ConnectionConsumer createSharedConnectionConsumer(Topic topic, String messageSelector, String sessionPool, ServerSessionPool arg3, int maxMessages) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConnectionConsumer createSharedDurableConnectionConsumer(Topic topic, String subscriptionName, String messageSelector, ServerSessionPool sessionPool, int maxMessages) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TopicSession createTopicSession(boolean transacted, int acknowledgeMode) throws JMSException {
+        return (TopicSession) Proxy.newProxyInstance(TopicSession.class.getClassLoader(),
+                                                     new Class[] { TopicSession.class },
+                                                     new NoOpSessionImpl());
+    }
+
+    @Override
+    public String getClientID() throws JMSException {
+        return tcf.mcf.getClientId();
+    }
+
+    @Override
+    public ExceptionListener getExceptionListener() throws JMSException {
+        return null;
+    }
+
+    @Override
+    public int getJMSMajorVersion() throws JMSException {
+        return 2;
+    }
+
+    @Override
+    public int getJMSMinorVersion() throws JMSException {
+        return 0;
+    }
+
+    @Override
+    public String getJMSProviderName() throws JMSException {
+        return "TestConfig Messaging Provider";
+    }
+
+    @Override
+    public String getJMSVersion() throws JMSException {
+        return "2.0";
+    }
+
+    @Override
+    public Enumeration<?> getJMSXPropertyNames() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getProviderMajorVersion() throws JMSException {
+        return 88;
+    }
+
+    @Override
+    public int getProviderMinorVersion() throws JMSException {
+        return 105;
+    }
+
+    @Override
+    public String getProviderVersion() throws JMSException {
+        return "88.105.137";
+    }
+
+    @Override
+    public ConnectionMetaData getMetaData() throws JMSException {
+        return this;
+    }
+
+    @Override
+    public void setClientID(String value) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setExceptionListener(ExceptionListener listener) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void start() throws JMSException {
+    }
+
+    @Override
+    public void stop() throws JMSException {
+    }
+
+}

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/ManagedJMSTopicConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/ManagedJMSTopicConnectionFactoryImpl.java
@@ -12,11 +12,12 @@ package org.test.config.jmsadapter;
 
 import javax.jms.TopicConnection;
 import javax.jms.TopicConnectionFactory;
+import javax.resource.NotSupportedException;
 import javax.resource.ResourceException;
+import javax.resource.spi.ConfigProperty;
 import javax.resource.spi.ConnectionDefinition;
 import javax.resource.spi.ConnectionManager;
 
-import org.test.config.adapter.ConnectionImpl;
 import org.test.config.adapter.ManagedConnectionFactoryImpl;
 
 /**
@@ -25,17 +26,28 @@ import org.test.config.adapter.ManagedConnectionFactoryImpl;
 @ConnectionDefinition(connectionFactory = TopicConnectionFactory.class,
                       connectionFactoryImpl = JMSTopicConnectionFactoryImpl.class,
                       connection = TopicConnection.class,
-                      connectionImpl = ConnectionImpl.class)
+                      connectionImpl = JMSTopicConnectionImpl.class)
 public class ManagedJMSTopicConnectionFactoryImpl extends ManagedConnectionFactoryImpl {
     private static final long serialVersionUID = 1L;
 
+    @ConfigProperty(defaultValue = "DefaultClientId")
+    String clientId;
+
     @Override
     public Object createConnectionFactory() throws ResourceException {
-        return createConnectionFactory(null);
+        throw new NotSupportedException();
     }
 
     @Override
     public Object createConnectionFactory(ConnectionManager cm) throws ResourceException {
-        return new JMSTopicConnectionFactoryImpl();
+        return new JMSTopicConnectionFactoryImpl(cm, this);
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String value) {
+        clientId = value;
     }
 }

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/NoOpSessionImpl.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-resourceadapter/src/org/test/config/jmsadapter/NoOpSessionImpl.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.test.config.jmsadapter;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+/**
+ * Proxy for JMS session where all methods return null.
+ */
+public class NoOpSessionImpl implements InvocationHandler {
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        String name = method.getName();
+
+        if ("hashCode".equals(name))
+            return System.identityHashCode(proxy);
+        if ("toString".equals(name))
+            return getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(proxy));
+
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jms/JMSConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jms/JMSConnectionFactoryValidator.java
@@ -55,6 +55,10 @@ public class JMSConnectionFactoryValidator implements JMSValidator {
                     String provVersion = conData.getProviderVersion();
                     if (provVersion != null && provVersion.length() > 0)
                         result.put("jmsProviderVersion", provVersion);
+
+                    String specVersion = conData.getJMSVersion();
+                    if (specVersion != null && specVersion.length() > 0)
+                        result.put("jmsProviderSpecVersion", specVersion);
                 } catch (UnsupportedOperationException ignore) {
                 }
 
@@ -89,6 +93,10 @@ public class JMSConnectionFactoryValidator implements JMSValidator {
                         String provVersion = conData.getProviderVersion();
                         if (provVersion != null && provVersion.length() > 0)
                             result.put("jmsProviderVersion", provVersion);
+
+                        String specVersion = conData.getJMSVersion();
+                        if (specVersion != null && specVersion.length() > 0)
+                            result.put("jmsProviderSpecVersion", specVersion);
                     } catch (UnsupportedOperationException ignore) {
                     }
 
@@ -123,6 +131,10 @@ public class JMSConnectionFactoryValidator implements JMSValidator {
                     String provVersion = conData.getProviderVersion();
                     if (provVersion != null && provVersion.length() > 0)
                         result.put("jmsProviderVersion", provVersion);
+
+                    String specVersion = conData.getJMSVersion();
+                    if (specVersion != null && specVersion.length() > 0)
+                        result.put("jmsProviderSpecVersion", specVersion);
                 } catch (UnsupportedOperationException ignore) {
                 }
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
@@ -74,6 +74,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
         assertEquals(err, "TestClient1", json.getString("clientID"));
     }
 
@@ -167,6 +168,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, j = j.getJsonObject("info"));
         assertEquals(err, "IBM", j.getString("jmsProviderName"));
         assertEquals(err, "1.0", j.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", j.getString("jmsProviderSpecVersion"));
         assertEquals(err, "clientID", j.getString("clientID"));
 
         // [1]: config.displayId=jmsConnectionFactory[jmscf1]
@@ -210,6 +212,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
         assertNull(err, json.get("clientID"));
     }
 
@@ -234,6 +237,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
         assertEquals(err, "clientID", json.getString("clientID"));
 
         assertNotNull(err, json = tcfs.getJsonObject(1));
@@ -245,6 +249,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
         assertEquals(err, "tcf2id", json.getString("clientID"));
 
         assertNotNull(err, json = tcfs.getJsonObject(2));
@@ -256,6 +261,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
         assertEquals(err, "tcf3id", json.getString("clientID"));
     }
 
@@ -274,6 +280,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
         assertNull(err, json.get("clientID"));
     }
 
@@ -292,6 +299,7 @@ public class ValidateJMSTest extends FATServletClient {
         assertNotNull(err, json = json.getJsonObject("info"));
         assertEquals(err, "IBM", json.getString("jmsProviderName"));
         assertEquals(err, "1.0", json.getString("jmsProviderVersion"));
+        assertEquals(err, "2.0", json.getString("jmsProviderSpecVersion"));
         assertEquals(err, "clientID", json.getString("clientID"));
     }
 }


### PR DESCRIPTION
Test coverage for validating an application-defined JMS topic connection factory via the validation REST endpoint.  Also, while working this, I noticed that the JMS spec version implemented by the JMS provider wasn't being included alongside the other metadata information in the validation result, so I added it.