### PR TITLE
add basic auth and error message

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
@@ -238,7 +238,10 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
                             value = URLDecoder.decode(value, "UTF-8");
                         }
                         lcProps.put(resolvePotentialVariable(name), resolvePotentialVariable(value));
-                    } // TODO else error
+                    } else {
+                        json.put("successful", false);
+                        json.put("failure", toJSONObject("message", "Login config property lacks delimiter '=' between key and value"));
+                    }
                 }
                 params.put("loginConfigProps", lcProps);
             }
@@ -247,7 +250,7 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
             if (validator == null) {
                 json.put("successful", false);
                 json.put("failure", toJSONObject("message", "Unable to obtain validator for " + configElementPid));
-            } else {
+            } else if (!json.containsKey("successful")) {
                 Map<String, ?> result;
                 try {
                     result = validator.validate(target, params, request.getLocale());

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
@@ -484,7 +484,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/validation.jms.result"
+security:
+  - basicAuth: []
 components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
   parameters:
     queryParams:
       name: queryParams

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
@@ -504,13 +504,13 @@ components:
     X-Validation-User:
       name: X-Validation-User
       in: header
-      description: "**User**. Supplies a user name when not using Container-managed authentication. All non-ASCII characters must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
+      description: "**User**. Supplies a user name when not using Container-managed authentication. All non-ASCII characters and other characters not allowed in a header must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
       schema:
         type: string
     X-Validation-Password:
       name: X-Validation-Password
       in: header
-      description: "**Password**. Supplies a password when not using Container-managed authentication. All non-ASCII characters must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
+      description: "**Password**. Supplies a password when not using Container-managed authentication. All non-ASCII characters and other characters not allowed in a header must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
       schema:
         type: string
         format: password
@@ -538,7 +538,7 @@ components:
     X-Login-Config-Props:
       name: X-Login-Config-Props
       in: header
-      description: "**Login Config Properties**. Supply login config properties as name/value pairs. Each name/value pair is a list element, within which the name and value are delimited by the first `=` character. For example, *prop1=value1*. All non-ASCII characters must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
+      description: "**Login Config Properties**. Supply login config properties as name/value pairs. Each name/value pair is a list element, within which the name and value are delimited by the first `=` character. For example, *prop1=value1*. All non-ASCII characters and other characters not allowed in a header must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
       schema:
         type: array
         items:
@@ -546,7 +546,7 @@ components:
     headerParamsURLEncoded:
       name: headerParamsURLEncoded
       in: query
-      description: "Enable this if you URL-encode values for header parameters, such as X-Validation-User, X-Validation-Password, or X-Login-Config-Props. URL encoding is necessary to supply values that include non-ASCII characters."
+      description: "Enable this if you URL-encode values for header parameters, such as X-Validation-User, X-Validation-Password, or X-Login-Config-Props. URL encoding is necessary to supply values that include non-ASCII characters and other characters that are not allowed in a header."
       schema:
         type: boolean
       example: false


### PR DESCRIPTION
Add option for basic authentication to yaml.
Add test case for URL encoded characters in header parameters.
Also add an error message for when the delimiter is missing.