### PR TITLE
Update eclipse settings for new components

### DIFF
--- a/dev/com.ibm.websphere.appserver.jsfApiStub-2.2/.classpath
+++ b/dev/com.ibm.websphere.appserver.jsfApiStub-2.2/.classpath
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test" output="bin_test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.websphere.appserver.jsfApiStub-2.2/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.websphere.appserver.jsfApiStub-2.2/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.websphere.appserver.jsfApiStub-2.3/.classpath
+++ b/dev/com.ibm.websphere.appserver.jsfApiStub-2.3/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.websphere.appserver.jsfApiStub-2.3/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.websphere.appserver.jsfApiStub-2.3/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.websphere.appserver.jsfApiStub-2.3/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.websphere.appserver.jsfApiStub-2.3/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.websphere.appserver.jsfApiStub-2.3/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.jsfApiStub-2.3/bnd.bnd
@@ -17,6 +17,10 @@ Bundle-SymbolicName: com.ibm.ws.org.apache.myfaces.2.3
 Bundle-Version: ${bVersion}.${libertyBundleMicroVersion}.apistub
 Eclipse-ExtensibleAPI: true
 
+javac.source: 1.8
+javac.target: 1.8
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
 publish.wlp.jar.suffix: dev/api/third-party
 
 -exportcontents: \

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/.classpath
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/.classpath
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test" output="bin_test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.classpath
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.project
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.websphere.appserver.thirdparty.cdi-2.0</name>
+	<name>com.ibm.websphere.appserver.thirdparty.jsf-2.3</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1


### PR DESCRIPTION
- Add missing bndtools prefs files.
- Add eclipse compile settings for Java 8 components
- Add .classpath files for new jsf components
- Make jsfAPIStub 2.3 project require Java 8 capability.
- Fix project name in .project file for thirdparty.jsf-2.3 component
- Add test directory to security.oauth component