### PR TITLE
Add tests for Fault Tolerance and Metrics 2.0

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/bnd.bnd
@@ -19,6 +19,8 @@ src: \
 
 fat.project: true
 
+tested.features: mpft-metrics-2.0-guard,\
+                 mpmetrics-1.1
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}
@@ -30,3 +32,4 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 # For all project names that match the pattern "*_fat*", dependencies for junit,
 # fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
 -buildpath: \
+  com.ibm.ws.microprofile.faulttolerance.cdi_fat;version=latest

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/build.gradle
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/build.gradle
@@ -10,6 +10,7 @@
  *******************************************************************************/
 	
 dependencies {
+  requiredLibs project(':com.ibm.ws.microprofile.faulttolerance.cdi_fat') // For RepeatFaultTolerance
 }
 	
 	

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/server.xml
@@ -10,11 +10,12 @@
  -->
 <server>
    <featureManager>
+        <feature>appSecurity-3.0</feature>
         <feature>mpFaultTolerance-2.0</feature>
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>mpConfig-1.3</feature>
-        <feature>mpMetrics-1.1</feature> 
+        <feature>mpMetrics-2.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>arquillian-support-1.0</feature>
    </featureManager>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-metrics-only.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-metrics-only.xml
@@ -1,0 +1,19 @@
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); you 
+    may not use this file except in compliance with the License. You may obtain 
+    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless 
+    required by applicable law or agreed to in writing, software distributed 
+    under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+    OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+    the specific language governing permissions and limitations under the License. -->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-faulttolerance-2.0-TCK" verbose="2"
+    configfailurepolicy="continue">
+
+    <test name="microprofile-faulttolerance 2.0 TCK">
+        <packages>
+            <package name="org.eclipse.microprofile.fault.tolerance.tck.metrics">
+            </package>
+        </packages>
+    </test>
+</suite>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/RepeatFaultTolerance.java
@@ -24,19 +24,19 @@ public class RepeatFaultTolerance {
 
     static final String[] MP13_FEATURES_ARRAY = { "mpConfig-1.2", "mpFaultTolerance-1.0", "servlet-3.1", "cdi-1.2", "appSecurity-2.0", "mpMetrics-1.0" };
     static final Set<String> MP13_FEATURE_SET = new HashSet<>(Arrays.asList(MP13_FEATURES_ARRAY));
-    static final String MP13_FEATURES_ID = "MICROPROFILE13";
+    public static final String MP13_FEATURES_ID = "MICROPROFILE13";
 
     static final String[] MP20_FEATURES_ARRAY = { "mpConfig-1.3", "mpFaultTolerance-1.1", "servlet-4.0", "cdi-2.0", "appSecurity-3.0", "mpMetrics-1.1" };
     static final Set<String> MP20_FEATURE_SET = new HashSet<>(Arrays.asList(MP20_FEATURES_ARRAY));
-    static final String MP20_FEATURES_ID = "MICROPROFILE20";
+    public static final String MP20_FEATURES_ID = "MICROPROFILE20";
 
     static final String[] FT20_FEATURES_ARRAY = { "mpConfig-1.3", "mpFaultTolerance-2.0", "servlet-4.0", "cdi-2.0", "appSecurity-3.0", "mpMetrics-1.1" };
     static final Set<String> FT20_FEATURE_SET = new HashSet<>(Arrays.asList(FT20_FEATURES_ARRAY));
-    static final String FT20_FEATURES_ID = "FAULTTOLERANCE20";
+    public static final String FT20_FEATURES_ID = "FAULTTOLERANCE20";
 
     static final String[] MP30_FEATURES_ARRAY = { "mpConfig-1.3", "mpFaultTolerance-2.0", "servlet-4.0", "cdi-2.0", "appSecurity-3.0", "mpMetrics-2.0", "mpFT-Metrics-2.0-guard" };
     static final Set<String> MP30_FEATURE_SET = new HashSet<>(Arrays.asList(MP30_FEATURES_ARRAY));
-    static final String MP30_FEATURES_ID = "MICROPROFILE30";
+    public static final String MP30_FEATURES_ID = "MICROPROFILE30";
 
     static final Set<String> ALL_FEATURE_SET = new HashSet<>();
     static {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/RepeatFaultTolerance.java
@@ -22,23 +22,28 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class RepeatFaultTolerance {
 
-    static final String[] MP13_FEATURES_ARRAY = { "mpConfig-1.2", "mpFaultTolerance-1.0", "servlet-3.1", "cdi-1.2", "appSecurity-2.0" };
+    static final String[] MP13_FEATURES_ARRAY = { "mpConfig-1.2", "mpFaultTolerance-1.0", "servlet-3.1", "cdi-1.2", "appSecurity-2.0", "mpMetrics-1.0" };
     static final Set<String> MP13_FEATURE_SET = new HashSet<>(Arrays.asList(MP13_FEATURES_ARRAY));
     static final String MP13_FEATURES_ID = "MICROPROFILE13";
 
-    static final String[] MP20_FEATURES_ARRAY = { "mpConfig-1.3", "mpFaultTolerance-1.1", "servlet-4.0", "cdi-2.0", "appSecurity-3.0" };
+    static final String[] MP20_FEATURES_ARRAY = { "mpConfig-1.3", "mpFaultTolerance-1.1", "servlet-4.0", "cdi-2.0", "appSecurity-3.0", "mpMetrics-1.1" };
     static final Set<String> MP20_FEATURE_SET = new HashSet<>(Arrays.asList(MP20_FEATURES_ARRAY));
     static final String MP20_FEATURES_ID = "MICROPROFILE20";
 
-    static final String[] FT20_FEATURES_ARRAY = { "mpConfig-1.3", "mpFaultTolerance-2.0", "servlet-4.0", "cdi-2.0", "appSecurity-3.0" };
+    static final String[] FT20_FEATURES_ARRAY = { "mpConfig-1.3", "mpFaultTolerance-2.0", "servlet-4.0", "cdi-2.0", "appSecurity-3.0", "mpMetrics-1.1" };
     static final Set<String> FT20_FEATURE_SET = new HashSet<>(Arrays.asList(FT20_FEATURES_ARRAY));
     static final String FT20_FEATURES_ID = "FAULTTOLERANCE20";
+
+    static final String[] MP30_FEATURES_ARRAY = { "mpConfig-1.3", "mpFaultTolerance-2.0", "servlet-4.0", "cdi-2.0", "appSecurity-3.0", "mpMetrics-2.0", "mpFT-Metrics-2.0-guard" };
+    static final Set<String> MP30_FEATURE_SET = new HashSet<>(Arrays.asList(MP30_FEATURES_ARRAY));
+    static final String MP30_FEATURES_ID = "MICROPROFILE30";
 
     static final Set<String> ALL_FEATURE_SET = new HashSet<>();
     static {
         ALL_FEATURE_SET.addAll(MP13_FEATURE_SET);
         ALL_FEATURE_SET.addAll(MP20_FEATURE_SET);
         ALL_FEATURE_SET.addAll(FT20_FEATURE_SET);
+        ALL_FEATURE_SET.addAll(MP30_FEATURE_SET);
     }
 
     public static FeatureReplacementAction mp20Features(String server) {
@@ -59,18 +64,24 @@ public class RepeatFaultTolerance {
                         .forServers(server);
     }
 
+    public static FeatureReplacementAction mp30Features(String server) {
+        return new FeatureReplacementAction(ALL_FEATURE_SET, MP30_FEATURE_SET)
+                        .withID(MP30_FEATURES_ID)
+                        .forServers(server);
+    }
+
     /**
      * Return a rule to repeat tests for FT 1.1 and 2.0
      * <p>
      * This is the default because FT 1.1 and 2.0 have a mostly separate implementation so we want to ensure both are tested
-     * mp20Features includes FT 1.1, as it is an older version it will only run in full mode. 
+     * mp20Features includes FT 1.1, as it is an older version it will only run in full mode.
      *
      * @param server the server name
      * @return the RepeatTests rule
      */
     public static RepeatTests repeatDefault(String server) {
         return RepeatTests.with(mp20Features(server).fullFATOnly())
-                        .andWith(ft20Features(server));
+                        .andWith(mp30Features(server));
     }
 
     /**
@@ -84,7 +95,8 @@ public class RepeatFaultTolerance {
     public static RepeatTests repeatAll(String server) {
         return RepeatTests.with(mp13Features(server))
                         .andWith(mp20Features(server))
-                        .andWith(ft20Features(server));
+                        .andWith(ft20Features(server))
+                        .andWith(mp30Features(server));
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/RepeatFaultTolerance.java
@@ -38,12 +38,17 @@ public class RepeatFaultTolerance {
     static final Set<String> MP30_FEATURE_SET = new HashSet<>(Arrays.asList(MP30_FEATURES_ARRAY));
     public static final String MP30_FEATURES_ID = "MICROPROFILE30";
 
+    static final String[] FT11_METRICS20_ARRAY = { "mpConfig-1.3", "mpFaultTolerance-1.1", "servlet-4.0", "cdi-2.0", "appSecurity-3.0", "mpMetrics-2.0", "mpFT-Metrics-2.0-guard" };
+    static final Set<String> FT11_METRICS20_FEATURE_SET = new HashSet<>(Arrays.asList(FT11_METRICS20_ARRAY));
+    public static final String FT11_METRICS20_ID = "FT11_METRICS20";
+
     static final Set<String> ALL_FEATURE_SET = new HashSet<>();
     static {
         ALL_FEATURE_SET.addAll(MP13_FEATURE_SET);
         ALL_FEATURE_SET.addAll(MP20_FEATURE_SET);
         ALL_FEATURE_SET.addAll(FT20_FEATURE_SET);
         ALL_FEATURE_SET.addAll(MP30_FEATURE_SET);
+        ALL_FEATURE_SET.addAll(FT11_METRICS20_FEATURE_SET);
     }
 
     public static FeatureReplacementAction mp20Features(String server) {
@@ -67,6 +72,12 @@ public class RepeatFaultTolerance {
     public static FeatureReplacementAction mp30Features(String server) {
         return new FeatureReplacementAction(ALL_FEATURE_SET, MP30_FEATURE_SET)
                         .withID(MP30_FEATURES_ID)
+                        .forServers(server);
+    }
+
+    public static FeatureReplacementAction ft11metrics20Features(String server) {
+        return new FeatureReplacementAction(ALL_FEATURE_SET, FT11_METRICS20_FEATURE_SET)
+                        .withID(FT11_METRICS20_ID)
                         .forServers(server);
     }
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
@@ -27,7 +27,9 @@ tested.features: mpFaultTolerance-1.1,\
                  cdi-1.2,\
                  cdi-2.0,\
                  appsecurity-3.0,\
-                 el-3.0
+                 el-3.0,\
+                 mpMetrics-2.0,\
+                 mpFT-Metrics-2.0-guard
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/CDIFallbackTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/CDIFallbackTest.java
@@ -34,7 +34,8 @@ public class CDIFallbackTest extends LoggingTest {
     public static SharedServer SHARED_SERVER = new SharedServer("CDIFaultToleranceMetrics");
 
     @ClassRule
-    public static RepeatTests rep = RepeatFaultTolerance.repeatAll(SHARED_SERVER.getServerName());
+    public static RepeatTests rep = RepeatFaultTolerance.repeatAll(SHARED_SERVER.getServerName())
+                    .andWith(RepeatFaultTolerance.ft11metrics20Features(SHARED_SERVER.getServerName()));
 
     @Test
     public void testFallback() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/MetricRemovalTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/MetricRemovalTest.java
@@ -49,7 +49,8 @@ public class MetricRemovalTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatFaultTolerance.repeatDefault(SERVER_NAME);
+    public static RepeatTests r = RepeatFaultTolerance.repeatDefault(SERVER_NAME)
+                    .andWith(RepeatFaultTolerance.ft11metrics20Features(SERVER_NAME));
 
     private final static String TEST_METRIC = "ft.com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal.RemovalBean.doWorkWithRetry.invocations.total";
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricTest.java
@@ -39,7 +39,8 @@ public class CircuitBreakerMetricTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatFaultTolerance.repeatDefault(SERVER_NAME);
+    public static RepeatTests r = RepeatFaultTolerance.repeatDefault(SERVER_NAME)
+                    .andWith(RepeatFaultTolerance.ft11metrics20Features(SERVER_NAME));
 
     @BeforeClass
     public static void setup() throws Exception {


### PR DESCRIPTION
* Run the Fault Tolerance 2.0 TCK with Metrics 2.0 instead of Metrics 1.1
* Additionally run the metrics tests from the FT 2.0 TCK with Metrics 1.1
* Update the default repeat mode for FT FATs. Now runs against MP 2.0 featureset and MP 3.0 featureset (i.e. FT 1.1 & Metrics 1.1 and FT 2.0 & Metrics 2.0)
* Update the comprehensive repeat mode to include both FT 2.0 with Metrics 1.1 and FT 2.0 with Metrics 2.0
* Additionally run the metrics FAT tests against FT 1.1 with Metrics 2.0