### PR TITLE
start of yaml for validation endpoint

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator_fat/.classpath
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-resourceadapter/src"/>
+	<classpathentry kind="src" path="test-applications/testOpenAPIApp/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -16,6 +16,7 @@ javac.target: 1.8
 
 src: \
 	fat/src,\
+	test-applications/testOpenAPIApp/src,\
 	test-resourceadapter/src
 
 fat.project: true

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
@@ -22,7 +22,8 @@ import componenttest.topology.utils.HttpUtils;
                 ValidateDataSourceTest.class,
                 ValidateJCATest.class,
                 ValidateJMSTest.class,
-                ValidateDSCustomLoginModuleTest.class
+                ValidateDSCustomLoginModuleTest.class,
+                ValidateOpenApiSchemaTest.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.rest.handler.validator.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.json.JsonObject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpsRequest;
+
+@RunWith(FATRunner.class)
+public class ValidateOpenApiSchemaTest extends FATServletClient {
+    @Server("com.ibm.ws.rest.handler.validator.openapi.fat")
+    public static LibertyServer server;
+
+    private static String VERSION_REGEX = "[0-9]+\\.[0-9]+.*";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive app = ShrinkWrap.create(WebArchive.class, "testOpenAPIApp.war")//
+                        .addPackages(true, "web")//
+                        .addAsManifestResource(new File("test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml"));
+        ShrinkHelper.exportDropinAppToServer(server, app);
+
+        server.startServer();
+
+        // Wait for the API to become available
+        List<String> messages = new ArrayList<>();
+        messages.add("CWWKS0008I"); // CWWKS0008I: The security service is ready.
+        messages.add("CWWKS4105I"); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        messages.add("CWPKI0803A"); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
+        messages.add("CWWKO0219I: .* defaultHttpEndpoint-ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        messages.add("CWWKT0016I"); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
+        server.waitForStringsInLogUsingMark(messages);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    /**
+     * Single test method to verify that validation REST endpoint is working at all.
+     */
+    @Test
+    public void testDefaultDataSource() throws Exception {
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource")
+                        .requestProp("X-Validation-User", "dbuser1")
+                        .requestProp("X-Validation-Password", "dbpwd1");
+        JsonObject json = request.run(JsonObject.class);
+        String err = "Unexpected json response: " + json.toString();
+        assertEquals(err, "DefaultDataSource", json.getString("uid"));
+        assertEquals(err, "DefaultDataSource", json.getString("id"));
+        assertNull(err, json.get("jndiName"));
+        assertTrue(err, json.getBoolean("successful"));
+        assertNull(err, json.get("failure"));
+        assertNotNull(err, json = json.getJsonObject("info"));
+        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
+        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
+        assertEquals(err, "DBUSER1", json.getString("schema"));
+        assertEquals(err, "dbuser1", json.getString("user"));
+
+        request.method("POST");
+        json = request.run(JsonObject.class);
+        err = "Unexpected json response: " + json.toString();
+        assertEquals(err, "DefaultDataSource", json.getString("uid"));
+        assertEquals(err, "DefaultDataSource", json.getString("id"));
+        assertNull(err, json.get("jndiName"));
+        assertTrue(err, json.getBoolean("successful"));
+        assertNull(err, json.get("failure"));
+        assertNotNull(err, json = json.getJsonObject("info"));
+        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
+        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
+    }
+}

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.openapi.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.openapi.fat/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.validation=all
+com.ibm.ws.logging.max.file.size=0
+ds.loglevel=debug

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.openapi.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.openapi.fat/server.xml
@@ -1,0 +1,48 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <include location="../fatTestPorts.xml" />
+
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>configValidator-1.0</feature> <!-- TODO replace when functionality is enabled via auto-feature -->
+    <feature>jdbc-4.2</feature>
+    <feature>mpOpenApi-1.1</feature>
+  </featureManager>
+
+  <variable name="onError" value="FAIL"/>
+
+  <keyStore id="defaultKeyStore" password="Liberty"/>
+  
+  <basicRegistry>
+    <user name="adminuser" password="adminpwd" />
+    <user name="reader" password="readerpwd" />
+    <user name="user" password="userpwd" />
+  </basicRegistry>
+  <administrator-role>
+    <user>adminuser</user>
+  </administrator-role>
+  <reader-role>
+    <user>reader</user>
+  </reader-role>
+    
+  <dataSource id="DefaultDataSource">
+    <jdbcDriver libraryRef="Derby"/>
+   	<properties.derby.embedded databaseName="memory:derbydb" createDatabase="create"/>
+   	<containerAuthData user="derbyuser1" password="derbypwd1"/>
+  </dataSource>
+
+  <library id="Derby">
+    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  </library>
+
+  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
@@ -1,0 +1,36 @@
+# *******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+# *******************************************************************************
+openapi: "3.0.2"
+info:
+  title: Validation API
+  version: "1.0"
+  description: The validation endpoint tests the basic configuration of resources by attempting to perform a simple operation on them.
+servers:
+  - url: https://127.0.0.1:8020/ibm/api
+paths:
+  /validation/dataSource/{uid}:
+    get:
+      summary: Validation of a Data Source
+      description: Shows the validation result for the specified data source.
+      parameters:
+        - name: uid
+          in: path
+          description: Unique identifier. For a dataSource configured at top level, this is the value of the `id` attribute, if present. Otherwise, it is a generated value, such as `dataSource[default-0]` or `databaseStore[defaultDatabaseStore]/dataSource[default-0]` or `transaction/dataSource[default-0]`.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Validation result retrieved
+          content:
+            application/json:
+              schema:
+                type: object

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/src/web/ValidationOpenAPITestServlet.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/src/web/ValidationOpenAPITestServlet.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import javax.servlet.annotation.WebServlet;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/ValidationOpenAPITestServlet")
+public class ValidationOpenAPITestServlet extends FATServlet {
+}


### PR DESCRIPTION
Create a basic yaml file that will be used to describe the /validation/ endpoint.  Initially, it will just be the start of a document.  I'll include it in an existing test bucket so that it isn't shipped, but it will still be tracked in git, and possible to write tests against it.