### PR TITLE
Allow auto-commit to be enabled

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/impl/KafkaConsumerImpl.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/impl/KafkaConsumerImpl.java
@@ -55,6 +55,17 @@ public class KafkaConsumerImpl<K, V> extends AbstractKafkaAdapter<org.apache.kaf
 
     /**
      * @param topics
+     */
+    @Override
+    public void subscribe(Collection<String> topics) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.logp(Level.FINEST, CLAZZ, "subscribe", "Topics: {0}", topics);
+        }
+        this.getDelegate().subscribe(topics);
+    }
+
+    /**
+     * @param topics
      * @param ackTracker
      */
     @Override

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/KafkaConsumer.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/KafkaConsumer.java
@@ -31,6 +31,11 @@ public interface KafkaConsumer<K, V> extends KafkaAdapter {
 
     /**
      * @param topics
+     */
+    void subscribe(Collection<String> topics);
+
+    /**
+     * @param topics
      * @param ackTracker
      */
     void subscribe(Collection<String> topics, ConsumerRebalanceListener listener);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaConnectorConstants.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaConnectorConstants.java
@@ -37,6 +37,9 @@ public class KafkaConnectorConstants {
     //Kafka property - org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
     public static final String ENABLE_AUTO_COMMIT = "enable.auto.commit";
 
+    //Kafka property - org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG
+    public static final String MAX_POLL_RECORDS = "max.poll.records";
+
     //The unique name of this MicroProfile Reactive Messaging Connector for Kafka
     public static final String CONNECTOR_NAME = "liberty-kafka";
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckReceptionBean.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.ack.auto;
+
+import static org.eclipse.microprofile.reactive.messaging.Acknowledgment.Strategy.MANUAL;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractReceptionBean;
+
+@ApplicationScoped
+public class KafkaAutoAckReceptionBean extends AbstractReceptionBean {
+
+    public static final String CHANNEL_IN = "auto-ack-in";
+
+    @Override
+    @Incoming(CHANNEL_IN)
+    @Acknowledgment(MANUAL)
+    public CompletionStage<Void> recieveMessage(Message<String> msg) {
+        return super.recieveMessage(msg);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.ack.auto;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaClientLibs;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
+
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClientProvider;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PropertiesAsset;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaConnectorConstants;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ *
+ */
+@RunWith(FATRunner.class)
+public class KafkaAutoAckTest {
+
+    private static final String APP_NAME = "KafkaAutoAckTest";
+
+    @Server("SimpleRxMessagingServer")
+    @TestServlet(contextRoot = APP_NAME, servlet = KafkaAutoAckTestServlet.class)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+
+        Map<String, Object> connectionProps = KafkaUtils.connectionProperties(PlaintextTests.kafkaContainer);
+
+        ConnectorProperties incomingConnection = ConnectorProperties.simpleIncomingChannel(connectionProps, KafkaAutoAckReceptionBean.CHANNEL_IN,
+                                                                                           KafkaAutoAckTestServlet.APP_GROUPID);
+        incomingConnection.addProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        incomingConnection.addProperty(KafkaConnectorConstants.UNACKED_LIMIT, "5"); // Set a small unacked limit
+        incomingConnection.addProperty(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "500"); // Set a small auto-commit interval so the test runs quickly
+
+        PropertiesAsset appConfig = new PropertiesAsset()
+                        .addProperty(KafkaTestClientProvider.CONNECTION_PROPERTIES_KEY, KafkaTestClientProvider.encodeProperties(connectionProps))
+                        .include(incomingConnection);
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addAsLibraries(kafkaClientLibs())
+                        .addAsManifestResource(kafkaPermissions(), "permissions.xml")
+                        .addPackage(KafkaAutoAckTestServlet.class.getPackage())
+                        .addPackage(KafkaTestClientProvider.class.getPackage())
+                        .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckTestServlet.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.ack.auto;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Duration;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.SimpleKafkaWriter;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/kafkaAutoAckTest")
+public class KafkaAutoAckTestServlet extends FATServlet {
+
+    /**  */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The kafka consumner group configured in the app config to be used by the connector
+     * <p>
+     * Must be referenced when checking the offset committed by the connector
+     */
+    public static final String APP_GROUPID = "auto-ack-app-group";
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+    @Inject
+    private KafkaTestClient kafkaTestClient;
+
+    @Inject
+    private KafkaAutoAckReceptionBean receptionBean;
+
+    @Test
+    public void testReceptionWithoutAck() throws InterruptedException {
+        // Baseline the offset
+        long offset = kafkaTestClient.getTopicOffset(KafkaAutoAckReceptionBean.CHANNEL_IN, APP_GROUPID);
+
+        // Send message directly
+        SimpleKafkaWriter<String> writer = kafkaTestClient.writerFor(KafkaAutoAckReceptionBean.CHANNEL_IN);
+        writer.sendMessage("test1");
+
+        // Assert message received
+        Message<String> message1 = receptionBean.getReceivedMessages(1, TIMEOUT).get(0);
+        assertThat(message1.getPayload(), is("test1"));
+
+        // Assert that the partition offset is committed
+        kafkaTestClient.assertTopicOffsetAdvancesTo(offset + 1, TIMEOUT, KafkaAutoAckReceptionBean.CHANNEL_IN, APP_GROUPID);
+
+        // Send another message
+        writer.sendMessage("test2");
+
+        // Assert message received
+        Message<String> message2 = receptionBean.getReceivedMessages(1, TIMEOUT).get(0);
+        assertThat(message2.getPayload(), is("test2"));
+
+        // Assert the partition offset is committed
+        kafkaTestClient.assertTopicOffsetAdvancesTo(offset + 2, TIMEOUT, KafkaAutoAckReceptionBean.CHANNEL_IN, APP_GROUPID);
+
+        // Ack message 1 and assert the partition offset does not go backwards
+        message1.ack();
+        Thread.sleep(1000);
+        assertThat(kafkaTestClient.getTopicOffset(KafkaAutoAckReceptionBean.CHANNEL_IN, APP_GROUPID), is(offset + 2));
+    }
+
+    /**
+     * Check that the unacked message limit is ignored when enable.auto.commit is true
+     */
+    @Test
+    public void testUnackedLimitIgnored() throws InterruptedException {
+        // Baseline the offset
+        long offset = kafkaTestClient.getTopicOffset(KafkaAutoAckReceptionBean.CHANNEL_IN, APP_GROUPID);
+
+        // Send 30 messages
+        SimpleKafkaWriter<String> writer = kafkaTestClient.writerFor(KafkaAutoAckReceptionBean.CHANNEL_IN);
+        for (int i = 0; i < 30; i++) {
+            writer.sendMessage("test-" + i);
+        }
+
+        // Assert 10 messages received
+        receptionBean.getReceivedMessages(30, TIMEOUT);
+
+        // Assert that the partition offset is committed
+        kafkaTestClient.assertTopicOffsetAdvancesTo(offset + 30, TIMEOUT, KafkaAutoAckReceptionBean.CHANNEL_IN, APP_GROUPID);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaPublisherVerification.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaPublisherVerification.java
@@ -31,6 +31,7 @@ import org.testng.annotations.BeforeMethod;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.SimpleKafkaWriter;
 import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.AckTracker;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaInput;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaConsumer;
@@ -97,7 +98,8 @@ public class KafkaPublisherVerification extends PublisherVerification<Message<St
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, FailingDeserializer.class.getName());
         config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         KafkaConsumer<String, String> kafkaConsumer = kafkaAdapterFactory.newKafkaConsumer(config);
-        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, kafkaConsumer, executor, Collections.singleton(topicName), MESSAGE_LIMIT);
+        AckTracker ackTracker = new AckTracker(kafkaAdapterFactory, executor, MESSAGE_LIMIT);
+        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, kafkaConsumer, executor, Collections.singleton(topicName), ackTracker);
         kafkaInputs.add(kafkaInput);
         return kafkaInput.getPublisher().buildRs();
     }
@@ -129,7 +131,8 @@ public class KafkaPublisherVerification extends PublisherVerification<Message<St
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         KafkaConsumer<String, String> kafkaConsumer = kafkaAdapterFactory.newKafkaConsumer(config);
-        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, kafkaConsumer, executor, Collections.singleton(topicName), MESSAGE_LIMIT);
+        AckTracker ackTracker = new AckTracker(kafkaAdapterFactory, executor, MESSAGE_LIMIT);
+        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, kafkaConsumer, executor, Collections.singleton(topicName), ackTracker);
         kafkaInputs.add(kafkaInput);
         return kafkaInput.getPublisher().buildRs();
     }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/PlaintextTests.java
@@ -17,6 +17,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.testcontainers.containers.KafkaContainer;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.ack.auto.KafkaAutoAckTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.delivery.KafkaAcknowledgementTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.partitions.KafkaPartitionTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.serializer.KafkaCustomSerializerTest;
@@ -33,6 +34,7 @@ import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
                 BasicReactiveMessagingTest.class,
                 KafkaMessagingTest.class,
                 KafkaAcknowledgementTest.class,
+                KafkaAutoAckTest.class,
                 KafkaCustomSerializerTest.class,
                 KafkaPartitionTest.class,
                 KafkaSharedLibTest.class,


### PR DESCRIPTION
Allow enable.auto.commit to be set on the KafkaIncomingConnector.

This allows the user to get away with not acknowledging messages (although we think the intention of the spec is to require all messages to be acknowledged).

Also default the limit of in-flight unacked messages to a more sensible value.

Fixes #8654 