### PR TITLE
Run Reactive Streams TCK against the Kafka reactive messaging connector

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -396,7 +396,7 @@ org.quartz-scheduler:quartz:2.2.1
 org.quartz-scheduler:quartz:2.2.1
 org.reactivestreams:reactive-streams-examples:1.0.2
 org.reactivestreams:reactive-streams:1.0.2
-org.reactivestreams:reactive-streams:1.0.2
+org.reactivestreams:reactive-streams-tck:1.0.2
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.slf4j:slf4j-api:1.7.7
 org.slf4j:slf4j-jdk14:1.7.7
@@ -453,6 +453,7 @@ org.testcontainers:jdbc:1.12.0
 org.testcontainers:kafka:1.12.0
 org.testcontainers:postgresql:1.12.0
 org.testcontainers:testcontainers:1.12.0
+org.testng:testng:6.14.3
 org.yaml:snakeyaml:1.18
 wsdl4j:wsdl4j:1.6.2
 xalan:xalan:2.7.1

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AckTracker.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AckTracker.java
@@ -21,10 +21,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-
-import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 
@@ -45,7 +44,7 @@ public class AckTracker implements ConsumerRebalanceListener {
     private static final TraceComponent tc = Tr.register(AckTracker.class);
 
     private final Map<TopicPartition, PartitionAckTracker> partitionTrackers;
-    private final ManagedScheduledExecutorService executor;
+    private final ScheduledExecutorService executor;
     private final int ackThreshold;
     private final AtomicInteger outstandingAcks;
 
@@ -53,7 +52,7 @@ public class AckTracker implements ConsumerRebalanceListener {
     private CompletableFuture<Void> ackThresholdStage = CompletableFuture.completedFuture(null);
     private final KafkaAdapterFactory kafkaAdapterFactory;
 
-    public AckTracker(KafkaAdapterFactory kafkaAdapterFactory, ManagedScheduledExecutorService executor, int ackThreshold) {
+    public AckTracker(KafkaAdapterFactory kafkaAdapterFactory, ScheduledExecutorService executor, int ackThreshold) {
         this.kafkaAdapterFactory = kafkaAdapterFactory;
         this.executor = executor;
         this.ackThreshold = ackThreshold;

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/Batcher.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/Batcher.java
@@ -14,9 +14,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
-import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -34,7 +33,7 @@ public class Batcher<T> {
     private final int maxBatchSize;
     private final Duration maxBatchTime;
     private final ProcessBatchAction<T> processBatchAction;
-    private final ManagedScheduledExecutorService executor;
+    private final ScheduledExecutorService executor;
 
     private boolean closed;
 
@@ -48,7 +47,7 @@ public class Batcher<T> {
     private Batcher(int maxBatchSize,
                     Duration maxBatchTime,
                     ProcessBatchAction<T> processBatchAction,
-                    ManagedScheduledExecutorService executor) {
+                    ScheduledExecutorService executor) {
         this.maxBatchSize = maxBatchSize;
         this.maxBatchTime = maxBatchTime;
         this.processBatchAction = processBatchAction;
@@ -124,7 +123,7 @@ public class Batcher<T> {
         private int maxBatchSize = -1;
         private Duration maxBatchTime;
         private ProcessBatchAction<T> processBatchAction;
-        private ManagedScheduledExecutorService executor;
+        private ScheduledExecutorService executor;
 
         private BatcherBuilder() {
             // No public constructor, use Batcher.create()
@@ -145,7 +144,7 @@ public class Batcher<T> {
             return this;
         }
 
-        public BatcherBuilder<T> withExecutor(ManagedScheduledExecutorService executor) {
+        public BatcherBuilder<T> withExecutor(ScheduledExecutorService executor) {
             this.executor = executor;
             return this;
         }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaInput.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaInput.java
@@ -22,10 +22,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
-
-import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
@@ -70,7 +69,7 @@ public class KafkaInput<K, V> {
      */
     private final ReentrantLock lock = new ReentrantLock();
 
-    public KafkaInput(KafkaAdapterFactory kafkaAdapterFactory, KafkaConsumer<K, V> kafkaConsumer, ManagedScheduledExecutorService executor, Collection<String> topics,
+    public KafkaInput(KafkaAdapterFactory kafkaAdapterFactory, KafkaConsumer<K, V> kafkaConsumer, ScheduledExecutorService executor, Collection<String> topics,
                       int unackedThreshold) {
         super();
         this.kafkaConsumer = kafkaConsumer;

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/bnd.bnd
@@ -22,14 +22,19 @@ tested.features: mpReactiveMessaging-1.0
 fat.project: true
 
 -buildpath: \
-	com.ibm.websphere.org.eclipse.microprofile.reactive.messaging.1.0;version=latest, \
-	com.ibm.websphere.org.eclipse.microprofile.reactive.streams.operators.1.0;version=latest, \
-	com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest, \
+	com.ibm.websphere.org.eclipse.microprofile.reactive.messaging.1.0;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.reactive.streams.operators.1.0;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
 	com.ibm.ws.org.slf4j.api.1.7.7;version=latest,\
 	org.apache.kafka:kafka-clients;version=2.3.0,\
 	org.testcontainers:testcontainers;version=1.12.0,\
 	org.testcontainers:kafka;version=1.12.0,\
 	org.rnorth.duct-tape:duct-tape;version=1.0.7,\
-	com.ibm.websphere.javaee.servlet.4.0;version=latest
-	
+	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
+	org.testng:testng;version=6.14.3,\
+	org.reactivestreams:reactive-streams-tck;version=1.0.2,\
+	com.ibm.websphere.org.reactivestreams.reactive-streams.1.0;version=latest,\
+	com.ibm.ws.io.smallrye.reactive.streams.operators.1.0;version=latest,\
+	com.ibm.ws.microprofile.reactive.messaging.kafka;version=latest,\
+	com.ibm.ws.microprofile.reactive.messaging.kafka.adapter;version=latest

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/build.gradle
@@ -1,3 +1,20 @@
+Properties props = new Properties()
+rootProject.file('generated.properties').withInputStream { props.load(it) }
+
+repositories {
+  if ((props.getProperty("artifactory.download.server") != null) && !props.getProperty('artifactory.force.external.repo')) {
+    maven {
+      credentials {
+        username props.getProperty("artifactory.download.user")
+        password props.getProperty("artifactory.download.token")
+      }
+      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+    }
+  } else {
+    mavenCentral()
+  }
+}
+
 configurations {
     kafkaClient
     requiredLibs.extendsFrom kafkaClient
@@ -17,6 +34,13 @@ dependencies {
     requiredLibs 'org.rnorth:tcp-unix-socket-proxy:1.0.2'
     requiredLibs 'net.java.dev.jna:jna:5.2.0'
     requiredLibs 'org.apache.commons:commons-compress:1.18'
+    requiredLibs 'org.testng:testng:6.14.3'
+    requiredLibs 'org.reactivestreams:reactive-streams-tck:1.0.2'
+    requiredLibs project(':com.ibm.websphere.org.reactivestreams.reactive-streams.1.0')
+    requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka')
+    requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka.adapter')
+    requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl')
+    requiredLibs project(':com.ibm.ws.io.smallrye.reactive.streams.operators.1.0')
 }
 
 task addKafkaClientLibs (type: Copy) {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaTestClient.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/KafkaTestClient.java
@@ -117,15 +117,17 @@ public class KafkaTestClient {
      * The following properties will be added with default values if they are not set in {@code config}
      * <ul>
      * <li>{@value ProducerConfig#BOOTSTRAP_SERVERS_CONFIG} = the test kafka broker</li>
-     * <li>{@value ProducerConfig#KEY_SERIALIZER_CLASS_CONFIG} = StringDeserializer</li>
-     * <li>{@value ProducerConfig#VALUE_SERIALIZER_CLASS_CONFIG} = StringDeserializer</li>
+     * <li>{@value ProducerConfig#KEY_SERIALIZER_CLASS_CONFIG} = StringSerializer</li>
+     * <li>{@value ProducerConfig#VALUE_SERIALIZER_CLASS_CONFIG} = StringSerializer</li>
      * </ul>
-     *
+     * 
+     * @param <T>       the type of the message written to Kafka. This must match the type serialized by the class configured with
+     *                      {@value ProducerConfig#VALUE_SERIALIZER_CLASS_CONFIG}
      * @param config    the producer config
      * @param topicName the topic to write to
      * @return the writer
      */
-    public SimpleKafkaWriter<String> writerFor(Map<String, Object> config, String topicName) {
+    public <T> SimpleKafkaWriter<T> writerFor(Map<String, Object> config, String topicName) {
         Map<String, Object> localConfig = new HashMap<>();
         localConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrap);
         localConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
@@ -134,8 +136,8 @@ public class KafkaTestClient {
         // Add in provided config (which will overwrite any defaults)
         localConfig.putAll(config);
 
-        KafkaProducer<String, String> kafkaProducer = new KafkaProducer<>(localConfig);
-        SimpleKafkaWriter<String> writer = new SimpleKafkaWriter<String>(kafkaProducer, topicName);
+        KafkaProducer<String, T> kafkaProducer = new KafkaProducer<>(localConfig);
+        SimpleKafkaWriter<T> writer = new SimpleKafkaWriter<T>(kafkaProducer, topicName);
         openClients.add(writer);
         return writer;
     }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/FailingDeserializer.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/FailingDeserializer.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.tck;
+
+import org.apache.kafka.common.serialization.Deserializer;
+
+/**
+ * A deserializer which always throws an exception
+ * <p>
+ * Used to test behavior in failing cases.
+ */
+public class FailingDeserializer implements Deserializer<String> {
+
+    @Override
+    public String deserialize(String topic, byte[] data) {
+        throw new RuntimeException("Test deserialization exception");
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaPublisherVerification.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaPublisherVerification.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.tck;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.SimpleKafkaWriter;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaInput;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaConsumer;
+
+/**
+ * Reactive Streams TCK test for the Kafka incoming connector
+ */
+public class KafkaPublisherVerification extends PublisherVerification<Message<String>> {
+
+    private final KafkaTestClient kafkaTestClient = new KafkaTestClient(PlaintextTests.kafkaContainer.getBootstrapServers());
+    private final KafkaAdapterFactory kafkaAdapterFactory = new TestKafkaAdapterFactory();
+    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
+    private static final int MESSAGE_LIMIT = 200;
+    private static final int TIMEOUT_MILLIS = 5000;
+    private int testNo = 0;
+    private String testName;
+    private final List<KafkaInput<?, ?>> kafkaInputs = new ArrayList<>();
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return publisherUnableToSignalOnComplete();
+    }
+
+    public KafkaPublisherVerification() {
+        super(new TestEnvironment(TIMEOUT_MILLIS));
+    }
+
+    @BeforeMethod
+    public void handleTestMethodName(Method method) {
+        testName = method.getName();
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        kafkaTestClient.cleanUp();
+        for (KafkaInput<?, ?> input : kafkaInputs) {
+            try {
+                input.shutdown();
+            } catch (Exception e) {
+            }
+        }
+        kafkaInputs.clear();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Publisher<Message<String>> createFailedPublisher() {
+        // Pick a kafka topic name
+        String topicName = "kafka-publisher-test-" + ++testNo + "-" + testName;
+
+        // Push one message into Kafka
+        try (SimpleKafkaWriter<String> writer = kafkaTestClient.writerFor(topicName)) {
+            writer.sendMessage("test");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        // Create the publisher, configured with a value deserializer which always throws an exception
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.CLIENT_ID_CONFIG, "kafka-publisher-verification-consumer-" + testNo);
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, PlaintextTests.kafkaContainer.getBootstrapServers());
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "kafka-publisher-verification");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, FailingDeserializer.class.getName());
+        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        KafkaConsumer<String, String> kafkaConsumer = kafkaAdapterFactory.newKafkaConsumer(config);
+        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, kafkaConsumer, executor, Collections.singleton(topicName), MESSAGE_LIMIT);
+        kafkaInputs.add(kafkaInput);
+        return kafkaInput.getPublisher().buildRs();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Publisher<Message<String>> createPublisher(long elements) {
+        // Pick a kafka topic name
+        String topicName = "kafka-publisher-test-" + ++testNo + "-" + testName;
+
+        elements = Math.min(elements, MESSAGE_LIMIT); // Cap count of messages we will create
+
+        // Push the required number of elements into Kafka
+        try (SimpleKafkaWriter<String> writer = kafkaTestClient.writerFor(topicName)) {
+            for (int i = 0; i < elements; i++) {
+                System.out.println("Sending test message to " + topicName);
+                writer.sendMessage("Test-message-" + i);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        // Create the publisher
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.CLIENT_ID_CONFIG, "kafka-publisher-verification-consumer-" + testNo);
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, PlaintextTests.kafkaContainer.getBootstrapServers());
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "kafka-publisher-verification");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        KafkaConsumer<String, String> kafkaConsumer = kafkaAdapterFactory.newKafkaConsumer(config);
+        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, kafkaConsumer, executor, Collections.singleton(topicName), MESSAGE_LIMIT);
+        kafkaInputs.add(kafkaInput);
+        return kafkaInput.getPublisher().buildRs();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaSubscriberVerification.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaSubscriberVerification.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.tck;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaOutput;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaProducer;
+
+/**
+ * Reactive Streams TCK test for the Kafka outgoing connector
+ */
+public class KafkaSubscriberVerification extends SubscriberWhiteboxVerification<Message<String>> {
+
+    private final KafkaTestClient kafkaTestClient = new KafkaTestClient(PlaintextTests.kafkaContainer.getBootstrapServers());
+    private final KafkaAdapterFactory kafkaAdapterFactory = new TestKafkaAdapterFactory();
+    private static final int TIMEOUT_MILLIS = 5000;
+    private int testNo = 0;
+    private String testName;
+    private final List<KafkaOutput<?, ?>> kafkaOutputs = new ArrayList<>();
+
+    @BeforeMethod
+    public void handleTestMethodName(Method method) {
+        testName = method.getName();
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        kafkaTestClient.cleanUp();
+        for (KafkaOutput<?, ?> output : kafkaOutputs) {
+            try {
+                output.shutdown(Duration.ofMillis(TIMEOUT_MILLIS));
+            } catch (Exception e) {
+            }
+        }
+        kafkaOutputs.clear();
+    }
+
+    /**
+     * @param env
+     */
+    public KafkaSubscriberVerification() {
+        super(new TestEnvironment(TIMEOUT_MILLIS));
+    }
+
+    @Override
+    public Subscriber<Message<String>> createSubscriber(WhiteboxSubscriberProbe<Message<String>> probe) {
+        // Pick a kafka topic name
+        String topicName = "kafka-subscriber-test-" + ++testNo + "-" + testName;
+
+        // Create the subscriber
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.CLIENT_ID_CONFIG, "kafka-publisher-verification-consumer-" + testNo);
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, PlaintextTests.kafkaContainer.getBootstrapServers());
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        KafkaProducer<String, String> kafkaProducer = kafkaAdapterFactory.newKafkaProducer(config);
+        KafkaOutput<String, String> kafkaOutput = new KafkaOutput<>(topicName, kafkaProducer);
+        kafkaOutputs.add(kafkaOutput);
+        return new VerificationSubscriber<>(probe, kafkaOutput);
+    }
+
+    @Override
+    public Message<String> createElement(int element) {
+        return Message.of("test-message-" + element);
+    }
+
+    public static class VerificationSubscriber<T> implements Subscriber<Message<T>> {
+
+        private final WhiteboxSubscriberProbe<Message<T>> probe;
+        private final Subscriber<Message<T>> delegate;
+
+        public VerificationSubscriber(WhiteboxSubscriberProbe<Message<T>> probe, KafkaOutput<?, T> kafkaOutput) {
+            super();
+            this.probe = probe;
+            this.delegate = kafkaOutput.getSubscriber().build();
+        }
+
+        @Override
+        public void onSubscribe(final Subscription s) {
+            delegate.onSubscribe(s);
+
+            // register a successful Subscription, and create a Puppet,
+            // for the WhiteboxVerification to be able to drive its tests:
+            probe.registerOnSubscribe(new SubscriberPuppet() {
+
+                @Override
+                public void triggerRequest(long elements) {
+                    // Do nothing, our subscriber always requests more
+                }
+
+                @Override
+                public void signalCancel() {
+                    // We can't prompt KafkaInput to cancel on demand so just do it directly
+                    // (It will cancel on next message, but that's not good enough for the test)
+                    s.cancel();
+                }
+            });
+        }
+
+        @Override
+        public void onNext(Message<T> element) {
+            // in addition to normal Subscriber work that you're testing, register onNext with the probe
+            delegate.onNext(element);
+            probe.registerOnNext(element);
+        }
+
+        @Override
+        public void onError(Throwable cause) {
+            // in addition to normal Subscriber work that you're testing, register onError with the probe
+            delegate.onError(cause);
+            probe.registerOnError(cause);
+        }
+
+        @Override
+        public void onComplete() {
+            // in addition to normal Subscriber work that you're testing, register onComplete with the probe
+            delegate.onComplete();
+            probe.registerOnComplete();
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/LoggingReporter.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/LoggingReporter.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.tck;
+
+import java.util.logging.Logger;
+
+import org.testng.reporters.VerboseReporter;
+
+/**
+ * TestNG reporter that logs using java.util.logging
+ */
+public class LoggingReporter extends VerboseReporter {
+
+    private static final Logger LOGGER = Logger.getLogger(LoggingReporter.class.getName());
+
+    public LoggingReporter() {
+        super(""); // No message prefix
+    }
+
+    @Override
+    protected void log(String message) {
+        LOGGER.info(message);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/ReactiveStreamsTckTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/ReactiveStreamsTckTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.tck;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.microprofile.reactive.streams.operators.core.ReactiveStreamsEngineResolver;
+import org.eclipse.microprofile.reactive.streams.operators.core.ReactiveStreamsFactoryImpl;
+import org.eclipse.microprofile.reactive.streams.operators.spi.ReactiveStreamsFactoryResolver;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testng.ITestNGListener;
+import org.testng.TestNG;
+import org.testng.reporters.JUnitXMLReporter;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import io.smallrye.reactive.streams.Engine;
+
+/**
+ * Runs the Reactive Streams TCK against our Kafka connector
+ * <p>
+ * The Reactive Streams TCK is written using TestNG, so this test is a wrapper which launches TestNG to run the tests.
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class ReactiveStreamsTckTest {
+
+    @BeforeClass
+    public static void setup() {
+        ReactiveStreamsFactoryResolver.setInstance(new ReactiveStreamsFactoryImpl());
+        ReactiveStreamsEngineResolver.setInstance(new Engine());
+    }
+
+    @AfterClass
+    public static void teardown() {
+        ReactiveStreamsFactoryResolver.setInstance(null);
+        ReactiveStreamsEngineResolver.setInstance(null);
+    }
+
+    @Test
+    public void runTck() {
+
+        // Launch TestNG so that it runs our test classes, logs to stdout and produces JUnit test reports named as the FAT framework expects
+
+        ITestNGListener junitReporter = new JUnitXMLReporter();
+        ITestNGListener loggingReporter = new LoggingReporter();
+
+        List<Class<?>> testClasses = Arrays.asList(KafkaPublisherVerification.class,
+                                                   KafkaSubscriberVerification.class);
+
+        TestNG testNg = new TestNG(false);
+        testNg.setXmlSuites(Collections.singletonList(createSuiteForTestClasses(testClasses)));
+        testNg.addListener(junitReporter);
+        testNg.addListener(loggingReporter);
+        testNg.setOutputDirectory("results/junit");
+        testNg.run();
+    }
+
+    /**
+     * Creates a test suite to run the given classes
+     * <p>
+     * The suite is structured so that the JUnit result files that it outputs matches what the FAT framework expects
+     *
+     * @param testClasses the TestNG test classes
+     * @return the TestNG suite
+     */
+    private XmlSuite createSuiteForTestClasses(List<Class<?>> testClasses) {
+        XmlSuite suite = new XmlSuite();
+        suite.setName(""); // No suite name so that result files are not put in a subdirectory
+
+        for (Class<?> testClass : testClasses) {
+            XmlTest test = new XmlTest(suite);
+            test.setName("TEST-" + testClass.getName()); // Use name format that the FAT framework expects
+            test.setClasses(Collections.singletonList(new XmlClass(testClass)));
+        }
+
+        return suite;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/TestKafkaAdapterFactory.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/TestKafkaAdapterFactory.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.tck;
+
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
+
+/**
+ * A KafkaAdaptorFactory for use in tests outside of liberty. It expects the Kafka library using its own classloader.
+ */
+public class TestKafkaAdapterFactory extends KafkaAdapterFactory {
+
+    @Override
+    protected ClassLoader getClassLoader() {
+        // In the test environments, everything shares the same classloader, all classes should be available
+        return TestKafkaAdapterFactory.class.getClassLoader();
+    }
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
@@ -21,6 +21,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.delivery.KafkaAcknow
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions.KafkaPartitionTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.serializer.KafkaCustomSerializerTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.sharedLib.KafkaSharedLibTest;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.tck.ReactiveStreamsTckTest;
 
 import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 
@@ -35,6 +36,7 @@ import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
                 KafkaCustomSerializerTest.class,
                 KafkaPartitionTest.class,
                 KafkaSharedLibTest.class,
+                ReactiveStreamsTckTest.class,
 })
 public class PlaintextTests {
 


### PR DESCRIPTION
The reactive streams TCK checks that a specific Subscriber or Publisher implementation behaves within the rules of the reactive streams specification.

I have followed the instructions for configuring it here: https://github.com/reactive-streams/reactive-streams-jvm/tree/master/tck

Fixes #8204 