### PR TITLE
Update to MP Context Propagation 1.0.1

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0
 singleton=true
--bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0"
+-bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0.1"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1
 singleton=true
--bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0"
+-bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0.1"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile Context Propagation TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.context.propagation.version>1.0</microprofile.context.propagation.version>
+        <microprofile.context.propagation.version>1.0.1</microprofile.context.propagation.version>
         <!-- Switch to the following to test a local SNAPSHOT instead of a release (1.0) or release candidate (1.0-RC3). -->
         <!-- <microprofile.context.propagation.version>1.0-SNAPSHOT</microprofile.context.propagation.version> -->
         <arquillian.version>1.3.0.Final</arquillian.version>


### PR DESCRIPTION
Update to the micro release of MP Context Propagation 1.0, which is 1.0.1.  This micro release includes no changes to the spec APIs, and was solely to allow more lenient TCK tests that enable implementations that might not support the full set of Java/Jakarta EE function to be able to pass the TCK.  Open Liberty was already passing the TCK before this, and continues to pass the TCK, so it makes no difference at all to Open Liberty.  The update to 1.0.1 for Open Liberty is being done solely for consistency with process of always running against the most recent TCK release.