### PR TITLE
internal lateTaskThreshold property as a way to gate prototype code

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@
   <AD id="enableTaskExecution"               type="Boolean" default="true" name="%enableTaskExecution" description="%enableTaskExecution.desc"/>
   <AD id="initialPollDelay"                  type="String"  default="0" ibm:type="duration" name="%initialPollDelay" description="%initialPollDelay.desc"/>
   <AD id="jndiName"                          type="String"  required="false" ibm:unique="jndiName" name="internal" description="internal use only"/>
+  <AD id="lateTaskThreshold"                 type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/>
   <AD id="pollInterval"                      type="String"  default="-1" ibm:type="duration" name="%pollInterval" description="%pollInterval.desc"/>
   <AD id="pollSize"                          type="Integer" required="false" min="1" name="%pollSize" description="%pollSize.desc"/>
   <AD id="retryInterval"                     type="String"  default="1m" ibm:type="duration" name="%retryInterval" description="%retryInterval.desc"/>

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,11 @@ class Config {
     final String jndiName;
 
     /**
+     * Amount of time beyond a task's scheduled time after which the task is eligible to be taken over by another member.
+     */
+    final long lateTaskThreshold;
+
+    /**
      * Interval between polling for tasks to run. A value of -1 disables all polling after the initial poll.
      */
     final long pollInterval;
@@ -71,6 +76,7 @@ class Config {
         jndiName = (String) properties.get("jndiName");
         enableTaskExecution = (Boolean) properties.get("enableTaskExecution");
         initialPollDelay = (Long) properties.get("initialPollDelay");
+        lateTaskThreshold = enableTaskExecution ? (Long) properties.get("lateTaskThreshold") : -1;
         pollInterval = enableTaskExecution ? (Long) properties.get("pollInterval") : -1;
         pollSize = enableTaskExecution ? (Integer) properties.get("pollSize") : null;
         retryInterval = (Long) properties.get("retryInterval");
@@ -79,6 +85,8 @@ class Config {
         id = xpathId.contains("]/persistentExecutor[") ? null : (String) properties.get("id");
 
         // Range checking on duration values, which cannot be enforced via metatype
+        if (lateTaskThreshold != -1 && lateTaskThreshold < 1)
+            throw new IllegalArgumentException("lateTaskThreshold: " + lateTaskThreshold + "s");
         if (initialPollDelay < -1)
             throw new IllegalArgumentException("initialPollDelay: " + initialPollDelay + "ms");
         if (pollInterval < -1)
@@ -94,10 +102,11 @@ class Config {
                         .append(",jndiName=").append(jndiName)
                         .append(",enableTaskExecution=").append(enableTaskExecution)
                         .append(",initialPollDelay=").append(initialPollDelay)
-                        .append(",pollInterval=").append(pollInterval)
-                        .append(",pollSize=").append(pollSize)
+                        .append("ms,lateTaskThreshold=").append(lateTaskThreshold)
+                        .append("s,pollInterval=").append(pollInterval)
+                        .append("ms,pollSize=").append(pollSize)
                         .append(",retryInterval=").append(retryInterval)
-                        .append(",retryLimit=").append(retryLimit)
+                        .append("ms,retryLimit=").append(retryLimit)
                         .append(",xpathId=").append(xpathId)
                         .append(",id=").append(id)
                         .toString();

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -2233,6 +2233,12 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                                 Tr.debug(PersistentExecutorImpl.this, tc, "Found task " + taskId + " already scheduled");
                         }
                     }
+
+                    if (config.lateTaskThreshold > 0) {
+                        if (trace && tc.isDebugEnabled())
+                            Tr.debug(PersistentExecutorImpl.this, tc, "Poll for tasks late by " + config.lateTaskThreshold + "s");
+                        // TODO poll
+                    }
                 } finally {
                     // Schedule next poll
                     config = configRef.get();


### PR DESCRIPTION
Create an internal config property (lateTaskThreshold) that we can use to gate entry into prototype code where we will experiment with some possible ways of doing failover for persistent EJB timers.