### PR TITLE
Add a more specific message when Jaeger libraries are not found

### DIFF
--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger/bnd.bnd
@@ -34,8 +34,6 @@ Private-Package: com.ibm.ws.microprofile.opentracing.jaeger.resources
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
-instrument.disabled: true
-
 src: src, resources
 
 -dsannotations: com.ibm.ws.microprofile.opentracing.jaeger.JaegerTracerFactory

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger/resources/com.ibm.ws.microprofile.opentracing.jaeger.resources/JaegerMessages.nlsprops
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger/resources/com.ibm.ws.microprofile.opentracing.jaeger.resources/JaegerMessages.nlsprops
@@ -83,6 +83,6 @@ JAEGER_PROPAGATION_INVALID_VALUE=CWMOT1006W: The JAEGER_PROPAGATION system prope
 JAEGER_PROPAGATION_INVALID_VALUE.explanation=The JAEGER_PROPAGATION system property or environment variable contains a value that is not valid. It is ignored.
 JAEGER_PROPAGATION_INVALID_VALUE.useraction=Use one of the valid values, which are JAEGER and B3.
 
-JAEGER_CLASS_NOT_FOUND=CWMOT1007E: Jaeger client libraries are not defined in server.xml or in WEB-INF/lib inside the webapp. Cause: {0}
-JAEGER_CLASS_NOT_FOUND.explanation=The Jaeger client libraries are not found in application classpath.
-JAEGER_CLASS_NOT_FOUND.useraction=Define the Jaeger client libraries in server.xml or in WEB-INF/lib inside the webapp.
+JAEGER_CLASS_NOT_FOUND=CWMOT1007E: The Jaeger client libraries are not defined in the server.xml file or in WEB-INF/lib directory inside the web application. Reason: {0}
+JAEGER_CLASS_NOT_FOUND.explanation=The Jaeger client libraries are not found in the application classpath.
+JAEGER_CLASS_NOT_FOUND.useraction=Define the Jaeger client libraries in the server.xml file or in the WEB-INF/lib directory inside the web application.

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger/resources/com.ibm.ws.microprofile.opentracing.jaeger.resources/JaegerMessages.nlsprops
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger/resources/com.ibm.ws.microprofile.opentracing.jaeger.resources/JaegerMessages.nlsprops
@@ -83,6 +83,6 @@ JAEGER_PROPAGATION_INVALID_VALUE=CWMOT1006W: The JAEGER_PROPAGATION system prope
 JAEGER_PROPAGATION_INVALID_VALUE.explanation=The JAEGER_PROPAGATION system property or environment variable contains a value that is not valid. It is ignored.
 JAEGER_PROPAGATION_INVALID_VALUE.useraction=Use one of the valid values, which are JAEGER and B3.
 
-JAEGER_CLASS_NOT_FOUND=CWMOT1007E: Jaeger client libraries are not defined in server.xml or in WEB-INF/lib of the webapp.
+JAEGER_CLASS_NOT_FOUND=CWMOT1007E: Jaeger client libraries are not defined in server.xml or in WEB-INF/lib inside the webapp. Cause: {0}
 JAEGER_CLASS_NOT_FOUND.explanation=The Jaeger client libraries are not found in application classpath.
-JAEGER_CLASS_NOT_FOUND.useraction=Define the Jaeger client libraries in server.xml or in WEB-INF/lib of the webapp.
+JAEGER_CLASS_NOT_FOUND.useraction=Define the Jaeger client libraries in server.xml or in WEB-INF/lib inside the webapp.

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger/resources/com.ibm.ws.microprofile.opentracing.jaeger.resources/JaegerMessages.nlsprops
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger/resources/com.ibm.ws.microprofile.opentracing.jaeger.resources/JaegerMessages.nlsprops
@@ -82,3 +82,7 @@ JAEGER_CONFIG_EXCEPTION.useraction=Correct the issues that were reported and try
 JAEGER_PROPAGATION_INVALID_VALUE=CWMOT1006W: The JAEGER_PROPAGATION system property or environment variable contains the {0} value, which is not valid.
 JAEGER_PROPAGATION_INVALID_VALUE.explanation=The JAEGER_PROPAGATION system property or environment variable contains a value that is not valid. It is ignored.
 JAEGER_PROPAGATION_INVALID_VALUE.useraction=Use one of the valid values, which are JAEGER and B3.
+
+JAEGER_CLASS_NOT_FOUND=CWMOT1007E: Jaeger client libraries are not defined in server.xml or in WEB-INF/lib of the webapp.
+JAEGER_CLASS_NOT_FOUND.explanation=The Jaeger client libraries are not found in application classpath.
+JAEGER_CLASS_NOT_FOUND.useraction=Define the Jaeger client libraries in server.xml or in WEB-INF/lib of the webapp.

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger/src/com/ibm/ws/microprofile/opentracing/jaeger/AdapterFactoryImpl.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger/src/com/ibm/ws/microprofile/opentracing/jaeger/AdapterFactoryImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import com.ibm.ws.microprofile.opentracing.jaeger.adapter.AppLibraryClassLoader;
 import com.ibm.ws.microprofile.opentracing.jaeger.adapter.Configuration;
