### PR TITLE
For non-english languages, merge with en message file

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/js/globalization.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/js/globalization.js
@@ -90,15 +90,23 @@ var globalization = (function() {
         // Set the documents's lang code
         document.documentElement.setAttribute("lang", languageCode);
         
+        var enMessages = messages;
+
         var url = (languageCode !== "en") ? "../../WEB-CONTENT/" + toolname + "/nls/" + languageCode + "/messages.js" : "../../WEB-CONTENT/" + toolname + "/nls/messages.js";
             
         var deferred = new $.Deferred();
         
-        // Retrieve the deploy message translations from the correct nls directory
+        // Retrieve the message translations from the correct nls directory
         var ajaxPromise = $.ajax({
             url: url,
             dataType: "script",
             success: function() {
+                if (languageCode !== "en") {
+                    // Assign any non-translated English message to the messages object
+                    // from the English translation.
+                    messages = $.extend({}, enMessages, messages);
+                }
+
                 replaceExternalizedStrings();
                 deferred.resolve();
             },


### PR DESCRIPTION
If a message is missing in a supported language, it should default back to the message in the English locale. To do this, if we are retrieving messages from a non-English file, then we merge those messages with the messages from the English messages file so that any strings not in the translated file would be in the merged file from the strings in the English file.