### PR TITLE
test config & validation REST endpoints for app-defined connection factory from an embedded resource adapter

### DIFF
--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/ConnectionFactoryService.java
@@ -497,8 +497,11 @@ public class ConnectionFactoryService extends AbstractConnectionFactoryService i
         if (metadata != null && metadata.isEmbedded()) { // metadata is null for SIB/MQ
             ComponentMetaData cData = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
             String currentApp = null;
-            if (cData != null)
+            if (cData != null) {
                 currentApp = cData.getJ2EEName().getApplication();
+                if ("com.ibm.ws.rest.handler".equals(currentApp))
+                    return; // Allow access by internally implemented REST endpoints such as /ibm/api/validation/
+            }
             String adapterName = bootstrapContext.getResourceAdapterName();
             String embeddedApp = metadata.getJ2EEName().getApplication();
             Utils.checkAccessibility(jndiName, adapterName, embeddedApp, currentApp, false);

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -39,7 +39,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -1016,12 +1015,6 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
      * Use the /ibm/api/validator REST endpoint to validate application-defined connection factories
      */
     @Test
-    @ExpectedFFDC("javax.resource.ResourceException") // TODO remove this once support is added for validating resources from embedded resource adapters
-    // javax.resource.ResourceException: J2CA8809E: Resource java:comp/env/eis/ds2 from embedded resource adapter AppDefResourcesApp.EmbTestAdapter is available only to application AppDefResourcesApp. An attempt was made to access it from application com.ibm.ws.rest.handler.
-    // at com.ibm.ws.jca.internal.Utils.checkAccessibility(Utils.java:315)
-    // at com.ibm.ws.jca.service.ConnectionFactoryService.checkAccess(ConnectionFactoryService.java:504)
-    // at com.ibm.ws.jca.cm.AbstractConnectionFactoryService.createResource(AbstractConnectionFactoryService.java:151)
-    // at com.ibm.ws.rest.handler.validator.jca.ConnectionFactoryValidator.validate(ConnectionFactoryValidator.java:157)
     public void testValidateAppDefinedConnectionFactories() throws Exception {
         JsonArray array = new HttpsRequest(server, "/ibm/api/validation/connectionFactory")
                         .run(JsonArray.class);
@@ -1057,16 +1050,16 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "AppDefResourcesApp", j.getString("application"));
         assertEquals(err, "AppDefResourcesEJB.jar", j.getString("module"));
         assertEquals(err, "AppDefinedResourcesBean", j.getString("component"));
-        // TODO assertTrue(err, j.getBoolean("successful"));
-        // assertNull(err, j.get("failure"));
-        //assertNotNull(err, j = j.getJsonObject("info"));
-        //assertEquals(err, "TestConfig Data Store, Enterprise Edition", j.getString("databaseProductName"));
-        //assertEquals(err, "48.55.72", j.getString("databaseProductVersion"));
-        //assertEquals(err, "TestConfigJDBCAdapter", j.getString("driverName"));
-        //assertEquals(err, "65.72.97", j.getString("driverVersion"));
-        //assertEquals(err, "TestConfigDB", j.getString("catalog"));
-        //assertEquals(err, "EUSER2", j.getString("schema"));
-        //assertEquals(err, "euser2", j.getString("user"));
+        assertTrue(err, j.getBoolean("successful"));
+        assertNull(err, j.get("failure"));
+        assertNotNull(err, j = j.getJsonObject("info"));
+        assertEquals(err, "TestConfig Data Store, Enterprise Edition", j.getString("databaseProductName"));
+        assertEquals(err, "48.55.72", j.getString("databaseProductVersion"));
+        assertEquals(err, "TestConfigJDBCAdapter", j.getString("driverName"));
+        assertEquals(err, "65.72.97", j.getString("driverVersion"));
+        assertEquals(err, "TestConfigDB", j.getString("catalog"));
+        assertEquals(err, "EUSER2", j.getString("schema"));
+        assertEquals(err, "euser2", j.getString("user"));
 
         assertNotNull(err, j = array.getJsonObject(2)); // a javax.sql.DataSource
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesEJB.jar]/connectionFactory[java:module/env/eis/cf1]", j.getString("uid"));

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
@@ -55,6 +55,9 @@
   
   <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 
+  <javaPermission codebase="${server.config.dir}/apps/AppDefResourcesApp.ear"
+                  className="java.lang.RuntimePermission" name="getClassLoader"/>  <!-- for the embedded RAR -->
+
   <javaPermission codebase="${server.config.dir}/connectors/ConfigTestAdapter.rar"
                   className="java.lang.RuntimePermission" name="getClassLoader"/>
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
@@ -31,7 +31,16 @@ import javax.resource.ConnectionFactoryDefinitions;
                                 @ConnectionFactoryDefinition(name = "java:module/env/eis/cf1", // same JNDI name is used in WAR module, but okay because different scope
                                                              interfaceName = "javax.sql.DataSource",
                                                              resourceAdapter = "ConfigTestAdapter",
-                                                             properties = "purgePolicy=FailingConnectionOnly")
+                                                             properties = "purgePolicy=FailingConnectionOnly"),
+                                @ConnectionFactoryDefinition(name = "java:comp/env/eis/cf2",
+                                                             interfaceName = "javax.sql.DataSource",
+                                                             resourceAdapter = "AppDefResourcesApp.EmbTestAdapter",
+                                                             maxPoolSize = 2,
+                                                             properties = {
+                                                                            "escapeChar=^",
+                                                                            "userName=euser2",
+                                                                            "password=epwd2"
+                                                             })
 })
 
 @DataSourceDefinition(name = "java:comp/env/jdbc/ds3", // same JNDI name is used in WAR module, but okay because different scope


### PR DESCRIPTION
Add an embedded resource adapter to one of our FAT buckets.
Define an app-defined connection factory pointing to it
and write a test that uses the /config/ REST endpoint to verify its configuration and available API.

Also write a test that uses the /validation/ REST endpoint to test the configured app-defined connection factory, and update product code to allow the /validation/ endpoint to access the connection factory for purposes of testing it.