### PR TITLE
Reapply "Update product and bundle version for release 19.0.0.9"

### DIFF
--- a/dev/cnf/resources/bnd/liberty-release.props
+++ b/dev/cnf/resources/bnd/liberty-release.props
@@ -12,12 +12,12 @@
 releaseTypeGA=true
 
 libertyBaseVersion=19.0.0
-libertyFixpackVersion=8
+libertyFixpackVersion=9
 libertyServiceVersion=${libertyBaseVersion}.${libertyFixpackVersion}
-libertyBetaVersion=2019.8.0.0
+libertyBetaVersion=2019.9.0.0
 libertyRelease=${if;${releaseTypeGA};${libertyServiceVersion};${libertyBetaVersion}}
 
-libertyBundleMicroVersion=31
+libertyBundleMicroVersion=32
 copyrightBuildYear=2019
 buildID=${libertyRelease}-${buildLabel}
 productEdition=BASE_ILAN


### PR DESCRIPTION
Re-delivering the version update for 19.0.0.9. It caused a Packaging Verification error the first time and will be delivered only when those issues have been fixed.