### PR TITLE
Fix xss violations in entity names on panels

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/accountManager.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/accountManager.js
@@ -22,7 +22,7 @@ var acctMgr = (function() {
         apiUtils.addAcctAppPasswordToken(providedName, generateType).done(function (response) {
 
             // Add new entry as table row
-            table.addTableRow(table.convertResponseForTable(response, generateType, providedName));
+            table.addTableRow(table.convertResponseForTable(response, generateType, utils.encodeData(providedName)));
 
             var authenticationValue;
             if (generateType === "app-password") {
@@ -89,7 +89,7 @@ var acctMgr = (function() {
             // Something else happended with the request.  Put up the generic error message.
             var generateTypeTitle = generateType === 'app-password' ? 'App-Password' : 'App-Token';
             var errTitle = utils.formatString(messages.GENERIC_GENERATE_FAIL, [generateTypeTitle]);
-            var errDescription = utils.formatString(messages.GENERIC_GENERATE_FAIL_MSG, [generateType, providedName]);
+            var errDescription = utils.formatString(messages.GENERIC_GENERATE_FAIL_MSG, [generateType, utils.encodeData(providedName)]);
             utils.showResultsDialog(true, errTitle, errDescription, true, true, false, table.reshowAddRegenDialog);
         });
     };

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
@@ -22,7 +22,7 @@ var table = (function() {
 
     var __getTableRowByName = function(name, authType) {
         var $table = $('#' + tableId + ' tbody');
-        var $row = $table.find('tr[data-filter="' + name.toLowerCase() + '"]');
+        var $row = $table.find('tr[data-filter="' + utils.escapeString(name.toLowerCase())+ '"]');
         if ($row.length > 1) {
             // Two rows with the same name.   Find requested one based on authType.
             var $correctAuthType = $row.find('td.authType').filter(function(){ return this.textContent === authType; });
@@ -124,7 +124,7 @@ var table = (function() {
         var textDir = bidiUtils.getDOMBidiTextDirection(); 
         // Create a table row and add the filter data attribute as the name lowecased.
         // This is used in sorting and filtering (when implemented).
-        var tableRow = "<tr data-filter='" + authData.name.toLowerCase() + "' " + textDir + ">" + name + type + issuedOn + expiresOn + regenerateButton + deleteButton + "</tr>";
+        var tableRow = "<tr data-filter='" + utils.encodeData(authData.name.toLowerCase()) + "' " + textDir + ">" + name + type + issuedOn + expiresOn + regenerateButton + deleteButton + "</tr>";
 
         return tableRow;
     };
@@ -229,7 +229,7 @@ var table = (function() {
         var $dialogInfo = $regenerateDlg.find('.tool_modal_body_info');
         // insert bidi text direction to the name
         var dirTextName = bidiUtils.getDOMBidiTextDirection(name);
-        var nameLabel = utils.formatString(messages.NAME_IDENTIFIER, ["<span class='tool_modal_body_info_value' " + dirTextName + ">" + name + "</span>"]);
+        var nameLabel = utils.formatString(messages.NAME_IDENTIFIER, ["<span class='tool_modal_body_info_value' " + dirTextName + ">" + utils.encodeData(name) + "</span>"]);
         $dialogInfo.find('.tool_modal_body_info_label').html(nameLabel);
         var $authType = $regenerateDlg.find('#authType');
         var $authValue = $regenerateDlg.find('.authValueDiv');
@@ -314,7 +314,7 @@ var table = (function() {
                 $("#auth_value_copy").get(0).focus();
 
                 // Update the row in the table with the returned information
-                var authData = convertResponseForTable(response, authType, name);
+                var authData = convertResponseForTable(response, authType, utils.encodeData(name));
                 var tableRow = __createTableRow(authData);   // Create new table row with new values
                 var $currentTableRow = __getTableRowByName(name, authType);
                 $currentTableRow.replaceWith(tableRow);      // In place replacement
@@ -344,7 +344,7 @@ var table = (function() {
                 // So, if something else happended with the request, put up the generic error message.
                 var regenerateTypeTitle = authType === 'app-password' ? 'App-Password' : 'App-Token';
                 var errTitle = utils.formatString(messages.GENERIC_REGENERATE_FAIL, [regenerateTypeTitle]);
-                var errDescription = utils.formatString(messages.GENERIC_REGENERATE_FAIL_CREATE_MSG, [authType, name]);
+                var errDescription = utils.formatString(messages.GENERIC_REGENERATE_FAIL_CREATE_MSG, [authType, utils.encodeData(name)]);
                 utils.showResultsDialog(true, errTitle, errDescription, true, true, false, reshowAddRegenDialog);
             });            
         }).fail(function(errResponse) {
@@ -355,7 +355,7 @@ var table = (function() {
             // So, if something else happended with the request, put up the generic error message.
             var regenDelTitle = authType === 'app-password' ? 'App-Password' : 'App-Token';
             var errDelTitle = utils.formatString(messages.GENERIC_REGENERATE_FAIL, [regenDelTitle]);
-            var errDelDescription = utils.formatString(messages.GENERIC_REGENERATE_FAIL_MSG, [authType, name]);
+            var errDelDescription = utils.formatString(messages.GENERIC_REGENERATE_FAIL_MSG, [authType, utils.encodeData(name)]);
             utils.showResultsDialog(true, errDelTitle, errDelDescription, true, true, false, reshowAddRegenDialog);
         });
     };
@@ -374,7 +374,7 @@ var table = (function() {
 
         // Find the delete dialog in the html
         var $deleteDlg = $('.tool_modal_container.ss_delete');
-        $deleteDlg.find('.tool_modal_title').html(name);
+        $deleteDlg.find('.tool_modal_title').html(utils.encodeData(name));
 
         if (type === 'app-password') {
             $deleteDlg.find('.tool_modal_secondary_title').html(messages.DELETE_PW);
@@ -420,7 +420,7 @@ var table = (function() {
             // So, if something else happended with the request, put up the generic error message.
             var deleteTypeTitle = authType === 'app-password' ? 'App-Password' : 'App-Token';
             var errTitle = utils.formatString(messages.GENERIC_DELETE_FAIL, [deleteTypeTitle]);
-            var errDescription = utils.formatString(messages.GENERIC_DELETE_FAIL_MSG, [authType, name]);
+            var errDescription = utils.formatString(messages.GENERIC_DELETE_FAIL_MSG, [authType, utils.encodeData(name)]);
             utils.showResultsDialog(true, errTitle, errDescription, true, true, false, __reshowDeleteDialog);
         });
     };

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
@@ -124,7 +124,7 @@ var table = (function() {
         var textDir = bidiUtils.getDOMBidiTextDirection(); 
         // Create a table row and add the filter data attribute as the name lowecased.
         // This is used in sorting and filtering (when implemented).
-        var tableRow = "<tr data-filter='" + utils.encodeData(authData.name.toLowerCase()) + "' " + textDir + ">" + name + type + issuedOn + expiresOn + regenerateButton + deleteButton + "</tr>";
+        var tableRow = "<tr data-filter='" + authData.name.toLowerCase() + "' " + textDir + ">" + name + type + issuedOn + expiresOn + regenerateButton + deleteButton + "</tr>";
 
         return tableRow;
     };

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/clientInputDialog.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/clientInputDialog.js
@@ -280,7 +280,7 @@ var clientInputDialog = (function() {
                     // Something happended with the request.  Put up the generic error message.
                     var errTitle = messages.GENERIC_REGISTER_FAIL;
                     // insert bidi text direction to the client name
-                    var errClientName = bidiUtils.getDOMSpanWithBidiTextDirection(client_name);
+                    var errClientName = bidiUtils.getDOMSpanWithBidiTextDirection(utils.encodeData(client_name));
                     var errDescription = utils.formatString(messages.GENERIC_REGISTER_FAIL_MSG, [errClientName]);
                     utils.showResultsDialog(true, errTitle, errDescription, true, true, false, __reshowAddEditDialog);
                 });                      
@@ -339,7 +339,7 @@ var clientInputDialog = (function() {
                     //     }
                     // }
                     // insert bidi text direction to the client name
-                    var msgClientName = bidiUtils.getDOMSpanWithBidiTextDirection(client_name);
+                    var msgClientName = bidiUtils.getDOMSpanWithBidiTextDirection(utils.encodeData(client_name));
                     if (errResponse.status === 404) {
                         if (errResponse.responseJSON.error && errResponse.responseJSON.error === "invalid_client") {
                             // Updating an OAuth client that no longer exists....message the user and delete

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/table.js
@@ -64,9 +64,9 @@ var table = (function() {
     var createTableRow = function(clientData, filterValue) {
         var clientName = "<td tabindex='-1'>" + clientData.client_name + "</td>";
         var clientId = "<td tabindex='-1'>" + clientData.client_id + "</td>";
-        var editAriaLabel = utils.formatString(messages.EDIT_ARIA, [clientData.client_name]);
+        var editAriaLabel = utils.formatString(messages.EDIT_ARIA, [utils.encodeData(clientData.client_name)]);
         var editButton = "<td><button id='edit_" + clientData.client_id + "' class='tool_table_button edit_client_button' type='button' aria-label='" + editAriaLabel + "'>" + messages.EDIT + "</button></td>";
-        var deleteAriaLabel = utils.formatString(messages.DELETE_ARIA, [clientData.client_name]);
+        var deleteAriaLabel = utils.formatString(messages.DELETE_ARIA, [utils.encodeData(clientData.client_name)]);
         var deleteButton = "<td><button id='delete_" + clientData.client_id + "' class='tool_table_button delete_client_button' type='button' aria-label='" + deleteAriaLabel + "'>" + messages.DELETE + "</button></td>";
 
         // Create a table row and add the filter data attribute as the client name lowercased.
@@ -74,7 +74,7 @@ var table = (function() {
 
         // insert bidi text direction to the table row
         var textDir = bidiUtils.getDOMBidiTextDirection(); 
-        var tableRow = "<tr data-filter='" + clientData.client_name.toLowerCase() + "' " + textDir + ">" + clientName + clientId + editButton  + deleteButton + "</tr>";
+        var tableRow = "<tr data-filter='" + utils.encodeData(clientData.client_name.toLowerCase()) + "' " + textDir + ">" + clientName + clientId + editButton  + deleteButton + "</tr>";
 
         var rowMatched = true;
         if (filterValue && filterValue !== "") {        // If no filter specified, row is a match.

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/js/tableUtils.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/js/tableUtils.js
@@ -240,6 +240,7 @@ var tableUtils = (function() {
     var filterRows = function(tableId, filterValue) {
         var filter = filterValue.trim().toLowerCase();  // Stored the name in <tr> element
                                                         // lower-cased for a case insensitive search
+        filter = utils.escapeString(filter);                                                        
 
         var $table = $('#' + tableId + ' tbody');
 

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/js/utils.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/js/utils.js
@@ -360,6 +360,34 @@ var utils = (function() {
         return coords;
     };
 
+    /**
+     * Encode untrusted data by replacing the following characters with HTML entity
+     * encoding values before inserting into the DOM.
+     * 
+     *      Characters replaced: &, <, >, ", ', #, and /
+     * 
+     * @param String dataString 
+     */
+    var encodeData = function(dataString) {
+        var chars = {'&': '&amp;',
+                     '<': '&lt;',
+                     '>': '&gt;',
+                     '"': '&quot;',
+                     "'": '&#039;',
+                     '#': '&#035;',
+                     '/': '&#x2F;'};
+        return dataString.replace( /[&<>'"#/]/g, function(c) { return chars[c]; } );
+    };
+
+    /**
+     * Escape the dataString so it is as it appears in the HTML.
+     * 
+     * @param String dataString
+     */
+    var escapeString = function(dataString) {
+        return dataString.replace(/([ #;&,.+*~\':"!^$[\]()=>|\/@])/g,'\\$1');
+    };
+
     return {
         formatString: formatString,
         copyToClipboard: copyToClipboard,
@@ -377,7 +405,9 @@ var utils = (function() {
         clearFocus: clearFocus,
         getTopFocusElement: getTopFocusElement,
         updateFocusAfterDelete: updateFocusAfterDelete,
-        getTableCellCoords: getTableCellCoords
+        getTableCellCoords: getTableCellCoords,
+        encodeData: encodeData,
+        escapeString: escapeString
     };
 
 })();

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
@@ -159,7 +159,7 @@ var table = (function() {
 
         // Create a table row and add the filter data attribute as the name lowecased.
         // This is used in sorting and filtering (when implemented).
-        var tableRow = "<tr data-filter='" + authData.name.toLowerCase() + "' data-authid='" + authData.authID + "' data-userid='" + authData.user + "'>" + selectBox + name + clientName + type + issuedOn + expiresOn + deleteButton + "</tr>";
+        var tableRow = "<tr data-filter='" + utils.encodeData(authData.name.toLowerCase()) + "' data-authid='" + authData.authID + "' data-userid='" + authData.user + "'>" + selectBox + name + clientName + type + issuedOn + expiresOn + deleteButton + "</tr>";
 
         return tableRow;
     };
@@ -262,7 +262,7 @@ var table = (function() {
 
         // Find the delete dialog in the html
         var $deleteDlg = $('.tool_modal_container.token_manager_delete');
-        var confirmationTitle = utils.formatString(messages.DELETE_FOR_USERID, [name, userID]);
+        var confirmationTitle = utils.formatString(messages.DELETE_FOR_USERID, [utils.encodeData(name), userID]);
         $deleteDlg.find('.tool_modal_title').html(confirmationTitle);
 
         if (type === 'app-password') {
@@ -342,7 +342,7 @@ var table = (function() {
             // So, if something else happended with the request, put up the generic error message.
             var deleteTypeTitle = authType === 'app-password' ? 'App-Password' : 'App-Token';
             var errTitle = utils.formatString(messages.GENERIC_DELETE_FAIL, [deleteTypeTitle]);
-            var errDescription = utils.formatString(messages.GENERIC_DELETE_FAIL_MSG, [authType, name]);
+            var errDescription = utils.formatString(messages.GENERIC_DELETE_FAIL_MSG, [authType, utils.encodeData(name)]);
             utils.showResultsDialog(true, errTitle, errDescription, true, true, false, __reshowDeleteDialog);
         });
     };
@@ -479,7 +479,7 @@ var table = (function() {
     };
 
     var __identifyAuthentication = function(authentication) {
-        return (utils.formatString(messages.IDENTIFY_AUTH, [authentication.authType, authentication.name]));   
+        return (utils.formatString(messages.IDENTIFY_AUTH, [authentication.authType, utils.encodeData(authentication.name)]));   
     };
 
     var __reshowDeleteDialog = function() {

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/tokenManager.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/tokenManager.js
@@ -113,7 +113,7 @@ var tokenMgr = (function() {
             utils.stopProcessingSpinner();
         }, function() {
             console.log("GET account passwords/token failed to retrieve all app-passwords or app-tokens");
-            var errMsg = utils.formatString(messages.GENERIC_FETCH_ALL_FAIL_MSG, [userID]);
+            var errMsg = utils.formatString(messages.GENERIC_FETCH_ALL_FAIL_MSG, [utils.encodeData(userID)]);
             utils.showResultsDialog(true, messages.GENERIC_FETCH_ALL_FAIL, errMsg, false, false, true);
 
             // Reset the table contents to 'no results' message


### PR DESCRIPTION
Fix XSS errors in printing out strings that may contain bad data on the UI for the OIDC client management, users token management, and personal token management applications.

Also allow single quote (') and double quote (") characters in a client or authentication name and in the client management application, allow these characters to be filtered on.