### PR TITLE
Consume the Fault Tolerance 2.0.1 release

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -241,7 +241,7 @@ org.eclipse.microprofile.config:microprofile-config-api:1.3
 org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.0
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.1
-org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.0
+org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.0.1
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0-M1
 org.eclipse.microprofile.health:microprofile-health-api:2.0.1
 org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.0

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.faulttolerance.2.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.faulttolerance.2.0/bnd.bnd
@@ -21,7 +21,7 @@ Export-Package: \
   org.eclipse.microprofile.faulttolerance.exceptions;version=1.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api;2.0;EXACT}
+  @${repo;org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api;2.0.1;EXACT}
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-tck</artifactId>
-            <version>2.0</version>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.apis</groupId>


### PR DESCRIPTION
The Fault Tolerance 2.0.1 release contains some improvements to the API documentation and to some TCK tests.