### PR TITLE
test bug: wait for ltpa key creation

### DIFF
--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_env.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_env.java
@@ -36,6 +36,7 @@ public class Mpjwt11TCKLauncher_aud_env {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
+        server.waitForStringInLog("CWWKS4105A", 30000); // wait for ltpa keys to be created, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_env.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_env.java
@@ -36,7 +36,7 @@ public class Mpjwt11TCKLauncher_aud_env {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105A", 30000); // wait for ltpa keys to be created, which can happen after startup.
+        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass


### PR DESCRIPTION
Address some intermittent test failures when ltpa key isn't created until after server is up for several seconds.