### PR TITLE
enable parts of SessionCacheTwoServerTest that only need 1 server

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/FATSuite.java
@@ -29,7 +29,7 @@ import componenttest.topology.utils.HttpUtils;
 @SuiteClasses({
                 // TODO enable tests as we get them converted over to infinispan
                 SessionCacheOneServerTest.class,
-                //SessionCacheTwoServerTest.class,
+                SessionCacheTwoServerTest.class,
                 SessionCacheTimeoutTest.class,
                 //SessionCacheTwoServerTimeoutTest.class,
                 //HazelcastClientTest.class

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
@@ -104,8 +104,8 @@ public class SessionCacheTimeoutTest extends FATServletClient {
      * Test that a session can still be used if it was valid when a servlet call began, even after timeout.
      * This mimics SessionDB behavior.
      */
-    //@Test
-    //@Mode(FULL)
+    @Test
+    @Mode(FULL)
     public void testServletTimeout() throws Exception {
         List<String> session = newSession();
         app.sessionPut("testServletTimeout-foo2", "bar", session, true);
@@ -117,8 +117,8 @@ public class SessionCacheTimeoutTest extends FATServletClient {
      * Tests that a locally cached session is still usable to the end of a servlet call after being invalidated,
      * and is no longer valid in a following servlet call.
      */
-    //@Test
-    //@Mode(FULL)
+    @Test
+    @Mode(FULL)
     public void testServletPutTimeout() throws Exception {
         List<String> session = newSession();
         app.invokeServlet("sessionPutTimeout&key=testServletPutTimeout-foo2&value=bar&createSession=true", session);
@@ -128,8 +128,8 @@ public class SessionCacheTimeoutTest extends FATServletClient {
     /**
      * Tests that after a session times out session attributes are removed from the cache.
      */
-    //@Test
-    //@Mode(FULL)
+    @Test
+    @Mode(FULL)
     public void testCacheInvalidationAfterTimeout() throws Exception {
         List<String> session = newSession();
         String sessionID = app.sessionPut("testCacheInvalidationAfterTimeout-foo", "bar", session, true);
@@ -142,8 +142,8 @@ public class SessionCacheTimeoutTest extends FATServletClient {
     /**
      * Test that the cache is invalidated after reaching invalidation timeout during a servlet call.
      */
-    //@Test
-    //@Mode(FULL)
+    @Test
+    @Mode(FULL)
     public void testCacheInvalidationAfterServletTimeout() throws Exception {
         List<String> session = newSession();
         app.sessionPut("testCacheInvalidationAfterServletTimeout-foo", "bar", session, true);

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
@@ -52,19 +52,19 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         appB = new SessionCacheApp(serverB, true, "session.cache.infinispan.web", "session.cache.infinispan.web.cdi", "session.cache.infinispan.web.listener1");
         serverB.useSecondaryHTTPPort();
 
-        String hazelcastConfigFile = "hazelcast-localhost-only.xml";
+        //String hazelcastConfigFile = "hazelcast-localhost-only.xml";
 
-        if (FATSuite.isMulticastDisabled()) {
-            Log.info(SessionCacheTwoServerTest.class, "setUp", "Disabling multicast in Hazelcast config.");
-            hazelcastConfigFile = "hazelcast-localhost-only-multicastDisabled.xml";
-        }
+        //if (FATSuite.isMulticastDisabled()) {
+        //    Log.info(SessionCacheTwoServerTest.class, "setUp", "Disabling multicast in Hazelcast config.");
+        //    hazelcastConfigFile = "hazelcast-localhost-only-multicastDisabled.xml";
+        //}
 
-        String configLocation = new File(serverB.getUserDir() + "/shared/resources/hazelcast/" + hazelcastConfigFile).getAbsolutePath();
-        String rand = UUID.randomUUID().toString();
-        serverA.setJvmOptions(Arrays.asList("-Dhazelcast.group.name=" + rand,
-                                            "-Dhazelcast.config.file=" + hazelcastConfigFile));
-        serverB.setJvmOptions(Arrays.asList("-Dhazelcast.group.name=" + rand,
-                                            "-Dhazelcast.config=" + configLocation));
+        //String configLocation = new File(serverB.getUserDir() + "/shared/resources/hazelcast/" + hazelcastConfigFile).getAbsolutePath();
+        //String rand = UUID.randomUUID().toString();
+        //serverA.setJvmOptions(Arrays.asList("-Dhazelcast.group.name=" + rand,
+        //                                    "-Dhazelcast.config.file=" + hazelcastConfigFile));
+        //serverB.setJvmOptions(Arrays.asList("-Dhazelcast.group.name=" + rand,
+        //                                    "-Dhazelcast.config=" + configLocation));
 
         serverA.startServer();
 
@@ -81,14 +81,14 @@ public class SessionCacheTwoServerTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            testFailover();
+            // TODO testFailover();
         } finally {
             try {
                 if (serverA.isStarted())
                     serverA.stopServer();
             } finally {
                 if (serverB.isStarted())
-                    serverB.stopServer();
+                    serverB.stopServer("CWWKL0058W:.*InfinispanLib"); // TODO why does this occur for Infinispan jar, but not Hazelcast?
             }
         }
     }
@@ -122,7 +122,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
      * serialized when the session is evicted from memory, and deserialized
      * when the session is accessed again.
      */
-    @Test
+    // TODO @Test
     public void testBasicSerialization() throws Exception {
         List<String> session = new ArrayList<>();
         try {
@@ -138,7 +138,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
      * Test that calling session.invalidate() on one server will propagate the
      * invalidation to the other server
      */
-    @Test
+    // TODO @Test
     public void testCrossServerInvalidation() throws Exception {
         List<String> session = new ArrayList<>();
         appA.invokeServlet("testSerialization", session);
@@ -208,7 +208,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
      * App A on server A uses GET_AND_SET_ATTRIBUTES, which means that an update made locally to an attribute after getting it
      * without performing a putAttribute will be written to the persistent store.
      */
-    @Test
+    // TODO @Test
     public void testModifyWithoutPut() throws Exception {
         List<String> session = new ArrayList<>();
         appA.sessionPut("testModifyWithoutPut-key", new StringBuffer("MyValue"), session, true);
@@ -256,7 +256,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
             assertTrue(response3, response3.contains("previous value for SessionScopedBean: [SSB1]"));
             assertTrue(response5, response5.contains("previous value for SessionScopedBean: [SSB2]"));
 
-            // Verify that the value is updated in the cache iself
+            // Verify that the value is updated in the cache itself
             int start;
             start = response2.indexOf("bytes for WELD_S#0: [") + 21;
             assertNotSame(response2, 20, start);
@@ -297,7 +297,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
      * that that value overrides the invalidation time configured in server.xml
      * for the given session.
      */
-    @Test
+    // TODO @Test
     public void testMaxInactiveInterval() throws Exception {
         List<String> session = new ArrayList<>();
         appA.sessionPut("testMaxInactiveInterval-key", 55901, session, true);

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverA/bootstrap.properties
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverA/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018,2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -10,3 +10,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.session.store.*=all
+# TODO enable java 2 security once more progress is made on test bucket
+websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverA/server.xml
@@ -11,12 +11,14 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="10m"/>
 
-    <httpSessionCache libraryRef="HazelcastLib" writeContents="GET_AND_SET_ATTRIBUTES">
+    <httpSessionCache libraryRef="InfinispanLib" writeContents="GET_AND_SET_ATTRIBUTES">
+        <!--  TODO
         <properties hazelcast.config.location="file:${shared.resource.dir}/hazelcast/${hazelcast.config.file}"/>
+        -->
     </httpSessionCache>
 
-    <library id="HazelcastLib">
-        <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    <library id="InfinispanLib">
+        <fileset dir="${shared.resource.dir}/infinispan" includes="*.jar"/>
     </library>
     
     <!-- Perms needed because the application uses Hazelcast directly   -->
@@ -41,6 +43,7 @@
     <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.sun.net.www.protocol.wsjar"/>
     
     <javaPermission codebase="${shared.resource.dir}/hazelcast/hazelcast.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/infinispan/*" className="java.security.AllPermission"/>
 
     <!--  Permissions for application to access mbeans -->
     <javaPermission codebase="${server.config.dir}/dropins/sessionCacheApp.war" className="javax.management.MBeanPermission" actions="queryNames"/>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/bootstrap.properties
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018,2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -10,3 +10,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.session.store.cache=all
+# TODO enable java 2 security once more progress is made on test bucket
+websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/server.xml
@@ -18,10 +18,10 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="10m"/>
 
-    <bell libraryRef="HazelcastLibB" service="javax.cache.spi.CachingProvider"/>
+    <bell libraryRef="InfinispanLib" service="javax.cache.spi.CachingProvider"/>
 
-    <library id="HazelcastLibB">
-        <file name="${shared.resource.dir}/hazelcast/hazelcast.jar"/>
+    <library id="InfinispanLib">
+        <fileset dir="${shared.resource.dir}/infinispan" includes="*.jar"/>
     </library>
     
     <!-- Perms needed because the application uses Hazelcast directly   -->
@@ -46,6 +46,7 @@
     <javaPermission className="java.lang.RuntimePermission" name="accessClassInPackage.sun.net.www.protocol.wsjar"/>
     
     <javaPermission codebase="${shared.resource.dir}/hazelcast/hazelcast.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/infinispan/*" className="java.security.AllPermission"/>
 
     <!--  Permissions for application to access mbeans -->
     <javaPermission codebase="${server.config.dir}/dropins/sessionCacheApp.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -764,7 +764,6 @@ public class SessionCacheTestServlet extends FATServlet {
         String sessionId = session.getId();
         // poll for entry to be invalidated from cache
         CacheManager cacheManager = getCacheManager(request);
-        System.out.println("Your cache manager is " + cacheManager);
         @SuppressWarnings("rawtypes")
         Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -85,11 +85,12 @@ public class SessionCacheTestServlet extends FATServlet {
      * A hacky way for the tests to get access to fields of an internal object, in order to check the
      * contents of the same cache that is used by HTTP Sessions code. NEVER DO THIS IN PRODUCTION CODE.
      */
-    private final CacheManager getCacheManager(HttpServletRequest request) throws Exception {
-        ClassLoader osgiLoader = request.getClass().getClassLoader();
+    public final static CacheManager getCacheManager() throws Exception {
+        Class<?> clclass = Thread.currentThread().getContextClassLoader().getClass();
+        ClassLoader osgiLoader = clclass.getClassLoader();
         Class<?> FrameworkUtil = osgiLoader.loadClass("org.osgi.framework.FrameworkUtil");
         Class<?> ServiceReference = osgiLoader.loadClass("org.osgi.framework.ServiceReference");
-        Object bundle = FrameworkUtil.getMethod("getBundle", Class.class).invoke(null, request.getClass());
+        Object bundle = FrameworkUtil.getMethod("getBundle", Class.class).invoke(null, clclass);
         Object bundleContext = bundle.getClass().getMethod("getBundleContext").invoke(bundle);
         Object[] serviceRefs = (Object[]) bundleContext.getClass()
                         .getMethod("getServiceReferences", String.class, String.class)
@@ -595,7 +596,7 @@ public class SessionCacheTestServlet extends FATServlet {
 
         List<String> expected = expectedAttributes == null ? Collections.emptyList() : Arrays.asList(expectedAttributes.split(","));
 
-        CacheManager cacheManager = getCacheManager(request);
+        CacheManager cacheManager = getCacheManager();
         Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
         ArrayList<?> values = cache.get(sessionId);
         @SuppressWarnings("unchecked")
@@ -622,7 +623,7 @@ public class SessionCacheTestServlet extends FATServlet {
             expected.add(o == null ? null : Arrays.toString(toBytes(o)));
         }
 
-        CacheManager cacheManager = getCacheManager(request);
+        CacheManager cacheManager = getCacheManager();
         Cache<String, byte[]> cache = cacheManager.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
         byte[] bytes = cache.get(key);
 
@@ -748,7 +749,7 @@ public class SessionCacheTestServlet extends FATServlet {
         String sessionId = session.getId();
 
         // poll for entry to be invalidated from cache
-        CacheManager cacheManager = getCacheManager(request);
+        CacheManager cacheManager = getCacheManager();
         @SuppressWarnings("rawtypes")
         Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));
@@ -763,7 +764,7 @@ public class SessionCacheTestServlet extends FATServlet {
         String value = request.getParameter("value");
         String sessionId = session.getId();
         // poll for entry to be invalidated from cache
-        CacheManager cacheManager = getCacheManager(request);
+        CacheManager cacheManager = getCacheManager();
         @SuppressWarnings("rawtypes")
         Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
 
@@ -782,7 +783,7 @@ public class SessionCacheTestServlet extends FATServlet {
         String key = request.getParameter("key");
         String value = request.getParameter("value");
         String sessionId = request.getParameter("sid");
-        CacheManager cacheManager = getCacheManager(request);
+        CacheManager cacheManager = getCacheManager();
         Cache<String, byte[]> cacheA = cacheManager.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
         byte[] result = cacheA.get(key);
         assertEquals(value, result == null ? null : Arrays.toString(result));
@@ -810,7 +811,7 @@ public class SessionCacheTestServlet extends FATServlet {
         String sessionId = session.getId();
 
         // poll for entry to be invalidated from cache
-        CacheManager cacheManager = getCacheManager(request);
+        CacheManager cacheManager = getCacheManager();
         @SuppressWarnings("rawtypes")
         Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.security.AccessController;
@@ -47,7 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.cache.Cache;
-import javax.cache.Caching;
+import javax.cache.CacheManager;
 import javax.cache.management.CacheMXBean;
 import javax.cache.management.CacheStatisticsMXBean;
 import javax.management.JMX;
@@ -78,6 +79,26 @@ public class SessionCacheTestServlet extends FATServlet {
         // We've configured the server to only hold a single session in memory.
         // By creating a new one, we flush the other one from memory.
         request.getSession();
+    }
+
+    /**
+     * A hacky way for the tests to get access to fields of an internal object, in order to check the
+     * contents of the same cache that is used by HTTP Sessions code. NEVER DO THIS IN PRODUCTION CODE.
+     */
+    private final CacheManager getCacheManager(HttpServletRequest request) throws Exception {
+        ClassLoader osgiLoader = request.getClass().getClassLoader();
+        Class<?> FrameworkUtil = osgiLoader.loadClass("org.osgi.framework.FrameworkUtil");
+        Class<?> ServiceReference = osgiLoader.loadClass("org.osgi.framework.ServiceReference");
+        Object bundle = FrameworkUtil.getMethod("getBundle", Class.class).invoke(null, request.getClass());
+        Object bundleContext = bundle.getClass().getMethod("getBundleContext").invoke(bundle);
+        Object[] serviceRefs = (Object[]) bundleContext.getClass()
+                        .getMethod("getServiceReferences", String.class, String.class)
+                        .invoke(bundleContext, null, "(component.name=com.ibm.ws.session.cache)");
+        Object serviceRef = serviceRefs[0];
+        Object cacheStoreService = bundleContext.getClass().getMethod("getService", ServiceReference).invoke(bundleContext, serviceRef);
+        Field CacheStoreService_cacheManager = cacheStoreService.getClass().getDeclaredField("cacheManager");
+        CacheStoreService_cacheManager.setAccessible(true);
+        return (CacheManager) CacheStoreService_cacheManager.get(cacheStoreService);
     }
 
     /**
@@ -574,7 +595,8 @@ public class SessionCacheTestServlet extends FATServlet {
 
         List<String> expected = expectedAttributes == null ? Collections.emptyList() : Arrays.asList(expectedAttributes.split(","));
 
-        Cache<String, ArrayList> cache = Caching.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
+        CacheManager cacheManager = getCacheManager(request);
+        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
         ArrayList<?> values = cache.get(sessionId);
         @SuppressWarnings("unchecked")
         TreeSet<String> attributeNames = (TreeSet<String>) values.get(values.size() - 1); // last entry is the session attribute names
@@ -600,7 +622,8 @@ public class SessionCacheTestServlet extends FATServlet {
             expected.add(o == null ? null : Arrays.toString(toBytes(o)));
         }
 
-        Cache<String, byte[]> cache = Caching.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
+        CacheManager cacheManager = getCacheManager(request);
+        Cache<String, byte[]> cache = cacheManager.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
         byte[] bytes = cache.get(key);
 
         String strValue = bytes == null ? null : Arrays.toString(bytes);
@@ -725,9 +748,9 @@ public class SessionCacheTestServlet extends FATServlet {
         String sessionId = session.getId();
 
         // poll for entry to be invalidated from cache
-        // TODO System.setProperty("hazelcast.config", InitialContext.doLookup("jcache/hazelcast.config")); // need to use same config file as server.xml
+        CacheManager cacheManager = getCacheManager(request);
         @SuppressWarnings("rawtypes")
-        Cache<String, ArrayList> cache = Caching.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
+        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));
 
         String actual = (String) session.getAttribute(key);
@@ -740,9 +763,10 @@ public class SessionCacheTestServlet extends FATServlet {
         String value = request.getParameter("value");
         String sessionId = session.getId();
         // poll for entry to be invalidated from cache
-        // TODO System.setProperty("hazelcast.config", InitialContext.doLookup("jcache/hazelcast.config")); // need to use same config file as server.xml
+        CacheManager cacheManager = getCacheManager(request);
+        System.out.println("Your cache manager is " + cacheManager);
         @SuppressWarnings("rawtypes")
-        Cache<String, ArrayList> cache = Caching.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
+        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
 
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));
         session.setAttribute(key, value);
@@ -759,15 +783,15 @@ public class SessionCacheTestServlet extends FATServlet {
         String key = request.getParameter("key");
         String value = request.getParameter("value");
         String sessionId = request.getParameter("sid");
-        // TODO System.setProperty("hazelcast.config", InitialContext.doLookup("jcache/hazelcast.config")); // need to use same config file as server.xml
-        Cache<String, byte[]> cacheA = Caching.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
+        CacheManager cacheManager = getCacheManager(request);
+        Cache<String, byte[]> cacheA = cacheManager.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
         byte[] result = cacheA.get(key);
         assertEquals(value, result == null ? null : Arrays.toString(result));
 
         //Validate session existence/deletion if we pass in a sessionId
         if (sessionId != null) {
             @SuppressWarnings("rawtypes")
-            Cache<String, ArrayList> cacheM = Caching.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
+            Cache<String, ArrayList> cacheM = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
             assertEquals(cacheM.containsKey(sessionId), value == null ? false : true);
         }
     }
@@ -787,12 +811,12 @@ public class SessionCacheTestServlet extends FATServlet {
         String sessionId = session.getId();
 
         // poll for entry to be invalidated from cache
-        // TODO System.setProperty("hazelcast.config", InitialContext.doLookup("jcache/hazelcast.config")); // need to use same config file as server.xml
+        CacheManager cacheManager = getCacheManager(request);
         @SuppressWarnings("rawtypes")
-        Cache<String, ArrayList> cache = Caching.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
+        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host.sessionCacheApp", String.class, ArrayList.class);
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));
 
-        Cache<String, byte[]> cacheAttr = Caching.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
+        Cache<String, byte[]> cacheAttr = cacheManager.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
         byte[] result = cacheAttr.get(key);
         assertEquals(expected, result == null ? null : Arrays.toString(result));
     }

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/cdi/SessionCDITestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/cdi/SessionCDITestServlet.java
@@ -17,7 +17,7 @@ import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.cache.Cache;
-import javax.cache.Caching;
+import javax.cache.CacheManager;
 import javax.inject.Inject;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import componenttest.app.FATServlet;
+import session.cache.infinispan.web.SessionCacheTestServlet;
 
 @SuppressWarnings("serial")
 @WebServlet("/SessionCDITestServlet")
@@ -72,15 +73,15 @@ public class SessionCDITestServlet extends FATServlet {
      * Directly read entries from the session attributes cache and writes to the servlet output so that
      * the caller can confirm that the values are written to the cache.
      */
-    public void testWeldSessionAttributes(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public void testWeldSessionAttributes(HttpServletRequest request, HttpServletResponse response) throws Exception {
         String sessionId = request.getParameter("sessionId");
         String key0 = sessionId + ".WELD_S#0";
         String key1 = sessionId + ".WELD_S#1";
 
-        Cache<String, byte[]> cache = Caching.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
+        CacheManager cacheManager = SessionCacheTestServlet.getCacheManager();
+        Cache<String, byte[]> cache = cacheManager.getCache("com.ibm.ws.session.attr.default_host.sessionCacheApp", String.class, byte[].class);
         byte[] value0 = cache.get(key0);
         byte[] value1 = cache.get(key1);
-        cache.close();
 
         String strValue0 = Arrays.toString(value0);
         String strValue1 = Arrays.toString(value1);


### PR DESCRIPTION
It should be possible to enable all of the tests under SessionCacheTwoServerTest for Infinispan which only use one of the two servers.  Other tests will need to wait until the test is eventually made to configure both servers to use the same cache.