### PR TITLE
Fix to handle whitespace in tokens

### DIFF
--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -23,6 +23,22 @@ pluginManagement {
     usrHomeProps.withInputStream { props.load(it) }
   }
 
+  // Artifactory connections fail if a user accidentally adds whitespace to tokens.
+  def stripTrailingWhitespace = [
+          'artifactory.download.user',
+          'artifactory.download.token',
+          'artifactory.download.server',
+          'artifactory.upload.user',
+          'artifactory.upload.token',
+          'artifactory.upload.server',
+  ]
+  stripTrailingWhitespace.each { key ->
+    if (props.get(key) != null) {
+      String value = props.get(key)
+      props.setProperty(key, value.stripTrailing())
+    }
+  }
+
   def isUsingArtifactory = false
 
   def fetchRepoPublic = ('aQute.bnd.repository.maven.provider.MavenBndRepository;'+

--- a/dev/wlp-gradle/bndSettings.gradle
+++ b/dev/wlp-gradle/bndSettings.gradle
@@ -113,7 +113,6 @@ def projectNames = startParameter.taskNames.collect { taskName ->
                 case 1:
                     return defaultProjectName
                 case 2:
-                    println elements[0]
                     return elements[0].empty ? bnd_build : elements[0]
                 default:
                     return elements[0].empty ? elements[1] : elements[0]


### PR DESCRIPTION
Users may mistakenly include whitespace in the Artifactory credential `artifactory.download.token` property resulting in an authentication failure. The error is misleading, so to better handle that this PR strips trailing whitespace from all Artifactory related properties read in from `~/gradle.startup.properties`.

```
FAILURE: Build failed with an exception.

* Where:
Script '/Users/erfritz/workspace/was/open-liberty/dev/wlp-gradle/bndSettings.gradle' line: 67

* What went wrong:
A problem occurred evaluating script.
> Could not resolve all files for configuration 'classpath'.
   > Could not resolve biz.aQute.bnd:biz.aQute.bnd.gradle:4.1.0.
     Required by:
         unspecified:unspecified:unspecified
      > Could not resolve biz.aQute.bnd:biz.aQute.bnd.gradle:4.1.0.
         > Could not get resource 'https://na.artifactory.swg-devops.com/artifactory/wasliberty-open-liberty/biz/aQute/bnd/biz.aQute.bnd.gradle/4.1.0/biz.aQute.bnd.gradle-4.1.0.pom'.
            > Could not HEAD 'https://na.artifactory.swg-devops.com/artifactory/wasliberty-open-liberty/biz/aQute/bnd/biz.aQute.bnd.gradle/4.1.0/biz.aQute.bnd.gradle-4.1.0.pom'. Received status code 401 from server: Unauthorized
   > Could not resolve gradle.plugin.net.ossindex:ossindex-gradle-plugin:0.4.11.
     Required by:
         unspecified:unspecified:unspecified
      > Could not resolve gradle.plugin.net.ossindex:ossindex-gradle-plugin:0.4.11.
         > Could not get resource 'https://na.artifactory.swg-devops.com/artifactory/wasliberty-open-liberty/gradle/plugin/net/ossindex/ossindex-gradle-plugin/0.4.11/ossindex-gradle-plugin-0.4.11.pom'.
            > Could not HEAD 'https://na.artifactory.swg-devops.com/artifactory/wasliberty-open-liberty/gradle/plugin/net/ossindex/ossindex-gradle-plugin/0.4.11/ossindex-gradle-plugin-0.4.11.pom'. Received status code 401 from server: Unauthorized
   > Could not resolve com.gradle:build-scan-plugin:2.1.
     Required by:
         unspecified:unspecified:unspecified
      > Could not resolve com.gradle:build-scan-plugin:2.1.
         > Could not get resource 'https://na.artifactory.swg-devops.com/artifactory/wasliberty-open-liberty/com/gradle/build-scan-plugin/2.1/build-scan-plugin-2.1.pom'.
            > Could not HEAD 'https://na.artifactory.swg-devops.com/artifactory/wasliberty-open-liberty/com/gradle/build-scan-plugin/2.1/build-scan-plugin-2.1.pom'. Received status code 401 from server: Unauthorized

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 15s```