### PR TITLE
Set qualifier correctly for ifix builds

### DIFF
--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -130,6 +130,7 @@ def setProperties = { props ->
     props.setProperty('version.qualifier', qualifier)
     props.setProperty('buildLabel', timestamp)
 
+    // The qualifier below is needed for service builds only, do not delete it.
     gradle.rootProject { rootProject ->
         rootProject.ext.qualifier = gradle.userProps.getProperty("version.qualifier")
         rootProject.ext.releaseVersionOverride = gradle.userProps.getProperty('release.version.override')

--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -130,6 +130,10 @@ def setProperties = { props ->
     props.setProperty('version.qualifier', qualifier)
     props.setProperty('buildLabel', timestamp)
 
+    gradle.rootProject { rootProject ->
+        rootProject.ext.qualifier = gradle.userProps.getProperty("version.qualifier")
+        rootProject.ext.releaseVersionOverride = gradle.userProps.getProperty('release.version.override')
+    }
     /**
      * For each property in `gradle.userProps`, set it to rootProject's extra project properties.
      */


### PR DESCRIPTION
The qualifier variable needs to be accessible elsewhere in the build to be used in service builds for WebSphere Liberty.