### PR TITLE
export jsf-2.3 impl classes as third-party

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.3/com.ibm.websphere.appserver.jsf-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.3/com.ibm.websphere.appserver.jsf-2.3.feature
@@ -51,6 +51,6 @@ Subsystem-Name: JavaServer Faces 2.3
  com.ibm.ws.cdi.interfaces, \
  com.ibm.ws.org.apache.commons.digester.1.8, \
  com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.websocket:javax.websocket-api:1.1", \
- com.ibm.websphere.appserver.thirdparty.jsf-2.3; location:="dev/api/third-party/"; mavenCoordinates="org.apache.myfaces.core:myfaces-impl:2.3.3"
+ com.ibm.websphere.appserver.thirdparty.jsf-2.3; location:="dev/api/third-party/"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.3/com.ibm.websphere.appserver.jsf-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.3/com.ibm.websphere.appserver.jsf-2.3.feature
@@ -26,7 +26,12 @@ IBM-API-Package: javax.faces; type="spec", \
  javax.faces.validator; type="spec", \
  javax.faces.view; type="spec", \
  javax.faces.view.facelets; type="spec", \
- javax.faces.webapp; type="spec"
+ javax.faces.webapp; type="spec", \
+ org.apache.myfaces.renderkit.html; type="third-party", \
+ org.apache.myfaces.shared.config; type="third-party", \
+ org.apache.myfaces.shared.renderkit; type="third-party", \
+ org.apache.myfaces.shared.renderkit.html; type="third-party", \
+ org.apache.myfaces.shared.renderkit.html.util; type="third-party"
 IBM-ShortName: jsf-2.3
 Subsystem-Name: JavaServer Faces 2.3
 -features=com.ibm.websphere.appserver.javax.cdi-2.0, \
@@ -45,6 +50,7 @@ Subsystem-Name: JavaServer Faces 2.3
  com.ibm.ws.jsf.shared, \
  com.ibm.ws.cdi.interfaces, \
  com.ibm.ws.org.apache.commons.digester.1.8, \
- com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.websocket:javax.websocket-api:1.1"
+ com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.websocket:javax.websocket-api:1.1", \
+ com.ibm.websphere.appserver.thirdparty.jsf-2.3; location:="dev/api/third-party/"; mavenCoordinates="org.apache.myfaces.core:myfaces-impl:2.3.3"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.classpath
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.project
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.websphere.appserver.thirdparty.jsf-2.3</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.3/bnd.bnd
@@ -1,0 +1,43 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Fragment-Host: com.ibm.ws.org.apache.myfaces.2.3;bundle-version=1.0
+
+Bundle-Name: WebSphere JSF MyFaces Third Party API
+Bundle-SymbolicName: com.ibm.websphere.appserver.thirdparty.jsf-2.3
+Bundle-Description: WebSphere JSF 2.3 MyFaces Third Party API
+Implementation-Version: 2.3.3
+
+javac.source: 1.8
+javac.target: 1.8
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+# Don't export the org.apache.myfaces.buildtools package as that is only needed for compilation.  The jar that contains the 
+# org.apache.myfaces.buildtools package is javax.j2ee.jsf-2.2/lib/myfaces-builder-annotations-1.0.9.jar
+Export-Package: \
+  org.apache.myfaces.renderkit.html;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.config;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.renderkit;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.renderkit.html;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.renderkit.html.util;version=${Implementation-Version}
+
+instrument.ffdc: false
+instrument.classesExcludes: \
+  org/**/*.class
+
+publish.wlp.jar.suffix: dev/api/third-party
+
+-fixupmessages.missingexport: "Used bundle version * for exported package";is:=ignore
+
+-buildpath: com.ibm.ws.org.apache.myfaces.2.3;version=project, \
+  org.apache.myfaces.core.impl;strategy=exact;version=${Implementation-Version}

--- a/dev/com.ibm.ws.jsf.2.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsf.2.3_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -46,7 +46,8 @@ src: \
     test-applications/CDIInjectionTests.war/src,\
     test-applications/CDICommon/src,\
     test-applications/CDIConfigByACP.war/src,\
-    test-applications/CDIConfigByACP.jar/src
+    test-applications/CDIConfigByACP.jar/src,\
+    test-applications/JSF23ThirdPartyApi.war/src
 
 fat.project: true
 
