### PR TITLE
Block contextual operations from lazily enlisting CDI beans

### DIFF
--- a/dev/com.ibm.ws.cdi.mp.context/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.mp.context/bnd.bnd
@@ -23,7 +23,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 WS-TraceGroup: JCDI
 
 Private-Package:\
-  com.ibm.ws.cdi.mp.context
+  com.ibm.ws.cdi.mp.context.*
 
 -dsannotations: \
   com.ibm.ws.cdi.mp.context.WeldContextProvider

--- a/dev/com.ibm.ws.cdi.mp.context/resources/com/ibm/ws/cdi/mp/context/resources/CDI_MP_CONTEXT.nlsprops
+++ b/dev/com.ibm.ws.cdi.mp.context/resources/com/ibm/ws/cdi/mp/context/resources/CDI_MP_CONTEXT.nlsprops
@@ -1,0 +1,33 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
+#ISMESSAGEFILE TRUE
+#NLS_ENCODING=UNICODE
+#
+#COMPONENTPREFIX CWWKC
+#COMPONENTNAMEFOR CWWKC MicroProfile Context Propagation
+#
+# NLS_MESSAGEFORMAT_VAR
+#
+#   Strings in this file which contain replacement variables are processed by the MessageFormat 
+#   class (single quote must be coded as 2 consecutive single quotes ''). Strings in this file 
+#   which do NOT contain replacement variables are NOT processed by the MessageFormat class 
+#   (single quote must be coded as one single quote '). 
+
+# This message bundle does not have its own message range, and instead reserves specific error messages from the 
+# com.ibm.ws.concurrent.mp.1.0 message bundle
+
+# do not translate: CDI, CompletionStage
+CWWKC1158.cannot.lazy.enlist.beans=CWWKC1158E: CDI beans used in contextual operations, such as a CompletionStage, must be accessed using a CDI bean operation, such as a public \
+method, before context for the operation is captured. The CDI beans that were not accessed before context was captured are: {0}  
+CWWKC1158.cannot.lazy.enlist.beans.explanation=When CDI context is captured, only CDI beans that have been accessed at that point in time have been created by the CDI \
+runtime. As a result, CDI beans that are first accessed in contextual operations cannot propagate their state correctly to subsequent contextual operations.
+CWWKC1158.cannot.lazy.enlist.beans.useraction=The application must be changed to invoke some CDI bean operation, such as a public method, before context for the operation is captured.

--- a/dev/com.ibm.ws.cdi.mp.context/resources/com/ibm/ws/cdi/mp/context/resources/CDI_MP_CONTEXT.nlsprops
+++ b/dev/com.ibm.ws.cdi.mp.context/resources/com/ibm/ws/cdi/mp/context/resources/CDI_MP_CONTEXT.nlsprops
@@ -26,8 +26,9 @@
 # com.ibm.ws.concurrent.mp.1.0 message bundle
 
 # do not translate: CDI, CompletionStage
-CWWKC1158.cannot.lazy.enlist.beans=CWWKC1158E: CDI beans used in contextual operations, such as a CompletionStage, must be accessed using a CDI bean operation, such as a public \
-method, before context for the operation is captured. The CDI beans that were not accessed before context was captured are: {0}  
-CWWKC1158.cannot.lazy.enlist.beans.explanation=When CDI context is captured, only CDI beans that have been accessed at that point in time have been created by the CDI \
-runtime. As a result, CDI beans that are first accessed in contextual operations cannot propagate their state correctly to subsequent contextual operations.
-CWWKC1158.cannot.lazy.enlist.beans.useraction=The application must be changed to invoke some CDI bean operation, such as a public method, before context for the operation is captured.
+CWWKC1158.cannot.lazy.enlist.beans=CWWKC1158E:You must access CDI beans prior to capturing context for the contextual action or task in order for the CDI \
+beans to behave correctly when accessed from the action or task. The following CDI beans must be accessed before capturing context: {0}.
+CWWKC1158.cannot.lazy.enlist.beans.explanation=When CDI context is captured, only CDI beans that have been accessed at that point in time have been created by \
+the CDI runtime. As a result, CDI beans that are first accessed in contextual operations cannot propagate their state correctly to subsequent contextual operations.
+CWWKC1158.cannot.lazy.enlist.beans.useraction=The application must be changed to invoke some CDI bean operation, such as a public method, before context for \
+the operation is captured.

--- a/dev/com.ibm.ws.cdi.mp.context/src/com/ibm/ws/cdi/mp/context/ContextualInstanceSnapshot.java
+++ b/dev/com.ibm.ws.cdi.mp.context/src/com/ibm/ws/cdi/mp/context/ContextualInstanceSnapshot.java
@@ -73,9 +73,16 @@ public class ContextualInstanceSnapshot {
         this.conInstances = conInstances == null ? emptySet() : conInstances;
     }
 
