### PR TITLE
Fix MP Config NPE during server shutdown

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.3/resources/com/ibm/ws/microprofile/config13/resources/Config13.nlsprops
+++ b/dev/com.ibm.ws.microprofile.config.1.3/resources/com/ibm/ws/microprofile/config13/resources/Config13.nlsprops
@@ -42,6 +42,11 @@ duplicate.application.configuration.name.CWMCG0203E=CWMCG0203E: More than one co
 duplicate.application.configuration.name.CWMCG0203E.explanation=The application configuration must be unique.
 duplicate.application.configuration.name.CWMCG0203E.useraction=Review the server message.log and FFDC logs to identify the problem.
 
+# An instance of the {0} service could not be found
+service.not.found.CWMCG0204E=CWMCG0204E: An instance of the {0} service could not be found.
+service.not.found.CWMCG0204E.explanation=An internal error occurred and a service could not be found.
+service.not.found.CWMCG0204E.useraction=Review the server message.log and FFDC logs to identify the problem.
+
 # Server XML Application Properties Config Source
 server.xml.appproperties.config.source=Server XML Application Properties Config Source
 

--- a/dev/com.ibm.ws.microprofile.config.1.3/resources/com/ibm/ws/microprofile/config13/resources/Config13.nlsprops
+++ b/dev/com.ibm.ws.microprofile.config.1.3/resources/com/ibm/ws/microprofile/config13/resources/Config13.nlsprops
@@ -44,8 +44,8 @@ duplicate.application.configuration.name.CWMCG0203E.useraction=Review the server
 
 # An instance of the {0} service could not be found
 service.not.found.CWMCG0204E=CWMCG0204E: An instance of the {0} service could not be found.
-service.not.found.CWMCG0204E.explanation=An internal error occurred and a service could not be found.
-service.not.found.CWMCG0204E.useraction=Review the server message.log and FFDC logs to identify the problem.
+service.not.found.CWMCG0204E.explanation=An internal error occurred and a service could not be found by MicroProfile Config.
+service.not.found.CWMCG0204E.useraction=Review the server message.log file and FFDC logs to identify the problem.
 
 # Server XML Application Properties Config Source
 server.xml.appproperties.config.source=Server XML Application Properties Config Source

--- a/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/AppPropertyConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/AppPropertyConfigSource.java
@@ -103,7 +103,11 @@ public class AppPropertyConfigSource extends InternalConfigSource implements Dyn
                     applicationName = OSGiConfigUtils.getApplicationName(bundleContext);
                 }
 
-                osgiConfigs = OSGiConfigUtils.getConfigurations(bundleContext, applicationName);
+                //if the Config is being obtained outside the context of an application then the applicationName may be null
+                //in which case there are no applicable application configuration elements to return
+                if (applicationName != null) {
+                    osgiConfigs = OSGiConfigUtils.getConfigurations(bundleContext, applicationName);
+                }
             }
             return osgiConfigs;
         };

--- a/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/InvalidFrameworkStateException.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/InvalidFrameworkStateException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,15 +8,21 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.microprofile.config13.interfaces;
+package com.ibm.ws.microprofile.config13.sources;
 
 /**
- * Constants for Config 1.3
+ *
  */
