### PR TITLE
Update 'th' properties to word break on word boundary for OIDC application tables.

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/css/tool.css
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/css/tool.css
@@ -171,7 +171,7 @@
     letter-spacing: 0;
     text-align: left;
     line-height: 20px;
-    word-break: break-all;
+    word-break: break-word;
     padding: 15px 0px 18px 28px;
 }
 


### PR DESCRIPTION
In Polish and German, the column label "Issued On" is displayed with mid-word line break in German and Polish. Line breaks should not be on word boundaries only.

Update the css for 'th' (table headers) to set word-break to break-word instead of break-all.