### PR TITLE
Jpa extended bean manager

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoadingServiceImpl.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoadingServiceImpl.java
@@ -667,6 +667,8 @@ public class ClassLoadingServiceImpl implements LibertyClassLoadingService, Clas
         // meaning the identifier would not be reliable
         if (classloader instanceof ThreadContextClassLoader && !(classloader instanceof ThreadContextClassLoaderForBundles)) {
             return ((ThreadContextClassLoader) classloader).getKey();
+        } else if (classloader instanceof AppClassLoader) {
+            return ((AppClassLoader) classloader).getKey().toString();
         } else {
             return null;
         }

--- a/dev/com.ibm.ws.jpa.container.v21.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.container.v21.cdi/bnd.bnd
@@ -36,6 +36,7 @@ Private-Package: \
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.cm,\
 	com.ibm.websphere.org.osgi.service.component,\
+	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.jpa.container.core;version=latest,\
 	com.ibm.websphere.javaee.persistence.2.1;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\

--- a/dev/com.ibm.ws.jpa.container.v21.cdi/src/com/ibm/ws/jpa/container/v21/cdi/internal/BeanManagerInvocationHandler.java
+++ b/dev/com.ibm.ws.jpa.container.v21.cdi/src/com/ibm/ws/jpa/container/v21/cdi/internal/BeanManagerInvocationHandler.java
@@ -73,15 +73,9 @@ public class BeanManagerInvocationHandler implements InvocationHandler {
                 Object listener = args[0]; //only one argument. 
                 Method proxyMethod = extendedBeanManager.getClass().getMethod("registerLifecycleListener", Object.class);
                 ret = proxyMethod.invoke(extendedBeanManager, listener);
+            //All other methods will be going to the bean manager, not the extended bean manager.
             } else {
-                //This is coming from the proxy object. Which will either recieve registerLifecycleListener or a method from the BeanManager interface
-                //Since we've already handled registerLifecycleListener we need to direct the method to a BeanManager and not an IBMHibernateExtendedBeanManager
-                if (getTarget() instanceof IBMHibernateExtendedBeanManager) {
-                    IBMHibernateExtendedBeanManager extendedBeanManager = (IBMHibernateExtendedBeanManager) getTarget();
-                    ret = method.invoke(extendedBeanManager.getBaseBeanManager(), args);
-                } else {
-                    ret = method.invoke(getTarget(), args);
-                }
+                ret = method.invoke(getTarget(), args);
             }
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "Invoked BeanManager method", cdiService, method, args, ret);
@@ -106,12 +100,7 @@ public class BeanManagerInvocationHandler implements InvocationHandler {
             if (bm == null) {
                 throw new UnsupportedOperationException("No current bean manager found in CDI service");
             }
-            if (extendedBeanManager == null) {
-                target = bm;
-            } else {
-                extendedBeanManager.setBaseBeanManager(bm);
-                target = extendedBeanManager;
-            }
+            target = bm;
         }
         return target;
     }

--- a/dev/com.ibm.ws.jpa.container.v21.cdi/src/com/ibm/ws/jpa/container/v21/cdi/internal/HibernateNotifier.java
+++ b/dev/com.ibm.ws.jpa.container.v21.cdi/src/com/ibm/ws/jpa/container/v21/cdi/internal/HibernateNotifier.java
@@ -14,6 +14,6 @@ import javax.enterprise.inject.spi.BeanManager;
 
 public interface HibernateNotifier {
 
-    public void notifyHibernateAfterBeanDiscovery(BeanManager beanManager);
+    public void notifyHibernateAfterBeanDiscovery(BeanManager beanManager, ClassLoader classLoader);
     public void notifyHibernateBeforeShutdown(BeanManager beanManager); 
 }


### PR DESCRIPTION
This PR makes it so that there is one IBMHibernateExtendedBeanManager per deployment, rather than one per BeanManager. 

This is possible because IBMHibernateExtendedBeanManager only handles listeners for a couple of CDI lifecycle events. 

In addition this PR uses information available during the cdi lifecycle event method to direct the event to the appropriate IBMHibernateExtendedBeanManager, rather than relying on the connection between a IBMHibernateExtendedBeanManager and an underlying bean manager. Which makes this function earlier in the lifecycle. 