### PR TITLE
Reestablish key traversal after Regenerate

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
@@ -313,6 +313,8 @@ var table = (function() {
                 // Get the replaced row in the table.
                 $currentTableRow = __getTableRowByName(name, authType);
                 $currentTableRow.addClass("rowMatched");
+                // Row elements were replaced ... so reset the key traversing event handlers.
+                tableUtils.initTableKeyTraversing(tableId, $currentTableRow);
                 __enableRowActions(authData.authID);
 
                 // Row was replaced so switch out the return focus button to the


### PR DESCRIPTION
During 'Regenerate' processing, the contents of the authorization's row in the table is replaced with new contents.   These new cells need to have their event handlers set for keyboard navigation through the table.  Invoke tableUtils.initTableKeyTraversing() to set this up.