### PR TITLE
reject codepath where user omits the config element parameter but specifies uid

### DIFF
--- a/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
+++ b/dev/com.ibm.websphere.rest.handler/src/com/ibm/wsspi/rest/config/ConfigBasedRESTHandler.java
@@ -174,6 +174,15 @@ public abstract class ConfigBasedRESTHandler implements RESTHandler {
         }
         String elementName = path.length() < (apiRoot.length() + 1) ? "" : URLDecoder.decode(path.substring(apiRoot.length() + 1, endElementName), "UTF-8");
 
+        // Just in case someone tries to do /config/dataSource[DefaultDataSource] missing the config element parameter,
+        // which was somehow getting through and erroneously returning a list of one data source.
+        // TODO it would be preferable to detect this more cleanly, but for now, at least reject it so that
+        // data isn't erroneously returned.
+        if (elementName.indexOf('[') >= 0) {
+            response.sendError(404, Tr.formatMessage(tc, request.getLocale(), "CWWKO1500_NOT_FOUND", elementName));
+            return;
+        }
+
         StringBuilder filter = new StringBuilder("(&");
         if (uid != null && (uid.startsWith(elementName + "[default-") || uid.matches(".*/.*\\[.*\\].*")))
             filter.append(FilterUtils.createPropertyFilter("config.displayId", uid));

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonString;
+import javax.json.JsonStructure;
 import javax.json.JsonValue;
 
 import org.junit.AfterClass;
@@ -624,6 +625,17 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "DefaultDataSource", json.getString("id"));
         assertNull(err, json.get("jndiName"));
         // other attributes are covered by testConfigDataSources
+    }
+
+    // Invoke REST endpoint with uid present, but the config element parameter missing. Expect an error.
+    @Test
+    public void testConfigDefaultDataSourceMissingElementName() throws Exception {
+        try {
+            JsonStructure json = new HttpsRequest(server, "/ibm/api/config/dataSource[DefaultDataSource]").run(JsonStructure.class);
+            String err = "unexpected response: " + json;
+        } catch (Exception ex) {
+            assertTrue("Expected 404 response", ex.getMessage().contains("404"));
+        }
     }
 
     // Ensure that the requested element type matches the returned config.

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
@@ -633,6 +633,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         try {
             JsonStructure json = new HttpsRequest(server, "/ibm/api/config/dataSource[DefaultDataSource]").run(JsonStructure.class);
             String err = "unexpected response: " + json;
+            fail(err);
         } catch (Exception ex) {
             assertTrue("Expected 404 response", ex.getMessage().contains("404"));
         }


### PR DESCRIPTION
@frowe was doing some creative testing and discovered a bug where an erroneous result (list of single element) was being returned when the user invokes a configuration-based REST endpoint with a uid but without the config element path parameter (which is required when uid is present).

This pull adds detection and forces this situation to be a proper error path.