### PR TITLE
Pass userid for single token deletes in usersTokenManagement

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/apiUtils.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/apiUtils.js
@@ -74,13 +74,13 @@ var apiUtils = (function() {
         return deferred;
     };
 
-    var deleteAcctAppPasswordToken = function(authID, authType) {
+    var deleteAcctAppPasswordToken = function(authID, authType, userID) {
         __initOauthProvider(); 
         var deferred = new $.Deferred();
         var authTypes = authType + 's';
 
         $.ajax({
-            url: "/oidc/endpoint/" + oauthProvider + "/" + authTypes + "/" + authID,
+            url: "/oidc/endpoint/" + oauthProvider + "/" + authTypes + "/" + authID + "?user_id=" + encodeURIComponent(userID),
             type: "DELETE",
             contentType: "application/x-www-form-urlencoded",
             headers: {
@@ -122,14 +122,14 @@ var apiUtils = (function() {
         return deferred;
     };
 
-    var deleteSelectedAppPasswordsTokens = function(authID, authType, name) {
+    var deleteSelectedAppPasswordsTokens = function(authID, authType, name, userID) {
         __initOauthProvider();
 
         var deferred = new $.Deferred();
         var authTypes = authType + 's';
 
         $.ajax({
-            url: "/oidc/endpoint/" + oauthProvider + "/" + authTypes + "/" + authID,
+            url: "/oidc/endpoint/" + oauthProvider + "/" + authTypes + "/" + authID + "?user_id=" + encodeURIComponent(userID),
             type: "DELETE",
             contentType: "application/x-www-form-urlencoded",
             headers: {

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
@@ -276,7 +276,7 @@ var table = (function() {
         $deleteDlg.find('.tool_modal_delete_button').off('click');
         $deleteDlg.find('.tool_modal_delete_button').on('click', function() {
             utils.startProcessingSpinner('delete_processing');
-           __deletePWorToken(authID, name, type);
+           __deletePWorToken(authID, name, type, userID);
         });
 
         $deleteDlg.removeClass('hidden');
@@ -320,9 +320,10 @@ var table = (function() {
      * @param String authID - unique ID for this app-password/app-token
      * @param String name - given name for this authentication (app-password/app-token)
      * @param String authType - 'app-password' or 'app-token'
+     * @param String userID - owner id of this authentication
      */
-    var __deletePWorToken = function(authID, name, authType) {
-        apiUtils.deleteAcctAppPasswordToken(authID, authType).done(function() {
+    var __deletePWorToken = function(authID, name, authType, userID) {
+        apiUtils.deleteAcctAppPasswordToken(authID, authType, userID).done(function() {
             deleteTableRow(authID);
             // Stop the processing spinner
             utils.stopProcessingSpinner();
@@ -399,7 +400,13 @@ var table = (function() {
         });
     };
 
-    var __deleteSelectedAuthentications = function() {
+    /**
+     * Delete selected app-passwords and app-tokens for this user and remove all
+     * associated rows from the table.
+     * 
+     * @param String userID - owner of the authentications shown in the table.
+     */
+    var __deleteSelectedAuthentications = function(userID) {
         // Get the selected rows
         var $table = $('#' + tableId + ' tbody');
         var $rows = $table.find('tr');
@@ -412,7 +419,7 @@ var table = (function() {
             var name = $(this).find('td.authName').text();
             var authType = $(this).find('td.authType').text();
             
-            delDeferreds.push(apiUtils.deleteSelectedAppPasswordsTokens(authID, authType, name));
+            delDeferreds.push(apiUtils.deleteSelectedAppPasswordsTokens(authID, authType, name, userID));
         });
 
         // $.when executes a callback based on zero or more Thenable objects.  Pass all the deferreds
@@ -528,7 +535,7 @@ var table = (function() {
                 $deleteDlg.find('.tool_modal_delete_button').off('click');
                 $deleteDlg.find('.tool_modal_delete_button').on('click', function() {
                     utils.startProcessingSpinner('delete_processing');
-                    __deleteSelectedAuthentications();
+                    __deleteSelectedAuthentications(userID);
                 });
             }
 


### PR DESCRIPTION
When a user with tokenManager role is logged in to the usersTokenManagement application they need to be able to delete app-passwords and app-tokens for other users.  In order for this to be successful, pass the user_id of the owner of the app-password or app-token to be deleted.