### PR TITLE
Add oidcServer dependency on com.ibm.ws.webcontainer.security.provider

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectServer-1.0/com.ibm.websphere.appserver.openidConnectServer-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectServer-1.0/com.ibm.websphere.appserver.openidConnectServer-1.0.feature
@@ -25,6 +25,7 @@ Subsystem-Name: OpenID Connect Provider 1.0
   com.ibm.ws.org.jose4j, \
   com.ibm.ws.org.json.simple.1.1.1, \
   com.ibm.ws.com.google.gson.2.2.4, \
+  com.ibm.ws.webcontainer.security.provider, \
   com.ibm.websphere.appserver.api.oidc; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.oidc_1.0-javadoc.zip
 kind=ga


### PR DESCRIPTION
After moving to OL, there were bundle resolution errors when starting a server with the openidConnectServer-1.0 feature.

Adding dependencies as needed to fix the bundle resolution.