### PR TITLE
Port changes from #8571 to integration

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.concurrent.mp-1.0
 visibility=private
 singleton=true
 -bundles=\
-  com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0",\
+  com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0",\
   com.ibm.ws.concurrent.mp.1.0
 kind=ga
 edition=core


### PR DESCRIPTION
#8571 fixed a bug with maven coordinates for MP Context Propagation in the 19.0.0.8 release branch.  This pull is to port the fix back to integration so that all following releases include it as well.