### PR TITLE
Fixes monitor 1.0, adds timeout constant

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -129,11 +129,12 @@ public class MonitorMetricsHandler {
 			try {
 				mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
 				if (sName.contains("ThreadPoolStats")) {
-					int maxTimeOut = 0;
-					while (mBeanObjectInstanceSet.isEmpty() && maxTimeOut <= 5000) {
+					final int MAX_TIME_OUT = 5000;
+					int currentTimeOut = 0;
+					while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
 						Thread.sleep(50);
 						mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
-						maxTimeOut+=50;
+						currentTimeOut+=50;
 					}
 				}
 		        for (ObjectInstance objInstance : mBeanObjectInstanceSet) {

--- a/dev/com.ibm.ws.microprofile.metrics.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetricsHandler.java
@@ -128,6 +128,15 @@ public class MonitorMetricsHandler {
 			Set<ObjectInstance> mBeanObjectInstanceSet;
 			try {
 				mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
+				if (sName.contains("ThreadPoolStats")) {
+					final int MAX_TIME_OUT = 5000;
+					int currentTimeOut = 0;
+					while (mBeanObjectInstanceSet.isEmpty() && currentTimeOut <= MAX_TIME_OUT) {
+						Thread.sleep(50);
+						mBeanObjectInstanceSet = mbs.queryMBeans(new ObjectName(sName), null);
+						currentTimeOut+=50;
+					}
+				}
 		        for (ObjectInstance objInstance : mBeanObjectInstanceSet) {
 		            String objectName = objInstance.getObjectName().toString();
 		            String[][] data = mappingTable.getData(objectName);


### PR DESCRIPTION
fixes: #7473

#build

This fix is implemented to fix `metrics.monitor`, the previous pull request fixed `metrics.monitor.2.0`.