### PR TITLE
Add WLP-Activation-Type header for parallel activation

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-1.0.feature
@@ -18,3 +18,4 @@ IBM-Process-Types: server, \
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.anno_1.1-javadoc.zip
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.artifact-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.artifact-1.0.feature
@@ -24,3 +24,4 @@ IBM-Process-Types: server, \
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.artifact_1.2-javadoc.zip
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.channelfw-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.channelfw-1.0.feature
@@ -9,3 +9,4 @@ IBM-Process-Types: server, \
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.endpoint_1.0-javadoc.zip
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.dynamicBundle-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.dynamicBundle-1.0.feature
@@ -5,3 +5,4 @@ IBM-Process-Types: server, \
 -bundles=com.ibm.ws.dynamic.bundle
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.httptransport-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.httptransport-1.0.feature
@@ -9,3 +9,4 @@ Subsystem-Version: 1.0
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.httptransport_4.1-javadoc.zip
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.injection-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.injection-1.0.feature
@@ -7,3 +7,4 @@ IBM-Process-Types: client, \
 -bundles=com.ibm.ws.injection
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeeCompatible-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeeCompatible-6.0.feature
@@ -6,3 +6,4 @@ Subsystem-Version: 6.0.0
 -bundles=com.ibm.ws.javaee.version
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeeCompatible-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeeCompatible-8.0.feature
@@ -6,3 +6,4 @@ Subsystem-Version: 8.0.0
 -bundles=com.ibm.ws.javaee.version
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeePlatform-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeePlatform-6.0.feature
@@ -6,3 +6,4 @@ IBM-Process-Types: client, server
  com.ibm.ws.security.java2sec
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeePlatform-7.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeePlatform-7.0.feature
@@ -7,3 +7,4 @@ IBM-Process-Types: client, server
  com.ibm.ws.javaee.version
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeePlatform-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeePlatform-8.0.feature
@@ -6,3 +6,4 @@ IBM-Process-Types: client, server
  com.ibm.ws.javaee.version
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeedd-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeedd-1.0.feature
@@ -21,3 +21,4 @@ IBM-Process-Types: server, \
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.javaeedd_1.3-javadoc.zip
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeeddSchema-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeeddSchema-1.0.feature
@@ -23,3 +23,4 @@ visibility=private
  dev/api/ibm/schema/ibm-ejb-jar-ext_1_1.xsd
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.1.feature
@@ -6,3 +6,4 @@ IBM-Process-Types: server, \
 -bundles=com.ibm.websphere.javaee.annotation.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.2"
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.3.feature
@@ -6,3 +6,4 @@ IBM-Process-Types: server, \
 -bundles=com.ibm.websphere.javaee.annotation.1.3; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.3.2"
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-3.1.feature
@@ -4,3 +4,4 @@ singleton=true
 -bundles=com.ibm.websphere.javaee.servlet.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:3.1.0"
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.servlet-4.0.feature
@@ -4,3 +4,4 @@ singleton=true
 -bundles=com.ibm.websphere.javaee.servlet.4.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.servlet:javax.servlet-api:4.0.1"
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.requestProbes-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.requestProbes-1.0.feature
@@ -4,3 +4,4 @@ Manifest-Version: 1.0
 -bundles=com.ibm.ws.request.probes
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.servlet-servletSpi1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.servlet-servletSpi1.0.feature
@@ -5,3 +5,4 @@ visibility=private
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.servlet_2.3-javadoc.zip
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.appLifecycle-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.appLifecycle-1.0.feature
@@ -6,3 +6,4 @@ IBM-Process-Types: server, \
 -bundles=com.ibm.ws.app.manager.lifecycle; start-phase:=SERVICE_EARLY
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.appmanager-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.appmanager-1.0.feature
@@ -27,3 +27,4 @@ IBM-Process-Types: server, \
  dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.application_1.1-javadoc.zip
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.classloading-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.classloading-1.0.feature
@@ -18,3 +18,4 @@ IBM-Process-Types: server, client
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.classloading_1.4-javadoc.zip
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.containerServices-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.containerServices-1.0.feature
@@ -22,3 +22,4 @@ IBM-Process-Types: server, \
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.containerServices_3.0-javadoc.zip
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-3.1/com.ibm.websphere.appserver.servlet-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-3.1/com.ibm.websphere.appserver.servlet-3.1.feature
@@ -70,3 +70,4 @@ Subsystem-Category: JavaEE7Application
 Subsystem-Name: Java Servlets 3.1
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-4.0/com.ibm.websphere.appserver.servlet-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-4.0/com.ibm.websphere.appserver.servlet-4.0.feature
@@ -71,3 +71,4 @@ Subsystem-Category: JavaEE8Application
 Subsystem-Name: Java Servlets 4.0
 kind=ga
 edition=core
+WLP-Activation-Type: parallel


### PR DESCRIPTION
With PR #7997 we now can individually mark features to have their bundles parallel activated.  This PR is to enable parallel activation for the public features servlet-3.1 and servlet-4.0 and the features these two public features pull in.