### PR TITLE
7491 Add workarea for embedded servers launched by liberty utils

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/asset/ServerAsset.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/asset/ServerAsset.java
@@ -36,7 +36,6 @@ import com.ibm.ws.kernel.boot.EmbeddedServerImpl;
 import com.ibm.ws.kernel.boot.cmdline.Utils;
 import com.ibm.ws.kernel.boot.internal.BootstrapConstants;
 import com.ibm.wsspi.kernel.embeddable.Server;
-import com.ibm.wsspi.kernel.embeddable.ServerBuilder;
 
 public class ServerAsset implements Comparable<ServerAsset> {
     private static final String TEMP_SERVER_NAME = "tempServer";
@@ -292,17 +291,20 @@ public class ServerAsset implements Comparable<ServerAsset> {
         private static EmbeddedServerImpl startServer(File serverXML, String serverName, Map<String, String> serverProps, boolean isTempServer) throws InstallException {
             validateFile(serverXML);
 
-            ServerBuilder sb = new ServerBuilder().setName(serverName);
+            File outputDir = null;
+            File logDir = null;
+            String workareaDirStr = null;
             if (isTempServer) {
-                sb.setOutputDir(serverXML.getParentFile().getParentFile());
+                outputDir = serverXML.getParentFile().getParentFile();
             } else {
-                sb.setOutputDir(Utils.getOutputDir());
+                outputDir = Utils.getOutputDir();
                 InstallLogUtils.getInstallLogger().log(Level.FINEST, "Set output dir to " + Utils.getOutputDir());
-                sb.setLogDir(Utils.getLogDir());
+                logDir = Utils.getLogDir();
                 InstallLogUtils.getInstallLogger().log(Level.FINEST, "Set log dir to " + (Utils.getLogDir() != null ? Utils.getLogDir() : Utils.getOutputDir()));
+                workareaDirStr = BootstrapConstants.LOC_AREA_NAME_WORKING_UTILS;
             }
-            sb.setUserDir(serverXML.getParentFile().getParentFile().getParentFile());
-            EmbeddedServerImpl server = (EmbeddedServerImpl) sb.build();
+            File userDir = serverXML.getParentFile().getParentFile().getParentFile();
+            EmbeddedServerImpl server = new EmbeddedServerImpl(serverName, userDir, outputDir, logDir, null, null, null, workareaDirStr);
 
             if (server.isRunning()) {
                 throw new InstallException(Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_UNABLE_TO_GET_FEATURES_FROM_RUNNING_SERVER",

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/BootstrapConfig.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/BootstrapConfig.java
@@ -133,6 +133,14 @@ public class BootstrapConfig {
 
     }
 
+    protected void findLocations(String newServerName,
+                                 String instanceDirStr,
+                                 String outputDirStr,
+                                 String logDirStr,
+                                 String consoleLogFileStr) throws LocationException {
+        findLocations(newServerName, instanceDirStr, outputDirStr, logDirStr, consoleLogFileStr, null);
+    }
+
     /**
      * Light processing: find main locations
      *
@@ -143,6 +151,7 @@ public class BootstrapConfig {
      * @param outputDirStr      Value of WLP_OUTPUT_DIR environment variable
      * @param logDirStr         Value of X_LOG_DIR or LOG_DIR environment variable
      * @param consoleLogFileStr Value of X_LOG_FILE or LOG_FILE environment variable
+     * @param workareaDirStr    Value of alternate workarea subpath or null for default
      *
      * @throws LocationException
      */
@@ -150,7 +159,8 @@ public class BootstrapConfig {
                                  String instanceDirStr,
                                  String outputDirStr,
                                  String logDirStr,
-                                 String consoleLogFileStr) throws LocationException {
+                                 String consoleLogFileStr,
+                                 String workareaDirStr) throws LocationException {
 
         // Server name only found via command line
         setProcessName(newServerName);
@@ -233,7 +243,10 @@ public class BootstrapConfig {
         consoleLogFile = new File(logDir, consoleLogFileStr != null ? consoleLogFileStr : BootstrapConstants.CONSOLE_LOG);
 
         // Server workarea always a child of outputDir
-        workarea = new File(outputDir, BootstrapConstants.LOC_AREA_NAME_WORKING);
+        if (workareaDirStr == null)
+            workarea = new File(outputDir, BootstrapConstants.LOC_AREA_NAME_WORKING);
+        else
+            workarea = new File(outputDir, BootstrapConstants.LOC_AREA_NAME_WORKING + "/" + workareaDirStr);
     }
 
     /**
@@ -482,7 +495,7 @@ public class BootstrapConfig {
     /**
      * Set a new property into the set of initial properties only if the
      * key does not already have an existing value.
-     * 
+     *
      * @param key   the key to set
      * @param value the value to set
      * @return the previous value associated with the specified key, or

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/EmbeddedServerImpl.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/EmbeddedServerImpl.java
@@ -90,7 +90,7 @@ public class EmbeddedServerImpl implements Server {
      * @see {@link ServerEventListener}
      */
     public EmbeddedServerImpl(String serverName, File userDir, File outputDir, ServerEventListener listener) {
-        this(serverName, userDir, outputDir, null, listener, null, null);
+        this(serverName, userDir, outputDir, null, listener, null, null, null);
     }
 
     /**
@@ -110,7 +110,7 @@ public class EmbeddedServerImpl implements Server {
      * @see {@link ServerEventListener}
      */
     public EmbeddedServerImpl(String serverName, File userDir, File outputDir, File logDir, ServerEventListener listener) {
-        this(serverName, userDir, outputDir, logDir, listener, null, null);
+        this(serverName, userDir, outputDir, logDir, listener, null, null, null);
     }
 
     /**
@@ -131,7 +131,7 @@ public class EmbeddedServerImpl implements Server {
      * @see {@link ServerEventListener}
      */
     public EmbeddedServerImpl(String serverName, File userDir, File outputDir, File logDir, ServerEventListener listener, HashMap<String, Properties> extraProductExtensions) {
-        this(serverName, userDir, outputDir, logDir, listener, extraProductExtensions, null);
+        this(serverName, userDir, outputDir, logDir, listener, extraProductExtensions, null, null);
     }
 
     /**
@@ -154,6 +154,30 @@ public class EmbeddedServerImpl implements Server {
      */
     public EmbeddedServerImpl(String serverName, File userDir, File outputDir, File logDir, ServerEventListener listener, HashMap<String, Properties> extraProductExtensions,
                               ExecutorService executor) {
+        this(serverName, userDir, outputDir, logDir, listener, extraProductExtensions, null, null);
+    }
+
+    /**
+     * This is an abridged version of what the Launcher does when invoked from the
+     * command line. The constructor just verifies the configuration of the server--
+     * reading of bootstrap properties and detailed processing of configuration is
+     * deferred until server start.
+     *
+     * <p>Note this is a new constructor with new enhancement to support an
+     * alternate workarea location for embedded servers launched by utilities.</p>
+     *
+     * @param serverName             ServerName: defaultServer will be used if this is null
+     * @param userDir                WLP_USER_DIR equivalent, may be null
+     * @param outputDir              WLP_OUTPUT_DIR equivalent, may be null
+     * @param listener               ServerEventListener that should receive notifications of Server lifecycle changes, may be null.
+     * @param extraProductExtensions HashMap of Properties, may be null
+     * @param executor               The executor service to use for start and stop operations
+     * @param workareaDirStr         Embedded workarea location, null for default
+     *
+     * @see {@link ServerEventListener}
+     */
+    public EmbeddedServerImpl(String serverName, File userDir, File outputDir, File logDir, ServerEventListener listener, HashMap<String, Properties> extraProductExtensions,
+                              ExecutorService executor, String workareaDirStr) {
         if (executor == null) {
             opQueue = Executors.newCachedThreadPool(new ThreadFactory() {
                 @Override
@@ -180,8 +204,9 @@ public class EmbeddedServerImpl implements Server {
         externalListener = listener;
 
         // Find location will throw standard exceptions w/ translated messages
-        // for bad serverName or bad directories.
-        bootProps.findLocations(serverName, userDirPath, outputDirPath, logDirPath, null);
+        // for bad serverName or bad directories.  Workareas for a server and
+        // embedded server instances launched by admin utilities must be separate.
+        bootProps.findLocations(serverName, userDirPath, outputDirPath, logDirPath, null, workareaDirStr);
 
         // PI20344 - 2014/06/16:  Setting a couple of java properties that are needed by the
         // com.ibm.ws.kernel.boot.cmdline.Utils class, which expects to have been launched from the

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/Launcher.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/Launcher.java
@@ -41,7 +41,7 @@ public class Launcher {
      * command line parameters. This method will call <code>System.exit</code> when the framework shuts down.
      *
      * @param args
-     *            Command line arguments.
+     *                 Command line arguments.
      * @throws Exception
      *
      * @see Launcher#createPlatform(String[])
@@ -58,7 +58,7 @@ public class Launcher {
      * running) will immediately return.
      *
      * @param args
-     *            Command line arguments
+     *                 Command line arguments
      *
      * @return 0 if platform was launched and shut down successfully, > 20 if
      *         an exception or unexpected condition occurred during
@@ -229,7 +229,7 @@ public class Launcher {
     /**
      * Handle the process action.
      *
-     * @param bootProps An instance of BootstrapConfig
+     * @param bootProps  An instance of BootstrapConfig
      * @param launchArgs An instance of LaunchArguments
      */
     protected ReturnCode handleActions(BootstrapConfig bootProps, LaunchArguments launchArgs) {
@@ -300,7 +300,7 @@ public class Launcher {
     /**
      * Find main locations
      *
-     * @param bootProps An instance of BootstrapConfig
+     * @param bootProps   An instance of BootstrapConfig
      * @param processName Process name to be used
      */
     protected void findLocations(BootstrapConfig bootProps, String processName) {
@@ -319,9 +319,9 @@ public class Launcher {
         if (consoleLogFileStr == null)
             consoleLogFileStr = getEnv(BootstrapConstants.ENV_LOG_FILE);
 
-        // Do enough processing to know where the directories should be..
+        // Do enough processing to know where the directories should be.
         // this should not cause any directories to be created
-        bootProps.findLocations(processName, userDirStr, serversDirStr, logDirStr, consoleLogFileStr);
+        bootProps.findLocations(processName, userDirStr, serversDirStr, logDirStr, consoleLogFileStr, null);
     }
 
     protected ReturnCode showHelp(LaunchArguments launchArgs) {
@@ -360,7 +360,7 @@ public class Launcher {
      * properties.
      *
      * @param key
-     *            Property key
+     *                Property key
      * @return Object value, or null if not found.
      */
     protected String getEnv(final String key) {

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapConstants.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/BootstrapConstants.java
@@ -125,6 +125,7 @@ public final class BootstrapConstants {
     public static final String LOC_AREA_NAME_EXTENSION = "extension";
     public static final String LOC_AREA_NAME_LIB = "lib";
     public static final String LOC_AREA_NAME_WORKING = "workarea";
+    public static final String LOC_AREA_NAME_WORKING_UTILS = "workarea-utils";
     public static final String LOC_AREA_NAME_APP = "apps";
     public static final String LOC_AREA_NAME_RES = "resources";
     public static final String LOC_AREA_NAME_CFG = "config";

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/FileUtils.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/FileUtils.java
@@ -155,7 +155,7 @@ public class FileUtils {
      * Recursively copy the files from one dir to the other.
      *
      * @param from The directory to copy from, must exist.
-     * @param to The directory to copy to, must exist, must be empty.
+     * @param to   The directory to copy to, must exist, must be empty.
      * @throws IOException
      * @throws FileNotFoundException
      */
@@ -556,11 +556,11 @@ public class FileUtils {
      * Recursively delete directory: used to clean up for clean start.
      *
      * @param fileToRemove
-     *            Name of file/directory to delete. If the File is a directory,
-     *            all sub-directories and files will also be deleted except for
-     *            the server lock and server running file.
+     *                         Name of file/directory to delete. If the File is a directory,
+     *                         all sub-directories and files will also be deleted except for
+     *                         the server lock and server running file.
      *
-     *            This method will return false if the file can not be read or deleted.
+     *                         This method will return false if the file can not be read or deleted.
      *
      * @return true if the clean succeeded, false otherwise
      */
@@ -615,14 +615,19 @@ public class FileUtils {
             for (File file : files) {
                 if (file.isDirectory()) {
                     success |= recursiveClean(file);
-                } else if ((file.getName().equals(BootstrapConstants.S_LOCK_FILE) &&
-                            fileToRemove.getName().equals(BootstrapConstants.LOC_AREA_NAME_WORKING))
-                           ||
-                           ((fileToRemove.getName().equals(BootstrapConstants.LOC_AREA_NAME_WORKING))) &&
-                              (file.getName().equals(BootstrapConstants.SERVER_RUNNING_FILE))) {
-                    // skip/preserve workarea/.sLock and workarea/.sRunning files
                 } else {
-                    success |= file.delete();
+                    String candidate = file.getName();
+                    String candidateParent = fileToRemove.getName();
+                    if ((BootstrapConstants.S_LOCK_FILE.equals(candidate) ||
+                         BootstrapConstants.SERVER_RUNNING_FILE.equals(candidate))
+                        &&
+                        (BootstrapConstants.LOC_AREA_NAME_WORKING.equals(candidateParent) ||
+                         BootstrapConstants.LOC_AREA_NAME_WORKING_UTILS.equals(candidateParent))) {
+                        // skip/preserve workarea/.sLock and workarea/.sRunning files, including those
+                        // in embedded server workarea
+                    } else {
+                        success |= file.delete();
+                    }
                 }
             }
             files = fileToRemove.listFiles();
@@ -653,7 +658,7 @@ public class FileUtils {
      * A method that translates a "file:" URL into a File.
      *
      * @param url
-     *            the "file:" URL to convert into a file name
+     *                the "file:" URL to convert into a file name
      * @return file derived from URL
      */
     public static File getFile(URL url) {

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommand.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommand.java
@@ -42,7 +42,6 @@ import com.ibm.ws.kernel.boot.internal.commands.ArchiveProcessor.Pair;
 import com.ibm.ws.kernel.boot.internal.commands.PackageProcessor.PackageOption;
 import com.ibm.ws.kernel.boot.logging.TextFileOutputStreamFactory;
 import com.ibm.wsspi.kernel.embeddable.Server;
-import com.ibm.wsspi.kernel.embeddable.ServerBuilder;
 
 /**
  *
@@ -352,9 +351,7 @@ public class PackageCommand {
         //tell user we are collecting.
         System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("info.serverPackagingCollectingInformation"),
                                                 serverName));
-        EmbeddedServerImpl server = (EmbeddedServerImpl) (new ServerBuilder()).setName(serverName).setOutputDir(new File(serverOutputDir).getParentFile()).setUserDir(bootProps.getUserRoot())
-                        //.setServerEventListener(this)
-                        .build();
+        EmbeddedServerImpl server = new EmbeddedServerImpl(serverName, bootProps.getUserRoot(), new File(serverOutputDir).getParentFile(), null, null, null, null, BootstrapConstants.LOC_AREA_NAME_WORKING_UTILS);
 
         //add in the 'do not pass go' property.
         //this will prevent the server raising the start level, preventing features starting

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/BootstrapConfigTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/BootstrapConfigTest.java
@@ -312,6 +312,11 @@ public class BootstrapConfigTest {
             assertSame("E: outputRoot should be same as processesRoot", bc.processesRoot, bc.outputRoot);
             assertSame("E: outputDir should be same as configDir", bc.configDir, bc.outputDir);
 
+            // Embedded workarea for utilities
+            bc = new TestBootstrapConfig();
+            bc.findLocations(testName.getMethodName(), null, null, null, null, BootstrapConstants.LOC_AREA_NAME_WORKING_UTILS);
+            assertTrue("F: workarea should be child of outputDir/workarea: ", new File(bc.outputDir, "workarea").equals(bc.workarea.getParentFile()));
+
         } finally {
             TestUtils.cleanTempFiles(test1);
             System.clearProperty(BootstrapConstants.LOC_PROPERTY_INSTANCE_DIR);

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/SharedBootstrapConfig.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/SharedBootstrapConfig.java
@@ -53,7 +53,7 @@ public class SharedBootstrapConfig extends BootstrapConfig {
 
         HashMap<String, String> map = new HashMap<String, String>();
 
-        this.findLocations(serverName, rootDirStr, null, null, null);
+        this.findLocations(serverName, rootDirStr, null, null, null, null);
         this.configure(map);
     }
 


### PR DESCRIPTION
Introduce a new workarea path, workarea-utils, for embedded servers launched by liberty commands and utilities. The new workarea-utils path reduces failures due to corrupt workarea data by ensuring that embedded and user-configured servers persist workarea data to separate locations.  Embedded servers launched by the server "package" command and by the support to get the required feature set of an existing, user-configured server will now use the workarea-utils path.  This solution nests the workarea-utils path within the user-configured servers' workarea.

#fixes 7491