### PR TITLE
Remove testClassLoaderCache

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ClassLoaderCacheTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/ClassLoaderCacheTest.java
@@ -68,33 +68,23 @@ public class ClassLoaderCacheTest extends FATServletClient {
     public static void setUp() throws Exception {
         JavaArchive testAppUtils = SharedShrinkWrapApps.getTestAppUtilsJar();
 
-        WebArchive classLoaderCacheA1_war = ShrinkWrap.create(WebArchive.class, WARA1_NAME)
-                        .addAsLibrary(testAppUtils)
-                        .addPackage("com.ibm.ws.microprofile.appConfig.classLoaderCache.test");
+        WebArchive classLoaderCacheA1_war = ShrinkWrap.create(WebArchive.class,
+                                                              WARA1_NAME).addAsLibrary(testAppUtils).addPackage("com.ibm.ws.microprofile.appConfig.classLoaderCache.test");
 
-        WebArchive classLoaderCacheA2_war = ShrinkWrap.create(WebArchive.class, WARA2_NAME)
-                        .addAsLibrary(testAppUtils)
-                        .addPackage("com.ibm.ws.microprofile.appConfig.classLoaderCache.test");
+        WebArchive classLoaderCacheA2_war = ShrinkWrap.create(WebArchive.class,
+                                                              WARA2_NAME).addAsLibrary(testAppUtils).addPackage("com.ibm.ws.microprofile.appConfig.classLoaderCache.test");
 
-        WebArchive classLoaderCacheB1_war = ShrinkWrap.create(WebArchive.class, WARB1_NAME)
-                        .addAsLibrary(testAppUtils)
-                        .addPackage("com.ibm.ws.microprofile.appConfig.classLoaderCache.test");
+        WebArchive classLoaderCacheB1_war = ShrinkWrap.create(WebArchive.class,
+                                                              WARB1_NAME).addAsLibrary(testAppUtils).addPackage("com.ibm.ws.microprofile.appConfig.classLoaderCache.test");
 
-        WebArchive classLoaderCacheB2_war = ShrinkWrap.create(WebArchive.class, WARB2_NAME)
-                        .addAsLibrary(testAppUtils)
-                        .addPackage("com.ibm.ws.microprofile.appConfig.classLoaderCache.test");
+        WebArchive classLoaderCacheB2_war = ShrinkWrap.create(WebArchive.class,
+                                                              WARB2_NAME).addAsLibrary(testAppUtils).addPackage("com.ibm.ws.microprofile.appConfig.classLoaderCache.test");
 
-        EnterpriseArchive classLoaderCacheA_ear = ShrinkWrap.create(EnterpriseArchive.class, EARA_NAME)
-                        .addAsManifestResource(new File("test-applications/" + EARA_NAME + "/resources/META-INF/application.xml"), "application.xml")
-                        .addAsManifestResource(new File("test-applications/" + EARA_NAME + "/resources/META-INF/permissions.xml"), "permissions.xml")
-                        .addAsModule(classLoaderCacheA1_war)
-                        .addAsModule(classLoaderCacheA2_war);
+        EnterpriseArchive classLoaderCacheA_ear = ShrinkWrap.create(EnterpriseArchive.class,
+                                                                    EARA_NAME).addAsManifestResource(new File("test-applications/" + EARA_NAME + "/resources/META-INF/application.xml"), "application.xml").addAsManifestResource(new File("test-applications/" + EARA_NAME + "/resources/META-INF/permissions.xml"), "permissions.xml").addAsModule(classLoaderCacheA1_war).addAsModule(classLoaderCacheA2_war);
 
-        EnterpriseArchive classLoaderCacheB_ear = ShrinkWrap.create(EnterpriseArchive.class, EARB_NAME)
-                        .addAsManifestResource(new File("test-applications/" + EARB_NAME + "/resources/META-INF/application.xml"), "application.xml")
-                        .addAsManifestResource(new File("test-applications/" + EARB_NAME + "/resources/META-INF/permissions.xml"), "permissions.xml")
-                        .addAsModule(classLoaderCacheB1_war)
-                        .addAsModule(classLoaderCacheB2_war);
+        EnterpriseArchive classLoaderCacheB_ear = ShrinkWrap.create(EnterpriseArchive.class,
+                                                                    EARB_NAME).addAsManifestResource(new File("test-applications/" + EARB_NAME + "/resources/META-INF/application.xml"), "application.xml").addAsManifestResource(new File("test-applications/" + EARB_NAME + "/resources/META-INF/permissions.xml"), "permissions.xml").addAsModule(classLoaderCacheB1_war).addAsModule(classLoaderCacheB2_war);
 
         ShrinkHelper.exportDropinAppToServer(server, classLoaderCacheA_ear);
         ShrinkHelper.exportDropinAppToServer(server, classLoaderCacheB_ear);
@@ -108,15 +98,6 @@ public class ClassLoaderCacheTest extends FATServletClient {
     @After
     public void stopServer() throws Exception {
         server.stopServer();
-    }
-
-    @Test
-    public void testClassLoaderCache() throws Exception {
-        runConfigTest(WARA1, 0, 2); //initially there are zero configs, the test is expected to load two; one specific to the war and one global one
-        runConfigTest(WARA2, 2, 3); //after the previous test there should be two configs, this test is expected to load one new one specific to the war and reuse the global one (total 3)
-        server.restartDropinsApplication(EARA_NAME); //restarting the app should clear out all three configs
-        runConfigTest(WARA1, 0, 2); //so performing the same tests again should yeild the same results
-        runConfigTest(WARA2, 2, 3);
     }
 
     @Test


### PR DESCRIPTION
#build 
testClassLoaderCache is unreliable because the logging and tracing code keeps hold of a SoftReference to the ClassLoader.

testMultiApplication appears to be OK so leaving that in place for now.