### PR TITLE
Uncouple some execution/instance operations to prevent deadlocks

### DIFF
--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/BaseStepControllerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/BaseStepControllerImpl.java
@@ -437,7 +437,8 @@ public abstract class BaseStepControllerImpl implements IExecutionElementControl
     // Will be overridden for partitioned steps by special method which
     // aggregates partition-level metrics
     protected void updateStepExecution() {
-        getPersistenceManagerService().updateStepExecution(runtimeStepExecution);
+        StepThreadExecutionEntity stepThreadExecutionEntity = getPersistenceManagerService().updateStepExecution(runtimeStepExecution);
+        stepThreadExecutionEntity.getJobExecution().setLastUpdatedTime(runtimeStepExecution.getLastUpdatedTime());
     }
 
     protected void markJobAndStepForFailure() {

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/PartitionedStepControllerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/PartitionedStepControllerImpl.java
@@ -46,6 +46,7 @@ import com.ibm.jbatch.container.execution.impl.RuntimeWorkUnitExecution;
 import com.ibm.jbatch.container.execution.impl.RuntimeWorkUnitExecution.StopLock;
 import com.ibm.jbatch.container.jsl.CloneUtility;
 import com.ibm.jbatch.container.persistence.jpa.EntityConstants;
+import com.ibm.jbatch.container.persistence.jpa.TopLevelStepExecutionEntity;
 import com.ibm.jbatch.container.persistence.jpa.TopLevelStepInstanceEntity;
 import com.ibm.jbatch.container.persistence.jpa.TopLevelStepInstanceKey;
 import com.ibm.jbatch.container.servicesmanager.ServicesManagerStaticAnchor;
@@ -1058,7 +1059,8 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
     @Override
     protected void updateStepExecution() {
         // Call special aggregating method
-        getPersistenceManagerService().updateStepExecutionWithPartitionAggregate(runtimeStepExecution);
+        TopLevelStepExecutionEntity topLevelStepExecutionEntity = getPersistenceManagerService().updateStepExecutionWithPartitionAggregate(runtimeStepExecution);
+        topLevelStepExecutionEntity.getJobExecution().setLastUpdatedTime(runtimeStepExecution.getLastUpdatedTime());
     }
 
     @Override

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntity.java
@@ -50,6 +50,9 @@ import com.ibm.jbatch.container.ws.WSJobExecution;
                  * " (SELECT MAX(e.executionNumberForThisInstance) FROM JobExecutionEntity e WHERE e.jobInstance.instanceId = :id)"),
                  */
 
