### PR TITLE
Running TCK tests for Microprofile.3.0

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncherMicroProfile.java
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncherMicroProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,51 +12,48 @@ package com.ibm.ws.testing.opentracing.test;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
 
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.MvnUtils;
 
 /**
- * <p>The open tracing FAT suite.</p>
- *
- * <p>This class *must* be named "FATSuite", since the test code is hard coded
- * to look for just that class.</p>
+ * This is a test class that runs a whole Maven TCK as one test FAT test.
  */
-@RunWith(Suite.class)
-@SuiteClasses({
-    TestSpanUtils.class,
-    FATOpentracing.class,
-    FATOpentracingHelloWorld.class,
-    FATMPOpenTracing.class,
-    MicroProfileNoTracer.class,
-    OpentracingTCKLauncher.class,
-    OpentracingTCKLauncherMicroProfile.class,
-    OpentracingRestClientTCKLauncher.class
-})
-public class FATSuite implements FATOpentracingConstants {
-    private static final Class<? extends FATSuite> CLASS = FATSuite.class;
+@RunWith(FATRunner.class)
+public class OpentracingTCKLauncherMicroProfile {
+
     private static final String FEATURE_NAME = "com.ibm.ws.opentracing.mock-1.3.mf";
     private static final String BUNDLE_NAME = "com.ibm.ws.opentracing.mock-1.3.jar";
 
-    private static void info(String methodName, String text) {
-        FATLogging.info(CLASS, methodName, text);
-    }
+    @Server("OpentracingTCKServerMicroProfile")
+    public static LibertyServer server;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        String methodName = "setUp";
-        info(methodName, "ENTER / RETURN");
-        LibertyServer server = LibertyServerFactory.getLibertyServer(OPENTRACING_FAT_SERVER1_NAME);
+        setUpServer();
+        server.startServer();
+    }
+    
+    private static void setUpServer() throws Exception {
         server.copyFileToLibertyInstallRoot("usr/extension/lib/features/", "features/" + FEATURE_NAME);
         server.copyFileToLibertyInstallRoot("usr/extension/lib/", "bundles/" + BUNDLE_NAME);
     }
 
+
     @AfterClass
     public static void tearDown() throws Exception {
-        String methodName = "tearDown";
-        info(methodName, "ENTER / RETURN");
+        server.stopServer();
+    }
+
+    @Test
+    @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
+    public void launchOpentracingTck() throws Exception {
+        // Use default tck-suite.xml
+        MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.opentracing.1.3_fat", this.getClass() + ":launchOpentracingTck");
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncherMicroProfile.java
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncherMicroProfile.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.testing.opentracing.test;
 
+import java.util.Collections;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,6 +56,8 @@ public class OpentracingTCKLauncherMicroProfile {
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchOpentracingTck() throws Exception {
         // Use default tck-suite.xml
-        MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.opentracing.1.3_fat", this.getClass() + ":launchOpentracingTck");
+        
+        MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.opentracing.1.3_fat", this.getClass() + ":launchOpentracingRestClientTck", "tck-and-rest-client-tck.xml", Collections.emptyMap(), Collections.emptySet());
+
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServerMicroProfile/apps/.gitignore
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServerMicroProfile/apps/.gitignore
@@ -1,0 +1,1 @@
+# This file is needed because the apps directory is needed and git doesn't support checking in empty directories.

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServerMicroProfile/bootstrap.properties
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServerMicroProfile/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServerMicroProfile/jvm.options
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServerMicroProfile/jvm.options
@@ -1,0 +1,2 @@
+-DUSE_MOCK_TRACER=true
+-Dcom.ibm.tools.attach.enable=yes

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServerMicroProfile/server.xml
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/servers/OpentracingTCKServerMicroProfile/server.xml
@@ -1,0 +1,27 @@
+<!--Copyright (c) 2017 IBM Corporation and others. All rights reserved. This 
+	program and the accompanying materials are made available under the terms 
+	of the Eclipse Public License v1.0 which accompanies this distribution, and 
+	is available at http://www.eclipse.org/legal/epl-v10.html Contributors: IBM 
+	Corporation - initial API and implementation -->
+<server>
+	<featureManager>
+		<feature>componenttest-1.0</feature>
+		<feature>webProfile-8.0</feature>
+		<feature>localConnector-1.0</feature>
+		<feature>microProfile-3.0</feature>
+		<feature>usr:opentracingMock-1.3</feature>
+		<feature>arquillian-support-1.0</feature>
+	</featureManager>
+
+	<include location="../fatTestPorts.xml" />
+
+	<keyStore id="defaultKeyStore" password="yourPassword" />
+	
+	<!--Java2 security -->
+	<javaPermission className="java.security.AllPermission"
+		name="*" actions="*" />
+
+	<logging
+		traceSpecification="*=info:com.ibm.ws.opentracing*=all:com.ibm.ws.microprofile.opentracing*=all"
+		maxFileSize="100" maxFiles="1" />
+</server>

--- a/dev/com.ibm.ws.opentracing.1.3_fat/publish/tckRunner/tck/tck-and-rest-client-tck.xml
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/publish/tckRunner/tck/tck-and-rest-client-tck.xml
@@ -1,0 +1,23 @@
+<!--Copyright (c) 2017 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
+    and is available at 
+        http://www.eclipse.org/legal/epl-v10.html 
+    Contributors: 
+        IBM Corporation - initial API and implementation
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-opentracing-and-rest-client-tck" verbose="2"
+    configfailurepolicy="continue">
+    <test name="tck-package-org.eclipse.microprofile.opentracing.tck">
+        <packages>
+            <package name="org.eclipse.microprofile.opentracing.tck" />
+        </packages>
+    </test>
+    <test name="tck-package-org.eclipse.microprofile.opentracing.tck.rest.client">
+        <packages>
+            <package name="org.eclipse.microprofile.opentracing.tck.rest.client" />
+        </packages>
+    </test>
+</suite>


### PR DESCRIPTION
Fixes: #7880

Running mpOpenTracing TCK against a server with microprofile-3.0.