### PR TITLE
Remove unneeded bundles / features from CDI and JAXRS features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.cxf.common-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.cxf.common-3.2.feature
@@ -9,7 +9,6 @@ Subsystem-Name: Internal Apache CXF 3.2 Common Feature for JAX-RS and JAX-WS
  com.ibm.ws.org.apache.neethi.3.0.2, \
  com.ibm.ws.org.apache.cxf.cxf.core.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2, \
- com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.0.feature
@@ -18,10 +18,10 @@ Subsystem-Name: Internal Java RESTful Services 2.0
  com.ibm.ws.jaxrs.2.0.common, \
  com.ibm.ws.jaxrs.2.x.config, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
- com.ibm.ws.jaxrs.2.0.tools, \
  com.ibm.ws.jaxrs.2.0.web, \
  com.ibm.ws.jaxrs.2.0.server, \
  com.ibm.ws.jaxrs.2.0.client
+-jars=com.ibm.ws.jaxrs.2.0.tools
 -files=bin/jaxrs/wadl2java, \
  bin/jaxrs/wadl2java.bat, \
  bin/jaxrs/tools/wadl2java.jar

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.0.feature
@@ -10,7 +10,6 @@ Subsystem-Name: Internal Java RESTful Services 2.0
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.servlet-3.1, \
  com.ibm.websphere.appserver.classloading-1.0, \
- com.ibm.websphere.appserver.javax.mail-1.5, \
  com.ibm.websphere.appserver.globalhandler-1.0, \
  com.ibm.websphere.appserver.json-1.0, \
  com.ibm.websphere.appserver.javaeeCompatible-7.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.1.feature
@@ -11,7 +11,6 @@ Subsystem-Name: Internal Java RESTful Services 2.1
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.servlet-4.0, \
  com.ibm.websphere.appserver.classloading-1.0, \
- com.ibm.websphere.appserver.javax.mail-1.6, \
  com.ibm.websphere.appserver.globalhandler-1.0, \
  com.ibm.websphere.appserver.httpcommons-1.0, \
  com.ibm.websphere.appserver.javaeeCompatible-8.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-2.1.feature
@@ -26,11 +26,12 @@ Subsystem-Name: Internal Java RESTful Services 2.1
  com.ibm.ws.org.apache.cxf.cxf.rt.rs.service.description.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.rs.sse.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2, \
- com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2, \
- com.ibm.ws.jaxrs.2.0.tools, \
  com.ibm.ws.jaxrs.2.0.web, \
  com.ibm.ws.jaxrs.2.0.server, \
  com.ibm.ws.jaxrs.2.0.client
+-jars=com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2, \
+ com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2, \
+ com.ibm.ws.jaxrs.2.0.tools
 -files=\
  bin/jaxrs/wadl2java, \
  bin/jaxrs/wadl2java.bat, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxws-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxws-2.3.feature
@@ -27,6 +27,7 @@ Subsystem-Name: Internal Java Web Services 2.3
  com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2, \
+ com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.tools.validator.3.2, \
  com.ibm.ws.org.jvnet.mimepull, \
  com.ibm.websphere.javaee.jws.1.0; require-java:="9"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.jws:jsr181-api:1.0-MR1",\

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
@@ -28,8 +28,8 @@ IBM-SPI-Package: com.ibm.wsspi.webservices.handler
   com.ibm.ws.org.apache.neethi.3.0.2, \
   com.ibm.ws.jaxrs.2.0.common, \
   com.ibm.ws.jaxrs.2.x.config, \
-  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
-  com.ibm.ws.jaxrs.2.0.tools
+  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3
+-jars=com.ibm.ws.jaxrs.2.0.tools
 -files=\
   bin/jaxrs/wadl2java, \
   bin/jaxrs/wadl2java.bat, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
@@ -18,7 +18,6 @@ IBM-SPI-Package: com.ibm.wsspi.webservices.handler
   com.ibm.websphere.appserver.containerServices-1.0, \
   com.ibm.websphere.appserver.servlet-3.1, \
   com.ibm.websphere.appserver.classloading-1.0, \
-  com.ibm.websphere.appserver.javax.mail-1.5, \
   com.ibm.websphere.appserver.globalhandler-1.0, \
   com.ibm.websphere.appserver.optional.jaxb-2.2; ibm.tolerates:=2.3, \
   com.ibm.websphere.appserver.json-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