+    public int getBeanCount() {
+        return reqInstances.size() +
+               sesInstances.size() +
+               conInstances.size();
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(super.toString())
+                        .append(" beanCount=" + getBeanCount())
                         .append('\n')
                         .append("RequestScoped instances = ")
                         .append(this.reqInstances)

--- a/dev/com.ibm.ws.cdi.mp.context/src/com/ibm/ws/cdi/mp/context/package-info.java
+++ b/dev/com.ibm.ws.cdi.mp.context/src/com/ibm/ws/cdi/mp/context/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 @Version("1.0.0")
-@TraceOptions(traceGroup = "JCDI")
+@TraceOptions(traceGroup = "JCDI", messageBundle = "com.ibm.ws.cdi.mp.context.resources.CDI_MP_CONTEXT")
 package com.ibm.ws.cdi.mp.context;
 
 import org.osgi.annotation.versioning.Version;

--- a/dev/com.ibm.ws.concurrent.mp.1.0/resources/com/ibm/ws/concurrent/mp/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/resources/com/ibm/ws/concurrent/mp/resources/CWWKCMessages.nlsprops
@@ -49,3 +49,5 @@ CWWKC1156.not.supported.useraction=Update the application to use the method that
 CWWKC1157.cannot.propagate.tx=CWWKC1157E: Propagating transactions to contextual actions and tasks is not supported.
 CWWKC1157.cannot.propagate.tx.explanation=A ManagedExecutor or ThreadContext that is configured to propagate transaction contexts can propagate empty transaction contexts only. Therefore, you cannot create contextual actions and tasks within a transaction.
 CWWKC1157.cannot.propagate.tx.useraction=Create the contextual action or task outside of a transaction. Alternatively, configure the ManagedExecutor or ThreadContext to not propagate transaction contexts.
+
+# CWWKC1158E used by com.ibm.ws.cdi.mp.context bundle

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualRunnable.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualRunnable.java
@@ -58,10 +58,7 @@ class ContextualRunnable implements Runnable, ContextualAction<Runnable> {
             if (threadContextDescriptor != null)
                 contextApplied = threadContextDescriptor.taskStarting();
             action.run();
-        } catch (Error x) {
-            failure = x;
-            throw x;
-        } catch (RuntimeException x) {
+        } catch (Error | RuntimeException x) {
             failure = x;
             throw x;
         } finally {
@@ -69,11 +66,8 @@ class ContextualRunnable implements Runnable, ContextualAction<Runnable> {
                 if (contextApplied != null)
                     threadContextDescriptor.taskStopping(contextApplied);
             } catch (RuntimeException x) {
-                // prioritize surfacing an actual task failure over a failure clearing context
-                if (failure == null) {
-                    failure = x;
-                    throw x;
-                }
+                failure = x;
+                throw x;
             } finally {
                 if (completableFuture != null)
                     if (failure == null)

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualRunnable.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualRunnable.java
@@ -68,6 +68,12 @@ class ContextualRunnable implements Runnable, ContextualAction<Runnable> {
             try {
                 if (contextApplied != null)
                     threadContextDescriptor.taskStopping(contextApplied);
+            } catch (RuntimeException x) {
+                // prioritize surfacing an actual task failure over a failure clearing context
+                if (failure == null) {
+                    failure = x;
+                    throw x;
+                }
             } finally {
                 if (completableFuture != null)
                     if (failure == null)

--- a/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualSupplierAction.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.0/src/com/ibm/ws/concurrent/mp/ContextualSupplierAction.java
@@ -47,16 +47,19 @@ class ContextualSupplierAction<T> implements Runnable {
             if (threadContextDescriptor != null)
                 contextApplied = threadContextDescriptor.taskStarting();
             result = action.get();
-        } catch (Error x) {
+        } catch (RuntimeException x) {
             failure = x;
             throw x;
-        } catch (RuntimeException x) {
+        } catch (Error x) {
             failure = x;
             throw x;
         } finally {
             try {
                 if (contextApplied != null)
                     threadContextDescriptor.taskStopping(contextApplied);
+            } catch (RuntimeException x) {
+                failure = x;
+                throw x;
             } finally {
                 if (failure == null)
                     if (superComplete)

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentCDITest.java
@@ -51,6 +51,6 @@ public class MPConcurrentCDITest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKC1158E"); // expected by testCDIContextPropagationBeanFirstUsedInCompletionStage
     }
 }

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/MPConcurrentCDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentCDIApp/src/concurrent/mp/fat/cdi/web/MPConcurrentCDITestServlet.java
@@ -235,7 +235,7 @@ public class MPConcurrentCDITestServlet extends FATServlet {
             }
         }
         assertTrue("CompletableFuture should have been marked done", cf.isDone());
-        assertTrue("CompletableFuture should have been marked as completex exceptionally", cf.isCompletedExceptionally());
+        assertTrue("CompletableFuture should have been marked as completed exceptionally", cf.isCompletedExceptionally());
     }
 
     /**


### PR DESCRIPTION
Intermediate solution to the MP Context Propagation issue identified here:
https://github.com/eclipse/microprofile-context-propagation/issues/167