### PR TITLE
Ignore connection-specific write headers on HTTP/2 connections

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
@@ -1108,7 +1108,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
                 //instead of marshallHeader
                 if (this.table != null) {
                     try {
-                        if (!H2Headers.checkIsValidH2WriteHeader(elem.getName())) {
+                        if (!H2Headers.checkIsValidH2WriteHeader(elem.getName(), elem.asString())) {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                 Tr.debug(tc, "On an HTTP/2 connection - will not encode this header header: " + elem.getName());
                             }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/hpack/H2Headers.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/hpack/H2Headers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2018 IBM Corporation and others.
+ * Copyright (c) 1997, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -468,12 +468,17 @@ public class H2Headers {
      * @param H2HeaderField
      * @throws CompressionException if the H2HeaderField is not valid
      */
-    public static boolean checkIsValidH2WriteHeader(String headerName) {
+    public static boolean checkIsValidH2WriteHeader(String headerName, String headerValue) {
         if (!headerName.startsWith(":")) {
             if ("Connection".equalsIgnoreCase(headerName)) {
                 return false;
             }
-            if ("TE".equalsIgnoreCase(headerName)) {
+            for (String name : HpackConstants.connectionSpecificHeaderList) {
+                if (name.equalsIgnoreCase(headerName)) {
+                    return false;
+                }
+            }
+            if ("TE".equalsIgnoreCase(headerName) && !"trailers".equalsIgnoreCase(headerValue)) {
                 return false;
             }
         }


### PR DESCRIPTION
Connection-specific write headers should be ignored on HTTP/2 connections.  From the spec[1]:

> An endpoint MUST NOT generate an HTTP/2 message containing connection-specific header fields; any message containing connection-specific header fields MUST be treated as malformed

Ignored headers will include `Keep-Alive`, `Proxy-Connection`, `Transfer-Encoding`, `Upgrade`, and `Connection`.  Additionally, `TE` will be ignored if it contains a value other than `trailers`.

Fixes #8546

[1] https://tools.ietf.org/html/rfc7540#section-8.1.2.2