### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/dev/com.ibm.ws.jmx.scripting.client/publish/clients/jython/restConnector.py
+++ b/dev/com.ibm.ws.jmx.scripting.client/publish/clients/jython/restConnector.py
@@ -60,14 +60,14 @@ class JMXRESTConnector(object):
 			self.connectAdvanced(host, port, args[0])
 
 	def connectAdvanced(self,host,port,map):
-		print "Connecting to the server..."
+		print("Connecting to the server...")
 		System.setProperty("javax.net.ssl.trustStore", self.trustStore)
 		System.setProperty("javax.net.ssl.trustStorePassword", self.trustStorePassword)
 		System.setProperty("javax.net.ssl.trustStoreType", "PKCS12");
 		url = JMXServiceURL("REST", host, port, "/IBMJMXConnectorREST")
 		self.connector = JMXConnectorFactory.newJMXConnector(url, map)
 		self.connector.connect()
-		print "Successfully connected to the server " + '"' + host + ':%i"' % port
+		print("Successfully connected to the server " + '"' + host + ':%i"' % port)
 
 	def connectBasic(self,host,port,user,password):
 		map = HashMap()


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

I know this code is intended for Jython which is currently only supports Python 2 but we can all hope that someday Jython will support Python 3.