### PR TITLE
OIDC: Remove possible space from ID of buttons on clientManagement table.

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
@@ -118,7 +118,7 @@ var table = (function() {
                 regenerateButton += " class='tool_table_button regenerate_auth_button' disabled value='" + messages.REGENERATE + "' aria-label='" + regenerateAriaLabel + "'></td>";
         }
         var deleteAriaLabel = utils.formatString(messages.DELETE_ARIA, [authData.authType, authData.name]);
-        var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value='" + messages.DELETE + "' aria-label='" + deleteAriaLabel + "'></td>";
+        var deleteButton = "<td><input id='delete_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value='" + messages.DELETE + "' aria-label='" + deleteAriaLabel + "'></td>";
 
         // insert bidi text direction to the table row
         var textDir = bidiUtils.getDOMBidiTextDirection(); 

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
@@ -111,14 +111,14 @@ var table = (function() {
         var regenerateButton = "<td><input id='regenerate_" + authData.authID + "' type='button' authID = " + authData.authID;
         if ((authData.authType === 'app-password' && window.globalAppPasswordsAllowed) ||
             (authData.authType === 'app-token' && window.globalAppTokensAllowed)) {
-                regenerateButton += " class='tool_table_button regenerate_auth_button' value=" + messages.REGENERATE + " aria-label='" + regenerateAriaLabel + "'></td>";
+                regenerateButton += " class='tool_table_button regenerate_auth_button' value='" + messages.REGENERATE + "' aria-label='" + regenerateAriaLabel + "'></td>";
         } else {
             // Disable the 'Regenerate' button if the OP was not defined with the appPasswordAllowed 
             // or appTokenAllowed flags.
-                regenerateButton += " class='tool_table_button regenerate_auth_button' disabled value=" + messages.REGENERATE + " aria-label='" + regenerateAriaLabel + "'></td>";
+                regenerateButton += " class='tool_table_button regenerate_auth_button' disabled value='" + messages.REGENERATE + "' aria-label='" + regenerateAriaLabel + "'></td>";
         }
         var deleteAriaLabel = utils.formatString(messages.DELETE_ARIA, [authData.authType, authData.name]);
-        var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value=" + messages.DELETE + " aria-label='" + deleteAriaLabel + "'></td>";
+        var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value='" + messages.DELETE + "' aria-label='" + deleteAriaLabel + "'></td>";
 
         // insert bidi text direction to the table row
         var textDir = bidiUtils.getDOMBidiTextDirection(); 

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/table.js
@@ -64,10 +64,11 @@ var table = (function() {
     var createTableRow = function(clientData, filterValue) {
         var clientName = "<td tabindex='-1'>" + clientData.client_name + "</td>";
         var clientId = "<td tabindex='-1'>" + clientData.client_id + "</td>";
+        var clientId_ID = clientData.client_id.replace(/\s/g, '__');
         var editAriaLabel = utils.formatString(messages.EDIT_ARIA, [utils.encodeData(clientData.client_name)]);
-        var editButton = "<td><button id='edit_" + clientData.client_id + "' class='tool_table_button edit_client_button' type='button' aria-label='" + editAriaLabel + "'>" + messages.EDIT + "</button></td>";
+        var editButton = "<td><button id='edit_" + clientId_ID + "' class='tool_table_button edit_client_button' type='button' aria-label='" + editAriaLabel + "'>" + messages.EDIT + "</button></td>";
         var deleteAriaLabel = utils.formatString(messages.DELETE_ARIA, [utils.encodeData(clientData.client_name)]);
-        var deleteButton = "<td><button id='delete_" + clientData.client_id + "' class='tool_table_button delete_client_button' type='button' aria-label='" + deleteAriaLabel + "'>" + messages.DELETE + "</button></td>";
+        var deleteButton = "<td><button id='delete_" + clientId_ID + "' class='tool_table_button delete_client_button' type='button' aria-label='" + deleteAriaLabel + "'>" + messages.DELETE + "</button></td>";
 
         // Create a table row and add the filter data attribute as the client name lowercased.
         // This will be used in filtering and sorting

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
@@ -155,7 +155,7 @@ var table = (function() {
 
         // Action button
         var deleteAriaLabel = utils.formatString(messages.DELETE_ARIA, [authData.authType, authData.name]);
-        var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value='" + messages.DELETE + "' aria-label='" + deleteAriaLabel + "'></td>";
+        var deleteButton = "<td><input id='delete_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value='" + messages.DELETE + "' aria-label='" + deleteAriaLabel + "'></td>";
 
         // Create a table row and add the filter data attribute as the name lowecased.
         // This is used in sorting and filtering (when implemented).

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
@@ -155,7 +155,7 @@ var table = (function() {
 
         // Action button
         var deleteAriaLabel = utils.formatString(messages.DELETE_ARIA, [authData.authType, authData.name]);
-        var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value=" + messages.DELETE + " aria-label='" + deleteAriaLabel + "'></td>";
+        var deleteButton = "<td><input id='edit_" + authData.authID + "' type='button' authID = " + authData.authID + " class='tool_table_button delete_auth_button' value='" + messages.DELETE + "' aria-label='" + deleteAriaLabel + "'></td>";
 
         // Create a table row and add the filter data attribute as the name lowecased.
         // This is used in sorting and filtering (when implemented).


### PR DESCRIPTION
Since the customer can create their own client IDs when registering an OAuth Client on the Client Management application then the ID may include a space.   The ID is used in assigning a unique ID to the buttons in the table of the clientManagement application.   Change the spaces to '__' so spaces do not appear in the ID.  Blanks are not valid in IDs for html elements.

Also updated the 'Delete' button name on the users token management application from 'Edit_*' to 'Delete_*'.