### PR TITLE
7491 Revert the workaround for issue 7448

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/BundleProcessor.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/BundleProcessor.java
@@ -395,7 +395,10 @@ class BundleProcessor implements SynchronousBundleListener, EventHandler, Runtim
                 Set<RegistryEntry> newEntries = new HashSet<RegistryEntry>();
                 for (Bundle b : bundles) {
                     if (b.getState() >= Bundle.RESOLVED) {
-                        newEntries.addAll(metatypeRegistry.addMetaType(b));
+                        Set<RegistryEntry> entries = metatypeRegistry.addMetaType(b);
+                        if (reprocessConfig || getExtendedBundle(b).needsReprocessing()) {
+                            newEntries.addAll(entries);
+                        }
                     }
                 }
 


### PR DESCRIPTION
For issue #7491 
For issue #7448

Reinstate the optimization to only process metatype config when things have changed because installUtility can wipe out cached configurations.  Issue 7941 ensures installUtility persists configuration data to a separate cache (workarea) location.