### PR TITLE
Add JIT trace to Fault Tolerance TCKs

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/servers/FaultTolerance11TCKServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/servers/FaultTolerance11TCKServer/jvm.options
@@ -1,1 +1,2 @@
 -Dcom.ibm.tools.attach.enable=yes
+-Xjit:{org/eclipse/microprofile/config/ConfigProvider.getConfig(Ljava/lang/ClassLoader;)Lorg/eclipse/microprofile/config/Config;}(tracefull,traceInlining,traceCG,log=getConfig.trace)

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/jvm.options
@@ -1,1 +1,2 @@
 -Dcom.ibm.tools.attach.enable=yes
+-Xjit:{org/eclipse/microprofile/config/ConfigProvider.getConfig(Ljava/lang/ClassLoader;)Lorg/eclipse/microprofile/config/Config;}(tracefull,traceInlining,traceCG,log=getConfig.trace)


### PR DESCRIPTION
To capture more information when the JVM crashes while jitting this class.