### PR TITLE
Set com.ibm.ws.app.manager to CONTAINER_EARLY start-phase

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.appmanager-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.appmanager-1.0.feature
@@ -19,7 +19,7 @@ IBM-Process-Types: server, \
  com.ibm.websphere.appserver.classloading-1.0, \
  
 -bundles=com.ibm.websphere.security, \
- com.ibm.ws.app.manager, \
+ com.ibm.ws.app.manager; start-phase:=CONTAINER_EARLY, \
  com.ibm.ws.app.manager.ready; start-phase:=APPLICATION
 -jars=com.ibm.websphere.appserver.api.basics; location:="dev/api/ibm/,lib/",\
  com.ibm.websphere.appserver.spi.application; location:=dev/spi/ibm/


### PR DESCRIPTION
The component com.ibm.ws.app.manager.internal.ApplicationConfigurator
has a load of synchronization in its methods that are called by
SCR whild holding the SCR implementation is holding the component
state change lock.  This can lead to certain deadlock which is
eventually broken out of, but results in the OSGi service
registry eventually returning null when other components are
trying to get the services provided by the ApplicationConfigurator
component.  To reduce this posibility the start-phase of the
com.ibm.ws.app.manager is being moved up so that this component
is fully activated (it is immediate) before the CONTAINER
start-phase is entered.