@@ -57,6 +58,8 @@ javac.target: 1.8
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
     net.sourceforge.htmlunit:htmlunit;version=2.20,\
     xml-apis:xml-apis;version=1.4.01,\
+    com.ibm.websphere.appserver.thirdparty.jsf-2.3;version=latest, \
+    com.ibm.ws.org.apache.myfaces.2.3;version=latest, \
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.jsf.2.3;version=latest,\
     com.ibm.websphere.javaee.validation.2.0;version=latest,\

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import com.ibm.ws.jsf23.fat.tests.JSF23JPA22Test;
 import com.ibm.ws.jsf23.fat.tests.JSF23JSF22SingletonFeatureTest;
 import com.ibm.ws.jsf23.fat.tests.JSF23MapSupportTests;
 import com.ibm.ws.jsf23.fat.tests.JSF23SelectOneRadioGroupTests;
+import com.ibm.ws.jsf23.fat.tests.JSF23ThirdPartyApiTests;
 import com.ibm.ws.jsf23.fat.tests.JSF23UIRepeatConditionTests;
 import com.ibm.ws.jsf23.fat.tests.JSF23UISelectManyTests;
 import com.ibm.ws.jsf23.fat.tests.JSF23ViewParametersTests;
@@ -88,7 +89,8 @@ import com.ibm.ws.jsf23.fat.tests.JSF23WebSocketTests;
                 CDIInjectionTests.class,
                 CDIFacesInMetaInfTests.class,
                 CDIFacesInWebXMLTests.class,
