### PR TITLE
Added wait statements to resolve server connection issues

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
@@ -79,13 +79,16 @@ public class MetricsAuthenticationTest {
     }
 
     private void waitForMetricsEndpoint(LibertyServer server) throws Exception {
-        assertNotNull("Web application is not available at */metrics/", server.waitForStringInLogUsingMark("CWWKT0016I.*/metrics/", server.getDefaultLogFile()));
+        // by default waitForStringInLogUsingMark will look at the default log when a log is not specified
+        assertNotNull("Web application is not available at */metrics/", server.waitForStringInLogUsingMark("CWWKT0016I.*/metrics/"));
     }
 
     private void waitForPrerequisites(LibertyServer server) throws Exception {
-        assertNotNull("TCP Channel defaultHttpEndpoint has not started (port 8010)", server.waitForStringInLog("CWWKO0219I.*8010.*", server.getDefaultLogFile()));
-        assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (port 8020)", server.waitForStringInLog("CWWKO0219I.*8020.*", server.getDefaultLogFile()));
-        assertNotNull("[/metrics] failed to initialize", server.waitForStringInLogUsingMark("SRVE0242I.*/metrics.*", server.getDefaultLogFile()));
+        String regex1 = "CWWKO0219I.*" + System.getProperty("bvt.prop.HTTP_default", "8010") + ".*";
+        String regex2 = "CWWKO0219I.*" + System.getProperty("bvt.prop.HTTP_default.secure", "8020") + ".*";
+        assertNotNull("TCP Channel defaultHttpEndpoint has not started", server.waitForStringInLog(regex1));
+        assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started", server.waitForStringInLog(regex2));
+        assertNotNull("[/metrics] failed to initialize", server.waitForStringInLogUsingMark("SRVE0242I.*/metrics.*"));
     }
 
     private static void setMetricsAuthConfig(LibertyServer server, Boolean authentication) throws Exception {
@@ -107,8 +110,6 @@ public class MetricsAuthenticationTest {
         //  i.e. requires authentication into metrics endpoint
 
         //check that opening connection to /metrics requires authentication by default
-
-        //Thread.sleep(10000);
 
         MetricsConnection authenticationNotSpecified = MetricsConnection.connection_administratorRole(server);
         authenticationNotSpecified.expectedResponseCode(HttpURLConnection.HTTP_OK).getConnection();
@@ -138,7 +139,6 @@ public class MetricsAuthenticationTest {
         setMetricsAuthConfig(server, false);
         waitForMetricsEndpoint(server);
         MetricsConnection authenticationFalse = MetricsConnection.connection_unauthenticated(server);
-        //Thread.sleep(5000);
         authenticationFalse.expectedResponseCode(HttpURLConnection.HTTP_OK).getConnection();
 
         //4. When mpMetrics authentication option is removed from the server.xml,

--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -79,7 +79,11 @@ public class MetricsAuthenticationTest {
     }
 
     private void waitForMetricsEndpoint(LibertyServer server) throws Exception {
-        assertNotNull("Web application is not available at */metrics/", server.waitForStringInLog("CWWKT0016I.*/metrics/", TIMEOUT * 2, server.getDefaultLogFile()));
+        assertNotNull("Web application is not available at */metrics/", server.waitForStringInLogUsingMark("CWWKT0016I.*/metrics/", server.getDefaultLogFile()));
+    }
+
+    private void waitForInstallationsToFinish(LibertyServer server) throws Exception {
+        assertNotNull("[/metrics] failed to initialize", server.waitForStringInLogUsingMark("SRVE0242I.*/metrics.*", server.getDefaultLogFile()));
     }
 
     private static void setMetricsAuthConfig(LibertyServer server, Boolean authentication) throws Exception {
@@ -94,12 +98,15 @@ public class MetricsAuthenticationTest {
 
     private void testMetricsAuth() throws Exception {
 
+        // wait for installations to complete before running test
+        waitForInstallationsToFinish(server);
+
         //1. When authentication is not explicitly set in server.xml, it defaults to private,
         //  i.e. requires authentication into metrics endpoint
 
         //check that opening connection to /metrics requires authentication by default
 
-        Thread.sleep(10000);
+        //Thread.sleep(10000);
 
         MetricsConnection authenticationNotSpecified = MetricsConnection.connection_administratorRole(server);
         authenticationNotSpecified.expectedResponseCode(HttpURLConnection.HTTP_OK).getConnection();

--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
@@ -82,7 +82,9 @@ public class MetricsAuthenticationTest {
         assertNotNull("Web application is not available at */metrics/", server.waitForStringInLogUsingMark("CWWKT0016I.*/metrics/", server.getDefaultLogFile()));
     }
 
-    private void waitForInstallationsToFinish(LibertyServer server) throws Exception {
+    private void waitForPrerequisites(LibertyServer server) throws Exception {
+        assertNotNull("TCP Channel defaultHttpEndpoint has not started (port 8010)", server.waitForStringInLog("CWWKO0219I.*8010.*", server.getDefaultLogFile()));
+        assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (port 8020)", server.waitForStringInLog("CWWKO0219I.*8020.*", server.getDefaultLogFile()));
         assertNotNull("[/metrics] failed to initialize", server.waitForStringInLogUsingMark("SRVE0242I.*/metrics.*", server.getDefaultLogFile()));
     }
 
@@ -98,8 +100,8 @@ public class MetricsAuthenticationTest {
 
     private void testMetricsAuth() throws Exception {
 
-        // wait for installations to complete before running test
-        waitForInstallationsToFinish(server);
+        // wait for installations to complete and TCP channels to be started before running test
+        waitForPrerequisites(server);
 
         //1. When authentication is not explicitly set in server.xml, it defaults to private,
         //  i.e. requires authentication into metrics endpoint


### PR DESCRIPTION
#build
Fixes #7667

Below describes the issue and solution in more detail

Issue : During the test we may get a connection refused or would not be able to reach an mpMetrics endpoint. The connection refused happens when the test is run before the TCP channels have been started and listening. The issue with not being able to reach the metrics endpoint occurs when the tests are run before the mpMetrics feature is fully initialized. 

Solution: Removed all time.sleep lines which are insufficient and replaced it with multiple wait statements  which wait for completion messages to be printed to message.log before running the test. Specifically we wait for the messages that indicate that the mpMetrics feature is initialized and that the TCP channels have been started and listening.

Other changes not directly related to the issue
- Removed unnecessary comment
- the usage of waitForStringInLogUsingMark no longer passes an unnecessary server,getDefaultLogFile as input. The default log file is checked when a log file is not explicitly passed into the method.