### PR TITLE
escape special characters from element name when used in OSGi filter

### DIFF
--- a/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
+++ b/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
@@ -175,7 +175,22 @@ public abstract class ConfigBasedRESTHandler implements RESTHandler {
             filter.append(FilterUtils.createPropertyFilter("config.displayId", uid));
         else if (elementName.length() > 0) {
             // If an element name was specified, ensure the filter matches the requested elementName exactly
-            filter.append("(|(config.displayId=*" + elementName + "[*)(config.displayId=*" + elementName + "))"); // TODO either check elementName for invalid chars or use something similar to createPropertyFilter, but preserving the * characters
+
+            // Escape invalid characters from filter
+            StringBuilder e = null;
+            for (int i = elementName.length() - 1; i >= 0; i--)
+                switch (elementName.charAt(i)) {
+                    case '*':
+                    case '\\':
+                    case '(':
+                    case ')':
+                        if (e == null)
+                            e = new StringBuilder(elementName);
+                        e.insert(i, '\\');
+                }
+            String en = e == null ? elementName : e.toString();
+
+            filter.append("(|(config.displayId=*").append(en).append("[*)(config.displayId=*").append(en).append("))");
             if (uid != null)
                 filter.append(FilterUtils.createPropertyFilter("id", uid));
         } else {

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
@@ -1004,6 +1004,20 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         }
     }
 
+    // Invoke /ibm/api/config REST API for a configuration element name that includes special characters.
+    // Attempt to use an "OSGi filter injection attack" to match an entry that shouldn't be matched
+    // and verify that no results are returned.
+    @Test
+    public void testElementNameUsesEscapedCharacters() throws Exception {
+        JsonArray array = new HttpsRequest(server, "/ibm/api/config/abc(d)\\k*m").run(JsonArray.class);
+        String err = "unexpected response: " + array;
+        assertEquals(err, 0, array.size());
+
+        array = new HttpsRequest(server, "/ibm/api/config/uvw)(id=DefaultDataSource)(id=xyz").run(JsonArray.class);
+        err = "unexpected response: " + array;
+        assertEquals(err, 0, array.size());
+    }
+
     // Invoke /ibm/api/config/dataSource/{uid} with HTTP POST (should not be allowed)
     @Test
     public void testPOSTRejected() throws Exception {


### PR DESCRIPTION
Special characters should be escaped when supplying the provided values to an OSGi filter.