### PR TITLE
Kafka Partition assignment FAT test

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/AbstractDeliveryBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/AbstractDeliveryBean.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * Test bean to drive delivery of messages into reactive messaging
+ * <p>
+ * To use this class, subclass it and override {@link #getMessage()} to add an {@code @Outgoing} annotation.
+ */
+public class AbstractDeliveryBean {
+
+    private final Queue<Message<String>> pendingMessages = new LinkedList<>();
+    private final Queue<CompletableFuture<Message<String>>> incompleteFutures = new LinkedList<>();
+
+    public AbstractDeliveryBean() {
+        super();
+    }
+
+    public CompletionStage<Message<String>> getMessage() {
+        synchronized (this) {
+            if (pendingMessages.isEmpty()) {
+                CompletableFuture<Message<String>> nextMessage = new CompletableFuture<>();
+                incompleteFutures.add(nextMessage);
+                System.out.println("Delivery bean returning incomplete CS");
+                return nextMessage;
+            } else {
+                System.out.println("Delivery bean returning completed CS");
+                return CompletableFuture.completedFuture(pendingMessages.poll());
+            }
+        }
+    }
+
+    /**
+     * Send a message through the connector
+     * <p>
+     * This creates a {@link Message} wrapper and queues it to be sent into the reactive messaging system
+     *
+     * @param message the string to send in the message
+     * @return a CompletableFuture which completes when the message is acknowledged
+     */
+    public CompletableFuture<Void> sendMessage(String message) {
+        CompletableFuture<Void> ackCf = new CompletableFuture<>();
+        Message<String> msg = Message.of(message, () -> {
+            ackCf.complete(null);
+            return CompletableFuture.completedFuture(null);
+        });
+        synchronized (this) {
+            CompletableFuture<Message<String>> nextMessage = incompleteFutures.poll();
+            if (nextMessage != null) {
+                System.out.println("Delivery bean passing message to incomplete CS");
+                nextMessage.complete(msg);
+            } else {
+                System.out.println("Delivery bean queuing message");
+                pendingMessages.add(msg);
+            }
+        }
+        return ackCf;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/AbstractReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/AbstractReceptionBean.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * Test bean to monitor reception of messages from reactive messaging
+ * <p>
+ * To use this class, subclass it and override {@link #recieveMessage(Message)} to add {@code @Incoming} and {@code @Acknowledgement} annotations.
+ */
+public class AbstractReceptionBean {
+
+    private final Queue<Message<String>> receivedMessages = new LinkedList<>();
+
+    public CompletionStage<Void> recieveMessage(Message<String> msg) {
+        synchronized (this) {
+            receivedMessages.add(msg);
+            this.notifyAll();
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public List<Message<String>> getReceivedMessages(int count, Duration timeout) throws InterruptedException {
+        ArrayList<Message<String>> result = new ArrayList<>();
+        Duration remaining = timeout;
+        long startTime = System.nanoTime();
+        while (!remaining.isNegative() && result.size() < count) {
+            synchronized (this) {
+                while (!receivedMessages.isEmpty() && result.size() < count) {
+                    result.add(receivedMessages.poll());
+                }
+                if (result.size() < count) {
+                    this.wait(remaining.toMillis());
+                }
+            }
+            Duration elapsed = Duration.ofNanos(System.nanoTime() - startTime);
+            remaining = timeout.minus(elapsed);
+        }
+        assertThat("Wrong number of records fetched from kafka", result, hasSize(count));
+        return result;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/AbstractReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/AbstractReceptionBean.java
@@ -60,4 +60,19 @@ public class AbstractReceptionBean {
         return result;
     }
 
+    /**
+     * Return any messages which have been received by the bean, without waiting
+     * 
+     * @return a list of messages, may be empty
+     */
+    public List<Message<String>> getReceivedMessages() {
+        ArrayList<Message<String>> result = new ArrayList<>();
+        synchronized (this) {
+            while (!receivedMessages.isEmpty()) {
+                result.add(receivedMessages.poll());
+            }
+        }
+        return result;
+    }
+
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/SimpleKafkaReader.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/SimpleKafkaReader.java
@@ -64,6 +64,15 @@ public class SimpleKafkaReader<T> implements AutoCloseable {
         return result;
     }
 
+    /**
+     * Get the underlying Kafka Consumer
+     *
+     * @return the consumer
+     */
+    public KafkaConsumer<String, T> getConsumer() {
+        return kafkaConsumer;
+    }
+
     @Override
     public void close() throws Exception {
         kafkaConsumer.close();

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/SimpleKafkaWriter.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/SimpleKafkaWriter.java
@@ -48,7 +48,17 @@ public class SimpleKafkaWriter<T> implements AutoCloseable {
 
     public RecordMetadata sendMessage(T message, Duration timeout) {
         try {
-            ProducerRecord<String, T> record = new ProducerRecord<String, T>(topic, message);
+            ProducerRecord<String, T> record = new ProducerRecord<>(topic, message);
+            Future<RecordMetadata> ack = kafkaProducer.send(record);
+            return ack.get(timeout.toMillis(), MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new RuntimeException("Error sending Kafka message", e);
+        }
+    }
+
+    public RecordMetadata sendMessage(T message, int partition, Duration timeout) {
+        try {
+            ProducerRecord<String, T> record = new ProducerRecord<>(topic, partition, null, message);
             Future<RecordMetadata> ack = kafkaProducer.send(record);
             return ack.get(timeout.toMillis(), MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.FATSuite.kafkaContainer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.FATSuite;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PropertiesAsset;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+
+@RunWith(FATRunner.class)
+public class KafkaPartitionTest {
+
+    private static final String APP_NAME = "KafkaPartitionTest";
+
+    @Server("SimpleRxMessagingServer")
+    @TestServlet(contextRoot = APP_NAME, servlet = KafkaPartitionTestServlet.class)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Create a topic with two partitions
+        Map<String, Object> adminClientProps = new HashMap<>();
+        adminClientProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, FATSuite.kafkaContainer.getBootstrapServers());
+        AdminClient adminClient = AdminClient.create(adminClientProps);
+
+        NewTopic newTopic = new NewTopic(PartitionTestReceptionBean.CHANNEL_NAME, 2, (short) 1);
+        adminClient.createTopics(Collections.singleton(newTopic)).all().get(KafkaPartitionTestServlet.TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+        // Create and deploy the app
+        PropertiesAsset appConfig = new PropertiesAsset()
+                        .addProperty(AbstractKafkaTestServlet.KAFKA_BOOTSTRAP_PROPERTY, kafkaContainer.getBootstrapServers())
+                        .include(ConnectorProperties.simpleIncomingChannel(kafkaContainer, PartitionTestReceptionBean.CHANNEL_NAME, KafkaPartitionTestServlet.APP_GROUPID));
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackage(KafkaTestClient.class.getPackage())
+                        .addPackage(KafkaPartitionTestServlet.class.getPackage())
+                        .addAsLibraries(KafkaUtils.kafkaClientLibs())
+                        .addAsManifestResource(KafkaUtils.kafkaPermissions(), "permissions.xml")
+                        .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void shutdown() throws Exception {
+        server.stopServer();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/KafkaPartitionTestServlet.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions;
+
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions.PartitionTestReceptionBean.CHANNEL_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.SimpleKafkaReader;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.SimpleKafkaWriter;
+
+@WebServlet("/KafkaPartitionTest")
+public class KafkaPartitionTestServlet extends AbstractKafkaTestServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String APP_GROUPID = "kafka-partition-test-group";
+    public static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+    @Inject
+    @ConfigProperty(name = KAFKA_BOOTSTRAP_PROPERTY)
+    private String kafkaBootstrap;
+
+    @Inject
+    private PartitionTestReceptionBean receptionBean;
+
+    /**
+     * Tests Kafka connector having partitions assigned and unassigned
+     * <p>
+     * In a microservices environment, the connector needs to cope correctly with new readers coming and going, which results in the broker assigning and unassigning partitions
+     * from it.
+     * <p>
+     * Outline of the test:
+     * <ul>
+     * <li> A topic with two partitions has already been set up.</li>
+     * <li>Initially the reactive messaging kafka connector should be subscribed to both, delivering all messages to the receptionBean.</li>
+     * <li>We start an additional test reader, reading from the same topic with the same consumer group ID as the kafka connector. This simulates another copy of the application
+     * starting and having one of the partitions assigned</li>
+     * <li>We assert that one of the partitions remains assigned to the kafka connector, while the other is assigned to our test reader</li>
+     * <li>We write messages to each partition, check they are delivered and that the partition offset is advanced correctly.</li>
+     * <li>We close the test writer, expecting that the kafka broker will now assign both partitions to the kafka connector.</li>
+     * <li>We write messages to each each partition and check that they are all delivered to the receptionBean and that the offsets of both partitions are advanced correctly.</li>
+     * </ul>
+     */
+    @Test
+    public void testPartitionRemovedAndAdded() throws Exception {
+        // Subscribe a new test reader in the same consumer group which auto-commits offsets
+        Map<String, Object> consumerConfig = new HashMap<>();
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, APP_GROUPID);
+        consumerConfig.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        SimpleKafkaReader<String> reader = kafkaTestClient.readerFor(consumerConfig, CHANNEL_NAME);
+
+        List<PartitionInfo> allPartitions = reader.getConsumer().partitionsFor(CHANNEL_NAME);
+
+        // Assert that the new reader is assigned one partition
+        Duration elapsed = Duration.ZERO;
+        long startTime = System.nanoTime();
+        Set<TopicPartition> assignedPartitions = Collections.emptySet();
+        while (elapsed.compareTo(TIMEOUT) < 0 && assignedPartitions.size() != 1) {
+            reader.getConsumer().poll(Duration.ZERO); // Kafka doesn't process partition assignment unless we poll
+            assignedPartitions = reader.getConsumer().assignment();
+            Thread.sleep(100);
+            elapsed = Duration.ofNanos(System.nanoTime() - startTime);
+        }
+        assertThat(assignedPartitions, hasSize(1));
+
+        // Work out which partition is now assigned to the test reader, and which should still be assigned to the reception bean
+        int testReaderPartitionId = assignedPartitions.iterator().next().partition();
+        int receptionBeanPartitionId = -1;
+        for (PartitionInfo p : allPartitions) {
+            if (p.partition() != testReaderPartitionId) {
+                receptionBeanPartitionId = p.partition();
+                break;
+            }
+        }
+
+        // We want to check that the offset is advanced correctly later, so take a baseline now
+        long testReaderPartitionOffset = kafkaTestClient.getTopicOffset(CHANNEL_NAME, testReaderPartitionId, APP_GROUPID);
+        long receptionBeanPartitionOffset = kafkaTestClient.getTopicOffset(CHANNEL_NAME, receptionBeanPartitionId, APP_GROUPID);
+
+        // Send a message to the partition assigned to the test reader and check the new reader receives it and advances the partition offset
+        SimpleKafkaWriter<String> writer = kafkaTestClient.writerFor(CHANNEL_NAME);
+        writer.sendMessage("test1", testReaderPartitionId, TIMEOUT);
+        List<String> testMessagesRead = reader.waitForMessages(1, TIMEOUT);
+        assertThat(testMessagesRead, contains("test1"));
+
+        // Send a message to the partition not assigned to the test reader and check that the bean receives it and advances the partition offset
+        writer.sendMessage("test2", receptionBeanPartitionId, TIMEOUT);
+        List<Message<String>> beanMessagesRead = receptionBean.getReceivedMessages(1, TIMEOUT);
+        List<String> beanMessagePayloads = beanMessagesRead.stream().map(Message::getPayload).collect(Collectors.toList());
+        beanMessagesRead.forEach(Message::ack);
+        assertThat(beanMessagePayloads, contains("test2"));
+        kafkaTestClient.assertTopicOffsetAdvancesTo(receptionBeanPartitionOffset + 1, TIMEOUT, CHANNEL_NAME, receptionBeanPartitionId, APP_GROUPID);
+
+        // Close the test reader
+        reader.close();
+
+        // With AUTO_COMMIT_CONFIG, we don't have control over when Kafka commits the partition offset for us
+        // but it should happen once we've closed the reader
+        kafkaTestClient.assertTopicOffsetAdvancesTo(testReaderPartitionOffset + 1, TIMEOUT, CHANNEL_NAME, testReaderPartitionId, APP_GROUPID);
+
+        // Send a message to each partition and check that the bean receives both of them and advances the offset of both partitions
+        writer.sendMessage("test3", testReaderPartitionId, TIMEOUT);
+        writer.sendMessage("test4", receptionBeanPartitionId, TIMEOUT);
+
+        // If the reception of these messages interacts with kafka partition reassignment, we may get duplicate messages which makes this check more complex :(
+        elapsed = Duration.ZERO;
+        startTime = System.nanoTime();
+        boolean done = false;
+        long testReaderFinalOffset = 0;
+        long receptionBeanFinalOffset = 0;
+        Set<String> messagePayloads = new HashSet<>();
+        // Loop, polling and checking offsets, until we see the topic offsets advance
+        while (elapsed.compareTo(TIMEOUT) < 0 && !done) {
+            List<Message<String>> newMessages = receptionBean.getReceivedMessages();
+            for (Message<String> m : newMessages) {
+                messagePayloads.add(m.getPayload());
+                m.ack();
+            }
+
+            testReaderFinalOffset = kafkaTestClient.getTopicOffset(CHANNEL_NAME, testReaderPartitionId, APP_GROUPID);
+            receptionBeanFinalOffset = kafkaTestClient.getTopicOffset(CHANNEL_NAME, receptionBeanPartitionId, APP_GROUPID);
+            if (testReaderFinalOffset == testReaderPartitionOffset + 2 && receptionBeanFinalOffset == receptionBeanPartitionOffset + 2) {
+                done = true;
+            }
+
+            elapsed = Duration.ofNanos(System.nanoTime() - startTime);
+            Thread.sleep(100);
+        }
+
+        // Check we got the right messages (using a set to ignore duplicates)
+        assertThat(messagePayloads, containsInAnyOrder("test3", "test4"));
+        assertEquals("Test reader partition offset did not advance correctly", testReaderPartitionOffset + 2, testReaderFinalOffset);
+        assertEquals("Reception bean partition offset did not advance correctly", receptionBeanPartitionOffset + 2, receptionBeanFinalOffset);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/PartitionTestReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/PartitionTestReceptionBean.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment.Strategy;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractReceptionBean;
+
+@ApplicationScoped
+public class PartitionTestReceptionBean extends AbstractReceptionBean {
+
+    public static final String CHANNEL_NAME = "partition-test-incoming-topic";
+
+    @Incoming(CHANNEL_NAME)
+    @Acknowledgment(Strategy.MANUAL)
+    @Override
+    public CompletionStage<Void> recieveMessage(Message<String> msg) {
+        return super.recieveMessage(msg);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/FATSuite.java
@@ -18,6 +18,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.testcontainers.containers.KafkaContainer;
 
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.delivery.KafkaAcknowledgementTest;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions.KafkaPartitionTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.serializer.KafkaCustomSerializerTest;
 
 import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
@@ -27,9 +28,9 @@ import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
                 BasicReactiveMessagingTest.class,
                 KafkaMessagingTest.class,
                 KafkaAcknowledgementTest.class,
-                KafkaCustomSerializerTest.class
+                KafkaCustomSerializerTest.class,
+                KafkaPartitionTest.class,
 })
-
 public class FATSuite {
 
     @ClassRule

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/permissions.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/permissions.xml
@@ -34,4 +34,11 @@
        <actions>connect</actions>
      </permission>
      
+     <!-- Kafka client loads serializers and deserializers by name -->
+     <permission>
+       <class-name>java.lang.RuntimePermission</class-name>
+       <name>getClassLoader</name>
+       <actions>*</actions>
+     </permission>
+     
 </permissions>


### PR DESCRIPTION
This FAT test verifies that the incoming reactive messaging Kafka connector correctly handles having partitions assigned and revoked by the broker.

Fixes #8229 