### PR TITLE
add missedTaskThreshold in simplicity and update tests

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
@@ -93,7 +93,7 @@ public class Failover1ServerTest extends FATServletClient {
             PersistentExecutor persistentExec1 = config.getPersistentExecutors().getById("persistentExec1");
             persistentExec1.setEnableTaskExecution("true");
             persistentExec1.setPollInterval("1s600ms");
-            persistentExec1.setExtraAttribute("missedTaskThreshold", "6h"); // TODO update simplicity object with proper setter
+            persistentExec1.setMissedTaskThreshold("6h");
             server.setMarkToEndOfLog();
             server.updateServerConfiguration(config);
             server.waitForConfigUpdateInLogUsingMark(APP_NAMES);
@@ -202,21 +202,21 @@ public class Failover1ServerTest extends FATServletClient {
             persistentExec3.setId("persistentExec3");
             persistentExec3.setPollInterval("2s");
             persistentExec3.setPollSize("4");
-            persistentExec3.setExtraAttribute("missedTaskThreshold", "3s"); // TODO update simplicity object with proper setter
+            persistentExec3.setMissedTaskThreshold("3s");
             config.getPersistentExecutors().add(persistentExec3);
 
             PersistentExecutor persistentExec4 = new PersistentExecutor();
             persistentExec4.setId("persistentExec4");
             persistentExec4.setPollInterval("2s");
             persistentExec4.setPollSize("4");
-            persistentExec4.setExtraAttribute("missedTaskThreshold", "3s"); // TODO update simplicity object with proper setter
+            persistentExec4.setMissedTaskThreshold("3s");
             config.getPersistentExecutors().add(persistentExec4);
 
             PersistentExecutor persistentExec5 = new PersistentExecutor();
             persistentExec5.setId("persistentExec5");
             persistentExec5.setPollInterval("2s");
             persistentExec5.setPollSize("4");
-            persistentExec5.setExtraAttribute("missedTaskThreshold", "3s"); // TODO update simplicity object with proper setter
+            persistentExec5.setMissedTaskThreshold("3s");
             config.getPersistentExecutors().add(persistentExec5);
 
             server.setMarkToEndOfLog();
@@ -282,19 +282,19 @@ public class Failover1ServerTest extends FATServletClient {
             PersistentExecutor persistentExec3 = new PersistentExecutor();
             persistentExec3.setId("persistentExec3");
             persistentExec3.setPollInterval("1s500ms");
-            persistentExec3.setExtraAttribute("missedTaskThreshold", "2s"); // TODO update simplicity object with proper setter
+            persistentExec3.setMissedTaskThreshold("2s");
             config.getPersistentExecutors().add(persistentExec3);
 
             PersistentExecutor persistentExec4 = new PersistentExecutor();
             persistentExec4.setId("persistentExec4");
             persistentExec4.setPollInterval("1s500ms");
-            persistentExec4.setExtraAttribute("missedTaskThreshold", "2s"); // TODO update simplicity object with proper setter
+            persistentExec4.setMissedTaskThreshold("2s");
             config.getPersistentExecutors().add(persistentExec4);
 
             PersistentExecutor persistentExec5 = new PersistentExecutor();
             persistentExec5.setId("persistentExec5");
             persistentExec5.setPollInterval("1s500ms");
-            persistentExec5.setExtraAttribute("missedTaskThreshold", "2s"); // TODO update simplicity object with proper setter
+            persistentExec5.setMissedTaskThreshold("2s");
             config.getPersistentExecutors().add(persistentExec5);
 
             server.setMarkToEndOfLog();
@@ -372,7 +372,7 @@ public class Failover1ServerTest extends FATServletClient {
             persistentExec1.setEnableTaskExecution("true");
             persistentExec1.setInitialPollDelay("200ms");
             persistentExec1.setPollInterval("1s500ms");
-            persistentExec1.setExtraAttribute("missedTaskThreshold", "2s"); // TODO update simplicity object with proper setter
+            persistentExec1.setMissedTaskThreshold("2s");
             server.setMarkToEndOfLog();
             server.updateServerConfiguration(config);
             server.waitForConfigUpdateInLogUsingMark(APP_NAMES);
@@ -410,7 +410,7 @@ public class Failover1ServerTest extends FATServletClient {
         // instance which cannot run tasks directly schedules the task onto the instance that can run tasks.
         ServerConfiguration config = originalConfig.clone();
         PersistentExecutor persistentExec2 = config.getPersistentExecutors().getById("persistentExec2");
-        persistentExec2.setExtraAttribute("missedTaskThreshold", "5h"); // TODO update simplicity object with proper setter
+        persistentExec2.setMissedTaskThreshold("5h");
 
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/PersistentExecutor.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/PersistentExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,9 @@ public class PersistentExecutor extends ConfigElement {
 
     /** JNDI Name attribute. */
     private String jndiName;
+
+    /** Missed task threshold attribute. */
+    private String missedTaskThreshold;
 
     /** Server polling interval attribute. */
     private String pollInterval;
@@ -196,6 +199,25 @@ public class PersistentExecutor extends ConfigElement {
     }
 
     /**
+     * Sets the missedTaskThreshold attribute value.
+     *
+     * @param missedTaskThreshold The missedTaskThreshold attribute value.
+     */
+    @XmlAttribute
+    public void setMissedTaskThreshold(String missedTaskThreshold) {
+        this.missedTaskThreshold = missedTaskThreshold;
+    }
+
+    /**
+     * Returns the missedTaskThreshold attribute value
+     *
+     * @return The missedTaskThreshold attribute value
+     */
+    public String getMissedTaskThreshold() {
+        return missedTaskThreshold;
+    }
+
+    /**
      * Sets the pollInterval attribute value.
      * 
      * @param schema The pollInterval attribute value.
@@ -243,6 +265,8 @@ public class PersistentExecutor extends ConfigElement {
             buf.append("initialPollDelay=\"" + initialPollDelay + "\", ");
         if (jndiName != null)
             buf.append("jndiName=\"" + jndiName + "\", ");
+        if (missedTaskThreshold != null)
+            buf.append("missedTaskThreshold=\"" + missedTaskThreshold + "\", ");
         if (pollInterval != null)
             buf.append("pollInterval=\"" + pollInterval + "\", ");
         if (pollSize != null)


### PR DESCRIPTION
Add the missedTaskThreshold attribute to the fattest.simplicity infrastructure for modelling server configuration, and then update test cases to utilize it when making configuration updates.