### PR TITLE
standardize and enforce parameters/results for validator implementations

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator.cloudant/src/com/ibm/ws/rest/handler/validator/cloudant/CloudantDatabaseValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.cloudant/src/com/ibm/ws/rest/handler/validator/cloudant/CloudantDatabaseValidator.java
@@ -38,13 +38,25 @@ public class CloudantDatabaseValidator implements Validator {
     private ResourceConfigFactory resourceConfigFactory;
 
     /**
+     * Identifies whether the specified query parameter is a valid parameter for the validator.
+     * Header parameters such as the user name & password return a false value because they are not query parameters.
+     *
+     * @param name query parameter name.
+     * @return true if a valid parameter for validation. Otherwise false.
+     */
+    public boolean isParameter(String name) {
+        return Validator.AUTH.equals(name)
+               || Validator.AUTH_ALIAS.equals(name);
+    }
+
+    /**
      * @see com.ibm.wsspi.validator.Validator#validate(java.lang.Object, java.util.Map, java.util.Locale)
      */
     @Override
     @FFDCIgnore(java.lang.NoSuchMethodException.class)
     public LinkedHashMap<String, ?> validate(Object instance, Map<String, Object> props, Locale locale) {
-        String auth = (String) props.get("auth");
-        String authAlias = (String) props.get("authAlias");
+        String auth = (String) props.get(AUTH);
+        String authAlias = (String) props.get(AUTH_ALIAS);
 
         boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
@@ -54,7 +66,7 @@ public class CloudantDatabaseValidator implements Validator {
 
         try {
             ResourceConfig config = null;
-            int authType = "container".equals(auth) ? 0 : "application".equals(auth) ? 1 : -1;
+            int authType = AUTH_CONTAINER.equals(auth) ? 0 : AUTH_APPLICATION.equals(auth) ? 1 : -1;
             if (authType >= 0) {
                 config = resourceConfigFactory.createResourceConfig("com.cloudant.client.api.Database");
                 config.setResAuthType(authType);
@@ -97,7 +109,7 @@ public class CloudantDatabaseValidator implements Validator {
             }
 
         } catch (Throwable x) {
-            result.put("failure", x);
+            result.put(FAILURE, x);
         }
 
         if (trace && tc.isEntryEnabled())

--- a/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jca/src/com/ibm/ws/rest/handler/validator/jca/ConnectionFactoryValidator.java
@@ -115,13 +115,13 @@ public class ConnectionFactoryValidator implements Validator {
                                              @Sensitive Map<String, Object> props, // @Sensitive prevents auto-FFDC from including password value
                                              Locale locale) {
         final String methodName = "validate";
-        String user = (String) props.get("user");
-        String password = (String) props.get("password");
-        String auth = (String) props.get("auth");
-        String authAlias = (String) props.get("authAlias");
-        String loginConfig = (String) props.get("loginConfig");
+        String user = (String) props.get(USER);
+        String password = (String) props.get(PASSWORD);
+        String auth = (String) props.get(AUTH);
+        String authAlias = (String) props.get(AUTH_ALIAS);
+        String loginConfig = (String) props.get(LOGIN_CONFIG);
         @SuppressWarnings("unchecked")
-        Map<String, String> loginConfigProps = (Map<String, String>) props.get("loginConfigProps");
+        Map<String, String> loginConfigProps = (Map<String, String>) props.get(LOGIN_CONFIG_PROPS);
 
         boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
@@ -131,8 +131,8 @@ public class ConnectionFactoryValidator implements Validator {
         LinkedHashMap<String, Object> result = new LinkedHashMap<String, Object>();
         try {
             ResourceConfig config = null;
-            int authType = "container".equals(auth) ? 0 //
-                            : "application".equals(auth) ? 1 //
+            int authType = AUTH_CONTAINER.equals(auth) ? 0 //
+                            : AUTH_APPLICATION.equals(auth) ? 1 //
                                             : -1;
 
             if (authType >= 0) {
@@ -174,11 +174,11 @@ public class ConnectionFactoryValidator implements Validator {
                 if (interfaces.contains("javax.jms.ConnectionFactory")) { // also covers QueueConnectionFactory and TopicConnectionFactory
                     jmsValidator = getJMSValidator();
                     if (jmsValidator == null)
-                        result.put("failure", "JMS feature is not enabled.");
+                        result.put(FAILURE, "JMS feature is not enabled.");
                     else
                         jmsValidator.validate(cf, user, password, result);
                 } else
-                    result.put("failure", "Validation is not implemented for " + cf.getClass().getName() + " which implements " + interfaces + ".");
+                    result.put(FAILURE, "Validation is not implemented for " + cf.getClass().getName() + " which implements " + interfaces + ".");
             }
         } catch (Throwable x) {
             ArrayList<String> sqlStates = new ArrayList<String>();
@@ -202,8 +202,8 @@ public class ConnectionFactoryValidator implements Validator {
                 errorCodes.add(errorCode);
             }
             result.put("sqlState", sqlStates);
-            result.put("errorCode", errorCodes);
-            result.put("failure", x);
+            result.put(FAILURE_ERROR_CODES, errorCodes);
+            result.put(FAILURE, x);
         }
 
         if (trace && tc.isEntryEnabled())
@@ -286,7 +286,7 @@ public class ConnectionFactoryValidator implements Validator {
 
                 String userName = conData.getUserName();
                 if (userName != null && userName.length() > 0)
-                    result.put("user", userName);
+                    result.put(USER, userName);
             } catch (NotSupportedException ignore) {
             } catch (UnsupportedOperationException ignore) {
             }
@@ -337,12 +337,12 @@ public class ConnectionFactoryValidator implements Validator {
 
             String userName = metadata.getUserName();
             if (userName != null && userName.length() > 0)
-                result.put("user", userName);
+                result.put(USER, userName);
 
             try {
                 boolean isValid = con.isValid(120); // TODO better ideas for timeout value?
                 if (!isValid)
-                    result.put("failure", "FALSE returned by JDBC driver's Connection.isValid operation");
+                    result.put(FAILURE, "FALSE returned by JDBC driver's Connection.isValid operation");
             } catch (SQLFeatureNotSupportedException x) {
             }
         } finally {

--- a/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
+++ b/dev/com.ibm.ws.rest.handler.validator.jdbc/src/com/ibm/ws/rest/handler/validator/jdbc/DataSourceValidator.java
@@ -53,13 +53,13 @@ public class DataSourceValidator implements Validator {
                                              @Sensitive Map<String, Object> props, // @Sensitive prevents auto-FFDC from including password value
                                              Locale locale) {
         final String methodName = "validate";
-        String user = (String) props.get("user");
-        String pass = (String) props.get("password");
-        String auth = (String) props.get("auth");
-        String authAlias = (String) props.get("authAlias");
-        String loginConfig = (String) props.get("loginConfig");
+        String user = (String) props.get(USER);
+        String pass = (String) props.get(PASSWORD);
+        String auth = (String) props.get(AUTH);
+        String authAlias = (String) props.get(AUTH_ALIAS);
+        String loginConfig = (String) props.get(LOGIN_CONFIG);
         @SuppressWarnings("unchecked")
-        Map<String, String> loginConfigProps = (Map<String, String>) props.get("loginConfigProps");
+        Map<String, String> loginConfigProps = (Map<String, String>) props.get(LOGIN_CONFIG_PROPS);
 
         boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
@@ -68,8 +68,8 @@ public class DataSourceValidator implements Validator {
         LinkedHashMap<String, Object> result = new LinkedHashMap<String, Object>();
         try {
             ResourceConfig config = null;
-            int authType = "container".equals(auth) ? 0 //
-                            : "application".equals(auth) ? 1 //
+            int authType = AUTH_CONTAINER.equals(auth) ? 0 //
+                            : AUTH_APPLICATION.equals(auth) ? 1 //
                                             : -1;
             if (authType >= 0) {
                 config = resourceConfigFactory.createResourceConfig(DataSource.class.getName());
@@ -113,12 +113,12 @@ public class DataSourceValidator implements Validator {
 
                 String userName = metadata.getUserName();
                 if (userName != null && userName.length() > 0)
-                    result.put("user", userName);
+                    result.put(USER, userName);
 
                 try {
                     boolean isValid = con.isValid(120); // TODO better ideas for timeout value?
                     if (!isValid)
-                        result.put("failure", "FALSE returned by JDBC driver's Connection.isValid operation");
+                        result.put(FAILURE, "FALSE returned by JDBC driver's Connection.isValid operation");
                 } catch (SQLFeatureNotSupportedException x) {
                 }
             } finally {
@@ -141,8 +141,8 @@ public class DataSourceValidator implements Validator {
                 errorCodes.add(errorCode);
             }
             result.put("sqlState", sqlStates);
-            result.put("errorCode", errorCodes);
-            result.put("failure", x);
+            result.put(FAILURE_ERROR_CODES, errorCodes);
+            result.put(FAILURE, x);
         }
 
         if (trace && tc.isEntryEnabled())

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
@@ -238,7 +238,10 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
                             value = URLDecoder.decode(value, "UTF-8");
                         }
                         lcProps.put(resolvePotentialVariable(name), resolvePotentialVariable(value));
-                    } // TODO else error
+                    } else {
+                        json.put("successful", false);
+                        json.put("failure", toJSONObject("message", "Login config property lacks delimiter '=' between key and value"));
+                    }
                 }
                 params.put("loginConfigProps", lcProps);
             }
@@ -247,7 +250,7 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
             if (validator == null) {
                 json.put("successful", false);
                 json.put("failure", toJSONObject("message", "Unable to obtain validator for " + configElementPid));
-            } else {
+            } else if (!json.containsKey("successful")) {
                 Map<String, ?> result;
                 try {
                     result = validator.validate(target, params, request.getLocale());

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/wsspi/validator/Validator.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/wsspi/validator/Validator.java
@@ -18,26 +18,77 @@ import java.util.Map;
 //Until then, it remains internal even though in wsspi package.
 //Also, should move to the validator bundle that is activated when restConnector+featureX is enabled. This (and the other SPI class) should not depend on apiDiscovery-1.0.
 /**
- * Invoked by the /validator/{elementName} API to provide validation for the configuration element type(s)
- * identified by the service property <code>applies.to.pid</code>.
+ * Invoked by the /validation/{elementName} API to provide a validation result for the configuration element type(s)
+ * identified by the service property <code>com.ibm.wsspi.rest.handler.config.pid</code>.
  * The value is a pid, for example, the pid for the dataSource element is <code>com.ibm.ws.jdbc.dataSource</code>.
  * Validator implementations should be registered as OSGi service in the service registry.
  */
 public interface Validator {
-    // TODO add constants for various reserved properties such as: user, password, and auth
+    /**
+     * Name of query parameter that selects the resource reference authentication type.
+     * It also serves as a key for the {@code props} parameter of {@link #validate(Object, Map, Locale) validate}.
+     */
+    public static final String AUTH = "auth";
+
+    /**
+     * Name of query parameter that specifies a resource reference authentication alias.
+     * It also serves as a key for the {@code props} parameter of {@link #validate(Object, Map, Locale) validate}.
+     */
+    public static final String AUTH_ALIAS = "authAlias";
+
+    /**
+     * Value for {@link #AUTH} which corresponds to application authentication in a resource reference.
+     */
+    public static final String AUTH_APPLICATION = "application";
+
+    /**
+     * Value for {@link #AUTH} which corresponds to container authentication in a resource reference.
+     */
+    public static final String AUTH_CONTAINER = "container";
+
+    /**
+     * Key for an Exception or Error that is reported in the {@link #validate(Object, Map, Locale) validate} result.
+     */
+    public static final String FAILURE = "failure";
+
+    /**
+     * Key for a list of error codes that is reported in the {@link #validate(Object, Map, Locale) validate} result.
+     * Each position in the list corresponds to the error code (if any) at that position in the exception chain.
+     */
+    public static final String FAILURE_ERROR_CODES = "errorCode";
+
+    /**
+     * Name of the query parameter that specifies the customer login configuration name.
+     * It also serves as a key for the {@code props} parameter of {@link #validate(Object, Map, Locale) validate}.
+     */
+    public static final String LOGIN_CONFIG = "loginConfig";
+
+    /**
+     * Key for the {@code props} parameter of {@link #validate(Object, Map, Locale) validate} that contains a map of custom login config properties.
+     */
+    public static final String LOGIN_CONFIG_PROPS = "loginConfigProps";
+
+    /**
+     * Key for the {@code props} parameter of {@link #validate(Object, Map, Locale) validate} that specifies the password.
+     */
+    public static final String PASSWORD = "password";
+
+    /**
+     * Key for the {@code props} parameter of {@link #validate(Object, Map, Locale) validate} that specifies the user name.
+     * This key is also used to report the user name in the result.
+     */
+    public static final String USER = "user";
 
     /**
      * Validates the specified instance.
      *
      * @param instance the instance to validate.
-     * @param props    properties describing the validation request, as determined by the ValidatorAPIProvider.
-     *                     Possible property keys include:
-     *                     <code>user</code>, <code>password</code>, <code>auth</code>, <code>authAlias</code>,
-     *                     <code>loginConfig</code>, <code>loginConfigProps</code>
-     *                     Possible values for <code>auth</code> are: <code>application</code>, <code>container</code>.
+     * @param props    properties describing the validation request. Possible property keys include:
+     *                     {@link #USER}, {@link #PASSWORD}, {@link #AUTH}, {@link #AUTH_ALIAS},
+     *                     {@link #LOGIN_CONFIG}, {@link #LOGIN_CONFIG_PROPS}
      * @param locale   locale of the client invoking the API.
      * @return ordered name/value pairs with information about the result. If the test operation is unsuccessful,
-     *         the "failure" key must be included, with the value either being a Throwable or a String indicating the error.
+     *         the {@link #FAILURE} key must be included, with the value either being a Throwable or a String indicating the error.
      */
     public LinkedHashMap<String, ?> validate(Object instance, Map<String, Object> props, Locale locale);
 }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -98,7 +98,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testVariableSubstitution() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource?user=bogus")
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource")
                         .requestProp("X-Validation-User", "${DB_USER}")
                         .requestProp("X-Validation-Password", "${DB_PASS}");
         JsonObject json = request.run(JsonObject.class);
@@ -109,7 +109,7 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testEnvVariableSubstitution() throws Exception {
-        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource?user=bogus")
+        HttpsRequest request = new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource")
                         .requestProp("X-Validation-User", "${env.DB_USER_ENV}")
                         .requestProp("X-Validation-Password", "${env.DB_PASS_ENV}");
         JsonObject json = request.run(JsonObject.class);
@@ -205,6 +205,16 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, json.get("info"));
         assertNotNull(err, json = json.getJsonObject("failure"));
         assertTrue(err, json.getString("message").contains("feature"));
+    }
+
+    /**
+     * Supply an invalid query parameter to the validation REST endpoint and expect an error.
+     */
+    @Test
+    public void testInvalidQueryParameter() throws Exception {
+        new HttpsRequest(server, "/ibm/api/validation/dataSource/DefaultDataSource?badParam=something")
+                        .expectCode(400)
+                        .run(JsonObject.class);
     }
 
     @Test

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
@@ -484,7 +484,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/validation.jms.result"
+security:
+  - basicAuth: []
 components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
   parameters:
     queryParams:
       name: queryParams

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
@@ -504,13 +504,13 @@ components:
     X-Validation-User:
       name: X-Validation-User
       in: header
-      description: "**User**. Supplies a user name when not using Container-managed authentication. All non-ASCII characters must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
+      description: "**User**. Supplies a user name when not using Container-managed authentication. All non-ASCII characters and other characters not allowed in a header must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
       schema:
         type: string
     X-Validation-Password:
       name: X-Validation-Password
       in: header
-      description: "**Password**. Supplies a password when not using Container-managed authentication. All non-ASCII characters must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
+      description: "**Password**. Supplies a password when not using Container-managed authentication. All non-ASCII characters and other characters not allowed in a header must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
       schema:
         type: string
         format: password
@@ -538,7 +538,7 @@ components:
     X-Login-Config-Props:
       name: X-Login-Config-Props
       in: header
-      description: "**Login Config Properties**. Supply login config properties as name/value pairs. Each name/value pair is a list element, within which the name and value are delimited by the first `=` character. For example, *prop1=value1*. All non-ASCII characters must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
+      description: "**Login Config Properties**. Supply login config properties as name/value pairs. Each name/value pair is a list element, within which the name and value are delimited by the first `=` character. For example, *prop1=value1*. All non-ASCII characters and other characters not allowed in a header must be URL encoded, in which case be sure to specify the *headerParamsURLEncoded* parameter."
       schema:
         type: array
         items:
@@ -546,7 +546,7 @@ components:
     headerParamsURLEncoded:
       name: headerParamsURLEncoded
       in: query
-      description: "Enable this if you URL-encode values for header parameters, such as X-Validation-User, X-Validation-Password, or X-Login-Config-Props. URL encoding is necessary to supply values that include non-ASCII characters."
+      description: "Enable this if you URL-encode values for header parameters, such as X-Validation-User, X-Validation-Password, or X-Login-Config-Props. URL encoding is necessary to supply values that include non-ASCII characters and other characters that are not allowed in a header."
       schema:
         type: boolean
       example: false


### PR DESCRIPTION
Define constants to standardize parameter names and result keys across validator implementations.
Add enforcement requiring only recognized parameter names to be used, along with the ability for implementations to extend or replace the list of valid parameters.