### PR TITLE
Process JAXRS FormParams

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.cxf.jaxrs.utils;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -87,7 +89,9 @@ import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.common.util.ReflectionUtil;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.DOMUtils;
+import org.apache.cxf.helpers.IOUtils;
 import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.io.DelegatingInputStream;
 import org.apache.cxf.io.ReaderInputStream;
 import org.apache.cxf.jaxrs.JAXRSServiceImpl;
 import org.apache.cxf.jaxrs.ext.ContextProvider;
@@ -869,22 +873,31 @@ public final class JAXRSUtils {
                 return new AsyncResponseImpl(message);
             }
 
-            // Liberty change start
-            InputStream is = message.getContent(InputStream.class);
-            if (is == null) {
-                Reader reader = message.getContent(Reader.class);
-                if (reader != null) {
-                    is = new ReaderInputStream(reader);
-                }
-            }
-            // Liberty change end
-
             String contentType = (String) message.get(Message.CONTENT_TYPE);
 
             if (contentType == null) {
                 String defaultCt = (String) message.getContextualProperty(DEFAULT_CONTENT_TYPE);
                 contentType = defaultCt == null ? MediaType.APPLICATION_OCTET_STREAM : defaultCt;
             }
+            
+            // Liberty Change Start
+            MessageContext mc = new MessageContextImpl(message);
+            MediaType mt = mc.getHttpHeaders().getMediaType();
+            
+            InputStream is;
+            if (mt == null || mt.isCompatible(MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
+                is = copyAndGetEntityStream(message);
+            } else { 
+                is = message.getContent(InputStream.class);
+            }
+            
+            if (is == null) {
+                Reader reader = message.getContent(Reader.class);
+                if (reader != null) {
+                    is = new ReaderInputStream(reader);
+                }
+            }
+            // Liberty Change End
 
             return readFromMessageBody(parameterClass,
                                        parameterType,
@@ -1010,8 +1023,9 @@ public final class JAXRSUtils {
             m.put(FormUtils.FORM_PARAM_MAP, params);
 
             if (mt == null || mt.isCompatible(MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
+                InputStream entityStream = copyAndGetEntityStream(m); // Liberty change
                 String enc = HttpUtils.getEncoding(mt, StandardCharsets.UTF_8.name());
-                String body = FormUtils.readBody(m.getContent(InputStream.class), enc);
+                String body = FormUtils.readBody(entityStream, enc); // Liberty change
                 FormUtils.populateMapFromStringOrHttpRequest(params, m, body, enc, decode);
             } else {
                 if ("multipart".equalsIgnoreCase(mt.getType())
@@ -1913,5 +1927,19 @@ public final class JAXRSUtils {
     public static JaxRsRuntimeException toJaxRsRuntimeException(Throwable ex) {
         return new JaxRsRuntimeException(ex);
     }
-
+    
+    // Liberty change start
+    // copy the input stream so that it is not inadvertently closed
+    private static InputStream copyAndGetEntityStream(Message m) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            IOUtils.copy(m.getContent(InputStream.class), baos);
+        } catch (IOException e) {
+            throw ExceptionUtils.toInternalServerErrorException(e, null);
+        }
+        final byte[] copiedBytes = baos.toByteArray();
+        m.setContent(InputStream.class, new ByteArrayInputStream(copiedBytes));
+        return new ByteArrayInputStream(copiedBytes);
+    }
+    // Liberty change end
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/.classpath
@@ -36,6 +36,7 @@
 	<classpathentry kind="src" path="test-applications/webcontainer/src"/>
 	<classpathentry kind="src" path="test-applications/servicescope/src"/>
 	<classpathentry kind="src" path="test-applications/resourcepkg/src"/>
+	<classpathentry kind="src" path="test-applications/beanparam/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
@@ -14,6 +14,7 @@ bVersion=1.0
 src: \
   fat/src,\
   test-applications/annotationscan/src,\
+  test-applications/beanparam/src,\
   test-applications/beanvalidation/src,\
   test-applications/bookcontinuationstore/src,\
   test-applications/bookstore/src,\

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.jaxrs20.fat.annotationscan.AnnotationScanTest;
+import com.ibm.ws.jaxrs20.fat.beanparam.BeanParamTest;
 import com.ibm.ws.jaxrs20.fat.beanvalidation.JAXRSClientServerValidationTest;
 import com.ibm.ws.jaxrs20.fat.beanvalidation.JAXRSPerRequestValidationTest;
 import com.ibm.ws.jaxrs20.fat.beanvalidation.JAXRSValidationDisabledTest;
@@ -64,6 +65,7 @@ import componenttest.rules.repeater.RepeatTests;
 @SuiteClasses({
                 AlwaysPassesTest.class,
                 AnnotationScanTest.class,
+                BeanParamTest.class,
                 CheckFeature12Test.class,
                 ClientTest.class,
                 ContextTest.class,

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/beanparam/BeanParamTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/beanparam/BeanParamTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.fat.beanparam;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jaxrs.fat.beanparam.ClientTestServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class BeanParamTest extends FATServletClient {
+
+    private static final String app = "beanparam";
+
+    @Server("com.ibm.ws.jaxrs.fat.beanparam")
+    @TestServlet(servlet = ClientTestServlet.class, contextRoot = app)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, app, "com.ibm.ws.jaxrs.fat.beanparam");
+
+        // Make sure we don't fail because we try to start an
+        // already started server
+        try {
+            server.startServer(true);
+        } catch (Exception e) {
+            System.out.println(e.toString());
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null) {
+            server.stopServer();
+        }
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.beanparam/.gitignore
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.beanparam/.gitignore
@@ -1,0 +1,1 @@
+/dropins

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.beanparam/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.beanparam/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.max.file.size=0
+
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.beanparam/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.beanparam/server.xml
@@ -1,0 +1,11 @@
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>jaxrs-2.0</feature>
+    </featureManager>
+    
+    <!-- the following property is the webcontainer property that we do not want to have to rely on -->
+    <!-- <webContainer enablemultireadofpostdata="true" /> -->
+  	<include location="../fatTestPorts.xml"/>
+  	<javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/BeanParamEntity.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/BeanParamEntity.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.beanparam;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.FormParam;
+
+public class BeanParamEntity {
+
+    @FormParam("form")
+    public String form;
+
+    @BeanParam
+    public InnerBeanParamEntity inner;
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/ClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/ClientTestServlet.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.beanparam;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.After;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@WebServlet(urlPatterns = "/ClientTestServlet")
+public class ClientTestServlet extends FATServlet {
+
+    private static final long serialVersionUID = 4563445389586844836L;
+
+    final static String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/beanparam/";
+
+    private Client client;
+
+    @Override
+    public void init() throws ServletException {
+        client = ClientBuilder.newClient();
+    }
+
+    @After
+    private void teardown() {
+        client.close();
+    }
+
+    @Test
+    public void testFormParamOnField() throws Exception {
+
+        Form form = new Form();
+        form.param("form", "FIRST");
+        form.param("innerForm", "SECOND");
+
+        String content = "content&form=FIRST&innerForm=SECOND";
+
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("formparam")
+                        .request(MediaType.TEXT_PLAIN_TYPE)
+                        .post(Entity.entity(content, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+        assertEquals(200, response.getStatus());
+        String actual = response.readEntity(String.class);
+
+        System.out.println("content=" + content);
+        System.out.println("actual=" + actual);
+        assertEquals(content + "&FIRST&SECOND", actual);
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/InnerBeanParamEntity.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/InnerBeanParamEntity.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.beanparam;
+
+import javax.ws.rs.FormParam;
+
+public class InnerBeanParamEntity {
+
+    @FormParam("innerForm")
+    public String innerForm;
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/TestApplication.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/TestApplication.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.beanparam;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class TestApplication extends Application {}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/TestResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/TestResource.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.beanparam;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Produces(MediaType.TEXT_PLAIN)
+@Path("/")
+public class TestResource {
+
+    @BeanParam
+    BeanParamEntity fieldBeanParam;
+
+    @POST
+    @Path("formparam")
+    public String formParam(String content, @BeanParam BeanParamEntity bean) {
+        System.out.println("content=" + content);
+        System.out.println("bean.form=" + bean.form);
+        System.out.println("bean.inner.innerForm=" + bean.inner.innerForm);
+        return content + "&" + bean.form + "&" + bean.inner.innerForm;
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.cxf.jaxrs.utils;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -89,6 +91,7 @@ import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.common.util.ReflectionUtil;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.DOMUtils;
+import org.apache.cxf.helpers.IOUtils;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.io.DelegatingInputStream;
 import org.apache.cxf.io.ReaderInputStream;
@@ -871,18 +874,6 @@ public final class JAXRSUtils {
                                                       OperationResourceInfo ori)
         throws IOException, WebApplicationException {
 
-        InputStream is = message.getContent(InputStream.class);
-        if (is == null) {
-            Reader reader = message.getContent(Reader.class);
-            if (reader != null) {
-                is = new ReaderInputStream(reader);
-            }
-        // Liberty change start
-        } else if (is instanceof DelegatingInputStream) {
-            ((DelegatingInputStream)is).cacheInput();
-        }
-        // Liberty change end
-
         if (parameterClass == AsyncResponse.class) {
             return new AsyncResponseImpl(message);
         }
@@ -894,6 +885,25 @@ public final class JAXRSUtils {
             contentType = defaultCt == null ? MediaType.APPLICATION_OCTET_STREAM : defaultCt;
         }
 
+        // Liberty Change Start
+        MessageContext mc = new MessageContextImpl(message);
+        MediaType mt = mc.getHttpHeaders().getMediaType();
+        
+        InputStream is;
+        if (mt == null || mt.isCompatible(MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
+            is = copyAndGetEntityStream(message);
+        } else { 
+            is = message.getContent(InputStream.class);
+        }
+        
+        if (is == null) {
+            Reader reader = message.getContent(Reader.class);
+            if (reader != null) {
+                is = new ReaderInputStream(reader);
+            }
+        }
+        // Liberty Change End
+        
         return readFromMessageBody(parameterClass,
                                    parameterType,
                                    parameterAnns,
@@ -1029,14 +1039,9 @@ public final class JAXRSUtils {
             m.put(FormUtils.FORM_PARAM_MAP, params);
 
             if (mt == null || mt.isCompatible(MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
-                // Liberty change start
-                InputStream is = m.getContent(InputStream.class);
-                if (is instanceof DelegatingInputStream) {
-                    ((DelegatingInputStream)is).cacheInput();
-                }
-                // Liberty change end
+                InputStream entityStream = copyAndGetEntityStream(m); // Liberty change
                 String enc = HttpUtils.getEncoding(mt, StandardCharsets.UTF_8.name());
-                String body = FormUtils.readBody(is, enc); // Liberty change
+                String body = FormUtils.readBody(entityStream, enc); // Liberty change
                 FormUtils.populateMapFromStringOrHttpRequest(params, m, body, enc, false);
             } else {
                 if ("multipart".equalsIgnoreCase(mt.getType())
@@ -1915,4 +1920,19 @@ public final class JAXRSUtils {
     public static JaxRsRuntimeException toJaxRsRuntimeException(Throwable ex) {
         return new JaxRsRuntimeException(ex);
     }
+    
+    // Liberty change start
+    // copy the input stream so that it is not inadvertently closed
+    private static InputStream copyAndGetEntityStream(Message m) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            IOUtils.copy(m.getContent(InputStream.class), baos);
+        } catch (IOException e) {
+            throw ExceptionUtils.toInternalServerErrorException(e, null);
+        }
+        final byte[] copiedBytes = baos.toByteArray();
+        m.setContent(InputStream.class, new ByteArrayInputStream(copiedBytes));
+        return new ByteArrayInputStream(copiedBytes);
+    }
+    // Liberty change end
 }


### PR DESCRIPTION
Cache the JAXRS entity stream to process both the request body and form parameters without relying on the 'webContainer enablemultireadofpostdata' property and add a test case based on the JakartaEE TCK

https://github.com/OpenLiberty/open-liberty/issues/8344

originally fixed under https://github.com/OpenLiberty/open-liberty/issues/2770 but was re-broken