### PR TITLE
consistent type for error code

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
@@ -204,9 +204,10 @@ public class ConnectionFactoryValidator implements Validator {
                 if (cause instanceof ResourceException)
                     errorCode = ((ResourceException) cause).getErrorCode();
                 else if (cause instanceof SQLException) {
-                    errorCode = cause instanceof SQLException ? ((SQLException) cause).getErrorCode() : null;
-                    if (sqlState == null && Integer.valueOf(0).equals(errorCode))
-                        errorCode = null; // Omit, because it is unlikely that the database actually returned an error code of 0
+                    int ec = ((SQLException) cause).getErrorCode();
+                    errorCode = sqlState == null && ec == 0 //
+                                    ? null // Omit, because it is unlikely that the database actually returned an error code of 0
+                                    : Integer.toString(ec);
                 }
                 errorCodes.add(errorCode);
             }

--- a/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
@@ -136,13 +136,17 @@ public class DataSourceValidator implements Validator {
             }
         } catch (Throwable x) {
             ArrayList<String> sqlStates = new ArrayList<String>();
-            ArrayList<Integer> errorCodes = new ArrayList<Integer>();
+            ArrayList<String> errorCodes = new ArrayList<String>();
             Set<Throwable> causes = new HashSet<Throwable>(); // avoid cycles in exception chain
             for (Throwable cause = x; cause != null && causes.add(cause); cause = cause.getCause()) {
                 String sqlState = cause instanceof SQLException ? ((SQLException) cause).getSQLState() : null;
-                Integer errorCode = cause instanceof SQLException ? ((SQLException) cause).getErrorCode() : null;
-                if (sqlState == null && Integer.valueOf(0).equals(errorCode))
-                    errorCode = null; // Omit, because it is unlikely that the database actually returned an error code of 0
+                String errorCode = null;
+                if (cause instanceof SQLException) {
+                    int ec = ((SQLException) cause).getErrorCode();
+                    errorCode = sqlState == null && ec == 0 //
+                                    ? null // Omit, because it is unlikely that the database actually returned an error code of 0
+                                    : Integer.toString(ec);
+                }
                 sqlStates.add(sqlState);
                 errorCodes.add(errorCode);
             }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -115,7 +115,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
         assertNull(err, json.get("failure"));
         assertNull(err, json.get("info"));
         assertEquals(err, "08004", getString(json, "sqlState"));
-        assertEquals(err, 40000, json.getInt("errorCode"));
+        assertEquals(err, "40000", json.getString("errorCode"));
         assertEquals(err, "java.sql.SQLNonTransientException", getString(json, "class"));
         assertTrue(err, getString(json, "message").contains("Invalid authentication"));
     }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -160,7 +160,7 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, json.get("failure"));
         assertNull(err, json.get("info"));
         assertEquals(err, "08004", json.getString("sqlState"));
-        assertEquals(err, 40000, json.getInt("errorCode"));
+        assertEquals(err, "40000", json.getString("errorCode"));
         assertEquals(err, "java.sql.SQLNonTransientException", json.getString("class"));
         assertTrue(err, json.getString("message").contains("Invalid authentication"));
     }
@@ -287,7 +287,7 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, j.get("info"));
         assertNotNull(err, j = j.getJsonObject("failure"));
         assertEquals(err, "XJ004", j.getString("sqlState"));
-        assertEquals(err, 40000, j.getInt("errorCode"));
+        assertEquals(err, "40000", j.getString("errorCode"));
         assertEquals(err, "java.sql.SQLException", j.getString("class"));
         assertTrue(err, j.getString("message").contains("memory:doesNotExist"));
         JsonArray stack = j.getJsonArray("stack");
@@ -486,7 +486,7 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, json.get("failure"));
         assertNull(err, json.get("info"));
         assertEquals(err, "XJ004", json.getString("sqlState"));
-        assertEquals(err, 40000, json.getInt("errorCode"));
+        assertEquals(err, "40000", json.getString("errorCode"));
         assertEquals(err, "java.sql.SQLException", json.getString("class"));
         assertTrue(err, json.getString("message").contains("memory:doesNotExist"));
         JsonArray stack = json.getJsonArray("stack");
