### PR TITLE
removed java 8 features

### DIFF
--- a/dev/com.ibm.ws.artifact.overlay/bnd.bnd
+++ b/dev/com.ibm.ws.artifact.overlay/bnd.bnd
@@ -11,8 +11,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
 
 Bundle-Name: Overlay FS
 Bundle-SymbolicName: com.ibm.ws.artifact.overlay

--- a/dev/com.ibm.ws.artifact.overlay/src/com/ibm/ws/artifact/overlay/internal/OverlayContainerFactoryImpl.java
+++ b/dev/com.ibm.ws.artifact.overlay/src/com/ibm/ws/artifact/overlay/internal/OverlayContainerFactoryImpl.java
@@ -141,7 +141,9 @@ public class OverlayContainerFactoryImpl implements OverlayContainerFactory, Con
             }
 
             //introspect each of the containers
-            snapshotSet.forEach(containerEntry -> containerEntry.introspect(outputWriter));
+            for(DirectoryBasedOverlayContainerImpl containerEntry : snapshotSet){
+                containerEntry.introspect(outputWriter);
+            }
 
         }
     }


### PR DESCRIPTION
Delivery of Overlay Introspector without java 8 features

Previous Delivery with Java 8 Features: #8416 
Revert of Previous Delivery: #8499 
Issue to re-introduce revert: #8500

Compiled Locally with Java 7 compiler