### PR TITLE
Fix BundleInstallOriginBundleListener

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/BundleInstallOriginBundleListener.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/BundleInstallOriginBundleListener.java
@@ -10,36 +10,32 @@
  *******************************************************************************/
 package com.ibm.ws.kernel.feature.internal;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.BundleListener;
-import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Constants;
 import org.osgi.framework.startlevel.BundleStartLevel;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.ffdc.FFDCFilter;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.wsspi.kernel.service.utils.FrameworkState;
+import com.ibm.websphere.ras.annotation.Trivial;
 
 /**
  * This class listens for {@link Bundle}.INSTALLED and {@link Bundle}.UNINSTALLED events.
@@ -63,137 +59,90 @@ import com.ibm.wsspi.kernel.service.utils.FrameworkState;
  * be adjusted so as to avoid starting the installee bundle that should no longer be present. Later server
  * starts will attempt to uninstall the bundle again.
  */
-public class BundleInstallOriginBundleListener implements BundleListener, Callable<Void> {
+public class BundleInstallOriginBundleListener implements BundleListener {
 
     private static final TraceComponent tc = Tr.register(BundleInstallOriginBundleListener.class);
 
     private static final String storagePath = "bundle.origin.cache";
-    private final Bundle featureManager;
+
     private final BundleContext ctx;
     private final File bundleOriginCache;
 
-    //stores the location of a bundle that has installed other bundles as a key to
-    //the set of the install locations of the bundles it has installed
-    private volatile ConcurrentHashMap<String, Set<String>> bundleOrigins = new ConcurrentHashMap<String, Set<String>>();
+    //stores the ID of a bundle that has installed other bundles as a key to
+    //the set of the install IDs of the bundles it has installed
+    private final Map<Long, Set<Long>> bundleOrigins = Collections.synchronizedMap(new HashMap<Long, Set<Long>>());
+    private final Set<Long> allTracked = new HashSet<>();
 
     /**
      * This constructor reads the persisted bundleOrigins data from disk and tidies it
      * to account for any removed installer bundles before completing.
      */
-
     BundleInstallOriginBundleListener(BundleContext ctx) {
-        this.ctx = ctx;
-        //this class is constructed in the feature manager, so get bundle from the ctx
-        featureManager = ctx.getBundle();
-        bundleOriginCache = featureManager.getDataFile(storagePath);
-        bundleOrigins = loadCacheFromDisk(true);
-        //set a purge up in case there aren't actually any more bundle events
-        delayPurge();
+        bundleOriginCache = ctx.getDataFile(storagePath);
+        // use system bundle context so we can lookup using bundle ID without worrying
+        // about hooks filtering them out.
+        this.ctx = ctx.getBundle(Constants.SYSTEM_BUNDLE_LOCATION).getBundleContext();
+        loadCacheFromDisk();
     }
 
-    @SuppressWarnings("unchecked")
-    @FFDCIgnore(IOException.class)
-    private synchronized ConcurrentHashMap<String, Set<String>> loadCacheFromDisk(boolean newInstance) {
-        ConcurrentHashMap<String, Set<String>> loadedOrigins = new ConcurrentHashMap<String, Set<String>>();
+    private void loadCacheFromDisk() {
         if (bundleOriginCache != null && bundleOriginCache.exists()) {
             debug("Found existing bundle origin cache", bundleOriginCache.toString(), bundleOriginCache);
             //read the contents of the cache file, which is a map of bundle locations
-            FileInputStream fis = null;
-            ObjectInputStream ois = null;
-            try {
-                ois = new ObjectInputStream((fis = new FileInputStream(bundleOriginCache)));
-                loadedOrigins = (ConcurrentHashMap<String, Set<String>>) ois.readObject();
+            readCacheFile();
 
-                debug("Repopulated origins cache from disk", loadedOrigins);
+            debug("Repopulated origins cache from disk", bundleOriginCache);
 
-                //if we are a new instance we need to clean up bundles that may have been
-                //removed while we weren't listening
-                if (newInstance) {
-                    Set<String> installerBundlesToRemove = new HashSet<String>();
-                    //remove from the loaded cache any bundles that have been removed while the server was down
-                    for (Map.Entry<String, Set<String>> bundleOriginEntry : loadedOrigins.entrySet()) {
-                        String installerBundleLocation = bundleOriginEntry.getKey();
-                        Bundle installerBundle = ctx.getBundle(installerBundleLocation);
-                        if (installerBundle == null) {
-                            debug("Installer bundle has been removed", installerBundleLocation);
-                            installerBundlesToRemove.add(installerBundleLocation);
-                        }
-                    }
-                    for (String installerBundleLocation : installerBundlesToRemove) {
-                        processUninstalledInstallerBundle(installerBundleLocation);
-                    }
-                }
-
-            } catch (FileNotFoundException e) {
-                //autoFFDC
-            } catch (IOException e) {
-                //manually FFDC here because we are preventing autoFFDC instrumentation for the finally block
-                FFDCFilter.processException(e, getClass().getName(), "118", new Object[] { bundleOriginCache });
-            } catch (ClassNotFoundException e) {
-                //autoFFDC
-            } finally {
-                if (ois != null) {
-                    try {
-                        ois.close();
-                    } catch (IOException e) {
-                        //suppress FFDC
-                    }
-                }
-                if (fis != null) {
-                    try {
-                        fis.close();
-                    } catch (IOException e) {
-                        //suppress FFDC
+            // we need to clean up bundles that may have been
+            // removed while we weren't listening
+            Set<Long> installerBundlesToRemove = new HashSet<Long>();
+            synchronized (bundleOrigins) {
+                //remove from the loaded cache any bundles that have been removed while the server was down
+                for (Map.Entry<Long, Set<Long>> bundleOriginEntry : bundleOrigins.entrySet()) {
+                    Long installerBundleId = bundleOriginEntry.getKey();
+                    Bundle installerBundle = ctx.getBundle(installerBundleId);
+                    if (installerBundle == null) {
+                        debug("Installer bundle has been removed", installerBundleId);
+                        installerBundlesToRemove.add(installerBundleId);
                     }
                 }
             }
-        }
-        return loadedOrigins;
-    }
-
-    private void loadCacheIfPurged() {
-        if (bundleOrigins == null) {
-            synchronized (this) {
-                //check still null
-                if (bundleOrigins == null)
-                    bundleOrigins = loadCacheFromDisk(false);
+            for (Long installerBundleId : installerBundlesToRemove) {
+                processUninstalledInstallerBundle(installerBundleId);
             }
         }
     }
 
     /** {@inheritDoc} */
     @Override
-    @FFDCIgnore(IOException.class)
     public void bundleChanged(BundleEvent event) {
         boolean store = false;
         switch (event.getType()) {
             case BundleEvent.INSTALLED:
-                Bundle installerBundle = event.getOrigin();
-                if (!featureManager.equals(installerBundle)) {
-                    loadCacheIfPurged();
+                Bundle installedBundle = event.getBundle();
+                if (!installedBundle.getLocation().startsWith(Provisioner.BUNDLE_LOC_FEATURE_TAG)) {
+                    Bundle installerBundle = event.getOrigin();
                     //the bundle was installed by something other than the feature manager
                     //we should associate it with its installer
-                    String installingBundleSN = installerBundle.getLocation();
-                    Set<String> installeeBundles = Collections.synchronizedSet(new HashSet<String>());
-                    Set<String> existingInstalleeBundles;
-                    existingInstalleeBundles = bundleOrigins.putIfAbsent(installingBundleSN, installeeBundles);
-                    if (existingInstalleeBundles == null)
-                        existingInstalleeBundles = installeeBundles;
-                    //add the location of the bundle being installed to the set for the origin bundle
-                    existingInstalleeBundles.add(event.getBundle().getLocation());
+                    debug("Tracking bundle {0} at location {1} installed by {2}.", installedBundle, installedBundle.getLocation(), installerBundle);
+                    synchronized (bundleOrigins) {
+                        Set<Long> existingInstalleeBundles = bundleOrigins.get(installerBundle.getBundleId());
+                        if (existingInstalleeBundles == null) {
+                            existingInstalleeBundles = new HashSet<>();
+                            bundleOrigins.put(installerBundle.getBundleId(), existingInstalleeBundles);
+                        }
+                        //add the ID of the bundle being installed to the set for the origin bundle
+                        existingInstalleeBundles.add(installedBundle.getBundleId());
+                        allTracked.add(installedBundle.getBundleId());
+                    }
                     //flag to store the data
                     store = true;
-                    //delay the purge of the origins cache
-                    delayPurge();
                 }
                 break;
             case BundleEvent.UNINSTALLED:
-                loadCacheIfPurged();
                 Bundle uninstalledBundle = event.getBundle();
                 //set the flag to store data to disk if the uninstall was one of our known installer bundles
-                store = processUninstalledInstallerBundle(uninstalledBundle.getLocation());
-                //delay the purge of the origins cache
-                delayPurge();
+                store = processUninstalledInstallerBundle(uninstalledBundle.getBundleId());
                 break;
             default:
                 break;
@@ -202,86 +151,74 @@ public class BundleInstallOriginBundleListener implements BundleListener, Callab
         //then we need to persist it to the workarea ready for a subsequent warm start
         if (store == true) {
             //persist the data after each event is processed
-            synchronized (bundleOriginCache) {
-                FileOutputStream fos = null;
-                ObjectOutputStream oos = null;
-                try {
-                    //create if it doesn't exist yet
-                    boolean created = bundleOriginCache.createNewFile();
-                    if (created || bundleOriginCache.exists()) {
-                        oos = new ObjectOutputStream((fos = new FileOutputStream(bundleOriginCache)));
-                        oos.writeObject(bundleOrigins);
-                    }
-                } catch (FileNotFoundException e) {
-                    //autoFFDC
-                } catch (IOException e) {
-                    //manually FFDC here because we are preventing autoFFDC instrumentation for the finally block
-                    FFDCFilter.processException(e, getClass().getName(), "201", new Object[] { bundleOrigins, bundleOriginCache });
-                } finally {
-                    if (oos != null) {
-                        try {
-                            oos.close();
-                        } catch (IOException e) {
-                            //suppress FFDC
-                        }
-                    }
-                    if (fos != null) {
-                        try {
-                            fos.close();
-                        } catch (IOException e) {
-                            //suppress FFDC
-                        }
-                    }
-                }
-
-            }
+            writeCacheFile();
         }
     }
 
     /**
-     * Determines if the uninstalled bundle location was an installer bundle and calls for the
+     * Determines if the uninstalled bundle ID was an installer bundle and calls for the
      * removal of any installees associated with it if it was.
      *
-     * @param installerBundleLocation
+     * @param installerBundleId
      * @return true if the parameter was an installer bundle
      */
-    private boolean processUninstalledInstallerBundle(String installerBundleLocation) {
-        //find out if the uninstalled bundle location was an installer bundle and remove its installees as well
-        Set<String> bundleLocationsToUninstall = bundleOrigins.remove(installerBundleLocation);
-        if (bundleLocationsToUninstall != null) {
-            debug("Installer bundle at location {0} had installees that need to be uninstalled", installerBundleLocation);
+    private boolean processUninstalledInstallerBundle(long installerBundleId) {
+        //find out if the uninstalled bundle ID was an installer bundle and remove its installees as well
+        Set<Long> bundleIdsToUninstall;
+        boolean tracked;
+        synchronized (bundleOrigins) {
+            bundleIdsToUninstall = bundleOrigins.remove(installerBundleId);
+            // use snapshot to avoid concurrent modification while iterating below
+            if (bundleIdsToUninstall != null) {
+                bundleIdsToUninstall = new HashSet<>(bundleIdsToUninstall);
+            }
+            tracked = allTracked.remove(installerBundleId);
+        }
+
+        boolean uninstalledTracked = bundleIdsToUninstall != null;
+        if (uninstalledTracked) {
+            debug("Installer bundle {0} had installees that need to be uninstalled", installerBundleId);
             //we recognized the bundle being uninstalled as an installer, try to remove its installees
-            Set<String> unsuccessfulUninstallLocations = uninstallInstalleeBundles(bundleLocationsToUninstall);
+            Set<Long> unsuccessfulUninstallLocations = uninstallInstalleeBundles(bundleIdsToUninstall);
             //check if we successfully uninstalled everything
             if (!unsuccessfulUninstallLocations.isEmpty()) {
                 //we weren't able to uninstall every installee
                 //we should update the map with the set of remaining bundle locations
                 //that way we will try to uninstall them again another time when it might work
-                bundleOrigins.put(installerBundleLocation, unsuccessfulUninstallLocations);
+                bundleOrigins.put(installerBundleId, unsuccessfulUninstallLocations);
                 debug("Not all installees were removed", unsuccessfulUninstallLocations);
+            } else {
+                bundleOrigins.remove(installerBundleId);
             }
-            return true;
         }
-        return false;
+        if (tracked) {
+            // may need to clean up the bundle from the sets
+            synchronized (bundleOrigins) {
+                for (Map.Entry<Long, Set<Long>> entry : bundleOrigins.entrySet()) {
+                    uninstalledTracked |= entry.getValue().remove(installerBundleId);
+                }
+            }
+        }
+        return uninstalledTracked;
     }
 
     /**
      * Iterates a set of installee bundles attempting to uninstall them.
      *
-     * @param installeeBundleLocationsToUninstall
-     * @return Set of bundle locations that could not be uninstalled
+     * @param installeeBundleIdsToUninstall
+     * @return Set of bundle IDs that could not be uninstalled
      */
-    private Set<String> uninstallInstalleeBundles(Set<String> installeeBundleLocationsToUninstall) {
-        Set<String> unsuccessfulUninstallLocations = new HashSet<String>();
-        for (String installeeBundleLocation : installeeBundleLocationsToUninstall) {
-            Bundle installeeBundleToUninstall = ctx.getBundle(installeeBundleLocation);
+    private Set<Long> uninstallInstalleeBundles(Set<Long> installeeBundleIdsToUninstall) {
+        Set<Long> unsuccessfulUninstallLocations = new HashSet<>();
+        for (Long installeeBundleId : installeeBundleIdsToUninstall) {
+            Bundle installeeBundleToUninstall = ctx.getBundle(installeeBundleId);
             if (installeeBundleToUninstall != null) {
                 try {
                     installeeBundleToUninstall.uninstall();
                 } catch (BundleException e) {
                     //this will auto FFDC
                     //uninstall failed, track it
-                    unsuccessfulUninstallLocations.add(installeeBundleLocation);
+                    unsuccessfulUninstallLocations.add(installeeBundleId);
                     //we couldn't uninstall the bundle, but we want to stop it starting
                     //set the bundle start level to MAX_INT
                     BundleStartLevel bsl = installeeBundleToUninstall.adapt(BundleStartLevel.class);
@@ -292,63 +229,52 @@ public class BundleInstallOriginBundleListener implements BundleListener, Callab
         return unsuccessfulUninstallLocations;
     }
 
+    @Trivial
     private void debug(String msg, Object... objs) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(this, tc, msg, objs);
         }
     }
 
-    private ScheduledFuture<?> futurePurge = null;
-    //if there have been no bundle events for 5 minutes, purge the map from memory
-    //it will be reloaded from disk if necessary
-    private final int purgeDelay = 5;
-
-    @FFDCIgnore(IllegalStateException.class)
-    private synchronized void delayPurge() {
-
-        // if the framework is stopping, dont create the delayed purge
-        if (FrameworkState.isStopping()) {
-            return;
-        }
-
-        //try to cancel any existing task if we can and it isn't running
-        if (futurePurge != null) {
-            futurePurge.cancel(false);
-        }
-
-        //any time this method is called we want to schedule a new purge for the future
-        ServiceReference<ScheduledExecutorService> sesRef = ctx.getServiceReference(ScheduledExecutorService.class);
-        if (sesRef != null) {
-            try {
-                ScheduledExecutorService executorService = ctx.getService(sesRef);
-                futurePurge = executorService.schedule(this, purgeDelay, TimeUnit.MINUTES);
-            } finally {
-                try {
-                    ctx.ungetService(sesRef);
-                } catch (IllegalStateException e) {
-                    // This is highly unlikely, but can happen.
-                    // Rather than do a boolean check, its more efficient in the 99.99% case
-                    // to just handle the exception if it occurs (which is unlikely)
-                    if (tc.isEventEnabled()) {
-                        Tr.event(tc,
-                                 "IllegalStateException while releasing ServiceReference<ScheduledExecutorService> sesRef - the bundle is stopped or in an otherwise invalid so we shouldn't care",
-                                 e);
+    private void writeCacheFile() {
+        // note that cache version is not stored here because we assume
+        // the impl bundle is re-installed if a new version is used which means we
+        // will be starting clean anyway
+        try (DataOutputStream out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(bundleOriginCache)))) {
+            synchronized (bundleOrigins) {
+                out.writeInt(bundleOrigins.size());
+                for (Entry<Long, Set<Long>> origin : bundleOrigins.entrySet()) {
+                    out.writeLong(origin.getKey());
+                    out.writeInt(origin.getValue().size());
+                    for (Long installed : origin.getValue()) {
+                        out.writeLong(installed);
                     }
                 }
             }
+        } catch (IOException e) {
+            // auto FFDC is fine here
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.util.concurrent.Callable#call()
-     */
-    @Override
-    public synchronized Void call() throws Exception {
-        //this gets called on schedule to clear the map for garbage collection
-        futurePurge = null;
-        bundleOrigins = null;
-        return null;
+    private void readCacheFile() {
+        try (DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(bundleOriginCache)))) {
+            synchronized (bundleOrigins) {
+                bundleOrigins.clear();
+                int numOrigins = in.readInt();
+                for (int i = 0; i < numOrigins; i++) {
+                    long installeeId = in.readLong();
+                    int numInstalled = in.readInt();
+                    Set<Long> installed = new HashSet<>(numInstalled);
+                    for (int j = 0; j < numInstalled; j++) {
+                        long id = in.readLong();
+                        installed.add(id);
+                        allTracked.add(id);
+                    }
+                    bundleOrigins.put(installeeId, installed);
+                }
+            }
+        } catch (IOException e) {
+            // auto FFDC is fine here
+        }
     }
 }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/Provisioner.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/Provisioner.java
@@ -91,7 +91,7 @@ import com.ibm.wsspi.kernel.service.utils.PathUtils;
  */
 public class Provisioner {
     private static final TraceComponent tc = Tr.register(Provisioner.class);
-    private static final String BUNDLE_LOC_FEATURE_TAG = "feature@";
+    public static final String BUNDLE_LOC_FEATURE_TAG = "feature@";
     static final String BUNDLE_LOC_REFERENCE_TAG = "reference:";
     private final String BUNDLE_LOC_FILE_REFERENCE_TAG = BUNDLE_LOC_REFERENCE_TAG + "file:";
     private static final String BUNDLE_LOC_PROD_EXT_TAG = "productExtension:";

--- a/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/FeatureManagerTest.java
+++ b/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/FeatureManagerTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -189,16 +188,7 @@ public class FeatureManagerTest {
                     //allow mock calls from the BundleInstallOriginBundleListener <init>
                     allowing(mockBundleContext).getBundle();
                     will(returnValue(mockBundle));
-                    one(mockBundle).getDataFile("bundle.origin.cache");
-                    //allow the BundleInstallOriginBundleListener to get a ScheduledExecutorService
-                    //and schedule a purge for the future
-                    one(mockBundleContext).getServiceReference(ScheduledExecutorService.class);
-                    will(returnValue(mockScheduledExecutorService));
-                    one(mockBundleContext).getService(mockScheduledExecutorService);
-                    will(returnValue(mockScheduledExecutorService.getService()));
-                    one(mockScheduledExecutorService.getService()).schedule(with(any(BundleInstallOriginBundleListener.class)), with(any(Integer.class)),
-                                                                            with(any(TimeUnit.class)));
-                    one(mockBundleContext).ungetService(mockScheduledExecutorService);
+                    one(mockBundleContext).getDataFile("bundle.origin.cache");
 
                     allowing(mockBundleContext).addBundleListener(with(any(BundleListener.class)));
 
@@ -480,16 +470,7 @@ public class FeatureManagerTest {
                     //allow mock calls from the BundleInstallOriginBundleListener <init>
                     allowing(mockBundleContext).getBundle();
                     will(returnValue(mockBundle));
-                    one(mockBundle).getDataFile("bundle.origin.cache");
-                    //allow the BundleInstallOriginBundleListener to get a ScheduledExecutorService
-                    //and schedule a purge for the future
-                    one(mockBundleContext).getServiceReference(ScheduledExecutorService.class);
-                    will(returnValue(mockScheduledExecutorService));
-                    one(mockBundleContext).getService(mockScheduledExecutorService);
-                    will(returnValue(mockScheduledExecutorService.getService()));
-                    one(mockScheduledExecutorService.getService()).schedule(with(any(BundleInstallOriginBundleListener.class)), with(any(Integer.class)),
-                                                                            with(any(TimeUnit.class)));
-                    one(mockBundleContext).ungetService(mockScheduledExecutorService);
+                    one(mockBundleContext).getDataFile("bundle.origin.cache");
 
                 }
             });

--- a/dev/com.ibm.ws.kernel.feature_fat/.classpath
+++ b/dev/com.ibm.ws.kernel.feature_fat/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry kind="src" path="test-bundles/test.feature.provisioner/src"/>
 	<classpathentry kind="src" path="test-bundles/test.feature.api/src"/>
 	<classpathentry kind="src" path="test-bundles/test.activation.type/src"/>
+	<classpathentry kind="src" path="test-bundles/test.origin.bundle/src"/>
 	<classpathentry kind="src" path="test-applications/test.feature.api.client.war/src"/>
 	<classpathentry kind="src" path="test-applications/ServletTest/src"/>
 	<classpathentry kind="src" path="test-applications/IgnoreAPI.ear/IgnoreAPIEJB.jar/src"/>

--- a/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
@@ -22,8 +22,9 @@ src: \
 	test-bundles/test.feature.provisioner/src, \
 	test-bundles/test.service.consumer/src, \
 	test-bundles/test.service.provider/src, \
-	test-bundles/test.activation.type/src
-	
+	test-bundles/test.activation.type/src, \
+	test-bundles/test.origin.bundle/src
+
 fat.project: true
 
 tested.features: featuref-1.0, productauto:pfeaturen-1.0, productauto:pfeaturem-1.0, featuree-1.0, productauto:pfeaturel-1.0, featureg-1.0, productauto:pfeaturef-1.0, productauto:pfeatureg-1.0, productauto:pfeaturee-1.0, capabilityc-1.0, badpathtool-1.0, emptyiconheader-1.0, goldenpathtool-1.0, icondirectivestool-1.0, noheadertool-1.0, missingiconstool-1.0, jwt-1.0, servlet-3.1

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/BundleOriginTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/BundleOriginTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.feature.fat;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+@RunWith(FATRunner.class)
+public class BundleOriginTest {
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.feature.origin.bundle");
+    private static final String TEST_MARKER = "BundleInstallOriginTest:";
+
+    @Test
+    public void testBundleOrigin() throws Exception {
+
+        server.startServer();
+        String result = server.waitForStringInLogUsingMark(TEST_MARKER);
+        assertTrue("Test failed: " + result, result.contains("PASSED"));
+
+        server.setMarkToEndOfLog();
+        server.changeFeatures(Arrays.asList("usr:test.origin.user-1.0"));
+        server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
+        result = server.waitForStringInLogUsingMark(TEST_MARKER);
+        assertTrue("Test failed: " + result, result.contains("PASSED"));
+    }
+
+    @BeforeClass
+    public static void installFeatures() throws Exception {
+        server.installSystemFeature("test.origin.system-1.0");
+        server.installSystemBundle("test.origin.bundle.system");
+
+        server.installUserFeature("test.origin.user-1.0");
+        server.installUserBundle("test.origin.bundle.user");
+    }
+
+    @AfterClass
+    public static void uninstallFeatures() throws Exception {
+        server.uninstallSystemFeature("test.origin.system-1.0");
+        server.uninstallSystemBundle("test.origin.bundle.system");
+
+        server.uninstallUserFeature("test.origin.user-1.0");
+        server.uninstallUserBundle("test.origin.bundle.user");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FATSuite.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
                 // Disabled FeatureProcessTypeTest.class,
+                BundleOriginTest.class,
                 ActivationTypeTest.class,
                 AutoFeaturesTest.class,
                 FeatureTest.class,

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.origin.system-1.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.origin.system-1.0.mf
@@ -1,0 +1,7 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: test.origin.system-1.0; visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Content: test.origin.bundle.system; version="[1,1.0.100)"
+Subsystem-Type: osgi.subsystem.feature
+IBM-API-Package: test.feature.api
+IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.origin.user-1.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.origin.user-1.0.mf
@@ -1,0 +1,7 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: test.origin.user-1.0; visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Content: test.origin.bundle.user; version="[1,1.0.100)"
+Subsystem-Type: osgi.subsystem.feature
+IBM-API-Package: test.feature.api
+IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.origin.bundle/.gitignore
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.origin.bundle/.gitignore
@@ -1,0 +1,1 @@
+/dropins

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.origin.bundle/bootstrap.properties
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.origin.bundle/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=com.ibm.ws.kernel.feature.internal.BundleInstallOriginBundleListener=debug

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.origin.bundle/server.xml
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.origin.bundle/server.xml
@@ -1,0 +1,9 @@
+<server>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>test.origin.system-1.0</feature>
+    </featureManager>
+    
+</server>

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.origin.bundle/src/test/origin/bundle/Activator.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.origin.bundle/src/test/origin/bundle/Activator.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.origin.bundle;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.Constants;
+import org.osgi.framework.startlevel.BundleStartLevel;
+
+/**
+ *
+ */
+public class Activator implements BundleActivator {
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        final Set<Bundle> tracked = Collections.synchronizedSet(new HashSet<Bundle>());
+
+        Set<Bundle> origins = new HashSet<>();
+        for (int i = 0; i < 10; i++) {
+            origins.add(installOrigin(i, tracked, context));
+        }
+        final CountDownLatch allTrackedRemoved = new CountDownLatch(tracked.size());
+        Thread.sleep(5000);
+        context.addBundleListener(new BundleListener() {
+            @Override
+            public void bundleChanged(BundleEvent event) {
+                if (BundleEvent.UNINSTALLED == event.getType()) {
+                    if (tracked.remove(event.getBundle())) {
+                        System.out.println("Uninstalled tracked bundle: " + event.getBundle().getSymbolicName());
+                        allTrackedRemoved.countDown();
+                    }
+                }
+            }
+        });
+
+        for (Bundle bundle : origins) {
+            bundle.uninstall();
+        }
+        allTrackedRemoved.await(5, TimeUnit.SECONDS);
+        if (tracked.isEmpty()) {
+            System.out.println("BundleInstallOriginTest: PASSED");
+        } else {
+            System.out.println("BundleInstallOriginTest: FAILED");
+        }
+    }
+
+    private Bundle installOrigin(int originId, Set<Bundle> tracked, BundleContext context) throws BundleException, IOException {
+        String originName = "origin." + originId;
+        // first install another bundle so we can get its BundleContext
+        Bundle origin = context.installBundle(originName, createBundle(originName));
+        System.out.println("Installed origin bundle: " + originName);
+        origin.adapt(BundleStartLevel.class).setStartLevel(1);
+        origin.start();
+        BundleContext originContext = origin.getBundleContext();
+        // now use the originContext to install other bundles
+        for (int i = 0; i < 10; i++) {
+            String trackedName = originName + ".tracked." + i;
+            tracked.add(originContext.installBundle(trackedName, createBundle(trackedName)));
+            System.out.println("Installed tracked bundle: " + trackedName);
+        }
+        return origin;
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+
+    }
+
+    private InputStream createBundle(String symbolicName) throws IOException {
+        Manifest m = new Manifest();
+        Attributes attributes = m.getMainAttributes();
+        attributes.putValue("Manifest-Version", "1.0");
+        attributes.putValue(Constants.BUNDLE_MANIFESTVERSION, "2");
+        attributes.putValue(Constants.BUNDLE_SYMBOLICNAME, symbolicName);
+        ByteArrayOutputStream bundleContent = new ByteArrayOutputStream();
+        JarOutputStream jos = new JarOutputStream(bundleContent, m);
+        jos.flush();
+        jos.close();
+        return new ByteArrayInputStream(bundleContent.toByteArray());
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test.origin.bundle.system.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/test.origin.bundle.system.bnd
@@ -1,0 +1,22 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+# Define the bundle for this FAT
+
+Bundle-Name: test.origin.bundle
+Bundle-SymbolicName: test.origin.bundle.system
+
+# hide the implementation packages
+Private-Package: test.origin.bundle
+
+Bundle-Activator: test.origin.bundle.Activator

--- a/dev/com.ibm.ws.kernel.feature_fat/test.origin.bundle.user.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/test.origin.bundle.user.bnd
@@ -1,0 +1,22 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+# Define the bundle for this FAT
+
+Bundle-Name: test.origin.bundle
+Bundle-SymbolicName: test.origin.bundle.user
+
+# hide the implementation packages
+Private-Package: test.origin.bundle
+
+Bundle-Activator: test.origin.bundle.Activator


### PR DESCRIPTION
The BundleInstallOriginBundleListener has several issues.
What lead me to look at this class was the cost to load
the cache.  It uses an object stream which is slow.  But
then I noticed that the cache also was way too big,
that was because it incorrectly is tracking bundles
installed by feature manager.  Then I noticed how complicated
the purging code was and thought it was way to much to try
and save some String storage in memory.  This can easily be
Bundle ID longs instead.

Stop using object stream, use data stream instead
Stop tracking bundles installed by feature manager
Stop purging the cache Map
Use simple Bundle ID longs instead of location strings to track

Add tests to actually make sure this stuff keeps working

