### PR TITLE
Fix server script missing ] message for debug launch

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1068,7 +1068,7 @@ case "$ACTION" in
         then
           WLP_DEBUG_SUSPEND=y
         fi
-        if [ "${WLP_DEBUG_REMOTE}" = "y"]
+        if [ "${WLP_DEBUG_REMOTE}" = "y" ]
         then
           WLP_DEBUG_REMOTE_HOST="0.0.0.0:"
         else


### PR DESCRIPTION
There is a small syntax issue with the server script that doesn't seem to cause an actual issue, but does result in the following error message when launching with the `debug` option:

```
bin/server: line 1071: [: missing `]'
```
The issue is a missing space in the `if` statement at line 1071
