### PR TITLE
Pull request to remove tr.error from RegistrationEndpointServices

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/RegistrationEndpointServices.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/RegistrationEndpointServices.java
@@ -140,7 +140,6 @@ public class RegistrationEndpointServices extends AbstractOidcEndpointServices {
                     "OAUTH_CLIENT_REGISTRATION_CLIENTID_NOT_FOUND",
                     new Object[] { clientId },
                     "CWWKS1424E: The client id {0} was not found.");
-            Tr.error(tc, errorMsg);
             throw new OidcServerException(errorMsg, OIDCConstants.ERROR_INVALID_CLIENT, HttpServletResponse.SC_NOT_FOUND);
         }
 


### PR DESCRIPTION
ERROR_INVALID_CLIENT from RegistrationEndpointServices.processHeadOrGetSingleClient may not actually be an error. 
We can't remove the ffdc that is emitted from OAuth20EndpointServices, but the Tr.error that is emitted from this processHeadOrGetSingleClient can be removed.