### PR TITLE
8573 fix illegal state exception mp health

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/bnd.bnd
@@ -14,9 +14,9 @@ bVersion=1.0
 src: \
 	fat/src, \
 	test-applications/MultipleHealthCheckApp/src, \
-	test-applications/DelayedHealthCheckApp/src
+	test-applications/DelayedHealthCheckApp/src, \
+	test-applications/DifferentAppNameHealthCheckApp/src
 
-	
 javac.source: 1.8
 javac.target: 1.8
 	

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/DifferentApplicationNameHealthCheckTest.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/DifferentApplicationNameHealthCheckTest.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.health20.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.net.HttpURLConnection;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+/**
+ *
+ */
+@RunWith(FATRunner.class)
+public class DifferentApplicationNameHealthCheckTest {
+    public static final String APP_NAME = "DifferentAppNameHealthCheckApp";
+
+    private final String HEALTH_ENDPOINT = "/health";
+    private final String READY_ENDPOINT = "/health/ready";
+    private final String LIVE_ENDPOINT = "/health/live";
+
+    private final int SUCCESS_RESPONSE_CODE = 200;
+    private final int FAILED_RESPONSE_CODE = 503;
+
+    @Server("DifferentAppNameHealthCheck")
+    public static LibertyServer server1;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        ShrinkHelper.defaultApp(server1, APP_NAME, "com.ibm.ws.microprofile.health20.different.app.name.health.checks.app");
+        server1.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server1.stopServer("CWWKE1102W", "CWWKE1105W", "CWMH0052W", "CWMH0053W");
+    }
+
+    @Test
+    public void testSuccessLivenessCheckWithDifferentApplicationName() throws Exception {
+        log("testSuccessLivenessCheckWithDifferentApplicationName", "Testing the /health/live endpoint");
+        HttpURLConnection conLive = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, LIVE_ENDPOINT);
+        assertEquals(SUCCESS_RESPONSE_CODE, conLive.getResponseCode());
+
+        JsonObject jsonResponse = getJSONPayload(conLive);
+        JsonArray checks = (JsonArray) jsonResponse.get("checks");
+        assertEquals(1, checks.size());
+        assertTrue("The health check name did not exist in JSON object.", checkIfHealthCheckNameExists(checks, "successful-simple-liveness-check"));
+        assertEquals(jsonResponse.getString("status"), "UP");
+    }
+
+    @Test
+    public void testFailedReadinessCheckWithDifferentApplicationName() throws Exception {
+        log("testFailedReadinessCheckWithDifferentApplicationName", "Testing the /health/ready endpoint");
+        HttpURLConnection conReady = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, READY_ENDPOINT);
+        assertEquals(FAILED_RESPONSE_CODE, conReady.getResponseCode());
+
+        JsonObject jsonResponse = getJSONPayload(conReady);
+        JsonArray checks = (JsonArray) jsonResponse.get("checks");
+        assertEquals(1, checks.size());
+        assertTrue("The health check name did not exist in JSON object.", checkIfHealthCheckNameExists(checks, "failed-simple-readiness-check"));
+        assertEquals(jsonResponse.getString("status"), "DOWN");
+    }
+
+    @Test
+    public void testDeprecatedHealthCheckWithDifferentApplicationName() throws Exception {
+        log("testDeprecatedHealthCheckWithDifferentApplicationName", "Testing the /health endpoint");
+        HttpURLConnection conHealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, HEALTH_ENDPOINT);
+        assertEquals(FAILED_RESPONSE_CODE, conHealth.getResponseCode());
+
+        JsonObject jsonResponse = getJSONPayload(conHealth);
+        JsonArray checks = (JsonArray) jsonResponse.get("checks");
+        assertEquals(3, checks.size());
+        assertEquals(jsonResponse.getString("status"), "DOWN");
+    }
+
+    public JsonObject getJSONPayload(HttpURLConnection con) throws Exception {
+        assertEquals("application/json; charset=UTF-8", con.getHeaderField("Content-Type"));
+
+        BufferedReader br = HttpUtils.getResponseBody(con, "UTF-8");
+        Json.createReader(br);
+        JsonObject jsonResponse = Json.createReader(br).readObject();
+        br.close();
+
+        log("getJSONPayload", "Response: jsonResponse= " + jsonResponse.toString());
+        assertNotNull("The contents of the health endpoint must not be null.", jsonResponse.getString("status"));
+
+        return jsonResponse;
+    }
+
+    /**
+     * Returns true if the expectedName, is found within JsonArray checks.
+     */
+    private boolean checkIfHealthCheckNameExists(JsonArray checks, String expectedName) {
+        for (int i = 0; i < checks.size(); i++) {
+            if (checks.getJsonObject(i).getString("name").equals(expectedName))
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Helper for simple logging.
+     */
+    private static void log(String method, String msg) {
+        Log.info(DifferentApplicationNameHealthCheckTest.class, method, msg);
+    }
+}

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/MultipleHealthCheckTest.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/MultipleHealthCheckTest.java
@@ -83,7 +83,7 @@ public class MultipleHealthCheckTest {
         JsonObject jsonResponse = getJSONPayload(conReady);
         JsonArray checks = (JsonArray) jsonResponse.get("checks");
         assertEquals(2, checks.size());
-        assertTrue(checkIfHealthCheckNameExists(checks, "failed-cdi-producer-liveness-check"));
+        assertTrue("The health check name did not exist in JSON object.", checkIfHealthCheckNameExists(checks, "failed-cdi-producer-liveness-check"));
         assertEquals(jsonResponse.getString("status"), "DOWN");
     }
 
@@ -96,7 +96,7 @@ public class MultipleHealthCheckTest {
         JsonObject jsonResponse = getJSONPayload(conReady);
         JsonArray checks = (JsonArray) jsonResponse.get("checks");
         assertEquals(2, checks.size());
-        assertTrue(checkIfHealthCheckNameExists(checks, "successful-readiness-check"));
+        assertTrue("The health check name did not exist in JSON object.", checkIfHealthCheckNameExists(checks, "successful-readiness-check"));
         assertEquals(jsonResponse.getString("status"), "UP");
     }
 
@@ -109,7 +109,7 @@ public class MultipleHealthCheckTest {
         JsonObject jsonResponse = getJSONPayload(conReady);
         JsonArray checks = (JsonArray) jsonResponse.get("checks");
         assertEquals(2, checks.size());
-        assertTrue(checkIfHealthCheckNameExists(checks, "successful-cdi-producer-readiness-check"));
+        assertTrue("The health check name did not exist in JSON object.", checkIfHealthCheckNameExists(checks, "successful-cdi-producer-readiness-check"));
         assertEquals(jsonResponse.getString("status"), "UP");
     }
 

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/suite/FATSuite.java
@@ -15,12 +15,14 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.microprofile.health20.fat.DelayAppStartupHealthCheckTest;
+import com.ibm.ws.microprofile.health20.fat.DifferentApplicationNameHealthCheckTest;
 import com.ibm.ws.microprofile.health20.fat.MultipleHealthCheckTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
                 DelayAppStartupHealthCheckTest.class,
-                MultipleHealthCheckTest.class
+                MultipleHealthCheckTest.class,
+                DifferentApplicationNameHealthCheckTest.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DifferentAppNameHealthCheck/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DifferentAppNameHealthCheck/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+osgi.console=7771

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DifferentAppNameHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DifferentAppNameHealthCheck/server.xml
@@ -1,0 +1,16 @@
+<server description="Server for testing multiple health checks with different application name.">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>osgiconsole-1.0</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>appSecurity-2.0</feature>
+        <feature>mpHealth-2.0</feature>
+    </featureManager>
+	
+	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:com.ibm.websphere.org.eclipse.microprofile.health.2.0.*=all=enabled"/>
+
+	<application name="DifferentAppNameHealthCheckApp-2.0" type="war" location="DifferentAppNameHealthCheckApp.war" autoStart="true"></application>
+	
+</server>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DifferentAppNameHealthCheckApp/src/com/ibm/ws/microprofile/health20/different/app/name/health/checks/app/SimpleHealthCheck.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DifferentAppNameHealthCheckApp/src/com/ibm/ws/microprofile/health20/different/app/name/health/checks/app/SimpleHealthCheck.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.health20.different.app.name.health.checks.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Health;
+
+/**
+ *
+ */
+@Health
+@ApplicationScoped
+public class SimpleHealthCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("successful-simple-health-check").up().build();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DifferentAppNameHealthCheckApp/src/com/ibm/ws/microprofile/health20/different/app/name/health/checks/app/SimpleLivenessCheck.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DifferentAppNameHealthCheckApp/src/com/ibm/ws/microprofile/health20/different/app/name/health/checks/app/SimpleLivenessCheck.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.health20.different.app.name.health.checks.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+/**
+ *
+ */
+@Liveness
+@ApplicationScoped
+public class SimpleLivenessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("successful-simple-liveness-check").up().build();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DifferentAppNameHealthCheckApp/src/com/ibm/ws/microprofile/health20/different/app/name/health/checks/app/SimpleReadinessCheck.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DifferentAppNameHealthCheckApp/src/com/ibm/ws/microprofile/health20/different/app/name/health/checks/app/SimpleReadinessCheck.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.health20.different.app.name.health.checks.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+/**
+ *
+ */
+@Readiness
+@ApplicationScoped
+public class SimpleReadinessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("failed-simple-readiness-check").down().build();
+    }
+
+}


### PR DESCRIPTION
Fixes #8573 
Fixes #8647

In the AppTrackerImpl class, the application name was retrieved using the appInfo.getName() method, which returned the WAR filename as the application name, instead of the defined application name in server.xml. The fix was to use appInfo.getDeploymentName(), instead.