### PR TITLE
fix test bucket to require Java 8 or higher

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.classpath
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
@@ -11,4 +11,4 @@ org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/bnd.bnd
@@ -11,6 +11,10 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+javac.source: 1.8
+javac.target: 1.8
+fat.minimum.java.level: 1.8
+
 src: \
 	fat/src,\
 	test-applications/failover1servApp/src

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/bnd.bnd
@@ -13,7 +13,6 @@ bVersion=1.0
 
 javac.source: 1.8
 javac.target: 1.8
-fat.minimum.java.level: 1.8
 
 src: \
 	fat/src,\


### PR DESCRIPTION
Test bucket updated to require Java 8 or higher because the test server config included versions of features that require at least Java 8, such as servlet-4.0.