### PR TITLE
WIP: Default trustStoreType to PKCS12

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -314,6 +314,7 @@
                         <!-- <wiremock.server.port>8765</wiremock.server.port> -->
                         <com.ibm.ws.jaxrs.testing>true</com.ibm.ws.jaxrs.testing>
                         <sun.rmi.transport.tcp.responseTimeout>${sun.rmi.transport.tcp.responseTimeout}</sun.rmi.transport.tcp.responseTimeout>
+                        <javax.net.ssl.trustStoreType>pkcs12</javax.net.ssl.trustStoreType>
                     </systemPropertyVariables>
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>


### PR DESCRIPTION
Test bug in the MP Rest Client 1.3 TCK - breaks with IBM JDK 8 because the test uses PKCS12 trust store type for the embedded Jetty test server for the SSL tests.  IBM JDK 8 assumes a default of JKS trust store type.  Oracle JDK 8 and all JDK versions >8 either default to PKCS12 or can detect it and roll with it.  This is a workaround so that Liberty passes the TCK with IBM JDK 8.