### PR TITLE
Add @NonNull support

### DIFF
--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/TypedElement.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/TypedElement.java
@@ -12,12 +12,12 @@ public class TypedElement {
     private final AnnotatedType javaType;
     private final List<? extends AnnotatedElement> elements;
 
-    TypedElement(AnnotatedType javaType, AnnotatedElement element) {
+    public TypedElement(AnnotatedType javaType, AnnotatedElement element) {
         this.javaType = javaType;
         this.elements = Utils.singletonList(element);
     }
 
-    TypedElement(AnnotatedType javaType, List<? extends AnnotatedElement> elements) {
+    public TypedElement(AnnotatedType javaType, List<? extends AnnotatedElement> elements) {
         this.javaType = javaType;
         this.elements = elements;
     }


### PR DESCRIPTION
Note, this does not include a snapshot of MP GraphQL APIs that contain the `@NonNull` annotation.  So this won't actually work until the API is brought in to OpenLiberty - but it won't break anything either.

This implements the MP GraphQL issue [68](https://github.com/eclipse/microprofile-graphql/issues/68).  The spec is still in progress, and this functionality is part of currently non-GA code, so it is not a release bug.

These changes were tested with MP GraphQL TCK tests that are part of PR [71](https://github.com/eclipse/microprofile-graphql/pull/71).