+import com.ibm.ws.microprofile.opentracing.jaeger.adapter.JaegerAdapter;
 import com.ibm.ws.microprofile.opentracing.jaeger.adapter.JaegerAdapterException;
 import com.ibm.ws.microprofile.opentracing.jaeger.adapter.JaegerAdapterFactory;
 import com.ibm.ws.microprofile.opentracing.jaeger.adapter.impl.AbstractJaegerAdapter;
@@ -31,6 +32,7 @@ public class AdapterFactoryImpl extends JaegerAdapterFactory {
         super();
         this.appLibLoader = AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
             List<Class<?>> interfaces = Arrays.asList(
+                    JaegerAdapter.class,
                     JaegerAdapterFactory.class,
                     JaegerAdapterException.class,
                     Configuration.class,

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger/src/com/ibm/ws/microprofile/opentracing/jaeger/JaegerTracerFactory.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger/src/com/ibm/ws/microprofile/opentracing/jaeger/JaegerTracerFactory.java
@@ -66,6 +66,8 @@ public class JaegerTracerFactory implements OpentracingTracerFactory {
 
     private static final String DEFAULT_AGENT_UDP_HOST = "localhost";
     private static final int DEFAULT_AGENT_UDP_COMPACT_PORT = 6831;
+    
+    private static boolean isErrorPrinted = false;
 
     @FFDCIgnore({JaegerAdapterException.class, IllegalArgumentException.class})
     private static Tracer createJaegerTracer(String appName) {
@@ -196,16 +198,24 @@ public class JaegerTracerFactory implements OpentracingTracerFactory {
             Tr.info(tc, "JAEGER_TRACER_CREATED", appName, dest);
 
         } catch (JaegerAdapterException jae) {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Jaeger library was not found or exception occurred during loading.  Exception:"
-                        + jae.getMessage(), jae);
-            }
+            boolean rethrow = true;
             if ((jae.getCause() != null) && (jae.getCause() instanceof InvocationTargetException)) {
                 InvocationTargetException ite = (InvocationTargetException) jae.getCause();
-                if (ite.getTargetException() instanceof NoClassDefFoundError) {
-                    Tr.error(tc, "JAEGER_CLASS_NOT_FOUND");
+                if ((ite.getTargetException() != null) && (ite.getTargetException() instanceof NoClassDefFoundError)) {
+                    if (!isErrorPrinted) {
+                        // Print error once only
+                        String[] lines = ite.getTargetException().toString().split("\n", 2);
+                        Tr.error(tc, "JAEGER_CLASS_NOT_FOUND", lines[0]);
+                        isErrorPrinted = true;
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Jaeger library was not found or exception occurred during loading.  Exception:"
+                                    + jae.getMessage(), jae);
+                        }
+                    }
+                    rethrow = false;
                 }
-            } else {
+            }
+            if (rethrow) {
                 throw jae;
             }
         } catch (IllegalArgumentException e) {

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger/src/com/ibm/ws/microprofile/opentracing/jaeger/JaegerTracerFactory.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger/src/com/ibm/ws/microprofile/opentracing/jaeger/JaegerTracerFactory.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.microprofile.opentracing.jaeger;
 
+import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.NumberFormat;
@@ -199,7 +200,14 @@ public class JaegerTracerFactory implements OpentracingTracerFactory {
                 Tr.debug(tc, "Jaeger library was not found or exception occurred during loading.  Exception:"
                         + jae.getMessage(), jae);
             }
-            throw jae;
+            if (jae.getCause() instanceof InvocationTargetException) {
+                InvocationTargetException ite = (InvocationTargetException) jae.getCause();
+                if (ite.getTargetException() instanceof NoClassDefFoundError) {
+                    Tr.error(tc, "JAEGER_CLASS_NOT_FOUND");
+                }
+            } else {
+                throw jae;
+            }
         } catch (IllegalArgumentException e) {
             Tr.error(tc, "JAEGER_CONFIG_EXCEPTION", e.getMessage());
             throw e;

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger/src/com/ibm/ws/microprofile/opentracing/jaeger/JaegerTracerFactory.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger/src/com/ibm/ws/microprofile/opentracing/jaeger/JaegerTracerFactory.java
@@ -200,7 +200,7 @@ public class JaegerTracerFactory implements OpentracingTracerFactory {
                 Tr.debug(tc, "Jaeger library was not found or exception occurred during loading.  Exception:"
                         + jae.getMessage(), jae);
             }
-            if (jae.getCause() instanceof InvocationTargetException) {
+            if ((jae.getCause() != null) && (jae.getCause() instanceof InvocationTargetException)) {
                 InvocationTargetException ite = (InvocationTargetException) jae.getCause();
                 if (ite.getTargetException() instanceof NoClassDefFoundError) {
                     Tr.error(tc, "JAEGER_CLASS_NOT_FOUND");


### PR DESCRIPTION
Fixes #8926

Add a more specific message when Jaeger libraries are not found and the message is printed once only.