### PR TITLE
Use jar protocol if wsjar protocol handler is not available

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/java2sec/PermissionManager.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/java2sec/PermissionManager.java
@@ -341,8 +341,13 @@ public class PermissionManager implements PermissionsCombiner {
         try {
             codeSource = new CodeSource(new URL("wsjar:file:/" + codeBase), certs);
         } catch (MalformedURLException e) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Unable to create code source for protection domain");
+            try {
+                codeSource = new CodeSource(new URL("jar:file:/" + codeBase), certs);
+            } catch (MalformedURLException e2) {
+                codeSource = new CodeSource(null, certs);
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Unable to create code source for protection domain");
+                }
             }
         }
         return codeSource;


### PR DESCRIPTION
This fixes a bug uncovered by a new feature (parallel bundle activation) - as such, it has not been made generally available yet, so it is not a release bug.

It works around a problem where the class loading PermissionManager attempts to use the wsjar protocol before the wsjar protocol handler has been registered.