### PR TITLE
Performance updates

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -246,7 +246,7 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
         return sharedClassCacheURL;
     }
 
-    private static byte[] getClassBytesFromHook(UniversalContainer.UniversalResource resource, String className, String resourceName, ClassLoaderHook hook) {
+    static byte[] getClassBytesFromHook(UniversalContainer.UniversalResource resource, String className, String resourceName, ClassLoaderHook hook) {
         byte[] bytes = null;
         if (hook != null) {
             final URL resourceURL = resource.getResourceURL("jar");

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ShadowClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ShadowClassLoader.java
@@ -126,6 +126,10 @@ class ShadowClassLoader extends IdentifiedLoader {
     protected Class<?> findClass(final String name) throws ClassNotFoundException {
         final ByteResourceInformation classBytesResourceInformation = shadowedLoader.findClassBytes(name);
 
+        if (classBytesResourceInformation == null) {
+            throw new ClassNotFoundException(name);
+        }
+
         // Now define a package for this class if it has one
         int lastDotIndex = name.lastIndexOf('.');
         if (lastDotIndex != -1) {

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
@@ -15,6 +15,7 @@ import static com.ibm.ws.classloading.internal.TestUtil.createAppClassloader;
 import static com.ibm.ws.classloading.internal.TestUtil.getClassLoadingService;
 import static com.ibm.ws.classloading.internal.TestUtil.getOtherClassesURL;
 import static com.ibm.ws.classloading.internal.TestUtil.getServletJarURL;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -54,12 +55,7 @@ public class LibertyClassLoaderTest {
 
     @Test
     public void testClassNotFound() {
-        try {
-            loader.findClassBytes("non.existent.Class");
-            fail("call should have thrown an exception");
-        } catch (ClassNotFoundException e) {
-            assertTrue("Should have thrown exception for non.existent.Class, but exception was:" + e, e.getMessage().contains("non.existent.Class"));
-        }
+        assertNull(loader.findClassBytes("non.existent.Class"));
     }
 
     @Test

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/java2sec/PermissionManagerTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/java2sec/PermissionManagerTest.java
@@ -72,7 +72,7 @@ public class PermissionManagerTest {
     @SuppressWarnings("unchecked")
     private final ServiceReference<URLStreamHandlerService> urlStreamHandlerServiceRef = mock.mock(ServiceReference.class, "urlStreamHandlerServiceRef");
 
-    private PermissionManager permissionManager = new PermissionManager();
+    private PermissionManager permissionManager = new PermissionManager(true);
     private final ComponentContext componentContext = mock.mock(ComponentContext.class);
     private final BundleContext bundleContext = mock.mock(BundleContext.class);
     private final ClassLoadingService classLoadingService = mock.mock(ClassLoadingService.class, "classLoadingService");
@@ -90,10 +90,10 @@ public class PermissionManagerTest {
         withSystemBundleAndCapabilities();
 
         savedPolicy = Policy.getPolicy();
-        permissionManager = new PermissionManager();
+        permissionManager = new PermissionManager(true);
         permissionManager.setWsjarURLStreamHandler(urlStreamHandlerServiceRef);
         permissionManager.setClassLoadingService(classLoadingService);
-        permissionManager.activate(componentContext, null);
+        permissionManager.activate(componentContext);
     }
 
     private void inServerProcess() {
@@ -273,7 +273,7 @@ public class PermissionManagerTest {
 
     @Test
     public void activateDeactivateSetsAndRemovesSelfInWLPDynamicPolicy() throws Exception {
-        final PermissionManager anotherPermissionManager = new PermissionManager();
+        final PermissionManager anotherPermissionManager = new PermissionManager(true);
         Policy.setPolicy(wlpDynamicPolicy);
         mock.checking(new Expectations() {
             {
@@ -284,7 +284,7 @@ public class PermissionManagerTest {
 
         withSharedLibraryProtectionDomains();
         anotherPermissionManager.setClassLoadingService(classLoadingService);
-        anotherPermissionManager.activate(componentContext, null);
+        anotherPermissionManager.activate(componentContext);
         anotherPermissionManager.deactivate(componentContext);
     }
 
@@ -387,7 +387,7 @@ public class PermissionManagerTest {
         }
 
         permissionManager.deactivate(componentContext);
-        permissionManager.activate(componentContext, null);
+        permissionManager.activate(componentContext);
     }
 
     private void usesBundleClassLoaderToLoadPermissionClass(final String bundlePermissionClassName) throws ClassNotFoundException {

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/VariableEvaluator.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/VariableEvaluator.java
@@ -243,7 +243,8 @@ public class VariableEvaluator {
         if (rawValue instanceof List) {
             List<Object> returnList = new ArrayList<Object>();
             List<Object> values = (List<Object>) rawValue;
-            for (Object o : values) {
+            for (int i = 0, size = values.size(); i < size; ++i) {
+                Object o = values.get(i);
                 Object processed = processVariableLists(o, attributeDef, context, ignoreWarnings);
                 if (processed instanceof List)
                     returnList.addAll((List<Object>) processed);

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/permissions/PermissionsAdapter.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/permissions/PermissionsAdapter.java
@@ -10,13 +10,9 @@
  *******************************************************************************/
 package com.ibm.ws.javaee.ddmodel.permissions;
 
-import org.osgi.framework.ServiceReference;
-import org.osgi.framework.Version;
-
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.javaee.dd.permissions.PermissionsConfig;
 import com.ibm.ws.javaee.ddmodel.DDParser.ParseException;
-import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.wsspi.adaptable.module.Container;
 import com.ibm.wsspi.adaptable.module.Entry;
 import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
@@ -28,21 +24,6 @@ import com.ibm.wsspi.artifact.overlay.OverlayContainer;
  *
  */
 public final class PermissionsAdapter implements ContainerAdapter<PermissionsConfig> {
-
-    private ServiceReference<JavaEEVersion> versionRef;
-    private volatile Version platformVersion = JavaEEVersion.DEFAULT_VERSION;
-
-    public synchronized void setVersion(ServiceReference<JavaEEVersion> reference) {
-        versionRef = reference;
-        platformVersion = Version.parseVersion((String) reference.getProperty("version"));
-    }
-
-    public synchronized void unsetVersion(ServiceReference<JavaEEVersion> reference) {
-        if (reference == this.versionRef) {
-            versionRef = null;
-            platformVersion = JavaEEVersion.DEFAULT_VERSION;
-        }
-    }
 
     @FFDCIgnore(ParseException.class)
     @Override

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -187,11 +187,11 @@ public class FrameworkManager {
      * Create and launch the OSGi framework
      *
      * @param config
-     *                        BootstrapConfig object encapsulating active initial framework
-     *                        properties
+     *            BootstrapConfig object encapsulating active initial framework
+     *            properties
      * @param logProvider
-     *                        The initialized/active log provider that must be included in
-     *                        framework management activities (start/stop/.. ), or null
+     *            The initialized/active log provider that must be included in
+     *            framework management activities (start/stop/.. ), or null
      * @param callback
      */
     public void launchFramework(BootstrapConfig config, LogProvider logProvider) {
@@ -472,9 +472,9 @@ public class FrameworkManager {
      * launch the platform/runtime.
      *
      * @param systemBundleCtx
-     *                            The framework system bundle context
+     *            The framework system bundle context
      * @param config
-     *                            The active bootstrap config
+     *            The active bootstrap config
      */
     private void registerLibertyProcessService(BundleContext systemBundleCtx, BootstrapConfig config) {
         List<String> cmds = config.getCmdArgs();
@@ -489,7 +489,7 @@ public class FrameworkManager {
      * Register the instrumentation class as a service in the OSGi registry
      *
      * @param systemBundleCtx
-     *                            The framework system bundle context
+     *            The framework system bundle context
      */
     protected void registerInstrumentationService(BundleContext systemContext) {
         Instrumentation inst = config.getInstrumentation();
@@ -507,7 +507,7 @@ public class FrameworkManager {
      * Register the PauseableComponentController class as a service in the OSGi registry
      *
      * @param systemBundleCtx
-     *                            The framework system bundle context
+     *            The framework system bundle context
      */
     protected void registerPauseableComponentController(BundleContext systemContext) {
         PauseableComponentControllerImpl pauseableComponentController = new PauseableComponentControllerImpl(systemContext);
@@ -890,11 +890,11 @@ public class FrameworkManager {
      * the elapsed time, in milliseconds, to format
      *
      * @param factor
-     *                   If true, the elapsed time will be factored into more detailed
-     *                   units: days/hours/minutes/seconds
-     *                   The decimal format of the seconds is #.### or #.## or #.# or # or 0
-     *                   If false it will be returned as the total of seconds
-     *                   The decimal format of the seconds is #.### or #.## or #.# or # or 0
+     *            If true, the elapsed time will be factored into more detailed
+     *            units: days/hours/minutes/seconds
+     *            The decimal format of the seconds is #.### or #.## or #.# or # or 0
+     *            If false it will be returned as the total of seconds
+     *            The decimal format of the seconds is #.### or #.## or #.# or # or 0
      *
      * @return A String containing the formatted elapsed time.
      *         Examples when the English language 'en' is the 'Locale':
@@ -905,9 +905,6 @@ public class FrameworkManager {
      */
     protected String getElapsedTime(boolean factor, long... testMilliseconds) {
         long elapsedTime;
-        String info_days = BootstrapConstants.messages.getString("info.days");
-        String info_hours = BootstrapConstants.messages.getString("info.hours");
-        String info_minutes = BootstrapConstants.messages.getString("info.minutes");
         String info_seconds = BootstrapConstants.messages.getString("info.seconds");
 
         if (testMilliseconds.length == 0) {
@@ -940,16 +937,22 @@ public class FrameworkManager {
             // losing some accuracy when we convert between 'Long' & 'Double'.
             long days = mod / dayMillis;
             mod = mod % dayMillis;
-            if (days > 0)
+            if (days > 0) {
+                String info_days = BootstrapConstants.messages.getString("info.days");
                 timeString.append(MessageFormat.format(info_days, days)).append(", ");
+            }
             long hours = mod / hourMillis;
             mod = mod % hourMillis;
-            if (hours > 0)
+            if (hours > 0) {
+                String info_hours = BootstrapConstants.messages.getString("info.hours");
                 timeString.append(MessageFormat.format(info_hours, hours)).append(", ");
+            }
             long minutes = mod / minuteMillis;
             mod = mod % minuteMillis;
-            if (minutes > 0)
+            if (minutes > 0) {
+                String info_minutes = BootstrapConstants.messages.getString("info.minutes");
                 timeString.append(MessageFormat.format(info_minutes, minutes)).append(", ");
+            }
             double seconds = mod / secMillis;
             mod = mod % (long) secMillis;
             if (mod == 0)
@@ -1068,9 +1071,9 @@ public class FrameworkManager {
      * server status from them.
      *
      * @param timestamp
-     *                            Create a unique dump folder based on the time stamp string.
+     *            Create a unique dump folder based on the time stamp string.
      * @param javaDumpActions
-     *                            The java dumps to create, or null for the default set.
+     *            The java dumps to create, or null for the default set.
      */
     public void introspectFramework(String timestamp, Set<JavaDumpAction> javaDumpActions) {
         Tr.audit(tc, "info.introspect.request.received");

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
@@ -117,7 +117,6 @@ public class FeatureDefinitionUtils {
         final File featureFile;
         final long lastModified;
         final long length;
-        public File checksumFile;
 
         ImmutableAttributes(String repoType,
                             String symbolicName,
@@ -155,9 +154,6 @@ public class FeatureDefinitionUtils {
             this.isSingleton = isSingleton;
 
             this.featureFile = featureFile;
-            if (featureFile != null) {
-                this.checksumFile = new File(featureFile.getParentFile(), "checksums/" + symbolicName + ".cs");
-            }
             this.lastModified = lastModified;
             this.length = fileSize;
         }
@@ -188,6 +184,13 @@ public class FeatureDefinitionUtils {
 
                 return s.toString();
             }
+        }
+
+        File getChecksumFile() {
+            if (featureFile == null) {
+                return null;
+            }
+            return new File(featureFile.getParentFile(), "checksums/" + symbolicName + ".cs");
         }
 
         File getLocalizationDirectory() {
@@ -259,7 +262,7 @@ public class FeatureDefinitionUtils {
      * manifest.
      *
      * @param details ManifestDetails containing manifest parser and accessor methods
-     *                    for retrieving information from the manifest.
+     *            for retrieving information from the manifest.
      * @return new ImmutableAttributes
      */
     static ImmutableAttributes loadAttributes(String repoType, File featureFile, ProvisioningDetails details) throws IOException {

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/SubsystemFeatureDefinitionImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/SubsystemFeatureDefinitionImpl.java
@@ -76,7 +76,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
     /**
      * Create a new subsystem definition with the specified immutable attributes.
      * Called when rebuilding from a cache.
-     * 
+     *
      * @param attr Immutable attributes
      * @param details Provisioning details (will be cleared when provisioning operation is complete)
      * @see #load(String, SubsystemFeatureDefinitionImpl)
@@ -98,7 +98,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
      * backing manifest file is (e.g. we're reading an entry from a zip).
      * <p>
      * Some operations, like finding resource bundles, may not work.
-     * 
+     *
      * @param repoType emtpy/null for core, "usr" for user extension, or the product
      *            extension name
      * @param inputStream The input stream to read from
@@ -119,11 +119,11 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
     /**
      * Create a new subsystem definition by reading information from the
      * specified input stream.
-     * 
+     *
      * @param repoType emtpy/null for core, "usr" for user extension, or the product
      *            extension name
      * @param file Subsystem feature definition manifest file
-     * 
+     *
      * @see ExtensionConstants#CORE_EXTENSION
      * @see ExtensionConstants#USER_EXTENSION
      * @see #load(String, File, InputStream)
@@ -149,7 +149,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
     /**
      * Set the provisioning details: used when preparing existing subsystem definition
      * for provisioning operation
-     * 
+     *
      * @param details reconstituted provisioning details
      */
     @Trivial
@@ -178,7 +178,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
 
     @Override
     public File getFeatureChecksumFile() {
-        return iAttr.checksumFile;
+        return iAttr.getChecksumFile();
     }
 
     @Override
@@ -268,10 +268,10 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
     protected ResourceBundle getResourceBundle(Locale locale) {
         File dir = iAttr.getLocalizationDirectory();
 
-        //KEEP IN SYNC WITH getLocalizationFiles !!!        
+        //KEEP IN SYNC WITH getLocalizationFiles !!!
         File[] files = new File[] { new File(dir, iAttr.symbolicName + "_" + locale.toString() + ".properties"),
-                                   new File(dir, iAttr.symbolicName + "_" + locale.getLanguage() + ".properties"),
-                                   new File(dir, iAttr.symbolicName + ".properties") };
+                                    new File(dir, iAttr.symbolicName + "_" + locale.getLanguage() + ".properties"),
+                                    new File(dir, iAttr.symbolicName + ".properties") };
 
         for (File file : files) {
             if (file.exists()) {
@@ -302,7 +302,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
         try {
             return mfDetails.getMainAttributeValue(header);
         } catch (IOException e) {
-            // We should be well beyond any IOException issues obtaining the manifest.. 
+            // We should be well beyond any IOException issues obtaining the manifest..
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "IOException reading manifest attribute from {0}: {1}", iAttr.featureFile, e);
             }
@@ -321,7 +321,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
 
         // If this is a localizable header that indicates it wants to be localized...
         if (value.charAt(0) == '%' && FeatureDefinitionUtils.LOCALIZABLE_HEADERS.contains(header)) {
-            // Find the resource bundle... 
+            // Find the resource bundle...
             ResourceBundle rb = getResourceBundle(locale);
             if (rb != null) {
                 // Find the new value in the resource bundle
@@ -388,7 +388,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.kernel.feature.FeatureDefinition#isCapabilitySatified(java.util.Collection)
      */
     @Override
@@ -419,7 +419,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
                 if (!satisfiedFeatureDefs.contains(featureDef)) {
 
                     // We have a mismatch between the key the filter is using to look up the feature name and the property containing the name in the
-                    // headers. So we need to add a new property for osgi.identity (filter key) that contains the value of the 
+                    // headers. So we need to add a new property for osgi.identity (filter key) that contains the value of the
                     // Subsystem-SymbolicName (manifest header).
                     // We also have to do this for the Subsystem-Type(manifest header) and the type (filter key).
                     Map<String, String> filterProps = new HashMap<String, String>();
@@ -429,7 +429,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
                         filterProps.put(FeatureDefinitionUtils.FILTER_TYPE_KEY,
                                         mfDetails.getMainAttributeValue(FeatureDefinitionUtils.TYPE));
                     } catch (IOException e) {
-                        // We should be well beyond any IOException issues.. 
+                        // We should be well beyond any IOException issues..
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Tr.debug(tc, "IOException reading manifest attribute from {0}: {1}", iAttr.featureFile, e);
                         }
@@ -442,7 +442,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
                     }
                 }
             }
-            // Once we've checked all the FeatureDefinitions, apply the result to the isCapabilitySatisfied boolean, 
+            // Once we've checked all the FeatureDefinitions, apply the result to the isCapabilitySatisfied boolean,
             // so we stop processing as soon as we know we don't have a match.
             isCapabilitySatisfied = featureMatch;
         }
@@ -466,7 +466,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition#getIconFiles()
      */
     @Override
@@ -486,7 +486,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.wsspi.kernel.feature.LibertyFeature#getBundles()
      */
     @Override
@@ -503,7 +503,7 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
 
             BundleContext ctx = FrameworkUtil.getBundle(FrameworkUtil.class).getBundleContext();
 
-            // symbolic name to bundle map. 
+            // symbolic name to bundle map.
             for (FeatureResource bundle : bundlesInFeature) {
                 String location = bundle.getLocation();
                 Bundle b = ctx.getBundle(location);

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/PathUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/PathUtils.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -43,17 +42,7 @@ public class PathUtils {
      * if system property "os.name" contains the text "windows" (using a case-insensitive
      * test). Used by {@link #fixPathString(File)} and related methods.
      */
-    private static final boolean isWindows;
-
-    static {
-        isWindows = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-            @Override
-            public Boolean run() {
-                return System.getProperty("os.name", "unknown").toUpperCase(Locale.ENGLISH).contains("WINDOWS");
-            }
-
-        });
-    }
+    private static final boolean isWindows = System.getProperty("os.name", "unknown").toUpperCase(Locale.ENGLISH).contains("WINDOWS");
 
     /**
      * Pattern used to determine if a URI is an absolute URI.

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/Tr.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/Tr.java
@@ -27,6 +27,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import com.ibm.websphere.ras.annotation.TraceOptions;
 import com.ibm.ws.logging.internal.TraceNLSResolver;
 import com.ibm.ws.logging.internal.TraceSpecification;
+import com.ibm.ws.logging.internal.TraceSpecification.TraceElement;
 import com.ibm.wsspi.logprovider.TrService;
 
 /**
@@ -117,11 +118,21 @@ import com.ibm.wsspi.logprovider.TrService;
 
 public class Tr {
 
+    static final TraceSpecification defaultTraceSpec;
+
+    static {
+        defaultTraceSpec = new TraceSpecification("", null, false);
+        List<TraceElement> elements = defaultTraceSpec.getSpecs();
+        if (elements.size() == 1) {
+            elements.get(0).setMatched(true);
+        }
+    }
+    
     /**
      * The current active trace specification. Initialize to the default trace
      * specification (should be *=info, but leave that to TraceSpecification).
      */
-    static volatile TraceSpecification activeTraceSpec = new TraceSpecification("", null, false);
+    static volatile TraceSpecification activeTraceSpec = defaultTraceSpec;
 
     /** Set of all trace components */
     static final Set<TraceComponent> allTraceComponents = Collections.newSetFromMap(new WeakHashMap<TraceComponent, Boolean>());
@@ -813,6 +824,10 @@ public class Tr {
                 return;
             }
             activeTraceSpec = spec;
+
+            if (activeTraceSpec != defaultTraceSpec && activeTraceSpec.equals(defaultTraceSpec)) {
+                activeTraceSpec = defaultTraceSpec;
+            }
 
             // update all of the current trace components
             for (TraceComponent t : allTraceComponents) {

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/TrConfigurator.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/TrConfigurator.java
@@ -236,8 +236,11 @@ public class TrConfigurator {
      *            the {@link TraceComponent} that was registered
      */
     static void traceComponentRegistered(TraceComponent tc) {
-        for (TraceComponentChangeListener listener : registeredListeners.get()) {
-            listener.traceComponentRegistered(tc);
+        Set<TraceComponentChangeListener> listeners = registeredListeners.get();
+        if (!listeners.isEmpty()) {
+            for (TraceComponentChangeListener listener : listeners) {
+                listener.traceComponentRegistered(tc);
+            }
         }
     }
 
@@ -249,8 +252,11 @@ public class TrConfigurator {
      *            the {@link TraceComponent} that was updated
      */
     static void traceComponentUpdated(TraceComponent tc) {
-        for (TraceComponentChangeListener listener : registeredListeners.get()) {
-            listener.traceComponentUpdated(tc);
+        Set<TraceComponentChangeListener> listeners = registeredListeners.get();
+        if (!listeners.isEmpty()) {
+            for (TraceComponentChangeListener listener : listeners) {
+                listener.traceComponentUpdated(tc);
+            }
         }
     }
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/DateFormatHelper.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/DateFormatHelper.java
@@ -27,20 +27,21 @@ public class DateFormatHelper {
      */
     private static final String localeDatePattern;
 
+    private static final boolean localeDateFormatInvald;
+
+    private static final boolean isoDateFormatInvalid;
+
     static {
-        String pattern;
-        int patternLength;
-        int endOfSecsIndex;
         // Retrieve a standard Java DateFormat object with desired format.
         DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM);
         if (formatter instanceof SimpleDateFormat) {
             // Retrieve the pattern from the formatter, since we will need to
             // modify it.
             SimpleDateFormat sdFormatter = (SimpleDateFormat) formatter;
-            pattern = sdFormatter.toPattern();
+            String pattern = sdFormatter.toPattern();
             // Append milliseconds and timezone after seconds
-            patternLength = pattern.length();
-            endOfSecsIndex = pattern.lastIndexOf('s') + 1;
+            int patternLength = pattern.length();
+            int endOfSecsIndex = pattern.lastIndexOf('s') + 1;
             StringBuilder newPattern = new StringBuilder(pattern.substring(0, endOfSecsIndex) + ":SSS z");
             if (endOfSecsIndex < patternLength)
                 newPattern.append(pattern.substring(endOfSecsIndex, patternLength));
@@ -49,6 +50,10 @@ public class DateFormatHelper {
         } else {
             localeDatePattern = "dd/MMM/yyyy HH:mm:ss:SSS z";
         }
+
+        localeDateFormatInvald = BurstDateFormat.isFormatInvalid(new SimpleDateFormat(localeDatePattern));
+
+        isoDateFormatInvalid = BurstDateFormat.isFormatInvalid(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
     }
 
     /**
@@ -108,7 +113,7 @@ public class DateFormatHelper {
         }
 
         if (dfs[index] == null) {
-            dfs[index] = new BurstDateFormat(new SimpleDateFormat(useIsoDateFormat ? "yyyy-MM-dd'T'HH:mm:ss.SSSZ" : localeDatePattern));
+            dfs[index] = useIsoDateFormat ? new BurstDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"), isoDateFormatInvalid) : new BurstDateFormat(new SimpleDateFormat(localeDatePattern), localeDateFormatInvald);
         }
 
         return dfs[index].format(timestamp);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -1068,7 +1068,7 @@ private final Map<MessageBodyReader<?>, List<MediaType>> readerMediaTypesMap = n
      * rather than calculating the media types for every provider on every request. If there is a cache miss, we
      * will look up the media types by calling JAXRSUtils.getProviderConsumeTypes(mbr).
      */
-    private static List<MediaType> getSortedProviderConsumeTypes(MessageBodyReader<?> mbr, Map<MessageBodyReader<?>, List<MediaType>> cache) {
+    static List<MediaType> getSortedProviderConsumeTypes(MessageBodyReader<?> mbr, Map<MessageBodyReader<?>, List<MediaType>> cache) {
         List<MediaType> mediaTypes = cache.get(mbr);
         if (mediaTypes == null) {
             mediaTypes = JAXRSUtils.getProviderConsumeTypes(mbr);
@@ -1112,7 +1112,7 @@ private final Map<MessageBodyReader<?>, List<MediaType>> readerMediaTypesMap = n
      * rather than calculating the media types for every provider on every request. If there is a cache miss, we
      * will look up the media types by calling JAXRSUtils.getProviderProduceTypes(mbw).
      */
-    private static List<MediaType> getSortedProviderProduceTypes(MessageBodyWriter<?> mbw, Map<MessageBodyWriter<?>, List<MediaType>> cache) {
+    static List<MediaType> getSortedProviderProduceTypes(MessageBodyWriter<?> mbw, Map<MessageBodyWriter<?>, List<MediaType>> cache) {
         List<MediaType> mediaTypes = cache.get(mbw);
         if (mediaTypes == null) {
             mediaTypes = JAXRSUtils.getProviderProduceTypes(mbw);

--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/LibertyTracingMethodAdapter.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/bci/LibertyTracingMethodAdapter.java
@@ -287,6 +287,12 @@ public class LibertyTracingMethodAdapter extends AbstractRasMethodAdapter<Abstra
     	                                                                                   Type.getType(String.class)}), false);
     	} else {
     	
+                String traceOptionName = getClassAdapter().getClassName();
+                if (traceOptionName != null) {
+                    visitLdcInsn(traceOptionName);
+                } else {
+                    visitInsn(ACONST_NULL);
+                }
     	
 		        visitGetClassForType(Type.getObjectType(getClassAdapter().getClassInternalName()));
 		
@@ -309,6 +315,7 @@ public class LibertyTracingMethodAdapter extends AbstractRasMethodAdapter<Abstra
 		                        TR_TYPE.getInternalName(),
 		                        "register",
 		                        Type.getMethodDescriptor(TRACE_COMPONENT_TYPE, new Type[] {
+		                                                                                   Type.getType(String.class),
 		                                                                                   Type.getType(Class.class),
 		                                                                                   Type.getType(String.class),
 		                                                                                   Type.getType(String.class) }), false);

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/srt/SRTInputStream31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/srt/SRTInputStream31.java
@@ -41,8 +41,8 @@ public class SRTInputStream31 extends SRTInputStream
     private InterChannelCallback callback;
     //The request we use to find out if Async has been started
     private SRTServletRequest31 request;
-    private Object lockObj = new Object() {};
-    private Object completeLockObj = new Object() {};  
+    private final Object lockObj = new Integer(0);
+    private final Object completeLockObj = new Integer(1);  
     private boolean asyncReadOutstanding = false;
     private boolean readLineCall = false;
     private boolean isClosed = false;


### PR DESCRIPTION
- Change SRTInputStream31 to just use Integer's to synchronize on
instead of making an inner class to synchronize on.
- Update trace injection to pass the class name to the Tr.register when
there is only one group just like we do when there are multiple groups
- Update TrConfigurator to not create an Iterator for when there aren't
any TraceComponentChangeListeners.
- Change feature cache data to lazily get the checksum file information
since it isn't needed at server startup
- Change to not process permissions when Java 2 security is not enabled
- Change to only process if a DateFormat is invalid once in a static
initializer instead of each time a BurstDateFormat is created
- Update to do less processing when the trace spec is the default of
*=info
- Update VariableEvaluator to not new up an iterator when processing a
List and instead to use List.get(index)
- Do not process kernel feature files when we are using feature definitions 
from cache.  The kernel features are only used when there are new features 
from the last start or it is a fresh start with no cache.