### PR TITLE
RepositoryResolver.resolveAsSet fix

### DIFF
--- a/dev/com.ibm.ws.repository.resolver/bnd.bnd
+++ b/dev/com.ibm.ws.repository.resolver/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -38,8 +38,8 @@ instrument.disabled: true
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 
 -testpath: \
-    ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     org.hamcrest:hamcrest-all;version=1.3, \
+    ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
     org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
     org.jmock:jmock;strategy=exact;version=2.5.1, \
     com.ibm.ws.repository.liberty;version=latest, \

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,7 @@ import com.ibm.ws.repository.connections.RepositoryConnectionList;
 import com.ibm.ws.repository.exceptions.RepositoryException;
 import com.ibm.ws.repository.resolver.RepositoryResolutionException.MissingRequirement;
 import com.ibm.ws.repository.resolver.RepositoryResolver.ResolvedFeatureSearchResult.ResultCategory;
+import com.ibm.ws.repository.resolver.internal.ResolutionMode;
 import com.ibm.ws.repository.resolver.internal.kernel.KernelResolverEsa;
 import com.ibm.ws.repository.resolver.internal.kernel.KernelResolverRepository;
 import com.ibm.ws.repository.resources.ApplicableToProduct;
@@ -57,6 +58,7 @@ public class RepositoryResolver {
     Collection<EsaResource> repoFeatures;
     Collection<SampleResource> repoSamples;
     RepositoryConnectionList repoConnections;
+    Collection<ProductDefinition> installDefinition;
 
     // ---
     // Fields computed during resolution
@@ -139,10 +141,10 @@ public class RepositoryResolver {
      *
      * @param installDefinition Information about the product(s) installed such as ID and edition. Must not be <code>null</code>.
      * @param installedFeatures The features that are installed. Must not be <code>null</code>.
-     * @param installedIFixes No longer used, parameter retained for backwards compatibility
-     * @param massiveUserId The user ID to use when logging into Massive. Must not be <code>null</code>.
-     * @param massivePassword The password to use when logging into Massive. Must not be <code>null</code>.
-     * @param massiveApiKey The API key to use when logging into Massive. Must not be <code>null</code>.
+     * @param installedIFixes   No longer used, parameter retained for backwards compatibility
+     * @param massiveUserId     The user ID to use when logging into Massive. Must not be <code>null</code>.
+     * @param massivePassword   The password to use when logging into Massive. Must not be <code>null</code>.
+     * @param massiveApiKey     The API key to use when logging into Massive. Must not be <code>null</code>.
      * @throws RepositoryException If there is a connection error with the Massive repository
      * @see ProductInfo#getAllProductInfo()
      * @see IFixUtils#getInstalledIFixes(java.io.File, com.ibm.ws.product.utility.CommandConsole)
@@ -153,8 +155,8 @@ public class RepositoryResolver {
                               RepositoryConnectionList repoConnections) throws RepositoryException {
 
         this.repoConnections = repoConnections;
+        this.installDefinition = installDefinition;
         fetchFromRepository(installDefinition);
-        initializeResolverRepository(installedFeatures, installDefinition);
         this.installedFeatures = installedFeatures;
         indexSamples();
     }
@@ -170,8 +172,8 @@ public class RepositoryResolver {
         this.repoFeatures = new ArrayList<>(repoFeatures);
         this.repoSamples = new ArrayList<>(repoSamples);
         this.installedFeatures = installedFeatures;
+        this.installDefinition = Collections.emptySet();
 
-        initializeResolverRepository(installedFeatures, Collections.<ProductDefinition> emptySet());
         indexSamples();
     }
 
@@ -207,8 +209,8 @@ public class RepositoryResolver {
         }
     }
 
-    void initializeResolverRepository(Collection<ProvisioningFeatureDefinition> installedFeatures, Collection<ProductDefinition> installDefintion) {
-        resolverRepository = new KernelResolverRepository(installDefintion, repoConnections);
+    void initializeResolverRepository(Collection<ProductDefinition> installDefintion, ResolutionMode mode) {
+        resolverRepository = new KernelResolverRepository(installDefintion, repoConnections, mode);
         resolverRepository.addInstalledFeatures(installedFeatures);
         resolverRepository.addFeatures(repoFeatures);
     }
@@ -237,9 +239,10 @@ public class RepositoryResolver {
      * want that, you may want to use {@link #resolveAsSet(Collection)} instead.</p>
      *
      * @param toResolve A collection of the identifiers of the resources to resolve. It should be in the form:</br>
-     *            <code>{name}/{version}</code></br>
-     *            <p>Where the <code>{name}</code> can be either the symbolic name, short name or lower case short name of the resource and <code>/{version}</code> is optional. The
-     *            collection may contain a mixture of symbolic names and short names. Must not be <code>null</code> or empty.</p>
+     *                      <code>{name}/{version}</code></br>
+     *                      <p>Where the <code>{name}</code> can be either the symbolic name, short name or lower case short name of the resource and <code>/{version}</code> is
+     *                      optional. The
+     *                      collection may contain a mixture of symbolic names and short names. Must not be <code>null</code> or empty.</p>
      * @return <p>A collection of ordered lists of {@link RepositoryResource}s to install. Each list represents a collection of resources that must be installed together or not
      *         at
      *         all. They should be installed in the iteration order of the list(s). Note that if a resource is required by multiple different resources then it will appear in
@@ -288,9 +291,10 @@ public class RepositoryResolver {
      * javaee-7.0 and javaee-8.0 contain features which conflict with each other (and other versions are not tolerated).
      *
      * @param toResolve A collection of the identifiers of the resources to resolve. It should be in the form:</br>
-     *            <code>{name}/{version}</code></br>
-     *            <p>Where the <code>{name}</code> can be either the symbolic name, short name or lower case short name of the resource and <code>/{version}</code> is optional. The
-     *            collection may contain a mixture of symbolic names and short names. Must not be <code>null</code> or empty.</p>
+     *                      <code>{name}/{version}</code></br>
+     *                      <p>Where the <code>{name}</code> can be either the symbolic name, short name or lower case short name of the resource and <code>/{version}</code> is
+     *                      optional. The
+     *                      collection may contain a mixture of symbolic names and short names. Must not be <code>null</code> or empty.</p>
      * @return <p>A collection of ordered lists of {@link RepositoryResource}s to install. Each list represents a collection of resources that must be installed together or not
      *         at
      *         all. They should be installed in the iteration order of the list(s). Note that if a resource is required by multiple different resources then it will appear in
@@ -316,6 +320,7 @@ public class RepositoryResolver {
 
     Collection<List<RepositoryResource>> resolve(Collection<String> toResolve, ResolutionMode resolutionMode) throws RepositoryResolutionException {
         initResolve();
+        initializeResolverRepository(installDefinition, resolutionMode);
 
         processNames(toResolve);
         findAutofeatureDependencies();
@@ -344,7 +349,7 @@ public class RepositoryResolver {
         requirementsFoundForOtherProducts = new HashSet<>();
         missingTopLevelRequirements = new ArrayList<>();
         missingRequirements = new ArrayList<>();
-        resolverRepository.clearPreferredVersions();
+        resolverRepository = null;
     }
 
     /**
@@ -629,10 +634,10 @@ public class RepositoryResolver {
      * Having done this, {@code distanceMap.keySet()} gives the set of all the dependencies of com.example.featureA. {@code distanceMap.get("com.example.featureB")} gives
      * the length of the longest dependency chain from featureA to featureB.
      *
-     * @param maxDistanceMap the map to be populated
-     * @param featureName the current feature
+     * @param maxDistanceMap  the map to be populated
+     * @param featureName     the current feature
      * @param currentDistance the distance to use for the current feature
-     * @param currentStack the set of feature names already in the current dependency chain (used to detect loops)
+     * @param currentStack    the set of feature names already in the current dependency chain (used to detect loops)
      * @return true if all requirements were found, false otherwise
      */
     boolean populateMaxDistanceMap(Map<String, Integer> maxDistanceMap, String featureName, int currentDistance, Set<ProvisioningFeatureDefinition> currentStack,
@@ -790,11 +795,6 @@ public class RepositoryResolver {
         }
 
         throw new RepositoryResolutionException(null, missingTopLevelRequirements, missingRequirementNames, missingProductInformation, missingRequirements);
-    }
-
-    enum ResolutionMode {
-        DETECT_CONFLICTS,
-        IGNORE_CONFLICTS,
     }
 
     static class ResolvedFeatureSearchResult {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/ResolutionMode.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/ResolutionMode.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.repository.resolver.internal;
+
+public enum ResolutionMode {
+    DETECT_CONFLICTS,
+    IGNORE_CONFLICTS,
+}

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import com.ibm.ws.repository.common.enums.ResourceType;
 import com.ibm.ws.repository.connections.ProductDefinition;
 import com.ibm.ws.repository.connections.RepositoryConnectionList;
 import com.ibm.ws.repository.exceptions.RepositoryBackendException;
+import com.ibm.ws.repository.resolver.internal.ResolutionMode;
 import com.ibm.ws.repository.resources.ApplicableToProduct;
 import com.ibm.ws.repository.resources.EsaResource;
 import com.ibm.ws.repository.resources.RepositoryResource;
@@ -55,7 +56,9 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
     private final Collection<ProductDefinition> productDefinitions;
     private final RepositoryConnectionList repositoryConnection;
 
-    public KernelResolverRepository(Collection<ProductDefinition> productDefinitions, RepositoryConnectionList repositoryConnection) {
+    private final ResolutionMode resolutionMode;
+
+    public KernelResolverRepository(Collection<ProductDefinition> productDefinitions, RepositoryConnectionList repositoryConnection, ResolutionMode resolutionMode) {
         this.repositoryConnection = repositoryConnection;
 
         if (productDefinitions == null) {
@@ -63,6 +66,8 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
         } else {
             this.productDefinitions = productDefinitions;
         }
+
+        this.resolutionMode = resolutionMode;
     }
 
     public void addFeatures(Collection<? extends EsaResource> esas) {
@@ -72,7 +77,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
     }
 
     public void addFeature(EsaResource esa) {
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, resolutionMode);
         addFeature(resolverEsa);
     }
 
@@ -127,7 +132,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * Checks whether {@code featureList} contains a feature with the same name and version as {@code feature}.
      *
      * @param featureList the list of features
-     * @param feature the feature
+     * @param feature     the feature
      * @return {@code true} if {@code featureList} contains a feature with the same symbolic name and version as {@code feature}, otherwise {@code false}
      */
     private boolean listContainsDuplicate(List<ProvisioningFeatureDefinition> featureList, ProvisioningFeatureDefinition feature) {
@@ -314,7 +319,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * When a preferred version is set, {@link #getFeature(String)} will return the preferred version if available, unless another version is already installed.
      *
      * @param featureName the short or symbolic feature name
-     * @param version the version
+     * @param version     the version
      */
     public void setPreferredVersion(String featureName, String version) {
         if (!symbolicNameToFeature.containsKey(featureName)) {
@@ -346,7 +351,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
      * If no preferred version has been configured for this symbolic name, or if the preferred version cannot be found in the list, return the latest version.
      *
      * @param symbolicName the symbolic name of the feature
-     * @param featureList the list of features, which should all have the same symbolic name
+     * @param featureList  the list of features, which should all have the same symbolic name
      * @return the best feature from the list
      */
     private ProvisioningFeatureDefinition getPreferredVersion(String symbolicName, List<ProvisioningFeatureDefinition> featureList) {

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolutionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corporation and others.
+ * Copyright (c) 2013, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.repository.resolver;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -18,7 +19,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.hamcrest.Matchers;
 import org.jmock.Mockery;
 import org.junit.Test;
 import org.osgi.service.resolver.ResolutionException;
@@ -42,6 +43,7 @@ import com.ibm.ws.kernel.productinfo.ProductInfoParseException;
 import com.ibm.ws.product.utility.extension.ifix.xml.IFixInfo;
 import com.ibm.ws.repository.common.enums.InstallPolicy;
 import com.ibm.ws.repository.common.enums.ResourceType;
+import com.ibm.ws.repository.common.enums.Visibility;
 import com.ibm.ws.repository.connections.ProductDefinition;
 import com.ibm.ws.repository.connections.RepositoryConnectionList;
 import com.ibm.ws.repository.connections.liberty.ProductInfoProductDefinition;
@@ -1913,10 +1915,178 @@ public class ResolutionTests {
     }
 
     /**
+     * Test the resoleAsSet method with 2 level feature dependencies
+     *
+     * Dependency chart
+     * Feature X -> Feature I 1.0
+     * Feature Y -> Feature I 1.1 tolerate 1.0
+     *
+     * Expected: Feature X, Feature Y, Feature I1.0
+     * Actual: Feature X, Feature Y, Feature I1.0
+     * This test case works as expected.
+     */
+    @Test
+    public void testSet() throws RepositoryException {
+        // initialize all of the features
+        EsaResourceWritable featureX = WritableResourceFactory.createEsa(null);
+        featureX.setProvideFeature("com.example.featureX-1.0");
+        featureX.addRequireFeatureWithTolerates("com.example.featureI-1.0", Collections.<String> emptyList());
+        featureX.setVisibility(Visibility.PUBLIC);
+        repoFeatures.add(featureX);
+
+        EsaResourceWritable featureY = WritableResourceFactory.createEsa(null);
+        featureY.setProvideFeature("com.example.featureY-1.0");
+        featureY.addRequireFeatureWithTolerates("com.example.featureI-1.1", Arrays.asList("1.0"));
+        featureY.setVisibility(Visibility.PUBLIC);
+        repoFeatures.add(featureY);
+
+        EsaResourceWritable featureI10 = WritableResourceFactory.createEsa(null);
+        featureI10.setProvideFeature("com.example.featureI-1.0");
+        featureI10.setVisibility(Visibility.PUBLIC);
+        featureI10.setSingleton("true");
+        repoFeatures.add(featureI10);
+
+        EsaResourceWritable featureI11 = WritableResourceFactory.createEsa(null);
+        featureI11.setProvideFeature("com.example.featureI-1.1");
+        featureI11.setVisibility(Visibility.PUBLIC);
+        featureI11.setSingleton("true");
+        repoFeatures.add(featureI11);
+
+        // build repository and resolve the features
+        RepositoryResolver resolver = createResolver();
+        Collection<List<RepositoryResource>> resolved = resolver.resolveAsSet(Arrays.asList(featureX.getProvideFeature(), featureY.getProvideFeature()));
+
+        assertThat(resolved, containsInAnyOrder(
+                                                Matchers.<RepositoryResource> contains(featureI10, featureX),
+                                                Matchers.<RepositoryResource> contains(featureI10, featureY)));
+
+    }
+
+    /**
+     * Test the resolveAsSet method with 3 level feature dependencies
+     *
+     * All features are public
+     *
+     * Dependency map
+     * Feature A -> Feature X -> Feature I 1.0
+     * Feature B -> Feature Y -> Feature I 1.1 tolerate 1.0
+     *
+     * Expected: resolution fails because Feature B does not tolerate Feature I 1.0
+     */
+    @Test
+    public void testSetTransitivePublic() throws RepositoryException {
+        // initialize all the features
+        EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
+        featureA.setProvideFeature("com.example.featureA-1.0");
+        featureA.addRequireFeatureWithTolerates("com.example.featureX-1.0", Collections.<String> emptyList());
+        featureA.setVisibility(Visibility.PUBLIC);
+        repoFeatures.add(featureA);
+
+        EsaResourceWritable featureB = WritableResourceFactory.createEsa(null);
+        featureB.setProvideFeature("com.example.featureB-1.0");
+        featureB.addRequireFeatureWithTolerates("com.example.featureY-1.0", Collections.<String> emptyList());
+        featureB.setVisibility(Visibility.PUBLIC);
+        repoFeatures.add(featureB);
+
+        EsaResourceWritable featureX = WritableResourceFactory.createEsa(null);
+        featureX.setProvideFeature("com.example.featureX-1.0");
+        featureX.addRequireFeatureWithTolerates("com.example.featureI-1.0", Collections.<String> emptyList());
+        featureX.setVisibility(Visibility.PUBLIC);
+        repoFeatures.add(featureX);
+
+        EsaResourceWritable featureY = WritableResourceFactory.createEsa(null);
+        featureY.setProvideFeature("com.example.featureY-1.0");
+        featureY.addRequireFeatureWithTolerates("com.example.featureI-1.1", Arrays.asList("1.0"));
+        featureY.setVisibility(Visibility.PUBLIC);
+        repoFeatures.add(featureY);
+
+        EsaResourceWritable featureI10 = WritableResourceFactory.createEsa(null);
+        featureI10.setProvideFeature("com.example.featureI-1.0");
+        featureI10.setVisibility(Visibility.PUBLIC);
+        featureI10.setSingleton("true");
+        repoFeatures.add(featureI10);
+
+        EsaResourceWritable featureI11 = WritableResourceFactory.createEsa(null);
+        featureI11.setProvideFeature("com.example.featureI-1.1");
+        featureI11.setVisibility(Visibility.PUBLIC);
+        featureI11.setSingleton("true");
+        repoFeatures.add(featureI11);
+
+        // build the repository and resolve the features
+        RepositoryResolver resolver = createResolver();
+        try {
+            Collection<List<RepositoryResource>> resolved = resolver.resolveAsSet(Arrays.asList(featureA.getProvideFeature(), featureB.getProvideFeature()));
+            fail("Resolution should fail, actual result: " + resolved);
+        } catch (RepositoryResolutionException e) {
+            // Expected
+        }
+
+    }
+
+    /**
+     * Test the resolveAsSet method with 3 level feature dependencies
+     *
+     * Feautre I is private
+     *
+     * Dependency map
+     * Feature A -> Feature X -> Feature I 1.0
+     * Feature B -> Feature Y -> Feature I 1.1 tolerate 1.0
+     *
+     * Expected: resolution succeeds because although Feature B does not tolerate Feature I 1.0, Feature I is private.
+     */
+    @Test
+    public void testSetTransitivePrivate() throws RepositoryException {
+        // initialize all the features
+        EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
+        featureA.setProvideFeature("com.example.featureA-1.0");
+        featureA.addRequireFeatureWithTolerates("com.example.featureX-1.0", Collections.<String> emptyList());
+        featureA.setVisibility(Visibility.PUBLIC);
+        repoFeatures.add(featureA);
+
+        EsaResourceWritable featureB = WritableResourceFactory.createEsa(null);
+        featureB.setProvideFeature("com.example.featureB-1.0");
+        featureB.addRequireFeatureWithTolerates("com.example.featureY-1.0", Collections.<String> emptyList());
+        featureB.setVisibility(Visibility.PUBLIC);
+        repoFeatures.add(featureB);
+
+        EsaResourceWritable featureX = WritableResourceFactory.createEsa(null);
+        featureX.setProvideFeature("com.example.featureX-1.0");
+        featureX.addRequireFeatureWithTolerates("com.example.featureI-1.0", Collections.<String> emptyList());
+        featureX.setVisibility(Visibility.PUBLIC);
+        repoFeatures.add(featureX);
+
+        EsaResourceWritable featureY = WritableResourceFactory.createEsa(null);
+        featureY.setProvideFeature("com.example.featureY-1.0");
+        featureY.addRequireFeatureWithTolerates("com.example.featureI-1.1", Arrays.asList("1.0"));
+        featureY.setVisibility(Visibility.PUBLIC);
+        repoFeatures.add(featureY);
+
+        EsaResourceWritable featureI10 = WritableResourceFactory.createEsa(null);
+        featureI10.setProvideFeature("com.example.featureI-1.0");
+        featureI10.setVisibility(Visibility.PRIVATE);
+        featureI10.setSingleton("true");
+        repoFeatures.add(featureI10);
+
+        EsaResourceWritable featureI11 = WritableResourceFactory.createEsa(null);
+        featureI11.setProvideFeature("com.example.featureI-1.1");
+        featureI11.setVisibility(Visibility.PRIVATE);
+        featureI11.setSingleton("true");
+        repoFeatures.add(featureI11);
+
+        // build the repository and resolve the features
+        RepositoryResolver resolver = createResolver();
+        Collection<List<RepositoryResource>> resolved = resolver.resolveAsSet(Arrays.asList(featureA.getProvideFeature(), featureB.getProvideFeature()));
+        assertThat(resolved, containsInAnyOrder(
+                                                Matchers.<RepositoryResource> contains(featureI10, featureX, featureA),
+                                                Matchers.<RepositoryResource> contains(featureI10, featureY, featureB)));
+
+    }
+
+    /**
      * Run a test to make sure that a sample with an applies to set is resolved correctly
      *
-     * @param name The name of the sample
-     * @param appliesTo The applies to to put onto the sample
+     * @param name           The name of the sample
+     * @param appliesTo      The applies to to put onto the sample
      * @param productVersion The product version to be
      * @throws RepositoryResourceException
      * @throws RepositoryBackendException
@@ -1937,9 +2107,9 @@ public class ResolutionTests {
     /**
      * Run a test against a product definition with the supplied version and expect a single result back.
      *
-     * @param name The name to resolve
+     * @param name           The name to resolve
      * @param productVersion The product version to use
-     * @param testResource The resource to expect
+     * @param testResource   The resource to expect
      * @throws IOException
      * @throws ProductInfoParseException
      * @throws RepositoryException
@@ -1984,8 +2154,8 @@ public class ResolutionTests {
      * Creates an {@link EsaResourceWritable} and adds it to the list of features in the repo with just the core fields set.
      *
      * @param symbolicName The symbolic name of the resource
-     * @param shortName The short name of the resource
-     * @param version The version of the resource
+     * @param shortName    The short name of the resource
+     * @param version      The version of the resource
      * @return The resource
      * @throws RepositoryResourceException
      * @throws RepositoryBackendException
@@ -2010,11 +2180,11 @@ public class ResolutionTests {
     /**
      * Creates an {@link EsaResourceWritable} and adds it to the list of features in the repo
      *
-     * @param symbolicName The symbolic name of the resource
-     * @param shortName The short name of the resource
-     * @param version The version of the resource
+     * @param symbolicName           The symbolic name of the resource
+     * @param shortName              The short name of the resource
+     * @param version                The version of the resource
      * @param dependencySymoblicName The symbolic names of dependencies
-     * @param appliesTo The product this feature applies to
+     * @param appliesTo              The product this feature applies to
      * @return The resource
      * @throws RepositoryBackendException
      */
@@ -2026,14 +2196,14 @@ public class ResolutionTests {
     /**
      * Creates an {@link EsaResourceWritable} and adds it to the list of features in the repo.
      *
-     * @param symbolicName The symbolic name of the resource
-     * @param shortName The short name of the resource
-     * @param version The version of the resource
-     * @param appliesTo The product this feature applies to
+     * @param symbolicName           The symbolic name of the resource
+     * @param shortName              The short name of the resource
+     * @param version                The version of the resource
+     * @param appliesTo              The product this feature applies to
      * @param dependencySymoblicName The symbolic names of dependencies
      * @param provisionSymbolicNames The symbolic name(s) of the capability required for this feature to be auto provision
-     * @param autoInstallable The autoInstallable value to use
-     * @param requiredFixes fixes required by this feature
+     * @param autoInstallable        The autoInstallable value to use
+     * @param requiredFixes          fixes required by this feature
      * @return The resource
      * @throws RepositoryBackendException
      */

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/FeatureResolverTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/FeatureResolverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.repository.resolver.internal.kernel;
 
+import static com.ibm.ws.repository.resolver.internal.ResolutionMode.IGNORE_CONFLICTS;
 import static com.ibm.ws.repository.resolver.internal.kernel.KernelResolverResultMatcher.result;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -36,7 +37,7 @@ public class FeatureResolverTest {
     @Test
     public void testSingleFeatureResolution() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
 
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
         esa.setProvideFeature("com.example.featureA");
@@ -51,7 +52,7 @@ public class FeatureResolverTest {
     @Test
     public void testDependencyResolution() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
 
         EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
         featureA.setProvideFeature("com.example.featureA");
@@ -72,7 +73,7 @@ public class FeatureResolverTest {
     @Test
     public void testToleratesChoosesPreferred() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
 
         EsaResourceWritable featureA10 = WritableResourceFactory.createEsa(null);
         featureA10.setProvideFeature("com.example.featureA-1.0");
@@ -98,7 +99,7 @@ public class FeatureResolverTest {
     @Test
     public void testToleratesUsedWhenPreferredMissing() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
 
         EsaResourceWritable featureA11 = WritableResourceFactory.createEsa(null);
         featureA11.setProvideFeature("com.example.featureA-1.1");
@@ -119,7 +120,7 @@ public class FeatureResolverTest {
     @Test
     public void testToleratesUsedWhenConflictingVersionsRequired() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
 
         EsaResourceWritable featureA10 = WritableResourceFactory.createEsa(null);
         featureA10.setProvideFeature("com.example.featureA-1.0");
@@ -153,7 +154,7 @@ public class FeatureResolverTest {
     @Test
     public void testToleratesNotUsedWhenNotSingleton() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
 
         // Note featureA-1.0 and 1.1 are not singletons so can resolve together
         EsaResourceWritable featureA10 = WritableResourceFactory.createEsa(null);
@@ -186,7 +187,7 @@ public class FeatureResolverTest {
     @Test
     public void testAutofeatureResolved() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
 
         EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
         featureA.setProvideFeature("com.example.featureA");

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsaTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsaTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.repository.resolver.internal.kernel;
 
+import static com.ibm.ws.repository.resolver.internal.ResolutionMode.DETECT_CONFLICTS;
+import static com.ibm.ws.repository.resolver.internal.ResolutionMode.IGNORE_CONFLICTS;
 import static com.ibm.ws.repository.resolver.internal.kernel.FeatureResourceMatcher.featureResource;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -40,7 +42,7 @@ public class KernelResolverEsaTest {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
         esa.setProvideFeature("com.example.featureA");
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
         assertThat(resolverEsa.getSymbolicName(), is("com.example.featureA"));
     }
 
@@ -49,7 +51,7 @@ public class KernelResolverEsaTest {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
         esa.setProvideFeature("com.example.featureA");
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
 
         assertThat(resolverEsa.getSymbolicName(), is("com.example.featureA"));
         assertThat(resolverEsa.getFeatureName(), is("com.example.featureA"));
@@ -67,7 +69,7 @@ public class KernelResolverEsaTest {
     public void testBundleRepositoryType() {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
         assertThat(resolverEsa.getBundleRepositoryType(), is(""));
     }
 
@@ -77,7 +79,7 @@ public class KernelResolverEsaTest {
         esa.setProvideFeature("com.example.featureA");
         esa.addRequireFeatureWithTolerates("com.example.featureB-1.0", Arrays.asList("1.1", "1.5"));
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
         assertThat(resolverEsa.getConstituents(SubsystemContentType.FEATURE_TYPE), contains(featureResource("com.example.featureB-1.0", "1.1", "1.5")));
     }
 
@@ -87,7 +89,7 @@ public class KernelResolverEsaTest {
         esa.setProvideFeature("com.example.featureA");
         esa.setShortName("featureA");
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
         assertThat(resolverEsa.getIbmShortName(), is("featureA"));
     }
 
@@ -105,9 +107,9 @@ public class KernelResolverEsaTest {
         autoFeature.setProvisionCapability("osgi.identity; filter:=\"(&(type=osgi.subsystem.feature)(osgi.identity=com.example.featureA))\","
                                            + "osgi.identity; filter:=\"(&(type=osgi.subsystem.feature)(osgi.identity=com.example.featureB))\"");
 
-        KernelResolverEsa resolverFeatureA = new KernelResolverEsa(featureA);
-        KernelResolverEsa resolverFeatureB = new KernelResolverEsa(featureB);
-        KernelResolverEsa resolverAutoFeature = new KernelResolverEsa(autoFeature);
+        KernelResolverEsa resolverFeatureA = new KernelResolverEsa(featureA, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverFeatureB = new KernelResolverEsa(featureB, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverAutoFeature = new KernelResolverEsa(autoFeature, IGNORE_CONFLICTS);
 
         assertThat(resolverFeatureA.isCapabilitySatisfied(Collections.<ProvisioningFeatureDefinition> emptySet()), is(true));
         assertThat(resolverFeatureB.isCapabilitySatisfied(Collections.<ProvisioningFeatureDefinition> emptySet()), is(true));
@@ -121,7 +123,7 @@ public class KernelResolverEsaTest {
     @Test
     public void testIsAutoFeature() {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
 
         assertThat(resolverEsa.isAutoFeature(), is(false));
 
@@ -136,7 +138,7 @@ public class KernelResolverEsaTest {
     public void testIsSingleton() {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
 
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
         assertThat(resolverEsa.isSingleton(), is(false));
 
         esa.setSingleton("true");
@@ -155,8 +157,8 @@ public class KernelResolverEsaTest {
         featureB.setProvideFeature("com.example.featureB");
         featureB.setShortName("featureB");
 
-        KernelResolverEsa resolverFeatureA = new KernelResolverEsa(featureA);
-        KernelResolverEsa resolverFeatureB = new KernelResolverEsa(featureB);
+        KernelResolverEsa resolverFeatureA = new KernelResolverEsa(featureA, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverFeatureB = new KernelResolverEsa(featureB, IGNORE_CONFLICTS);
 
         assertThat(resolverFeatureA.getFeatureName(), is("com.example.featureA"));
         assertThat(resolverFeatureB.getFeatureName(), is("featureB"));
@@ -180,10 +182,11 @@ public class KernelResolverEsaTest {
         installFeature.setProvideFeature("com.example.installFeature");
         installFeature.setVisibility(Visibility.INSTALL);
 
-        KernelResolverEsa resolverPublicFeature = new KernelResolverEsa(publicFeature);
-        KernelResolverEsa resolverPrivateFeature = new KernelResolverEsa(privateFeature);
-        KernelResolverEsa resolverProtectedFeature = new KernelResolverEsa(protectedFeature);
-        KernelResolverEsa resolverInstallFeature = new KernelResolverEsa(installFeature);
+        // Test visibility for normal resolution
+        KernelResolverEsa resolverPublicFeature = new KernelResolverEsa(publicFeature, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverPrivateFeature = new KernelResolverEsa(privateFeature, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverProtectedFeature = new KernelResolverEsa(protectedFeature, IGNORE_CONFLICTS);
+        KernelResolverEsa resolverInstallFeature = new KernelResolverEsa(installFeature, IGNORE_CONFLICTS);
 
         // Note: no matter the visibility of the EsaResource, the ResolverEsa should always report as PUBLIC
         // this is because we allow installation of private and protected resources by name, even though they're
@@ -192,27 +195,41 @@ public class KernelResolverEsaTest {
         assertThat(resolverPrivateFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PUBLIC));
         assertThat(resolverProtectedFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PUBLIC));
         assertThat(resolverInstallFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PUBLIC));
+
+        // Test visibility for resolving as a set
+        KernelResolverEsa resolverSetPublicFeature = new KernelResolverEsa(publicFeature, DETECT_CONFLICTS);
+        KernelResolverEsa resolverSetPrivateFeature = new KernelResolverEsa(privateFeature, DETECT_CONFLICTS);
+        KernelResolverEsa resolverSetProtectedFeature = new KernelResolverEsa(protectedFeature, DETECT_CONFLICTS);
+        KernelResolverEsa resolverSetInstallFeature = new KernelResolverEsa(installFeature, DETECT_CONFLICTS);
+
+        // Note: when resolving as a set, the visibility of the ResolverEsa must match the EsaResource because
+        // it affects the rules for feature toleration, which is only used for set resolution.
+        assertThat(resolverSetPublicFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PUBLIC));
+        assertThat(resolverSetPrivateFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PRIVATE));
+        assertThat(resolverSetProtectedFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.PROTECTED));
+        assertThat(resolverSetInstallFeature.getVisibility(), is(com.ibm.ws.kernel.feature.Visibility.INSTALL));
+
     }
 
     @Test
     public void testVersion() {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
-        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa);
+        KernelResolverEsa resolverEsa = new KernelResolverEsa(esa, IGNORE_CONFLICTS);
         assertThat(resolverEsa.getVersion(), is(Version.emptyVersion));
 
         EsaResourceWritable esa2 = WritableResourceFactory.createEsa(null);
         esa2.setVersion("1.0");
-        KernelResolverEsa resolverEsa2 = new KernelResolverEsa(esa2);
+        KernelResolverEsa resolverEsa2 = new KernelResolverEsa(esa2, IGNORE_CONFLICTS);
         assertThat(resolverEsa2.getVersion(), is(Version.valueOf("1.0.0")));
 
         EsaResourceWritable esa3 = WritableResourceFactory.createEsa(null);
         esa3.setVersion("4.8.2");
-        KernelResolverEsa resolverEsa3 = new KernelResolverEsa(esa3);
+        KernelResolverEsa resolverEsa3 = new KernelResolverEsa(esa3, IGNORE_CONFLICTS);
         assertThat(resolverEsa3.getVersion(), is(Version.valueOf("4.8.2")));
 
         EsaResourceWritable esa4 = WritableResourceFactory.createEsa(null);
         esa2.setVersion("wibble");
-        KernelResolverEsa resolverEsa4 = new KernelResolverEsa(esa4);
+        KernelResolverEsa resolverEsa4 = new KernelResolverEsa(esa4, IGNORE_CONFLICTS);
         assertThat(resolverEsa4.getVersion(), is(Version.emptyVersion));
     }
 

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepositoryTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepositoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.repository.resolver.internal.kernel;
 
+import static com.ibm.ws.repository.resolver.internal.ResolutionMode.IGNORE_CONFLICTS;
 import static com.ibm.ws.repository.resolver.internal.kernel.KernelResolverEsaMatcher.resolverEsaWrapping;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -40,7 +41,7 @@ public class KernelResolverRepositoryTest {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
         esa.setProvideFeature("com.example.featureA");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeature(esa);
 
         assertThat(repo.getFeature("com.example.featureA"), is(resolverEsaWrapping(esa)));
@@ -54,7 +55,7 @@ public class KernelResolverRepositoryTest {
         publicEsa.setShortName("publicFeature");
         publicEsa.setVisibility(Visibility.PUBLIC);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeature(publicEsa);
 
         // Lookup by symbolic name works case insensitively
@@ -73,7 +74,7 @@ public class KernelResolverRepositoryTest {
         privateEsa.setShortName("privateFeature");
         privateEsa.setVisibility(Visibility.PRIVATE);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeature(privateEsa);
 
         // Lookup by symbolic name works case insensitively
@@ -92,7 +93,7 @@ public class KernelResolverRepositoryTest {
         protectedEsa.setShortName("protectedFeature");
         protectedEsa.setVisibility(Visibility.PROTECTED);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeature(protectedEsa);
 
         // Lookup by symbolic name works case insensitively
@@ -111,7 +112,7 @@ public class KernelResolverRepositoryTest {
         installEsa.setShortName("installFeature");
         installEsa.setVisibility(Visibility.INSTALL);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeature(installEsa);
 
         // Lookup by symbolic name works case insensitively
@@ -128,7 +129,7 @@ public class KernelResolverRepositoryTest {
         EsaResourceWritable esa = WritableResourceFactory.createEsa(null);
         esa.setProvideFeature("com.example.featureA");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeature(esa);
 
         // GetConfiguredTolerates should always return an empty list
@@ -139,7 +140,7 @@ public class KernelResolverRepositoryTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testGetAutoFeatures() {
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
 
         EsaResourceWritable featureA = WritableResourceFactory.createEsa(null);
         featureA.setProvideFeature("com.example.featureA");
@@ -174,7 +175,7 @@ public class KernelResolverRepositoryTest {
         featureAduplicate.setProvideFeature("com.example.featureA");
         featureAduplicate.setShortName("featureA");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeatures(Arrays.asList(featureA, featureB, featureAduplicate));
 
         assertThat(repo.getFeature("com.example.featureA"), is(resolverEsaWrapping(featureA)));
@@ -195,7 +196,7 @@ public class KernelResolverRepositoryTest {
         featureA_11.setProvideFeature("com.example.featureA-1.0");
         featureA_11.setVersion("1.1");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeatures(Arrays.asList(featureA_10, featureA_11));
 
         // The latest version should be returned
@@ -212,7 +213,7 @@ public class KernelResolverRepositoryTest {
         featureA_11.setProvideFeature("com.example.featureA-1.0");
         featureA_11.setVersion("1.1");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeatures(Arrays.asList(featureA_10, featureA_11));
         repo.setPreferredVersion("com.example.featureA-1.0", "1.0");
 
@@ -235,7 +236,7 @@ public class KernelResolverRepositoryTest {
         featureA_110.setProvideFeature("com.example.featureA-1.0");
         featureA_110.setVersion("1.10");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeatures(Arrays.asList(featureA_19, featureA_110));
         repo.setPreferredVersion("com.example.featureA-1.0", "1.9");
 
@@ -259,7 +260,7 @@ public class KernelResolverRepositoryTest {
         featureA_wibble.setProvideFeature("com.example.featureA-1.0");
         featureA_wibble.setVersion("wibble");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeatures(Arrays.asList(featureA_wibble, featureA_1));
 
         // The feature with the valid version should be returned
@@ -276,7 +277,7 @@ public class KernelResolverRepositoryTest {
         Mockery mockery = new Mockery();
         ProvisioningFeatureDefinition installedFeature = ResolverTestUtils.mockSimpleFeatureDefinition(mockery, "com.example.featureA", Version.valueOf("1.0.0"), null);
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
 
         // With just the esa added, it should be returned
         repo.addFeature(esa);
@@ -306,7 +307,7 @@ public class KernelResolverRepositoryTest {
         ProvisioningFeatureDefinition installedFeature = ResolverTestUtils.mockSimpleFeatureDefinition(mockery, "com.example.featureA", Version.valueOf("1.0.0"), "featureA",
                                                                                                        "foo:featureA");
 
-        KernelResolverRepository repo = new KernelResolverRepository(null, null);
+        KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeature(installedFeature);
         assertThat(repo.getFeature("foo:featureA"), is(installedFeature));
     }


### PR DESCRIPTION
* When resolving as a set, report visibility correctly as this affects how rules for dependency toleration are applied
* Update existing unit tests
* Update resolution tests adapted from the failure cases provided by @TayyabDev 
* Add conflict chain information to `RepositoryResolutionException`
* Update the message for `RepositoryResolutionException` to aid debugging