### PR TITLE
create nonship mpContextPropagation-1.1 feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.1.feature
@@ -1,0 +1,15 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.concurrent.mp-1.1
+visibility=private
+singleton=true
+-features=\
+com.ibm.websphere.appserver.contextService-1.0
+-bundles=\
+  com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0",\
+  com.ibm.ws.concurrent.mp.1.0,\
+  com.ibm.ws.javaee.platform.defaultresource, \
+  com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.0", \
+  com.ibm.ws.resource, \
+  com.ibm.ws.concurrent
+kind=noship
+edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
@@ -10,7 +10,7 @@ Subsystem-Name: Concurrency Utilities for Java EE 1.0
 -features=com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.appLifecycle-1.0, \
  com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
- com.ibm.websphere.appserver.concurrent.mp-0.0.0.noImpl; ibm.tolerates:=1.0, \
+ com.ibm.websphere.appserver.concurrent.mp-0.0.0.noImpl; ibm.tolerates:="1.0, 1.1", \
  com.ibm.websphere.appserver.contextService-1.0
 -bundles=com.ibm.ws.javaee.platform.defaultresource, \
  com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.0", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxrsClient-2.1/com.ibm.websphere.appserver.jaxrsClient-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxrsClient-2.1/com.ibm.websphere.appserver.jaxrsClient-2.1.feature
@@ -18,7 +18,7 @@ Subsystem-Name: Java RESTful Services Client 2.1
 -features=com.ibm.websphere.appserver.jaxrs.common-2.1, \
  com.ibm.websphere.appserver.javaeeCompatible-8.0, \
  com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
- com.ibm.websphere.appserver.concurrent.mp-1.0
+ com.ibm.websphere.appserver.concurrent.mp-1.0; ibm.tolerates:="1.1"
 -bundles=com.ibm.ws.jaxrs.2.0.client, \
 com.ibm.ws.cxf.client
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.1/com.ibm.websphere.appserver.mpContextPropagation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.1/com.ibm.websphere.appserver.mpContextPropagation-1.1.feature
@@ -1,0 +1,18 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.mpContextPropagation-1.1
+visibility=public
+singleton=true
+IBM-ShortName: mpContextPropagation-1.1
+Subsystem-Name: MicroProfile Context Propagation 1.1
+IBM-App-ForceRestart: install, uninstall
+IBM-API-Package: \
+  org.eclipse.microprofile.context; type="stable", \
+  org.eclipse.microprofile.context.spi; type="stable"
+-features=\
+  com.ibm.websphere.appserver.concurrent-1.0, \
+  com.ibm.websphere.appserver.concurrent.mp-1.1, \
+  com.ibm.websphere.appserver.javaeeCompatible-8.0
+-bundles=\
+  com.ibm.ws.require.java8
+kind=noship
+edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.1/resources/l10n/com.ibm.websphere.appserver.mpContextPropagation-1.1.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.1/resources/l10n/com.ibm.websphere.appserver.mpContextPropagation-1.1.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2018,2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature implements the MicroProfile Context Propagation 1.1 specification, which allows you to obtain class instances of CompletableFuture that are backed by an instance of ManagedExecutor and provides the ability to contextualize CompletableFuture actions.


### PR DESCRIPTION
Create nonship feature, which to start out with, will point to the v1.0 binaries.
This will gate any future experimentation with proposed 1.1 spec changes.