### PR TITLE
FT 1.1: Do explicit counting of concurrent executions

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/async/AsyncOuterExecutorImpl.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
@@ -66,6 +67,7 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
     private final BulkheadPolicy bulkheadPolicy;
     private final WSContextService contextService;
     private final ExecutorService executorService;
+    private final AtomicInteger inProgressExecutions;
 
     /**
      * The collection of contexts to capture under createThreadContext.
@@ -97,6 +99,7 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
 
         this.bulkheadPolicy = bulkheadPolicy;
         this.contextService = contextService;
+        this.inProgressExecutions = new AtomicInteger(0);
 
         if (policyExecutorProvider != null) {
             //this is the normal case when running in Liberty
@@ -112,7 +115,7 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
                 policyExecutor.maxConcurrency(maxThreads);
                 policyExecutor.maxQueueSize(queueSize);
                 metricRecorder.setBulkheadQueuePopulationSupplier(() -> queueSize - policyExecutor.queueCapacityRemaining());
-                metricRecorder.setBulkheadConcurentExecutionCountSupplier(policyExecutor::getRunningTaskCount);
+                metricRecorder.setBulkheadConcurentExecutionCountSupplier(inProgressExecutions::get);
             }
 
             this.executorService = policyExecutor;
@@ -167,7 +170,7 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
             }
         }
 
-        QueuedFuture<R> queuedFuture = new QueuedFuture<>();
+        QueuedFuture<R> queuedFuture = new QueuedFuture<>(inProgressExecutions);
         context.setQueuedFuture(queuedFuture);
 
         return super.execute(callable, executionContext);
@@ -279,7 +282,7 @@ public class AsyncOuterExecutorImpl<R> extends SynchronousExecutorImpl<Future<R>
      * without corrupting the internal state.
      *
      * @param context the execution context
-     * @param ex the exception which caused the failure
+     * @param ex      the exception which caused the failure
      */
     private void reportFailure(ExecutionContextImpl context, Exception ex) {
         CircuitBreakerImpl breaker = context.getCircuitBreaker();

--- a/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/QueuedFutureTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/test/src/com/ibm/ws/microprofile/faulttolerance/test/QueuedFutureTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -58,7 +59,7 @@ public class QueuedFutureTest {
 
     @Test
     public void testCancellation() {
-        QueuedFuture<Void> qf = new QueuedFuture<>();
+        QueuedFuture<Void> qf = new QueuedFuture<>(new AtomicInteger());
 
         CompletableFuture<Void> latch = newLatch();
 
@@ -78,7 +79,8 @@ public class QueuedFutureTest {
 
     @Test
     public void testGet() throws InterruptedException, ExecutionException, TimeoutException {
-        QueuedFuture<String> qf = new QueuedFuture<>();
+        AtomicInteger inProgressCounter = new AtomicInteger(0);
+        QueuedFuture<String> qf = new QueuedFuture<>(inProgressCounter);
 
         CompletableFuture<String> latch = newLatch();
 
@@ -88,6 +90,7 @@ public class QueuedFutureTest {
 
         latch.complete("OK");
         assertEquals("Incorrect result returned", "OK", qf.get(2, TimeUnit.MINUTES));
+        assertEquals("InProgressCounter was non-zero when get() returned", 0, inProgressCounter.get());
         assertTrue("Queued future not done", qf.isDone());
         assertFalse("Queued future cancelled", qf.isCancelled());
 
@@ -96,7 +99,7 @@ public class QueuedFutureTest {
 
     @Test
     public void testAbort() {
-        QueuedFuture<String> qf = new QueuedFuture<>();
+        QueuedFuture<String> qf = new QueuedFuture<>(new AtomicInteger(0));
 
         CompletableFuture<String> latch = newLatch();
 


### PR DESCRIPTION
Switch from relying on the PolicyExecutor to indicate how many
executions are running to doing our own counting.

This ensures we can decrement the counter _before_ the Future is
completed, avoiding a race condition that was causing intermittent test
failures.