### PR TITLE
Setting system prop in order to use localConnector-1.0 on zOS

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingRestClientTCKServer/jvm.options
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingRestClientTCKServer/jvm.options
@@ -1,1 +1,2 @@
 -DUSE_MOCK_TRACER=true
+-Dcom.ibm.tools.attach.enable=yes


### PR DESCRIPTION
Fixes: #7269

In order to use the localConnector-1.0 feature on zOS, the "-Dcom.ibm.tools.attach.enable=yes" system prop needs to be set.