### PR TITLE
Disable Regenerate button on personalTokenManagement when flag not set

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
@@ -108,7 +108,15 @@ var table = (function() {
 
         // Action buttons
         var regenerateAriaLabel = utils.formatString(messages.REGENERATE_ARIA, [authData.authType, authData.name]);
-        var regenerateButton = "<td><input id='regenerate_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button regenerate_auth_button' value=" + messages.REGENERATE + " aria-label='" + regenerateAriaLabel + "'></td>";
+        var regenerateButton = "<td><input id='regenerate_" + authData.authID + "' type='button' authID = " + authData.authID;
+        if ((authData.authType === 'app-password' && window.globalAppPasswordsAllowed) ||
+            (authData.authType === 'app-token' && window.globalAppTokensAllowed)) {
+                regenerateButton += " class='tool_table_button regenerate_auth_button' value=" + messages.REGENERATE + " aria-label='" + regenerateAriaLabel + "'></td>";
+        } else {
+            // Disable the 'Regenerate' button if the OP was not defined with the appPasswordAllowed 
+            // or appTokenAllowed flags.
+                regenerateButton += " class='tool_table_button regenerate_auth_button' disabled value=" + messages.REGENERATE + " aria-label='" + regenerateAriaLabel + "'></td>";
+        }
         var deleteAriaLabel = utils.formatString(messages.DELETE_ARIA, [authData.authType, authData.name]);
         var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value=" + messages.DELETE + " aria-label='" + deleteAriaLabel + "'></td>";
 

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/css/tool.css
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/css/tool.css
@@ -340,6 +340,12 @@ th.table_sort_column:hover {      /* ....except for the button in the sortable c
     background-color: transparent;   /* for mobile */
 }
 
+.tool_table_button:disabled {
+    opacity: .5;
+    cursor: not-allowed;
+    text-decoration: none;
+}
+
 
 /* Table footer ... pagination */
 .tool_table_pagination {


### PR DESCRIPTION
If the OAuth Provider does not have the appPasswordAllowed or appTokenAllowed flag set, then a user accessing this provider should not be able to create app-passwords or app-tokens (respectively).  On the personalTokenManagement application, also disable the 'Regenerate' button in the table since this action will also fail if the respective flag is not set on the OP.