### PR TITLE
WIP: Server startup notifications

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/wsspi/kernel/feature/ServerStarted.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/wsspi/kernel/feature/ServerStarted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,11 +8,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.kernel.feature;
+package com.ibm.wsspi.kernel.feature;
 
 /**
- * This is a marker interface for the server started service.
+ * An implementation of this service is registered to indicate Liberty has started.
+ * Components wanting to take an action on server startup should watch for this being
+ * registered and take action then. This provides an asynchronous notification of startup.
  */
-public interface ServerStarted extends com.ibm.wsspi.kernel.feature.ServerStarted {
+public interface ServerStarted {
 
 }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/wsspi/kernel/feature/SynchronousServerStartedListener.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/wsspi/kernel/feature/SynchronousServerStartedListener.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.wsspi.kernel.feature;
+
+/**
+ * Components wishing to receive a synchronous notification that the server is
+ * started should register an implementation of this service implementation.
+ * Asychronous notifications are provided by watching for the ServerStarted
+ * service being registered. If the server is already started when this method
+ * is called then it will be called immediately.
+ */
+public interface SynchronousServerStartedListener {
+
+    /**
+     * This method is called prior to the ServerStarted service being registered
+     * and the server started log message being written. It is called synchronous
+     * to startup meaning those other two events will not occur until this method
+     * has returned.
+     */
+    public void serverStarted();
+}


### PR DESCRIPTION
We need a way to provide sync (and async) notification of Liberty startup. There is an internal async, but there are people building user features that would like a public way to do this. Also need a sync way.

The sync approach is being done using a listener service registered in the SR. This is called before the message is output. The intent is this will be used by the channel framework to start ports on startup.

The async approach is just creating an SPI version of the existing internal ServerStarted interface. Essentially this means that you can watch the service registry and react based on the service being registered.