### PR TITLE
Add oracle jdbc maven dependency

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiple/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiple/build.gradle
@@ -10,8 +10,6 @@
  *******************************************************************************/
 //TODO this can be moved to the wlp-gradle/subprojects/fat.gradle 
 
-def isOracleAvailable = file("../prereq.dbtest/lib/Oracle/jars/Oracle/18.3.0.0.0/ojdbc8_g.jar").exists()
-
 configurations {
   jdbcDrivers
 }
@@ -37,12 +35,8 @@ dependencies {
   jdbcDrivers 	'com.ibm.db2:jcc:11.1.4.4',
   				'org.postgresql:postgresql:42.2.5',
   				'com.microsoft.sqlserver:mssql-jdbc:7.4.1.jre8',
-  				'org.apache.derby:derby:10.11.1.1'
-  
-  //Oracle JDBC Driver				
-  if (isOracleAvailable) {
-    jdbcDrivers files("../prereq.dbtest/lib/Oracle/jars/Oracle/18.3.0.0.0/ojdbc8_g.jar")
-  }
+  				'org.apache.derby:derby:10.11.1.1',
+  				'com.oracle.ojdbc:ojdbc8_g:19.3.0.0'
 }
 
 task addJdbcDrivers(type: Copy) {
@@ -53,7 +47,7 @@ task addJdbcDrivers(type: Copy) {
   rename 'jcc.*.jar', 'db2jcc.jar'
   rename 'mssql-jdbc.*.jar', 'mssql-jdbc.jar'
   rename 'postgresql.*.jar', 'postgresql.jar'
-  rename 'ojdbc.*.jar', 'ojdbc8_g.jar'
+  rename 'ojdbc8_g.*.jar', 'ojdbc8_g.jar'
 }
 
 addRequiredLibraries {

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiple/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiple/build.gradle
@@ -11,7 +11,11 @@
 //TODO this can be moved to the wlp-gradle/subprojects/fat.gradle 
 
 configurations {
-  jdbcDrivers
+  //Transitive dependencies in Oracle Maven pom are not necessary when just using
+  //the base JDBC driver.  Excluding these dependencies will speed up test time and reduce clutter.
+  jdbcDrivers {
+    transitive = false
+  }
 }
 
 dependencies {

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/build.gradle
@@ -10,7 +10,11 @@
  *******************************************************************************/
 
 configurations {
-  jdbcDrivers
+  //Transitive dependencies in Oracle Maven pom are not necessary when just using
+  //the base JDBC driver.  Excluding these dependencies will speed up test time and reduce clutter.
+  jdbcDrivers {
+    transitive = false
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Now that the Oracle JDBC driver is available via Maven Central this FAT bucket has been changed to pull from this repository.  This will allow for users to run this test bucket against oracle without needing to provide their own JDBC driver. 

Also excluding unnecessary transitive dependencies included in the Maven Central POM for features, such as, UCP. 