### PR TITLE
Update settings to match between eclipse and bnd

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.cdi/bnd.bnd
@@ -15,11 +15,13 @@ Bundle-Name: JAX-WS CDI
 Bundle-SymbolicName: com.ibm.ws.jaxws.2.3.cdi
 Bundle-Description: IBM JAX-WS CDI support; version=${bVersion}
 
-# jaxws-cdi is part of EE7 and therefore requires java 1.7
+javac.source: 1.8
+javac.target: 1.8
+
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))" 
 
 Import-Package: \
-  javax.enterprise.inject.spi; version="[1.1,3)",\
+  javax.enterprise.inject.spi; version="[2.0,3)",\
    *
 
 # If you need use MESSAGE, you must enable this Private-Package, or message will translate wrong

--- a/dev/com.ibm.ws.microprofile.faulttolerance.metrics.1.1/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.metrics.1.1/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.microprofile.faulttolerance.metrics.2.0/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.metrics.2.0/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1


### PR DESCRIPTION
- jaxws.2.3.cdi said requires java 8, but was generating java 7 byte
code.  Now will generate Java 8 byte code
- Changed to import version 2.0 to 3 for cdi.  Since it requires CDI
2.0, don't need to import from older 1.1 or 1.2 versions of CDI.
- Added missing bndtools.core.prefs files.