### PR TITLE
Do not use the 27.0.1-jre version of google guava.

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -20,7 +20,6 @@ com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.4.1
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.9.1
 com.google.code.gson:gson:2.2.4
 com.google.guava:guava:27.0.1-android
-com.google.guava:guava:27.0.1-jre
 com.google.inject:guice:2.0
 com.graphql-java:graphql-java:11.0
 com.graphql-java:graphql-java-servlet:6.1.3


### PR DESCRIPTION
27.0.1-jre is build with Java 8 and has Java 8 byte code which prevents
function from working on Java 7.  Only have the 27.0.1-android version
so that we can run with Java 7.  the android version is compiled with
Java 7.
