### PR TITLE
Enable discovery of revocation endpoint (Issue 8250)

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OIDCConstants.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OIDCConstants.java
@@ -125,6 +125,7 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String OIDC_DISC_REQUIRE_REQ_URI_REGISTRATION = "require_request_uri_registration";
     public static final String OIDC_DISC_OP_POLICY_URI = "op_policy_uri";
     public static final String OIDC_DISC_OP_TOS_URI = "op_tos_uri";
+    public static final String OIDC_DISC_REVOKE_EP = "revocation_endpoint";
 
     /* parameters for oidc discovery response with origins from session management */
     public static final String OIDC_SESS_CHECK_SESSION_IFRAME = "check_session_iframe";
@@ -227,6 +228,7 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String KEY_OIDC_COVERAGE_MAP_EP = "coverageMapEndpoint";
     public static final String KEY_OIDC_PROXY_EP = "proxyEndpoint";
     public static final String KEY_OIDC_BACKING_IDP_URI_PREFIX = "backingIdpUriPrefix";
+    public static final String KEY_OIDC_REVOKE_EP = "revocationEndpoint";
 
     // Server config property for coverageMap
     static final String JSA_QUAL = "jsa.provider.";
@@ -261,6 +263,7 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String KEY_OIDC_COVERAGE_MAP_EP_QUAL = OIDC_QUAL + KEY_OIDC_COVERAGE_MAP_EP;
     public static final String KEY_OIDC_PROXY_EP_QUAL = OIDC_QUAL + KEY_OIDC_PROXY_EP;
     public static final String KEY_OIDC_BACKING_IDP_URI_PREFIX_QUAL = OIDC_QUAL + KEY_OIDC_BACKING_IDP_URI_PREFIX;
+    public static final String KEY_OIDC_REVOKE_EP_QUAL = OIDC_QUAL + KEY_OIDC_REVOKE_EP;
 
     /**
      * Supported OIDC client registration parameter names

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/OidcDiscoveryProviderConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/OidcDiscoveryProviderConfig.java
@@ -30,7 +30,8 @@ public class OidcDiscoveryProviderConfig {
 
     //Disallow default construction
     @SuppressWarnings("unused")
-    private OidcDiscoveryProviderConfig() {}
+    private OidcDiscoveryProviderConfig() {
+    }
 
     public OidcDiscoveryProviderConfig(String providerId, HttpServletRequest request) {
         this.request = request;
@@ -43,7 +44,7 @@ public class OidcDiscoveryProviderConfig {
 
     /**
      * Calculates and returns the calculated endpoint.
-     * 
+     *
      * @param endpointProp is a qualified endpoint property key
      * @return Endpoint for a given provider. Returns calculated value.
      */
