### PR TITLE
Remove bus extensions that will never be loadable.

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/resources/META-INF/cxf/bus-extensions.txt
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/resources/META-INF/cxf/bus-extensions.txt
@@ -11,10 +11,6 @@ org.apache.cxf.bus.resource.ResourceManagerImpl:org.apache.cxf.resource.Resource
 org.apache.cxf.catalog.OASISCatalogManager:org.apache.cxf.catalog.OASISCatalogManager:true
 
 org.apache.cxf.transport.http.HTTPTransportFactory::true
-org.apache.cxf.transport.http.HTTPWSDLExtensionLoader::true:true
-org.apache.cxf.transport.http.policy.HTTPClientAssertionBuilder::true:true
-org.apache.cxf.transport.http.policy.HTTPServerAssertionBuilder::true:true
-org.apache.cxf.transport.http.policy.NoOpPolicyInterceptorProvider::true:true
 
 org.apache.cxf.transport.http.asyncclient.AsyncHTTPConduitFactory:org.apache.cxf.transport.http.HTTPConduitFactory:true:true
 org.apache.cxf.transport.http.asyncclient.AsyncHttpTransportFactory:org.apache.cxf.transport.ConduitInitiator:true:true


### PR DESCRIPTION
Avoid getting NoClassDefFoundErrors and ClassNotFoundExceptions for classes that cannot load because of imports that are not in that class's bundle, or classes that are not exported.