### PR TITLE
basic test case where automatic persistent timer fails over to another server

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FailoverTimersTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FailoverTimersTest.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.persistent.fat.failovertimers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
@@ -46,15 +49,20 @@ public class FailoverTimersTest extends FATServletClient {
     private static ServerConfiguration originalConfigA;
     private static ServerConfiguration originalConfigB;
 
-    @Server("com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA")
+    private static final String SERVER_A_NAME = "com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA";
+    private static final String SERVER_B_NAME = "com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB";
+
+    @Server(SERVER_A_NAME)
     @TestServlet(servlet = FailoverTimersTestServlet.class, contextRoot = APP_NAME)
     public static LibertyServer serverA;
 
-    @Server("com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB")
+    @Server(SERVER_B_NAME)
     @TestServlet(servlet = FailoverTimersTestServlet.class, contextRoot = APP_NAME)
     public static LibertyServer serverB;
 
     private static final ExecutorService testThreads = Executors.newFixedThreadPool(3);
+
+    private static final String TIMER_LAST_RAN_ON = "Timer last ran on server: ";
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -87,11 +95,28 @@ public class FailoverTimersTest extends FATServletClient {
     }
 
     /**
-     * TODO write a useful test now that test bucket has been created
+     * Determine which server an automatic peristent timer is running on.
+     * Stop that server and verify that the timer starts running on a different server.
      */
     @Test
-    public void testSomething() throws Exception {
-        runTestWithResponse(serverA, APP_NAME + "/FailoverTimersTestServlet", "test1&test=testSomething[A]");
-        runTestWithResponse(serverB, APP_NAME + "/FailoverTimersTestServlet", "test1&test=testSomething[B]");
+    public void testTimerFailsOverWhenServerStops() throws Exception {
+        StringBuilder sb = runTestWithResponse(serverA, APP_NAME + "/FailoverTimersTestServlet",
+                "findServerWhereTimerRuns&timer=AutomaticCountingTimer&test=testTimerFailsOverWhenServerStops[1]");
+        assertEquals(sb.toString(), 0, sb.indexOf(TIMER_LAST_RAN_ON));
+        String serverName = sb.substring(TIMER_LAST_RAN_ON.length(), sb.lastIndexOf("."));
+        assertTrue(serverName, SERVER_A_NAME.equals(serverName) || SERVER_B_NAME.equals(serverName));
+
+        LibertyServer serverToStop = SERVER_A_NAME.equals(serverName) ? serverA : serverB;
+        try {
+            serverToStop.stopServer();
+
+            String nameOfServerForFailover = serverToStop == serverA ? SERVER_B_NAME : SERVER_A_NAME;
+            LibertyServer serverForFailover = serverToStop == serverA ? serverB : serverA;
+
+            runTest(serverForFailover, APP_NAME + "/FailoverTimersTestServlet",
+                    "testTimerFailover&timer=AutomaticCountingTimer&server=" + nameOfServerForFailover + "&test=testTimerFailsOverWhenServerStops[2]");
+        } finally {
+            serverToStop.startServer();
+        }
     }
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/autotimer/AutoCountingTimer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/autotimer/AutoCountingTimer.java
@@ -10,15 +10,25 @@
  *******************************************************************************/
 package failovertimers.ejb.autotimer;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
 import javax.annotation.Resource;
 import javax.ejb.Schedule;
 import javax.ejb.SessionContext;
 import javax.ejb.Singleton;
 import javax.ejb.Timer;
+import javax.sql.DataSource;
+
+import failovertimers.web.FailoverTimersTestServlet;
 
 @Singleton
 public class AutoCountingTimer {
     private int count;
+
+    @Resource
+    private DataSource ds;
 
     @Resource
     private SessionContext sessionContext;
@@ -35,6 +45,30 @@ public class AutoCountingTimer {
         String wlpUserDir = System.getProperty("wlp.user.dir");
         String serverName = serverConfigDir.substring(wlpUserDir.length() + "servers/".length(), serverConfigDir.length() - 1);
 
-        System.out.println("Running execution " + (++count) + " of timer " + timer.getInfo() + " on " + serverName);
+        System.out.println("Running timer " + timer.getInfo() + " on " + serverName);
+
+        try (Connection con = ds.getConnection()) {
+            boolean found;
+            try {
+                PreparedStatement stmt = con.prepareStatement("UPDATE TIMERLOG SET SERVERNAME=?, COUNT=COUNT+1 WHERE TIMERNAME=?");
+                stmt.setString(1, serverName);
+                stmt.setString(2, (String) timer.getInfo());
+                found = stmt.executeUpdate() == 1;
+            } catch (SQLException x) {
+                found = false;
+                FailoverTimersTestServlet.createTables(ds);
+            }
+            if (!found) { // insert new entry
+                PreparedStatement stmt = con.prepareStatement("INSERT INTO TIMERLOG VALUES (?,?,?)");
+                stmt.setString(1, (String) timer.getInfo());
+                stmt.setInt(2, 1);
+                stmt.setString(3, serverName);
+                stmt.executeUpdate();
+            }
+        } catch (SQLException x) {
+            System.out.println("Timer " + timer.getInfo() + " failed.");
+            x.printStackTrace(System.out);
+            throw new RuntimeException(x);
+        }
     }
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/web/FailoverTimersTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/web/FailoverTimersTestServlet.java
@@ -12,16 +12,22 @@ package failovertimers.web;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Resource;
 import javax.ejb.EJB;
 import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -43,12 +49,74 @@ public class FailoverTimersTestServlet extends FATServlet {
     private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
     @Resource
+    private DataSource ds;
+
+    @Resource
     private UserTransaction tx;
 
     /**
-     * TODO write a useful test now that the test bucket is created and running cleanly
+     * Create (if not already created) a table where EJB timers can write data when they run indicating which
+     * server executed the timer.
      */
-    public void test1(HttpServletRequest request, HttpServletResponse response) throws Exception {
-        System.out.println("test1");
+    public static void createTables(DataSource ds) {
+        try (Connection con = ds.getConnection(); Statement s = con.createStatement()) {
+            s.execute("CREATE TABLE TIMERLOG(TIMERNAME VARCHAR(254) NOT NULL PRIMARY KEY, COUNT INT NOT NULL, SERVERNAME VARCHAR(254) NOT NULL)");
+            System.out.println("Table created.");
+        } catch (SQLException x) {
+            System.out.println("Table might have already been created: " + x.getMessage());
+        }
+    }
+
+    /**
+     * Writes the name of the server upon which the automatic timer is running to the server output.
+     */
+    public void findServerWhereTimerRuns(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String timerName = request.getParameter("timer");
+
+        try (Connection con = ds.getConnection()) {
+            PreparedStatement st = con.prepareStatement("SELECT SERVERNAME FROM TIMERLOG WHERE TIMERNAME=?");
+            st.setString(1, timerName);
+
+            for (long start = System.nanoTime(); System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(POLL_INTERVAL_MS)) {
+                ResultSet result = st.executeQuery();
+                if (result.next()) {
+                    response.getWriter().println("Timer last ran on server: " + result.getString(1) + '.');
+                    return;
+                }
+            }
+        }
+
+        response.getWriter().println("Timer did not run within allotted interval.");
+    }
+
+    @Override
+    public void init(ServletConfig c) throws ServletException {
+        createTables(ds);
+    }
+
+    /**
+     * Verify that the specified persistent timer fails over to the specified server within a reasonable amount of time.
+     */
+    public void testTimerFailover(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String timerName = request.getParameter("timer");
+        String expectedServerName = request.getParameter("server");
+
+        String serverName = null;
+
+        try (Connection con = ds.getConnection()) {
+            PreparedStatement st = con.prepareStatement("SELECT SERVERNAME FROM TIMERLOG WHERE TIMERNAME=?");
+            st.setString(1, timerName);
+
+            for (long start = System.nanoTime(); System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(POLL_INTERVAL_MS)) {
+                ResultSet result = st.executeQuery();
+                if (result.next()) {
+                    serverName = result.getString(1);
+                    if (expectedServerName.equals(serverName))
+                        return;
+                }
+            }
+        }
+
+        fail("Timer last ran on server: " + serverName);
     }
 }


### PR DESCRIPTION
Create a basic test case where an automatic persistent EJB timer fails over to another server when the server where it was running on goes down.