### PR TITLE
Update OAuth client metatype API to return UTF-16

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20ClientMetatypeService.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20ClientMetatypeService.java
@@ -12,6 +12,7 @@ package com.ibm.ws.security.oauth20.web;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -126,6 +127,7 @@ public class OAuth20ClientMetatypeService {
                 return;
             }
             response.setHeader("Content-Type", "application/json");
+            response.setCharacterEncoding(StandardCharsets.UTF_16.toString());
             PrintWriter writer = response.getWriter();
             writer.println(metadataJson.toString());
             writer.flush();


### PR DESCRIPTION
Ensures the metatype API response supports double byte character encoding and adds a dedicated FAT test to ensure it works.