### PR TITLE
Make TimeoutStateImplTest more reliable

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/AsyncBulkheadStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/AsyncBulkheadStateImplTest.java
@@ -40,6 +40,7 @@ import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState.Bulkhea
 import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState.ExceptionHandler;
 import com.ibm.ws.microprofile.faulttolerance20.state.AsyncBulkheadState.ExecutionReference;
 
+@SuppressWarnings("restriction") // Unit test accesses non-exported *PolicyImpl classes
 public class AsyncBulkheadStateImplTest {
 
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/CircuitBreakerStateImplTest.java
@@ -23,6 +23,7 @@ import com.ibm.ws.microprofile.faulttolerance.utils.DummyMetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance20.impl.MethodResult;
 import com.ibm.ws.microprofile.faulttolerance20.state.CircuitBreakerState;
 
+@SuppressWarnings("restriction") // Unit test accesses non-exported *PolicyImpl classes
 public class CircuitBreakerStateImplTest {
 
     private static MetricRecorder dummyMetrics = DummyMetricRecorder.get();

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/MockScheduledExecutorService.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/MockScheduledExecutorService.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance20.state.impl;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A mock scheduled executor service for unit tests
+ * <p>
+ * Most methods are not implemented
+ * <p>
+ * {@link #getTasks()} returns a list of tasks which have been scheduled so they can be inspected and run
+ */
+public class MockScheduledExecutorService implements ScheduledExecutorService {
+
+    private final List<MockScheduledTask<?>> scheduledTasks = new ArrayList<>();
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        MockScheduledFuture<Void> future = new MockScheduledFuture<>();
+        MockScheduledTask<Void> task = new MockScheduledTask<>(command, Duration.of(unit.toNanos(delay), ChronoUnit.NANOS), future);
+        scheduledTasks.add(task);
+        return future;
+    }
+
+    public List<MockScheduledTask<?>> getTasks() {
+        return new ArrayList<>(scheduledTasks);
+    }
+
+    static UnsupportedOperationException notImplemented() {
+        return new UnsupportedOperationException("Method not implemented in test mock");
+    }
+
+    @Override
+    public void shutdown() {
+        throw notImplemented();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        throw notImplemented();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        throw notImplemented();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        throw notImplemented();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        throw notImplemented();
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        throw notImplemented();
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        throw notImplemented();
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        throw notImplemented();
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        throw notImplemented();
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        throw notImplemented();
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        throw notImplemented();
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        throw notImplemented();
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        throw notImplemented();
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        throw notImplemented();
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        throw notImplemented();
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        throw notImplemented();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/MockScheduledFuture.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/MockScheduledFuture.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance20.state.impl;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class MockScheduledFuture<V> implements ScheduledFuture<V> {
+
+    private boolean cancelled = false;
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        cancelled = true;
+        return true;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public boolean isDone() {
+        throw MockScheduledExecutorService.notImplemented();
+    }
+
+    @Override
+    public V get() throws InterruptedException, ExecutionException {
+        throw MockScheduledExecutorService.notImplemented();
+    }
+
+    @Override
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        throw MockScheduledExecutorService.notImplemented();
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        throw MockScheduledExecutorService.notImplemented();
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        throw MockScheduledExecutorService.notImplemented();
+    }
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/MockScheduledTask.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/MockScheduledTask.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance20.state.impl;
+
+import java.time.Duration;
+
+public class MockScheduledTask<V> {
+    private final Runnable command;
+    private final Duration delay;
+    private final MockScheduledFuture<V> future;
+
+    public MockScheduledTask(Runnable command, Duration delay, MockScheduledFuture<V> future) {
+        super();
+        this.command = command;
+        this.delay = delay;
+        this.future = future;
+    }
+
+    public Duration getDelay() {
+        return delay;
+    }
+
+    public void run() {
+        command.run();
+    }
+
+    public MockScheduledFuture<V> getFuture() {
+        return future;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/MockScheduledTaskMatcher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/MockScheduledTaskMatcher.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.faulttolerance20.state.impl;
+
+import java.time.Duration;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+/**
+ * Matcher for MockScheduledTasks to make tests simpler
+ */
+public class MockScheduledTaskMatcher extends TypeSafeDiagnosingMatcher<MockScheduledTask<?>> {
+
+    private final boolean isCancelled;
+    private final Duration expectedDelay;
+
+    /**
+     * Match a non-cancelled task scheduled with the expected delay
+     */
+    public static MockScheduledTaskMatcher taskWithDelay(Duration expectedDelay) {
+        return new MockScheduledTaskMatcher(false, expectedDelay);
+    }
+
+    /**
+     * Match a cancelled task
+     */
+    public static MockScheduledTaskMatcher cancelledTask() {
+        return new MockScheduledTaskMatcher(true, null);
+    }
+
+    public MockScheduledTaskMatcher(boolean isCancelled, Duration expectedDelay) {
+        super();
+        this.isCancelled = isCancelled;
+        this.expectedDelay = expectedDelay;
+    }
+
+    @Override
+    public void describeTo(Description desc) {
+        desc.appendText("Task which is ").appendText(isCancelled ? "cancelled" : "not cancelled").appendText(" scheduled for ").appendValue(expectedDelay);
+    }
+
+    @Override
+    protected boolean matchesSafely(MockScheduledTask<?> task, Description desc) {
+        boolean matches = true;
+
+        if (isCancelled != task.getFuture().isCancelled()) {
+            desc.appendText("isCancelled: ");
+            desc.appendText("expected: ").appendValue(isCancelled);
+            desc.appendText(", actual: ").appendValue(task.getFuture().isCancelled());
+            desc.appendText("\n");
+            matches = false;
+        }
+
+        if (expectedDelay != null && !expectedDelay.equals(task.getDelay())) {
+            desc.appendText("Delay: ");
+            desc.appendText("expected: ").appendValue(expectedDelay);
+            desc.appendText(", actual: ").appendValue(task.getDelay());
+            desc.appendText("\n");
+            matches = false;
+        }
+
+        return matches;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/RetryStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/RetryStateImplTest.java
@@ -34,6 +34,7 @@ import com.ibm.ws.microprofile.faulttolerance.utils.DummyMetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance20.impl.MethodResult;
 import com.ibm.ws.microprofile.faulttolerance20.state.RetryState.RetryResult;
 
+@SuppressWarnings("restriction") // Unit test accesses non-exported *PolicyImpl classes
 public class RetryStateImplTest {
 
     private static MetricRecorder dummyMetrics = DummyMetricRecorder.get();

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/SyncBulkheadStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/SyncBulkheadStateImplTest.java
@@ -40,6 +40,7 @@ import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance.utils.DummyMetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance20.impl.MethodResult;
 
+@SuppressWarnings("restriction") // Unit test accesses non-exported *PolicyImpl classes
 public class SyncBulkheadStateImplTest {
 
     ExecutorService executor = Executors.newFixedThreadPool(10);

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/TimeoutStateImplTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/test/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/TimeoutStateImplTest.java
@@ -30,6 +30,7 @@ import com.ibm.ws.microprofile.faulttolerance.impl.policy.TimeoutPolicyImpl;
 import com.ibm.ws.microprofile.faulttolerance.spi.MetricRecorder;
 import com.ibm.ws.microprofile.faulttolerance.utils.DummyMetricRecorder;
 
+@SuppressWarnings("restriction") // Unit test accesses non-exported *PolicyImpl classes
 public class TimeoutStateImplTest {
 
     private MockScheduledExecutorService scheduledExecutorService;

--- a/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/policy/CircuitBreakerPolicyImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/src/com/ibm/ws/microprofile/faulttolerance/impl/policy/CircuitBreakerPolicyImpl.java
@@ -58,7 +58,6 @@ public class CircuitBreakerPolicyImpl implements CircuitBreakerPolicy {
     }
 
     /** {@inheritDoc} */
-    @SuppressWarnings("unchecked")
     @Override
     public void setFailOn(Class<? extends Throwable>... failOn) {
         this.failOn = failOn;


### PR DESCRIPTION
Change from using a real `ScheduledExecutorService` and `Thread.sleep()` to
using a mocked `ScheduledExecutorService` to avoid very occasional timing
issues.

This also makes the test slightly faster.

Additionally, hide some of the unhelpful warnings across the StateImpl tests.