### PR TITLE
New test case for MP Rest Client with FT Fallback class specified

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/MyFallback.java
+++ b/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/MyFallback.java
@@ -1,0 +1,15 @@
+/**
+ * 
+ */
+package mpRestClientFT.retry;
+
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+
+public class MyFallback implements FallbackHandler<String>{
+
+    @Override
+    public String handle(ExecutionContext context) {
+        return "MyFallbackClass";
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/RetryClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/RetryClient.java
@@ -43,6 +43,11 @@ public interface RetryClient {
     @Fallback(fallbackMethod="defaultFallback")
     String useDefaultFallbackMethod();
 
+    @GET
+    @Path("/alwaysFail")
+    @Fallback(MyFallback.class)
+    String useDefaultFallbackClass();
+
     default String defaultFallback() {
         return "defaultFallback";
     }

--- a/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/RetryTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client.FT_fat/test-applications/retryApp/src/mpRestClientFT/retry/RetryTestServlet.java
@@ -81,4 +81,9 @@ public class RetryTestServlet extends FATServlet {
     public void testDefaultFallbackMethod(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         assertEquals("defaultFallback", client.useDefaultFallbackMethod());
     }
+
+    @Test
+    public void testFallbackHandlerClass(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        assertEquals("MyFallbackClass", client.useDefaultFallbackClass());
+    }
 }


### PR DESCRIPTION
New test case that confirms that MP Rest Client methods annotated with `@Fallback` that specifies a `FallbackHandler` class (as opposed to a method on the same client interface) works as expected.

This is just a new test case and is not a release bug.