### PR TITLE
Fix incorrect security manager check

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/helpers/FileUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/helpers/FileUtils.java
@@ -399,7 +399,7 @@ public final class FileUtils {
 
     //Liberty change start - no longer needed at CXF 3.3.3
     public static boolean exists(File file) {
-        if (System.getSecurityManager() != null) {
+        if (System.getSecurityManager() == null) {
             return file.exists();
         }
         return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {


### PR DESCRIPTION
Fixes a Java 2 security manager check that was incorrect - was only using the doPriv if the security manager _wasn't_ set.  