### PR TITLE
Modification needed in server.xml due to lack of java.net.URLPermission class for Java 7

### DIFF
--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBInWarServiceTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBInWarServiceTest.java
@@ -36,6 +36,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -64,6 +65,12 @@ public class EJBInWarServiceTest {
         WebArchive warclient = ShrinkWrap.create(WebArchive.class, ejbinwarservicewarclient + ".war").addPackages(true, "com.ibm.ws.jaxws.ejbinwar");
         ShrinkHelper.addDirectory(warclient, "test-applications/EJBInWarServiceClient/resources/");
         ShrinkHelper.exportDropinAppToServer(server, warclient);
+
+        // Java 7 throws "java.lang.ClassNotFoundException[java.net.URLPermission]" due to java.net.URLPermission defined in server.xml
+        // Using java7_server.xml in which java.net.URLPermission settings are removed solve this test run problem
+        if (7 == JavaInfo.forServer(server).majorVersion()) {
+            server.setServerConfigurationFile("EJBInWarService/java7_server.xml");
+        }
 
         try {
             server.startServer();

--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBJndiTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBJndiTest.java
@@ -37,6 +37,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -79,6 +80,12 @@ public class EJBJndiTest {
         ear.add(new FileAsset(new File("lib/LibertyFATTestFiles/EJBJndi/application.xml")), "/META-INF/application.xml");
 
         ShrinkHelper.exportDropinAppToServer(server, ear);
+
+        // Java 7 throws "java.lang.ClassNotFoundException[java.net.URLPermission]" due to java.net.URLPermission defined in server.xml
+        // Using java7_server.xml in which java.net.URLPermission settings are removed solve this test run problem
+        if (7 == JavaInfo.forServer(server).majorVersion()) {
+            server.setServerConfigurationFile("EJBJndi/java7_server.xml");
+        }
 
         try {
             server.startServer();

--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSBasicTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSBasicTest.java
@@ -35,6 +35,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -64,6 +65,12 @@ public class EJBWSBasicTest {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ejbwsbasicear + ".ear").addAsModule(jar).addAsModule(war);
 
         ShrinkHelper.exportDropinAppToServer(server, ear);
+
+        // Java 7 throws "java.lang.ClassNotFoundException[java.net.URLPermission]" due to java.net.URLPermission defined in server.xml
+        // Using java7_server.xml in which java.net.URLPermission settings are removed solve this test run problem
+        if (7 == JavaInfo.forServer(server).majorVersion()) {
+            server.setServerConfigurationFile("EJBWSBasic/java7_server.xml");
+        }
 
         try {
             server.startServer();

--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSContextTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSContextTest.java
@@ -38,6 +38,7 @@ import com.ibm.ws.jaxws.ejbwscontext.ObjectFactory;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -72,6 +73,12 @@ public class EJBWSContextTest {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ejbwscontextear + ".ear").addAsModule(jar).addAsModule(war);
 
         ShrinkHelper.exportAppToServer(server, ear);
+
+        // Java 7 throws "java.lang.ClassNotFoundException[java.net.URLPermission]" due to java.net.URLPermission defined in server.xml
+        // Using java7_server.xml in which java.net.URLPermission settings are removed solve this test run problem
+        if (7 == JavaInfo.forServer(server).majorVersion()) {
+            server.setServerConfigurationFile("EJBWSContext/java7_server.xml");
+        }
 
         try {
             server.startServer();

--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSInterceptorTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSInterceptorTest.java
@@ -33,6 +33,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -61,6 +62,12 @@ public class EJBWSInterceptorTest {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ejbwsinterceptorear + ".ear").addAsModule(war).addAsModule(jar);
 
         ShrinkHelper.exportDropinAppToServer(server, ear);
+
+        // Java 7 throws "java.lang.ClassNotFoundException[java.net.URLPermission]" due to java.net.URLPermission defined in server.xml
+        // Using java7_server.xml in which java.net.URLPermission settings are removed solve this test run problem
+        if (7 == JavaInfo.forServer(server).majorVersion()) {
+            server.setServerConfigurationFile("EJBWSInterceptor/java7_server.xml");
+        }
 
         try {
             server.startServer();

--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSLifeCycleTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBWSLifeCycleTest.java
@@ -36,6 +36,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -74,6 +75,12 @@ public class EJBWSLifeCycleTest {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ejbwslifecycleear + ".ear").addAsModule(jar).addAsModule(war);
 
         ShrinkHelper.exportDropinAppToServer(server, ear);
+
+        // Java 7 throws "java.lang.ClassNotFoundException[java.net.URLPermission]" due to java.net.URLPermission defined in server.xml
+        // Using java7_server.xml in which java.net.URLPermission settings are removed solve this test run problem
+        if (7 == JavaInfo.forServer(server).majorVersion()) {
+            server.setServerConfigurationFile("EJBWSLifeCycle/java7_server.xml");
+        }
 
         try {
             server.startServer();

--- a/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBInWarService/java7_server.xml
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBInWarService/java7_server.xml
@@ -1,0 +1,25 @@
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>jsp-2.3</feature>
+        <feature>jaxws-2.2</feature>
+        <feature>ejbLite-3.2</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <!-- TESTING THE UPLOAD! -->
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="createClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+	<javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+  	<javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+  	<javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read"/>
+  	<javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+
+  	<javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="get"/>
+  	<javaPermission className="java.net.NetPermission" name="setDefaultAuthenticator"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.com.sun.org.apache.xerces.internal.dom"/>
+ 	
+</server>

--- a/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBJndi/java7_server.xml
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBJndi/java7_server.xml
@@ -1,0 +1,23 @@
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>jsp-2.3</feature>
+        <feature>jaxws-2.2</feature>
+        <feature>ejbLite-3.2</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="createClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.com.sun.org.apache.xerces.internal.dom"/>
+	<javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+  	<javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+  	<javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read"/>
+  	<javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+    
+    <javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="get"/>
+  	<javaPermission className="java.net.NetPermission" name="setDefaultAuthenticator"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBWSBasic/java7_server.xml
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBWSBasic/java7_server.xml
@@ -1,0 +1,24 @@
+<server>
+    <featureManager>
+    	<feature>componenttest-1.0</feature>
+        <feature>jsp-2.3</feature>
+        <feature>jaxws-2.2</feature>
+        <feature>ejbLite-3.2</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="createClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+	<javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+  	<javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+  	<javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read"/>
+  	<javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+    
+    <javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="get"/>
+    
+  	<javaPermission className="java.net.NetPermission" name="setDefaultAuthenticator"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.com.sun.org.apache.xerces.internal.dom"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+
+</server>

--- a/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBWSContext/java7_server.xml
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBWSContext/java7_server.xml
@@ -1,0 +1,42 @@
+<server>
+   <featureManager>
+   		<feature>componenttest-1.0</feature>
+        <feature>jsp-2.3</feature>
+        <feature>jaxws-2.2</feature>
+        <feature>ejbLite-3.2</feature>
+        <feature>appSecurity-2.0</feature>
+    </featureManager>
+
+    <executor stealPolicy="NEVER"/>
+
+    <include location="../fatTestPorts.xml"/>
+    
+    <basicRegistry id="basic" realm="SampleRealm">
+    		<user name="user1" password="u1pwd" />
+    		<user name="user2" password="u2pwd" />
+    </basicRegistry>
+    
+    <application type="ear" id="EJBWSContext" name="EJBWSContext" location="EJBWSContext.ear">
+    		<application-bnd>
+    			<security-role name="role_1">
+        				<user name="user1" />
+        				
+    			</security-role>
+    			<security-role name="role_2">
+        				<user name="user2" />        				
+    			</security-role>    				
+    		</application-bnd>
+    </application>
+  	<javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="createClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+	<javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+  	<javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+  	<javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read"/>
+  	<javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+  	
+  	<javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="get"/>
+  	<javaPermission className="java.net.NetPermission" name="setDefaultAuthenticator"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    
+</server>

--- a/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBWSInterceptor/java7_server.xml
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBWSInterceptor/java7_server.xml
@@ -1,0 +1,22 @@
+<server>
+    <featureManager>
+    	<feature>componenttest-1.0</feature>
+        <feature>jsp-2.3</feature>
+        <feature>jaxws-2.2</feature>
+        <feature>ejbLite-3.2</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+   	<javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="createClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+	<javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+  	<javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+  	<javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read"/>
+
+  	<javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="get"/>
+  	<javaPermission className="java.net.NetPermission" name="setDefaultAuthenticator"/>
+  	<javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+    <javaPermission className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+
+</server>

--- a/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBWSLifeCycle/java7_server.xml
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/publish/files/EJBWSLifeCycle/java7_server.xml
@@ -1,0 +1,23 @@
+<server>
+    <!-- Enable features -->
+    <featureManager>
+     	<feature>componenttest-1.0</feature>
+        <feature>jsp-2.3</feature>
+        <feature>jaxws-2.2</feature>
+        <feature>ejbLite-3.2</feature>
+    </featureManager>
+
+	<include location="../fatTestPorts.xml"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="createClassLoader"/>
+  	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+	<javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+  	<javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+  	<javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read"/>
+  	<javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+
+  	<javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="get"/>
+  	<javaPermission className="java.net.NetPermission" name="setDefaultAuthenticator"/>
+    <javaPermission className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+
+</server>


### PR DESCRIPTION
Java 7 throws "java.lang.ClassNotFoundException[java.net.URLPermission]" due to java.net.URLPermission defined in server.xml. Using java7_server.xml in which java.net.URLPermission settings are removed solved this test run problem for com.ibm.ws.jaxws.ejb_fat bundle


