### PR TITLE
SCR does not handle when configurations are deleted while it is using them

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -87,8 +87,7 @@ org.apache.cxf:cxf-core:3.3.3.20190529
 org.apache.cxf:cxf-rt-frontend-jaxrs:3.3.3.20190529
 org.apache.cxf:cxf-rt-rs-client:3.3.3.20190529
 org.apache.cxf:cxf-rt-rs-mp-client:3.3.3.20190529
-com.ibm.ws.org.apache.felix:org.apache.felix.scr:2.1.17.ibm20190708-1
-
+com.ibm.ws.org.apache.felix:org.apache.felix.scr:2.1.17.ibm20190717-1
 com.googlecode.jsontoken:jsontoken:1.1.0-ibm-s20140416-2113
 com.ibm.ws:com.ibm.ws.eba.blueprint.extensions.interceptors:1.0.0
 com.ibm.ws:com.ibm.ws.eba.blueprint.transform:1.0.0

--- a/dev/com.ibm.ws.org.apache.felix.scr/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.felix.scr/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -9,16 +9,16 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= \
- jar:${fileuri;${repo;com.ibm.ws.org.apache.felix:org.apache.felix.scr;2.1.17.ibm20190708-1;EXACT}}!/META-INF/MANIFEST.MF,\
+ jar:${fileuri;${repo;com.ibm.ws.org.apache.felix:org.apache.felix.scr;2.1.17.ibm20190717-1;EXACT}}!/META-INF/MANIFEST.MF,\
  bnd.overrides
 
 -includeresource: \
    OSGI-INF=resources/OSGI-INF, \
-   @${repo;com.ibm.ws.org.apache.felix:org.apache.felix.scr;2.1.17.ibm20190708-1;EXACT}!/!META-INF/maven/*,\
+   @${repo;com.ibm.ws.org.apache.felix:org.apache.felix.scr;2.1.17.ibm20190717-1;EXACT}!/!META-INF/maven/*,\
    @${repo;org.osgi:org.osgi.util.function;1.1.0;EXACT}!/!(OSGI-OPT|META-INF)/*,\
    @${repo;org.osgi:org.osgi.util.promise;1.1.1;EXACT}!/!(OSGI-OPT|META-INF)/*
 
 -buildpath: \
-	com.ibm.ws.org.apache.felix:org.apache.felix.scr;strategy=exact;version=2.1.17.ibm20190708-1,\
+	com.ibm.ws.org.apache.felix:org.apache.felix.scr;strategy=exact;version=2.1.17.ibm20190717-1,\
 	org.osgi:org.osgi.util.function;strategy=exact;version=1.1.0,\
 	org.osgi:org.osgi.util.promise;strategy=exact;version=1.1.1


### PR DESCRIPTION
Something like the following can happen if a config is deleted while SCR is trying to use it to configure a component:
```
java.lang.IllegalStateException: Configuration pid com.ibm.ws.kernel.metatype.helper.fileset_18 was deleted.
at com.ibm.ws.config.admin.internal.ExtendedConfigurationImpl.exceptionIfDeleted(ExtendedConfigurationImpl.java:666)
at com.ibm.ws.config.admin.internal.ExtendedConfigurationImpl.getPid(ExtendedConfigurationImpl.java:289)
at com.ibm.ws.config.admin.internal.ExtendedConfigurationImpl.getPid(ExtendedConfigurationImpl.java:282)
at org.apache.felix.scr.impl.manager.RegionConfigurationSupport.configureComponentHolder(RegionConfigurationSupport.java:187)
at org.apache.felix.scr.impl.BundleComponentActivator.setRegionConfigurationSupport(BundleComponentActivator.java:763)
at org.apache.felix.scr.impl.helper.ConfigAdminTracker$1.addingService(ConfigAdminTracker.java:69)
at org.apache.felix.scr.impl.helper.ConfigAdminTracker$1.addingService(ConfigAdminTracker.java:41)
at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:943)
at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:1)
at org.osgi.util.tracker.AbstractTracked.trackAdding(AbstractTracked.java:256)
at org.osgi.util.tracker.AbstractTracked.trackInitial(AbstractTracked.java:183)
at org.osgi.util.tracker.ServiceTracker.open(ServiceTracker.java:321)
```

This is happening because of felix bug https://issues.apache.org/jira/browse/FELIX-6159 we will need to pull in a patched version of SCR to fix this until a full release of SCR is done that includes the fix.