### PR TITLE
Correct OAuth app password NLS messages being logged in correct locale

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/error/impl/BrowserAndServerLogMessage.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/error/impl/BrowserAndServerLogMessage.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.oauth20.error.impl;
+
+import java.util.Enumeration;
+import java.util.Locale;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Small helper class to obtain an NLS message in both the locale of the browser and the locale of the server. This is meant
+ * to avoid maintaining two or more lines to get the same NLS message. It can be easy to miss updating one of the lines if the
+ * other line is updated at some point.
+ */
+public class BrowserAndServerLogMessage {
+
+    private final String browserMsg;
+    private final String serverMsg;
+
+    public BrowserAndServerLogMessage(TraceComponent tc, Enumeration<Locale> requestLocales, String msgKey, Object... inserts) {
+        browserMsg = Tr.formatMessage(tc, requestLocales, msgKey, inserts);
+        serverMsg = Tr.formatMessage(tc, msgKey, inserts);
+    }
+
+    public String getBrowserErrorMessage() {
+        return browserMsg;
+    }
+
+    public String getServerErrorMessage() {
+        return serverMsg;
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/error/impl/BrowserAndServerLogMessageTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/error/impl/BrowserAndServerLogMessageTest.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.oauth20.error.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.oauth20.web.TraceConstants;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+public class BrowserAndServerLogMessageTest extends CommonTestClass {
+
+    private static TraceComponent tc = Tr.register(BrowserAndServerLogMessageTest.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
+
+    private static final String MSG_KEY_NO_INSERTS = "OAUTH_ROLE_CONFIG_PROCESSED";
+    private static final String MSG_KEY_WITH_INSERTS = "OAUTH_INVALID_CLIENT";
+    private static final String MSG_REGEX_NO_INSERTS_EN = "CWWKS1404I.*successfully processed";
+    private static final String MSG_REGEX_NO_INSERTS_FR = "CWWKS1404I.*a abouti";
+    private static final String MSG_REGEX_NO_INSERTS_ZH = "CWWKS1404I.*\u914d\u7f6e";
+    private static final String MSG_REGEX_WITH_INSERTS_EN = "CWWKS1406E.*" + "%s" + ".*invalid client credential.*" + "%s";
+    private static final String MSG_REGEX_WITH_INSERTS_FR = "CWWKS1406E.*" + "%s" + ".*identification utilisateur non valides.*" + "%s";
+
+    @Before
+    public void beforeTest() {
+        System.out.println("Entering test " + testName.getMethodName());
+    }
+
+    @After
+    public void afterTest() {
+        System.out.println("Exiting test " + testName.getMethodName());
+    }
+
+    @Test
+    public void testUnknownLocales_expectEnglishMessages() {
+        Enumeration<Locale> requestLocales = getLocales("xyz", "123", "does not exist");
+        BrowserAndServerLogMessage msg = new BrowserAndServerLogMessage(tc, requestLocales, MSG_KEY_NO_INSERTS);
+        verifyPattern(msg.getServerErrorMessage(), MSG_REGEX_NO_INSERTS_EN, "Server error message did not match expected regex.");
+        verifyPattern(msg.getBrowserErrorMessage(), MSG_REGEX_NO_INSERTS_EN, "Browser error message did not match expected regex.");
+    }
+
+    @Test
+    public void testAllEnglishMessagesExpected_noInserts() {
+        Enumeration<Locale> requestLocales = getLocales("en");
+        BrowserAndServerLogMessage msg = new BrowserAndServerLogMessage(tc, requestLocales, MSG_KEY_NO_INSERTS);
+        verifyPattern(msg.getServerErrorMessage(), MSG_REGEX_NO_INSERTS_EN, "Server error message did not match expected regex.");
+        verifyPattern(msg.getBrowserErrorMessage(), MSG_REGEX_NO_INSERTS_EN, "Browser error message did not match expected regex.");
+    }
+
+    @Test
+    public void testFrenchBrowserMessagesExpected_noInserts() {
+        Enumeration<Locale> requestLocales = getLocales("fr");
+        BrowserAndServerLogMessage msg = new BrowserAndServerLogMessage(tc, requestLocales, MSG_KEY_NO_INSERTS);
+        verifyPattern(msg.getServerErrorMessage(), MSG_REGEX_NO_INSERTS_EN, "Server error message did not match expected regex.");
+        verifyPattern(msg.getBrowserErrorMessage(), MSG_REGEX_NO_INSERTS_FR, "Browser error message did not match expected regex.");
+    }
+
+    @Test
+    public void testFrenchExtendedBrowserMessagesExpected_noInserts() {
+        Enumeration<Locale> requestLocales = getLocales("fr", "fr-FR", "fr-ca", "fr-CA", "en");
+        BrowserAndServerLogMessage msg = new BrowserAndServerLogMessage(tc, requestLocales, MSG_KEY_NO_INSERTS);
+        verifyPattern(msg.getServerErrorMessage(), MSG_REGEX_NO_INSERTS_EN, "Server error message did not match expected regex.");
+        verifyPattern(msg.getBrowserErrorMessage(), MSG_REGEX_NO_INSERTS_FR, "Browser error message did not match expected regex.");
+    }
+
+    @Test
+    public void testChineseBrowserMessagesExpected_noInserts() {
+        Enumeration<Locale> requestLocales = getLocales("zh", "fr", "en");
+        BrowserAndServerLogMessage msg = new BrowserAndServerLogMessage(tc, requestLocales, MSG_KEY_NO_INSERTS);
+        verifyPattern(msg.getServerErrorMessage(), MSG_REGEX_NO_INSERTS_EN, "Server error message did not match expected regex.");
+        verifyPattern(msg.getBrowserErrorMessage(), MSG_REGEX_NO_INSERTS_ZH, "Browser error message did not match expected regex.");
+    }
+
+    @Test
+    public void testAllEnglishMessagesExpected_withInserts() {
+        Enumeration<Locale> requestLocales = getLocales("en");
+        String insert0 = "insert0";
+        String insert1 = "insert1";
+        BrowserAndServerLogMessage msg = new BrowserAndServerLogMessage(tc, requestLocales, MSG_KEY_WITH_INSERTS, insert0, insert1);
+        verifyPattern(msg.getServerErrorMessage(), String.format(MSG_REGEX_WITH_INSERTS_EN, insert0, insert1), "Server error message did not match expected regex.");
+        verifyPattern(msg.getBrowserErrorMessage(), String.format(MSG_REGEX_WITH_INSERTS_EN, insert0, insert1), "Browser error message did not match expected regex.");
+    }
+
+    @Test
+    public void testFrenchBrowserMessagesExpected_withInserts() {
+        Enumeration<Locale> requestLocales = getLocales("fr");
+        String insert0 = "insert0";
+        String insert1 = "insert1";
+        BrowserAndServerLogMessage msg = new BrowserAndServerLogMessage(tc, requestLocales, MSG_KEY_WITH_INSERTS, insert0, insert1);
+        verifyPattern(msg.getServerErrorMessage(), String.format(MSG_REGEX_WITH_INSERTS_EN, insert0, insert1), "Server error message did not match expected regex.");
+        verifyPattern(msg.getBrowserErrorMessage(), String.format(MSG_REGEX_WITH_INSERTS_FR, insert0, insert1), "Browser error message did not match expected regex.");
+    }
+
+    private Enumeration<Locale> getLocales(String... locales) {
+        List<Locale> localeList = new ArrayList<Locale>();
+        if (locales != null) {
+            for (String locale : locales) {
+                localeList.add(new Locale(locale));
+            }
+        }
+        return Collections.enumeration(localeList);
+    }
+
+}


### PR DESCRIPTION
PR https://github.com/OpenLiberty/open-liberty/pull/8317 delivered a change to return NLS messages in the locale of the incoming request back to the web browser. However that also inadvertently changed the logic to log the messages in the server log in the same locale as the request instead of the locale of the server.