### PR TITLE
Update line-height to include font size

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/css/tool.css
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/css/tool.css
@@ -628,7 +628,7 @@ th.table_sort_column:hover {      /* ....except for the button in the sortable c
     margin-bottom: 12px;
     font-size: 20px;
     letter-spacing: 0;
-    line-height: 18px;
+    line-height: 22px;
 }
 
 span.tool_modal_body_info_label {


### PR DESCRIPTION
The line-height css setting for the .tool_modal_body_info_item entry in common/css/tool.css was not sufficient to hold the font-size.   Increase the line-height to hold the font size.