### PR TITLE
Update product and bundle version for release 19.0.0.10

### DIFF
--- a/dev/cnf/resources/bnd/liberty-release.props
+++ b/dev/cnf/resources/bnd/liberty-release.props
@@ -12,12 +12,12 @@
 releaseTypeGA=true
 
 libertyBaseVersion=19.0.0
-libertyFixpackVersion=9
+libertyFixpackVersion=10
 libertyServiceVersion=${libertyBaseVersion}.${libertyFixpackVersion}
-libertyBetaVersion=2019.9.0.0
+libertyBetaVersion=2019.10.0.0
 libertyRelease=${if;${releaseTypeGA};${libertyServiceVersion};${libertyBetaVersion}}
 
-libertyBundleMicroVersion=32
+libertyBundleMicroVersion=33
 copyrightBuildYear=2019
 buildID=${libertyRelease}-${buildLabel}
 productEdition=BASE_ILAN


### PR DESCRIPTION
This PR takes only the version update from https://github.com/OpenLiberty/open-liberty/pull/8868
The original PR also includes a revert that I don't know if we want or not.