@@ -533,7 +533,7 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, json.get("failure"));
         assertNull(err, json.get("info"));
         assertEquals(err, "08004", json.getString("sqlState"));
-        assertEquals(err, 40000, json.getInt("errorCode"));
+        assertEquals(err, "40000", json.getString("errorCode"));
         assertEquals(err, "java.sql.SQLNonTransientException", json.getString("class"));
         assertTrue(err, json.getString("message").contains("Invalid authentication"));
     }
@@ -560,7 +560,7 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, json.get("failure"));
         assertNull(err, json.get("info"));
         assertEquals(err, "08004", json.getString("sqlState"));
-        assertEquals(err, 40000, json.getInt("errorCode"));
+        assertEquals(err, "40000", json.getString("errorCode"));
         assertEquals(err, "java.sql.SQLNonTransientException", json.getString("class"));
         assertTrue(err, json.getString("message").contains("Invalid authentication"));
     }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
@@ -151,7 +151,7 @@ public class ValidateJCATest extends FATServletClient {
 
         assertNotNull(err, json = json.getJsonObject("failure"));
         assertEquals(err, "08001", json.getString("sqlState"));
-        assertEquals(err, 127, json.getInt("errorCode"));
+        assertEquals(err, "127", json.getString("errorCode"));
         assertEquals(err, "java.sql.SQLNonTransientConnectionException", json.getString("class"));
         assertEquals(err, "Connection rejected for user names that end in '5'.", json.getString("message"));
         JsonArray stack = json.getJsonArray("stack");
@@ -176,7 +176,7 @@ public class ValidateJCATest extends FATServletClient {
         // cause
         assertNotNull(err, json = json.getJsonObject("cause"));
         assertEquals(err, "28000", json.getString("sqlState"));
-        assertEquals(err, 0, json.getInt("errorCode"));
+        assertEquals(err, "0", json.getString("errorCode"));
         assertEquals(err, "java.sql.SQLInvalidAuthorizationSpecException", json.getString("class"));
         assertEquals(err, "The database is unable to accept user names that include a '5'.", json.getString("message"));
         stack = json.getJsonArray("stack");
@@ -309,7 +309,7 @@ public class ValidateJCATest extends FATServletClient {
 
         // cause
         assertNotNull(err, json = json.getJsonObject("cause"));
-        assertEquals(err, -13579, json.getInt("errorCode"));
+        assertEquals(err, "-13579", json.getString("errorCode"));
         assertEquals(err, "08006", json.getString("sqlState"));
         assertEquals(err, "java.sql.SQLNonTransientConnectionException", json.getString("class"));
         assertTrue(err, json.getString("message").startsWith("Database appears to be down."));

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 import javax.json.JsonObject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -49,6 +51,15 @@ public class ValidateOpenApiSchemaTest extends FATServletClient {
                         .addPackages(true, "web")//
                         .addAsManifestResource(new File("test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml"));
         ShrinkHelper.exportDropinAppToServer(server, app);
+
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "TestValAdapter.rar")
+                        .addAsLibraries(ShrinkWrap.create(JavaArchive.class)
+                                        .addPackage("org.test.validator.adapter"));
+        ShrinkHelper.exportToServer(server, "dropins", rar);
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "customLoginModule.jar");
+        jar.addPackage("com.ibm.ws.rest.handler.validator.loginmodule");
+        ShrinkHelper.exportToServer(server, "/", jar);
 
         server.startServer();
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.openapi.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.openapi.fat/server.xml
@@ -33,7 +33,12 @@
   <reader-role>
     <user>reader</user>
   </reader-role>
-    
+
+  <connectionFactory id="cf1" jndiName="eis/cf1">
+    <containerAuthData user="cfuser1" password="1cfuser"/>
+    <properties.TestValAdapter.ConnectionFactory hostName="myhost.openliberty.io" portNumber="6543"/>
+  </connectionFactory>
+
   <dataSource id="DefaultDataSource">
     <jdbcDriver libraryRef="Derby"/>
    	<properties.derby.embedded databaseName="memory:derbydb" createDatabase="create"/>

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
@@ -16,6 +16,74 @@ info:
 servers:
   - url: https://127.0.0.1:8020/ibm/api
 paths:
+  /validation/connectionFactory/:
+    get:
+      tags:
+      - Validation
+      summary: Validation of all connection factories
+      description: "Retrieves the validation results for all connection factories (apart from JMS, which uses different config elements). Validation involves establishing a connection to the backend, querying basic metadata information, and performing additional interface-specific operations. For JDBC connection factories, the `java.sql.Connection.isValid` operation is invoked. For CCI connection factories, the `javax.resource.cci.Connection.createInteraction` operation is invoked."
+      parameters:
+        - $ref: "#/components/parameters/X-Validation-User"
+        - $ref: "#/components/parameters/X-Validation-Password"
+        - $ref: "#/components/parameters/auth"
+        - $ref: "#/components/parameters/authAlias"
+        - $ref: "#/components/parameters/loginConfig"
+      # requestBody in GET will be allowed again in a newer version of OpenAPI
+      # see https://github.com/OAI/OpenAPI-Specification/pull/1937
+      #requestBody:
+      #  $ref: "#/components/requestBodies/loginConfigProperties"
+      responses:
+        200:
+          description: Validation results retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/validation.connectionFactory.result"
+  /validation/connectionFactory/{uid}:
+    get:
+      tags:
+      - Validation
+      summary: Validation of a Connection Factory
+      description: "Retrieves the validation result for the specified connection factory. Validation involves establishing a connection to the backend, querying basic metadata information, and performing additional interface-specific operations. For JDBC connection factories, the `java.sql.Connection.isValid` operation is invoked. For CCI connection factories, the `javax.resource.cci.Connection.createInteraction` operation is invoked."
+      parameters:
+        - name: uid
+          in: path
+          description: "**Unique identifier**. For a connection factory configured at top level, this is the value of the `id` attribute, if present. Otherwise, it is a generated value, such as *connectionFactory[default-0]*."
+          required: true
+          schema:
+            type: string
+            example: "MyConFactory"
+          examples:
+            example-cf-id:
+              summary: "Top-level connection factory with id"
+              description: "In this case, the uid is the same as the id."
+              value: "myConFactory"
+            example-cf-no-id:
+              summary: "Top-level connection factory without id"
+              description: "A generated uid for top-level connection factories which lack an id is computed based on the order of appearance within server config, starting at 0."
+              value: "connectionFactory[default-0]"
+            example-cf-app-def:
+              summary: "App-defined connection factory"
+              description: "References a connection factory defined by @ConnectionFactoryDefinition within the MyApp application, with a name of java:app/env/eis/cf1"
+              value: "application[MyApp]/connectionFactory[java:app/env/eis/cf1]"
+        - $ref: "#/components/parameters/X-Validation-User"
+        - $ref: "#/components/parameters/X-Validation-Password"
+        - $ref: "#/components/parameters/auth"
+        - $ref: "#/components/parameters/authAlias"
+        - $ref: "#/components/parameters/loginConfig"
+      # requestBody in GET will be allowed again in a newer version of OpenAPI
+      # see https://github.com/OAI/OpenAPI-Specification/pull/1937
+      #requestBody:
+      #  $ref: "#/components/requestBodies/loginConfigProperties"
+      responses:
+        200:
+          description: Validation result retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/validation.connectionFactory.result"
   /validation/dataSource/:
     get:
       tags:
@@ -54,7 +122,7 @@ paths:
           required: true
           schema:
             type: string
-            example: DefaultDataSource
+            example: "DefaultDataSource"
           examples:
             example-ds-id:
               summary: "Top-level dataSource with id"
@@ -75,7 +143,7 @@ paths:
             example-ds-app-def:
               summary: "App-defined data source"
               description: "References a data source defined by @DataSourceDefinition within the MyApp application, in the MyWebModule module, with a name of java:module/env/jdbc/ds1"
-              value: "application[MyApp]/module[MyWebModule]/dataSource[java:comp/module/env/jdbc/ds1]"
+              value: "application[MyApp]/module[MyWebModule]/dataSource[java:module/env/jdbc/ds1]"
         - $ref: "#/components/parameters/X-Validation-User"
         - $ref: "#/components/parameters/X-Validation-Password"
         - $ref: "#/components/parameters/auth"
@@ -145,6 +213,77 @@ components:
                 loginProp1: val1
                 loginProp2: val2
   schemas:
+    validation.connectionFactory.result:
+      type: object
+      properties:
+        uid:
+          description: "unique identifier"
+          type: string
+        id:
+          description: "id of connectionFactory"
+          type: string
+        jndiName:
+          description: "jndiName of connectionFactory"
+          type: string
+        successful:
+          description: "result of validation"
+          type: boolean
+        info:
+          anyOf:
+            - type: object
+              properties:
+                resourceAdapterName:
+                  type: string
+                resourceAdapterVersion:
+                  type: string
+                resourceAdapterVendor:
+                  type: string
+                resourceAdapterDescription:
+                  type: string
+                connectorSpecVersion:
+                  type: string
+                eisProductName:
+                  type: string
+                eisProductVersion:
+                  type: string
+                user:
+                  type: string
+            - $ref: "#/components/schemas/info"
+        failure:
+          $ref: "#/components/schemas/cause"
+      required:
+        - uid
+        - successful
+      example:
+        uid: "myConnectionFactory"
+        id: "myConnectionFactory"
+        jndiName: "eis/conFactory1"
+        successful: false
+        info:
+          resourceAdapterName: "LibConnect Adapter"
+          resourceAdapterVersion: "104.153.185"
+          resourceAdapterVendor: "OpenLiberty"
+          resourceAdapterDescription: "This isn't a real resource adapter."
+          connectorSepcVersion: "1.7"
+          eisProductName: "VeryFast Enterprise DB"
+          eisProductVersion: "44.117.125"
+          user: "dbuser1"
+        failure:
+          errorCode: "ERR_NOT_AUTHORIZED"
+          class: "javax.resource.spi.SecurityException"
+          message: "User has insufficient privileges to access the backend data store."
+          stack:
+            - "org.example.lca.ConnectionImpl.isValid(EFConnection.java:)"
+            - "com.ibm.ws.rest.handler.validator.jca.ConnectionFactoryValidator.validateCCIConnectionFactory(ConnectionFactoryValidator.java:304)"
+            - "com.ibm.ws.rest.handler.validator.jca.ConnectionFactoryValidator.validate(ConnectionFactoryValidator.java:169)"
+            - "com.ibm.ws.rest.handler.validator.internal.ValidatorRestHandler.handleSingleInstance(ValidatorRestHandler:231)"
+          cause:
+            class: "javax.security.auth.login.LoginException"
+            message: "unauthorized"
+            stack:
+              - "org.example.lca.AuthHelper.verifyPrivileges(AuthHelper.java:82)"
+              - "org.example.lca.ConnectionImpl.authenticate(EFConnection.java:223)"
+              - "org.example.lca.ConnectionImpl.deferredLogin(EFConnection.java:385)"
     validation.dataSource.result:
       type: object
       properties:
@@ -161,22 +300,7 @@ components:
           description: "result of validation"
           type: boolean
         info:
-          type: object
-          properties:
-            databaseProductName:
-              type: string
-            databaseProductVersion:
-              type: string
-            jdbcDriverName:
-              type: string
-            jdbcDriverVersion:
-              type: string
-            catalog:
-              type: string
-            schema:
-              type: string
-            user:
-              type: string
+          $ref: "#/components/schemas/info"
         failure:
           $ref: "#/components/schemas/cause"
       required:
@@ -203,7 +327,7 @@ components:
           stack:
             - "org.example.efjdbc.EFConnection.isValid(EFConnection.java:253)"
             - "com.ibm.ws.rest.handler.validator.jdbc.DataSourceValidator(DataSourceValidator.java:129)"
-            - "com.ibm.ws.rest.handler.validator.internal.ValidatorRestHandler.validateSingleInstance(ValidatorRestHandler:231)"
+            - "com.ibm.ws.rest.handler.validator.internal.ValidatorRestHandler.handleSingleInstance(ValidatorRestHandler:231)"
           cause:
             class: "javax.security.auth.login.LoginException"
             message: "unauthorized"
@@ -211,12 +335,30 @@ components:
               - "org.example.efjdbc.AuthHelper.verifyPrivileges(AuthHelper.java:82)"
               - "org.example.efjdbc.EFConnection.authenticate(EFConnection.java:223)"
               - "org.example.efjdbc.EFConnection.deferredLogin(EFConnection.java:385)"
+    info:
+      type: object
+      properties:
+        databaseProductName:
+          type: string
+        databaseProductVersion:
+          type: string
+        jdbcDriverName:
+          type: string
+        jdbcDriverVersion:
+          type: string
+        catalog:
+          type: string
+        schema:
+          type: string
+        user:
+          type: string
     cause:
       type: object
       properties:
         sqlState:
           type: string
         errorCode:
+          #TODO type is not consistent between JCA and JDBC. Convert to string?
           type: integer
         class:
           type: string

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
@@ -273,7 +273,7 @@ components:
           class: "javax.resource.spi.SecurityException"
           message: "User has insufficient privileges to access the backend data store."
           stack:
-            - "org.example.lca.ConnectionImpl.isValid(EFConnection.java:)"
+            - "org.example.lca.ConnectionImpl.createInteraction(ConnectionImpl.java:146)"
             - "com.ibm.ws.rest.handler.validator.jca.ConnectionFactoryValidator.validateCCIConnectionFactory(ConnectionFactoryValidator.java:304)"
             - "com.ibm.ws.rest.handler.validator.jca.ConnectionFactoryValidator.validate(ConnectionFactoryValidator.java:169)"
             - "com.ibm.ws.rest.handler.validator.internal.ValidatorRestHandler.handleSingleInstance(ValidatorRestHandler:231)"

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
@@ -321,7 +321,7 @@ components:
           user: "dbuser1"
         failure:
           sqlState: "08004"
-          errorCode: 9409
+          errorCode: "9409"
           class: "java.sql.SQLInvalidAuthorizationSpecException"
           message: "User has insufficient privileges to access database."
           stack:
@@ -358,8 +358,7 @@ components:
         sqlState:
           type: string
         errorCode:
-          #TODO type is not consistent between JCA and JDBC. Convert to string?
-          type: integer
+          type: string
         class:
           type: string
         message:

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
@@ -16,6 +16,31 @@ info:
 servers:
   - url: https://127.0.0.1:8020/ibm/api
 paths:
+  /validation/dataSource/:
+    get:
+      tags:
+      - Validation
+      summary: Validation of all Data Sources
+      description: "Retrieves the validation results for all data sources. Validation involves establishing a connection to the database, querying basic metadata information, and performing the `java.sql.Connection.isValid` operation."
+      parameters:
+        - $ref: "#/components/parameters/X-Validation-User"
+        - $ref: "#/components/parameters/X-Validation-Password"
+        - $ref: "#/components/parameters/auth"
+        - $ref: "#/components/parameters/authAlias"
+        - $ref: "#/components/parameters/loginConfig"
+      # requestBody in GET will be allowed again in a newer version of OpenAPI
+      # see https://github.com/OAI/OpenAPI-Specification/pull/1937
+      #requestBody:
+      #  $ref: "#/components/requestBodies/loginConfigProperties"
+      responses:
+        200:
+          description: Validation results retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/validation.dataSource.result"
   /validation/dataSource/{uid}:
     get:
       tags:
@@ -51,108 +76,142 @@ paths:
               summary: "App-defined data source"
               description: "References a data source defined by @DataSourceDefinition within the MyApp application, in the MyWebModule module, with a name of java:module/env/jdbc/ds1"
               value: "application[MyApp]/module[MyWebModule]/dataSource[java:comp/module/env/jdbc/ds1]"
-        - name: X-Validation-User
-          in: header
-          description: "**User**. Supplies a user name when not using Container-managed authentication."
-          schema:
-            type: string
-        - name: X-Validation-Password
-          in: header
-          description: "**Password**. Supplies a password when not using Container-managed authentication."
-          schema:
-            type: string
-            format: password
-        - name: auth
-          in: query
-          description: "**Authentication**. Determines whether to use a resource reference with Application-managed or Container-managed authentication, or no resource reference."
-          schema:
-           type: string
-           enum:
-             - application
-             - container
-        - name: authAlias
-          in: query
-          description: "**Authentication Alias**. Supplies the `id` of an `authData` to use for Container-managed authentication."
-          schema:
-            type: string
-        - name: loginConfig
-          in: query
-          description: "**Custom Login**. Supplies the `name` of a `jaasLoginContextEntry` to use for Container-managed authentication."
-          schema:
-            type: string
-# requestBody in GET will be allowed again in a newer version of OpenAPI
-# see https://github.com/OAI/OpenAPI-Specification/pull/1937
-#      requestBody:
-#        description: "Additional details for request, including **Login Config Properties**"
-#        content:
-#          application/json:
-#            schema:
-#              type: object
-#              properties:
-#                loginConfigProperties:
-#                  type: object
-#                  additionalProperties:
-#                    type: string
-#              example:
-#                loginConfigProperties:
-#                  loginProp1: val1
-#                  loginProp2: val2
+        - $ref: "#/components/parameters/X-Validation-User"
+        - $ref: "#/components/parameters/X-Validation-Password"
+        - $ref: "#/components/parameters/auth"
+        - $ref: "#/components/parameters/authAlias"
+        - $ref: "#/components/parameters/loginConfig"
+      # requestBody in GET will be allowed again in a newer version of OpenAPI
+      # see https://github.com/OAI/OpenAPI-Specification/pull/1937
+      #requestBody:
+      #  $ref: "#/components/requestBodies/loginConfigProperties"
       responses:
         200:
           description: Validation result retrieved
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  uid:
-                    description: "unique identifier"
-                    type: string
-                    example: "myDataSource"
-                  id:
-                    description: "id of dataSource"
-                    type: string
-                    example: "myDataSource"
-                  jndiName:
-                    description: "jndiName of dataSource"
-                    type: string
-                    example: "jdbc/ds1"
-                  successful:
-                    description: "result of validation"
-                    type: boolean
-                    example: false
-                  info:
-                    type: object
-                    properties:
-                      databaseProductName:
-                        type: string
-                        example: "VeryFast Enterprise DB"
-                      databaseProductVersion:
-                        type: string
-                        example: "44.117.125"
-                      jdbcDriverName:
-                        type: string
-                        example: "EvenFaster JDBC"
-                      jdbcDriverVersion:
-                        type: string
-                        example: "52.165.173"
-                      catalog:
-                        type: string
-                        example: "exampledb"
-                      schema:
-                        type: string
-                        example: "MYSCHEMA"
-                      user:
-                        type: string
-                        example: "dbuser1"
-                  failure:
-                    $ref: "#/components/schemas/validation.dataSource.cause"
-                required:
-                  - uid
-                  - successful
+                $ref: "#/components/schemas/validation.dataSource.result"
 components:
+  parameters:
+    X-Validation-User:
+      name: X-Validation-User
+      in: header
+      description: "**User**. Supplies a user name when not using Container-managed authentication."
+      schema:
+        type: string
+    X-Validation-Password:
+      name: X-Validation-Password
+      in: header
+      description: "**Password**. Supplies a password when not using Container-managed authentication."
+      schema:
+        type: string
+        format: password
+    auth:
+      name: auth
+      in: query
+      description: "**Authentication**. Determines whether to use a resource reference with Application-managed or Container-managed authentication, or no resource reference."
+      schema:
+       type: string
+       enum:
+         - application
+         - container
+    authAlias:
+      name: authAlias
+      in: query
+      description: "**Authentication Alias**. Supplies the `id` of an `authData` to use for Container-managed authentication."
+      schema:
+        type: string
+    loginConfig:
+      name: loginConfig
+      in: query
+      description: "**Custom Login**. Supplies the `name` of a `jaasLoginContextEntry` to use for Container-managed authentication."
+      schema:
+        type: string
+  requestBodies:
+    loginConfigProperties:
+      description: "Additional details for request, including **Login Config Properties**"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              loginConfigProperties:
+                type: object
+                additionalProperties:
+                  type: string
+            example:
+              loginConfigProperties:
+                loginProp1: val1
+                loginProp2: val2
   schemas:
-    validation.dataSource.cause:
+    validation.dataSource.result:
+      type: object
+      properties:
+        uid:
+          description: "unique identifier"
+          type: string
+        id:
+          description: "id of dataSource"
+          type: string
+        jndiName:
+          description: "jndiName of dataSource"
+          type: string
+        successful:
+          description: "result of validation"
+          type: boolean
+        info:
+          type: object
+          properties:
+            databaseProductName:
+              type: string
+            databaseProductVersion:
+              type: string
+            jdbcDriverName:
+              type: string
+            jdbcDriverVersion:
+              type: string
+            catalog:
+              type: string
+            schema:
+              type: string
+            user:
+              type: string
+        failure:
+          $ref: "#/components/schemas/cause"
+      required:
+        - uid
+        - successful
+      example:
+        uid: "myDataSource"
+        id: "myDataSource"
+        jndiName: "jdbc/ds1"
+        successful: false
+        info:
+          databaseProductName: "VeryFast Enterprise DB"
+          databaseProductVersion: "44.117.125"
+          jdbcProductName: "EvenFaster JDBC"
+          jdbcProductVersion: "52.165.173"
+          catalog: "exampledb"
+          schema: "MYSCHEMA"
+          user: "dbuser1"
+        failure:
+          sqlState: "08004"
+          errorCode: 9409
+          class: "java.sql.SQLInvalidAuthorizationSpecException"
+          message: "User has insufficient privileges to access database."
+          stack:
+            - "org.example.efjdbc.EFConnection.isValid(EFConnection.java:253)"
+            - "com.ibm.ws.rest.handler.validator.jdbc.DataSourceValidator(DataSourceValidator.java:129)"
+            - "com.ibm.ws.rest.handler.validator.internal.ValidatorRestHandler.validateSingleInstance(ValidatorRestHandler:231)"
+          cause:
+            class: "javax.security.auth.login.LoginException"
+            message: "unauthorized"
+            stack:
+              - "org.example.efjdbc.AuthHelper.verifyPrivileges(AuthHelper.java:82)"
+              - "org.example.efjdbc.EFConnection.authenticate(EFConnection.java:223)"
+              - "org.example.efjdbc.EFConnection.deferredLogin(EFConnection.java:385)"
+    cause:
       type: object
       properties:
         sqlState:
@@ -168,20 +227,4 @@ components:
           items:
             type: string
         cause:
-          $ref: "#/components/schemas/validation.dataSource.cause"
-      example:
-        sqlState: "08004"
-        errorCode: 9409
-        class: "java.sql.SQLInvalidAuthorizationSpecException"
-        message: "User has insufficient privileges to access database."
-        stack:
-          - "org.example.efjdbc.EFConnection.isValid(EFConnection.java:253)"
-          - "com.ibm.ws.rest.handler.validator.jdbc.DataSourceValidator(DataSourceValidator.java:129)"
-          - "com.ibm.ws.rest.handler.validator.internal.ValidatorRestHandler.validateSingleInstance(ValidatorRestHandler:231)"
-        cause:
-          class: "javax.security.auth.login.LoginException"
-          message: "unauthorized"
-          stack:
-            - "org.example.efjdbc.AuthHelper.verifyPrivileges(AuthHelper.java:82)"
-            - "org.example.efjdbc.EFConnection.authenticate(EFConnection.java:223)"
-            - "org.example.efjdbc.EFConnection.deferredLogin(EFConnection.java:385)"
+          $ref: "#/components/schemas/cause"


### PR DESCRIPTION
Use a consistent type for error codes across exception info that is display by the validation REST endopint, so that we can more straightforwardly represent the exception chain, regardless of exception type, in schema.