### PR TITLE
Update pii collection to match CL

### DIFF
--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -126,8 +126,11 @@ task copyPiiFiles(type: Copy) {
   from project.file('resources')
   into ext.destinationDir
   include '**/*.nlsprops'
-  include 'OSGI-INF/l10n/*.properties'
-  include 'l10n/*.properties'
+  include 'OSGI-INF/l10n/*'
+  include 'l10n/*'
+  include 'publish/features/l10n/*.properties'
+  include 'WEB-CONTENT/**/nls/*.js'
+  include 'OSGI-INF/**/nls/*.js'
 }
 
 sourceSets {


### PR DESCRIPTION
Updating the copyPiiFiles task to include more files, matching what we have been collecting in the ant build side of Commercial Liberty.  This is especially needed with some projects with files matching these patterns moving to OL soon.

#build