### PR TITLE
Print elapsed time message on completion of SlowRequest in com.ibm.ws.request.timing

### DIFF
--- a/dev/com.ibm.ws.request.probes/src/com/ibm/wsspi/requestContext/RequestContext.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/wsspi/requestContext/RequestContext.java
@@ -161,8 +161,8 @@ public class RequestContext {
 		return isSlow;
 	}
 	
-	public void setSlow(boolean b) {
-		 isSlow = true;
+	public void setSlow(boolean isSlowStatus) {
+		 isSlow = isSlowStatus;
 	}
 
 	/**

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/wsspi/requestContext/RequestContext.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/wsspi/requestContext/RequestContext.java
@@ -157,6 +157,14 @@ public class RequestContext {
 		return threadId;
 	}
 
+	public boolean isSlow() {
+		return isSlow;
+	}
+	
+	public void setSlow(boolean b) {
+		 isSlow = true;
+	}
+
 	/**
 	 * This method is used to get the stack trace for requested Thread ID. Using
 	 * the Thread class getAllStackTraces() method we get the stack traces for
@@ -195,7 +203,5 @@ public class RequestContext {
 				+ requestId + ", state=" + state + "]";
 	}
 	
-	public boolean getisSlow() {
-		return isSlow;
-	}
+
 }

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/wsspi/requestContext/RequestContext.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/wsspi/requestContext/RequestContext.java
@@ -200,7 +200,7 @@ public class RequestContext {
 	@Override
 	public String toString() {
 		return "RequestContext [threadId=" + threadId + ", requestId="
-				+ requestId + ", state=" + state + "]";
+				+ requestId + ", state=" + state + ", isSlow=" + isSlow() + ", eventCount=" + eventCount + "]";
 	}
 	
 

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/wsspi/requestContext/RequestContext.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/wsspi/requestContext/RequestContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,7 @@ public class RequestContext {
 	private volatile int state = -1;
 	private int eventCount = -1;
 	private static final RequestIdGeneratorPUID idgen = new RequestIdGeneratorPUID();
-	public boolean isSlow;
+	private boolean isSlow;
 	
 	/**
 	 * Request states.

--- a/dev/com.ibm.ws.request.probes/src/com/ibm/wsspi/requestContext/RequestContext.java
+++ b/dev/com.ibm.ws.request.probes/src/com/ibm/wsspi/requestContext/RequestContext.java
@@ -38,6 +38,7 @@ public class RequestContext {
 	private volatile int state = -1;
 	private int eventCount = -1;
 	private static final RequestIdGeneratorPUID idgen = new RequestIdGeneratorPUID();
+	public boolean isSlow;
 	
 	/**
 	 * Request states.
@@ -192,5 +193,9 @@ public class RequestContext {
 	public String toString() {
 		return "RequestContext [threadId=" + threadId + ", requestId="
 				+ requestId + ", state=" + state + "]";
+	}
+	
+	public boolean getisSlow() {
+		return isSlow;
 	}
 }

--- a/dev/com.ibm.ws.request.timing/resources/com/ibm/ws/request/timing/internal/resources/LoggingMessages.nlsprops
+++ b/dev/com.ibm.ws.request.timing/resources/com/ibm/ws/request/timing/internal/resources/LoggingMessages.nlsprops
@@ -27,6 +27,9 @@ REQUEST_TIMER_WARNING=TRAS0112W: Request {0} has been running on thread {1} for 
 REQUEST_TIMER_WARNING.explanation=The request has been running for longer than the configured slow request duration. The information in the table shows what events have already run as part of the request. Events that are still running are indicated with a + next to the duration. The default value for slow request duration is 10 seconds, check the server.xml file for the current value.
 REQUEST_TIMER_WARNING.useraction=Use the information in the table to determine what part of the request is slower than expected.  If many warnings are provided for different requests at nearly the same time it may indicate that something slowed down the entire server process, such as another process on the same system consuming a large amount of processing resources.
 
+# Warning message telling the user that the previously detected slow request has finished in a set amount of time.
+REQUEST_TIMER_FINISH_SLOW=TRAS0112W: Request {0} on thread {1} which was previously detected to be slow, has completed after {2}ms.
+
 # Warning message telling the user that the request time has exceed the configured hungRequestThreshold time.
 HUNG_REQUEST_WARNING=TRAS0114W: Request {0} has been running on thread {1} for at least {2}ms. The following table shows the events that have run during this request.\n{3}
 HUNG_REQUEST_WARNING.explanation=The request has been running for longer than the configured hung request duration. The information in the table shows what events have already run as part of the request. Java cores will automatically be triggered to collect further information about what may be causing the request to hang. The default value for hung request duration is 10 minutes, check the server.xml file for the current value.

--- a/dev/com.ibm.ws.request.timing/resources/com/ibm/ws/request/timing/internal/resources/LoggingMessages.nlsprops
+++ b/dev/com.ibm.ws.request.timing/resources/com/ibm/ws/request/timing/internal/resources/LoggingMessages.nlsprops
@@ -27,8 +27,10 @@ REQUEST_TIMER_WARNING=TRAS0112W: Request {0} has been running on thread {1} for 
 REQUEST_TIMER_WARNING.explanation=The request has been running for longer than the configured slow request duration. The information in the table shows what events have already run as part of the request. Events that are still running are indicated with a + next to the duration. The default value for slow request duration is 10 seconds, check the server.xml file for the current value.
 REQUEST_TIMER_WARNING.useraction=Use the information in the table to determine what part of the request is slower than expected.  If many warnings are provided for different requests at nearly the same time it may indicate that something slowed down the entire server process, such as another process on the same system consuming a large amount of processing resources.
 
-# Warning message telling the user that the previously detected slow request has finished in a set amount of time.
-REQUEST_TIMER_FINISH_SLOW=TRAS0112W: Request {0} on thread {1} which was previously detected to be slow, has completed after {2}ms.
+# Information message telling the user that the previously detected slow request has finished in a set amount of time.
+REQUEST_TIMER_FINISH_SLOW=TRAS0113I: The {0} request on the {1} thread, which was previously detected as slow, completed after {2} ms.
+REQUEST_TIMER_FINISH_SLOW.explanation=The request has been running for longer than the configured slow request duration. The request completed in the posted time.
+REQUEST_TIMER_FINISH_SLOW.useraction=No action required.
 
 # Warning message telling the user that the request time has exceed the configured hungRequestThreshold time.
 HUNG_REQUEST_WARNING=TRAS0114W: Request {0} has been running on thread {1} for at least {2}ms. The following table shows the events that have run during this request.\n{3}

--- a/dev/com.ibm.ws.request.timing/resources/com/ibm/ws/request/timing/internal/resources/LoggingMessages.nlsprops
+++ b/dev/com.ibm.ws.request.timing/resources/com/ibm/ws/request/timing/internal/resources/LoggingMessages.nlsprops
@@ -28,7 +28,7 @@ REQUEST_TIMER_WARNING.explanation=The request has been running for longer than t
 REQUEST_TIMER_WARNING.useraction=Use the information in the table to determine what part of the request is slower than expected.  If many warnings are provided for different requests at nearly the same time it may indicate that something slowed down the entire server process, such as another process on the same system consuming a large amount of processing resources.
 
 # Information message telling the user that the previously detected slow request has finished in a set amount of time.
-REQUEST_TIMER_FINISH_SLOW=TRAS0113I: The {0} request on the {1} thread, which was previously detected as slow, completed after {2} ms.
+REQUEST_TIMER_FINISH_SLOW=TRAS0113I: Request {0} on thread {1}, which was previously detected as slow, completed after {2} ms.
 REQUEST_TIMER_FINISH_SLOW.explanation=The request has been running for longer than the configured slow request duration. The request completed in the posted time.
 REQUEST_TIMER_FINISH_SLOW.useraction=No action required.
 

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/manager/SlowRequestManager.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/manager/SlowRequestManager.java
@@ -133,6 +133,7 @@ public class SlowRequestManager {
 										//Re-check the state of the request, if it has completed don't log it.
 										if(requestContext.getRootEvent().getEndTime() == 0){
 											Tr.warning(tc, "REQUEST_TIMER_WARNING",	requestContext.getRequestId().getId(), threadId, requestDuration, stackTrace,	dumpTree);
+											requestContext.isSlow=true;
 										}
 									}
 									// This enables to count new slow threads and not duplicates

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/manager/SlowRequestManager.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/manager/SlowRequestManager.java
@@ -133,7 +133,7 @@ public class SlowRequestManager {
 										//Re-check the state of the request, if it has completed don't log it.
 										if(requestContext.getRootEvent().getEndTime() == 0){
 											Tr.warning(tc, "REQUEST_TIMER_WARNING",	requestContext.getRequestId().getId(), threadId, requestDuration, stackTrace,	dumpTree);
-											requestContext.isSlow=true;
+											requestContext.setSlow(true);
 										}
 									}
 									// This enables to count new slow threads and not duplicates

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/probeExtensionImpl/SlowRequestProbeExtension.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/probeExtensionImpl/SlowRequestProbeExtension.java
@@ -86,7 +86,7 @@ public class SlowRequestProbeExtension implements ProbeExtension {
 				String requestDuration = String.format("%.3f", activeTime);
 				String stackTrace = requestContext.getStackTrace().toString();
 				
-				Tr.warning(tc, "REQUEST_TIMER_FINISH_SLOW",	requestContext.getRequestId().getId(), threadId, requestDuration);
+				Tr.info(tc, "REQUEST_TIMER_FINISH_SLOW",	requestContext.getRequestId().getId(), threadId, requestDuration);
 			}
 		}
 	}

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/probeExtensionImpl/SlowRequestProbeExtension.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/probeExtensionImpl/SlowRequestProbeExtension.java
@@ -14,10 +14,10 @@ import java.util.List;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.DataFormatHelper;
 import com.ibm.ws.request.timing.internal.config.SlowRequestTimingConfig;
 import com.ibm.ws.request.timing.manager.ProbationaryRequestManager;
 import com.ibm.ws.request.timing.manager.SlowRequestManager;
-import com.ibm.ws.request.timing.manager.TraceNLS;
 import com.ibm.ws.request.timing.queue.DelayedRequestQueue;
 import com.ibm.ws.request.timing.queue.SlowRequest;
 import com.ibm.wsspi.probeExtension.ProbeExtension;


### PR DESCRIPTION
Add an isSlow boolean to RequestContext, and if slow, print out time elapsed on completion

PR for feature request https://github.ibm.com/was-liberty/WS-CD-Open/issues/18039

#build