### PR TITLE
Enable javax.net.debug trace for testcontainers buckets

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_postgresql/fat/src/com/ibm/ws/jdbc/fat/postgresql/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/fat/src/com/ibm/ws/jdbc/fat/postgresql/FATSuite.java
@@ -24,6 +24,12 @@ import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 })
 public class FATSuite {
 
+    static {
+        // TODO: temporary debug setting so we can further investigate intermittent
+        // testcontainers ping issues on remote build machines
+        System.setProperty("javax.net.debug", "all");
+    }
+
     @BeforeClass
     public static void setupBukcet() throws Exception {
         ExternalTestServiceDockerClientStrategy.clearTestcontainersConfig();

--- a/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/fat/src/com/ibm/ws/rest/handler/validator/cloudant/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/fat/src/com/ibm/ws/rest/handler/validator/cloudant/fat/FATSuite.java
@@ -23,6 +23,12 @@ import componenttest.topology.utils.HttpUtils;
 })
 public class FATSuite {
 
+    static {
+        // TODO: temporary debug setting so we can further investigate intermittent
+        // testcontainers ping issues on remote build machines
+        System.setProperty("javax.net.debug", "all");
+    }
+
     @BeforeClass
     public static void setup() throws Exception {
         HttpUtils.trustAllCertificates();

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestServiceDockerClientStrategy.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestServiceDockerClientStrategy.java
@@ -65,6 +65,8 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
     @Override
     public void test() throws InvalidConfigurationException {
         try {
+            System.setOut(new JULPipe(System.out, "java.net"));
+            System.setErr(new JULPipe(System.err, "java.net"));
             ExternalTestService.getService("docker-engine", new AvailableDockerHostFilter());
         } catch (Exception e) {
             throw new InvalidConfigurationException("Unable to localte any healthy docker-engine instances", e);
@@ -100,7 +102,7 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
 
         public void test() throws InvalidConfigurationException {
             final String m = "test";
-            final int maxAttempts = FATRunner.FAT_TEST_LOCALRUN ? 1 : 10; // attempt up to 10 times for remote builds
+            final int maxAttempts = FATRunner.FAT_TEST_LOCALRUN ? 1 : 7; // attempt up to 7 times for remote builds
             config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
             client = getClientForConfig(config);
             Throwable firstIssue = null;
@@ -109,6 +111,8 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
                     Log.info(c, m, "Attempting to ping docker daemon. Attempt [" + attempt + "]");
                     String dockerHost = config.getDockerHost().toASCIIString().replace("tcp://", "https://");
                     Log.info(c, m, "  Pinging URL: " + dockerHost);
+                    Log.info(c, m, "  javax.net.debug=" + System.getProperty("javax.net.debug"));
+                    Log.info(c, m, "  BEGIN PING >>>>>>>>>>>>>>>>>>>>>>");
                     SocketFactory sslSf = config.getSSLConfig().getSSLContext().getSocketFactory();
                     String resp = new HttpsRequest(dockerHost + "/_ping")
                                     .sslSocketFactory(sslSf)
@@ -125,13 +129,15 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
                     if (firstIssue == null)
                         firstIssue = t;
                     if (attempt < maxAttempts) {
-                        int sleepForSec = ((15 * attempt) % 120); // increase wait by 15s each attempt up to 120s max
+                        int sleepForSec = Math.min(10 * attempt, 45); // increase wait by 10s each attempt up to 45s max
                         Log.info(c, m, "Waiting " + sleepForSec + " seconds before attempting again");
                         try {
                             Thread.sleep(sleepForSec * 1000);
                         } catch (InterruptedException e) {
                         }
                     }
+                } finally {
+                    Log.info(c, m, "  END PING <<<<<<<<<<<<<<<<<<<<<<");
                 }
             }
             if (firstIssue instanceof InvalidConfigurationException)

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/JULPipe.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/JULPipe.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.topology.utils;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.logging.Logger;
+
+/**
+ * Pipes data from a PrintStream (usually System.out or System.err)
+ * to java.util.logging
+ */
+public class JULPipe extends PrintStream {
+
+    private final Logger log;
+
+    public JULPipe() {
+        this(System.out, Logger.GLOBAL_LOGGER_NAME);
+    }
+
+    /**
+     * @param original The PrintStream to wrap and pipe to Log4j
+     * @param name     The name of the logger to use
+     */
+    public JULPipe(PrintStream original, String name) {
+        super(original);
+        log = Logger.getLogger(name);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        String msg = new String(b);
+        if (msg != null && msg.endsWith("\n"))
+            msg = msg.substring(0, msg.length() - 2);
+        log.info(msg);
+    }
+
+    @Override
+    public void println() {
+        log.info("\n");
+    }
+
+    @Override
+    public void println(char x) {
+        log.info("" + x);
+    }
+
+    @Override
+    public void println(boolean x) {
+        log.info("" + x);
+    }
+
+    @Override
+    public void println(char[] x) {
+        log.info(Arrays.toString(x));
+    }
+
+    @Override
+    public void println(double x) {
+        log.info("" + x);
+    }
+
+    @Override
+    public void println(float x) {
+        log.info("" + x);
+    }
+
+    @Override
+    public void println(int x) {
+        log.info("" + x);
+    }
+
+    @Override
+    public void println(long x) {
+        log.info("" + x);
+    }
+
+    @Override
+    public void println(Object x) {
+        log.info("" + x);
+    }
+
+    @Override
+    public void println(String x) {
+        log.info("" + x);
+    }
+
+}


### PR DESCRIPTION
Enable `-Djavax.net.debug=all` for testcontainers FATs so we can try to catch intermittent ping failures that are happening on some remote builds.