### PR TITLE
Switched System.getProperty to server.getHttpDefaultPort to get the default ports

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
@@ -84,8 +84,8 @@ public class MetricsAuthenticationTest {
     }
 
     private void waitForPrerequisites(LibertyServer server) throws Exception {
-        String regex1 = "CWWKO0219I.*" + System.getProperty("bvt.prop.HTTP_default", "8010") + ".*";
-        String regex2 = "CWWKO0219I.*" + System.getProperty("bvt.prop.HTTP_default.secure", "8020") + ".*";
+        String regex1 = "CWWKO0219I.*" + server.getHttpDefaultPort() + ".*";
+        String regex2 = "CWWKO0219I.*" + server.getHttpDefaultSecurePort() + ".*";
         assertNotNull("TCP Channel defaultHttpEndpoint has not started", server.waitForStringInLog(regex1));
         assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started", server.waitForStringInLog(regex2));
         assertNotNull("[/metrics] failed to initialize", server.waitForStringInLogUsingMark("SRVE0242I.*/metrics.*"));


### PR DESCRIPTION
#build
Fixes #7976 

Issue:
In the waitForPrerequisites the method used to obtain the http default port was System.getProperty("bvt.prop.HTTP_default", "8010"). A similar method was used to obtain the secure port. However, this is an issue as bvt.prop.HTTP_default may not exist and 8010 is not necessarily the default port   when bvt.prop.HTTP_default does not exist. Thus, the FAT test fails as it is looking at the wrong port number

Solution:
System.getProperty("bvt.prop.HTTP_default", "8010") is replaced with server.getHttpDefaultPort(). This method ensures that the correct port number is used regardless of the machine running the test.
This fixed was suggested by Tom Evans as seen in the comments in the related RTC defect (RTC #264237)