-                CDIConfigByACPTests.class
+                CDIConfigByACPTests.class,
+                JSF23ThirdPartyApiTests.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23ThirdPartyApiTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23ThirdPartyApiTests.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jsf23.fat.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.jsf23.fat.JSFUtils;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Tests that the correct MyFaces packages are accessible when an application is configured to use third-party APIs
+ */
+@Mode(TestMode.LITE)
+@RunWith(FATRunner.class)
+public class JSF23ThirdPartyApiTests {
+
+    protected static final Class<?> c = JSF23ThirdPartyApiTests.class;
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Server("jsf23ThirdPartyAPIServer")
+    public static LibertyServer jsf23ThirdPartyApiServer;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ShrinkHelper.defaultApp(jsf23ThirdPartyApiServer, "JSF23ThirdPartyApi.war", "com.ibm.ws.jsf23.fat.thirdpartyapi");
+
+        // Start the server and use the class name so we can find logs easily.
+        // Many tests use the same server.
+        jsf23ThirdPartyApiServer.startServer(JSF23ThirdPartyApiTests.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server
+        if (jsf23ThirdPartyApiServer != null && jsf23ThirdPartyApiServer.isStarted()) {
+            jsf23ThirdPartyApiServer.stopServer();
+        }
+    }
+
+    /**
+     * Test that an application with the "third-party" classloader visibility enabled has access to the jsf-2.3 org.apache.myfaces packages.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testJSFThirdPartyAPIAccess() throws Exception {
+        String contextRoot = "JSF23ThirdPartyApi";
+        WebClient webClient = new WebClient();
+
+        // Construct the URL for the test
+        URL url = JSFUtils.createHttpUrl(jsf23ThirdPartyApiServer, contextRoot, "JSF23ThirdPartyAPI.xhtml");
+
+        HtmlPage page = (HtmlPage) webClient.getPage(url);
+
+        // Log the page for debugging if necessary in the future.
+        Log.info(c, name.getMethodName(), page.asText());
+        Log.info(c, name.getMethodName(), page.asXml());
+
+        assertTrue("The MyFaces API classes were not accessible by the application:\n" + page.asText(), page.asXml().contains("test passed!"));
+        webClient.close();
+    }
+
+    /**
+     * Test that the same app cannot access those org.apache.myfaces packages which have not been exposed
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testJSFThirdPartyAPIAccessFails() throws Exception {
+        String contextRoot = "JSF23ThirdPartyApi";
+        WebClient webClient = new WebClient();
+
+        // Construct the URL for the test
+        URL url = JSFUtils.createHttpUrl(jsf23ThirdPartyApiServer, contextRoot, "JSF23ThirdPartyAPIFailure.xhtml");
+
+        HtmlPage page = (HtmlPage) webClient.getPage(url);
+
+        // Log the page for debugging if necessary in the future.
+        Log.info(c, name.getMethodName(), page.asText());
+        Log.info(c, name.getMethodName(), page.asXml());
+
+        assertTrue("org.apache.myfaces classes were accessible when they should not have been:\n" + page.asText(), page.asXml().contains("test passed!"));
+        webClient.close();
+    }
+}

--- a/dev/com.ibm.ws.jsf.2.3_fat/publish/servers/jsf23ThirdPartyAPIServer/.gitignore
+++ b/dev/com.ibm.ws.jsf.2.3_fat/publish/servers/jsf23ThirdPartyAPIServer/.gitignore
@@ -1,0 +1,2 @@
+/dropins
+/apps

--- a/dev/com.ibm.ws.jsf.2.3_fat/publish/servers/jsf23ThirdPartyAPIServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jsf.2.3_fat/publish/servers/jsf23ThirdPartyAPIServer/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+osgi.console=7777
+ 

--- a/dev/com.ibm.ws.jsf.2.3_fat/publish/servers/jsf23ThirdPartyAPIServer/server.xml
+++ b/dev/com.ibm.ws.jsf.2.3_fat/publish/servers/jsf23ThirdPartyAPIServer/server.xml
@@ -1,0 +1,25 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing jsf-2.3 third-party API access">
+    <include location="../fatTestPorts.xml"/>
+    
+    <featureManager>
+        <feature>jsf-2.3</feature>
+        <feature>cdi-2.0</feature>
+    </featureManager>
+
+    <application id="JSF23ThirdPartyApi" name="JSF23ThirdPartyApi" type="war" location="JSF23ThirdPartyApi.war">
+        <classloader apiTypeVisibility="spec, ibm-api, stable, third-party"/>
+    </application>
+     
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
+</server>

--- a/dev/com.ibm.ws.jsf.2.3_fat/test-applications/JSF23ThirdPartyApi.war/resources/JSF23ThirdPartyAPI.xhtml
+++ b/dev/com.ibm.ws.jsf.2.3_fat/test-applications/JSF23ThirdPartyApi.war/resources/JSF23ThirdPartyAPI.xhtml
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:head>
+        </h:head>
+        <h:body>
+            <h3>JSF 2.3 third-party API test</h3>
+            <p>This test will attempt to invoke com.ibm.ws.jsf23.fat.thirdpartyapi.ThirdPartyBean.success</p>
+            <p>result: <h:outputText value="#{thirdPartyBean.success}"/></p>
+        </h:body>
+</html>

--- a/dev/com.ibm.ws.jsf.2.3_fat/test-applications/JSF23ThirdPartyApi.war/resources/JSF23ThirdPartyAPIFailure.xhtml
+++ b/dev/com.ibm.ws.jsf.2.3_fat/test-applications/JSF23ThirdPartyApi.war/resources/JSF23ThirdPartyAPIFailure.xhtml
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:head>
+        </h:head>
+        <h:body>
+            <h3>JSF 2.3 third-party API test</h3>
+            <p>This test will attempt to invoke com.ibm.ws.jsf23.fat.thirdpartyapi.ThirdPartyBean.failure</p>
+            <p>result: <h:outputText value="#{thirdPartyBean.failure}"/></p>
+        </h:body>
+</html>

--- a/dev/com.ibm.ws.jsf.2.3_fat/test-applications/JSF23ThirdPartyApi.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.3_fat/test-applications/JSF23ThirdPartyApi.war/resources/WEB-INF/web.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-app id="WebApp_ID" version="4.0"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
+    
+  <display-name>JSF23ThirdPartyAPITests</display-name>
+
+  <servlet>
+    <servlet-name>Faces Servlet</servlet-name>
+    <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+  </servlet>
+  
+  <servlet-mapping>
+    <servlet-name>Faces Servlet</servlet-name>
+    <url-pattern>*.xhtml</url-pattern>
+  </servlet-mapping>
+  
+  <welcome-file-list>  
+    <welcome-file>index.xhtml</welcome-file>  
+  </welcome-file-list>  
+
+</web-app>

--- a/dev/com.ibm.ws.jsf.2.3_fat/test-applications/JSF23ThirdPartyApi.war/src/com/ibm/ws/jsf23/fat/thirdpartyapi/ThirdPartyBean.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/test-applications/JSF23ThirdPartyApi.war/src/com/ibm/ws/jsf23/fat/thirdpartyapi/ThirdPartyBean.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jsf23.fat.thirdpartyapi;
+
+import org.apache.myfaces.config.RuntimeConfig;
+import org.apache.myfaces.renderkit.html.HtmlListboxRenderer;
+import org.apache.myfaces.shared.config.MyfacesConfig;
+import org.apache.myfaces.shared.renderkit.RendererUtils;
+import org.apache.myfaces.shared.renderkit.html.HtmlRendererUtils;
+import org.apache.myfaces.shared.renderkit.html.util.HTMLEncoder;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+ 
+@Named
+@RequestScoped
+public class ThirdPartyBean {
+
+    /**
+     * Invoke a method from each package that is currently exposed by JSF as third-party API.
+     * If any package isn't available to applications at runtime, this test will return a failure.
+     */
+    public String getSuccess() {
+
+        try {
+            String passed = "";
+
+            HtmlListboxRenderer hlb = new HtmlListboxRenderer();
+            passed += hlb.getRendersChildren() + ":";
+
+            MyfacesConfig mfc = new MyfacesConfig();
+            passed += mfc.isAutoScroll() + ":";
+            passed += RendererUtils.isDefaultAttributeValue(null)+ ":";
+            passed += HtmlRendererUtils.isDisplayValueOnly(null)+ ":";
+
+            return HTMLEncoder.encode(passed + " test passed!");
+        } catch (Exception e) {
+            return "test failed; exception = " + e;
+        }
+    }
+    
+    public void setSuccess(String s) {
+    }
+
+    /**
+     * Invoke a method from a package that is currently NOT exposed by JSF as third-party API.
+     * A NoClassDefFoundError should be caught, and will result in the test passing
+     */
+    public String getFailure() {
+
+        try {
+            RuntimeConfig rc = new RuntimeConfig();
+            // the NoClassDefFoundError should be thrown from here
+            String test =  rc.getFacesVersion();
+            return "test failed!!";
+        } catch (java.lang.NoClassDefFoundError ncdfe) {
+            return "test passed!";
+        } catch (Exception e) {
+            return "test failed; exception = " + e;
+        }
+    }
+
+    public void setFailure(String s) {
+    }
+}

