### PR TITLE
add a test (currently disabled) for cleaning up old entries

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
@@ -10,7 +10,8 @@
  -->
 <server>
   <featureManager>
-  	<feature>componenttest-1.0</feature>
+    <feature>componenttest-1.0</feature>
+    <feature>jdbc-4.2</feature>
     <feature>jndi-1.0</feature>
     <!-- <feature>osgiConsole-1.0</feature> -->
     <feature>persistentExecutor-1.0</feature>


### PR DESCRIPTION
Write a test case that inserts some expired heartbeat entries and expects the detection logic (to be added under feature) to clean them up.