### PR TITLE
Use correct system property for FAT server HTTP port

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/BasicMutationTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/BasicMutationTestServlet.java
@@ -52,7 +52,7 @@ public class BasicMutationTestServlet extends FATServlet {
     @Override
     public void init() throws ServletException {
         String contextPath = getSysProp("com.ibm.ws.microprofile.graphql.fat.contextpath", "graphql");
-        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP", "8010") + "/basicMutationApp/" + contextPath;
+        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010") + "/basicMutationApp/" + contextPath;
         LOG.info("baseUrl = " + baseUriStr);
         URI baseUri = URI.create(baseUriStr);
         builder = RestClientBuilder.newBuilder()

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicQueryApp/src/mpGraphQL10/basicQuery/BasicQueryTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicQueryApp/src/mpGraphQL10/basicQuery/BasicQueryTestServlet.java
@@ -55,7 +55,7 @@ public class BasicQueryTestServlet extends FATServlet {
     @Override
     public void init() throws ServletException {
         String contextPath = getSysProp("com.ibm.ws.microprofile.graphql.fat.contextpath", "graphql");
-        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP", "8010") + "/basicQueryApp/" + contextPath;
+        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010") + "/basicQueryApp/" + contextPath;
         LOG.info("baseUrl = " + baseUriStr);
         URI baseUri = URI.create(baseUriStr);
         builder = RestClientBuilder.newBuilder()

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/defaultvalueApp/src/mpGraphQL10/defaultvalue/DefaultValueTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/defaultvalueApp/src/mpGraphQL10/defaultvalue/DefaultValueTestServlet.java
@@ -59,7 +59,7 @@ public class DefaultValueTestServlet extends FATServlet {
     @Override
     public void init() throws ServletException {
         String contextPath = getSysProp("com.ibm.ws.microprofile.graphql.fat.contextpath", "graphql");
-        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP", "8010") + "/defaultvalueApp/" + contextPath;
+        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010") + "/defaultvalueApp/" + contextPath;
         LOG.info("baseUrl = " + baseUriStr);
         URI baseUri = URI.create(baseUriStr);
         builder = RestClientBuilder.newBuilder()

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/deprecationApp/src/mpGraphQL10/deprecation/DeprecationTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/deprecationApp/src/mpGraphQL10/deprecation/DeprecationTestServlet.java
@@ -59,7 +59,7 @@ public class DeprecationTestServlet extends FATServlet {
     @Override
     public void init() throws ServletException {
         String contextPath = getSysProp("com.ibm.ws.microprofile.graphql.fat.contextpath", "graphql");
-        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP", "8010") + "/deprecationApp/" + contextPath;
+        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010") + "/deprecationApp/" + contextPath;
         LOG.info("baseUrl = " + baseUriStr);
         URI baseUri = URI.create(baseUriStr);
         builder = RestClientBuilder.newBuilder()

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ifaceApp/src/mpGraphQL10/iface/InterfaceTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ifaceApp/src/mpGraphQL10/iface/InterfaceTestServlet.java
@@ -54,7 +54,7 @@ public class InterfaceTestServlet extends FATServlet {
     @Override
     public void init() throws ServletException {
         String contextPath = getSysProp("com.ibm.ws.microprofile.graphql.fat.contextpath", "graphql");
-        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP", "8010") + "/ifaceApp/" + contextPath;
+        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010") + "/ifaceApp/" + contextPath;
         LOG.info("baseUrl = " + baseUriStr);
         URI baseUri = URI.create(baseUriStr);
         builder = RestClientBuilder.newBuilder()

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ignoreApp/src/mpGraphQL10/ignore/IgnoreTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ignoreApp/src/mpGraphQL10/ignore/IgnoreTestServlet.java
@@ -59,7 +59,7 @@ public class IgnoreTestServlet extends FATServlet {
     @Override
     public void init() throws ServletException {
         String contextPath = getSysProp("com.ibm.ws.microprofile.graphql.fat.contextpath", "graphql");
-        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP", "8010") + "/ignoreApp/" + contextPath;
+        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010") + "/ignoreApp/" + contextPath;
         LOG.info("baseUrl = " + baseUriStr);
         URI baseUri = URI.create(baseUriStr);
         builder = RestClientBuilder.newBuilder()

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/typesApp/src/mpGraphQL10/types/TypesTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/typesApp/src/mpGraphQL10/types/TypesTestServlet.java
@@ -54,7 +54,7 @@ public class TypesTestServlet extends FATServlet {
     @Override
     public void init() throws ServletException {
         String contextPath = getSysProp("com.ibm.ws.microprofile.graphql.fat.contextpath", "graphql");
-        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP", "8010") + "/typesApp/" + contextPath;
+        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010") + "/typesApp/" + contextPath;
         LOG.info("baseUrl = " + baseUriStr);
         URI baseUri = URI.create(baseUriStr);
         builder = RestClientBuilder.newBuilder()


### PR DESCRIPTION
The GraphQL FAT tests currently look for the wrong system property when determining the server's HTTP port - it looks for "bvt.prop.HTTP" when it should look for "bvt.prop.HTTP_default" - if unspecified, it defaults to 8010 (which is the default test port) - that's why these tests pass most of the time.  But when a port other than 8010 is used, the tests fail.  This change uses the correct system property for determining the server port.