### PR TITLE
Update com.ibm.ws.jpa_spec10_fat bucket for better multi-db support.

### DIFF
--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/DatabaseVendor.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/DatabaseVendor.java
@@ -27,6 +27,7 @@ public enum DatabaseVendor {
 
     public static DatabaseVendor resolveDBProduct(String dbProductName) {
         if (dbProductName == null || "".equals(dbProductName.trim())) {
+            System.err.println("Cannot resolve database product " + dbProductName);
             return null;
         }
 

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Callback_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Callback_EJB.java
@@ -115,6 +115,16 @@ public class Callback_EJB extends JPAFATServletClient {
         bannerStart(Callback_EJB.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Callback_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Callback_Web.java
@@ -79,6 +79,16 @@ public class Callback_Web extends JPAFATServletClient {
         bannerStart(Callback_Web.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Inheritance_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Inheritance_EJB.java
@@ -71,6 +71,16 @@ public class Inheritance_EJB extends JPAFATServletClient {
         bannerStart(Inheritance_EJB.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Inheritance_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Inheritance_Web.java
@@ -67,6 +67,16 @@ public class Inheritance_Web extends JPAFATServletClient {
         bannerStart(Inheritance_Web.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXMany_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXMany_EJB.java
@@ -88,6 +88,16 @@ public class Relationships_ManyXMany_EJB extends JPAFATServletClient {
         bannerStart(Relationships_ManyXMany_EJB.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXMany_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXMany_Web.java
@@ -73,6 +73,16 @@ public class Relationships_ManyXMany_Web extends JPAFATServletClient {
         bannerStart(Relationships_ManyXMany_Web.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXOne_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXOne_EJB.java
@@ -82,6 +82,16 @@ public class Relationships_ManyXOne_EJB extends JPAFATServletClient {
         bannerStart(Relationships_ManyXOne_EJB.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXOne_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_ManyXOne_Web.java
@@ -71,6 +71,16 @@ public class Relationships_ManyXOne_Web extends JPAFATServletClient {
         bannerStart(Relationships_ManyXOne_Web.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXMany_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXMany_EJB.java
@@ -82,6 +82,16 @@ public class Relationships_OneXMany_EJB extends JPAFATServletClient {
         bannerStart(Relationships_OneXMany_EJB.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXMany_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXMany_Web.java
@@ -71,6 +71,16 @@ public class Relationships_OneXMany_Web extends JPAFATServletClient {
         bannerStart(Relationships_OneXMany_Web.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXOne_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXOne_EJB.java
@@ -92,6 +92,16 @@ public class Relationships_OneXOne_EJB extends JPAFATServletClient {
         bannerStart(Relationships_OneXOne_EJB.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXOne_Web.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/fat/src/com/ibm/ws/jpa/spec10/Relationships_OneXOne_Web.java
@@ -72,6 +72,16 @@ public class Relationships_OneXOne_Web extends JPAFATServletClient {
         bannerStart(Relationships_OneXOne_Web.class);
         timestart = System.currentTimeMillis();
 
+        int appStartTimeout = server1.getAppStartTimeout();
+        if (appStartTimeout < (120 * 1000)) {
+            server1.setAppStartTimeout(120 * 1000);
+        }
+
+        int configUpdateTimeout = server1.getConfigUpdateTimeout();
+        if (configUpdateTimeout < (120 * 1000)) {
+            server1.setConfigUpdateTimeout(120 * 1000);
+        }
+
         server1.startServer();
 
         setupDatabaseApplication(server1, RESOURCE_ROOT + "ddl/");

--- a/dev/com.ibm.ws.jpa_spec10_fat/publish/servers/JPA10Server/database.xml
+++ b/dev/com.ibm.ws.jpa_spec10_fat/publish/servers/JPA10Server/database.xml
@@ -1,0 +1,27 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+ <server>
+    <dataSource id="jdbc/JPA_DS" jndiName="jdbc/JPA_DS" fat.modify="true">
+            <jdbcDriver libraryRef="JDBCLib"/>
+            <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <dataSource id="jdbc/JPA_NJTADS" jndiName="jdbc/JPA_NJTADS" fat.modify="true" transactional="false">
+            <jdbcDriver libraryRef="JDBCLib"/>
+            <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+    
+    <library id="JDBCLib" fat.modify="true" apiTypeVisibility="+third-party">
+        <fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
+    </library>
+    
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+</server>

--- a/dev/com.ibm.ws.jpa_spec10_fat/publish/servers/JPA10Server/server.xml
+++ b/dev/com.ibm.ws.jpa_spec10_fat/publish/servers/JPA10Server/server.xml
@@ -12,40 +12,23 @@
 
 	<featureManager>
 	    <feature>ejblite-3.2</feature>
-	    <!-- 
-	    <feature>servlet-3.1</feature>
-		<feature>jpa-2.1</feature>
-		-->
 		<feature>servlet-4.0</feature>
 		<feature>jpa-2.2</feature>
-
+           <!-- 
+           <feature>servlet-3.1</feature>
+               <feature>jpa-2.1</feature>
+           -->
 	    <feature>componenttest-1.0</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>
+    <include location="database.xml"/>
     
-    <dataSource id="jdbc/JPA_DS" jndiName="jdbc/JPA_DS" fat.modify="true">
-    	    <jdbcDriver libraryRef="DerbyLib"/>
-    	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
-    </dataSource>
-    
-    <dataSource id="jdbc/JPA_NJTADS" jndiName="jdbc/JPA_NJTADS" fat.modify="true" transactional="false">
-    	    <jdbcDriver libraryRef="DerbyLib"/>
-    	    <properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
-    </dataSource>
-    
-    <library id="DerbyLib" fat.modify="true">
-    	<fileset dir="${shared.resource.dir}/derby" includes="*.jar"/>
-    </library>
-    
-    
-    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 <!--  
     <logging  traceSpecification="JPA=all=enabled:EJBContainer=all=enabled"
--->
-    <logging  traceSpecification="applications=all"
               traceFileName="trace.log"
               maxFileSize="2000"
               maxFiles="10"
               traceFormat="BASIC" />
+-->
 </server>

--- a/dev/com.ibm.ws.jpa_spec10_fat/test-applications/helpers/DatabaseManagement/src/jpahelper/databasemanagement/DatabaseManagementServlet.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/test-applications/helpers/DatabaseManagement/src/jpahelper/databasemanagement/DatabaseManagementServlet.java
@@ -14,6 +14,7 @@ package jpahelper.databasemanagement;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.sql.Connection;
@@ -22,6 +23,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Base64.Encoder;
+import java.util.Properties;
 
 import javax.annotation.Resource;
 import javax.servlet.ServletException;
@@ -81,15 +84,27 @@ public class DatabaseManagementServlet extends HttpServlet {
     private void getInfo(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         Connection conn = null;
         try {
+            System.out.println("DatabaseManagement servicing getInfo request...");
             conn = dsRl.getConnection();
             final DatabaseMetaData dbMeta = conn.getMetaData();
+            Properties properties = new Properties();
+            properties.put("dbproduct_name", dbMeta.getDatabaseProductName());
+            properties.put("dbproduct_version", dbMeta.getDatabaseProductVersion());
+            properties.put("jdbcdriver_version", dbMeta.getDatabaseProductVersion());
+            properties.put("jdbc_url", dbMeta.getURL());
+            properties.put("jdbc_username", dbMeta.getUserName());
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(properties);
+            oos.flush();
+            oos.close();
+
+            final Encoder base64Encoder = java.util.Base64.getEncoder();
+            final String base64EncodedData = base64Encoder.encodeToString(baos.toByteArray());
 
             final PrintWriter pw = resp.getWriter();
-            pw.println("dbproduct_name=" + dbMeta.getDatabaseProductName());
-            pw.println("dbproduct_version=" + dbMeta.getDatabaseProductVersion());
-            pw.println("jdbcdriver_version=" + dbMeta.getDriverVersion());
-            pw.println("jdbc_url=" + dbMeta.getURL());
-            pw.println("jdbc_username=" + dbMeta.getUserName());
+            pw.println(base64EncodedData);
         } catch (SQLException e) {
             throw new ServletException(e);
         } finally {
@@ -99,6 +114,7 @@ public class DatabaseManagementServlet extends HttpServlet {
                 } catch (Throwable t) {
                 }
             }
+            System.out.println("DatabaseManagement getInfo request service complete.");
         }
 
     }
@@ -226,12 +242,19 @@ public class DatabaseManagementServlet extends HttpServlet {
         sb.append("DB Username: ").append(dbMeta.getUserName()).append("\n");
 
         sb.append("DB Schemas:\n");
-        ResultSet schemas = dbMeta.getSchemas();
-        while (schemas.next()) {
-            sb.append("  ").append(schemas.getString("TABLE_SCHEM")).append("\n");
+        try {
+            ResultSet schemas = dbMeta.getSchemas();
+            while (schemas.next()) {
+                sb.append("  ").append(schemas.getString("TABLE_SCHEM")).append("\n");
+            }
+        } catch (Throwable t) {
+            // Ouch
+            sb.append("   DB SCHEMAS NOT AVAILABLE -- " + t.getMessage());
+            t.printStackTrace();
         }
 
         sb.append("################################################################################\n");
         System.out.println(sb);
     }
+
 }

--- a/dev/com.ibm.ws.jpa_spec10_fat/test-framework/src/com/ibm/ws/testtooling/testlogic/AbstractTestLogic.java
+++ b/dev/com.ibm.ws.jpa_spec10_fat/test-framework/src/com/ibm/ws/testtooling/testlogic/AbstractTestLogic.java
@@ -303,4 +303,64 @@ public abstract class AbstractTestLogic {
 
         };
     }
+
+    protected String getTestName() {
+        final StackTraceElement[] steArr = Thread.currentThread().getStackTrace();
+
+        String cn = null;
+        for (int index = 0; index < steArr.length; index++) {
+            final String name = steArr[index].getClassName();
+            if (name.startsWith("java.") || name.startsWith("javax.")) {
+                continue;
+            }
+            cn = name;
+            break;
+        }
+
+        String methodName = cn.substring(cn.lastIndexOf('.'));
+
+        return this.getClass().getSimpleName() + "." + methodName;
+    }
+
+    // Basing determination off product version using
+    // info from https://www.ibm.com/support/knowledgecenter/en/SSEPEK_11.0.0/java/src/tpc/imjcc_c0053013.html
+    protected boolean isDB2ForZOS(String prodVersion) throws Exception {
+        if (prodVersion != null && prodVersion.toLowerCase().startsWith("dsn")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected boolean isDB2ForLUW(String prodVersion) throws Exception {
+        if (prodVersion != null && prodVersion.toLowerCase().startsWith("sql")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected boolean isDB2ForISeries(String prodVersion) throws Exception {
+        if (prodVersion != null && prodVersion.toLowerCase().startsWith("qsq")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected boolean isDB2ForVM_VSE(String prodVersion) throws Exception {
+        if (prodVersion != null && prodVersion.toLowerCase().startsWith("ari")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected boolean isDB2(String prodVersion) throws Exception {
+        return isDB2ForLUW(prodVersion) || isDB2ForZOS(prodVersion) || isDB2ForISeries(prodVersion);
+    }
+
+    protected boolean isDerby(String lDbProductName) throws Exception {
+        return (lDbProductName == null) ? false : lDbProductName.contains("derby");
+    }
 }


### PR DESCRIPTION
Update the com.ibm.ws.jpa_spec10_fat FAT bucket with the database support changes that went into the jpa injection and query buckets.