### PR TITLE
Ensure tracked kafka partitions are cleaned up on shutdown

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AckTracker.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AckTracker.java
@@ -142,8 +142,13 @@ public class AckTracker implements ConsumerRebalanceListener {
             Iterator<PartitionAckTracker> i = partitionTrackers.values().iterator();
             while (i.hasNext()) {
                 PartitionAckTracker tracker = i.next();
-                tracker.close();
                 i.remove();
+                try {
+                    tracker.close();
+                } catch (Exception e) {
+                    // Ensures we try to close all trackers
+                    // and that we get an FFDC on error
+                }
             }
         }
     }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AckTracker.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AckTracker.java
@@ -12,6 +12,7 @@ package com.ibm.ws.microprofile.reactive.messaging.kafka;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -56,7 +57,7 @@ public class AckTracker implements ConsumerRebalanceListener {
         this.kafkaAdapterFactory = kafkaAdapterFactory;
         this.executor = executor;
         this.ackThreshold = ackThreshold;
-        this.partitionTrackers = new HashMap<>();
+        this.partitionTrackers = Collections.synchronizedMap(new HashMap<>());
         this.outstandingAcks = new AtomicInteger(0);
     }
 
@@ -129,6 +130,22 @@ public class AckTracker implements ConsumerRebalanceListener {
      */
     public CompletionStage<Void> waitForAckThreshold() {
         return this.ackThresholdStage;
+    }
+
+    /**
+     * Shutdown the ack tracker
+     * <p>
+     * This will cause all incomplete acks() to fail and ensure that we don't try to commit any more messages.
+     */
+    public void shutdown() {
+        synchronized (partitionTrackers) {
+            Iterator<PartitionAckTracker> i = partitionTrackers.values().iterator();
+            while (i.hasNext()) {
+                PartitionAckTracker tracker = i.next();
+                tracker.close();
+                i.remove();
+            }
+        }
     }
 
     private void incrementOutstandingAcks() {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
@@ -66,7 +66,12 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory {
     private void shutdown() {
         synchronized (kafkaInputs) {
             for (KafkaInput<?, ?> kafkaInput : kafkaInputs) {
-                kafkaInput.shutdown();
+                try {
+                    kafkaInput.shutdown();
+                } catch (Exception e) {
+                    // Ensures we attempt to shutdown all inputs
+                    // and also that we get an FFDC for any errors
+                }
             }
         }
     }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaInput.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaInput.java
@@ -144,6 +144,8 @@ public class KafkaInput<K, V> {
         } finally {
             this.lock.unlock();
         }
+
+        ackTracker.shutdown();
     }
 
     @FFDCIgnore(WakeupException.class)


### PR DESCRIPTION
Cleanup code already existed for closing a PartitionAckTracker when the
kafka broker unassigned a partition from us, we just need to ensure that
same code is called when the app is shut down.

This prevents us from trying to commit offsets after the app has closed.

This is a follow up to #8103 which improved the cleanup code, but didn't actually ensure it was called on shutdown.