### PR TITLE
Minor TCK tweaks

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/FATSuite.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.microprofile.rest.client.tck;
+package org.eclipse.microprofile.graphql.tck;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.microprofile.rest.client.tck;
+package org.eclipse.microprofile.graphql.tck;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -22,7 +22,7 @@
                     </script>
                 </method-selector>
             </method-selectors>
-            <package name="org.eclipse.microprofile.graphql.tck.dynamic.*"></package>
+            <package name="org.eclipse.microprofile.graphql.tck.*"></package>
         </packages>
     </test>
 </suite>


### PR DESCRIPTION
1) Rename "rest.client" to "graphql" - leftover from a copy/paste.
2) Include non-dynamic TCK test cases.

Only test fixes to unreleased functions - not a release bug.