-public class Config13Constants {
+public class InvalidFrameworkStateException extends Exception {
 
-    public static final int APP_PROPERTY_ORDINAL = 600;
-    public static final int SERVER_XML_VARIABLE_ORDINAL = 500;
-    public static final int SERVER_XML_DEFAULT_VARIABLE_ORDINAL = 1;
+    /**
+     * @param message
+     */
+    public InvalidFrameworkStateException() {
+        super("Invalid OSGi Framework State");
+    }
+
+    /**  */
+    private static final long serialVersionUID = 1L;
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/OSGiConfigUtils.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/OSGiConfigUtils.java
@@ -108,7 +108,8 @@ public class OSGiConfigUtils {
      *
      * @param bundleContext the bundle context to use to find the service
      * @return the admin service
-     * @throws InvalidFrameworkStateException
+     * @throws InvalidFrameworkStateException if the server OSGi framework is being shutdown
+     * @throws ServiceNotFoundException       if an instance of the requested service can not be found
      */
     private static ConfigurationAdmin getConfigurationAdmin(BundleContext bundleContext) throws InvalidFrameworkStateException {
         return getService(bundleContext, ConfigurationAdmin.class);
@@ -118,8 +119,9 @@ public class OSGiConfigUtils {
      * Get the CDIService if available
      *
      * @param bundleContext the context to use to find the CDIService
-     * @return the CDIService or null
-     * @throws InvalidFrameworkStateException
+     * @return the CDIService
+     * @throws InvalidFrameworkStateException if the server OSGi framework is being shutdown
+     * @throws ServiceNotFoundException       if an instance of the requested service can not be found
      */
     private static CDIService getCDIService(BundleContext bundleContext) throws InvalidFrameworkStateException {
         return getService(bundleContext, CDIService.class);
@@ -129,8 +131,9 @@ public class OSGiConfigUtils {
      * Get the Config Variables service if available
      *
      * @param bundleContext the context to use to find the ConfigVariables service
-     * @return the ConfigVariables service or null
-     * @throws InvalidFrameworkStateException
+     * @return the ConfigVariables service
+     * @throws InvalidFrameworkStateException if the server OSGi framework is being shutdown
+     * @throws ServiceNotFoundException       if an instance of the requested service can not be found
      */
     private static ConfigVariables getConfigVariables(BundleContext bundleContext) throws InvalidFrameworkStateException {
         return getService(bundleContext, ConfigVariables.class);
@@ -141,23 +144,24 @@ public class OSGiConfigUtils {
      *
      * @param bundleContext The context to use to find the service
      * @param serviceClass  The class of the required service
-     * @return the service instance or null
-     * @throws InvalidFrameworkStateException
+     * @return the service instance
+     * @throws InvalidFrameworkStateException if the server OSGi framework is being shutdown
+     * @throws ServiceNotFoundException       if an instance of the requested service can not be found
      */
     private static <T> T getService(BundleContext bundleContext, Class<T> serviceClass) throws InvalidFrameworkStateException {
-        T service = null;
-        if (FrameworkState.isValid()) {
-            ServiceReference<T> ref = bundleContext.getServiceReference(serviceClass);
-
-            if (ref != null) {
-                service = bundleContext.getService(ref);
-            }
-            if (service == null) {
-                String msg = Tr.formatMessage(tc, "service.not.found.CWMCG0204E", serviceClass.getName());
-                throw new ServiceNotFoundException(msg);
-            }
-        } else {
+        if (!FrameworkState.isValid()) {
             throw new InvalidFrameworkStateException();
+        }
+
+        ServiceReference<T> ref = bundleContext.getServiceReference(serviceClass);
+
+        T service = null;
+        if (ref != null) {
+            service = bundleContext.getService(ref);
+        }
+
+        if (service == null) {
+            throw new ServiceNotFoundException(serviceClass);
         }
         return service;
     }

--- a/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/ServiceNotFoundException.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/ServiceNotFoundException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,15 +8,23 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.microprofile.config13.interfaces;
+package com.ibm.ws.microprofile.config13.sources;
+
+import com.ibm.ws.microprofile.config.interfaces.ConfigException;
 
 /**
- * Constants for Config 1.3
+ *
  */
-public class Config13Constants {
+public class ServiceNotFoundException extends ConfigException {
 
-    public static final int APP_PROPERTY_ORDINAL = 600;
-    public static final int SERVER_XML_VARIABLE_ORDINAL = 500;
-    public static final int SERVER_XML_DEFAULT_VARIABLE_ORDINAL = 1;
+    /**
+     * @param message
+     */
+    public ServiceNotFoundException(String message) {
+        super(message);
+    }
+
+    /**  */
+    private static final long serialVersionUID = 1L;
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/ServiceNotFoundException.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/ServiceNotFoundException.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config13.sources;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.microprofile.config.interfaces.ConfigException;
 
 /**
@@ -17,11 +19,10 @@ import com.ibm.ws.microprofile.config.interfaces.ConfigException;
  */
 public class ServiceNotFoundException extends ConfigException {
 
-    /**
-     * @param message
-     */
-    public ServiceNotFoundException(String message) {
-        super(message);
+    private static final TraceComponent tc = Tr.register(ServiceNotFoundException.class);
+
+    public ServiceNotFoundException(Class<?> serviceClass) {
+        super(Tr.formatMessage(tc, "service.not.found.CWMCG0204E", serviceClass.getName()));
     }
 
     /**  */


### PR DESCRIPTION
NPE reported...
>Stack Dump = java.lang.NullPointerException
>at com.ibm.ws.microprofile.config13.sources.OSGiConfigUtils.getVariableFromServerXML(OSGiConfigUtils.java:328)
>at com.ibm.ws.microprofile.config13.sources.ServerXMLVariableConfigSource.lambda$getServerXMLVariables$0(ServerXMLVariableConfigSource.java:63)
>at com.ibm.ws.microprofile.config13.sources.ServerXMLVariableConfigSource$Lambda$141.000000003860CAD0.run(Unknown Source)
>at java.base/java.security.AccessController.doPrivileged(AccessController.java:647)
>at com.ibm.ws.microprofile.config13.sources.ServerXMLVariableConfigSource.getServerXMLVariables(ServerXMLVariableConfigSource.java:69)
>at com.ibm.ws.microprofile.config13.sources.ServerXMLVariableConfigSource.getProperties(ServerXMLVariableConfigSource.java:46)
>at com.ibm.ws.microprofile.config.archaius.composite.PollingDynamicConfig.update(PollingDynamicConfig.java:158)
>at com.ibm.ws.microprofile.config.archaius.composite.PollingDynamicConfig.access$300(PollingDynamicConfig.java:43)
>at com.ibm.ws.microprofile.config.archaius.composite.PollingDynamicConfig$Refresher.run(PollingDynamicConfig.java:305)
>at com.ibm.ws.threading.internal.SchedulingRunnableFixedHelper.run(SchedulingRunnableFixedHelper.java:272)
>at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
>at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)

#build 