### PR TITLE
enable additional codepath for testing with infinispan

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
@@ -249,7 +249,7 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
      * while the server is running. The session must remain valid, and must exhibit the new behavior (MANUAL_UPDATE) after
      * the configuration change.
      */
-    // TODO @Test
+    @Test
     public void testWriteFrequency() throws Exception {
         // Verify default behavior: writeFrequency=END_OF_SERVLET_SERVICE
         List<String> session = new ArrayList<>();
@@ -266,7 +266,8 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
 
         // Set a new attribute value without performing a manual sync, the value in the cache should not be updated
         run("testSetAttribute&attribute=testWriteFrequency&value=2_MANUAL_UPDATE", session);
-        run("testCacheContains&attribute=testWriteFrequency&value=1_END_OF_SERVLET_SERVICE", session);
+        // TODO the Infinispan local cache (no config) is destroyed during the Liberty config update. Enable this once we switch to a cache configured with multicast.
+        // run("testCacheContains&attribute=testWriteFrequency&value=1_END_OF_SERVLET_SERVICE", session);
 
         // Perform a manual update within the same servlet request
         run("testManualUpdate&attribute=testWriteFrequency&value=3_MANUAL_UPDATE", session);

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
@@ -42,7 +42,8 @@ public class SessionCacheOneServerTest extends FATServletClient {
 
     public static SessionCacheApp app = null;
 
-    public static final ExecutorService executor = Executors.newFixedThreadPool(12);
+    // TODO this is temporarily set to single-threaded in order to ensure coverage of codepath without actually enabling concurrent use yet (only invokeAll is used)
+    public static final ExecutorService executor = Executors.newFixedThreadPool(1); // TODO Executors.newFixedThreadPool(12);
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -73,7 +74,7 @@ public class SessionCacheOneServerTest extends FATServletClient {
      * Verify that all of the attributes (and no others) are added to the session, with their respective values.
      * After attributes have been added, submit concurrent requests to remove some of them.
      */
-    // TODO enable @Test
+    @Test
     public void testConcurrentPutNewAttributesAndRemove() throws Exception {
         final int NUM_THREADS = 9;
 
@@ -153,7 +154,7 @@ public class SessionCacheOneServerTest extends FATServletClient {
     /**
      * Submit concurrent requests to replace the value of the same attributes within a single session.
      */
-    // TODO enable @Test
+    @Test
     public void testConcurrentReplaceAttributes() throws Exception {
         final int NUM_ATTRS = 2;
         final int NUM_THREADS = 8;
@@ -215,7 +216,7 @@ public class SessionCacheOneServerTest extends FATServletClient {
      * There will be no guarantee whether or not the session attribute exists at the end of the test,
      * but if it does exist, it must have one of the values that was set during the test.
      */
-    // TODO enable @Test
+    @Test
     public void testConcurrentSetGetAndRemove() throws Exception {
         final int NUM_THREADS = 12;
 


### PR DESCRIPTION
Several tests can be partially enabled to run with Infinispan, which will improve coverage.