--- a/dev/com.ibm.ws.org.apache.myfaces.2.3/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.myfaces.2.3/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2018 IBM Corporation and others.
+# Copyright (c) 2017, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -14,9 +14,9 @@ bVersion=1.0
 Bundle-Name: WAS JSF 2.3
 Bundle-SymbolicName: com.ibm.ws.org.apache.myfaces.2.3
 Bundle-Description: WAS JSF 2.3, version ${bVersion}
-Implementation-Version: 2.3.3
 WLP-ServerName: IBM WebSphere Application Server
 WLP-ServerVersion: ${liberty.beta.version}
+Implementation-Version: 2.3.3
 
 app-resources= \
   META-INF/services/org.apache.myfaces.config.annotation.LifecycleProviderFactory | \
@@ -84,58 +84,62 @@ Include-Resource: \
 
 # Don't export the org.apache.myfaces.buildtools package as that is only needed for compilation.  The jar that contains the 
 # org.apache.myfaces.buildtools package is javax.j2ee.jsf-2.2/lib/myfaces-builder-annotations-1.0.9.jar
-
+# Additionally, a subset of these org.apache.myfaces packages are exported by the thirdparty.jsf-2.3 bundle - so we exclude them here.
 Export-Package: \
   !org.apache.myfaces.buildtools.*, \
-  org.apache.myfaces.*;version="1.0.17", \
+  !org.apache.myfaces.renderkit.html, \
+  !org.apache.myfaces.shared.config, \
+  !org.apache.myfaces.shared.renderkit, \
+  !org.apache.myfaces.shared.renderkit.html, \
+  !org.apache.myfaces.shared.renderkit.html.util, \
   com.ibm.ws.jsf.cdi, \
-  com.ibm.ws.jsf.config.*;thread-context=true;mandatory:="thread-context", \
+  com.ibm.ws.jsf.config.*;thread-context=true, \
   com.ibm.ws.jsf.ee, \
   com.ibm.ws.jsf.spi.*, \
   com.ibm.ws.jsf.extprocessor, \
