### PR TITLE
Create a new ApplicationInfo object if the Application was replaced.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
@@ -209,6 +209,9 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
         /**
          * step 5: set ApplicationInfo object to ServerFactoryBean
          */
+        if (replaced) {
+            appinfo = new ApplicationInfo(app, this.getBus());
+        }
         super.setApplicationInfo(appinfo);
         endpointInfo.setApp(app);
     }


### PR DESCRIPTION
if CDI or EJB replace the application object with a different object we
need to create a new ApplicationInfo object like what was done
previously always.  It will only create a new ApplicationInfo object
though if the replace happens instead of how it was doing it
unconditionally before which is what caused the perf problem.
