### PR TITLE
Changes for ordering tasks in parallel

### DIFF
--- a/dev/build.gradle
+++ b/dev/build.gradle
@@ -34,6 +34,7 @@ ext {
   }
 }
 
+
 /**
  * Apply Java plugin to all subprojects.
  * See: https://docs.gradle.org/current/userguide/java_plugin.html

--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -167,6 +167,7 @@ task packageOpenLiberty(type: PackageLibertyWithFeatures) {
     enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
     dependsOn parent.subprojects.assemble
     dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+    dependsOn ':wlp.lib.extract:publishExtract'
     withFeatures this.&gaPublicFeatures
     outputTo packageDir
 }
@@ -175,6 +176,7 @@ task packageOpenLibertyKernel(type: PackageLibertyWithFeatures) {
     enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
     dependsOn parent.subprojects.assemble
     dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+    dependsOn ':wlp.lib.extract:publishExtract'
     withFeatures { '' }
     outputTo packageDir
 }
@@ -206,6 +208,7 @@ task packageOpenLibertyWebProfile8(type: PackageLibertyWithFeatures) {
     enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
     dependsOn parent.subprojects.assemble
     dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+    dependsOn ':wlp.lib.extract:publishExtract'
     withFeatures this.&webProfile8Features
     outputTo packageDir
     doLast {
@@ -233,6 +236,7 @@ task packageOpenLibertyJavaee8(type: PackageLibertyWithFeatures) {
     enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
     dependsOn parent.subprojects.assemble
     dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+    dependsOn ':wlp.lib.extract:publishExtract'
     withFeatures this.&javaee8Features
     outputTo packageDir
     doLast {
@@ -260,6 +264,7 @@ task packageOpenLibertyMicroProfile3(type: PackageLibertyWithFeatures) {
     enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
     dependsOn parent.subprojects.assemble
     dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+    dependsOn ':wlp.lib.extract:publishExtract'
     withFeatures this.&microProfile3Features
     outputTo packageDir
     doLast {
@@ -277,6 +282,7 @@ task packageOpenLibertyMicroProfile3(type: PackageLibertyWithFeatures) {
 task zipOpenLibertyAll(type: Zip) {
     dependsOn parent.subprojects.assemble
     dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+    dependsOn ':wlp.lib.extract:publishExtract'
     baseName 'openliberty-all'
     from projectDir
     include 'wlp/**'
@@ -395,8 +401,16 @@ publishing {
             version project.version
             artifact zipOpenLibertyJavaee8
         }
+        openLibertyMicroProfile3(MavenPublication) {
+            groupId 'io.openliberty'
+            artifactId 'openliberty-microProfile3'
+            version project.version
+            artifact zipOpenLibertyMicroProfile3
+        }
     }
 }
+
+//tasks.getByName("publishOpenLibertyJavaee8PublicationToMavenRepository") { it.dependsOn zipOpenLibertyJavaee8 }
 
 task createOLRuntimePoms {
     dependsOn packageOpenLiberty
@@ -539,6 +553,7 @@ task zipOpenLibertyMaven(type: Zip) {
 }
 if (isRelease) {
     publish.dependsOn zipOpenLibertyMaven
+
 }
 
 task zipTestReport(type: Zip) {

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -80,6 +80,8 @@ task initialize {
     doLast {
         println "Gradle Initialized"
     }
+    copyMavenLibs.mustRunAfter cleanRepos
+    updatePluginClasses.mustRunAfter cleanRepos
 }
 
 clean {
@@ -120,11 +122,17 @@ String getVersionFromReleaseRepo(String org, String name) {
 }
 
 task everythingElseHasBeenReleased {
-    dependsOn parent.subprojects.minus(project).release
+
+
+    parent.subprojects.minus(project).each { pr -> dependsOn("${pr.path}:release")
+                                        project.logger.info("${pr.name} release dep applied") }
+    
 }
 
 task createGradleBootstrap {
     dependsOn everythingElseHasBeenReleased
+
+
     doLast {
         println 'Generating gradle bootstrap'
 
@@ -298,6 +306,7 @@ task zipGradleBootstrap(type: Zip) {
 }
 
 task libertyReleaseVersions {
+  dependsOn zipGradleBootstrap
   inputs.file('resources/bnd/liberty-release.props')
   outputs.file('build/liberty-versions.props')
   doLast {
@@ -313,10 +322,6 @@ task libertyReleaseVersions {
   }
 }
 
-publish {
-  dependsOn libertyReleaseVersions
-}
-
 publishing {
   publications {
     gradle(MavenPublication) {
@@ -330,6 +335,11 @@ publishing {
         artifact project.file('build/liberty-versions.props')
     }
   }
+}
+
+publish {
+  dependsOn libertyReleaseVersions
+  publishLibertyVersionsPublicationToMavenRepository.mustRunAfter libertyReleaseVersions
 }
 
 task printProjectDependencies() {

--- a/dev/com.ibm.ws.app.manager_fat/build.gradle
+++ b/dev/com.ibm.ws.app.manager_fat/build.gradle
@@ -10,6 +10,7 @@
  *******************************************************************************/
 
 task copyBundles {
+  mustRunAfter assemble
   enabled project.file('test-bundles').exists()
   doLast {
     new File(project.buildDir, 'buildfiles').eachLine { String line ->

--- a/dev/com.ibm.ws.cdi.extension_fat/build.gradle
+++ b/dev/com.ibm.ws.cdi.extension_fat/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
 //This task has a different output directory to the generic one in fat.gradle
 task copyCDIFeatureBundles {
+  mustRunAfter assemble
   enabled project.file('test-bundles').exists()
   doLast {
     new File(project.buildDir, 'buildfiles').eachLine { String line ->

--- a/dev/com.ibm.ws.kernel.feature_fat/build.gradle
+++ b/dev/com.ibm.ws.kernel.feature_fat/build.gradle
@@ -14,6 +14,7 @@
    }
 
 task copyBundles {
+  mustRunAfter assemble
   enabled project.file('test-bundles').exists()
   doFirst {
     new File(project.buildDir, 'buildfiles').eachLine { String line ->

--- a/dev/com.ibm.ws.logging_fat/build.gradle
+++ b/dev/com.ibm.ws.logging_fat/build.gradle
@@ -10,6 +10,7 @@
  *******************************************************************************/
 
 task copyBundles {
+  mustRunAfter assemble
   enabled project.file('test-bundles').exists()
   doLast {
     new File(project.buildDir, 'buildfiles').eachLine { String line ->

--- a/dev/com.ibm.ws.mongo_fat/build.gradle
+++ b/dev/com.ibm.ws.mongo_fat/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 }
 
 task addMongoDriver {
+  mustRunAfter assemble
   doLast {
     // Put the version of Mongo we want on the classpath into autoFVT/build/lib/
     copy {

--- a/dev/com.ibm.ws.runtime.update_fat/build.gradle
+++ b/dev/com.ibm.ws.runtime.update_fat/build.gradle
@@ -1,5 +1,6 @@
 
 task copyBundles {
+  mustRunAfter assemble
   enabled project.file('test-bundles').exists()
   doLast {
     new File(project.buildDir, 'buildfiles').eachLine { String line ->

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/build.gradle
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 }
 
 task copyCommonFiles {
+  mustRunAfter assemble
   doLast {
     /*
      * Copy test application resources.

--- a/dev/com.ibm.ws.security.javaeesec_fat.3/build.gradle
+++ b/dev/com.ibm.ws.security.javaeesec_fat.3/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 }
 
 task copyCommonFiles {
+  mustRunAfter assemble
   doLast {
     /*
      * Copy test application resources.

--- a/dev/com.ibm.ws.security.javaeesec_fat/build.gradle
+++ b/dev/com.ibm.ws.security.javaeesec_fat/build.gradle
@@ -28,6 +28,7 @@ addRequiredLibraries.dependsOn addDerby
  * com.ibm.ws.security.javaeesec_fat not used for now, maybe requried once jsr375/jaspi coexisting test. 
  **/
 task copyFeatureBundle {
+  mustRunAfter assemble
   doLast {
     copy {
       from new File(buildDir, 'com.ibm.ws.security.jaspi.test.jar')

--- a/dev/wlp-gradle/biz.aQute.bnd.gradle
+++ b/dev/wlp-gradle/biz.aQute.bnd.gradle
@@ -68,6 +68,7 @@ subprojects {
   // will publish jar updates to the local `build.image/wlp` image and `cnf/release` repository
   release.dependsOn assemble
   release.dependsOn publish
+  publish.mustRunAfter assemble
 }
 
 // Ensure the root project has the 'audit' task so it shows up in the output of `./gradlew tasks`

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -50,7 +50,7 @@ task addDerby(type: Copy) {
 }
 
 task copyFeatureBundles {
-  shouldRunAfter assemble
+  mustRunAfter assemble
   enabled project.file('test-bundles').exists()
   doLast {
     new File(project.buildDir, 'buildfiles').eachLine { String line ->
@@ -65,6 +65,7 @@ task copyFeatureBundles {
 }
 
 task autoFVT {
+  mustRunAfter assemble
   dependsOn jar
   dependsOn ':cnf:copyMavenLibs'
   dependsOn addRequiredLibraries
@@ -419,4 +420,5 @@ buildfat {
 task buildandrun {
   dependsOn buildfat
   dependsOn runfat
+  runfat.mustRunAfter buildfat
 }

--- a/dev/wlp.lib.extract/build.gradle
+++ b/dev/wlp.lib.extract/build.gradle
@@ -10,20 +10,26 @@
  *******************************************************************************/
 
 task publishManifest(type: Copy) {
-    dependsOn jar
+	dependsOn jar
+	mustRunAfter assemble
     from(zipTree(new File(buildDir, project.name + '.jar')))
     include 'META-INF/MANIFEST.MF'
     into buildImage.file('wlp/lib/extract')
 }
 
 task publishExtract(type: Copy) {
-    dependsOn jar
+	dependsOn jar
+	mustRunAfter assemble
     dependsOn publishManifest
     from(zipTree(new File(buildDir, project.name + '.jar')))
     exclude 'META-INF/'
     into buildImage.projectDir
 }
 
-assemble {
+release {
     dependsOn publishExtract
 }
+
+compileJava.dependsOn ':cnf:initialize'
+
+


### PR DESCRIPTION
This enables the Open Liberty gradle build to be run using parallel execution.

No change is required from developers.

git clean -dxf
./gradlew cnf:initialize
./gradle releaseNeeded

Initial tests show over 50% perf improvement for local builds