### PR TITLE
Add oidcClient dependency on com.ibm.ws.webcontainer.security.provider

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectClient-1.0/com.ibm.websphere.appserver.openidConnectClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectClient-1.0/com.ibm.websphere.appserver.openidConnectClient-1.0.feature
@@ -27,6 +27,7 @@ Subsystem-Name: OpenID Connect Client
   com.ibm.ws.com.google.gson.2.2.4, \
   com.ibm.ws.org.jose4j, \
   com.ibm.ws.org.json.simple.1.1.1, \
+  com.ibm.ws.webcontainer.security.provider, \
   com.ibm.websphere.appserver.api.oidc; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.oidc_1.0-javadoc.zip
 kind=ga


### PR DESCRIPTION
Fixes #8332 

Fixing bundle resolution errors in OL servers containing openidConnectClient-1.0.

#build