### PR TITLE
Grant kafka test permission to connect to any hostname

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/apps/kafka/permissions.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/apps/kafka/permissions.xml
@@ -30,7 +30,7 @@
      <!-- Kafka client connects to the kafka broker server -->
      <permission>
        <class-name>java.net.SocketPermission</class-name>
-       <name>localhost</name>
+       <name>*</name>
        <actions>connect</actions>
      </permission>
      


### PR DESCRIPTION
Initially I thought that testcontainers provided a local proxy and so
the kafka client would only need to connect to localhost but this is not
the case.

The names of our test systems are not guaranteed to stay the same so we
need to grant this test permission to connect out to any host.