### PR TITLE
Defect resolution for configupdate fat bucket

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/PersistentExecutorConfigUpdateTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/PersistentExecutorConfigUpdateTest.java
@@ -13,6 +13,7 @@ package com.ibm.ws.concurrent.persistent.fat.configupd;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -21,12 +22,16 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Set;
 
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.PersistentExecutor;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
@@ -38,6 +43,8 @@ import componenttest.topology.impl.LibertyServer;
  */
 public class PersistentExecutorConfigUpdateTest {
     private static final Set<String> appNames = Collections.singleton("persistcfgtest");
+
+    public static final String APP_NAME = "persistcfgtest";
 
     private static ServerConfiguration originalConfig;
 
@@ -98,8 +105,11 @@ public class PersistentExecutorConfigUpdateTest {
     @BeforeClass
     public static void setUp() throws Exception {
         originalConfig = server.getServerConfiguration();
-        for (String name : appNames)
-            server.addInstalledAppForValidation(name);
+
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                .addPackage("web")
+                .addAsWebInfResource(new File("test-applications/" + APP_NAME + "/resources/WEB-INF/web.xml"));
+		    ShrinkHelper.exportToServer(server, "dropins", app);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate/publish/servers/com.ibm.ws.concurrent.persistent.fat.configupdate/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate/publish/servers/com.ibm.ws.concurrent.persistent.fat.configupdate/server.xml
@@ -44,10 +44,10 @@
     <properties.derby.embedded createDatabase="create" databaseName="memory:persistcfgdb"/>
   </dataSource>
   <library id="DerbyLib">
-    <fileset dir="${server.config.dir}/derby" includes="derby.jar"/>
+    <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
   </library>
 
-  <javaPermission codebase="${server.config.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
   
   <variable name="onError" value="FAIL"/>
 </server>


### PR DESCRIPTION
Application and Derby driver were not correctly configured to be on the build path for this fat test.
This has been resolved by using shrinkwrap and updating the server.xml config

