### PR TITLE
add HTTP call to the testLibertyWebConfigProvider method

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFServerTest.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFServerTest.java
@@ -114,6 +114,11 @@ public class JSFServerTest {
     @Test
     @SkipForRepeat("JSF-2.3")
     public void testLibertyWebConfigProvider() throws Exception {
+        WebClient webClient = new WebClient();
+        URL url = JSFUtils.createHttpUrl(jsfTestServer1, contextRoot, "");
+        // Ensure the isErrorPagePresent message is logged in the trace during the RESTORE_VIEW phase.
+        HtmlPage page = (HtmlPage) webClient.getPage(url);
+
         String msgToSearchFor = "isErrorPagePresent ENTRY";
 
         // Check the trace.log to see if the LibertyWebConfigProvider has any entry trace.


### PR DESCRIPTION
Fixes #8919 

Move the testServlet code into the testLibertyWebConfigProvider method.

The " isErrorPagePresent ENTRY" is logged during the restore view phase of the JSF life cycle. 
This means it needs a HTTP request for this particular test. 

However, sometimes, the testServlet runs after the testLibertyWebConfigProvider because the _order of the junit tests is not guaranteed._ 

No other tests need to be modified since the rest of the messages are logged (or not found) during normal app start up. 