### PR TITLE
PR for OIDC provider may get exception using Oracle database

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/db/DetectDatabaseType.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/db/DetectDatabaseType.java
@@ -35,7 +35,7 @@ public interface DetectDatabaseType {
     public enum DBType {
         DB2(true, true),
         CLOUDSCAPE(false, true),
-        ORACLE(true, true),
+        ORACLE(false, true),
         MSSQL(true, true),
         DERBY(false, true),
         POSTGRESQL(false, false),


### PR DESCRIPTION
When using an OIDC provider with an Oracle database, the following exception can be observed during cache cleanup:
java.sql.SQLSyntaxErrorException: ORA-00933: SQL command not properly ended