### PR TITLE
test where application closes Infinspan Caching Provider

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
@@ -107,7 +107,7 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
     /**
      * Verify that application usage of a caching provider does not interfere with the sessionCache feature.
      */
-    // TODO @Test
+    @Test
     public void testApplicationClosesCachingProvider() throws Exception {
         // Add application: jcacheApp
         ServerConfiguration config = server.getServerConfiguration();

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/jcacheApp/src/test/cache/infinispan/web/JCacheConfigTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/jcacheApp/src/test/cache/infinispan/web/JCacheConfigTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,16 +22,16 @@ import componenttest.app.FATServlet;
 @WebServlet("/JCacheConfigTestServlet")
 public class JCacheConfigTestServlet extends FATServlet {
     /**
-     * Have the application obtain and close the caching provider instance for the configured Hazelcast library.
+     * Have the application obtain and close the caching provider instance for the configured Infinispan library.
      * The session cache implementation ultimately uses this library but would like to do so in a way that is
      * isolated from applications so that it controls its own life cycle and makes it more difficult for
      * applications to access cached session data other than through the proper HttpSession API.
      */
     public void testCloseCachingProvider(HttpServletRequest request, HttpServletResponse response) throws Exception {
         // Try to end up with the same CachingProvider instance as the sessionCache feature by using the configured library's class loader.
-        ClassLoader hazelcastClassLoader = Class.forName("com.hazelcast.cache.HazelcastCachingProvider").getClassLoader();
-        System.out.println("Class loader for HazelcastCachingProvider is " + hazelcastClassLoader);
-        CachingProvider cachingProvider = Caching.getCachingProvider(hazelcastClassLoader);
+        ClassLoader infinispanClassLoader = Class.forName("org.infinispan.jcache.embedded.JCachingProvider").getClassLoader();
+        System.out.println("Class loader for Infinispan JCachingProvider is " + infinispanClassLoader);
+        CachingProvider cachingProvider = Caching.getCachingProvider(infinispanClassLoader);
         System.out.println("Provider instance is " + Integer.toHexString(System.identityHashCode(cachingProvider)) + " " + cachingProvider);
         cachingProvider.close();
     }


### PR DESCRIPTION
Update bucket and enable test where an application closes the Infinispan CachingProvider.  Ensure that closing it does not interfere with HTTP Sessions usage of Infinispan.