### PR TITLE
Add setting to ignore rate limit setting on OSS audit

### DIFF
--- a/dev/wlp-gradle/biz.aQute.bnd.gradle
+++ b/dev/wlp-gradle/biz.aQute.bnd.gradle
@@ -53,6 +53,7 @@ subprojects {
       audit {
         group = "verification"
         failOnError = true
+        rateLimitAsError = false
       }
     }
 


### PR DESCRIPTION
Ignore rate limit exceptions during the OSSIndex audit calls