### PR TITLE
WIP: Use file url protocol instead of wsjar

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/java2sec/PermissionManager.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/java2sec/PermissionManager.java
@@ -339,8 +339,9 @@ public class PermissionManager implements PermissionsCombiner {
         Certificate[] certs = null;
         CodeSource codeSource = null;
         try {
-            codeSource = new CodeSource(new URL("wsjar:file:/" + codeBase), certs);
+            codeSource = new CodeSource(new URL("file:/" + codeBase), certs);
         } catch (MalformedURLException e) {
+            codeSource = new CodeSource(null, certs);
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "Unable to create code source for protection domain");
             }


### PR DESCRIPTION
Testing out whether we can use the file protocol for shared library code sources, rather than wsjar protocol.  If so, this should simplify the PermissionManager service.