### PR TITLE
Fix for when jks and p12 defaults exists

### DIFF
--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
@@ -237,41 +237,43 @@ public class WSKeyStore extends Properties {
 
         this.isDefault = LibertyConstants.DEFAULT_KEYSTORE_REF_ID.equals(name);
 
-        boolean storeFileExists = defaultFileExists(this.location);
-
-        if (this.isDefault && !storeFileExists) {
-
-            // if a type is specified in server.xml, and it's JKS, use the default location for the key.jks keystore; else we'll use PKCS12
-
-            // check if we have an existing key.jks.  If so, use that instead of creating a PKCS12 keystore
-            File f = new File(res);
+        if (this.isDefault) {
 
             //location from metatype sometimes has a extra slashes, need to normalize it
             this.location = this.location.replaceAll("/+", "/");
 
-            if (f.exists() && this.location.toLowerCase().equals(default_location.toLowerCase())) {
-                // use the JKS file instead, as it exists
-                this.location = LibertyConstants.DEFAULT_OUTPUT_LOCATION + LibertyConstants.DEFAULT_FALLBACK_KEY_STORE_FILE;
-                specifiedType = Constants.KEYSTORE_TYPE_JKS;
-                this.type = Constants.KEYSTORE_TYPE_JKS;
-            }
+            boolean checkForFallback = checkForFallback(this.location, default_location);
 
-            // check if they've specified a type, and create the corresponding key.jks or key.p12
-            if (type.equals(Constants.KEYSTORE_TYPE_JKS) && this.location.toLowerCase().endsWith("/key.p12")) {
-                this.location = LibertyConstants.DEFAULT_OUTPUT_LOCATION + LibertyConstants.DEFAULT_FALLBACK_KEY_STORE_FILE;
-                specifiedType = Constants.KEYSTORE_TYPE_JKS;
-                this.type = Constants.KEYSTORE_TYPE_JKS;
+            if (checkForFallback) {
+                // if a type is specified in server.xml, and it's JKS, use the default location for the key.jks keystore; else we'll use PKCS12
 
-            } else if (type.equals(Constants.KEYSTORE_TYPE_PKCS12) && this.location.toLowerCase().endsWith("/key.p12")) {
-                specifiedType = Constants.KEYSTORE_TYPE_PKCS12;
-                this.type = Constants.KEYSTORE_TYPE_PKCS12;
-            } else if (!type.equals(Constants.KEYSTORE_TYPE_JKS)) {
-                if (this.location.toLowerCase().endsWith(".jks")) {
-                    this.type = LibertyConstants.DEFAULT_FALLBACK_TYPE;
-                    specifiedType = type;
+                // check if we have an existing key.jks.  If so, use that instead of creating a PKCS12 keystore
+                File f = new File(res);
+
+                if (f.exists() && this.location.toLowerCase().equals(default_location.toLowerCase())) {
+                    // use the JKS file instead, as it exists
+                    this.location = LibertyConstants.DEFAULT_OUTPUT_LOCATION + LibertyConstants.DEFAULT_FALLBACK_KEY_STORE_FILE;
+                    specifiedType = Constants.KEYSTORE_TYPE_JKS;
+                    this.type = Constants.KEYSTORE_TYPE_JKS;
                 }
-            }
 
+                // check if they've specified a type, and create the corresponding key.jks or key.p12
+                if (type.equals(Constants.KEYSTORE_TYPE_JKS) && this.location.toLowerCase().endsWith("/key.p12")) {
+                    this.location = LibertyConstants.DEFAULT_OUTPUT_LOCATION + LibertyConstants.DEFAULT_FALLBACK_KEY_STORE_FILE;
+                    specifiedType = Constants.KEYSTORE_TYPE_JKS;
+                    this.type = Constants.KEYSTORE_TYPE_JKS;
+
+                } else if (type.equals(Constants.KEYSTORE_TYPE_PKCS12) && this.location.toLowerCase().endsWith("/key.p12")) {
+                    specifiedType = Constants.KEYSTORE_TYPE_PKCS12;
+                    this.type = Constants.KEYSTORE_TYPE_PKCS12;
+                } else if (!type.equals(Constants.KEYSTORE_TYPE_JKS)) {
+                    if (this.location.toLowerCase().endsWith(".jks")) {
+                        this.type = LibertyConstants.DEFAULT_FALLBACK_TYPE;
+                        specifiedType = type;
+                    }
+                }
+
+            }
         } else {
             // this is not the default keystore, but a location has been specified.  If the keystore is JKS type, set the type to JKS
             if (this.location.toUpperCase().endsWith(Constants.KEYSTORE_TYPE_JKS)) {
@@ -304,18 +306,32 @@ public class WSKeyStore extends Properties {
      * @param location2
      * @return
      */
-    private boolean defaultFileExists(String ksFile) {
+    private boolean checkForFallback(String ksFile, String def_loc) {
 
+        boolean locIsDefault = false;
         boolean exists = false;
-        // check if the file from the configuration exists.
-        if (ksFile != null) {
-            File f = new File(ksFile);
 
-            if (f.exists()) {
-                exists = true;
-            }
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Looking at keystores: ", new Object[] { ksFile, def_loc });
         }
-        return exists;
+
+        //If the keystore is not in the default location an it exists then use it
+        if (ksFile.toLowerCase().equals(def_loc.toLowerCase())) {
+            locIsDefault = true;
+        }
+
+        // check if the file from the configuration exists.
+        File f = new File(ksFile);
+
+        if (f.exists()) {
+            exists = true;
+        }
+
+        if (!locIsDefault && exists)
+            return false;
+
+        return true;
+
     }
 
     /**

--- a/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/CommonSSLTest.java
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/CommonSSLTest.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.rules.TestName;
 
 import com.ibm.websphere.simplicity.Machine;
+import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.webcontainer.security.test.servlets.SSLBasicAuthClient;
@@ -310,4 +311,51 @@ public abstract class CommonSSLTest {
         // if we make it here something is wrong with cert and
         return false;
     }
+
+    /**
+     * @param ext
+     * @param subject
+     * @param hostname
+     * @return
+     */
+    protected int createTestCert(LibertyServer libertyServer, String subject, String ext) {
+
+        ProgramOutput po = null;
+        String subjectDN = "CN=nohost,O=ibm,C=us";
+        String extension = "BC=ca:true";
+
+        if (subject != null)
+            subjectDN = subject;
+
+        if (ext != null)
+            extension = ext;
+
+        try {
+            po = libertyServer.getMachine().execute(System.getProperty("java.home") + "/bin/keytool",
+                                                    new String[] { "-genKeyPair",
+                                                                   "-keystore", server.getServerRoot() + "/resources/security/key.p12",
+                                                                   "-alias", "default",
+                                                                   "-storepass", "password",
+                                                                   "-keypass", "password",
+                                                                   "-keyalg", "RSA",
+                                                                   "-sigalg", "sha256withRSA",
+                                                                   "-keysize", "2048",
+                                                                   "-storetype", "PKCS12",
+                                                                   "-dname", subjectDN,
+                                                                   "-ext", extension
+                                                    },
+                                                    server.getServerRoot(),
+                                                    null);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        Log.info(c, name.getMethodName(), "genKeyPair RC: " + po.getReturnCode());
+        Log.info(c, name.getMethodName(), "genKeyPair stdout:\n" + po.getStdout());
+        Log.info(c, name.getMethodName(), "genKeyPair stderr:\n" + po.getStderr());
+
+        return po.getReturnCode();
+
+    }
+
 }

--- a/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultJKSExistsSSLTest.java
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultJKSExistsSSLTest.java
@@ -14,9 +14,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,8 +42,6 @@ public class DefaultJKSExistsSSLTest extends CommonSSLTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        if (!isIBMJVM() && isVersion6())
-            isOracle6 = true;
     }
 
     @Override
@@ -67,7 +62,6 @@ public class DefaultJKSExistsSSLTest extends CommonSSLTest {
     public void testSSLFeatureNoSSLConfigExistingJKSUsesJKSKeyStore() throws Exception {
 
         Log.info(c, name.getMethodName(), "Entering " + name.getMethodName());
-        String protocol = isOracle6 ? TLS_PROTOCOL : TLSV11_PROTOCOL;
 
         server.setServerConfigurationFile(NO_SSL_CONFIG_BUT_DOES_INCLUDE_SSL_FEATURE);
         server.startServer(name.getMethodName() + ".log");
@@ -92,7 +86,7 @@ public class DefaultJKSExistsSSLTest extends CommonSSLTest {
         SSLBasicAuthClient sslClient = null;
         String response = null;
         try {
-            sslClient = createSSLClientWithTrust("resources/security/key.jks", DEFAULT_GENERATED_KEY_PASSWORD, protocol);
+            sslClient = createSSLClientWithTrust("resources/security/key.jks", DEFAULT_GENERATED_KEY_PASSWORD);
             response = sslClient.accessUnprotectedServlet(SSLBasicAuthClient.UNPROTECTED_NO_SECURITY_CONSTRAINT);
         } catch (Exception e) {
         }
@@ -127,7 +121,6 @@ public class DefaultJKSExistsSSLTest extends CommonSSLTest {
     public void testDefaultMinimalSSLCertificateFileKeyJKSFileDoesExist() throws Exception {
 
         Log.info(c, name.getMethodName(), "Entering " + name.getMethodName());
-        String protocol = isOracle6 ? TLS_PROTOCOL : TLSV11_PROTOCOL;
 
         server.setServerConfigurationFile(DEFAULT_MINIMAL_SSL_CONFIG);
         server.startServer(name.getMethodName() + ".log");
@@ -151,7 +144,7 @@ public class DefaultJKSExistsSSLTest extends CommonSSLTest {
         SSLBasicAuthClient sslClient = null;
         String response = null;
         try {
-            sslClient = createSSLClientWithTrust("resources/security/key.jks", DEFAULT_GENERATED_KEY_PASSWORD, protocol);
+            sslClient = createSSLClientWithTrust("resources/security/key.jks", DEFAULT_GENERATED_KEY_PASSWORD);
             response = sslClient.accessUnprotectedServlet(SSLBasicAuthClient.UNPROTECTED_NO_SECURITY_CONSTRAINT);
         } catch (Exception e) {
         }
@@ -170,24 +163,57 @@ public class DefaultJKSExistsSSLTest extends CommonSSLTest {
 
     }
 
-    private static boolean isIBMJVM() {
-        String vendorName = AccessController.doPrivileged(new PrivilegedAction<String>() {
-            @Override
-            public String run() {
-                return System.getProperty("java.vendor");
-            }
-        });
-        return (vendorName != null && vendorName.toLowerCase().contains("ibm"));
-    }
+    /**
+     * Using a minimal SSL default configuration, if both a key.p12 and key.jks file both exist
+     * then the key.jks should be used.
+     */
+    @Test
+    @AllowedFFDC("java.lang.NoClassDefFoundError")
+    public void testDefaultMinimalSSLCertificateFileKeyJKSAndP12Exists() throws Exception {
 
-    private static boolean isVersion6() {
-        String version = AccessController.doPrivileged(new PrivilegedAction<String>() {
-            @Override
-            public String run() {
-                return System.getProperty("java.version");
-            }
-        });
-        return (version != null && version.startsWith("1.6"));
-    }
+        Log.info(c, name.getMethodName(), "Entering " + name.getMethodName());
 
+        server.setServerConfigurationFile(DEFAULT_MINIMAL_SSL_CONFIG);
+
+        //Create a key.p12 file in the and make sure it exists
+        createTestCert(server, "CN=bothkstest", null);
+
+        // Check to see if the file has been generated; it should already exist and not be generated
+        assertTrue("The expected key file " + "resources/security/key.p12" + " was not generated",
+                   fileExists(server, "resources/security/key.p12"));
+
+        server.startServer(name.getMethodName() + ".log");
+
+        // Requires info trace
+        server.addInstalledAppForValidation("basicauth");
+        assertNotNull("SSL TCP Channel did not start in time.",
+                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+        assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
+                      server.waitForStringInLog("CWWKF0011I"));
+
+        // Check to see if the file has been generated; it should already exist and not be generated
+        assertTrue("The expected key file " + "resources/security/key.jks" + " was not generated",
+                   fileExists(server, "resources/security/key.jks"));
+
+        // Need to verify the certificate
+        assertTrue("Default certificate not created correctly",
+                   verifyDefaultCert(server, "resources/security/key.jks"));
+
+        // Hit the servlet on the SSL port and validate it requires SSL
+        SSLBasicAuthClient sslClient = null;
+        String response = null;
+        try {
+            sslClient = createSSLClientWithTrust("resources/security/key.jks", DEFAULT_GENERATED_KEY_PASSWORD);
+            response = sslClient.accessUnprotectedServlet(SSLBasicAuthClient.UNPROTECTED_NO_SECURITY_CONSTRAINT);
+        } catch (Exception e) {
+        }
+        if (response != null)
+            assertTrue("Did not get the expected response",
+                       sslClient.verifyUnauthenticatedResponse(response));
+        else
+            assertTrue("Did not get the expected response", false);
+
+        Log.info(c, name.getMethodName(), "Exiting " + name.getMethodName());
+
+    }
 }


### PR DESCRIPTION
Change code to make sure jks keystone file is used when default location is contains both jks and p12 default keystores.  