### PR TITLE
Fix double byte character encoding for OAuth client metatype API

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20ClientMetatypeService.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20ClientMetatypeService.java
@@ -127,9 +127,9 @@ public class OAuth20ClientMetatypeService {
                 return;
             }
             response.setHeader("Content-Type", "application/json");
-            response.setCharacterEncoding(StandardCharsets.UTF_16.toString());
+            response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
             PrintWriter writer = response.getWriter();
-            writer.println(metadataJson.toString());
+            writer.println(new String(metadataJson.toString().getBytes(StandardCharsets.UTF_16.toString()), StandardCharsets.UTF_16));
             writer.flush();
             writer.close();
         } catch (IOException e) {


### PR DESCRIPTION
Fixes the OAuth client metatype API to set the response header character encoding to UTF-8, but to write the API string itself as a UTF-16 string.