@@ -9,7 +9,6 @@ IBM-App-ForceRestart: uninstall, \
   com.ibm.websphere.appserver.containerServices-1.0, \
   com.ibm.websphere.appserver.servlet-4.0, \
   com.ibm.websphere.appserver.classloading-1.0, \
-  com.ibm.websphere.appserver.javax.mail-1.6, \
   com.ibm.websphere.appserver.globalhandler-1.0, \
   com.ibm.websphere.appserver.httpcommons-1.0, \
   com.ibm.websphere.appserver.jsonpInternal-1.1, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
@@ -26,7 +26,8 @@ IBM-App-ForceRestart: uninstall, \
   com.ibm.ws.org.apache.cxf.cxf.rt.rs.client.3.2, \
   com.ibm.ws.org.apache.cxf.cxf.rt.rs.service.description.3.2, \
   com.ibm.ws.org.apache.cxf.cxf.rt.rs.sse.3.2, \
-  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2, \
+  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2
+-jars=com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2, \
   com.ibm.ws.org.apache.cxf.cxf.tools.wadlto.jaxrs.3.2, \
   com.ibm.ws.jaxrs.2.0.tools
 -files=\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
@@ -41,7 +41,6 @@ Subsystem-Name: Contexts and Dependency Injection 2.0
  com.ibm.websphere.appserver.javaeePlatform-7.0, \
  com.ibm.websphere.appserver.javax.ejb-3.2, \
  com.ibm.websphere.appserver.javax.annotation-1.3, \
- com.ibm.websphere.appserver.javax.validation-2.0, \
  com.ibm.websphere.appserver.javaeeCompatible-8.0, \
  com.ibm.websphere.appserver.javax.interceptor-1.2, \
  com.ibm.websphere.appserver.javax.cdi-2.0, \
@@ -50,7 +49,6 @@ Subsystem-Name: Contexts and Dependency Injection 2.0
  com.ibm.websphere.appserver.appmanager-1.0, \
  com.ibm.websphere.appserver.transaction-1.2, \
  com.ibm.websphere.appserver.javax.servlet-4.0, \
- com.ibm.websphere.appserver.javax.jsf-2.3, \
  com.ibm.websphere.appserver.internal.slf4j-1.7.7, \
  com.ibm.websphere.appserver.contextService-1.0
 -bundles=com.ibm.ws.org.jboss.weld3, \
@@ -63,8 +61,6 @@ Subsystem-Name: Contexts and Dependency Injection 2.0
  com.ibm.ws.cdi.2.0.weld, \
  com.ibm.websphere.javaee.jaxb.2.2; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/",\
  com.ibm.websphere.javaee.jaxws.2.2; apiJar=false; require-java:="9"; location:="dev/api/spec/,lib/", \
- com.ibm.websphere.javaee.jstl.1.2; apiJar=false; location:="dev/api/spec/,lib/", \
- com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/", \
  com.ibm.ws.cdi.interfaces
 -jars=com.ibm.websphere.appserver.thirdparty.cdi-2.0; location:="dev/api/third-party/,lib/"; mavenCoordinates="org.jboss.weld:weld-osgi-bundle:3.0.3.Final"
 -files=dev/api/ibm/schema/ibm-managed-bean-bnd_1_0.xsd, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
@@ -12,6 +12,7 @@ Subsystem-Name: MicroProfile GraphQL 1.0
  com.ibm.websphere.appserver.servlet-4.0, \
  com.ibm.websphere.appserver.internal.slf4j-1.7.7
 -bundles=com.ibm.ws.require.java8, \
+ com.ibm.websphere.javaee.websocket.1.1; apiJar=false; location:="dev/api/spec/,lib/", \
  com.ibm.ws.com.fasterxml.jackson.2.9.1, \
  com.ibm.ws.io.leangen.graphql.spqr.0.9.9, \
  com.ibm.ws.io.leangen.geantyref.1.3, \


### PR DESCRIPTION
- Remove reference to javamail API bundle in JAXRS features
- Remove features / bundles from CDI that aren't needed.
- Remove jaxrs tools jar from bundle list and move to jar list since they aren't needed to be loaded as bundles.