### PR TITLE
export jsf-2.2 impl classes as third-party

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.2/com.ibm.websphere.appserver.jsf-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsf-2.2/com.ibm.websphere.appserver.jsf-2.2.feature
@@ -23,7 +23,12 @@ IBM-API-Package: javax.faces; type="spec", \
  javax.faces.validator; type="spec", \
  javax.faces.view; type="spec", \
  javax.faces.view.facelets; type="spec", \
- javax.faces.webapp; type="spec"
+ javax.faces.webapp; type="spec", \
+ org.apache.myfaces.renderkit.html; type="third-party", \
+ org.apache.myfaces.shared.config; type="third-party", \
+ org.apache.myfaces.shared.renderkit; type="third-party", \
+ org.apache.myfaces.shared.renderkit.html; type="third-party", \
+ org.apache.myfaces.shared.renderkit.html.util; type="third-party"
 IBM-ShortName: jsf-2.2
 Subsystem-Name: JavaServer Faces 2.2
 -features=com.ibm.websphere.appserver.javax.cdi-1.2, \
@@ -41,6 +46,7 @@ Subsystem-Name: JavaServer Faces 2.2
  com.ibm.ws.org.apache.commons.codec.1.3, \
  com.ibm.ws.org.apache.commons.logging.1.0.3, \
  com.ibm.ws.cdi.interfaces, \
- com.ibm.ws.org.apache.commons.digester.1.8
+ com.ibm.ws.org.apache.commons.digester.1.8, \
+ com.ibm.websphere.appserver.thirdparty.jsf-2.2; location:="dev/api/third-party/"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/.classpath
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/.project
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.websphere.appserver.thirdparty.jsf-2.2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.jsf-2.2/bnd.bnd
@@ -1,0 +1,39 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Fragment-Host: com.ibm.ws.jsf.2.2;bundle-version=1.0
+Bundle-Name: WebSphere JSF MyFaces Third Party API
+Bundle-SymbolicName: com.ibm.websphere.appserver.thirdparty.jsf-2.2
+Bundle-Description: WebSphere JSF 2.2 MyFaces Third Party API
+
+# Don't export the org.apache.myfaces.buildtools package as that is only needed for compilation.  The jar that contains the 
+# org.apache.myfaces.buildtools package is javax.j2ee.jsf-2.2/lib/myfaces-builder-annotations-1.0.9.jar
+Export-Package: \
+  org.apache.myfaces.renderkit.html;thread-context=true, \
+  org.apache.myfaces.shared.config, \
+  org.apache.myfaces.shared.renderkit, \
+  org.apache.myfaces.shared.renderkit.html, \
+  org.apache.myfaces.shared.renderkit.html.util
+
+publish.wlp.jar.suffix: dev/api/third-party
+
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
+
+instrument.ffdc: false
+  instrument.classesExcludes: \
+  com/ibm/ws/jsf/resources/*.class, \
+  org/**/*.class
+
+-fixupmessages.missingexport: "Used bundle version * for exported package";is:=ignore
+
+-buildpath: com.ibm.ws.jsf.2.2;version=project

--- a/dev/com.ibm.ws.jsf.2.2/bnd.bnd
+++ b/dev/com.ibm.ws.jsf.2.2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -68,53 +68,58 @@ Service-Component: \
 
 # Don't export the org.apache.myfaces.buildtools package as that is only needed for compilation.  The jar that contains the 
 # org.apache.myfaces.buildtools package is javax.j2ee.jsf-2.2/lib/myfaces-builder-annotations-1.0.9.jar
+# Additionally, a subset of these org.apache.myfaces packages are exported by the thirdparty.jsf-2.2 bundle - so we exclude them here.
 Export-Package: \
   !org.apache.myfaces.buildtools.*, \
-  org.apache.myfaces.*;version="1.0.16", \
+  !org.apache.myfaces.renderkit.html, \
+  !org.apache.myfaces.shared.config, \
+  !org.apache.myfaces.shared.renderkit, \
+  !org.apache.myfaces.shared.renderkit.html, \
+  !org.apache.myfaces.shared.renderkit.html.util, \
   com.ibm.ws.jsf.cdi, \
   com.ibm.ws.jsf.config.*, \
   com.ibm.ws.jsf.ext, \
   com.ibm.ws.jsf.spi.*, \
   com.ibm.ws.jsf.extprocessor, \
