### PR TITLE
Fix bad version on export packages

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.api.2.6/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.api.2.6/bnd.overrides
@@ -28,8 +28,8 @@ Import-Package: \
  
 Export-Package: \
   !org.apache.cxf.internal.*, \
-  org.apache.cxf.*;version="[2.6.2,2.6.3)"
+  org.apache.cxf.*;version=2.6.2
  
 Private-Package: \
-  org.apache.cxf.internal;version="[2.6.2,2.6.3)"
+  org.apache.cxf.internal;version=2.6.2
   


### PR DESCRIPTION
CXF API bundle has invalid syntax on the `Export-Package` header in `overrides.bnd` file. 