### PR TITLE
Make JIT trace conditional on JVM vendor

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck11Launcher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck11Launcher.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.microprofile.faulttolerance.tck;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -22,6 +23,8 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.custom.junit.runner.TestModeFilter;
+import componenttest.topology.impl.JavaInfo;
+import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.MvnUtils;
 
@@ -40,6 +43,15 @@ public class FaultToleranceTck11Launcher {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        Vendor vendor = JavaInfo.forServer(server).vendor();
+        // For J9 JVMs, add JIT trace for getConfig method to diagnose crashes
+        if (vendor == Vendor.IBM || vendor == Vendor.OPENJ9) {
+            Map<String, String> jvmOptions = server.getJvmOptionsAsMap();
+            jvmOptions.put("-Xjit:{org/eclipse/microprofile/config/ConfigProvider.getConfig(Ljava/lang/ClassLoader;)Lorg/eclipse/microprofile/config/Config;}(tracefull,traceInlining,traceCG,log=getConfig.trace)",
+                           null);
+            server.setJvmOptions(jvmOptions);
+        }
+
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/servers/FaultTolerance11TCKServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/servers/FaultTolerance11TCKServer/jvm.options
@@ -1,2 +1,1 @@
 -Dcom.ibm.tools.attach.enable=yes
--Xjit:{org/eclipse/microprofile/config/ConfigProvider.getConfig(Ljava/lang/ClassLoader;)Lorg/eclipse/microprofile/config/Config;}(tracefull,traceInlining,traceCG,log=getConfig.trace)

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck20Launcher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck20Launcher.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.microprofile.faulttolerance.tck;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -22,6 +23,8 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.custom.junit.runner.TestModeFilter;
+import componenttest.topology.impl.JavaInfo;
+import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.MvnUtils;
 
@@ -40,6 +43,15 @@ public class FaultToleranceTck20Launcher {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        Vendor vendor = JavaInfo.forServer(server).vendor();
+        // For J9 JVMs, add JIT trace for getConfig method to diagnose crashes
+        if (vendor == Vendor.IBM || vendor == Vendor.OPENJ9) {
+            Map<String, String> jvmOptions = server.getJvmOptionsAsMap();
+            jvmOptions.put("-Xjit:{org/eclipse/microprofile/config/ConfigProvider.getConfig(Ljava/lang/ClassLoader;)Lorg/eclipse/microprofile/config/Config;}(tracefull,traceInlining,traceCG,log=getConfig.trace)",
+                           null);
+            server.setJvmOptions(jvmOptions);
+        }
+
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/jvm.options
@@ -1,2 +1,1 @@
 -Dcom.ibm.tools.attach.enable=yes
--Xjit:{org/eclipse/microprofile/config/ConfigProvider.getConfig(Ljava/lang/ClassLoader;)Lorg/eclipse/microprofile/config/Config;}(tracefull,traceInlining,traceCG,log=getConfig.trace)


### PR DESCRIPTION
Only add the JIT trace options to the Fault Tolerance TCK servers when
we're running on a JVM which understands them.