### PR TITLE
Enable endpt discovery of app pw and tokens ui management endpoints

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OIDCConstants.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OIDCConstants.java
@@ -128,6 +128,9 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String OIDC_DISC_REVOKE_EP = "revocation_endpoint";
     public static final String OIDC_DISC_APP_PASSWORDS_EP = "app_passwords_endpoint";
     public static final String OIDC_DISC_APP_TOKENS_EP = "app_tokens_endpoint";
+    public static final String OIDC_DISC_PERSONAL_TOKEN_MGMT_EP = "personal_token_mgmt_endpoint";
+    public static final String OIDC_DISC_USERS_TOKEN_MGMT_EP = "users_token_mgmt_endpoint";
+    public static final String OIDC_DISC_CLIENT_MGMT_EP = "client_mgmt_endpoint";
 
     /* parameters for oidc discovery response with origins from session management */
     public static final String OIDC_SESS_CHECK_SESSION_IFRAME = "check_session_iframe";
@@ -233,6 +236,9 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String KEY_OIDC_REVOKE_EP = "revocationEndpoint";
     public static final String KEY_OIDC_APP_PASSWORDS_EP = "appPasswordsEndpoint";
     public static final String KEY_OIDC_APP_TOKENS_EP = "appTokensEndpoint";
+    public static final String KEY_OIDC_PERSONAL_TOKEN_MGMT_EP = "personalTokenMgmtEndpoint";
+    public static final String KEY_OIDC_USERS_TOKEN_MGMT_EP = "usersTokenMgmtEndpoint";
+    public static final String KEY_OIDC_CLIENT_MGMT_EP = "clientMgmtEndpoint";
 
     // Server config property for coverageMap
     static final String JSA_QUAL = "jsa.provider.";
@@ -270,6 +276,9 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String KEY_OIDC_REVOKE_EP_QUAL = OIDC_QUAL + KEY_OIDC_REVOKE_EP;
     public static final String KEY_OIDC_APP_PASSWORDS_EP_QUAL = OIDC_QUAL + KEY_OIDC_APP_PASSWORDS_EP;
     public static final String KEY_OIDC_APP_TOKENS_EP_QUAL = OIDC_QUAL + KEY_OIDC_APP_TOKENS_EP;
