### PR TITLE
Display messages missing from UI

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/index.jsp
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/index.jsp
@@ -114,6 +114,7 @@ if (request.getAttribute("ui_app_tok_enabled") != null) {
                     <div class="tool_modal_body_info_item" style="margin-bottom: 13px;">
                         <span class="tool_modal_body_info_label"></span>
                     </div>
+                    <div class="tool_modal_body_description"></div>
                 </div>
                 <div id='authType'>
                     <fieldset class='tool_modal_radio_button_fieldset'>

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
@@ -69,8 +69,12 @@ var table = (function() {
         var $rowsChecked = $table.find('td.table_column_checkbox input:checkbox:checked');
 
         // Update the message
-        var $tableToolbar = $('.tool_table_toolbar');        
-        $tableToolbar.find('#batch_selected_msg').text(utils.formatString(messages.ITEMS_SELECTED, [$rowsChecked.length]));
+        var $tableToolbar = $('.tool_table_toolbar');
+        if ($rowsChecked.length === 1) {
+            $tableToolbar.find('#batch_selected_msg').text(utils.formatString(messages.SINGLE_ITEM_SELECTED, [$rowsChecked.length]));
+        } else {
+            $tableToolbar.find('#batch_selected_msg').text(utils.formatString(messages.ITEMS_SELECTED, [$rowsChecked.length]));
+        }  
     };
 
     /**


### PR DESCRIPTION
Several messages were dropped from being displayed in the UI.  This issue adds the messages back in.

1) In the Personal Token Management application, the REGENERATE_PW_WARNING and REGENERATE_TOKEN_WARNING messages were added to the Regenerate dialogs.

![image](https://user-images.githubusercontent.com/29490139/62149455-60901b80-b2c1-11e9-9df9-4d997cbb1d3f.png)

![image](https://user-images.githubusercontent.com/29490139/62149516-83223480-b2c1-11e9-99aa-391fd7ca82e2.png)

2) In the Users Token Management application, the SINGLE_ITEM_SELECTED message is now posted in the blue bar when only one checkbox is selected.

![image](https://user-images.githubusercontent.com/29490139/62149650-d3999200-b2c1-11e9-8343-47eef9d21f01.png)