+                @NamedQuery(name = JobExecutionEntity.GET_JOB_EXECUTIONIDS_BY_JOB_INST_ID, query = "SELECT e.jobExecId FROM JobExecutionEntity e" +
+                                                                                                   " WHERE e.jobInstance.instanceId in :instanceList ORDER BY e.createTime DESC"),
+
                 @NamedQuery(name = JobExecutionEntity.GET_JOB_EXECUTIONIDS_BY_NAME_AND_STATUSES_QUERY, query = "SELECT e.jobExecId FROM JobExecutionEntity e" +
                                                                                                                " WHERE e.jobInstance.jobName=:name AND e.batchStatus IN :status ORDER BY e.createTime DESC"),
                 @NamedQuery(name = JobExecutionEntity.GET_JOB_EXECUTIONS_BY_SERVERID_AND_STATUSES_QUERY, query = "SELECT e FROM JobExecutionEntity e" +
@@ -76,6 +79,7 @@ public class JobExecutionEntity extends JobThreadExecutionBase implements JobExe
     public static final String GET_JOB_EXECUTIONS_BY_SERVERID_AND_STATUSES_QUERY = "JobExecutionEntity.getJobExecutionsByServerIdAndStatusesQuery";
     public static final String GET_JOB_EXECUTIONS_MOST_TO_LEAST_RECENT_BY_INSTANCE = "JobExecutionEntity.getJobExecutionsMostToLeastRecentByInstanceQuery";
     public static final String GET_JOB_EXECUTIONS_BY_JOB_INST_ID_AND_JOB_EXEC_NUM = "JobExecutionEntity.getJobExecutionsByJobInstanceIdAndJobExecNumberQuery";
+    public static final String GET_JOB_EXECUTIONIDS_BY_JOB_INST_ID = "JobExecutionEntity.getJobExecutionsByJobInstanceId";
     /*
      * Key
      */

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntity.java
@@ -41,6 +41,7 @@ import com.ibm.jbatch.container.ws.InstanceState;
 import com.ibm.jbatch.container.ws.WSJobInstance;
 
 @NamedQueries({
+                @NamedQuery(name = JobInstanceEntity.GET_JOBINSTANCEIDS_BY_NAME_AND_STATUSES_QUERY, query = "SELECT i.instanceId FROM JobInstanceEntity i WHERE i.batchStatus IN :status AND i.jobName = :name"),
                 @NamedQuery(name = JobInstanceEntity.GET_JOBINSTANCES_SORT_BY_CREATETIME_FIND_ALL_QUERY, query = "SELECT i FROM JobInstanceEntity i ORDER BY i.createTime DESC"),
                 @NamedQuery(name = JobInstanceEntity.GET_JOBINSTANCES_SORT_BY_CREATETIME_FIND_BY_SUBMITTER_QUERY, query = "SELECT i FROM JobInstanceEntity i WHERE i.submitter = :submitter ORDER BY i.createTime DESC"),
                 @NamedQuery(name = JobInstanceEntity.GET_JOB_NAMES_SET_QUERY, query = "SELECT DISTINCT i.jobName FROM JobInstanceEntity i"),
@@ -63,6 +64,7 @@ public class JobInstanceEntity implements JobInstance, WSJobInstance, EntityCons
     public static final String GET_JOBINSTANCE_COUNT_BY_JOBNAME_AND_SUBMITTER_QUERY = "JobInstanceEntity.getJobInstanceCountByJobNameAndSubmitterQuery";
     public static final String GET_JOB_NAMES_SET_QUERY = "JobInstanceEntity.getJobNamesSetQuery";
     public static final String GET_JOB_NAMES_SET_BY_SUBMITTER_QUERY = "JobInstanceEntity.getJobNamesSetBySubmitterQuery";
+    public static final String GET_JOBINSTANCEIDS_BY_NAME_AND_STATUSES_QUERY = "JobInstanceEntity.getJobInstancesByNameAndStatus";
 
     /*
      * Key, and constructors

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java
@@ -75,14 +75,14 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * Creates a JobIntance
      *
      * @param appName
-     *            The batch application or module name associated with this job
-     *            instance. Null is allowed.
+     *                       The batch application or module name associated with this job
+     *                       instance. Null is allowed.
      * @param jobXMLName
-     *            the JSL file name
+     *                       the JSL file name
      * @param submitter
-     *            the application tag that owns this job
+     *                       the application tag that owns this job
      * @param date
-     *            creation time
+     *                       creation time
      *
      * @return the job instance
      */
@@ -92,16 +92,16 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * Creates a JobIntance
      *
      * @param appName
-     *            The batch application or module name associated with this job
-     *            instance. Null is allowed.
+     *                       The batch application or module name associated with this job
+     *                       instance. Null is allowed.
      * @param jobXMLName
-     *            the JSL file name
+     *                       the JSL file name
      * @param jsl
-     *            the entire JSL file String
+     *                       the entire JSL file String
      * @param submitter
-     *            the application tag that owns this job
+     *                       the application tag that owns this job
      * @param date
-     *            creation time
+     *                       creation time
      *
      * @return the job instance
      */
@@ -140,9 +140,9 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * TODO - order?
      *
      * @param page
-     *            The page of rows to get (starts at 0)
+     *                     The page of rows to get (starts at 0)
      * @param pageSize
-     *            The number of rows per page
+     *                     The number of rows per page
      *
      * @return a list of (top-level only) job instances, ordered from most-to-least-recent creation time.
      */
@@ -150,13 +150,13 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
 
     /**
      * @param page
-     *            The page of rows to get (starts at 0)
+     *                      The page of rows to get (starts at 0)
      * @param pageSize
-     *            The number of rows per page
+     *                      The number of rows per page
      * @param submitter
-     *            Only return jobs owned by user. User can be null. Specify null
-     *            string to include all users.
-     *            TODO - is null still allowed?
+     *                      Only return jobs owned by user. User can be null. Specify null
+     *                      string to include all users.
+     *                      TODO - is null still allowed?
      *
      * @return a list of (top-level only) job instances owned by given user, ordered in descending order of instance id
      */
@@ -205,11 +205,11 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * Update the given jobinstance record with the given jobName and jobXml
      *
      * @param jobInstanceId
-     *            the jobinstance to update
+     *                          the jobinstance to update
      * @param jobName
-     *            the job name
+     *                          the job name
      * @param jobXml
-     *            the job JSL source (XML)
+     *                          the job JSL source (XML)
      */
     public JobInstance updateJobInstanceWithJobNameAndJSL(long jobInstanceId, String jobName, String jobXml);
 
@@ -240,7 +240,7 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      *
      * @return the updated JobExecution
      *
-     * @throws NoSuchJobExecutionException if the job execution is not located by the find query
+     * @throws NoSuchJobExecutionException        if the job execution is not located by the find query
      * @throws ExecutionAssignedToServerException if the execution has been assigned to a server/endpoint (serverid set)
      */
     JobExecution updateJobExecutionAndInstanceOnStopBeforeServerAssigned(long jobExecutionId,
@@ -259,7 +259,7 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      *
      * @param jobInstanceId
      * @param jobParameters
-     * @param create time
+     * @param create        time
      * @return
      */
     public JobExecutionEntity createJobExecution(long jobInstanceId, Properties jobParameters, Date createTime);
@@ -289,7 +289,7 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      *         associated with the given job instance ID.
      *
      * @throws IllegalStateException if no executions are found
-     *             NoSuchJobInstanceException if instance itself isn't found
+     *                                   NoSuchJobInstanceException if instance itself isn't found
      */
     public JobExecutionEntity getJobExecutionMostRecent(long jobInstanceId) throws IllegalStateException, NoSuchJobInstanceException;
 
@@ -327,7 +327,7 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * @param execId
      *
      * @throws NoSuchJobExecutionException if this job execution is not located by the find query
-     * @throws JobStoppedException if the specified execution has been stopped at the time this update is attempted
+     * @throws JobStoppedException         if the specified execution has been stopped at the time this update is attempted
      *
      * @return the updated execution
      */
@@ -414,8 +414,8 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * @param topLevelStepExecutionId
      * @return
      * @throws IllegalArgumentException if either:
-     *             1) we have no entry at all with id equal to <code>stepExecutionId</code>
-     *             2) we have a partition-level StepThreadExecutionEntity with this id (but not a top-level entry).
+     *                                      1) we have no entry at all with id equal to <code>stepExecutionId</code>
+     *                                      2) we have a partition-level StepThreadExecutionEntity with this id (but not a top-level entry).
      */
     public TopLevelStepExecutionEntity getStepExecutionTopLevel(long topLevelStepExecutionId) throws IllegalArgumentException;
 