-  org.apache.myfaces.application;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.application.viewstate;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.cdi.model;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.cdi.view;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.cdi.util;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.component;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.component.search;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.component.visit;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.context;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.context.servlet;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.config.annotation;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.config.impl.digester.elements;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.flow;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.flow.cdi;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.lifecycle;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.push.cdi;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.renderkit;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.renderkit.html;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.shared.context.flash;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.shared.taglib;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.shared.taglib.core;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.shared.util;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.spi.impl;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.taglib.core;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.taglib.html;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.compiler;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.component;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.el;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.impl;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.pool;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.pool.impl;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.composite;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.jsf;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.jsf.core;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.jsf.html;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.jstl.core;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.jstl.fn;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.ui;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.util;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.webapp;thread-context=true;mandatory:="thread-context"
+  org.apache.myfaces.application;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.application.viewstate;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.cdi.model;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.cdi.view;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.cdi.util;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.component;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.component.search;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.component.visit;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.context;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.context.servlet;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.config.annotation;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.config.impl.digester.elements;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.flow;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.flow.cdi;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.lifecycle;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.push.cdi;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.renderkit;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.context.flash;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.taglib;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.taglib.core;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.shared.util;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.spi.impl;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.taglib.core;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.taglib.html;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.compiler;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.component;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.el;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.impl;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.pool;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.pool.impl;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.composite;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.jsf;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.jsf.core;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.jsf.html;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.jstl.core;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.jstl.fn;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.tag.ui;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.view.facelets.util;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.webapp;thread-context=true;version=${Implementation-Version}, \
+  org.apache.myfaces.*;version=${Implementation-Version}
 
 # Import everything we need except for the below exclusions that will not be needed at runtime.
 Import-Package: \
@@ -146,35 +150,21 @@ Import-Package: \
   *
 
 -buildpath: \
-  org.apache.myfaces.core.impl;strategy=exact;version=2.3.3,\
+  org.apache.myfaces.core.impl;strategy=exact;version=${Implementation-Version},\
   org.apache.myfaces.buildtools:myfaces-builder-annotations;version=1.0.9,\
   com.ibm.ws.jsf.shared;version=latest,\
   com.ibm.websphere.javaee.jsf.2.3;version=latest,\
-  com.ibm.websphere.javaee.jstl.1.2;version=latest,\
-  com.ibm.websphere.javaee.persistence.2.1;version=latest,\
-  com.ibm.ws.org.apache.commons.digester.1.8;version=latest,\
-  com.ibm.ws.org.apache.commons.beanutils.1.8.3;version=latest,\
-  com.ibm.ws.com.google.guice.2.0;version=latest,\
   com.ibm.ws.classloading;version=latest,\
   com.ibm.ws.webcontainer;version=latest,\
   com.ibm.ws.serialization;version=latest,\
   com.ibm.ws.container.service;version=latest,\
   com.ibm.ws.adaptable.module;version=latest,\
-  com.ibm.ws.javaee.dd;version=latest,\
-  com.ibm.ws.javaee.dd.common;version=latest,\
   com.ibm.ws.anno;version=latest,\
   com.ibm.ws.managedobject;version=latest,\
   com.ibm.ws.jsp;version=latest,\
-  com.ibm.ws.org.apache.commons.collections;version=latest,\
-  com.ibm.ws.beanvalidation.core;version=latest,\
   com.ibm.websphere.javaee.el.3.0;version=latest,\
-  com.ibm.websphere.javaee.jsp.2.3;version=latest,\
   com.ibm.websphere.javaee.servlet.4.0;version=latest,\
   com.ibm.websphere.javaee.cdi.2.0;version=latest,\
-  com.ibm.websphere.javaee.ejb.3.2;version=latest,\
-  com.ibm.websphere.javaee.websocket.1.1;version=latest,\
-  com.ibm.websphere.javaee.validation.2.0;version=latest,\
-  com.ibm.ws.cdi.interfaces;version=latest,\
   com.ibm.ws.logging.core,\
   com.ibm.websphere.appserver.spi.kernel.service,\
   com.ibm.websphere.org.osgi.core;version=latest,\


### PR DESCRIPTION
This PR un-reverts #7768, and additionally limits the scope of the `org.apache.myfaces` packages that are made available to third-party API classloaders.

fixes #7767