### PR TITLE
Update code to release memory when stopping applications

### DIFF
--- a/dev/com.ibm.ws.beanvalidation.v11.cdi/src/com/ibm/ws/beanvalidation/v11/cdi/internal/ValidationExtensionService.java
+++ b/dev/com.ibm.ws.beanvalidation.v11.cdi/src/com/ibm/ws/beanvalidation/v11/cdi/internal/ValidationExtensionService.java
@@ -51,30 +51,24 @@ public abstract class ValidationExtensionService {
     private static final String REFERENCE_CLASSLOADING_SERVICE = "classLoadingService";
 
     protected final AtomicServiceReference<BeanValidation> beanValidation = new AtomicServiceReference<BeanValidation>(REFERENCE_BEANVALIDATION_SERVICE);
-    final AtomicServiceReference<ClassLoadingService> classLoadingServiceSR =
-                    new AtomicServiceReference<ClassLoadingService>(REFERENCE_CLASSLOADING_SERVICE);
+    final AtomicServiceReference<ClassLoadingService> classLoadingServiceSR = new AtomicServiceReference<ClassLoadingService>(REFERENCE_CLASSLOADING_SERVICE);
 
     protected ValidationConfig validationConfig;
-    protected ValidatorFactory factory;
-    protected ClassLoader factoryAppClassLoader;
 
     private static volatile ValidationExtensionService svInstance = null;
-    
-    protected static final PrivilegedAction<ThreadContextAccessor> getThreadContextAccessorAction =
-                    new PrivilegedAction<ThreadContextAccessor>() {
-                        @Override
-                        public ThreadContextAccessor run() {
-                            return ThreadContextAccessor.getThreadContextAccessor();
-                        }
-                    };
 
-    static ValidationExtensionService instance()
-    {
+    protected static final PrivilegedAction<ThreadContextAccessor> getThreadContextAccessorAction = new PrivilegedAction<ThreadContextAccessor>() {
+        @Override
+        public ThreadContextAccessor run() {
+            return ThreadContextAccessor.getThreadContextAccessor();
+        }
+    };
+
+    static ValidationExtensionService instance() {
         return svInstance;
     }
 
-    static void setInstance(ValidationExtensionService instance)
-    {
+    static void setInstance(ValidationExtensionService instance) {
         if (svInstance != null && instance != null) {
             throw new IllegalStateException("instance already set");
         }
@@ -85,7 +79,7 @@ public abstract class ValidationExtensionService {
 
     /**
      * Called by DS to activate this service
-     * 
+     *
      * @param compcontext the context of this component
      */
     protected void activate(ComponentContext compcontext) {
@@ -99,7 +93,7 @@ public abstract class ValidationExtensionService {
 
     /**
      * Called by DS to deactivate this service
-     * 
+     *
      * @param compcontext the context of this component
      */
     protected void deactivate(ComponentContext compcontext) {
@@ -113,7 +107,7 @@ public abstract class ValidationExtensionService {
 
     /**
      * Called by DS to set the service reference
-     * 
+     *
      * @param ref the reference from DS
      */
     @Reference(name = REFERENCE_BEANVALIDATION_SERVICE, service = BeanValidation.class)
@@ -123,7 +117,7 @@ public abstract class ValidationExtensionService {
 
     /**
      * Called by DS to remove the service reference
-     * 
+     *
      * @param ref the reference from DS
      */
     protected void unsetBeanValidation(ServiceReference<BeanValidation> ref) {
@@ -132,7 +126,7 @@ public abstract class ValidationExtensionService {
 
     /**
      * Called by DS to set the service reference
-     * 
+     *
      * @param ref the reference from DS
      */
     @Reference(name = REFERENCE_CLASSLOADING_SERVICE,
@@ -143,7 +137,7 @@ public abstract class ValidationExtensionService {
 
     /**
      * Called by DS to remove the service reference
-     * 
+     *
      * @param ref the reference from DS
      */
     protected void unsetClassLoadingService(ServiceReference<ClassLoadingService> ref) {
@@ -202,9 +196,7 @@ public abstract class ValidationExtensionService {
         BValExtension bValExtension;
         try {
             classLoader = configureBvalClassloader(null);
-            ThreadContextAccessor tca = System.getSecurityManager() == null ?
-                            ThreadContextAccessor.getThreadContextAccessor() :
-                            AccessController.doPrivileged(getThreadContextAccessorAction);
+            ThreadContextAccessor tca = System.getSecurityManager() == null ? ThreadContextAccessor.getThreadContextAccessor() : AccessController.doPrivileged(getThreadContextAccessorAction);
 
             // set the thread context class loader to be used, must be reset in finally block
             setClassLoader = new SetContextClassLoaderPrivileged(tca);

--- a/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/OSGiBeanValidationImpl.java
+++ b/dev/com.ibm.ws.beanvalidation/src/com/ibm/ws/beanvalidation/OSGiBeanValidationImpl.java
@@ -558,11 +558,19 @@ public class OSGiBeanValidationImpl extends AbstractBeanValidation implements Mo
                 }
 
                 Class<?> clazz = classLoader.loadClass("org.apache.bval.jsr.ConstraintAnnotationAttributes");
-                final Field methodByNameAndClass = clazz.getDeclaredField("METHOD_BY_NAME_AND_CLASS");
+                Field methodByNameAndClass = clazz.getDeclaredField("METHOD_BY_NAME_AND_CLASS");
 
                 priv.setAccessible(methodByNameAndClass, true);
 
                 Map<?, ?> methodMap = (Map<?, ?>) methodByNameAndClass.get(null);
+                methodMap.clear();
+
+                clazz = classLoader.loadClass("org.apache.bval.util.PropertyAccess");
+                methodByNameAndClass = clazz.getDeclaredField("PROPERTY_DESCRIPTORS");
+
+                priv.setAccessible(methodByNameAndClass, true);
+
+                methodMap = (Map<?, ?>) methodByNameAndClass.get(null);
                 methodMap.clear();
             } catch (Exception e) {
                 //ffdc

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
@@ -654,6 +654,8 @@ public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
 
             this.deploymentDBAs.clear();
             this.applicationBDAs.clear();
+            this.extensionBDAs.clear();
+            this.orderedBDAs.clear();
             this.classloader = null;
             this.extensionClassLoaders.clear();
             this.cdiEnabled = false;

--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImpl.java
@@ -404,14 +404,13 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
             methodParameters = Arrays.asList(methodArguments);
         }
 
-        ejbAuditHashMap.put("methodArguments", methodArguments);
         ejbAuditHashMap.put("applicationName", applicationName);
         ejbAuditHashMap.put("moduleName", moduleName);
         ejbAuditHashMap.put("methodName", methodName);
         ejbAuditHashMap.put("methodInterface", methodInterface);
         ejbAuditHashMap.put("methodSignature", methodSignature);
         ejbAuditHashMap.put("beanName", beanName);
-        ejbAuditHashMap.put("methodParameters", methodParameters);
+        ejbAuditHashMap.put("methodParameters", methodParameters == null ? "null" : methodParameters.toString());
 
     }
 
@@ -423,7 +422,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
      * <li>is EVERYONE granted to any of the required roles</li>
      * <li>is the subject authorized to any of the required roles</li>
      *
-     * @param EBJRequestData the info on the EJB method to call
+     * @param EJBRequestData the info on the EJB method to call
      * @param subject the subject authorize
      * @throws EJBAccessDeniedException when the subject is not authorized to the EJB
      */

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi/src/com/ibm/ws/jaxrs20/cdi/component/ThreadBasedHashMap.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi/src/com/ibm/ws/jaxrs20/cdi/component/ThreadBasedHashMap.java
@@ -12,6 +12,7 @@ package com.ibm.ws.jaxrs20.cdi.component;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 import com.ibm.ws.managedobject.ManagedObject;
 
@@ -23,7 +24,7 @@ public class ThreadBasedHashMap extends HashMap<Class<?>, ManagedObject<?>> {
     ThreadLocal<Map<Class<?>, ManagedObject<?>>> tlMap = new ThreadLocal<Map<Class<?>, ManagedObject<?>>>() {
         @Override
         protected Map<Class<?>, ManagedObject<?>> initialValue() {
-            return new HashMap<>();
+            return new WeakHashMap<>();
         }
     };
 

--- a/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/component/JaxRsClientModuleMetaDataListener.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/component/JaxRsClientModuleMetaDataListener.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.client.component;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.container.service.metadata.MetaDataEvent;
+import com.ibm.ws.container.service.metadata.ModuleMetaDataListener;
+import com.ibm.ws.jaxrs20.client.JAXRSClientImpl;
+import com.ibm.ws.runtime.metadata.ModuleMetaData;
+
+/**
+ * Listening a Web/EJB module metadata events, and clean up JAXRSClientImpl objects on destroy.
+ */
+@Component(immediate = true, property = { "service.vendor=IBM" }, configurationPolicy = ConfigurationPolicy.OPTIONAL)
+public class JaxRsClientModuleMetaDataListener implements ModuleMetaDataListener {
+
+    private static final TraceComponent tc = Tr.register(JaxRsClientModuleMetaDataListener.class);
+
+    @Override
+    public void moduleMetaDataCreated(MetaDataEvent<ModuleMetaData> event) {
+        //NO-OP
+    }
+
+    @Activate
+    protected void activate(ComponentContext cc) {
+        //NO-OP
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext cc) {
+        //NO-OP
+    }
+
+    @Override
+    public void moduleMetaDataDestroyed(MetaDataEvent<ModuleMetaData> event) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "moduleMetaDataDestroyed(" + event.getMetaData().getName() + ") : " + event.getMetaData());
+        }
+
+        JAXRSClientImpl.closeClients(event.getMetaData());
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.ejb/src/com/ibm/ws/jaxrs20/ejb/JaxRsFactoryBeanEJBCustomizer.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.ejb/src/com/ibm/ws/jaxrs20/ejb/JaxRsFactoryBeanEJBCustomizer.java
@@ -56,7 +56,6 @@ import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
 @Component(name = "com.ibm.ws.jaxrs20.ejb.JaxRsFactoryEJBBeanCustomizer", immediate = true, property = { "service.vendor=IBM" })
 public class JaxRsFactoryBeanEJBCustomizer implements JaxRsFactoryBeanCustomizer {
     private final TraceComponent tc = Tr.register(JaxRsFactoryBeanEJBCustomizer.class);
-    private CXFJaxRsProviderResourceHolder cxfPRHolder;
 
     //private final Set<Class<ExceptionMapper<?>>> exceptionMappers = new HashSet<Class<ExceptionMapper<?>>>();
 
@@ -133,10 +132,10 @@ public class JaxRsFactoryBeanEJBCustomizer implements JaxRsFactoryBeanCustomizer
                 }
 
             }
-            cxfPRHolder = context.getCxfRPHolder();
-            findEJBClass(ejbEndpointList, perRequestIterator, true);
-            findEJBClass(ejbEndpointList, singletonIterator, false);
-            handleAbstractClassInterface(moduleMetaData, ejbEndpointList, endpointInfo.getAbstractClassInterfaceList(), perRequestProviderAndPathInfos,
+            CXFJaxRsProviderResourceHolder cxfPRHolder = context.getCxfRPHolder();
+            findEJBClass(cxfPRHolder, ejbEndpointList, perRequestIterator, true);
+            findEJBClass(cxfPRHolder, ejbEndpointList, singletonIterator, false);
+            handleAbstractClassInterface(cxfPRHolder, moduleMetaData, ejbEndpointList, endpointInfo.getAbstractClassInterfaceList(), perRequestProviderAndPathInfos,
                                          singletonProviderAndPathInfos, ejbModuleName);
         } catch (UnableToAdaptException e) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -158,7 +157,8 @@ public class JaxRsFactoryBeanEJBCustomizer implements JaxRsFactoryBeanCustomizer
      * @param perRequestProviderAndPathInfos
      * @param cxfPRHolder
      */
-    private void handleAbstractClassInterface(JaxRsModuleMetaData moduleMetaData, List<EJBEndpoint> ejbEndpointList, List<String> abstractClassInterfaceList,
+    private void handleAbstractClassInterface(CXFJaxRsProviderResourceHolder cxfPRHolder, JaxRsModuleMetaData moduleMetaData, List<EJBEndpoint> ejbEndpointList,
+                                              List<String> abstractClassInterfaceList,
                                               Set<ProviderResourceInfo> perRequestProviderAndPathInfos, Set<ProviderResourceInfo> singletonProviderAndPathInfos,
                                               String ejbModuleName) {
         for (String abstractClassInterfaceName : abstractClassInterfaceList) {
@@ -387,7 +387,7 @@ public class JaxRsFactoryBeanEJBCustomizer implements JaxRsFactoryBeanCustomizer
         return jndiName.toString();
     }
 
-    private void findEJBClass(List<EJBEndpoint> ejbEndpointList,
+    private void findEJBClass(CXFJaxRsProviderResourceHolder cxfPRHolder, List<EJBEndpoint> ejbEndpointList,
                               Iterator<ProviderResourceInfo> providerResourceInfoIterator,
                               Boolean perRequest) {
         while (providerResourceInfoIterator.hasNext()) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/ForwardIncident.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/ForwardIncident.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.internal.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.Date;
+
+import com.ibm.wsspi.logging.Incident;
+
+/**
+ * This implementation of Incident has a reference to the Throwable, caller and objectArray[] passed
+ * into FFDC for the exception that occurred. These objects are used by the getIntrospectedCallerDump()
+ * method. We do not want to keep these objects referenced in memory in the collection of Incidents.
+ */
+public class ForwardIncident implements Incident {
+
+    private final Incident originalIncident;
+    private final Throwable th;
+    private final Object callerThis;
+    private final Object[] objectArray;
+
+    ForwardIncident(Incident originalIncident, Throwable th, Object callerThis, Object[] objectArray) {
+        this.originalIncident = originalIncident;
+        this.th = th;
+        this.callerThis = callerThis;
+        this.objectArray = objectArray;
+    }
+
+    @Override
+    public String getSourceId() {
+        return originalIncident.getSourceId();
+    }
+
+    @Override
+    public String getProbeId() {
+        return originalIncident.getProbeId();
+    }
+
+    @Override
+    public String getExceptionName() {
+        return originalIncident.getExceptionName();
+    }
+
+    @Override
+    public int getCount() {
+        return originalIncident.getCount();
+    }
+
+    @Override
+    public long getTimeStamp() {
+        return originalIncident.getTimeStamp();
+    }
+
+    @Override
+    public Date getDateOfFirstOccurrence() {
+        return originalIncident.getDateOfFirstOccurrence();
+    }
+
+    @Override
+    public String getLabel() {
+        return originalIncident.getLabel();
+    }
+
+    @Override
+    public long getThreadId() {
+        return originalIncident.getThreadId();
+    }
+
+    @Override
+    public String getIntrospectedCallerDump() {
+        String dump = null;
+        ByteArrayOutputStream oStream = new ByteArrayOutputStream();
+
+        IncidentStreamImpl iStream = null;
+
+        try {
+            iStream = new IncidentStreamImpl(oStream);
+        } catch (Exception e) {
+            // darn. Prevent the exception logging the error from percolating upward
+        }
+
+        if (iStream != null) {
+            try {
+                new IncidentLogger().logIncident(iStream, this, th, callerThis, objectArray, true);
+            } catch (Throwable e) {
+                iStream.printStackTrace(e);
+            } finally {
+                LoggingFileUtils.tryToClose(iStream);
+
+                try {
+                    dump = oStream.toString("UTF-8");
+                } catch (UnsupportedEncodingException e) {
+                    // darn. Prevent the exception logging the error from percolating upward
+                }
+            }
+        }
+
+        return dump;
+    }
+}

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/IncidentImpl.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/IncidentImpl.java
@@ -10,9 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.logging.internal.impl;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -37,11 +35,8 @@ public class IncidentImpl implements Incident {
         final String probeId;
         final String exceptionName;
         final long threadId;
-        final Throwable th;
-        final Object callerThis;
-        final Object[] objectArray;
 
-        public Key(String sourceId, String probeId, Throwable th, Object callerThis, Object[] objectArray) {
+        public Key(String sourceId, String probeId, Throwable th) {
             this.sourceId = sourceId;
             this.probeId = probeId;
             if (th == null) {
@@ -50,9 +45,6 @@ public class IncidentImpl implements Incident {
                 exceptionName = th.getClass().getName();
             }
             this.threadId = Thread.currentThread().getId();
-            this.th = th;
-            this.callerThis = callerThis;
-            this.objectArray = objectArray;
         }
 
         @Override
@@ -329,34 +321,7 @@ public class IncidentImpl implements Incident {
 
     @Override
     public String getIntrospectedCallerDump() {
-        String dump = null;
-        ByteArrayOutputStream oStream = new ByteArrayOutputStream();
-
-        IncidentStreamImpl iStream = null;
-
-        try {
-            iStream = new IncidentStreamImpl(oStream);
-        } catch (Exception e) {
-            // darn. Prevent the exception logging the error from percolating upward
-        }
-
-        if (iStream != null) {
-            try {
-                new IncidentLogger().logIncident(iStream, this, key.th, key.callerThis, key.objectArray, true);
-            } catch (Throwable e) {
-                iStream.printStackTrace(e);
-            } finally {
-                LoggingFileUtils.tryToClose(iStream);
-
-                try {
-                    dump = oStream.toString("UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    // darn. Prevent the exception logging the error from percolating upward
-                }
-            }
-        }
-
-        return dump;
+        return "";
     }
 
     /**

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/IncidentLogger.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/IncidentLogger.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.ibm.ws.ffdc.DiagnosticModule;
 import com.ibm.ws.ffdc.FFDC;
 import com.ibm.ws.ffdc.IncidentStream;
+import com.ibm.wsspi.logging.Incident;
 
 /**
  * An IncidentStreamImpl is a lightweight implementation of an Incident stream
@@ -31,11 +32,11 @@ import com.ibm.ws.ffdc.IncidentStream;
  */
 public final class IncidentLogger {
 
-    public void logIncident(IncidentStream iStream, IncidentImpl incident, Throwable th, Object callerThis, Object[] objectArray) {
+    public void logIncident(IncidentStream iStream, Incident incident, Throwable th, Object callerThis, Object[] objectArray) {
         logIncident(iStream, incident, th, callerThis, objectArray, false);
     }
 
-    public void logIncident(IncidentStream iStream, IncidentImpl incident, Throwable th, Object callerThis, Object[] objectArray, boolean callerDumpOnly) {
+    public void logIncident(IncidentStream iStream, Incident incident, Throwable th, Object callerThis, Object[] objectArray, boolean callerDumpOnly) {
 
         final String time = formatTime();
 

--- a/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/internal/impl/BasicFFDCServiceTest.java
+++ b/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/internal/impl/BasicFFDCServiceTest.java
@@ -31,11 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
-import test.LoggingTestUtils;
-import test.TestConstants;
-import test.common.SharedOutputManager;
-import test.common.TestFile;
-
 import com.ibm.websphere.ras.SharedTr;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.ffdc.DiagnosticModule;
@@ -46,6 +41,11 @@ import com.ibm.ws.ffdc.FFDCSelfIntrospectable;
 import com.ibm.ws.ffdc.IncidentStream;
 import com.ibm.ws.ffdc.SharedFFDCConfigurator;
 import com.ibm.wsspi.logprovider.LogProviderConfig;
+
+import test.LoggingTestUtils;
+import test.TestConstants;
+import test.common.SharedOutputManager;
+import test.common.TestFile;
 
 public class BasicFFDCServiceTest {
 
@@ -188,7 +188,7 @@ public class BasicFFDCServiceTest {
         }
 
         // Find the incident that should be the common denominator for all of these exceptions
-        IncidentImpl incident = baseFFDC.getIncident("sourceId", "probeId", new Exception(), this, new Object[] {});
+        IncidentImpl incident = baseFFDC.getIncident("sourceId", "probeId", new Exception());
         assertEquals("Incident should have 10 associated files", 10, incident.getFiles().size());
 
         // Now "roll" the logs: should get new/replacement files created for the new exception messages
@@ -375,7 +375,7 @@ public class BasicFFDCServiceTest {
     public void testFFDCSummary() throws Exception {
         BaseFFDCService ffdcService = new BaseFFDCService();
 
-        // Non-destructive pre-config value: 
+        // Non-destructive pre-config value:
         assertEquals("maxFiles should start out as 0", 0, ffdcService.summaryLogSet.getMaxFiles());
 
         // Apply initial configuration
@@ -448,7 +448,7 @@ public class BasicFFDCServiceTest {
 
     /**
      * Gets all of the FFDC logs from the ffdc folder. Returns an empty array if there are no files in there.
-     * 
+     *
      * @return An array of the ffdc log files
      */
     private File[] getFfdcLogs() {

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/srt/SRTConnectionContext31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/srt/SRTConnectionContext31.java
@@ -171,9 +171,13 @@ public class SRTConnectionContext31 extends com.ibm.ws.webcontainer.osgi.srt.SRT
                             Tr.debug(tc, "tcm -->" + tcm);
                         }
                         tcm.pushContextData();
-                        
-                        //call application handler init 
-                        handler.init(upgradedCon);
+
+                        try {
+                            //call application handler init 
+                            handler.init(upgradedCon);
+                        } finally {
+                            tcm.popContextData();
+                        }
                     }
                 }
                 catch (Throwable th)

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/webapp/WebApp31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/osgi/webapp/WebApp31.java
@@ -530,12 +530,14 @@ public class WebApp31 extends com.ibm.ws.webcontainer.osgi.webapp.WebApp
               cmdai = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor();
               cmdai.beginContext(getModuleMetaData().getCollaboratorComponentMetaData());
         }
-        
-        super.handleRequest(request, response);
-        
-        //defect 168286 - end the context after the request for CDI 1.2
-        if(cmdai != null) {
-            cmdai.endContext();
+
+        try {
+            super.handleRequest(request, response);
+        } finally {
+            //defect 168286 - end the context after the request for CDI 1.2
+            if(cmdai != null) {
+                cmdai.endContext();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #7986 

Fixes many places that are holding onto references to the application classes or classloader.  Keeping these references after application is stopped causes the application to stay in memory.  

Each commit in this pull request includes details of what I changed and is labeled with the area that was fixed with that pull request.