### PR TITLE
Adding mpRestClient.1.3 support in the OT auto feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpOpenTracing1.3-mpRestClient1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpOpenTracing1.3-mpRestClient1.2.feature
@@ -4,7 +4,7 @@ visibility=private
 singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpOpenTracing-1.3))", \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.2))"
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.2)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.3)))"
 -bundles=com.ibm.ws.microprofile.opentracing.rest.client.1.3
 IBM-Install-Policy: when-satisfied
 kind=ga


### PR DESCRIPTION
Fixes #7480

Adding compatibility for mpRestClient.1.3 with the Opentracing-Rest Client auto feature.