### PR TITLE
Allow unit tests to leverage Consul

### DIFF
--- a/dev/com.ibm.ws.security.oauth/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth/bnd.bnd
@@ -194,5 +194,8 @@ Include-Resource.zh: ${if;${include.zh};com/ibm/ws/security/oauth20/resources/Pr
     com.ibm.ws.kernel.boot;version=latest, \
     com.ibm.ws.security.test.common;version=latest, \
     org.apache.derby:derby;version=10.11.1.1, \
-    com.ibm.ws.org.joda.time.1.6.2;version=latest
-
+    com.ibm.ws.org.joda.time.1.6.2;version=latest, \
+    fattest.simplicity;version=latest, \
+    com.ibm.ws.componenttest:public.api;version=latest, \
+    com.ibm.ws.org.glassfish.json.1.0;version=latest, \
+    com.ibm.websphere.javaee.jaxb.2.2;version=latest

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -14,6 +14,8 @@
  */
 defaultTasks 'clean', 'build'
 
+def userBuildProperties = new Properties()
+
 // Project version is the Bundle-Version attribute if a bundle gets released, otherwise the version is the buildID.
 project.version = bnd('Bundle-Version', bnd.buildID)
 jar {
@@ -163,11 +165,29 @@ compileJava {
   options.fork = true
 }
 
+task setUserBuildProperties {
+  doFirst {
+    def filePath = System.getProperty("user.home") + "/user.build.properties"
+    println "Reading user build properties from $filePath"
+    File userBuildPropsFile = file(filePath)
+    if (userBuildPropsFile.exists()) {
+      userBuildPropsFile.withInputStream { userBuildProperties.load(it) }
+    }
+  }
+}
+
 test {
-  dependsOn ':cnf:copyMavenLibs'
+  dependsOn ':cnf:copyMavenLibs', setUserBuildProperties
   def testports = fileTree(dir: compileTestJava.destinationDir, include: 'unittestports.properties')
 
   doFirst {
+    // Pass the user build properties as JVM arguments so unit tests can make use of Consul services
+    userBuildProperties.each { key, value ->
+      println "Adding JVM arg for user build property [$key]"
+      if (value != null) {
+        jvmArgs "-D$key=$value"
+      }
+    }
     if (testports.isEmpty())
       return
     def propertiesFile = new File(compileTestJava.destinationDir, 'unittestports.properties')


### PR DESCRIPTION
Updates the default `test` Gradle task to read properties that are defined in `~/user.build.properties` and sets them as JVM arguments to the kicked off unit tests. The `user.build.properties` file should have the following properties that allow developers to use Consul:
- `global.ghe.access.token`
- `global.consulServerList`

Projects then have to add the following lines to their `-testpath` directive in `bnd.bnd`:
```
-testpath: \
    ...
    fattest.simplicity;version=latest, \
    com.ibm.ws.componenttest:public.api;version=latest, \
    com.ibm.ws.org.glassfish.json.1.0;version=latest, \
    com.ibm.websphere.javaee.jaxb.2.2;version=latest
```

This will allow unit tests to pull down data from Consul and use them in tests. Obtaining a service from Consul can be done similar to the following way:
```Java
ExternalTestService service = ExternalTestService.getService("selenium");
System.out.println(service.getAddress() + ":" + service.getPort());
System.out.println(service.getProperties());
// Do something with the service
service.release();
```