### PR TITLE
Update .classpath files to make things build in eclipse again.

### DIFF
--- a/dev/com.ibm.websphere.org.eclipse.microprofile.metrics.2.0/.classpath
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.metrics.2.0/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.health.2.0/.classpath
+++ b/dev/com.ibm.ws.microprofile.health.2.0/.classpath
@@ -2,61 +2,8 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="resources"/>
-	<classpathentry kind="src" path="test/src"/>
+	<classpathentry kind="src" path="test/src" output="bin_test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="lib" path="/Users/prashanth/.m2/repository/org/osgi/org.osgi.service.component.annotations/1.4.0/org.osgi.service.component.annotations-1.4.0.jar" sourcepath="/Users/prashanth/.m2/repository/org/osgi/org.osgi.service.component.annotations/1.4.0/org.osgi.service.component.annotations-1.4.0.jar">
-		<attributes>
-			<attribute name="bsn" value="org.osgi.service.component.annotations"/>
-			<attribute name="type" value="REPO"/>
-			<attribute name="project" value="com.ibm.ws.security.wim.repository_test.custom"/>
-			<attribute name="version" value="latest"/>
-		</attributes>
-		<accessrules>
-			<accessrule kind="accessible" pattern="org/osgi/service/component/annotations/*"/>
-			<accessrule ignoreifbetter="true" kind="discouraged" pattern="**"/>
-		</accessrules>
-	</classpathentry>
-	<classpathentry kind="lib" path="/Users/prashanth/.m2/repository/javax/servlet/javax.servlet-api/4.0.0/javax.servlet-api-4.0.0.jar">
-		<attributes>
-			<attribute name="bsn" value="javax.servlet:javax.servlet-api"/>
-			<attribute name="type" value="REPO"/>
-			<attribute name="project" value="com.ibm.websphere.javaee.servlet.4.0"/>
-			<attribute name="version" value="4.0.0"/>
-		</attributes>
-		<accessrules>
-			<accessrule kind="accessible" pattern="javax/servlet/*"/>
-			<accessrule kind="accessible" pattern="javax/servlet/annotation/*"/>
-			<accessrule kind="accessible" pattern="javax/servlet/http/*"/>
-			<accessrule kind="accessible" pattern="javax/servlet/descriptor/*"/>
-			<accessrule ignoreifbetter="true" kind="discouraged" pattern="**"/>
-		</accessrules>
-	</classpathentry>
-	<classpathentry kind="lib" path="/Users/prashanth/.m2/repository/org/osgi/org.osgi.service.component/1.4.0/org.osgi.service.component-1.4.0.jar" sourcepath="/Users/prashanth/.m2/repository/org/osgi/org.osgi.service.component/1.4.0/org.osgi.service.component-1.4.0.jar">
-		<attributes>
-			<attribute name="bsn" value="org.osgi:org.osgi.service.component"/>
-			<attribute name="type" value="REPO"/>
-			<attribute name="project" value="com.ibm.websphere.org.osgi.service.component"/>
-			<attribute name="version" value="1.4.0"/>
-		</attributes>
-		<accessrules>
-			<accessrule kind="accessible" pattern="org/osgi/service/component/*"/>
-			<accessrule kind="accessible" pattern="org/osgi/service/component/propertytypes/*"/>
-			<accessrule kind="accessible" pattern="org/osgi/service/component/runtime/*"/>
-			<accessrule kind="accessible" pattern="org/osgi/service/component/runtime/dto/*"/>
-			<accessrule ignoreifbetter="true" kind="discouraged" pattern="**"/>
-		</accessrules>
-	</classpathentry>
-	<classpathentry kind="lib" path="/Users/prashanth/.m2/repository/javax/javaee-api/7.0/javaee-api-7.0.jar">
-		<attributes>
-			<attribute name="bsn" value="javax:javaee-api"/>
-			<attribute name="type" value="REPO"/>
-			<attribute name="project" value="com.ibm.ws.ejbcontainer_test"/>
-			<attribute name="version" value="7.0"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="src" path="/com.ibm.websphere.org.eclipse.microprofile.health.2.0"/>
-	<classpathentry kind="src" path="/com.ibm.ws.microprofile.health"/>
-	<classpathentry kind="lib" path="/com.ibm.websphere.org.eclipse.microprofile.health.2.0/build/libs/com.ibm.websphere.org.eclipse.microprofile.health.2.0.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/.classpath
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/.classpath
@@ -3,13 +3,5 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="lib" path="/Users/prashanth/.m2/repository/org/jboss/arquillian/test/arquillian-test-spi/1.3.0.Final/arquillian-test-spi-1.3.0.Final.jar">
-		<attributes>
-			<attribute name="bsn" value="org.jboss.arquillian.test:arquillian-test-spi"/>
-			<attribute name="type" value="REPO"/>
-			<attribute name="project" value="fattest.simplicity"/>
-			<attribute name="version" value="1.3.0.Final"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
- Remove classpath entries and only use bnd settings to get the
classpath
- Remove non existent src dir from metrics 2.0
- Update output directory for test directory to be bin_test