### PR TITLE
Prevent Batcher trying to commit batches after the app has closed

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AckTracker.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AckTracker.java
@@ -273,6 +273,7 @@ public class AckTracker implements ConsumerRebalanceListener {
          * Called when we are no longer tracking acks for the partition
          */
         private void close() {
+            messageBatcher.close();
             synchronized (this.unackedMessages) {
                 for (MessageAckData ackData : this.unackedMessages) {
                     if (ackData.getCompletion() != null) {


### PR DESCRIPTION
Add some shutdown logic to the batcher so that if we lose the partition
or the app is shut down we don't try to commit any more offsets.

In particular this prevents the problem where the batcher schedules an
update for some time in the future and the application shuts down in the
mean time so the CDI beans aren't valid by the time it runs.