### PR TITLE
Update concurrent mp features to use parallel activation

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
@@ -13,3 +13,4 @@ com.ibm.websphere.appserver.contextService-1.0
   com.ibm.ws.concurrent
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.1.feature
@@ -13,3 +13,4 @@ com.ibm.websphere.appserver.contextService-1.0
   com.ibm.ws.concurrent
 kind=noship
 edition=full
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.concurrencyPolicy-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.concurrencyPolicy-1.0.feature
@@ -4,3 +4,4 @@ visibility=protected
 -bundles=com.ibm.ws.concurrency.policy
 kind=ga
 edition=core
+WLP-Activation-Type: parallel


### PR DESCRIPTION
- Change concurrent.mp and concurrencyPolicy features to use
parallel activation.  They are loaded now as part of JAXRS where
they previously were not.