### PR TITLE
Revert "Fix for when jks and p12 defaults exists"

### DIFF
--- a/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/CommonSSLTest.java
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/CommonSSLTest.java
@@ -24,7 +24,6 @@ import org.junit.Rule;
 import org.junit.rules.TestName;
 
 import com.ibm.websphere.simplicity.Machine;
-import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.webcontainer.security.test.servlets.SSLBasicAuthClient;
@@ -311,51 +310,4 @@ public abstract class CommonSSLTest {
         // if we make it here something is wrong with cert and
         return false;
     }
-
-    /**
-     * @param ext
-     * @param subject
-     * @param hostname
-     * @return
-     */
-    protected int createTestCert(LibertyServer libertyServer, String subject, String ext) {
-
-        ProgramOutput po = null;
-        String subjectDN = "CN=nohost,O=ibm,C=us";
-        String extension = "BC=ca:true";
-
-        if (subject != null)
-            subjectDN = subject;
-
-        if (ext != null)
-            extension = ext;
-
-        try {
-            po = libertyServer.getMachine().execute(System.getProperty("java.home") + "/bin/keytool",
-                                                    new String[] { "-genKeyPair",
-                                                                   "-keystore", server.getServerRoot() + "/resources/security/key.p12",
-                                                                   "-alias", "default",
-                                                                   "-storepass", "password",
-                                                                   "-keypass", "password",
-                                                                   "-keyalg", "RSA",
-                                                                   "-sigalg", "sha256withRSA",
-                                                                   "-keysize", "2048",
-                                                                   "-storetype", "PKCS12",
-                                                                   "-dname", subjectDN,
-                                                                   "-ext", extension
-                                                    },
-                                                    server.getServerRoot(),
-                                                    null);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        Log.info(c, name.getMethodName(), "genKeyPair RC: " + po.getReturnCode());
-        Log.info(c, name.getMethodName(), "genKeyPair stdout:\n" + po.getStdout());
-        Log.info(c, name.getMethodName(), "genKeyPair stderr:\n" + po.getStderr());
-
-        return po.getReturnCode();
-
-    }
-
 }


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#9000

Believed this change Caused the Java 8 Builds to fail with messages like

[9/22/19 23:38:57:953 UTC] 00000024 com.ibm.ws.ssl.config.WSKeyStore                             E CWPKI0033E: The keystore located at /home/jazz_build/_jn8SkN13Eemj16mobcy1ZA-EBC.PROD.WASRTC-BX1-000-00-00/jbe/build/dev/image/output/wlp/usr/servers/TestServer1/resources/security/mykey.jks did not load because of the following error: Keystore type is not PKCS12
[9/22/19 23:38:57:955 UTC] 00000024 com.ibm.ws.ssl.config.WSKeyStore                             W CWPKI0809W: There is a failure loading the defaultKeyStore keystore. If an SSL configuration references the defaultKeyStore keystore, then the SSL configuration will fail to initialize.  