### PR TITLE
remaining tests in SessionCacheTimeoutTest

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
@@ -104,8 +104,8 @@ public class SessionCacheTimeoutTest extends FATServletClient {
      * Test that a session can still be used if it was valid when a servlet call began, even after timeout.
      * This mimics SessionDB behavior.
      */
-    //@Test
-    //@Mode(FULL)
+    @Test
+    @Mode(FULL)
     public void testServletTimeout() throws Exception {
         List<String> session = newSession();
         app.sessionPut("testServletTimeout-foo2", "bar", session, true);
@@ -117,8 +117,8 @@ public class SessionCacheTimeoutTest extends FATServletClient {
      * Tests that a locally cached session is still usable to the end of a servlet call after being invalidated,
      * and is no longer valid in a following servlet call.
      */
-    //@Test
-    //@Mode(FULL)
+    @Test
+    @Mode(FULL)
     public void testServletPutTimeout() throws Exception {
         List<String> session = newSession();
         app.invokeServlet("sessionPutTimeout&key=testServletPutTimeout-foo2&value=bar&createSession=true", session);
@@ -128,8 +128,8 @@ public class SessionCacheTimeoutTest extends FATServletClient {
     /**
      * Tests that after a session times out session attributes are removed from the cache.
      */
-    //@Test
-    //@Mode(FULL)
+    @Test
+    @Mode(FULL)
     public void testCacheInvalidationAfterTimeout() throws Exception {
         List<String> session = newSession();
         String sessionID = app.sessionPut("testCacheInvalidationAfterTimeout-foo", "bar", session, true);
@@ -142,8 +142,8 @@ public class SessionCacheTimeoutTest extends FATServletClient {
     /**
      * Test that the cache is invalidated after reaching invalidation timeout during a servlet call.
      */
-    //@Test
-    //@Mode(FULL)
+    @Test
+    @Mode(FULL)
     public void testCacheInvalidationAfterServletTimeout() throws Exception {
         List<String> session = newSession();
         app.sessionPut("testCacheInvalidationAfterServletTimeout-foo", "bar", session, true);

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -764,7 +764,6 @@ public class SessionCacheTestServlet extends FATServlet {
         String sessionId = session.getId();
         // poll for entry to be invalidated from cache
         CacheManager cacheManager = getCacheManager(request);
-        System.out.println("Your cache manager is " + cacheManager);
         @SuppressWarnings("rawtypes")
         Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.security.AccessController;
@@ -47,7 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.cache.Cache;
-import javax.cache.Caching;
+import javax.cache.CacheManager;
 import javax.cache.management.CacheMXBean;
 import javax.cache.management.CacheStatisticsMXBean;
 import javax.management.JMX;
@@ -78,6 +79,26 @@ public class SessionCacheTestServlet extends FATServlet {
         // We've configured the server to only hold a single session in memory.
         // By creating a new one, we flush the other one from memory.
         request.getSession();
+    }
+
+    /**
+     * A hacky way for the tests to get access to fields of an internal object, in order to check the
+     * contents of the same cache that is used by HTTP Sessions code. NEVER DO THIS IN PRODUCTION CODE.
+     */
+    private final CacheManager getCacheManager(HttpServletRequest request) throws Exception {
+        ClassLoader osgiLoader = request.getClass().getClassLoader();
+        Class<?> FrameworkUtil = osgiLoader.loadClass("org.osgi.framework.FrameworkUtil");
+        Class<?> ServiceReference = osgiLoader.loadClass("org.osgi.framework.ServiceReference");
+        Object bundle = FrameworkUtil.getMethod("getBundle", Class.class).invoke(null, request.getClass());
+        Object bundleContext = bundle.getClass().getMethod("getBundleContext").invoke(bundle);
+        Object[] serviceRefs = (Object[]) bundleContext.getClass()
+                        .getMethod("getServiceReferences", String.class, String.class)
+                        .invoke(bundleContext, null, "(component.name=com.ibm.ws.session.cache)");
+        Object serviceRef = serviceRefs[0];
+        Object cacheStoreService = bundleContext.getClass().getMethod("getService", ServiceReference).invoke(bundleContext, serviceRef);
+        Field CacheStoreService_cacheManager = cacheStoreService.getClass().getDeclaredField("cacheManager");
+        CacheStoreService_cacheManager.setAccessible(true);
+        return (CacheManager) CacheStoreService_cacheManager.get(cacheStoreService);
     }
 
     /**
@@ -574,7 +595,8 @@ public class SessionCacheTestServlet extends FATServlet {
 
         List<String> expected = expectedAttributes == null ? Collections.emptyList() : Arrays.asList(expectedAttributes.split(","));
 
-        Cache<String, ArrayList> cache = Caching.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
+        CacheManager cacheManager = getCacheManager(request);
+        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
         ArrayList<?> values = cache.get(sessionId);
         @SuppressWarnings("unchecked")
         TreeSet<String> attributeNames = (TreeSet<String>) values.get(values.size() - 1); // last entry is the session attribute names
@@ -600,7 +622,8 @@ public class SessionCacheTestServlet extends FATServlet {
             expected.add(o == null ? null : Arrays.toString(toBytes(o)));
         }
 
-        Cache<String, byte[]> cache = Caching.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
+        CacheManager cacheManager = getCacheManager(request);
+        Cache<String, byte[]> cache = cacheManager.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
         byte[] bytes = cache.get(key);
 
         String strValue = bytes == null ? null : Arrays.toString(bytes);
@@ -725,9 +748,9 @@ public class SessionCacheTestServlet extends FATServlet {
         String sessionId = session.getId();
 
         // poll for entry to be invalidated from cache
-        // TODO System.setProperty("hazelcast.config", InitialContext.doLookup("jcache/hazelcast.config")); // need to use same config file as server.xml
+        CacheManager cacheManager = getCacheManager(request);
         @SuppressWarnings("rawtypes")
-        Cache<String, ArrayList> cache = Caching.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
+        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));
 
         String actual = (String) session.getAttribute(key);
@@ -740,9 +763,10 @@ public class SessionCacheTestServlet extends FATServlet {
         String value = request.getParameter("value");
         String sessionId = session.getId();
         // poll for entry to be invalidated from cache
-        // TODO System.setProperty("hazelcast.config", InitialContext.doLookup("jcache/hazelcast.config")); // need to use same config file as server.xml
+        CacheManager cacheManager = getCacheManager(request);
+        System.out.println("Your cache manager is " + cacheManager);
         @SuppressWarnings("rawtypes")
-        Cache<String, ArrayList> cache = Caching.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
+        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
 
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));
         session.setAttribute(key, value);
@@ -759,15 +783,15 @@ public class SessionCacheTestServlet extends FATServlet {
         String key = request.getParameter("key");
         String value = request.getParameter("value");
         String sessionId = request.getParameter("sid");
-        // TODO System.setProperty("hazelcast.config", InitialContext.doLookup("jcache/hazelcast.config")); // need to use same config file as server.xml
-        Cache<String, byte[]> cacheA = Caching.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
+        CacheManager cacheManager = getCacheManager(request);
+        Cache<String, byte[]> cacheA = cacheManager.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
         byte[] result = cacheA.get(key);
         assertEquals(value, result == null ? null : Arrays.toString(result));
 
         //Validate session existence/deletion if we pass in a sessionId
         if (sessionId != null) {
             @SuppressWarnings("rawtypes")
-            Cache<String, ArrayList> cacheM = Caching.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
+            Cache<String, ArrayList> cacheM = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
             assertEquals(cacheM.containsKey(sessionId), value == null ? false : true);
         }
     }
@@ -787,12 +811,12 @@ public class SessionCacheTestServlet extends FATServlet {
         String sessionId = session.getId();
 
         // poll for entry to be invalidated from cache
-        // TODO System.setProperty("hazelcast.config", InitialContext.doLookup("jcache/hazelcast.config")); // need to use same config file as server.xml
+        CacheManager cacheManager = getCacheManager(request);
         @SuppressWarnings("rawtypes")
-        Cache<String, ArrayList> cache = Caching.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
+        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));
 
-        Cache<String, byte[]> cacheAttr = Caching.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
+        Cache<String, byte[]> cacheAttr = cacheManager.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
         byte[] result = cacheAttr.get(key);
         assertEquals(expected, result == null ? null : Arrays.toString(result));
     }


### PR DESCRIPTION
Enable the remaining tests in SessionCacheTimeoutTest.
The tests need to be able to access the same caches that are used internally by HTTP sessions in order to check contents.  This should be possible for a test case via reflection.