### PR TITLE
Override Arquillian URIResourceProvider

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/health20/tck/Health20TCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/health20/tck/Health20TCKLauncher.java
@@ -23,8 +23,6 @@ import com.ibm.websphere.simplicity.PortType;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.MvnUtils;
 
@@ -33,7 +31,6 @@ import componenttest.topology.utils.MvnUtils;
  * There is a detailed output on specific
  */
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
 public class Health20TCKLauncher {
 
     @Server("Health20TCKServer")

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/servers/Health20TCKServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/servers/Health20TCKServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:HEALTH=all
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:com.ibm.ws.webcontainer.extension.*=all

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/servers/Health20TCKServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/servers/Health20TCKServer/server.xml
@@ -19,4 +19,14 @@
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="${bvt.prop.HTTP_default}"
+                  httpsPort="${bvt.prop.HTTP_default.secure}">
+        <accessLogging
+            filepath="${server.output.dir}/logs/http_defaultEndpoint_access.log"
+            logFormat='%h %u %t "%r" %s %b %D %{User-agent}i'>
+        </accessLogging>         
+     </httpEndpoint>
 </server>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.1.14.Final</version>
+                <version>${arquillian.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/src/test/java/com/ibm/ws/microprofile/health20/test/ArquillianLoadableExtension.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/src/test/java/com/ibm/ws/microprofile/health20/test/ArquillianLoadableExtension.java
@@ -13,18 +13,18 @@ package com.ibm.ws.microprofile.health20.test;
 import java.util.EnumSet;
 import java.util.Set;
 
-import com.ibm.ws.fat.util.tck.AbstractArquillianLoadableExtension;
-import com.ibm.ws.fat.util.tck.TCKArchiveModifications;
-
+import org.jboss.arquillian.container.test.impl.enricher.resource.URIResourceProvider;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
+import com.ibm.ws.fat.util.tck.AbstractArquillianLoadableExtension;
+import com.ibm.ws.fat.util.tck.TCKArchiveModifications;
 
 public class ArquillianLoadableExtension extends AbstractArquillianLoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
-        builder.service(ResourceProvider.class, URIProviderProducer.class);
+        builder.override(ResourceProvider.class, URIResourceProvider.class, URIProviderProducer.class);
     }
-    
+
     @Override
     public Set<TCKArchiveModifications> getModifications() {
         return EnumSet.of(TCKArchiveModifications.TEST_LOGGER, TCKArchiveModifications.HAMCREST);

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/src/test/java/com/ibm/ws/microprofile/health20/test/URIProviderProducer.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/src/test/java/com/ibm/ws/microprofile/health20/test/URIProviderProducer.java
@@ -11,26 +11,22 @@
 package com.ibm.ws.microprofile.health20.test;
 
 import java.lang.annotation.Annotation;
-
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 import java.net.URI;
+
+import org.jboss.arquillian.container.test.impl.enricher.resource.URIResourceProvider;
+import org.jboss.arquillian.test.api.ArquillianResource;
+
 /**
  *
  */
-public class URIProviderProducer implements ResourceProvider {
+public class URIProviderProducer extends URIResourceProvider {
 
     public final static String LIBERTY_ROOT_URI = System.getProperty("test.url");
-    
+
     @Override
     public Object lookup(ArquillianResource arquillianResource, Annotation... annotations) {
         System.out.println("WLP: Liberty Root URI: " + LIBERTY_ROOT_URI);
         return URI.create(LIBERTY_ROOT_URI);
-    }
-
-    @Override
-    public boolean canProvide(Class<?> type) {
-        return type.isAssignableFrom(URI.class);
     }
 
 }


### PR DESCRIPTION
Fixes #8023

Arquillian already has `URIResourceProvider` for `URI`.  Our own `URIProviderProducer` was racing with `URIResourceProvider` to inject to `URI`.

- Change Arquillian version from `1.1.14.Final` to `1.3.0.Final`
- Also remove the FULL test annotation so it will become a LITE test. 
- Enabled access log for debugging
- Change `URIProviderProducer` to extend `URIResourceProvider` and override `URIResourceProvider` with `URIProviderProducer`