### PR TITLE
Reduce runtime of ZipFileReaperTest

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/test/com/ibm/ws/artifact/zip/cache/test/ZipFileReaperTest.java
+++ b/dev/com.ibm.ws.artifact.zip/test/com/ibm/ws/artifact/zip/cache/test/ZipFileReaperTest.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
-//import java.util.function.Consumer;
 
 import org.junit.Test;
 
@@ -160,7 +159,7 @@ public class ZipFileReaperTest {
         runProfile(iterations, maxTestDuration, profile, allTestOps); // throws Exception
     }
 
-    public static final int TEST_ITERATIONS = 3;
+    public static final int TEST_ITERATIONS = 2;
 
     @Test
     public void testDefaultReaper_Simple() throws Exception {
@@ -204,12 +203,12 @@ public class ZipFileReaperTest {
         runProfile(TEST_ITERATIONS, noQuickProfile, scatterWorkerData_One_Short); // throws Exception
     }
 
-    @Test
+    //@Test
     public void testDefaultReaper_Scatter_One_Long() throws Exception {
         runProfile(TEST_ITERATIONS, defaultProfile, scatterWorkerData_One_Long); // throws Exception
     }
 
-    @Test
+    //@Test
     public void testNoQuick_Scatter_One_Long() throws Exception {
         runProfile(TEST_ITERATIONS, noQuickProfile, scatterWorkerData_One_Long); // throws Exception
     }
@@ -224,12 +223,12 @@ public class ZipFileReaperTest {
         runProfile(TEST_ITERATIONS, noQuickProfile, scatterWorkerData_Many_Short); // throws Exception
     }
 
-    @Test
+    //@Test
     public void testDefaultReaper_Scatter_Many_Long() throws Exception {
         runProfile(TEST_ITERATIONS, defaultProfile, scatterWorkerData_Many_Long); // throws Exception
     }
 
-    @Test
+    //@Test
     public void testNoQuick_Scatter_Many_Long() throws Exception {
         runProfile(TEST_ITERATIONS, noQuickProfile, scatterWorkerData_Many_Long); // throws Exception
     }
@@ -270,7 +269,7 @@ public class ZipFileReaperTest {
 
     @Test
     public void testDefault_Tiny_One() throws Exception {
-        runProfile(TEST_ITERATIONS * 100, tinyTestDuration, defaultProfile, tinyWorkerData_One); // throws Exception
+        runProfile(TEST_ITERATIONS, tinyTestDuration, defaultProfile, tinyWorkerData_One); // throws Exception
     }
 
     @Test


### PR DESCRIPTION
Currently the ZipFileReaperTest alone accounts for >10% of our unit test runtime. When I ran this task on my Windows machine it took 7m19s, with certain test cases taking significantly longer than others (see test breakdown below).

Ultimately this sort of long-running test should be moved to a FAT. But for now I think it's acceptable to disable the tests that are taking >10s because they aren't testing anything unique from the other tests -- they are just holding files open for longer to stress test the ZipFileReaper in a different way.

The proposed changes cut the test runtime from ~7 minutes to ~2 minutes.

Test | Duration | Result
-- | -- | --
testDefaultReaper_Burst | 9.010s | passed
testDefaultReaper_Dribble_Many | 9.994s | passed
testDefaultReaper_Dribble_One | 9.515s | passed
testDefaultReaper_Overflow | 9.009s | passed
testDefaultReaper_Scatter_Many_Long | 53.339s | passed
testDefaultReaper_Scatter_Many_Short | 9.009s | passed
testDefaultReaper_Scatter_One_Long | 22.402s | passed
testDefaultReaper_Scatter_One_Short | 9.008s | passed
testDefaultReaper_Simple | 16.346s | passed
testDefault_Arq | 9.009s | passed
testDefault_Tiny_Many | 1.234s | passed
testDefault_Tiny_One | 2m3.38s | passed
testNoQuick_Arq | 9.007s | passed
testNoQuick_Burst | 9.006s | passed
testNoQuick_Dribble_Many | 9.981s | passed
testNoQuick_Dribble_One | 9.593s | passed
testNoQuick_Overflow | 9.008s | passed
testNoQuick_Scatter_Many_Long | 53.022s | passed
testNoQuick_Scatter_Many_Short | 9.009s | passed
testNoQuick_Scatter_One_Long | 22.310s | passed
testNoQuick_Scatter_One_Short | 9.009s | passed
testNoQuick_Simple | 16.313s | passed
testNoQuick_Tiny_Many | 1.232s | passed
testNoQuick_Tiny_One | 1.233s | passed
