### PR TITLE
Replacing original copyright years

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/fat/src/com/ibm/ws/concurrent/persistent/fat/compat/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/fat/src/com/ibm/ws/concurrent/persistent/fat/compat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/fat/src/com/ibm/ws/concurrent/persistent/fat/compat/PersistentExecutorCompatibilityTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/fat/src/com/ibm/ws/concurrent/persistent/fat/compat/PersistentExecutorCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,9 +19,6 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import org.jboss.shrinkwrap.api.GenericArchive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.importer.ExplodedImporter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -33,7 +30,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.annotation.MinimumJavaLevel;
 import componenttest.topology.impl.LibertyServer;
 
 /**

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/publish/servers/com.ibm.ws.concurrent.persistent.fat.compat/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/publish/servers/com.ibm.ws.concurrent.persistent.fat.compat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/publish/servers/com.ibm.ws.concurrent.persistent.fat.compat/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/publish/servers/com.ibm.ws.concurrent.persistent.fat.compat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/ejb/MyTimerEJBInWAR.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/ejb/MyTimerEJBInWAR.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/CounterCallable.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/CounterCallable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/CounterCallableTriggerTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/CounterCallableTriggerTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/ExecTimeCallable.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/ExecTimeCallable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/MapCounter.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/MapCounter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/MapCounterRunnable.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/MapCounterRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/NonSerializableResultTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/NonSerializableResultTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/PersistentExecCompatibilityTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/PersistentExecCompatibilityTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/SkipFailingTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/SkipFailingTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/SkippingTwoTimeTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/SkippingTwoTimeTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/TwoTimeTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/test-applications/persistentcompattest/src/web/TwoTimeTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/CommonUtils.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/CommonUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/FatTestConcurrentCompatible.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/fat/src/com/ibm/ws/concurrent/persistent/fat/compatibility/FatTestConcurrentCompatible.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/publish/servers/com.ibm.ws.concurrent.persistent.fat.compatibility/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/publish/servers/com.ibm.ws.concurrent.persistent.fat.compatibility/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2012, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/publish/servers/com.ibm.ws.concurrent.persistent.fat.compatibility/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/publish/servers/com.ibm.ws.concurrent.persistent.fat.compatibility/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2012, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/test-applications/PersistentExecutor/src/com/ibm/test/servlet/LongRunningTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/test-applications/PersistentExecutor/src/com/ibm/test/servlet/LongRunningTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/test-applications/PersistentExecutor/src/com/ibm/test/servlet/ScheduleStartServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/test-applications/PersistentExecutor/src/com/ibm/test/servlet/ScheduleStartServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/test-applications/PersistentExecutor/src/com/ibm/test/servlet/SimpleTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compatibility/test-applications/PersistentExecutor/src/com/ibm/test/servlet/SimpleTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/db/CommonUtils.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/db/CommonUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/db/ExecEnabledDBStoreConfigUpdateTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/db/ExecEnabledDBStoreConfigUpdateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,6 @@ import com.ibm.websphere.simplicity.config.dsprops.Properties_derby_embedded;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.annotation.MinimumJavaLevel;
 import componenttest.topology.impl.LibertyServer;
 
 /**

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/db/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/db/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/db/PersistentExecutionConfigUpdateDBStoreTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/fat/src/com/ibm/ws/concurrent/persistent/fat/configupd/db/PersistentExecutionConfigUpdateDBStoreTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/publish/servers/com.ibm.ws.concurrent.persistent.fat.configupdate.dbtaskstore/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/publish/servers/com.ibm.ws.concurrent.persistent.fat.configupdate.dbtaskstore/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2015, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/publish/servers/com.ibm.ws.concurrent.persistent.fat.configupdate.dbtaskstore/derby.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/publish/servers/com.ibm.ws.concurrent.persistent.fat.configupdate.dbtaskstore/derby.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2015, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/publish/servers/com.ibm.ws.concurrent.persistent.fat.configupdate.dbtaskstore/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/publish/servers/com.ibm.ws.concurrent.persistent.fat.configupdate.dbtaskstore/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2015, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/test-applications/persistcfgdbtest/src/web/AlternatingTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/test-applications/persistcfgdbtest/src/web/AlternatingTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/test-applications/persistcfgdbtest/src/web/CountingTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/test-applications/persistcfgdbtest/src/web/CountingTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/test-applications/persistcfgdbtest/src/web/ScheduleStartServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/test-applications/persistcfgdbtest/src/web/ScheduleStartServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/test-applications/persistcfgdbtest/src/web/SimpleTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/test-applications/persistcfgdbtest/src/web/SimpleTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/fat/src/com/ibm/ws/concurrent/persistent/delayexec/DelayExecutionFATTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/fat/src/com/ibm/ws/concurrent/persistent/delayexec/DelayExecutionFATTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/fat/src/com/ibm/ws/concurrent/persistent/delayexec/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/fat/src/com/ibm/ws/concurrent/persistent/delayexec/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/publish/servers/com.ibm.ws.concurrent.persistent.delayexec.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/publish/servers/com.ibm.ws.concurrent.persistent.delayexec.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/publish/servers/com.ibm.ws.concurrent.persistent.delayexec.fat/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/publish/servers/com.ibm.ws.concurrent.persistent.delayexec.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/test-applications/DelayExecution/src/web/NoDbOpTestTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/test-applications/DelayExecution/src/web/NoDbOpTestTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/test-applications/DelayExecution/src/web/PersistentExecutorsTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/test-applications/DelayExecution/src/web/PersistentExecutorsTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/test-bundles/userFeature/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/test-bundles/userFeature/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/test-bundles/userFeature/src/test/concurrent/persistent/delayexec/internal/TestServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/test-bundles/userFeature/src/test/concurrent/persistent/delayexec/internal/TestServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/publish/servers/com.ibm.ws.concurrent.persistent.fat.errorpaths/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/publish/servers/com.ibm.ws.concurrent.persistent.fat.errorpaths/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/publish/servers/com.ibm.ws.concurrent.persistent.fat.errorpaths/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/publish/servers/com.ibm.ws.concurrent.persistent.fat.errorpaths/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/DerbyShutdownTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/DerbyShutdownTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/ExtendedIllegalArgumentException.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/ExtendedIllegalArgumentException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/FailingTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/FailingTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/ImmediateSkippingTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/ImmediateSkippingTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/LoadClassTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/LoadClassTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/LookupTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/LookupTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/NextTenthOfSecondTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/NextTenthOfSecondTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/NoExecutionsTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/NoExecutionsTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/NonSerializableTaskAndResult.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/NonSerializableTaskAndResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/PersistentErrorTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/PersistentErrorTestServlet.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package web;
 
 import java.io.IOException;

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/ResultThatFailsSerialization.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/ResultThatFailsSerialization.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/SharedCounterTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/SharedCounterTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/SharedFailingTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/SharedFailingTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/SharedSkippingTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/SharedSkippingTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/TaskThatFailsSerialization.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/TaskThatFailsSerialization.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/TenSecondTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/TenSecondTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/TriggerThatFailsSerialization.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/TriggerThatFailsSerialization.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/TwoExecutionsTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/TwoExecutionsTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/fat/src/com/ibm/ws/concurrent/persistent/fat/execdisabled/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/fat/src/com/ibm/ws/concurrent/persistent/fat/execdisabled/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/fat/src/com/ibm/ws/concurrent/persistent/fat/execdisabled/PersistentExecutorExecutionDisabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/fat/src/com/ibm/ws/concurrent/persistent/fat/execdisabled/PersistentExecutorExecutionDisabledTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,7 +29,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
-import componenttest.annotation.MinimumJavaLevel;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/publish/servers/com.ibm.ws.concurrent.persistent.fat.execdisabled/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/publish/servers/com.ibm.ws.concurrent.persistent.fat.execdisabled/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/publish/servers/com.ibm.ws.concurrent.persistent.fat.execdisabled/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/publish/servers/com.ibm.ws.concurrent.persistent.fat.execdisabled/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/test-applications/persistentnoexectest/src/web/HourlyTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/test-applications/persistentnoexectest/src/web/HourlyTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/test-applications/persistentnoexectest/src/web/ImmediateTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/test-applications/persistentnoexectest/src/web/ImmediateTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/test-applications/persistentnoexectest/src/web/NamedTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/test-applications/persistentnoexectest/src/web/NamedTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/test-applications/persistentnoexectest/src/web/PersistentExecDisabledTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/test-applications/persistentnoexectest/src/web/PersistentExecDisabledTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/fat/src/com/ibm/ws/concurrent/persistent/feature/ConcurrentPersistentFeatureFATTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/fat/src/com/ibm/ws/concurrent/persistent/feature/ConcurrentPersistentFeatureFATTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/fat/src/com/ibm/ws/concurrent/persistent/feature/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/fat/src/com/ibm/ws/concurrent/persistent/feature/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/publish/servers/com.ibm.ws.concurrent.persistent.feature.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/publish/servers/com.ibm.ws.concurrent.persistent.feature.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/publish/servers/com.ibm.ws.concurrent.persistent.feature.fat/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/publish/servers/com.ibm.ws.concurrent.persistent.feature.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-applications/CPFeatureApp/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-applications/CPFeatureApp/resources/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-applications/CPFeatureApp/src/com/ibm/feature/ConcurrentPersistentFeatureServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-applications/CPFeatureApp/src/com/ibm/feature/ConcurrentPersistentFeatureServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-applications/CPFeatureApp/src/com/ibm/feature/NoDbOpTestTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-applications/CPFeatureApp/src/com/ibm/feature/NoDbOpTestTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-bundles/userFeature/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-bundles/userFeature/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-bundles/userFeature/src/test/concurrent/persistent/feature/TaskStoreTester.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-bundles/userFeature/src/test/concurrent/persistent/feature/TaskStoreTester.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-bundles/userFeature/src/test/concurrent/persistent/feature/internal/ExecutorFactoryServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_feature/test-bundles/userFeature/src/test/concurrent/persistent/feature/internal/ExecutorFactoryServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/fat/src/com/ibm/ws/concurrent/persistent/fat/initial/polling/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/fat/src/com/ibm/ws/concurrent/persistent/fat/initial/polling/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/fat/src/com/ibm/ws/concurrent/persistent/fat/initial/polling/InitialPollingTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/fat/src/com/ibm/ws/concurrent/persistent/fat/initial/polling/InitialPollingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/publish/servers/com.ibm.ws.concurrent.persistent.fat.polling/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/publish/servers/com.ibm.ws.concurrent.persistent.fat.polling/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/publish/servers/com.ibm.ws.concurrent.persistent.fat.polling/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/publish/servers/com.ibm.ws.concurrent.persistent.fat.polling/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/test-applications/initialpollingtest/src/web/ManagedCountingTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/test-applications/initialpollingtest/src/web/ManagedCountingTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/test-applications/initialpollingtest/src/web/PersistentExecutorsTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/test-applications/initialpollingtest/src/web/PersistentExecutorsTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/test-applications/initialpollingtest/src/web/RepeatingTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/test-applications/initialpollingtest/src/web/RepeatingTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/fat/src/fat/concurrent/persistent/jca/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/fat/src/fat/concurrent/persistent/jca/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/fat/src/fat/concurrent/persistent/jca/PersistRATest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/fat/src/fat/concurrent/persistent/jca/PersistRATest.java
@@ -1,5 +1,4 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +13,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -22,9 +20,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/fat/src/fat/concurrent/persistent/jca/PersistRATest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/fat/src/fat/concurrent/persistent/jca/PersistRATest.java
@@ -1,4 +1,5 @@
 /*******************************************************************************
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/publish/servers/com.ibm.ws.concurrent.persistent.fat.jca/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/publish/servers/com.ibm.ws.concurrent.persistent.fat.jca/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2012, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/publish/servers/com.ibm.ws.concurrent.persistent.fat.jca/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/publish/servers/com.ibm.ws.concurrent.persistent.fat.jca/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2012, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-applications/fvtweb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-applications/fvtweb/resources/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2012, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-applications/fvtweb/src/web/PersistRAServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-applications/fvtweb/src/web/PersistRAServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/resources/META-INF/application.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/resources/META-INF/application.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2012, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/PSETestResourceAdapter.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/PSETestResourceAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/RAResult.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/RAResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/RASerializableTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/RASerializableTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/RASerializableTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/RASerializableTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/RATask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/RATask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/RATrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/RATrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/package-info.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_jca/test-resourceadapters/PersistRA/src/fat/persistra/resourceadapter/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/fat/src/com/ibm/ws/concurrent/persistent/fat/load/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/fat/src/com/ibm/ws/concurrent/persistent/fat/load/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/fat/src/com/ibm/ws/concurrent/persistent/fat/load/LoadTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/fat/src/com/ibm/ws/concurrent/persistent/fat/load/LoadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/publish/files/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/publish/files/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2015, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/publish/servers/com.ibm.ws.concurrent.persistent.fat.loadtest/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/publish/servers/com.ibm.ws.concurrent.persistent.fat.loadtest/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2015, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/resources/WEB-INF/beans.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2015, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/LoadTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/LoadTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/TaskResultStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/TaskResultStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/task/CancelTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/task/CancelTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/task/MultiRunSeparateTriggerFailSometimesResultTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/task/MultiRunSeparateTriggerFailSometimesResultTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/task/MultiRunTriggerResultTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/task/MultiRunTriggerResultTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/task/SingleRunResultTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/task/SingleRunResultTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/task/SingleRunTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/test-applications/schedtest/src/web/task/SingleRunTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/fat/src/com/ibm/ws/concurrent/persistent/fat/mbean/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/fat/src/com/ibm/ws/concurrent/persistent/fat/mbean/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/fat/src/com/ibm/ws/concurrent/persistent/fat/mbean/PersistentExecutorMBeanTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/fat/src/com/ibm/ws/concurrent/persistent/fat/mbean/PersistentExecutorMBeanTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/publish/files/server2.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/publish/files/server2.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/publish/servers/com.ibm.ws.concurrent.persistent.fat.mbean/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/publish/servers/com.ibm.ws.concurrent.persistent.fat.mbean/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/publish/servers/com.ibm.ws.concurrent.persistent.fat.mbean/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/publish/servers/com.ibm.ws.concurrent.persistent.fat.mbean/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/test-applications/persistentmbeantest/src/web/MBeanCounterCallable.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/test-applications/persistentmbeantest/src/web/MBeanCounterCallable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/test-applications/persistentmbeantest/src/web/PersistentExecMBeanTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/test-applications/persistentmbeantest/src/web/PersistentExecMBeanTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiserver/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiserver/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/OneExecutorRunsAllTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/OneExecutorRunsAllTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/publish/servers/com.ibm.ws.concurrent.persistent.fat.oneexec/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/publish/servers/com.ibm.ws.concurrent.persistent.fat.oneexec/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/publish/servers/com.ibm.ws.concurrent.persistent.fat.oneexec/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/publish/servers/com.ibm.ws.concurrent.persistent.fat.oneexec/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-applications/persistoneexectest/src/web/NamedTriggerTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-applications/persistoneexectest/src/web/NamedTriggerTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-applications/persistoneexectest/src/web/OneExecutorRunsAllTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-applications/persistoneexectest/src/web/OneExecutorRunsAllTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-applications/persistoneexectest/src/web/RepeatingTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-applications/persistoneexectest/src/web/RepeatingTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-applications/persistoneexectest/src/web/RepeatingTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-applications/persistoneexectest/src/web/RepeatingTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-bundles/singletonTestFeature/src/test/feature/ejb/singleton/SingletonTriggerTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-bundles/singletonTestFeature/src/test/feature/ejb/singleton/SingletonTriggerTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/fat/src/com/ibm/ws/concurrent/persistent/fat/simctrl/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/fat/src/com/ibm/ws/concurrent/persistent/fat/simctrl/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/fat/src/com/ibm/ws/concurrent/persistent/fat/simctrl/SimulatedControllerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/fat/src/com/ibm/ws/concurrent/persistent/fat/simctrl/SimulatedControllerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/publish/servers/com.ibm.ws.concurrent.persistent.fat.simctrl/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/publish/servers/com.ibm.ws.concurrent.persistent.fat.simctrl/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2014, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/publish/servers/com.ibm.ws.concurrent.persistent.fat.simctrl/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/publish/servers/com.ibm.ws.concurrent.persistent.fat.simctrl/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2014, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/test-applications/persistctrltest/src/web/RepeatTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/test-applications/persistctrltest/src/web/RepeatTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/test-applications/persistctrltest/src/web/RepeatTrigger.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/test-applications/persistctrltest/src/web/RepeatTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/test-applications/persistctrltest/src/web/SimulatedControllerPXTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/test-applications/persistctrltest/src/web/SimulatedControllerPXTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/test-bundles/simcontroller/src/test/concurrent/persistent/fat/simctrl/SimulatedController.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_simctrl/test-bundles/simcontroller/src/test/concurrent/persistent/fat/simctrl/SimulatedController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/timers/DatabaseContainerFactory.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/timers/DatabaseContainerFactory.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.ws.concurrent.persistent.fat.timers;
 
 import java.time.Duration;

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/timers/DerbyNoopContainer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/timers/DerbyNoopContainer.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.ws.concurrent.persistent.fat.timers;
 
 import java.util.concurrent.Future;


### PR DESCRIPTION
Moved FAT buckets from CL to OL, but did not bring over the original copyright years originally.  Also removing unused imports where necessary. 

