### PR TITLE
validation endpoint must avoid logging password to FFDC and trace

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
@@ -112,7 +112,9 @@ public class ConnectionFactoryValidator implements Validator {
     }
 
     @Override
-    public LinkedHashMap<String, ?> validate(Object instance, Map<String, Object> props, Locale locale) {
+    public LinkedHashMap<String, ?> validate(Object instance,
+                                             @Sensitive Map<String, Object> props, // @Sensitive prevents auto-FFDC from including password value
+                                             Locale locale) {
         final String methodName = "validate";
         String user = (String) props.get("user");
         String password = (String) props.get("password");

--- a/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
@@ -31,6 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.wsspi.resource.ResourceConfig;
 import com.ibm.wsspi.resource.ResourceConfigFactory;
 import com.ibm.wsspi.resource.ResourceFactory;
@@ -49,7 +50,9 @@ public class DataSourceValidator implements Validator {
      * @see com.ibm.wsspi.validator.Validator#validate(java.lang.Object, java.util.Map, java.util.Locale)
      */
     @Override
-    public LinkedHashMap<String, ?> validate(Object instance, Map<String, Object> props, Locale locale) {
+    public LinkedHashMap<String, ?> validate(Object instance,
+                                             @Sensitive Map<String, Object> props, // @Sensitive prevents auto-FFDC from including password value
+                                             Locale locale) {
         final String methodName = "validate";
         String user = (String) props.get("user");
         String pass = (String) props.get("password");

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
@@ -215,7 +215,7 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
                 params.put("user", resolvePotentialVariable(user));
             String pass = request.getHeader("X-Validation-Password");
             if (pass != null)
-                params.put("password", resolvePotentialVariable(pass));
+                params.put("password", pass == null ? null : variableRegistry.resolveRawString(pass));
             String contentType = request.getContentType();
             if ("application/json".equalsIgnoreCase(contentType)) {
                 params.put(Validator.JSON_BODY_KEY, read(request.getInputStream()));


### PR DESCRIPTION
In preparing the /validation/ REST point to become product-worthy code, I checked for, and found, a couple of places where it allows the password value to be logged to trace and FFDC logs.  This pull includes updates to prevent the password value from being logged.