### PR TITLE
Update to MP Reactive Messaging 1.0 API and TCK

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -251,7 +251,7 @@ org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.2
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.3
 org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-api:1.0
 org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-core:1.0
-org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:1.0-RC1
+org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:1.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.0.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.2.0

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.reactive.messaging.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.reactive.messaging.1.0/bnd.bnd
@@ -34,7 +34,7 @@ instrument.disabled: true
 publish.wlp.jar.suffix: dev/api/stable
 
 -buildpath: \
-        org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api;version=1.0.0.RC1, \
+        org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api;version=1.0.0, \
         com.ibm.websphere.javaee.cdi.2.0;version=latest, \
         com.ibm.websphere.org.eclipse.microprofile.reactive.streams.operators.1.0;version=latest,\
         com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile Reactive Streams TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.reactive.messaging.version>1.0-RC4</microprofile.reactive.messaging.version>
+        <microprofile.reactive.messaging.version>1.0</microprofile.reactive.messaging.version>
         <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->


### PR DESCRIPTION
Previously we were using a release candidate, but now that the release is done we can upgrade to the stable artifacts.

Fixes #4084 