### PR TITLE
Clean up build/libs for FATs on automated builds to conserve disk space

### DIFF
--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -22,6 +22,15 @@ task cleanFat(type: Delete) {
   delete autoFvtDir
 }
 
+if (isAutomatedBuild && project.file('fat').exists()) {
+  release {
+    doLast {
+      delete autoFvtDir
+      delete distsDir
+    }
+  }
+}
+
 task cleanBeforeRun(type: Delete) {
   delete new File(autoFvtDir, 'output')
   delete new File(autoFvtDir, 'results')


### PR DESCRIPTION
After the release task for a FAT project runs, the jar uploaded to libertyfs for launching FAT buckets on child builds is located in `cnf/release`, so we don't need to keep the generated files in `build/libs`. That saves 12G of disk space.

Changed to delete `build/libs/autoFVT` and `build/libs/distribution` directories because the build/libs/componentname.jar may be used to compile other FATs.

Before:
```
$ find . -regex '.*build/libs' -print0 | du --files0-from=- -ch | tail -1
12G	total
```

After:
```
$ find . -regex '.*build/libs' -print0 | du --files0-from=- -ch | tail -1
2.3G	total
```