### PR TITLE
Don't use translated label for values in selection lists or radio button groups.

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/clientInputDialog.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/clientInputDialog.js
@@ -498,7 +498,7 @@ var clientInputDialog = (function() {
                 "               <div class='tool_multiSelect_menuItem_option'>" +
                 "                   <div class='tool_checkbox_wrapper'>" +
                 "                       <input id='" + optionId + "' class='tool_checkbox' type='checkbox' value='" + option.value + "'>" +
-                "                       <label class='tool_checkbox_label' for='" + optionId + "'>" + option.label + "</label>" +
+                "                       <label class='tool_checkbox_label' for='" + optionId + "'>" + option.value + "</label>" +
                 "                   </div>" +
                 "               </div>" + 
                 "           </div>";
@@ -534,7 +534,7 @@ var clientInputDialog = (function() {
                 "       <input id='" + optionId + "' class='tool_modal_radio_button' type='radio' name='" + fldId + "' value='" + option.value + "' data-default=" + defaultValue + "></input>" +
                 "       <label for='" + optionId + "' class='tool_modal_radio_button_label'>" +
                 "           <span class='tool_modal_radio_button_appearance'></span>" + 
-                "           " + option.label + 
+                "           " + option.value + 
                 "       </label>";
         }
 


### PR DESCRIPTION
In the add/edit OAuth client dialog in the OIDC clientManagement application, the OIDC client registration attributes that are formatted as multi-selection dropdown lists or radio button groups are displayed with api defined values to select from.   The values are retrieved from the oidc/endpoint/OP/clientMetatype where they are defined with a 'value' and 'label'.  The 'label' is a translated value.  However, we don't want to show the 'label' since the 'value' is what is known to the API and defined in the OAuth client registration API documentation (see https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/twlp_client_registration.html).   Therefore, update the code to show the 'value' on the screen, not the 'label' for these widgets.