### PR TITLE
Wrong metricName value when creating MetricID in MpMetrics 2.0 Monitor (auto) feature

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java
@@ -55,7 +55,7 @@ public class MonitorMetrics {
             if (metricTagName != null) {
             	metricTag = new Tag(metricTagName, getMBeanStatsString());
             }
-            MetricID metricID = new MetricID(metricTagName, metricTag);
+            MetricID metricID = new MetricID(metricName, metricTag);
             MetricType type = MetricType.valueOf(metricData[MappingTable.METRIC_TYPE]);
             
             if (MetricType.COUNTER.equals(type)) {


### PR DESCRIPTION
fixes #7993 
#build