### PR TITLE
Make PermissionManager's dependency on WsJar service non-optional

### DIFF
--- a/dev/com.ibm.ws.classloading/bnd.bnd
+++ b/dev/com.ibm.ws.classloading/bnd.bnd
@@ -60,10 +60,10 @@ Service-Component: \
     permission=com.ibm.ws.classloading.java2sec.JavaPermissionsConfiguration; \
     classLoadingService=com.ibm.wsspi.classloading.ClassLoadingService; \
     wsjarURLStreamHandler='org.osgi.service.url.URLStreamHandlerService(url.handler.protocol=wsjar)'; \
-    dynamic:='permission,wsjarURLStreamHandler'; \
+    dynamic:='permission'; \
     multiple:='permission'; \
     greedy:='permission'; \
-    optional:='permission,wsjarURLStreamHandler'; \
+    optional:='permission'; \
     properties:="service.vendor=IBM"
 
 instrument.classesExcludes: com/ibm/ws/classloading/internal/resources/*.class


### PR DESCRIPTION
This resolves a possible regression that may have been introduced with parallel bundle start where the WsJar protocol handler is not registered before the `PermissionManager` attempts to use it.