### PR TITLE
Revert "temporarily disable the PureCXFTest in com.ibm.ws.jaxws.2.2.webcontai…"

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
@@ -23,7 +23,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 CatalogFacilityTest.class,
                 WebServiceRefFeaturesTest.class,
                 ServerSideStubClientTest.class,
-//                PureCXFTest.class,
+                PureCXFTest.class,
                 WsBndServiceRefOverrideTest.class,
                 WsBndEndpointOverrideTest.class,
                 CXFJMXSupportTest.class,


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#8068

Artifacts are re-uploaded and we need to reenable this test.