@@ -443,8 +443,8 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * @param topLevelStepExecutionId
      * @return step exec aggregate
      * @throws IllegalArgumentException if either:
-     *             1) we have no entry at all with id equal to <code>stepExecutionId</code>
-     *             2) we have a partition-level StepThreadExecutionEntity with this id (but not a top-level entry).
+     *                                      1) we have no entry at all with id equal to <code>stepExecutionId</code>
+     *                                      2) we have a partition-level StepThreadExecutionEntity with this id (but not a top-level entry).
      */
     public WSStepThreadExecutionAggregate getStepExecutionAggregate(long topLevelStepExecutionId) throws IllegalArgumentException;
 
@@ -467,7 +467,7 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * accessible through standard, public APIs.)
      *
      * @param runtimeStepExecution
-     *            the runtime StepExecution
+     *                                 the runtime StepExecution
      */
     public TopLevelStepExecutionEntity updateStepExecutionWithPartitionAggregate(RuntimeStepExecution runtimeStepExecution);
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/AbstractPersistenceManager.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/AbstractPersistenceManager.java
@@ -300,9 +300,6 @@ public abstract class AbstractPersistenceManager implements IPersistenceManagerS
             throw new PersistenceException(e);
         }
         updateStepExecutionMetrics(stepExec, runtimeStepExecution.getMetrics());
-
-        // Note there's nothing in the spec that says we have to do this, but seems useful.
-        stepExec.getJobExecution().setLastUpdatedTime(runtimeStepExecution.getLastUpdatedTime());
     }
 
     private void updateStepExecutionMetrics(StepThreadExecutionEntity stepData, List<Metric> metrics) {


### PR DESCRIPTION
This change is being made to prevent the possibility of two deadlocks:

1) In BaseStepControllerImpl.updateStepExecution, the current code attempts to update the step execution as well as the lastUpdated time in the associated job execution.  In updateStepExecution, there is: TranRequest<StepThreadExecutionEntity>(em) and that's where we call updateStepExecutionStatusTimeStampsUserDataAndMetrics).  In the reported issue, we see the indexes being locked for both tables.

It is not important that this be viewed atomically/consistently, so the lastUpdated time update can be done at the same stage in the lifecycle, just not in the same transaction.

2) During the use of the getJobExecutionsRunning API, the database query makes use of two tables for the execution and instance.  It will locate the instances with the specified jobName, and uses that to locate the executions with a "running" status (started, starting or stopping).  In the reported issue, we see the indexes being locked for both tables.

The proposed fix performs the two aformentioned operations in seperate transactions.