### PR TITLE
Add a couple tests to OAuth BrowserAndServerLogMessageTest

### DIFF
--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/error/impl/BrowserAndServerLogMessageTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/error/impl/BrowserAndServerLogMessageTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.security.oauth20.error.impl;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -45,6 +47,23 @@ public class BrowserAndServerLogMessageTest extends CommonTestClass {
     @After
     public void afterTest() {
         System.out.println("Exiting test " + testName.getMethodName());
+    }
+
+    @Test
+    public void testUnknownMessageBundle() {
+        TraceComponent tcUnknownBundle = Tr.register(BrowserAndServerLogMessageTest.class, "SOMEGROUP", "com.ibm.ws.unknown.bundle");
+        Enumeration<Locale> requestLocales = getLocales("en");
+        BrowserAndServerLogMessage msg = new BrowserAndServerLogMessage(tcUnknownBundle, requestLocales, MSG_KEY_NO_INSERTS);
+        assertEquals("Server error message should have just been the message key since the registered message bundle is unknown.", MSG_KEY_NO_INSERTS, msg.getServerErrorMessage());
+        assertEquals("Browser error message should have just been the message key since the registered message bundle is unknown.", MSG_KEY_NO_INSERTS, msg.getBrowserErrorMessage());
+    }
+
+    @Test
+    public void testNullLocales() {
+        Enumeration<Locale> requestLocales = null;
+        BrowserAndServerLogMessage msg = new BrowserAndServerLogMessage(tc, requestLocales, MSG_KEY_NO_INSERTS);
+        verifyPattern(msg.getServerErrorMessage(), MSG_REGEX_NO_INSERTS_EN, "Server error message did not match expected regex.");
+        verifyPattern(msg.getBrowserErrorMessage(), MSG_REGEX_NO_INSERTS_EN, "Browser error message did not match expected regex.");
     }
 
     @Test


### PR DESCRIPTION
Adds a couple unit tests to ensure that null locales objects and `tc` variables that point to unknown bundles produce the expected results. Namely, a null locales object should fall back to using English and a `tc` variable that points to an unknown message bundle should just output the message key (and object array, if one was provided) as-is.