### PR TITLE
Set HealthCheckService on AppTracker for mpHealth 1.0

### DIFF
--- a/dev/com.ibm.ws.microprofile.health/src/com/ibm/ws/microprofile/health/internal/HealthCheckServiceImpl.java
+++ b/dev/com.ibm.ws.microprofile.health/src/com/ibm/ws/microprofile/health/internal/HealthCheckServiceImpl.java
@@ -55,6 +55,7 @@ public class HealthCheckServiceImpl implements HealthCheckService {
     @Reference(service = AppTracker.class)
     protected void setAppTracker(AppTracker service) {
         this.appTracker = service;
+        appTracker.setHealthCheckService(this);
     }
 
     protected void unsetAppTracker(AppTracker service) {


### PR DESCRIPTION
This change is needed so we remove reference to the CDI BeanManager when
an application is stopped.  The logic was done correctly for mpHealth
2.0, but one line was missed for mp Heatlh 1.0.

For issue #8304 