### PR TITLE
Move com.ibm.ws.artifact.zip to CONTAINER_EARLY start-phase

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.artifact-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.artifact-1.0.feature
@@ -15,7 +15,7 @@ IBM-Process-Types: server, \
  com.ibm.ws.adaptable.module, \
  com.ibm.ws.artifact.url; start-phase:=CONTAINER_EARLY, \
  com.ibm.ws.classloading.configuration, \
- com.ibm.ws.artifact.zip, \
+ com.ibm.ws.artifact.zip; start-phase:=CONTAINER_EARLY, \
  com.ibm.ws.artifact.overlay, \
  com.ibm.ws.artifact.bundle, \
  com.ibm.ws.artifact.equinox.module, \


### PR DESCRIPTION
com.ibm.ws.artifact.url provides
com.ibm.ws.artifact.url.internal.WSJarURLStreamHandler service component
which needs com.ibm.ws.artifact.zip.cache.ZipCachingService provided by
com.ibm.ws.artifact.zip.  Moving com.ibm.ws.artifact.zip to the same
start-phase as com.ibm.ws.artifact.url to makes sure the wsjar protocol
is available by the time CONTAINER_EARLY is done.
