### PR TITLE
Update createProperty logic

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent/bnd.bnd
@@ -74,5 +74,4 @@ instrument.classesExcludes: com/ibm/ws/concurrent/persistent/resources/*.class
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.kernel.feature;version=latest,\
 	com.ibm.ws.kernel.service;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.websphere.appserver.thirdparty.eclipselink
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.concurrent.persistent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent/bnd.bnd
@@ -74,4 +74,5 @@ instrument.classesExcludes: com/ibm/ws/concurrent/persistent/resources/*.class
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.kernel.feature;version=latest,\
 	com.ibm.ws.kernel.service;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.websphere.appserver.thirdparty.eclipselink

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
@@ -278,8 +278,8 @@ public class DatabaseTaskStore implements TaskStore {
             em.flush();
         } catch (EntityExistsException x) {
             /*
-             * FIXME JPA Spec says em.persist should throw EntityExistsException if entity already exists.
-             * EclipseLink implementation throws PersistanceException during the flush operation instead.
+             * FIXME JPA Spec says em.persist can throw EntityExistsException if entity already exists.
+             * EclipseLink implementation chooses to throw PersistanceException during the flush operation.
              * If EclipseLink changes behavior or another JPA Impl is used, this exception will notify the JPA
              * team so that we can update this code path, and remove extraneous PersistenceException checks.
              */
@@ -298,7 +298,7 @@ public class DatabaseTaskStore implements TaskStore {
                     SQLException sqle = (SQLException) cause;
                     String sqlState = sqle.getSQLState();
 
-                    //SQL State 23xxx also indicates also indicates an integrity constraint violation
+                    //SQL State 23xxx also indicates an integrity constraint violation
                     if (sqlState != null && sqlState.length() == 5 && sqlState.startsWith("23")) {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Tr.debug(tc, "createProperty", sqle.getMessage(), sqlState, sqle.getErrorCode());

--- a/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
@@ -482,8 +482,7 @@ public class SchedulerFATServlet extends HttpServlet {
      * Test that persistent executor properties can be used to coordinate single scheduling of a task
      * across multiple servers. To simulate this, we just invoke the createProperty operation twice.
      */
-    //@Test
-    //FIXME enable test again once improved createProperty method works with all databases
+    @Test
     public void testCoordinateTaskScheduleAndRemove(PrintWriter out) throws Exception {
         DBIncrementTask task = new DBIncrementTask("testCoordinateTaskScheduleAndRemove");
         String taskName = task.getExecutionProperties().get(ManagedTask.IDENTITY_NAME);
@@ -535,8 +534,7 @@ public class SchedulerFATServlet extends HttpServlet {
      * To simulate this, we just invoke the createProperty operation twice
      * and use setProperty to update with the task id within the same transaction.
      */
-    //@Test
-    //FIXME enable test again once improved createProperty method works with all databases
+    @Test
     public void testCoordinateTaskScheduleAndRemoveById(PrintWriter out) throws Exception {
         DBIncrementTask task = new DBIncrementTask("testCoordinateTaskScheduleAndRemoveById");
         String taskName = task.getExecutionProperties().get(ManagedTask.IDENTITY_NAME);
@@ -589,8 +587,7 @@ public class SchedulerFATServlet extends HttpServlet {
      * Use the getProperty interface to simulate querying for existence of a task group.
      * Use the removeProperty interface to simulate removal of a task group.
      */
-    //@Test
-    //FIXME enable test again once improved createProperty method works with all databases
+    @Test
     public void testCreateAndRemoveTaskGroup(PrintWriter out) throws Exception {
         TimersPersistentExecutor timersExecutor = (TimersPersistentExecutor) scheduler;
 


### PR DESCRIPTION
Align createProperty exception checking to investigate SQL State when an eclipselink DatabaseException is thrown for situations when we can determine that property already exists.

