### PR TITLE
Added delay before modifying files in test case

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -362,6 +362,7 @@ public class TestEnableDisableFeaturesTest {
     	serverEDF10.startServer();
     	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF10.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Remove JAX-WS application ------");
+    	Thread.sleep(4000);
     	boolean rc1 = serverEDF10.removeAndStopDropinsApplications("testJaxWsApp.war");
     	Log.info(c, testName, "------- " + (rc1 ? "successfully removed" : "failed to remove") + " JAX-WS application ------");
     	Assert.assertNotNull("CWWKT0017I NOT FOUND",serverEDF10.waitForStringInLogUsingMark(".*CWWKT0017I.*testJaxWsApp.*"));


### PR DESCRIPTION
Fixes: #263198

#build

Added a small 4s delay after the last server request before attempting to modify file paths within the test case to follow correct practices. Done in parallel with a Windows File Locking fix.