### PR TITLE
Revert "Enable App Manager and OSGi Console parallel activation"

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-1.0.feature
@@ -18,4 +18,3 @@ IBM-Process-Types: server, \
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.anno_1.1-javadoc.zip
 kind=ga
 edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.artifact-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.artifact-1.0.feature
@@ -24,4 +24,3 @@ IBM-Process-Types: server, \
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.artifact_1.2-javadoc.zip
 kind=ga
 edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.dynamicBundle-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.dynamicBundle-1.0.feature
@@ -5,4 +5,3 @@ IBM-Process-Types: server, \
 -bundles=com.ibm.ws.dynamic.bundle
 kind=ga
 edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeedd-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeedd-1.0.feature
@@ -21,4 +21,3 @@ IBM-Process-Types: server, \
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.javaeedd_1.3-javadoc.zip
 kind=ga
 edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.annotation-1.1.feature
@@ -6,4 +6,3 @@ IBM-Process-Types: server, \
 -bundles=com.ibm.websphere.javaee.annotation.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.annotation:javax.annotation-api:1.2"
 kind=ga
 edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.appLifecycle-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.appLifecycle-1.0.feature
@@ -6,4 +6,3 @@ IBM-Process-Types: server, \
 -bundles=com.ibm.ws.app.manager.lifecycle; start-phase:=SERVICE_EARLY
 kind=ga
 edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.appmanager-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.appmanager-1.0.feature
@@ -27,4 +27,3 @@ IBM-Process-Types: server, \
  dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.application_1.1-javadoc.zip
 kind=ga
 edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.classloading-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.classloading-1.0.feature
@@ -18,4 +18,3 @@ IBM-Process-Types: server, client
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.classloading_1.4-javadoc.zip
 kind=ga
 edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.containerServices-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.containerServices-1.0.feature
@@ -22,4 +22,3 @@ IBM-Process-Types: server, \
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.containerServices_3.0-javadoc.zip
 kind=ga
 edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/osgiConsole-1.0/com.ibm.websphere.appserver.osgiConsole-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/osgiConsole-1.0/com.ibm.websphere.appserver.osgiConsole-1.0.feature
@@ -11,4 +11,3 @@ Subsystem-Name: OSGi Debug Console 1.0
  com.ibm.ws.org.apache.felix.gogo.runtime; start-phase:=SERVICE_EARLY
 kind=ga
 edition=core
-WLP-Activation-Type: parallel


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#8151

Reverting not because this PR has shown to cause any failures, but instead to keep integration stable as possible while we cut a release.