### PR TITLE
Update eclipse settings for new cxf components.

### DIFF
--- a/dev/com.ibm.ws.jaxws.cdi_fat/.classpath
+++ b/dev/com.ibm.ws.jaxws.cdi_fat/.classpath
@@ -2,11 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/simpleTestService/src"/>
-<!--<classpathentry kind="lib" path="/ant_build/lib/junit.jar"/>
-	<classpathentry kind="lib" path="/build.sharedResources/lib/httpclient/4.3.1/httpclient-4.3.1.jar"/>
-	<classpathentry kind="lib" path="/build.sharedResources/lib/httpclient/4.3.1/httpcore-4.3.jar"/>
-	<classpathentry kind="lib" path="lib/appclasses.jar"/>
-	<classpathentry kind="lib" path="lib/org.apache.httpcomponents.httpclient_4.3.4.jar"/> -->
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.core.2.6/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.core.2.6/.classpath
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.2.6/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.2.6/.classpath
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.2.6/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.2.6/.classpath
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.2.6/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.2.6/.classpath
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.management.2.6/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.management.2.6/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
- Update new cxf components' .classpath to have bnd container classpath settings
- Add JRE_CONTAINER to new cxf components' .classpath files
- Update CDI fat .classpath to remove non bnd settings from the .classpath.
- Update Java from 8 to 7 for one of the cxf components.