@@ -54,19 +55,11 @@ public class OidcDiscoveryProviderConfig {
     private String getCalculatedIssuerId(String providerId) {
         String fullServletPath = HttpUtils.getFullCtxServletPath(this.request);
 
-        return (new StringBuffer())
-                        .append(fullServletPath)
-                        .append((fullServletPath.endsWith("/") ? "" : "/"))
-                        .append(providerId)
-                        .toString();
+        return (new StringBuffer()).append(fullServletPath).append((fullServletPath.endsWith("/") ? "" : "/")).append(providerId).toString();
     }
 
     private String getCalculatedEndpoint(String endpoint) {
-        return (new StringBuffer())
-                        .append(this.issuerId)
-                        .append((this.issuerId.endsWith("/") ? "" : "/"))
-                        .append(endpoint)
-                        .toString();
+        return (new StringBuffer()).append(this.issuerId).append((this.issuerId.endsWith("/") ? "" : "/")).append(endpoint).toString();
     }
 
     static {
@@ -80,5 +73,6 @@ public class OidcDiscoveryProviderConfig {
         endpointMap.put(OIDCConstants.KEY_OIDC_END_SESSION_EP_QUAL, EndpointType.end_session.name());
         endpointMap.put(OIDCConstants.KEY_OIDC_COVERAGE_MAP_EP_QUAL, EndpointType.coverage_map.name());
         endpointMap.put(OIDCConstants.KEY_OIDC_PROXY_EP_QUAL, EndpointType.proxy.name());
+        endpointMap.put(OIDCConstants.KEY_OIDC_REVOKE_EP_QUAL, EndpointType.revoke.name());
     }
 }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCAbstractDiscoveryModel.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCAbstractDiscoveryModel.java
@@ -16,10 +16,10 @@ import com.ibm.ws.security.openidconnect.token.JsonTokenUtil;
 
 /**
  * OIDC Discovery Service Bean
- * 
+ *
  * Properties based off Draft 21:
  * http://openid.bitbucket.org/openid-connect-discovery-1_0.html
- * 
+ *
  * Note that several properties have been commented out because they are currently not being utilized.
  */
 public abstract class OIDCAbstractDiscoveryModel {
@@ -45,6 +45,7 @@ public abstract class OIDCAbstractDiscoveryModel {
     private boolean require_request_uri_registration;
     private String check_session_iframe;
     private String end_session_endpoint;
+    private String revocation_endpoint;
 
     /**
      * OIDC Properties not utilized in implementation
@@ -58,14 +59,15 @@ public abstract class OIDCAbstractDiscoveryModel {
     //private String[] request_object_signing_alg_values_supported;
     //private String[] request_object_encryption_alg_values_supported;
     //private String[] request_object_encryption_enc_values_supported;
-    //private String[] token_endpoint_auth_signing_alg_values_supported;    
+    //private String[] token_endpoint_auth_signing_alg_values_supported;
     //private String service_documentation;
     //private String[] claims_locales_supported;
     //private String[] ui_locales_supported;
     //private String op_policy_uri;
     //private String op_tos_uri;
 
-    protected OIDCAbstractDiscoveryModel() {}
+    protected OIDCAbstractDiscoveryModel() {
+    }
 
     /**
      * @return the issuer
@@ -373,6 +375,20 @@ public abstract class OIDCAbstractDiscoveryModel {
      */
     public void setEndSessionEndpoint(String endSessionEndpoint) {
         this.end_session_endpoint = endSessionEndpoint;
+    }
+
+    /**
+     * @return the revocationEndpoint
+     */
+    public String getRevocationEndpoint() {
+        return revocation_endpoint;
+    }
+
+    /**
+     * @param revocationEndpoint the revocationEndpoint to set
+     */
+    public void setRevocationEndpoint(String revocationEndpoint) {
+        this.revocation_endpoint = revocationEndpoint;
     }
 
     private String[] defensiveCopy(String[] strArr) {

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/Discovery.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/Discovery.java
@@ -23,12 +23,10 @@ import com.ibm.ws.security.openidconnect.server.internal.OidcDiscoveryProviderCo
 import com.ibm.ws.security.openidconnect.server.plugins.OIDCWASDiscoveryModel;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcServerConfig;
 
-public class Discovery
-{
+public class Discovery {
     private static TraceComponent tc = Tr.register(Discovery.class);
 
-    public void processRequest(OidcServerConfig provider, HttpServletRequest request, HttpServletResponse response) throws IOException
-    {
+    public void processRequest(OidcServerConfig provider, HttpServletRequest request, HttpServletResponse response) throws IOException {
         OIDCWASDiscoveryModel discoveryObj = new OIDCWASDiscoveryModel();
 
         OidcDiscoveryProviderConfig discoverConfig = new OidcDiscoveryProviderConfig(provider.getProviderId(), request);
@@ -87,14 +85,12 @@ public class Discovery
 
         discoveryObj.setProxyEndpoint(provider.getAuthProxyEndpointUrl());
 
+        discoveryObj.setRevocationEndpoint(discoverConfig.getEndpoint(OIDCConstants.KEY_OIDC_REVOKE_EP_QUAL));
+
         String discoverJSONString = discoveryObj.toJSONString();
 
         if (tc.isDebugEnabled()) {
-            Tr.debug(tc, (new StringBuffer())
-                            .append("Discover response for provider ")
-                            .append(provider.getProviderId())
-                            .append(" :")
-                            .append(discoverJSONString).toString());
+            Tr.debug(tc, (new StringBuffer()).append("Discover response for provider ").append(provider.getProviderId()).append(" :").append(discoverJSONString).toString());
         }
 
         //Set Headers and Status


### PR DESCRIPTION
This PR is opened to address issue 8250 such that the OpenID Connect server will return information on the revocation_endpoint when a call is made to the discovery endpoint.  

