### PR TITLE
Revert "Update product and bundle version for release 19.0.0.9"

### DIFF
--- a/dev/cnf/resources/bnd/liberty-release.props
+++ b/dev/cnf/resources/bnd/liberty-release.props
@@ -12,12 +12,12 @@
 releaseTypeGA=true
 
 libertyBaseVersion=19.0.0
-libertyFixpackVersion=9
+libertyFixpackVersion=8
 libertyServiceVersion=${libertyBaseVersion}.${libertyFixpackVersion}
-libertyBetaVersion=2019.9.0.0
+libertyBetaVersion=2019.8.0.0
 libertyRelease=${if;${releaseTypeGA};${libertyServiceVersion};${libertyBetaVersion}}
 
-libertyBundleMicroVersion=32
+libertyBundleMicroVersion=31
 copyrightBuildYear=2019
 buildID=${libertyRelease}-${buildLabel}
 productEdition=BASE_ILAN


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#8541 the version change numbers breaks one of our package verification ignores