### PR TITLE
Add small wait to make sure server.xml change is recognized

### DIFF
--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/ActivationTypeTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/ActivationTypeTest.java
@@ -40,6 +40,9 @@ public class ActivationTypeTest {
 
         // Note that usr/product features are never parallel activated
         server.setMarkToEndOfLog();
+        // Our new server.xml is the same size as the old one, so wait a couple seconds to make
+        // sure the config runtime will recognize the change.
+        Thread.sleep(2000);
         server.changeFeatures(Arrays.asList("usr:test.activation.parallel.user-1.0"));
         server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
         server.waitForStringInLogUsingMark("test.activation.type.parallel.user: false");


### PR DESCRIPTION
The ActivationTypeTest replaces one server.xml with another that has an identical size. On some JDKs (particularly older Oracle versions) the timestamps don't have enough precision to recognize that the file was changed. So, if the test happens to update server.xml within 1 second of the last update, we will ignore the change. 

I'm going to add a small delay so that we will always pick up this change. 