### PR TITLE
Update smallrye code to work with bnd tools in eclipse.

### DIFF
--- a/dev/com.ibm.ws.io.smallrye.reactive.messaging/src/io/smallrye/reactive/messaging/PublisherMediator.java
+++ b/dev/com.ibm.ws.io.smallrye.reactive.messaging/src/io/smallrye/reactive/messaging/PublisherMediator.java
@@ -109,17 +109,17 @@ public class PublisherMediator extends AbstractMediator {
   }
 
   private <T> void produceIndividualPayloads() {
-    setPublisher(ReactiveStreams.<T>generate(this::invoke)
+    setPublisher(ReactiveStreams.<T>generate(() -> invoke())
       .map(Message::of));
   }
 
   private void produceIndividualCompletionStageOfMessages() {
-    setPublisher(ReactiveStreams.<CompletionStage<Message>>generate(this::invoke)
+    setPublisher(ReactiveStreams.<CompletionStage<Message>>generate(() -> invoke())
       .flatMapCompletionStage(Function.identity()));
   }
 
   private <P> void produceIndividualCompletionStageOfPayloads() {
-    setPublisher(ReactiveStreams.<CompletionStage<P>>generate(this::invoke)
+    setPublisher(ReactiveStreams.<CompletionStage<P>>generate(() -> invoke())
       .flatMapCompletionStage(Function.identity())
       .map(Message::of));
   }


### PR DESCRIPTION
The source for smallrye put into open liberty has an issue with the bnd tools for determining dependencies.  @bjhargrave will probably need to figure that problem out at some point, but at least we can work around the problem until that fix is available.