### PR TITLE
Fix IllegalStateException on ConfigurationStore

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/admin/internal/ConfigurationStore.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/admin/internal/ConfigurationStore.java
@@ -216,13 +216,7 @@ class ConfigurationStore implements Runnable {
         }
         readLock();
         try {
-            List<ExtendedConfigurationImpl> persistConfigs = new ArrayList<>();
-            for (ExtendedConfigurationImpl persistConfig : configurations.values()) {
-                if (persistConfig.getReadOnlyProperties() != null) {
-                    persistConfigs.add(persistConfig);
-                }
-            }
-            ConfigurationStorageHelper.store(persistentConfig, persistConfigs);
+            ConfigurationStorageHelper.store(persistentConfig, configurations.values());
             if (shutdown && currentSaveTask != null) {
                 currentSaveTask.cancel(false);
             }


### PR DESCRIPTION
The ConfigurationStore saves all configurations
currently available in the configurations map
but this has timing issues if a Configuration
is in the process of being deleted.  Additional
safeguards are needed to avoid the
IllegalStateException when saving configs

For issue #7831