### PR TITLE
BB 265329: Restrict fat_init_pooling to java 8+

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/.classpath
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/.settings/org.eclipse.jdt.core.prefs
@@ -1,14 +1,12 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/bnd.bnd
@@ -11,6 +11,10 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+#jdbc-4.2 feature is only 1.8 and above
+javac.source: 1.8
+javac.target: 1.8
+
 src: \
 	fat/src,\
 	test-applications/initialpollingtest/src


### PR DESCRIPTION
Fat bucket uses jdbc-4.2 which is only supported on java 8+

