### PR TITLE
Update TransactionContext processing

### DIFF
--- a/dev/com.ibm.ws.transaction.cdi/src/com/ibm/tx/jta/cdi/TransactionContext.java
+++ b/dev/com.ibm.ws.transaction.cdi/src/com/ibm/tx/jta/cdi/TransactionContext.java
@@ -59,9 +59,8 @@ public class TransactionContext implements AlterableContext, TransactionScopeDes
             return TransactionScoped.class;
         }
     };
-    
 
-    private BeanManager beanManager = null;
+    private final BeanManager beanManager;
 
     public TransactionContext(BeanManager beanManager) {
         this.beanManager = beanManager;
@@ -94,8 +93,8 @@ public class TransactionContext implements AlterableContext, TransactionScopeDes
         data = new InstanceAndContext<T>(contextual, creationalContext, t);
         storage.put(contextId, data);
 
-        //A new transaction has called get() for the first time. This is what we consider to be the start of a transaction scope. 
-        beanManager.fireEvent("Initializing transaction context" , initializedQualifier);
+        //A new transaction has called get() for the first time. This is what we consider to be the start of a transaction scope.
+        beanManager.fireEvent("Initializing transaction context", initializedQualifier);
 
         //Put this into the registry so it can be found when it's time to call destroy.
         tsr.putResource("transactionScopeDestroyer", this);
@@ -291,7 +290,6 @@ public class TransactionContext implements AlterableContext, TransactionScopeDes
             return sb.toString();
         }
     }
-
 
     //These can be removed in java 8.
     public abstract static class DestroyedQualifier extends AnnotationLiteral<Destroyed> implements Destroyed {} 

--- a/dev/com.ibm.ws.transaction.cdi/src/com/ibm/tx/jta/cdi/TransactionContextExtension.java
+++ b/dev/com.ibm.ws.transaction.cdi/src/com/ibm/tx/jta/cdi/TransactionContextExtension.java
@@ -10,32 +10,17 @@
  *******************************************************************************/
 package com.ibm.tx.jta.cdi;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
 
+import org.osgi.service.component.annotations.Component;
+
 import com.ibm.tx.TranConstants;
 import com.ibm.tx.util.logging.Tr;
 import com.ibm.tx.util.logging.TraceComponent;
-import com.ibm.ws.cdi.CDIService;
 import com.ibm.ws.cdi.extension.WebSphereCDIExtension;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
-import org.osgi.service.component.ComponentContext;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 @Component(service = WebSphereCDIExtension.class,
            property = { "bean.defining.annotations=javax.transaction.TransactionScoped" })
@@ -43,44 +28,8 @@ public class TransactionContextExtension implements Extension, WebSphereCDIExten
 
     private static final TraceComponent tc = Tr.register(TransactionContext.class, TranConstants.TRACE_GROUP, TranConstants.NLS_FILE);
 
-    //This is not actually used since weld will create a new instance of this class seperate from the one OSGI has populated. 
-    //But this stays so that OSGI will manage the extensions lifecycle. 
-    @Reference
-    private CDIService cdiSvc;
-
-    private BeanManager beanManager = null;
-
     public void afterBeanDiscovery(@Observes AfterBeanDiscovery event, BeanManager manager) {
-        TransactionContext tc = new TransactionContext(getBeanManager());
+        TransactionContext tc = new TransactionContext(manager);
         event.addContext(tc);
     }
-
-    private BeanManager getBeanManager() {
-        if (beanManager == null) {
-            CDIService cdiService = getCDIService();
-            if (cdiService != null) {
-                beanManager = cdiService.getCurrentBeanManager();
-            } else {
-                throw new IllegalStateException("Failed to get the beanManager.");
-            }
-        }
-        return beanManager;
-    }
-
-    private CDIService getCDIService() {
-        final Bundle bundle = FrameworkUtil.getBundle(CDIService.class);
-        CDIService cdiService = AccessController.doPrivileged(new PrivilegedAction<CDIService>() {
-            @Override
-            public CDIService run() {
-                BundleContext bCtx = bundle.getBundleContext();
-                ServiceReference<CDIService> svcRef = bCtx.getServiceReference(CDIService.class);
-                return svcRef == null ? null : bCtx.getService(svcRef);
-            }
-        });
-        if (cdiService == null) {
-            throw new IllegalStateException("Failed to get the CDIService.");
-        }
-        return cdiService;
-    }
-
 }


### PR DESCRIPTION
- In TransactionContext, make the BeanManager field final
- In TransactionContextExtension, use the BeanManager that is passed to
the afterBeanDiscovery method instead of looking it up each time.