### PR TITLE
remove erroneous override of library id

### DIFF
--- a/dev/com.ibm.ws.classloading/resources/OSGI-INF/metatype/library.xml
+++ b/dev/com.ibm.ws.classloading/resources/OSGI-INF/metatype/library.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011 IBM Corporation and others.
+    Copyright (c) 2011,2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -20,14 +20,7 @@
         required="false" 
         type="String"      
     />
-    
-     <AD name="internal" description="internal use only"  
-        id="id" 
-        required="false" 
-        type="String"
-        default="${service.pid}"      
-    />
-    
+
      <AD name="%library.description" description="%library.description.desc"  
         id="description" 
         required="false" 

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/providers/Providers.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/providers/Providers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import com.ibm.ws.classloading.internal.util.CompositeIterable;
 import com.ibm.ws.library.internal.SharedLibraryFactory;
 import com.ibm.wsspi.classloading.ApiType;
 import com.ibm.wsspi.classloading.ClassLoaderConfiguration;
+import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 import com.ibm.wsspi.library.Library;
 
 public class Providers {
@@ -128,7 +129,7 @@ public class Providers {
         }
 
         // Filter the SharedLibrary service references by ID.
-        String filter = "(" + "id=" + id + ")";
+        String filter = FilterUtils.createPropertyFilter("id", id);
         Collection<ServiceReference<Library>> refs = null;
         try {
             refs = bundleContext.getServiceReferences(Library.class, filter);

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/library/internal/SharedLibraryImpl.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/library/internal/SharedLibraryImpl.java
@@ -37,6 +37,7 @@ import com.ibm.wsspi.artifact.factory.ArtifactContainerFactory;
 import com.ibm.wsspi.classloading.ApiType;
 import com.ibm.wsspi.classloading.ClassLoadingService;
 import com.ibm.wsspi.config.Fileset;
+import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 import com.ibm.wsspi.kernel.service.utils.PathUtils;
 import com.ibm.wsspi.library.Library;
 import com.ibm.wsspi.library.LibraryChangeListener;
@@ -108,7 +109,8 @@ public class SharedLibraryImpl implements Library {
             // which will be a list of pid (or, if cardinality=0, then just a pid).
             try {
                 listenerFilter = FrameworkUtil.createFilter("(&(objectClass=" + LibraryChangeListener.class.getName() +
-                                                            ")(|(library=" + instanceId + ")(libraryRef=*" + instancePid + "*)))");
+                                                            ")(|" + FilterUtils.createPropertyFilter("library", instanceId)
+                                                                  + "(libraryRef=*" + instancePid + "*)))");
             } catch (InvalidSyntaxException e) {
                 //auto FFDC because the syntax shouldn't be wrong!
                 Tr.error(tc, "cls.library.id.invalid", instanceId, e.toString());


### PR DESCRIPTION
The metatype for the library element overrides the id attribute and defines a default value for the id, being a variable reference to the service.pid.  However, it isn't valid to use variables within id values. After consulting with Brent Daniel, I've opened this pull to remove this invalid default and submit a build against it to help confirm that nothing will break if we fix it.