### PR TITLE
claim the right to run a late timer task

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@
   <AD id="enableTaskExecution"               type="Boolean" default="true" name="%enableTaskExecution" description="%enableTaskExecution.desc"/>
   <AD id="initialPollDelay"                  type="String"  default="0" ibm:type="duration" name="%initialPollDelay" description="%initialPollDelay.desc"/>
   <AD id="jndiName"                          type="String"  required="false" ibm:unique="jndiName" name="internal" description="internal use only"/>
+  <AD id="lateTaskThreshold"                 type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/>
   <AD id="pollInterval"                      type="String"  default="-1" ibm:type="duration" name="%pollInterval" description="%pollInterval.desc"/>
   <AD id="pollSize"                          type="Integer" required="false" min="1" name="%pollSize" description="%pollSize.desc"/>
   <AD id="retryInterval"                     type="String"  default="1m" ibm:type="duration" name="%retryInterval" description="%retryInterval.desc"/>

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,11 @@ class Config {
     final String jndiName;
 
     /**
+     * Amount of time beyond a task's scheduled time after which the task is eligible to be taken over by another member.
+     */
+    final long lateTaskThreshold;
+
+    /**
      * Interval between polling for tasks to run. A value of -1 disables all polling after the initial poll.
      */
     final long pollInterval;
@@ -71,6 +76,7 @@ class Config {
         jndiName = (String) properties.get("jndiName");
         enableTaskExecution = (Boolean) properties.get("enableTaskExecution");
         initialPollDelay = (Long) properties.get("initialPollDelay");
+        lateTaskThreshold = enableTaskExecution ? (Long) properties.get("lateTaskThreshold") : -1;
         pollInterval = enableTaskExecution ? (Long) properties.get("pollInterval") : -1;
         pollSize = enableTaskExecution ? (Integer) properties.get("pollSize") : null;
         retryInterval = (Long) properties.get("retryInterval");
@@ -79,6 +85,8 @@ class Config {
         id = xpathId.contains("]/persistentExecutor[") ? null : (String) properties.get("id");
 
         // Range checking on duration values, which cannot be enforced via metatype
+        if (lateTaskThreshold != -1 && lateTaskThreshold < 1)
+            throw new IllegalArgumentException("lateTaskThreshold: " + lateTaskThreshold + "s");
         if (initialPollDelay < -1)
             throw new IllegalArgumentException("initialPollDelay: " + initialPollDelay + "ms");
         if (pollInterval < -1)
@@ -94,10 +102,11 @@ class Config {
                         .append(",jndiName=").append(jndiName)
                         .append(",enableTaskExecution=").append(enableTaskExecution)
                         .append(",initialPollDelay=").append(initialPollDelay)
-                        .append(",pollInterval=").append(pollInterval)
-                        .append(",pollSize=").append(pollSize)
+                        .append("ms,lateTaskThreshold=").append(lateTaskThreshold)
+                        .append("s,pollInterval=").append(pollInterval)
+                        .append("ms,pollSize=").append(pollSize)
                         .append(",retryInterval=").append(retryInterval)
-                        .append(",retryLimit=").append(retryLimit)
+                        .append("ms,retryLimit=").append(retryLimit)
                         .append(",xpathId=").append(xpathId)
                         .append(",id=").append(id)
                         .toString();

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -2233,6 +2233,12 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                                 Tr.debug(PersistentExecutorImpl.this, tc, "Found task " + taskId + " already scheduled");
                         }
                     }
+
+                    if (config.lateTaskThreshold > 0) {
+                        if (trace && tc.isDebugEnabled())
+                            Tr.debug(PersistentExecutorImpl.this, tc, "Poll for tasks late by " + config.lateTaskThreshold + "s");
+                        // TODO poll
+                    }
                 } finally {
                     // Schedule next poll
                     config = configRef.get();

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -446,7 +446,7 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     /**
      * Utility method that deserializes an object from bytes.
      *
-     * @param bytes from which to deserialize an object. If null, then null should be returned as the result.
+     * @param bytes  from which to deserialize an object. If null, then null should be returned as the result.
      * @param loader optional class loader to use when deserializing.
      * @return deserialized object.
      * @throws IOException if an error occurs deserializing the object.
@@ -480,9 +480,9 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      *
      * This method is for the mbean only.
      *
-     * @param hostName the host name.
-     * @param userDir wlp.user.dir
-     * @param libertyServerName name of the Liberty server.
+     * @param hostName           the host name.
+     * @param userDir            wlp.user.dir
+     * @param libertyServerName  name of the Liberty server.
      * @param executorIdentifier config.displayId of the persistent executor.
      * @return a list of partition information. Each entry in the list consists of
      *         (partitionId, hostName, userDir, libertyServerName, executorIdentifier)
@@ -555,10 +555,10 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      *
      * This method is for the mbean only.
      *
-     * @param partition identifier of the partition in which to search for tasks.
-     * @param state a task state. For example, TaskState.SCHEDULED
-     * @param inState indicates whether to include or exclude results with the specified state
-     * @param minId minimum value for task id to be returned in the results. A null value means no minimum.
+     * @param partition  identifier of the partition in which to search for tasks.
+     * @param state      a task state. For example, TaskState.SCHEDULED
+     * @param inState    indicates whether to include or exclude results with the specified state
+     * @param minId      minimum value for task id to be returned in the results. A null value means no minimum.
      * @param maxResults limits the number of results to return to the specified maximum value. A null value means no limit.
      * @return in-memory, ordered list of task ID.
      * @throws Exception if an error occurs when attempting to access the persistent task store.
@@ -1027,10 +1027,10 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     /**
      * Create and persist a new task to the persistent store.
      *
-     * @param task the task.
+     * @param task     the task.
      * @param taskInfo information to store with the task in binary form which is not directly queryable.
-     * @param trigger trigger for the task (if any).
-     * @param result optional predetermined result for the task (if any).
+     * @param trigger  trigger for the task (if any).
+     * @param result   optional predetermined result for the task (if any).
      * @return snapshot of task status reflecting the initial creation of the task.
      */
     private <T> TimerStatus<T> newTask(Object task, TaskInfo taskInfo, Trigger trigger, Object result) {
@@ -1206,9 +1206,9 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     /**
      * Invoked by a controller to notify a persistent executor that a task has been assigned to it.
      *
-     * @param taskId unique identifier for the task.
-     * @param nextExecTime next execution time for the task.
-     * @param binaryFlags combination of bits for various binary values.
+     * @param taskId             unique identifier for the task.
+     * @param nextExecTime       next execution time for the task.
+     * @param binaryFlags        combination of bits for various binary values.
      * @param transactionTimeout transaction timeout.
      */
     public void notifyOfTaskAssignment(long taskId, long nextExecTime, short binaryFlags, int transactionTimeout) {
@@ -1279,9 +1279,9 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      *
      * This method is for the mbean only.
      *
-     * @param hostName the host name.
-     * @param userDir wlp.user.dir
-     * @param libertyServerName name of the Liberty server.
+     * @param hostName           the host name.
+     * @param userDir            wlp.user.dir
+     * @param libertyServerName  name of the Liberty server.
      * @param executorIdentifier config.displayId of the persistent executor.
      * @return the number of entries removed from the persistent store.
      * @throws Exception if an error occurs.
@@ -1534,7 +1534,8 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      * @param ref reference to the service
      */
     @Reference(service = ApplicationRecycleCoordinator.class)
-    protected void setAppRecycleService(ServiceReference<ApplicationRecycleCoordinator> ref) {}
+    protected void setAppRecycleService(ServiceReference<ApplicationRecycleCoordinator> ref) {
+    }
 
     /**
      * Declarative Services method for setting the class loader identifier service.
@@ -1637,7 +1638,7 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     /**
      * Declarative Services method for setting the database store
      *
-     * @param svc the service
+     * @param svc   the service
      * @param props service properties
      */
     @Reference(target = "(id=unbound)")
@@ -1746,8 +1747,8 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      *
      * This method is for the mbean only.
      *
-     * @param maxTaskId task id including and up to which to transfer non-ended tasks from the old partition to this partition.
-     *            If null, all non-ended tasks are transferred from the old partition to this partition.
+     * @param maxTaskId      task id including and up to which to transfer non-ended tasks from the old partition to this partition.
+     *                           If null, all non-ended tasks are transferred from the old partition to this partition.
      * @param oldPartitionId partition id to which tasks are currently assigned.
      * @return count of transferred tasks.
      */
@@ -1793,7 +1794,8 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      *
      * @param ref reference to the service
      */
-    protected void unsetAppRecycleService(ServiceReference<ApplicationRecycleCoordinator> ref) {}
+    protected void unsetAppRecycleService(ServiceReference<ApplicationRecycleCoordinator> ref) {
+    }
 
     /**
      * Declarative Services method for unsetting the class loader identifier service.
@@ -1863,7 +1865,8 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      *
      * @param svc the service
      */
-    protected void unsetTaskStore(DatabaseStore svc) {}
+    protected void unsetTaskStore(DatabaseStore svc) {
+    }
 
     /**
      * Declarative Services method for unsetting the transaction manager
@@ -1899,13 +1902,13 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      *
      * This method is for the mbean only.
      *
-     * @param oldHostName the host name to update.
-     * @param oldUserDir wlp.user.dir to update.
-     * @param oldLibertyServerName name of the Liberty server to update.
+     * @param oldHostName           the host name to update.
+     * @param oldUserDir            wlp.user.dir to update.
+     * @param oldLibertyServerName  name of the Liberty server to update.
      * @param oldExecutorIdentifier config.displayId of the persistent executor to update.
-     * @param newHostName the new host name.
-     * @param newUserDir the new wlp.user.dir.
-     * @param newLibertyServerName the new name of the Liberty server.
+     * @param newHostName           the new host name.
+     * @param newUserDir            the new wlp.user.dir.
+     * @param newLibertyServerName  the new name of the Liberty server.
      * @param newExecutorIdentifier config.displayId of the new persistent executor.
      * @return the number of entries removed from the persistent store.
      * @throws Exception if an error occurs.
@@ -2184,7 +2187,84 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
         }
 
         @Override
-        public void beforeCompletion() {}
+        public void beforeCompletion() {
+        }
+
+        /**
+         * Attempt to claim a late task, and if successful in doing so, submit it to run.
+         *
+         * @param taskData          list of task detail, as returned by TaskStore.findLateTasks
+         * @param lateTaskThreshold number of seconds beyond which a task is considered late.
+         * @return true if a claim on the task was registered in the persistent store,
+         *         regardless of whether the task was actually transferred to this instance.
+         *         Otherwise false.
+         * @throws Exception if an error occurs.
+         */
+        private boolean claimLateTask(Object[] taskData, long lateTaskThreshold) throws Exception {
+            final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+            long taskId = (long) taskData[0];
+            long expectedExecTime = (long) taskData[2];
+            long now = new Date().getTime();
+
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(PersistentExecutorImpl.this, tc, "Task " + taskId + " is late by " + (now - expectedExecTime) + "ms");
+
+            // Attempt to claim ownership of the late task
+            boolean claimed = false;
+            String reassignment = ":CLAIM:" + taskId; // starting with non-alphanumeric indicates the property is for internal use
+            now = new Date().getTime();
+            long lateTaskThresholdMS = TimeUnit.SECONDS.toMillis(lateTaskThreshold);
+            String validUntil = String.format("%019d", now + lateTaskThresholdMS);
+
+            EmbeddableWebSphereTransactionManager tranMgr = tranMgrRef.getServiceWithException();
+            tranMgr.begin();
+            try {
+                claimed = taskStore.createProperty(reassignment, validUntil);
+            } finally {
+                if (!claimed)
+                    tranMgr.rollback(); // JPA marks the transaction as rollback-only for exceptional path
+                else
+                    tranMgr.commit();
+            }
+
+            if (!claimed) {
+                String comparisonValue = String.format("%019d", now);
+                tranMgr.begin();
+                try {
+                    claimed = taskStore.setPropertyIfLessThanOrEqual(reassignment, validUntil, comparisonValue);
+                } finally {
+                    tranMgr.commit();
+                }
+            }
+
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(PersistentExecutorImpl.this, tc, "Task " + taskId + " claimed? " + claimed);
+
+            if (claimed) {
+                int currentVersion = (Integer) taskData[4];
+
+                boolean transferred;
+                tranMgr.begin();
+                try {
+                    transferred = false; // TODO taskStore.transfer(taskId, newPartitionId, currentVersion);
+                } finally {
+                    tranMgr.commit();
+                }
+
+                if (transferred) {
+                    inMemoryTaskIds.put(taskId, Boolean.TRUE);
+                    short mbits = (Short) taskData[1];
+                    int txTimeout = (Integer) taskData[3];
+                    InvokerTask task = new InvokerTask(PersistentExecutorImpl.this, taskId, expectedExecTime, mbits, txTimeout);
+                    if (trace && tc.isDebugEnabled())
+                        Tr.debug(PersistentExecutorImpl.this, tc, "Submit task " + taskId + " for immediate execution");
+                    executor.submit(task); // TODO include something to clean up the PROPERTIES table?
+                }
+            }
+
+            return claimed;
+        }
 
         @Override
         public void run() {
@@ -2238,21 +2318,20 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                     if (config.lateTaskThreshold > 0) {
                         if (trace && tc.isDebugEnabled())
                             Tr.debug(PersistentExecutorImpl.this, tc, "Poll for tasks late by " + config.lateTaskThreshold + "s");
+                        long lateTaskThresholdMS = TimeUnit.SECONDS.toMillis(config.lateTaskThreshold);
                         tranMgr.begin();
                         try {
-                            results = taskStore.findLateTasks(now - TimeUnit.SECONDS.toMillis(config.lateTaskThreshold), getPartitionId(), config.pollSize);
+                            results = taskStore.findLateTasks(now - lateTaskThresholdMS, getPartitionId(), config.pollSize);
                         } catch (Throwable x) {
                             throw failure = x;
                         } finally {
                             tranMgr.commit();
                         }
-                        for (Object[] result : results) {
-                            long taskId = (long) result[0];
-                            long expectedExecTime = (long) result[2];
-                            if (trace && tc.isDebugEnabled())
-                                Tr.debug(PersistentExecutorImpl.this, tc, "Task " + taskId + " is late by " + (now - expectedExecTime) + "ms");
-                            // TODO attempt to take over late tasks
-                        }
+                        boolean anyClaimed = false;
+                        for (Object[] result : results)
+                            anyClaimed |= claimLateTask(result, config.lateTaskThreshold);
+                        if (anyClaimed)
+                            ; // TODO schedule a task to clean up the properties table once claims would expire
                     }
                 } finally {
                     // Schedule next poll

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -116,7 +116,7 @@ public interface TaskStore {
      * @param maxNextExecTime  expected next execution time threshold before which an unexecuted task is considered late.
      * @param excludePartition current partition number, which is excluded from the query because it was just polled.
      * @param maxResults       maximum number of results to return. Null means unlimited.
-     * @return List of (Id, MiscBinaryFlags, NextExecutionTime, TransactionTimeout) tuples.
+     * @return List of (Id, MiscBinaryFlags, NextExecutionTime, TransactionTimeout, Version) tuples.
      *         This list is ordered by next execution time only if maxResults is specified.
      * @throws Exception if an error occurs when attempting to access the persistent task store.
      */
@@ -328,7 +328,7 @@ public interface TaskStore {
     boolean removeProperty(String name) throws Exception;
 
     /**
-     * Assigns the value of the property with the specified name, if it exists in the persistent store.
+     * Assigns the value of the property if it exists in the persistent store.
      * 
      * @param name property name.
      * @param value new value for the property.
@@ -337,6 +337,18 @@ public interface TaskStore {
      * @throws Exception if an error occurs when attempting to update the persistent task store.
      */
     boolean setProperty(String name, String value) throws Exception;
+
+    /**
+     * Assigns the value of the property if it exists in the persistent store
+     * and has a value that is less than or equal to the comparisonValue.
+     *
+     * @param name            property name.
+     * @param value           new value for the property.
+     * @param comparisonValue the value against which the current value is compared.
+     * @return true if the property value was assigned to the new value.
+     * @throws Exception if an error occurs when attempting to update the persistent task store.
+     */
+    boolean setPropertyIfLessThanOrEqual(String name, String value, String comparisonValue) throws Exception;
 
     /**
      * Transfers tasks that have not yet completed all executions to another partition.

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -108,6 +108,19 @@ public interface TaskStore {
      * @throws Exception if an error occurs when attempting to access the persistent task store.
      */
     TaskRecord findById(long taskId, String owner, boolean includeTrigger) throws Exception;
+
+    /**
+     * Find all pending tasks which are late beyond the specified expected execution time without a
+     * successful execution of the task.
+     *
+     * @param maxNextExecTime  expected next execution time threshold before which an unexecuted task is considered late.
+     * @param excludePartition current partition number, which is excluded from the query because it was just polled.
+     * @param maxResults       maximum number of results to return. Null means unlimited.
+     * @return List of (Id, MiscBinaryFlags, NextExecutionTime, TransactionTimeout) tuples.
+     *         This list is ordered by next execution time only if maxResults is specified.
+     * @throws Exception if an error occurs when attempting to access the persistent task store.
+     */
+    List<Object[]> findLateTasks(long maxNextExecTime, long excludePartition, Integer maxResults) throws Exception;
 
     /**
      * Creates an entry for a partition record if one with the specified combination of executor/host/server/userdir

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.classpath
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/failover1servApp/src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.project
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.ws.concurrent.persistent_fat_failover1serv</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.settings/org.eclipse.core.resources.prefs
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/bnd.bnd=UTF-8

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,14 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.7

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/bnd.bnd
@@ -1,0 +1,31 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+src: \
+	fat/src,\
+	test-applications/failover1servApp/src
+
+fat.project: true
+
+-buildpath: \
+	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
+	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
+	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
+	com.ibm.websphere.org.osgi.service.component;version=latest,\
+	com.ibm.ws.concurrent.persistent;version=latest,\
+	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.ws.kernel.service;version=latest,\
+	javax.enterprise.concurrent-api;version=latest,\
+	org.osgi.service.component.annotations;version=latest

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+
+addRequiredLibraries.dependsOn addDerby

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/FATSuite.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.persistent.fat.failover1serv;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({ Failover1ServerTest.class })
+public class FATSuite {
+}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.persistent.fat.failover1serv;
+
+import static org.junit.Assert.fail;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import failover1serv.web.Failover1ServerTestServlet;
+
+/**
+ * This test bucket attempts to simulate failover of tasks.
+ * For this oversimplified scenario, we don't actually have multiple servers, just multiple
+ * persistent executor instances on a single server.
+ * We can simulate an instance going down by removing it from the configuration.
+ */
+@RunWith(FATRunner.class)
+public class Failover1ServerTest extends FATServletClient {
+	private static final String APP_NAME = "failover1servApp";
+
+    @Server("com.ibm.ws.concurrent.persistent.fat.failover1serv")
+    @TestServlet(servlet = Failover1ServerTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    private static final String TASK_ID_MESSAGE = "Task id is ";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, APP_NAME, "failover1serv.web");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    @Test
+    public void testScheduleOnOneServerRunOnAnother() throws Exception {
+        // Schedule on the instance that cannot run tasks
+        StringBuilder result = runTestWithResponse(server, APP_NAME + "/Failover1ServerTestServlet",
+                "testScheduleOneTimeTask&jndiName=persistent/exec1&initialDelayMS=0&test=testScheduleOnOneServerRunOnAnother[1]");
+
+        int start = result.indexOf(TASK_ID_MESSAGE);
+        if (start < 0)
+            fail("Task id of scheduled task not found in servlet output: " + result);
+        String taskId = result.substring(start += TASK_ID_MESSAGE.length(), result.indexOf(".", start));
+
+        System.out.println("Scheduled task " + taskId);
+        Thread.sleep(6000); // TODO once supported, have this test check for task completion
+    }
+}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
@@ -64,6 +64,6 @@ public class Failover1ServerTest extends FATServletClient {
         String taskId = result.substring(start += TASK_ID_MESSAGE.length(), result.indexOf(".", start));
 
         System.out.println("Scheduled task " + taskId);
-        Thread.sleep(6000); // TODO once supported, have this test check for task completion
+        Thread.sleep(12000); // TODO once supported, have this test check for task completion
     }
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/bootstrap.properties
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+
+com.ibm.ws.logging.trace.specification=*=info=enabled:persistentExecutor=all:logservice=all
+com.ibm.ws.logging.max.file.size=0
+
+ds.loglevel=debug 
+
+osgi.console=5678

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
@@ -1,0 +1,41 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <featureManager>
+  	<feature>componenttest-1.0</feature>
+    <feature>jndi-1.0</feature>
+    <!-- <feature>osgiConsole-1.0</feature> -->
+    <feature>persistentExecutor-1.0</feature>
+    <feature>servlet-4.0</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+  <!-- cannot run tasks -->
+  <persistentExecutor id="persistentExec1" jndiName="persistent/exec1" enableTaskExecution="false"/>
+
+  <!-- runs its own tasks and takes late tasks from others -->
+  <persistentExecutor id="persistentExec2" jndiName="persistent/exec2" pollInterval="2s" lateTaskThreshold="3s"/>
+
+  <!-- database for scheduled tasks -->
+  <dataSource id="DefaultDataSource">
+    <jdbcDriver libraryRef="JDBCLib"/>
+    <properties.derby.embedded createDatabase="create" databaseName="memory:failover1db"/>
+  </dataSource>
+
+  <library id="JDBCLib">
+    <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+  </library>
+  
+  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+
+  <variable name="onError" value="FAIL"/>
+</server>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/test-applications/failover1servApp/src/failover1serv/web/Failover1ServerTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/test-applications/failover1servApp/src/failover1serv/web/Failover1ServerTestServlet.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package failover1serv.web;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ManagedTask;
+import javax.naming.InitialContext;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.transaction.UserTransaction;
+
+import org.junit.Test;
+
+import com.ibm.websphere.concurrent.persistent.PersistentExecutor;
+import com.ibm.websphere.concurrent.persistent.TaskState;
+import com.ibm.websphere.concurrent.persistent.TaskStatus;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/Failover1ServerTestServlet")
+public class Failover1ServerTestServlet extends FATServlet {
+    /**
+     * Maximum number of nanoseconds to wait for a task to finish.
+     */
+    private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
+
+    @Resource
+    private UserTransaction tx;
+
+    /**
+     * Schedules a one-time task. The task id is written to the servlet output
+     */
+    public void testScheduleOneTimeTask(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String jndiName = request.getParameter("jndiName");
+        long initialDelayMS = Long.parseLong(request.getParameter("initialDelayMS"));
+
+        IncTask task = new IncTask();
+
+        PersistentExecutor executor = (PersistentExecutor) new InitialContext().lookup(jndiName);
+        TaskStatus<Integer> status = executor.schedule(task, initialDelayMS, TimeUnit.MILLISECONDS);
+        long taskId = status.getTaskId();
+
+        response.getWriter().println("Task id is " + taskId + ".");
+    }
+}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/test-applications/failover1servApp/src/failover1serv/web/IncTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/test-applications/failover1servApp/src/failover1serv/web/IncTask.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package failover1serv.web;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+
+import com.ibm.websphere.concurrent.persistent.TaskIdAccessor;
+
+/**
+ * A simple task that increments a counter each time it runs.
+ */
+public class IncTask implements Callable<Integer>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    int counter;
+
+    @Override
+    public Integer call() throws Exception {
+        ++counter;
+        System.out.println("IncTask " + TaskIdAccessor.get() + " execution attempt #" + counter);
+        return counter;
+    }
+}


### PR DESCRIPTION
Experiment with reserving a database entry for an amount of time to enforce the right of one instance to attempt to run a late timer task.

ID review is not needed. This only includes a translatable metatype file because builds are backed up and prerequisite commits are unable to merge..