### PR TITLE
Adding a check for https security endpoint for each FAT Test

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
@@ -95,7 +95,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.1 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor.xml");
     	server.startServer();
-    	Log.info(c, testName, server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- server started -----");
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLogUsingMark("CWWKT0016I"));
       	checkStrings(getHttpsServlet("/metrics"), 
@@ -117,7 +117,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-2.0 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor2.xml");
     	server.startServer();
-    	Log.info(c, testName, server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- server started -----");
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLogUsingMark("CWWKT0016I"));
       	checkStrings(getHttpsServlet("/metrics"), 
@@ -140,11 +140,11 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.0 and monitor-1.0: vendor metrics should not be available ------");
     	server.setServerConfigurationFile("server_mpMetric10Monitor10.xml");
     	server.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
         String logMsg = server.waitForStringInLog("SRVE9103I",60000);   
         Log.info(c, testName, logMsg);
         Assert.assertNotNull("No SRVE9103I message", logMsg);    
         Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",60000));
-        Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog(".*CWWKO0219I.*defaultHttpEndpoint-ssl.*",60000));
         Log.info(c, testName, "------- server started -----");
       	checkStrings(getHttpsServlet("/metrics"), 
           	new String[] { "base:" }, 

--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -158,7 +158,7 @@ public class TestEnableDisableFeaturesTest {
         serverEDF1.setServerConfigurationFile("server_mpMetric20.xml");
         serverEDF1.startServer();
         Assert.assertNotNull("Web application /metrics not loaded", serverEDF1.waitForStringInLog("CWWKT0016I: Web application available \\(default_host\\): http:\\/\\/.*:.*\\/metrics\\/"));
-        Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF1.waitForStringInLogUsingMark("defaultHttpEndpoint-ssl"));
+        Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF1.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
         Assert.assertNotNull("SRVE9103I NOT FOUND",serverEDF1.waitForStringInLogUsingMark("SRVE9103I"));
         Log.info(c, testName, "------- server started -----");
         checkStrings(getHttpsServlet("/metrics", serverEDF1), 
@@ -172,6 +172,7 @@ public class TestEnableDisableFeaturesTest {
     	String testName = "testEDF2";
     	Log.info(c, testName, "------- Enable mpMetrics-2.0 and monitor-1.0: threadpool metrics should be available ------");
     	serverEDF2.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF2.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	serverEDF2.setServerConfigurationFile("server_monitor2.xml");
     	// CWMPI2003I is for mpMetrics-2.0 and monitor-1.0; CWMPI2001I is for mpMetrics-1.x and monitor-1.0
         String logMsg = serverEDF2.waitForStringInLogUsingMark("CWPMI2003I");
@@ -195,6 +196,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF3;
     	String testName = "testEDF3";
     	serverEDF3.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF3.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Add session application and run session servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF3, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -215,6 +217,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF4;
     	String testName = "testEDF4";
     	serverEDF4.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF4.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Add session application ------");
        	ShrinkHelper.defaultDropinApp(serverEDF4, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -252,6 +255,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF5;
     	String testName = "testEDF5";
     	serverEDF5.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF5.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Add jax-ws endpoint application and run jax-ws client servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF5, "testJaxWsApp", "com.ibm.ws.microprofile.metrics.monitor_fat.jaxws","com.ibm.ws.microprofile.metrics.monitor_fat.jaxws.client");
        	Log.info(c, testName, "------- added testJaxWsApp to dropins -----");
@@ -280,6 +284,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF6;
     	String testName = "testEDF6";
     	serverEDF6.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF6.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Monitor filter ThreadPool and WebContainer  ------");
     	serverEDF6.setServerConfigurationFile("server_monitorFilter1.xml");
         Assert.assertNotNull("CWWKG0017I NOT FOUND",serverEDF6.waitForStringInLogUsingMark("CWWKG0017I"));
@@ -296,6 +301,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF6;
     	String testName = "testEDF7";
     	serverEDF6.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF6.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Monitor filter WebContainer and Session ------");
        	serverEDF6.setMarkToEndOfLog();
        	serverEDF6.setServerConfigurationFile("server_monitorFilter2.xml");
@@ -313,6 +319,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF8;
     	String testName = "testEDF8";
     	serverEDF8.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF8.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF8), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter Session and ConnectionPool ------");
@@ -331,6 +338,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF9;
     	String testName = "testEDF9";
     	serverEDF9.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF9.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF9), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter ThreadPool, WebContainer, Session and ConnectionPool ------");
@@ -352,6 +360,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF10;
     	String testName = "testEDF10";
     	serverEDF10.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF10.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Remove JAX-WS application ------");
     	boolean rc1 = serverEDF10.removeAndStopDropinsApplications("testJaxWsApp.war");
     	Log.info(c, testName, "------- " + (rc1 ? "successfully removed" : "failed to remove") + " JAX-WS application ------");
@@ -372,6 +381,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF11;
     	String testName = "testEDF11";
     	serverEDF11.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF11.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Remove JDBC application ------");
     	boolean rc2 = serverEDF11.removeAndStopDropinsApplications("testJDBCApp.war");
     	Log.info(c, testName, "------- " + (rc2 ? "successfully removed" : "failed to remove") + " JDBC application ------");
@@ -389,6 +399,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF12;
     	String testName = "testEDF12";
     	serverEDF12.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF12.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Assert.assertNotNull("CWWKF0011I NOT FOUND",serverEDF12.waitForStringInLogUsingMark("CWWKF0011I"));
     	Log.info(c, testName, "------- Remove monitor-1.0 ------");
     	serverEDF12.setMarkToEndOfLog();

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
@@ -95,6 +95,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.1 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor.xml");
     	server.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- server started -----");
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLogUsingMark("CWWKT0016I"));
@@ -117,11 +118,11 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.0 and monitor-1.0: vendor metrics should not be available ------");
     	server.setServerConfigurationFile("server_mpMetric10Monitor10.xml");
     	server.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
         String logMsg = server.waitForStringInLog("SRVE9103I",60000);   
         Log.info(c, testName, logMsg);
         Assert.assertNotNull("No SRVE9103I message", logMsg);    
         Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",60000));
-        Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog(".*CWWKO0219I.*defaultHttpEndpoint-ssl.*",60000));
         Log.info(c, testName, "------- server started -----");
       	checkStrings(getHttpsServlet("/metrics"), 
           	new String[] { "base:" }, 
@@ -136,9 +137,9 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable microProfile-1.3 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_microProfile13Monitor10.xml");
     	server.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, server.waitForStringInLog("CWWKS5500I",60000));
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",60000));
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog(".*CWWKO0219I.*defaultHttpEndpoint-ssl.*",60000));
     	Log.info(c, testName, "------- server started -----");
       	checkStrings(getHttpsServlet("/metrics"),
           	new String[] { "vendor:" }, 

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -157,8 +157,8 @@ public class TestEnableDisableFeaturesTest {
         Log.info(c, testName, "------- No monitor-1.0: no vendor metrics should be available ------");
         serverEDF1.setServerConfigurationFile("server_mpMetric11.xml");
         serverEDF1.startServer();
+        Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF1.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
         Assert.assertNotNull("Web application /metrics not loaded", serverEDF1.waitForStringInLog("CWWKT0016I: Web application available \\(default_host\\): http:\\/\\/.*:.*\\/metrics\\/"));
-        Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF1.waitForStringInLogUsingMark("defaultHttpEndpoint-ssl"));
         Assert.assertNotNull("SRVE9103I NOT FOUND",serverEDF1.waitForStringInLogUsingMark("SRVE9103I"));
         Log.info(c, testName, "------- server started -----");
         checkStrings(getHttpsServlet("/metrics", serverEDF1), 
@@ -172,6 +172,7 @@ public class TestEnableDisableFeaturesTest {
     	String testName = "testEDF2";
     	Log.info(c, testName, "------- Enable mpMetrics-1.1 and monitor-1.0: threadpool metrics should be available ------");
     	serverEDF2.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF2.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	serverEDF2.setServerConfigurationFile("server_monitor.xml");
         String logMsg = serverEDF2.waitForStringInLogUsingMark("CWPMI2001I");
         Log.info(c, testName, logMsg);
@@ -193,6 +194,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF3;
     	String testName = "testEDF3";
     	serverEDF3.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF3.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Add session application and run session servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF3, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -213,6 +215,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF4;
     	String testName = "testEDF4";
     	serverEDF4.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF4.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Add session application ------");
        	ShrinkHelper.defaultDropinApp(serverEDF4, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -250,6 +253,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF5;
     	String testName = "testEDF5";
     	serverEDF5.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF5.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Add jax-ws endpoint application and run jax-ws client servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF5, "testJaxWsApp", "com.ibm.ws.microprofile.metrics.monitor_fat.jaxws","com.ibm.ws.microprofile.metrics.monitor_fat.jaxws.client");
        	Log.info(c, testName, "------- added testJaxWsApp to dropins -----");
@@ -278,6 +282,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF6;
     	String testName = "testEDF6";
     	serverEDF6.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF6.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Monitor filter ThreadPool and WebContainer  ------");
     	serverEDF6.setServerConfigurationFile("server_monitorFilter1.xml");
         Assert.assertNotNull("CWWKG0017I NOT FOUND",serverEDF6.waitForStringInLogUsingMark("CWWKG0017I"));
@@ -294,6 +299,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF6;
     	String testName = "testEDF7";
     	serverEDF6.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF6.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Monitor filter WebContainer and Session ------");
        	serverEDF6.setMarkToEndOfLog();
        	serverEDF6.setServerConfigurationFile("server_monitorFilter2.xml");
@@ -311,6 +317,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF8;
     	String testName = "testEDF8";
     	serverEDF8.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF8.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF8), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter Session and ConnectionPool ------");
@@ -329,6 +336,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF9;
     	String testName = "testEDF9";
     	serverEDF9.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF9.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF9), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter ThreadPool, WebContainer, Session and ConnectionPool ------");
@@ -350,6 +358,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF10;
     	String testName = "testEDF10";
     	serverEDF10.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF10.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Remove JAX-WS application ------");
     	boolean rc1 = serverEDF10.removeAndStopDropinsApplications("testJaxWsApp.war");
     	Log.info(c, testName, "------- " + (rc1 ? "successfully removed" : "failed to remove") + " JAX-WS application ------");
@@ -370,6 +379,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF11;
     	String testName = "testEDF11";
     	serverEDF11.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF11.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Remove JDBC application ------");
     	boolean rc2 = serverEDF11.removeAndStopDropinsApplications("testJDBCApp.war");
     	Log.info(c, testName, "------- " + (rc2 ? "successfully removed" : "failed to remove") + " JDBC application ------");
@@ -387,6 +397,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF12;
     	String testName = "testEDF12";
     	serverEDF12.startServer();
+    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF12.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Assert.assertNotNull("CWWKF0011I NOT FOUND",serverEDF12.waitForStringInLogUsingMark("CWWKF0011I"));
     	Log.info(c, testName, "------- Remove monitor-1.0 ------");
     	serverEDF12.setMarkToEndOfLog();


### PR DESCRIPTION
Fixes #7385 
#build
For tests that use ssl, after the server starts up a check is put in to wait for the ssl endpoint to be available before moving on to the rest of the test