+    public static final String KEY_OIDC_PERSONAL_TOKEN_MGMT_EP_QUAL = OIDC_QUAL + KEY_OIDC_PERSONAL_TOKEN_MGMT_EP;
+    public static final String KEY_OIDC_USERS_TOKEN_MGMT_EP_QUAL = OIDC_QUAL + KEY_OIDC_USERS_TOKEN_MGMT_EP;
+    public static final String KEY_OIDC_CLIENT_MGMT_EP_QUAL = OIDC_QUAL + KEY_OIDC_CLIENT_MGMT_EP;
 
     /**
      * Supported OIDC client registration parameter names

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/OidcDiscoveryProviderConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/OidcDiscoveryProviderConfig.java
@@ -76,5 +76,8 @@ public class OidcDiscoveryProviderConfig {
         endpointMap.put(OIDCConstants.KEY_OIDC_REVOKE_EP_QUAL, EndpointType.revoke.name());
         endpointMap.put(OIDCConstants.KEY_OIDC_APP_PASSWORDS_EP_QUAL, EndpointType.app_password_effective_name);
         endpointMap.put(OIDCConstants.KEY_OIDC_APP_TOKENS_EP_QUAL, EndpointType.app_token_effective_name);
+        endpointMap.put(OIDCConstants.KEY_OIDC_PERSONAL_TOKEN_MGMT_EP_QUAL, EndpointType.personalTokenManagement.name());
+        endpointMap.put(OIDCConstants.KEY_OIDC_USERS_TOKEN_MGMT_EP_QUAL, EndpointType.usersTokenManagement.name());
+        endpointMap.put(OIDCConstants.KEY_OIDC_CLIENT_MGMT_EP_QUAL, EndpointType.clientManagement.name());
     }
 }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCAbstractDiscoveryModel.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCAbstractDiscoveryModel.java
@@ -48,6 +48,9 @@ public abstract class OIDCAbstractDiscoveryModel {
     private String revocation_endpoint;
     private String app_passwords_endpoint;
     private String app_tokens_endpoint;
+    private String personal_token_mgmt_endpoint;
+    private String users_token_mgmt_endpoint;
+    private String client_mgmt_endpoint;
 
     /**
      * OIDC Properties not utilized in implementation
@@ -419,6 +422,48 @@ public abstract class OIDCAbstractDiscoveryModel {
      */
     public void setAppTokensEndpoint(String appTokensEndpoint) {
         this.app_tokens_endpoint = appTokensEndpoint;
+    }
+
+    /**
+     * @return the personalTokenMgmtEndpoint
+     */
+    public String getPersonalTokenMgmtEndpoint() {
+        return personal_token_mgmt_endpoint;
+    }
+
+    /**
+     * @param personalTokenMgmtEndpoint the personalTokenMgmtEndpoint to set
+     */
+    public void setPersonalTokenMgmtEndpoint(String personalTokenMgmtEndpoint) {
+        this.personal_token_mgmt_endpoint = personalTokenMgmtEndpoint;
+    }
+
+    /**
+     * @return the usersTokenMgmtEndpoint
+     */
+    public String getUsersTokenMgmtEndpoint() {
+        return users_token_mgmt_endpoint;
+    }
+
+    /**
+     * @param usersTokenMgmtEndpoint the usersTokenMgmtEndpoint to set
+     */
+    public void setUsersTokenMgmtEndpoint(String usersTokenMgmtEndpoint) {
+        this.users_token_mgmt_endpoint = usersTokenMgmtEndpoint;
+    }
+
+    /**
+     * @return the clientMgmtEndpoint
+     */
+    public String getClientMgmtEndpoint() {
+        return client_mgmt_endpoint;
+    }
+
+    /**
+     * @param clientMgmtEndpoint the clientMgmtEndpoint to set
+     */
+    public void setClientMgmtEndpoint(String clientMgmtEndpoint) {
+        this.client_mgmt_endpoint = clientMgmtEndpoint;
     }
 
     private String[] defensiveCopy(String[] strArr) {

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/Discovery.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/Discovery.java
@@ -91,6 +91,12 @@ public class Discovery {
 
         discoveryObj.setAppTokensEndpoint(discoverConfig.getEndpoint(OIDCConstants.KEY_OIDC_APP_TOKENS_EP_QUAL));
 
+        discoveryObj.setPersonalTokenMgmtEndpoint(discoverConfig.getEndpoint(OIDCConstants.KEY_OIDC_PERSONAL_TOKEN_MGMT_EP_QUAL));
+
+        discoveryObj.setUsersTokenMgmtEndpoint(discoverConfig.getEndpoint(OIDCConstants.KEY_OIDC_USERS_TOKEN_MGMT_EP_QUAL));
+
+        discoveryObj.setClientMgmtEndpoint(discoverConfig.getEndpoint(OIDCConstants.KEY_OIDC_CLIENT_MGMT_EP_QUAL));
+
         String discoverJSONString = discoveryObj.toJSONString();
 
         if (tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/DiscoveryTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/DiscoveryTest.java
@@ -83,6 +83,9 @@ public class DiscoveryTest {
     private final static String REVOCATION_URI = ISSUER_URI + "/revoke";
     private final static String APP_PASSWORDS_URI = ISSUER_URI + "/app_passwords";
     private final static String APP_TOKENS_URI = ISSUER_URI + "/app_tokens";
+    private final static String CLIENT_MGMT_URI = ISSUER_URI + "/clientManagement";
+    private final static String PERSONAL_TOKEN_MGMT_URI = ISSUER_URI + "/personalTokenManagement";
+    private final static String USERS_TOKEN_MGMT_URI = ISSUER_URI + "/usersTokenManagement";
     private static String expectedDiscoveryModelJsonString;
     private static HttpServletRequest request;
     private static OidcServerConfig provider;
@@ -184,6 +187,9 @@ public class DiscoveryTest {
             assertEquals("Discovery model property should have matched.", expectedDiscoveryModel.getRevocationEndpoint(), REVOCATION_URI);
             assertEquals("Discovery model property should have matched.", expectedDiscoveryModel.getAppPasswordsEndpoint(), APP_PASSWORDS_URI);
             assertEquals("Discovery model property should have matched.", expectedDiscoveryModel.getAppTokensEndpoint(), APP_TOKENS_URI);
+            assertEquals("Discovery model property should have matched.", expectedDiscoveryModel.getClientMgmtEndpoint(), CLIENT_MGMT_URI);
+            assertEquals("Discovery model property should have matched.", expectedDiscoveryModel.getPersonalTokenMgmtEndpoint(), PERSONAL_TOKEN_MGMT_URI);
+            assertEquals("Discovery model property should have matched.", expectedDiscoveryModel.getUsersTokenMgmtEndpoint(), USERS_TOKEN_MGMT_URI);
 
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
@@ -301,6 +307,9 @@ public class DiscoveryTest {
         model.setRevocationEndpoint(REVOCATION_URI);
         model.setAppPasswordsEndpoint(APP_PASSWORDS_URI);
         model.setAppTokensEndpoint(APP_TOKENS_URI);
+        model.setClientMgmtEndpoint(CLIENT_MGMT_URI);
+        model.setPersonalTokenMgmtEndpoint(PERSONAL_TOKEN_MGMT_URI);
+        model.setUsersTokenMgmtEndpoint(USERS_TOKEN_MGMT_URI);
 
         return model;
     }


### PR DESCRIPTION
This PR enables the discovery of UI endpoints for password and token management.  With this change, the OpenID Connect Discovery Endpoint will now include the following endpoints in its list of endpoints provided by the OpenID Connect Provider --https://localhost:8947/oidc/endpoint/OidcProvider/personalTokenManagement
https://localhost:8947/oidc/endpoint/OidcProvider/usersTokenManagement
https://localhost:8947/oidc/endpoint/OidcProvider/clientManagement

