### PR TITLE
temporarily disable the PureCXFTest in com.ibm.ws.jaxws.2.2.webcontai…

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
@@ -23,7 +23,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 CatalogFacilityTest.class,
                 WebServiceRefFeaturesTest.class,
                 ServerSideStubClientTest.class,
-                PureCXFTest.class,
+//                PureCXFTest.class,
                 WsBndServiceRefOverrideTest.class,
                 WsBndEndpointOverrideTest.class,
                 CXFJMXSupportTest.class,


### PR DESCRIPTION
…ner_fat while we sort out some dependency jar issues in Artifactory

We will reenable the test after fixing the jars in artifactory