### PR TITLE
rename to missedTaskThreshold

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
@@ -26,7 +26,7 @@
   <AD id="enableTaskExecution"               type="Boolean" default="true" name="%enableTaskExecution" description="%enableTaskExecution.desc"/>
   <AD id="initialPollDelay"                  type="String"  default="0" ibm:type="duration" name="%initialPollDelay" description="%initialPollDelay.desc"/>
   <AD id="jndiName"                          type="String"  required="false" ibm:unique="jndiName" name="internal" description="internal use only"/>
-  <AD id="lateTaskThreshold"                 type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/>
+  <AD id="missedTaskThreshold"               type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/>
   <AD id="pollInterval"                      type="String"  default="-1" ibm:type="duration" name="%pollInterval" description="%pollInterval.desc"/>
   <AD id="pollSize"                          type="Integer" required="false" min="1" name="%pollSize" description="%pollSize.desc"/>
   <AD id="retryInterval"                     type="String"  default="1m" ibm:type="duration" name="%retryInterval" description="%retryInterval.desc"/>

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
@@ -40,9 +40,10 @@ class Config {
     final String jndiName;
 
     /**
-     * Amount of time beyond a task's scheduled time after which the task is eligible to be taken over by another member.
+     * Amount of time beyond a task's scheduled time after which the task is considered to be missed
+     * and is eligible to be taken over by another member.
      */
-    final long lateTaskThreshold;
+    final long missedTaskThreshold;
 
     /**
      * Interval between polling for tasks to run. A value of -1 disables all polling after the initial poll.
@@ -76,7 +77,7 @@ class Config {
         jndiName = (String) properties.get("jndiName");
         enableTaskExecution = (Boolean) properties.get("enableTaskExecution");
         initialPollDelay = (Long) properties.get("initialPollDelay");
-        lateTaskThreshold = enableTaskExecution ? (Long) properties.get("lateTaskThreshold") : -1;
+        missedTaskThreshold = enableTaskExecution ? (Long) properties.get("missedTaskThreshold") : -1;
         pollInterval = enableTaskExecution ? (Long) properties.get("pollInterval") : -1;
         pollSize = enableTaskExecution ? (Integer) properties.get("pollSize") : null;
         retryInterval = (Long) properties.get("retryInterval");
@@ -85,8 +86,8 @@ class Config {
         id = xpathId.contains("]/persistentExecutor[") ? null : (String) properties.get("id");
 
         // Range checking on duration values, which cannot be enforced via metatype
-        if (lateTaskThreshold != -1 && lateTaskThreshold < 1)
-            throw new IllegalArgumentException("lateTaskThreshold: " + lateTaskThreshold + "s");
+        if (missedTaskThreshold != -1 && missedTaskThreshold < 1)
+            throw new IllegalArgumentException("missedTaskThreshold: " + missedTaskThreshold + "s");
         if (initialPollDelay < -1)
             throw new IllegalArgumentException("initialPollDelay: " + initialPollDelay + "ms");
         if (pollInterval < -1)
@@ -102,7 +103,7 @@ class Config {
                         .append(",jndiName=").append(jndiName)
                         .append(",enableTaskExecution=").append(enableTaskExecution)
                         .append(",initialPollDelay=").append(initialPollDelay)
-                        .append("ms,lateTaskThreshold=").append(lateTaskThreshold)
+                        .append("ms,missedTaskThreshold=").append(missedTaskThreshold)
                         .append("s,pollInterval=").append(pollInterval)
                         .append("ms,pollSize=").append(pollSize)
                         .append(",retryInterval=").append(retryInterval)

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
@@ -93,7 +93,7 @@ public class Failover1ServerTest extends FATServletClient {
             PersistentExecutor persistentExec1 = config.getPersistentExecutors().getById("persistentExec1");
             persistentExec1.setEnableTaskExecution("true");
             persistentExec1.setPollInterval("1s600ms");
-            persistentExec1.setExtraAttribute("lateTaskThreshold", "6h"); // TODO update simplicity object with proper setter
+            persistentExec1.setExtraAttribute("missedTaskThreshold", "6h"); // TODO update simplicity object with proper setter
             server.setMarkToEndOfLog();
             server.updateServerConfiguration(config);
             server.waitForConfigUpdateInLogUsingMark(APP_NAMES);
@@ -202,21 +202,21 @@ public class Failover1ServerTest extends FATServletClient {
             persistentExec3.setId("persistentExec3");
             persistentExec3.setPollInterval("2s");
             persistentExec3.setPollSize("4");
-            persistentExec3.setExtraAttribute("lateTaskThreshold", "3s"); // TODO update simplicity object with proper setter
+            persistentExec3.setExtraAttribute("missedTaskThreshold", "3s"); // TODO update simplicity object with proper setter
             config.getPersistentExecutors().add(persistentExec3);
 
             PersistentExecutor persistentExec4 = new PersistentExecutor();
             persistentExec4.setId("persistentExec4");
             persistentExec4.setPollInterval("2s");
             persistentExec4.setPollSize("4");
-            persistentExec4.setExtraAttribute("lateTaskThreshold", "3s"); // TODO update simplicity object with proper setter
+            persistentExec4.setExtraAttribute("missedTaskThreshold", "3s"); // TODO update simplicity object with proper setter
             config.getPersistentExecutors().add(persistentExec4);
 
             PersistentExecutor persistentExec5 = new PersistentExecutor();
             persistentExec5.setId("persistentExec5");
             persistentExec5.setPollInterval("2s");
             persistentExec5.setPollSize("4");
-            persistentExec5.setExtraAttribute("lateTaskThreshold", "3s"); // TODO update simplicity object with proper setter
+            persistentExec5.setExtraAttribute("missedTaskThreshold", "3s"); // TODO update simplicity object with proper setter
             config.getPersistentExecutors().add(persistentExec5);
 
             server.setMarkToEndOfLog();
@@ -282,19 +282,19 @@ public class Failover1ServerTest extends FATServletClient {
             PersistentExecutor persistentExec3 = new PersistentExecutor();
             persistentExec3.setId("persistentExec3");
             persistentExec3.setPollInterval("1s500ms");
-            persistentExec3.setExtraAttribute("lateTaskThreshold", "2s"); // TODO update simplicity object with proper setter
+            persistentExec3.setExtraAttribute("missedTaskThreshold", "2s"); // TODO update simplicity object with proper setter
             config.getPersistentExecutors().add(persistentExec3);
 
             PersistentExecutor persistentExec4 = new PersistentExecutor();
             persistentExec4.setId("persistentExec4");
             persistentExec4.setPollInterval("1s500ms");
-            persistentExec4.setExtraAttribute("lateTaskThreshold", "2s"); // TODO update simplicity object with proper setter
+            persistentExec4.setExtraAttribute("missedTaskThreshold", "2s"); // TODO update simplicity object with proper setter
             config.getPersistentExecutors().add(persistentExec4);
 
             PersistentExecutor persistentExec5 = new PersistentExecutor();
             persistentExec5.setId("persistentExec5");
             persistentExec5.setPollInterval("1s500ms");
-            persistentExec5.setExtraAttribute("lateTaskThreshold", "2s"); // TODO update simplicity object with proper setter
+            persistentExec5.setExtraAttribute("missedTaskThreshold", "2s"); // TODO update simplicity object with proper setter
             config.getPersistentExecutors().add(persistentExec5);
 
             server.setMarkToEndOfLog();
@@ -372,7 +372,7 @@ public class Failover1ServerTest extends FATServletClient {
             persistentExec1.setEnableTaskExecution("true");
             persistentExec1.setInitialPollDelay("200ms");
             persistentExec1.setPollInterval("1s500ms");
-            persistentExec1.setExtraAttribute("lateTaskThreshold", "2s"); // TODO update simplicity object with proper setter
+            persistentExec1.setExtraAttribute("missedTaskThreshold", "2s"); // TODO update simplicity object with proper setter
             server.setMarkToEndOfLog();
             server.updateServerConfiguration(config);
             server.waitForConfigUpdateInLogUsingMark(APP_NAMES);
@@ -410,7 +410,7 @@ public class Failover1ServerTest extends FATServletClient {
         // instance which cannot run tasks directly schedules the task onto the instance that can run tasks.
         ServerConfiguration config = originalConfig.clone();
         PersistentExecutor persistentExec2 = config.getPersistentExecutors().getById("persistentExec2");
-        persistentExec2.setExtraAttribute("lateTaskThreshold", "5h"); // TODO update simplicity object with proper setter
+        persistentExec2.setExtraAttribute("missedTaskThreshold", "5h"); // TODO update simplicity object with proper setter
 
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
@@ -24,7 +24,7 @@
   <persistentExecutor id="persistentExec1" jndiName="persistent/exec1" enableTaskExecution="false"/>
 
   <!-- runs its own tasks and takes late tasks from others -->
-  <persistentExecutor id="persistentExec2" jndiName="persistent/exec2" pollInterval="2s" lateTaskThreshold="3s"/>
+  <persistentExecutor id="persistentExec2" jndiName="persistent/exec2" pollInterval="2s" missedTaskThreshold="3s"/>
 
   <!-- database for scheduled tasks -->
   <dataSource id="DefaultDataSource">

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA/server.xml
@@ -21,7 +21,7 @@
 
   <application location="failoverTimersApp.war"/>
 
-  <persistentExecutor id="DefaultPersistentExecutor" pollInterval="1s400ms" lateTaskThreshold="3s"/>
+  <persistentExecutor id="DefaultPersistentExecutor" pollInterval="1s400ms" missedTaskThreshold="3s"/>
 
   <!-- database for persistent EJB timerss -->
   <dataSource id="DefaultDataSource">

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/server.xml
@@ -26,7 +26,7 @@
 
   <application location="failoverTimersApp.war"/>
 
-  <persistentExecutor id="DefaultPersistentExecutor" pollInterval="1s500ms" lateTaskThreshold="3s"/>
+  <persistentExecutor id="DefaultPersistentExecutor" pollInterval="1s500ms" missedTaskThreshold="3s"/>
 
   <!-- database for persistent EJB timerss -->
   <dataSource id="DefaultDataSource">


### PR DESCRIPTION
Rename lateTaskThreshold to missedTaskThreshold, because the former could suggest that the task is late in starting (when actually it might not start at all).  The former is more indicative of the threshold specifying the time after which the task is considered to have been missed and therefore, some other member should try to run it instead.