### PR TITLE
Add quotes around button values so multiple words don't get separated

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
@@ -111,14 +111,14 @@ var table = (function() {
         var regenerateButton = "<td><input id='regenerate_" + authData.authID + "' type='button' authID = " + authData.authID;
         if ((authData.authType === 'app-password' && window.globalAppPasswordsAllowed) ||
             (authData.authType === 'app-token' && window.globalAppTokensAllowed)) {
-                regenerateButton += " class='tool_table_button regenerate_auth_button' value=" + messages.REGENERATE + " aria-label='" + regenerateAriaLabel + "'></td>";
+                regenerateButton += " class='tool_table_button regenerate_auth_button' value='" + messages.REGENERATE + "' aria-label='" + regenerateAriaLabel + "'></td>";
         } else {
             // Disable the 'Regenerate' button if the OP was not defined with the appPasswordAllowed 
             // or appTokenAllowed flags.
-                regenerateButton += " class='tool_table_button regenerate_auth_button' disabled value=" + messages.REGENERATE + " aria-label='" + regenerateAriaLabel + "'></td>";
+                regenerateButton += " class='tool_table_button regenerate_auth_button' disabled value='" + messages.REGENERATE + "' aria-label='" + regenerateAriaLabel + "'></td>";
         }
         var deleteAriaLabel = utils.formatString(messages.DELETE_ARIA, [authData.authType, authData.name]);
-        var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value=" + messages.DELETE + " aria-label='" + deleteAriaLabel + "'></td>";
+        var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value='" + messages.DELETE + "' aria-label='" + deleteAriaLabel + "'></td>";
 
         // insert bidi text direction to the table row
         var textDir = bidiUtils.getDOMBidiTextDirection(); 

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
@@ -155,7 +155,7 @@ var table = (function() {
 
         // Action button
         var deleteAriaLabel = utils.formatString(messages.DELETE_ARIA, [authData.authType, authData.name]);
-        var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value=" + messages.DELETE + " aria-label='" + deleteAriaLabel + "'></td>";
+        var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value='" + messages.DELETE + "' aria-label='" + deleteAriaLabel + "'></td>";
 
         // Create a table row and add the filter data attribute as the name lowecased.
         // This is used in sorting and filtering (when implemented).


### PR DESCRIPTION
For the Input elements representing the buttons in the html for the tables on the OIDC applications set the value attribute to the translated string.  The value attribute value was not being quoted and therefore was not being added to the input element correctly.  So, added quotes to the value elements in the DOM.