### PR TITLE
PR to Change SAML20UnsloictedState in Constants

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/Constants.java
+++ b/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/Constants.java
@@ -104,7 +104,7 @@ public class Constants {
     public static final String DEFAULT_NAME_ID_FORMAT = NameIDType.EMAIL;
     public static final String DEFAULT_IDP_NAME_ID_FORMAT = "email";
 
-    public static final String COOKIE_WAS_REQUEST = "SAML20UnsloictedState";
+    public static final String COOKIE_WAS_REQUEST = "SAML20UnsolicitedState";
 
     public static final String NAME_ID_FORMAT_UNSPECIFIED = NameIDType.UNSPECIFIED; // "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
     public static final String NAME_ID_FORMAT_EMAIL = NameIDType.EMAIL; // "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";


### PR DESCRIPTION
A SAML SSO cookie contains a word that is misspelled: SAML20UnsloictedState. That should be fixed.