-  org.apache.myfaces.application;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.application.viewstate;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.cdi.view;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.cdi.util;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.component;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.component.visit;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.context;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.context.servlet;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.config.annotation;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.config.impl.digester.elements;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.flow;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.flow.cdi;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.lifecycle;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.renderkit;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.renderkit.html;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.shared.context.flash;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.shared.taglib;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.shared.taglib.core;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.spi.impl;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.taglib.core;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.taglib.html;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.compiler;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.component;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.el;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.impl;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.pool;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.pool.impl;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.composite;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.jsf;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.jsf.core;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.jsf.html;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.jstl.core;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.jstl.fn;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.tag.ui;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.view.facelets.util;thread-context=true;mandatory:="thread-context", \
-  org.apache.myfaces.webapp;thread-context=true;mandatory:="thread-context"
+  org.apache.myfaces.application;thread-context=true, \
+  org.apache.myfaces.application.viewstate;thread-context=true, \
+  org.apache.myfaces.cdi.view;thread-context=true, \
+  org.apache.myfaces.cdi.util;thread-context=true, \
+  org.apache.myfaces.component;thread-context=true, \
+  org.apache.myfaces.component.visit;thread-context=true, \
+  org.apache.myfaces.context;thread-context=true, \
+  org.apache.myfaces.context.servlet;thread-context=true, \
+  org.apache.myfaces.config.annotation;thread-context=true, \
+  org.apache.myfaces.config.impl.digester.elements;thread-context=true, \
+  org.apache.myfaces.flow;thread-context=true, \
+  org.apache.myfaces.flow.cdi;thread-context=true, \
+  org.apache.myfaces.lifecycle;thread-context=true, \
+  org.apache.myfaces.renderkit;thread-context=true, \
+  org.apache.myfaces.shared.context.flash;thread-context=true, \
+  org.apache.myfaces.shared.taglib;thread-context=true, \
+  org.apache.myfaces.shared.taglib.core;thread-context=true, \
+  org.apache.myfaces.spi.impl;thread-context=true, \
+  org.apache.myfaces.taglib.core;thread-context=true, \
+  org.apache.myfaces.taglib.html;thread-context=true, \
+  org.apache.myfaces.view;thread-context=true, \
+  org.apache.myfaces.view.facelets;thread-context=true, \
+  org.apache.myfaces.view.facelets.compiler;thread-context=true, \
+  org.apache.myfaces.view.facelets.component;thread-context=true, \
+  org.apache.myfaces.view.facelets.el;thread-context=true, \
+  org.apache.myfaces.view.facelets.impl;thread-context=true, \
+  org.apache.myfaces.view.facelets.pool;thread-context=true, \
+  org.apache.myfaces.view.facelets.pool.impl;thread-context=true, \
+  org.apache.myfaces.view.facelets.tag;thread-context=true, \
+  org.apache.myfaces.view.facelets.tag.composite;thread-context=true, \
+  org.apache.myfaces.view.facelets.tag.jsf;thread-context=true, \
+  org.apache.myfaces.view.facelets.tag.jsf.core;thread-context=true, \
+  org.apache.myfaces.view.facelets.tag.jsf.html;thread-context=true, \
+  org.apache.myfaces.view.facelets.tag.jstl.core;thread-context=true, \
+  org.apache.myfaces.view.facelets.tag.jstl.fn;thread-context=true, \
+  org.apache.myfaces.view.facelets.tag.ui;thread-context=true, \
+  org.apache.myfaces.view.facelets.util;thread-context=true, \
+  org.apache.myfaces.webapp;thread-context=true, \
+  org.apache.myfaces.*
 
 # Import everything we need except for the below exclusions that will not be needed at runtime.
 #


### PR DESCRIPTION
This PR un-reverts #7768, and additionally limits the scope of the org.apache.myfaces packages that are made available to third-party API classloaders.

fixes #8521 and #7767