### PR TITLE
update to release candidate 3 of MP Context Propagation

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -235,7 +235,7 @@ org.eclipse.jetty.websocket:websocket-common:9.4.7.RC0
 org.eclipse.microprofile.config:microprofile-config-api:1.1
 org.eclipse.microprofile.config:microprofile-config-api:1.2.1
 org.eclipse.microprofile.config:microprofile-config-api:1.3
-org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0-RC1
+org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0-RC3
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.0
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.concurrent.mp-1.0
 visibility=private
 singleton=true
 -bundles=\
-  com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:0.20190322.204445",\
+  com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0-RC3",\
   com.ibm.ws.concurrent.mp.1.0
 kind=beta
 edition=core

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextManagerImpl.java
@@ -149,7 +149,7 @@ public class ContextManagerImpl implements ContextManager {
      * @param defaultValue value to use if not found in MicroProfile Config.
      * @return default value.
      */
-    <T> T getDefault(String mpConfigPropName, String oldName, T defaultValue) { // TODO remove the old name after spec change
+    <T> T getDefault(String mpConfigPropName, T defaultValue) {
         MPConfigAccessor accessor = cmProvider.mpConfigAccessor;
         if (accessor != null) {
             Object mpConfig = mpConfigRef.get();
@@ -158,7 +158,6 @@ public class ContextManagerImpl implements ContextManager {
                     mpConfig = mpConfigRef.get();
 
             if (mpConfig != null) {
-                defaultValue = accessor.get(mpConfig, oldName, defaultValue); // TODO remove this line after spec change
                 defaultValue = accessor.get(mpConfig, mpConfigPropName, defaultValue);
             }
         }

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ManagedExecutorBuilderImpl.java
@@ -55,10 +55,10 @@ public class ManagedExecutorBuilderImpl implements ManagedExecutor.Builder {
 
     @Override
     public ManagedExecutor build() {
-        Set<String> cleared = this.cleared == null ? contextManager.getDefault("mp.context.ManagedExecutor.cleared", "ManagedExecutor/cleared", DEFAULT_CLEARED) : this.cleared;
-        int maxAsync = this.maxAsync == UNDEFINED ? contextManager.getDefault("mp.context.ManagedExecutor.maxAsync", "ManagedExecutor/maxAsync", -1) : this.maxAsync;
-        int maxQueued = this.maxQueued == UNDEFINED ? contextManager.getDefault("mp.context.ManagedExecutor.maxQueued", "ManagedExecutor/maxQueued", -1) : this.maxQueued;
-        Set<String> propagated = this.propagated == null ? contextManager.getDefault("mp.context.ManagedExecutor.propagated", "ManagedExecutor/propagated", DEFAULT_PROPAGATED) : this.propagated;
+        Set<String> cleared = this.cleared == null ? contextManager.getDefault("mp.context.ManagedExecutor.cleared", DEFAULT_CLEARED) : this.cleared;
+        int maxAsync = this.maxAsync == UNDEFINED ? contextManager.getDefault("mp.context.ManagedExecutor.maxAsync", -1) : this.maxAsync;
+        int maxQueued = this.maxQueued == UNDEFINED ? contextManager.getDefault("mp.context.ManagedExecutor.maxQueued", -1) : this.maxQueued;
+        Set<String> propagated = this.propagated == null ? contextManager.getDefault("mp.context.ManagedExecutor.propagated", DEFAULT_PROPAGATED) : this.propagated;
 
         // For detection of unknown and overlapping types,
         HashSet<String> unknown = new HashSet<String>(cleared);

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ThreadContextBuilderImpl.java
@@ -53,9 +53,9 @@ public class ThreadContextBuilderImpl implements ThreadContext.Builder {
 
     @Override
     public ThreadContext build() {
-        Set<String> cleared = this.cleared == null ? contextManager.getDefault("mp.context.ThreadContext.cleared", "ThreadContext/cleared", DEFAULT_CLEARED) : this.cleared;
-        Set<String> propagated = this.propagated == null ? contextManager.getDefault("mp.context.ThreadContext.propagated", "ThreadContext/propagated", DEFAULT_PROPAGATED) : this.propagated;
-        Set<String> unchanged = this.unchanged == null ? contextManager.getDefault("mp.context.ThreadContext.unchanged", "ThreadContext/unchanged", DEFAULT_UNCHANGED) : this.unchanged;
+        Set<String> cleared = this.cleared == null ? contextManager.getDefault("mp.context.ThreadContext.cleared", DEFAULT_CLEARED) : this.cleared;
+        Set<String> propagated = this.propagated == null ? contextManager.getDefault("mp.context.ThreadContext.propagated", DEFAULT_PROPAGATED) : this.propagated;
+        Set<String> unchanged = this.unchanged == null ? contextManager.getDefault("mp.context.ThreadContext.unchanged", DEFAULT_UNCHANGED) : this.unchanged;
 
         // For detection of unknown and overlapping types,
         HashSet<String> unknown = new HashSet<String>(cleared);

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile Context Propagation TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.context.propagation.version>1.0-RC2</microprofile.context.propagation.version>
+        <microprofile.context.propagation.version>1.0-RC3</microprofile.context.propagation.version>
         <!-- Switch to the following to test a local SNAPSHOT instead of a release candidate. -->
         <!-- <microprofile.context.propagation.version>1.0-SNAPSHOT</microprofile.context.propagation.version> -->
         <arquillian.version>1.3.0.Final</arquillian.version>


### PR DESCRIPTION
Update to MP Context Propagation 1.0 RC 3.
Along with this, remove the temporary code to accept the old style of MP Config properties for default values (ManagedExecutor/propagated)