### PR TITLE
test case for updating configuration of infinispan library

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheErrorPathsTest.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.File;
+import com.ibm.websphere.simplicity.config.Fileset;
 import com.ibm.websphere.simplicity.config.Library;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
@@ -322,12 +323,12 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
         }
     }
 
-    //@AllowedFFDC(value = { "javax.cache.CacheException" }) // expected on error path: No CachingProviders have been configured
-    // TODO @Test
+    @AllowedFFDC(value = { "javax.cache.CacheException" }) // expected on error path: No CachingProviders have been configured
+    @Test
     public void testModifyFileset() throws Exception {
         ServerConfiguration config = server.getServerConfiguration();
-        com.ibm.websphere.simplicity.config.File hazelcastFile = config.getLibraries().getById("HazelcastLib").getNestedFile();
-        String originalName = hazelcastFile.getName();
+        Fileset infinispanFileset = config.getLibraries().getById("InfinispanLib").getNestedFileset();
+        String originalDir = infinispanFileset.getDir();
         server.startServer(testName.getMethodName() + ".log");
 
         // Use sessionCache with original (good) config
@@ -336,7 +337,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
         run("testCacheContains&attribute=testModifyFileset&value=0", session);
 
         // Change the fileset to reference a bogus file
-        hazelcastFile.setName("${shared.resource.dir}/hazelcast/bogus.jar");
+        infinispanFileset.setDir("${shared.resource.dir}/bogus");
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES);
@@ -344,7 +345,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
         run("testSessionCacheNotAvailable", session);
 
         // Restore the original config and expect the new cache to be usable
-        hazelcastFile.setName(originalName);
+        infinispanFileset.setDir(originalDir);
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES);


### PR DESCRIPTION
Starting with the copied test case for updating configuration of hazelcast library for HTTP Session caching, convert the test case to be based on Infinispan, which, because it involves multiple JARs, will require updates to the library's fileset rather than file element.  The intent of this test is to ensure that a user who has misconfigured the library can observe the error and correct the server configuration to get HTTP Sessions working, without needing to restart the server.