### PR TITLE
Improve init_pooling test failure logic

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/test-applications/initialpollingtest/src/web/PersistentExecutorsTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/test-applications/initialpollingtest/src/web/PersistentExecutorsTestServlet.java
@@ -126,7 +126,8 @@ public class PersistentExecutorsTestServlet extends HttpServlet {
 
         for (long start = System.nanoTime(); System.nanoTime() - start < TIMEOUT_NS && !status.hasResult(); status = executor.getStatus(taskId))
             Thread.sleep(POLL_INTERVAL);
-        if (!status.isDone())
+       
+        if (status.getNextExecutionTime() != null || !status.isDone())
             throw new Exception("Task did not complete within alotted interval. " + status);
 
         int result = status.get();


### PR DESCRIPTION
This test checks to see if a task completes in the allotted time when pooling. 
The for-loop checks the status and resolves when the task should have completed.
When we check to see if the task has completed we first need to check to see if task is still scheduled. 
Otherwise, evaluation of `status.isDone()` will throw it's own exception instead of falling through to the test exception.

This change will ensure that this test will properly fail if a task does not completed in the expected amount of time. 