### PR TITLE
change SSL initialize timeout value

### DIFF
--- a/dev/com.ibm.ws.cdi.visibility_fat/publish/servers/cdi12ValidatorInJarServer/server.xml
+++ b/dev/com.ibm.ws.cdi.visibility_fat/publish/servers/cdi12ValidatorInJarServer/server.xml
@@ -12,6 +12,6 @@
 		<user name="mlee" password="p@ssw0rd" />
     </basicRegistry>
 
-	
+	<orb id="defaultOrb" orbSSLInitTimeout="60"/>
 
 </server>


### PR DESCRIPTION
fixes #8734 
The SSL initialization timeout value is changed to 60 seconds.