### PR TITLE
Scan for approved packages at build time

### DIFF
--- a/dev/com.ibm.json4j/bnd.bnd
+++ b/dev/com.ibm.json4j/bnd.bnd
@@ -24,5 +24,12 @@ Private-Package: \
 
 instrument.disabled: true
 
+wlp.approved.packages: \
+  com.ibm.json,\
+  com.ibm.json.java,\
+  com.ibm.json.java.internal,\
+  com.ibm.json.xml,\
+  com.ibm.json.xml.internal
+
 -buildpath: \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -163,6 +163,38 @@ compileJava {
   options.fork = true
 }
 
+task approvedPackages {
+  dependsOn jar
+  def publishWlpJarDefault = parseBoolean(bnd('test.project', 'false')) ? 'true' : 'false'
+  enabled bnd('publish.tool.jar', '').empty && !parseBoolean(bnd('publish.wlp.jar.disabled', publishWlpJarDefault))
+  inputs.files project.file('bnd.bnd')
+  outputs.files jar.archiveFile
+  doLast {
+    def approvedPackages = new HashSet();
+    def foundPackages = new HashSet();
+    bnd('wlp.approved.packages').split(",").each{pkg -> approvedPackages.add(pkg)}
+    def jarFile = new java.util.jar.JarFile(file(jar.archiveFile));
+    jarFile.entries().each{
+      def name = it.getName();
+      if (name.endsWith(".class")) {
+        foundPackages.add(name.substring(0, name.lastIndexOf('/')).replace('/', '.'));
+      }
+    };
+    jarFile.close();
+    if (foundPackages.size() == 0) {
+      throw new GradleException("Found a jar that is published to the wlp install but it did not contain any packages: " + file(jar.archiveFile).absolutePath);
+    }
+    foundPackages.removeAll(approvedPackages);
+    if (foundPackages.size() != 0) {
+      throw new GradleException("Found new packages which have not been approved by the legal team yet.\n" + 
+                                "Add the new packages to the 'wlp.approved.packages' list in this project's bnd.bnd file and\n" + 
+                                "seek a code review from the legal team to ensure they are aware of the new package.\n" + 
+                                "Unapproved packages located:\n" + foundPackages);
+    }
+  }
+}
+assemble.dependsOn approvedPackages
+
 test {
   dependsOn ':cnf:copyMavenLibs'
   def testports = fileTree(dir: compileTestJava.destinationDir, include: 'unittestports.properties')

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -187,8 +187,8 @@ task approvedPackages {
     foundPackages.removeAll(approvedPackages);
     if (foundPackages.size() != 0) {
       throw new GradleException("Found new packages which have not been approved by the legal team yet.\n" + 
-                                "Add the new packages to the 'wlp.approved.packages' list in this project's bnd.bnd file and\n" + 
-                                "seek a code review from the legal team to ensure they are aware of the new package.\n" + 
+                                "Add the new packages to the 'wlp.approved.packages' property in " + project.file('bnd.bnd').absolutePath + "\n" + 
+                                "and seek a code review from the legal team to ensure they are aware of the new package.\n" + 
                                 "Unapproved packages located:\n" + foundPackages);
     }
   }


### PR DESCRIPTION
Currently packages approvals are checked very late in the delivery process, and the master list is housed in a separate github repository, which makes updates tedious to coordinate.

Replace this approval mechanism with a list of approved packages in each project's `bnd.bnd` file via a new `wlp.approved.packages` property list, such as:
```
wlp.approved.packages: \
  com.ibm.json,\
  com.ibm.json.java,\
  com.ibm.json.java.internal,\
  com.ibm.json.xml,\
  com.ibm.json.xml.internal
```

If any new packages are added and are not approved by legal, they would be caught immediately at build time with clear instructions on how to resolve the missing approval.

Sample failure output:
```
$ ./gradlew :com.ibm.json4j:assemble

...

> Task :com.ibm.json4j:approvedPackages FAILED

FAILURE: Build failed with an exception.

* Where:
Script '/Users/aguibert/dev/git/open-liberty/dev/wlp-gradle/subprojects/tasks.gradle' line: 189

* What went wrong:
Execution failed for task ':com.ibm.json4j:approvedPackages'.
> Found new packages which have not been approved by the legal team yet.
  Add the new packages to the 'wlp.approved.packages' property in /Users/aguibert/dev/git/open-liberty/dev/com.ibm.json4j/bnd.bnd
  and seek a code review from the legal team to ensure they are aware of the new package.
  Unapproved packages located:
  [com.ibm.json.java.internal, com.ibm.json.xml.internal]

BUILD FAILED in 17s
7 actionable tasks: 4 executed, 3 up-to-date
```